### PR TITLE
shadow-dom: Add reftest for styles

### DIFF
--- a/shadow-dom/styles/not-apply-in-shadow-root-001-ref.html
+++ b/shadow-dom/styles/not-apply-in-shadow-root-001-ref.html
@@ -21,7 +21,7 @@ div {
 </style>
 </head>
 <body>
-<p>Test passes if CSS rules declared in an enclosing tree must not apply in a shadow tree.</p>
+<p>Test passes if following box is green.</p>
 <div></div>
 </body>
 </html>

--- a/shadow-dom/styles/not-apply-in-shadow-root-001-ref.html
+++ b/shadow-dom/styles/not-apply-in-shadow-root-001-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<title>Shadow DOM Test</title>
+<link rel="author" title="Kazuhito Hokamura" href="mailto:k.hokamura@gmail.com">
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if CSS rules declared in an enclosing tree must not apply in a shadow tree.</p>
+<div></div>
+</body>
+</html>

--- a/shadow-dom/styles/not-apply-in-shadow-root-001.html
+++ b/shadow-dom/styles/not-apply-in-shadow-root-001.html
@@ -25,7 +25,7 @@ div {
 </style>
 </head>
 <body>
-<p>Test passes if CSS rules declared in an enclosing tree must not apply in a shadow tree.</p>
+<p>Test passes if following box is green.</p>
 <div id="shadow-host"></div>
 <script>
 var shadowHost = document.getElementById('shadow-host');

--- a/shadow-dom/styles/not-apply-in-shadow-root-001.html
+++ b/shadow-dom/styles/not-apply-in-shadow-root-001.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<title>Shadow DOM Test - Tests CSS rules must not apply in a shadow root</title>
+<link rel="reference" href="not-apply-in-shadow-root-001-ref.html">
+<link rel="author" title="Kazuhito Hokamura" href="mailto:k.hokamura@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#styles">
+<meta name="assert" content="Styles: CSS rules declared in an enclosing tree must not apply in a shadow tree if apply-author-styles flag is not set.">
+<script src="../testcommon.js"></script>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+</head>
+<body>
+<p>Test passes if CSS rules declared in an enclosing tree must not apply in a shadow tree.</p>
+<div id="shadow-host"></div>
+<script>
+var shadowHost = document.getElementById('shadow-host');
+var shadowRoot = createSR(shadowHost);
+var style = document.createElement('style');
+style.innerHTML = 'div { background: red }';
+
+shadowRoot.appendChild(style);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Add reftest: CSS rules declared in an enclosing tree must not apply in a shadow tree.
http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#styles
