### PR TITLE
The older shadow tree is not used

### DIFF
--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005-ref.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Shadow DOM - Older shadow tree is not used</title>
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com" />
+  </head>
+  <body>
+    <div>
+      <p>2nd shadow tree's node</p>
+      <p>Original tree's node</p>
+    </div>
+  </body>
+</html>

--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005-ref.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005-ref.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Shadow DOM - Older shadow tree is not used</title>
-    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com" />
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com">
   </head>
   <body>
     <div>

--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8" />
+    <meta charset="utf-8">
     <title>Shadow DOM Test - The older shadow tree is not used.</title>
-    <link rel="reference" href="hosting-multiple-shadow-trees-005-ref.html" />
-    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/shadow-dom/#multiple-shadow-trees" />
+    <link rel="reference" href="hosting-multiple-shadow-trees-005-ref.html">
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com">
+    <link rel="help" href="http://www.w3.org/TR/shadow-dom/#multiple-shadow-trees">
     <script src="../testcommon.js"></script>
-    <meta name="assert" content="The older shadow tree is not used when the youngest shadow tree doesn't have <shadow>. The original tree's node is inserted into <content> instead." />
+    <meta name="assert" content="The older shadow tree is not used when the youngest shadow tree doesn't have <shadow>. The original tree's node is inserted into <content> instead.">
   </head>
   <body>
     <div id='host'>

--- a/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005.html
+++ b/shadow-dom/shadow-trees/hosting-multiple-shadow-trees-005.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Shadow DOM Test - The older shadow tree is not used.</title>
+    <link rel="reference" href="hosting-multiple-shadow-trees-005-ref.html" />
+    <link rel="author" title="Hiroyuki Hayashi" href="mailto:hyshhryk@gmail.com" />
+    <link rel="help" href="http://www.w3.org/TR/shadow-dom/#multiple-shadow-trees" />
+    <script src="../testcommon.js"></script>
+    <meta name="assert" content="The older shadow tree is not used when the youngest shadow tree doesn't have <shadow>. The original tree's node is inserted into <content> instead." />
+  </head>
+  <body>
+    <div id='host'>
+      <p>Original tree's node</p>
+    </div>
+  <script>
+    var shadowRoot = createSR(host);
+    shadowRoot.innerHTML = "<div><p>1st shadow tree's node</p><shadow></shadow></div>";
+    var shadowRoot = createSR(host);
+    shadowRoot.innerHTML = "<div><p>2nd shadow tree's node</p><content></content></div>";
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
when the youngest shadow tree doesn't have <shadow>. The original tree's node is inserted into <content> instead.
