### PR TITLE
progress-events: change the file constructor.html to that of the approve...

### DIFF
--- a/progress-events/constructor.html
+++ b/progress-events/constructor.html
@@ -13,7 +13,6 @@ test(function() {
   assert_equals(ev.bubbles, false)
   assert_equals(ev.cancelable, false)
   assert_equals(ev.defaultPrevented, false)
-  assert_equals(ev.isTrusted, false)
   assert_true(ev.timeStamp > 0)
   assert_true("initEvent" in ev)
   assert_equals(ev.lengthComputable, false)
@@ -41,9 +40,4 @@ test(function() {
   assert_equals(ev.type, "Xx")
   assert_equals(ev.lengthComputable, false)
 }, "ProgressEventInit members must be matched case-sensitively.")
-test(function() {
-  assert_throws("NotSupportedError", function() {
-    document.createEvent("ProgressEvent")
-  })
-}, "document.createEvent() should not work with ProgressEvent.")
 </script>


### PR DESCRIPTION
...d file.

The file was copied from:
https://dvcs.w3.org/hg/webapps/file/01bd97d7d635/ProgressEvents/tests/submissions/Ms2ger/constructor.html

This commit changes it to:
https://dvcs.w3.org/hg/webapps/file/01bd97d7d635/ProgressEvents/tests/approved/constructor.html
