### PR TITLE
Fixed a bug where using a port number in the url would cause the test to fail.

### DIFF
--- a/webmessaging/event.origin.htm
+++ b/webmessaging/event.origin.htm
@@ -41,12 +41,13 @@
     
     window.onmessage = t.step_func(function(e)
     {
-        ActualResult.push(e.data, e.origin);
-        
-        if (ActualResult.length >= ExpectedResult.length)
-        {
-            assert_array_equals(ActualResult, ExpectedResult, "ActualResult");
-            t.done();
+        // testharness.js uses postMessage so we must check what data we want to receive
+        if (e.data.toString() === "#1" || e.data.toString() === "#2") {
+        	ActualResult.push(e.data, e.origin);
+            if (ActualResult.length === ExpectedResult.length) {
+            	assert_array_equals(ActualResult, ExpectedResult, "ActualResult");
+            	t.done();
+            }
         }
     });
 </script>

--- a/webmessaging/event.origin.htm
+++ b/webmessaging/event.origin.htm
@@ -23,7 +23,7 @@
     var TARGET1 = document.querySelectorAll("iframe")[0];
     var TARGET2 = document.querySelectorAll("iframe")[1];
     var XORIGIN = "http://www1.w3c-test.org";
-    var SORIGIN = "http://" + location.hostname;
+    var SORIGIN = "http://" + location.host;
     var ExpectedResult = ["#1", XORIGIN, "#2", SORIGIN];
     var ActualResult = [];
     var loaded = 0;


### PR DESCRIPTION
If a url contains a port number the test would fail as e.source returns url & port when not default 80, but the test comparison is against location.hostname which does not include a port number.
