### PR TITLE
shadow-dom: Remove .gitattributes.

### DIFF
--- a/shadow-dom/.gitattributes
+++ b/shadow-dom/.gitattributes
@@ -1,4 +1,0 @@
-# Let Git normalize the line endings even if the core.autocrlf configuration
-# variable is not set.
-# See also: <https://help.github.com/articles/dealing-with-line-endings>
-* text=auto


### PR DESCRIPTION
This change removes the .gitattributes file, based on the discussion at
https://github.com/w3c/web-platform-tests/pull/120.
