### PR TITLE
shadow-dom: Added tests that checks inheritance of contentEditable

### DIFF
--- a/shadow-dom/user-interaction/editing/inheritance-of-content-editable-001.html
+++ b/shadow-dom/user-interaction/editing/inheritance-of-content-editable-001.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<title>Shadow DOM Test: Inheritance of contentEditable attribute</title>
+<link rel="author" title="Moto Ishizawa" href="mailto:summerwind.jp@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#editing">
+<meta name="assert" content="User Interaction: Shadow trees must not be propagated contentEditable attribute from shadow host">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(unit(function (ctx) {
+	var d = newRenderedHTMLDocument(ctx);
+
+	var host = d.createElement('div');
+	host.contentEditable = "true";
+	d.body.appendChild(host);
+
+	var s = createSR(host);
+
+	assert_equals(host.contentEditable, "true");
+    assert_equals(s.contentEditable, undefined);
+}), 'contentEditable of shadow trees must be undefined when contentEditable attribute of shadow host is "true"');
+
+test(unit(function (ctx) {
+	var d = newRenderedHTMLDocument(ctx);
+
+	var host = d.createElement('div');
+	host.contentEditable = "false";
+	d.body.appendChild(host);
+
+	var s = createSR(host);
+
+	assert_equals(host.contentEditable, 'false');
+    assert_equals(s.contentEditable, undefined);
+}), 'contentEditable of shadow trees must be undefined when contentEditable of shadow host is "false"');
+
+test(unit(function (ctx) {
+	var d = newRenderedHTMLDocument(ctx);
+
+	var host = d.createElement('div');
+	d.body.appendChild(host);
+	d.body.contentEditable = "true";
+
+	var s = createSR(host);
+	
+	assert_equals(host.contentEditable, 'inherit');
+    assert_equals(s.contentEditable, undefined);
+}), 'contentEditable of shadow trees must be undefined when contentEditable attribute of shadow host is "inherit"');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Added tests of inheritance of contentEditable of shadow host.
This tests is related to the 'Editing' sections of User Interaction of the specs.
http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#editing
