### PR TITLE
Test that XHR abort() should not fire an "abort" event after a timeout happens.

### DIFF
--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -16,6 +16,8 @@
         // the download would otherwise take 500ms
         // we check after 300ms to make sure abort does not fire an "abort" event
 
+        var timeoutFired = false;
+
         var client = new XMLHttpRequest();
         client.timeout = 100;
 
@@ -24,10 +26,15 @@
 
             client.abort();
 
+            assert_true(timeoutFired);
             assert_equals(client.readyState, 0);
 
             test.done();
         }), 300);
+
+        client.ontimeout = function () {
+            timeoutFired = true;
+        };
 
         client.onabort = test.step_func(function () {
             // this should not fire!

--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -19,14 +19,18 @@
         var timeoutFired = false;
 
         var client = new XMLHttpRequest();
+
+        assert_true('timeout' in client, 'xhr.timeout is not supported in this user agent');
+
         client.timeout = 100;
 
         setTimeout(test.step_func(function() {
+            assert_true(timeoutFired);
+
             // abort should not cause the "abort" event to fire
 
             client.abort();
 
-            assert_true(timeoutFired);
             assert_equals(client.readyState, 0);
 
             test.done();

--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>XMLHttpRequest: abort() after successful receive should not fire "abort" event</title>
+    <title>XMLHttpRequest: abort() after a timeout should not fire "abort" event</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" />

--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -1,21 +1,25 @@
 <!doctype html>
 <html>
-  <head>
+<head>
     <title>XMLHttpRequest: abort() after successful receive should not fire "abort" event</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" />
-  </head>
-  <body>
-    <div id="log"></div>
-    <script>
-      var test = async_test();
+</head>
+<body>
+<div id="log"></div>
+<script>
+    var test = async_test();
 
-      test.step(function() {
+    test.step(function() {
+        // timeout is 100ms
+        // the download would otherwise take 500ms
+        // we check after 300ms to make sure abort does not fire an "abort" event
+
         var client = new XMLHttpRequest();
+        client.timeout = 100;
 
-        client.onreadystatechange = test.step_func(function() {
-          if (client.readyState == 4) {
+        setTimeout(test.step_func(function() {
             // abort should not cause the "abort" event to fire
 
             client.abort();
@@ -23,8 +27,7 @@
             assert_equals(client.readyState, 0);
 
             test.done();
-          }
-        });
+        }), 300);
 
         client.onabort = test.step_func(function () {
             // this should not fire!
@@ -32,9 +35,9 @@
             assert_unreached("abort() should not cause the abort event to fire");
         });
 
-        client.open("GET", "resources/well-formed.xml", true);
+        client.open("GET", "resources/delay.php?ms=500000", true);
         client.send(null);
-      });
-    </script>
-  </body>
+    });
+</script>
+</body>
 </html>


### PR DESCRIPTION
Added abort-after-timeout test.
Fixed a typo in abort-after-receive.
