### PR TITLE
Fixed a bug where if testharness.js sends a postMessage before either of the iframes reply, the test ends with a fail.

### DIFF
--- a/webmessaging/event.data.htm
+++ b/webmessaging/event.data.htm
@@ -43,13 +43,15 @@
     
     window.onmessage = t.step_func(function(e)
     {
-        ActualResult.push(e.data, typeof(e.data));
+        if (e.data.toString() === "STRING") {
+        	ActualResult.push(e.data, typeof(e.data));
         
-        if (ActualResult.length >= ExpectedResult.length)
-        {
-            assert_array_equals(ActualResult, ExpectedResult, "ActualResult");
-            t.done();
-        }
+	        if (ActualResult.length >= ExpectedResult.length)
+	        {
+	            assert_array_equals(ActualResult, ExpectedResult, "ActualResult");
+	            t.done();
+	        }
+		}
     });
 </script>
 </body>


### PR DESCRIPTION
Fixed a bug where if testharness.js sends a postMessage before either of the iframes reply, the test ends with a fail. 
At the time of this commit testharness.js would send an object type which breaks the expected string type for the test. As we do not know what testhardness.js will send in the future, checking the data itself is the most secure method to make sure we are testing the right data in the right message.
