### PR TITLE
Bug fix for postMessage with urls containing port numbers

### DIFF
--- a/webmessaging/event.origin.htm
+++ b/webmessaging/event.origin.htm
@@ -23,7 +23,7 @@
     var TARGET1 = document.querySelectorAll("iframe")[0];
     var TARGET2 = document.querySelectorAll("iframe")[1];
     var XORIGIN = "http://www1.w3c-test.org";
-    var SORIGIN = "http://" + location.hostname;
+    var SORIGIN = "http://" + location.host;
     var ExpectedResult = ["#1", XORIGIN, "#2", SORIGIN];
     var ActualResult = [];
     var loaded = 0;


### PR DESCRIPTION
Fixed a bug where if a url contains a port number the test would fail as e.source returns a url & port, but the test comparison is against location.hostname which does not include the port number.
