### PR TITLE
Add relatedTarget retargeting test

### DIFF
--- a/shadow-dom/05-events/03-retargeting-focus-events/test-004.html
+++ b/shadow-dom/05-events/03-retargeting-focus-events/test-004.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<title>Shadow DOM Test: A_05_03_04</title>
+<link rel="author" title="David Thevenin" href="mailto:david.thevenin@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#retargeting-focus-events">
+<meta name="assert" content="Retargeting focus events:The blur event must be treated in the same way as events with a relatedTarget, where the node that is gaining focus causing the blurring of target acts as the related target">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+</head>
+<body>
+<div id="log"></div>
+<script>
+//test blur event
+
+var A_05_03_04_T01 = async_test('A_05_03_04_T01');
+
+A_05_03_04_T01.step(unit(function (ctx) {
+
+    var d = newRenderedHTMLDocument(ctx);
+
+    var invoked = false;
+
+    var roots = createTestMediaPlayer(d);
+
+    roots.playerShadowRoot.querySelector('.volume-slider').focus();
+
+    //expected result of what relative target should be see
+    //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
+
+    //For #outside-controlrelative target is #player-shadow-root
+    d.querySelector('#outside-control').addEventListener('focus',
+            A_05_03_04_T01.step_func(function(event) {
+                invoked = true;
+
+                assert_equals(event.relatedTarget.getAttribute('id'), 'player-shadow-root',
+                        'Wrong target');
+        }), false);
+
+    // move focus out of shadow tree. blur should be fired
+    d.querySelector('#outside-control').focus();
+
+    assert_true(invoked, 'Event listener was not invoked');
+
+    A_05_03_04_T01.done();
+}));
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test if the relatedTarget event attribute is correctly retargeted to the shadow host.

Test is based on the "player-shadow-root" example from the http://www.w3.org/TR/shadow-dom/#events specification.
