### PR TITLE
Add missing upload.php helper file

### DIFF
--- a/XMLHttpRequest/tests/submissions/Opera/resources/upload.php
+++ b/XMLHttpRequest/tests/submissions/Opera/resources/upload.php
@@ -1,0 +1,12 @@
+<?php
+ksort($_POST);
+ksort($_FILES);
+if (!empty($_POST))
+  foreach ($_POST as $k => $v)
+		echo "{$k}={$v},";
+echo "\n";
+if (!empty($_FILES))
+	foreach ($_FILES as $k => $v)
+		echo "{$k}={$v['name']}:{$v['type']}:{$v['size']},";
+
+?>


### PR DESCRIPTION
Some tests (e.g. FormData tests) rely on the upload.php helper file, it appears to be missing from the W3C repo
