### PR TITLE
TestTWF tokyo test fixes

### DIFF
--- a/XMLHttpRequest/abort-after-receive.htm
+++ b/XMLHttpRequest/abort-after-receive.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: abort() after successful receive should not fire "abort" event</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" data-tested-assertations="following::ol[1]/li[4]"/>
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" data-tested-assertations="following::ol[1]/li[4] following::ol[1]/li[5]"/>
   </head>
   <body>
     <div id="log"></div>
@@ -22,7 +22,9 @@
 
             assert_equals(client.readyState, 0);
 
-            test.done();
+            setTimeout(function(){ // use a timeout to catch any implementation that might queue an abort event for later - just in case
+              test.step(function(){test.done();});
+            }, 200);
           }
         });
 

--- a/XMLHttpRequest/abort-after-receive.htm
+++ b/XMLHttpRequest/abort-after-receive.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: abort() after successful receive should not fire "abort" event</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" />
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" data-tested-assertations="following::ol[1]/li[4]"/>
   </head>
   <body>
     <div id="log"></div>

--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -29,6 +29,7 @@
             assert_true(timeoutFired);
 
             // abort should not cause the "abort" event to fire
+            client.abort();
 
             setTimeout(function(){ // use a timeout to catch any implementation that might queue an abort event for later - just in case
               test.step(function(){test.done();});

--- a/XMLHttpRequest/abort-after-timeout.htm
+++ b/XMLHttpRequest/abort-after-timeout.htm
@@ -4,7 +4,8 @@
     <title>XMLHttpRequest: abort() after a timeout should not fire "abort" event</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" />
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-abort()-method" data-tested-assertations="following::ol[1]/li[4] following::ol[1]/li[5]"/>
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-timeout-attribute" data-tested-assertations="following::ol[1]/li[2]"/>
 </head>
 <body>
 <div id="log"></div>
@@ -29,7 +30,9 @@
 
             // abort should not cause the "abort" event to fire
 
-            client.abort();
+            setTimeout(function(){ // use a timeout to catch any implementation that might queue an abort event for later - just in case
+              test.step(function(){test.done();});
+            }, 200);
 
             assert_equals(client.readyState, 0);
 

--- a/XMLHttpRequest/event-readystatechange-loaded.htm
+++ b/XMLHttpRequest/event-readystatechange-loaded.htm
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>XMLHttpRequest: the LOADED state change should only happen once</title>
+    <title>XMLHttpRequest: the LOADING state change should only happen once</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method">
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" >
 </head>
 
 <div id="log"></div>

--- a/XMLHttpRequest/event-readystatechange-loaded.htm
+++ b/XMLHttpRequest/event-readystatechange-loaded.htm
@@ -5,7 +5,9 @@
     <title>XMLHttpRequest: the LOADING state change should only happen once</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" >
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" data-tested-assertations="following::ol[1]/li[10]/dt[1]">
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#infrastructure-for-the-send()-method" data-tested-assertations="following::dt[7] following::a[contains(@href,'#switch-loading')]/..">
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#switch-loading" data-tested-assertations="following::ol[1]/li[1] following::ol[1]/li[2]">
 </head>
 
 <div id="log"></div>

--- a/XMLHttpRequest/response-data-gzip.htm
+++ b/XMLHttpRequest/response-data-gzip.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: GZIP response was correctly inflated</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" />
+    <link rel="help" href="https://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" data-tested-assertations="following::p[contains(text(),'content-encodings')]" />
   </head>
   <body>
     <div id="log"></div>

--- a/XMLHttpRequest/response-data-progress.htm
+++ b/XMLHttpRequest/response-data-progress.htm
@@ -5,7 +5,8 @@
     <title>XMLHttpRequest: progress events grow response body size</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method">
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-send()-method" data-tested-assertations="following::a[contains(@href,'#make-progress-notifications')]/.. following::a[contains(@href,'#make-progress-notifications')]/../following:p[1]" />
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#make-progress-notifications" data-tested-assertations=".." />
     <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#handler-xhr-onprogress" data-tested-assertations="/../.." />
     <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#event-xhr-progress" data-tested-assertations="/../.." />
 </head>


### PR DESCRIPTION
A few changes for the recently contributed Test The Web Forward XHR tests. Mostly adding LINKs and XPath expressions (which I use to map the exact assertations being tested), one TITLE fix, two code changes.

Many thanks to @ronkorving for the contributions!
