### PR TITLE
Add mappings between the directory names and /TR. 

### DIFF
--- a/tr-mappings.json
+++ b/tr-mappings.json
@@ -1,0 +1,18 @@
+{
+    "DOMCore": "domcore",
+    "WebMessaging": "webmessaging",
+    "DOMEvents": "DOM-Level-3-Events",
+    "WebSockets": "websockets",
+    "html": "html5",
+    "WebStorage": "webstorage",
+    "Workers": "workers",
+    "PointerEvents": "pointerevents",
+    "canvas2d": "2dcontext",
+    "ProgressEvents": "progress-events",
+    "crypto-api": "WebCryptoAPI",
+    "SelectorsAPI": "selectors-api",
+    "ServerSentEvents": "eventsource",
+    "typedarrays": "typedarrays",
+    "ShadowDOM": "shadow-dom",
+    "ext-xhtml-pubid": "xhtml-pubid"
+}

--- a/tr-mappings.json
+++ b/tr-mappings.json
@@ -12,7 +12,6 @@
     "crypto-api": "WebCryptoAPI",
     "SelectorsAPI": "selectors-api",
     "ServerSentEvents": "eventsource",
-    "typedarrays": "typedarrays",
     "ShadowDOM": "shadow-dom",
     "ext-xhtml-pubid": "xhtml-pubid"
 }


### PR DESCRIPTION
This is needed for various scripts I'm working on.

Hopefully this is a temp fix until we can rename the directories to match the short names on /TR.
