### PR TITLE
The only first <shadow> element is used

### DIFF
--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-004-ref.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-004-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Shadow DOM - The only first shadow element is used.</title>
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com">
+  </head>
+  <body>
+    <div>
+      <p>1st shadow tree's node</p>
+      <p>2nd shadow tree's node</p>
+    </div>
+  </body>
+</html>

--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-004.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-004.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Shadow DOM Test - The only first shadow element is used.</title>
+    <link rel="reference" href="hosting-multiple-shadow-trees-004-ref.html">
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com">
+    <link rel="help" href="http://www.w3.org/TR/shadow-dom/#multiple-shadow-trees">
+    <script src="../testcommon.js"></script>
+    <meta name="assert" content="The only first <shadow> element is used when the shadow tree has multiple <shadow> elements. Original tree's node is not inserted into the second <shadow> element.">
+  </head>
+  <body>
+    <div id='host'>
+      <p>Original tree's node</p>
+    </div>
+  <script>
+    var shadowRoot = createSR(host);
+    shadowRoot.innerHTML = "<div><p>1st shadow tree's node</p></div>";
+    var shadowRoot = createSR(host);
+    shadowRoot.innerHTML = "<div><shadow></shadow><p>2nd shadow tree's node</p><shadow></shadow></div>";
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
when the shadow tree has multiple <shadow> elements. Original tree's node is not inserted into the second <shadow> element.
