### PR TITLE
shadow-dom: Added tests that checks invalid pseudo element value

### DIFF
--- a/shadow-dom/shadow-trees/custom-pseudo-elements/invalid-pseudo-element-value-001.html
+++ b/shadow-dom/shadow-trees/custom-pseudo-elements/invalid-pseudo-element-value-001.html
@@ -36,7 +36,7 @@ test(unit(function (ctx) {
 
     var invalid_values = ['thumb', 'xthumb', '-thumb'];
     var elems = {};
-    for (var i=0, len=invalid_values.length; i<len; i++) {
+    for (var i = 0, len = invalid_values.length; i < len; i++) {
         var val = invalid_values[i];
 
         var span = d.createElement('span');

--- a/shadow-dom/shadow-trees/custom-pseudo-elements/invalid-pseudo-element-value-001.html
+++ b/shadow-dom/shadow-trees/custom-pseudo-elements/invalid-pseudo-element-value-001.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<title>Shadow DOM Test: Invalid pseudo-element value</title>
+<link rel="author" title="Moto Ishizawa" href="mailto:summerwind.jp@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#custom-pseudo-elements">
+<meta name="assert" content="Custom Pseudo-Elements: Tests of invalid pseudo-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(unit(function (ctx) {
+    var d = newRenderedHTMLDocument(ctx);
+
+    var style = d.createElement('style');
+    style.innerHTML = 'span { font-size: 10px; }';
+    d.head.appendChild(style);
+
+    var widget = d.createElement('div');
+    d.body.appendChild(widget);
+
+    var s = createSR(widget);
+
+    var invalid_values = ['thumb', 'xthumb', '-thumb'];
+    var elems = {};
+    for (var i=0, len=invalid_values.length; i<len; i++) {
+        var val = invalid_values[i];
+
+        var span = d.createElement('span');
+        span.innerHTML = 'This is a invalid pseudo-element';
+        span.pseudo = val;
+        s.appendChild(span);
+
+        var height = span.offsetHeight;
+        assert_true(height > 0, 'Element should be rendered');
+        elems[val] = {
+            elem: span, 
+            height: height
+        };
+    }
+
+    style = d.createElement('style');
+    style.innerHTML = '';
+    style.innerHTML += 'div::x-thumb { font-size: 30px; }';
+    style.innerHTML += 'div::xthumb { font-size: 30px; }';
+    style.innerHTML += 'div::-thumb { font-size: 30px; }';
+    style.innerHTML += 'div::thumb { font-size: 30px; }';
+    d.body.appendChild(style);
+
+    for (var val in elems) {
+        assert_equals(elems[val].elem.offsetHeight, elems[val].height, 'Invalid pseudo-element style should not be applied');
+    }
+}), 'Invalid pseudo-element value must be ignored');
+</script>
+</body>
+</html>


### PR DESCRIPTION
Added tests of invalid pseudo element values.
This tests is related to the 'Custom Pseudo-Elements' sections of the specs.
http://www.w3.org/TR/shadow-dom/#custom-pseudo-elements
