### PR TITLE
Added idlharness tests for html5 forms elements

### DIFF
--- a/html/semantics/forms/the-button-element/button_idlharness.html
+++ b/html/semantics/forms/the-button-element/button_idlharness.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: button_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-button-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLButtonElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface ValidityState {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLButtonElement : HTMLElement {
+                 attribute boolean autofocus;
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+                 attribute DOMString formAction;
+                 attribute DOMString formEnctype;
+                 attribute DOMString formMethod;
+                 attribute boolean formNoValidate;
+                 attribute DOMString formTarget;
+                 attribute DOMString name;
+                 attribute DOMString type;
+                 attribute DOMString value;
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+
+        readonly attribute NodeList labels;
+      };
+    </pre>
+
+    <div>
+      <form style="display:none">
+        <button id="testElement">Button</button>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLButtonElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-datalist-element/datalist_idlharness.html
+++ b/html/semantics/forms/the-datalist-element/datalist_idlharness.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: datalist_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-datalist-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLDataListElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLCollection {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLDataListElement : HTMLElement {
+       readonly attribute HTMLCollection options;
+      };
+    </pre>
+
+    <div>
+      <form style='display:none'>
+        <datalist id="testdatalist">
+          <option>TEST1</option>
+          <option>TEST2</option>
+        </datalist>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testdatalist");
+
+            idl_array.add_objects({HTMLDataListElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-fieldset-element/fieldset_idlharness.html
+++ b/html/semantics/forms/the-fieldset-element/fieldset_idlharness.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: fieldset_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-fieldset-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLFieldSetElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface HTMLFormControlsCollection {
+      };
+      interface ValidityState {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLFieldSetElement : HTMLElement {
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+                 attribute DOMString name;
+
+        readonly attribute DOMString type;
+
+        readonly attribute HTMLFormControlsCollection elements;
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+      };
+    </pre>
+
+    <div>
+      <form style="display:none">
+        <fieldset id="testElement"></fieldset>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLFieldSetElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-form-element/form_idlharness.html
+++ b/html/semantics/forms/the-form-element/form_idlharness.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: form_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-form-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLFormElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormControlsCollection {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLFormElement : HTMLElement {
+                 attribute DOMString acceptCharset;
+                 attribute DOMString action;
+                 attribute DOMString autocomplete;
+                 attribute DOMString enctype;
+                 attribute DOMString encoding;
+                 attribute DOMString method;
+                 attribute DOMString name;
+                 attribute boolean noValidate;
+                 attribute DOMString target;
+
+        readonly attribute HTMLFormControlsCollection elements;
+        readonly attribute long length;
+        getter Element (unsigned long index);
+        getter object (DOMString name);
+
+        void submit();
+        void reset();
+        boolean checkValidity();
+      };
+    </pre>
+
+    <div>
+      <form id="testElement" style="display:none">
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLFormElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-input-element/input_idlharness.html
+++ b/html/semantics/forms/the-input-element/input_idlharness.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: input_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-input-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLInputElement interface included in the HTML5.0 specification</p>
+
+    <pre id="untested_idl" style="display:none">
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface FileList {
+      };
+      interface Date {
+      };
+      interface ValidityState {
+      };
+    </pre>
+
+    <pre id="idl" style="display:none">
+      interface HTMLInputElement : HTMLElement {
+                 attribute DOMString accept;
+                 attribute DOMString alt;
+                 attribute DOMString autocomplete;
+                 attribute boolean autofocus;
+                 attribute boolean defaultChecked;
+                 attribute boolean checked;
+                 attribute DOMString dirName;
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+        readonly attribute FileList? files;
+                 attribute DOMString formAction;
+                 attribute DOMString formEnctype;
+                 attribute DOMString formMethod;
+                 attribute boolean formNoValidate;
+                 attribute DOMString formTarget;
+                 attribute unsigned long height;
+                 attribute boolean indeterminate;
+        readonly attribute HTMLElement? list;
+                 attribute DOMString max;
+                 attribute long maxLength;
+                 attribute DOMString min;
+                 attribute boolean multiple;
+                 attribute DOMString name;
+                 attribute DOMString pattern;
+                 attribute DOMString placeholder;
+                 attribute boolean readOnly;
+                 attribute boolean required;
+                 attribute unsigned long size;
+                 attribute DOMString src;
+                 attribute DOMString step;
+                 attribute DOMString type;
+                 attribute DOMString defaultValue;
+        [TreatNullAs=EmptyString] attribute DOMString value;
+                 attribute Date? valueAsDate;
+                 attribute unrestricted double valueAsNumber;
+                 attribute unsigned long width;
+
+        void stepUp(optional long n);
+        void stepDown(optional long n);
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+
+        readonly attribute NodeList labels;
+
+        void select();
+                 attribute unsigned long selectionStart;
+                 attribute unsigned long selectionEnd;
+                 attribute DOMString selectionDirection;
+
+        void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+      };
+    </pre>
+
+    <div>
+      <form style="display:none">
+        <input id="testInput" type="text">
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testInput");
+
+            idl_array.add_objects({HTMLInputElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-label-element/label_idlharness.html
+++ b/html/semantics/forms/the-label-element/label_idlharness.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: label_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-label-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLLabelElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLLabelElement : HTMLElement {
+        readonly attribute HTMLFormElement? form;
+                 attribute DOMString htmlFor;
+        readonly attribute HTMLElement? control;
+      };
+    </pre>
+
+    <div>
+      <label id="testElement"></label>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLLabelElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-legend-element/legend_idlharness.html
+++ b/html/semantics/forms/the-legend-element/legend_idlharness.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: legend_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-legend-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLLegendElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLLegendElement : HTMLElement {
+        readonly attribute HTMLFormElement? form;
+      };
+    </pre>
+
+    <div>
+      <form style="display:none">
+        <fieldset>
+          <legend id="testElement">Legend</legend>
+        </fieldset>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLLegendElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-meter-element/meter_idlharness.html
+++ b/html/semantics/forms/the-meter-element/meter_idlharness.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: meter_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-meter-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLMeterElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id='idl' style='display: none'>
+      interface HTMLMeterElement : HTMLElement {
+                 attribute double value;
+                 attribute double min;
+                 attribute double max;
+                 attribute double low;
+                 attribute double high;
+                 attribute double optimum;
+        readonly attribute NodeList labels;
+      };
+    </pre>
+
+    <div id ="log"></div>
+
+    <meter id="testMeter" style="display: none"></meter>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testMeter");
+
+            idl_array.add_objects({HTMLMeterElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-optgroup-element/optgroup_idlharness.html
+++ b/html/semantics/forms/the-optgroup-element/optgroup_idlharness.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: optgroup_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-optgroup-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLOptGroupElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      interface HTMLOptGroupElement : HTMLElement {
+           attribute boolean disabled;
+           attribute DOMString label;
+      };
+    </pre>
+
+    <div>
+      <form id="testForm" name="testForm" style="display:none">
+        <p>
+        <select name="c">
+          <optgroup label="8.01 Physics I: Classical Mechanics" id="optgroup1">
+            <option value="8.01.1">Lecture 01: Powers of Ten
+            <option value="8.01.2">Lecture 02: 1D Kinematics
+            <option value="8.01.3">Lecture 03: Vectors
+          <optgroup label="8.02 Electricity and Magnestism">
+            <option value="8.02.1">Lecture 01: What holds our world together?
+            <option value="8.02.2">Lecture 02: Electric Field
+            <option value="8.02.3">Lecture 03: Electric Flux
+        </select>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("optgroup1");
+
+            idl_array.add_objects({HTMLOptGroupElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-option-element/option_idlharness.html
+++ b/html/semantics/forms/the-option-element/option_idlharness.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: option_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-option-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLOptionElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+    </pre>
+
+    <pre id='idl' style='display:none'>
+      [NamedConstructor=Option(),
+       NamedConstructor=Option(DOMString text),
+       NamedConstructor=Option(DOMString text, DOMString value),
+       NamedConstructor=Option(DOMString text, DOMString value, boolean defaultSelected),
+       NamedConstructor=Option(DOMString text, DOMString value, boolean defaultSelected, boolean selected)]
+      interface HTMLOptionElement : HTMLElement {
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+                 attribute DOMString label;
+                 attribute boolean defaultSelected;
+                 attribute boolean selected;
+                 attribute DOMString value;
+
+                 attribute DOMString text;
+        readonly attribute long index;
+      };
+    </pre>
+
+    <div>
+      <form style="display: none">
+        <select>
+          <option id="testOption">Option</option>
+        </select>
+      </form>
+    </div>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testOption");
+
+            idl_array.add_objects({HTMLOptionElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-output-element/output_idlharness.html
+++ b/html/semantics/forms/the-output-element/output_idlharness.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: output_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-output-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLOutputElement interface included in the HTML5.0 specification</p>
+
+    <pre id="untested_idl" style="display:none">
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface ValidityState {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id="idl" style="display:none">
+      interface HTMLOutputElement : HTMLElement {
+        [PutForwards=value] readonly attribute DOMSettableTokenList htmlFor;
+        readonly attribute HTMLFormElement? form;
+                 attribute DOMString name;
+
+        readonly attribute DOMString type;
+                 attribute DOMString defaultValue;
+                 attribute DOMString value;
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+
+       readonly attribute NodeList labels;
+      };
+    </pre>
+
+    <output id="output" style="display:none"></output>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("output");
+
+            idl_array.add_objects({HTMLOutputElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-progress-element/progress_idlharness.html
+++ b/html/semantics/forms/the-progress-element/progress_idlharness.html
@@ -1,0 +1,50 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML TEST : progress_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-progress-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLProgressElement interface included in the HTML5.0 specification</p>
+
+    <pre id="untested_idl" style="display: none">
+      interface HTMLElement {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id="idl" style="display: none">
+      interface HTMLProgressElement : HTMLElement {
+                 attribute double value;
+                 attribute double max;
+        readonly attribute double position;
+        readonly attribute NodeList labels;
+      };
+    </pre>
+
+    <progress id="testProgress" style="display:none"></progress>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testProgress");
+
+            idl_array.add_objects({HTMLProgressElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-select-element/select_idlharness.html
+++ b/html/semantics/forms/the-select-element/select_idlharness.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: select_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-select-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLSelectElement interface included in the HTML5.0 specification</p>
+
+    <pre id='untested_idl' style='display:none'>
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface HTMLOptionsCollection {
+      };
+      interface HTMLOptionElement {
+      };
+      interface HTMLOptGroupElement {
+      };
+      interface ValidityState {
+      };
+      interface HTMLCollection {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id='idl' style='display: none'>
+      interface HTMLSelectElement : HTMLElement {
+                 attribute boolean autofocus;
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+                 attribute boolean multiple;
+                 attribute DOMString name;
+                 attribute boolean required;
+                 attribute unsigned long size;
+
+        readonly attribute DOMString type;
+
+        readonly attribute HTMLOptionsCollection options;
+                 attribute unsigned long length;
+        getter Element item(unsigned long index);
+        object namedItem(DOMString name);
+        void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+        void remove(long index);
+        setter creator void (unsigned long index, HTMLOptionElement? option);
+
+        readonly attribute HTMLCollection selectedOptions;
+                 attribute long selectedIndex;
+                 attribute DOMString value;
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+
+        readonly attribute NodeList labels;
+      };
+    </pre>
+
+    <select id="testselect" style="display: none">
+      <option value="1"> Miner </option>
+      <option value="2" selected> Puffer </option>
+    </select>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testselect");
+
+            idl_array.add_objects({HTMLSelectElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/the-textarea-element/textarea_idlharness.html
+++ b/html/semantics/forms/the-textarea-element/textarea_idlharness.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: textarea_idlharness</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-textarea-element">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/webidl2/lib/webidl2.js"></script>
+    <script src="/resources/idlharness.js"></script>
+  </head>
+  <body>
+    <p>This test verifies the HTMLTextAreaElement interface included in the HTML5.0 specification</p>
+
+    <pre id="untested_idl" style="display: none">
+      interface HTMLElement {
+      };
+      interface HTMLFormElement {
+      };
+      interface ValidityState {
+      };
+      interface NodeList {
+      };
+    </pre>
+
+    <pre id="idl" style="display: none">
+      interface HTMLTextAreaElement : HTMLElement {
+                 attribute boolean autofocus;
+                 attribute unsigned long cols;
+                 attribute DOMString dirName;
+                 attribute boolean disabled;
+        readonly attribute HTMLFormElement? form;
+                 attribute long maxLength;
+                 attribute DOMString name;
+                 attribute DOMString placeholder;
+                 attribute boolean readOnly;
+                 attribute boolean required;
+                 attribute unsigned long rows;
+                 attribute DOMString wrap;
+
+        readonly attribute DOMString type;
+                 attribute DOMString defaultValue;
+        [TreatNullAs=EmptyString] attribute DOMString value;
+        readonly attribute unsigned long textLength;
+
+        readonly attribute boolean willValidate;
+        readonly attribute ValidityState validity;
+        readonly attribute DOMString validationMessage;
+        boolean checkValidity();
+        void setCustomValidity(DOMString error);
+
+        readonly attribute NodeList labels;
+
+        void select();
+                 attribute unsigned long selectionStart;
+                 attribute unsigned long selectionEnd;
+                 attribute DOMString selectionDirection;
+
+        void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+      };
+    </pre>
+
+    <textarea id="testElement" style="display:none"></textarea>
+
+    <div id="log"></div>
+
+    <script>
+        (function() {
+            var idl_array = new IdlArray();
+
+            idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+            idl_array.add_idls(document.getElementById("idl").textContent);
+
+            var testElement = document.getElementById("testElement");
+
+            idl_array.add_objects({HTMLTextAreaElement: [testElement]});
+
+            idl_array.test();
+        })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
These tests are to verify the IDL interfaces included in
http://www.w3.org/TR/2012/CR-html5-20121217/forms.html
