### PR TITLE
Added test formAction_document_address.html

### DIFF
--- a/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
+++ b/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
@@ -4,10 +4,10 @@
     <meta charset="utf-8">
     <title>HTML Test: formAction_document_address</title>
     <link rel="author" title="Intel" href="http://www.intel.com/">
-    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#dom-fs-formaction">
-    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/dom.html#the-document's-address">
-    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-button-element">
-    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-input-element">
+    <link rel="help" href="http://www.w3.org/TR/html5/forms.html#dom-fs-formaction">
+    <link rel="help" href="http://www.w3.org/TR/html5/dom.html#the-document's-address">
+    <link rel="help" href="http://www.w3.org/TR/html5/forms.html#the-button-element">
+    <link rel="help" href="http://www.w3.org/TR/html5/forms.html#the-input-element">
     <meta name="assert" content="On getting the formAction IDL attribute, when the content attribute is missing or its value is the empty string, the document's address must be returned instead.">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
+++ b/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
@@ -14,34 +14,61 @@
   </head>
   <body>
     <div id="log"></div>
-    <div>
-      <form style="display:none">
-        <button id="testButton" type="submit" formaction>Submit</button>
-        <input id="testInput" type="submit" name="submit" formaction>
-      </form>
+
+    <div id="missing" style="display:none">
+      <button type="submit">Submit</button>
+      <input type="submit">
     </div>
+
+    <div id="empty_string" style="display:none">
+      <button type="submit" formaction="">Submit</button>
+      <input type="submit" formaction="">
+    </div>
+
+    <div id="no_assigned_value" style="display:none">
+      <button type="submit" formaction>Submit</button>
+      <input type="submit" formaction>
+    </div>
+
     <script>
-        var button = document.getElementById("testButton");
-        var input = document.getElementById("testInput");
-        var url = document.location.href;
+      // formaction content attribute is missing
+      test(function() {
+        var formAction = document.querySelector('#missing button').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if button.formAction is the document's address when formaction content attribute is missing");
 
-        test(function() {
-            assert_equals(button.formAction, url);
-        }, "Check if button.formAction is the document's address when formAction content attribute is missing");
+      test(function() {
+        var formAction = document.querySelector('#missing input').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if input.formAction is the document's address when formaction content attribute is missing");
 
-        button.formAction = "";
-        test(function() {
-            assert_equals(button.formAction, url);
-        }, "Check if button.formAction is the document's address when formAction content attribute is empty string");
+      // formaction content attribute value is empty string
+      test(function() {
+        var formAction = document.querySelector('#empty_string button').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if button.formAction is the document's address when formaction content attribute value is empty string");
 
-        test(function() {
-            assert_equals(input.formAction, url);
-        }, "Check if input.formAction is the document's address when formAction content attribute is missing");
+      test(function() {
+        var formAction = document.querySelector('#empty_string input').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if input.formAction is the document's address when formaction content attribute value is empty string");
 
-        input.formAction = "";
-        test(function() {
-            assert_equals(input.formAction, url);
-        }, "Check if input.formAction is the document's address when formAction content attribute is empty string");
+      // formaction content attribute value is not assigned, just for comparison with empty string above
+      test(function() {
+        var formAction = document.querySelector('#no_assigned_value button').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if button.formAction is the document's address when formaction content attribute value is not assigned");
+
+      test(function() {
+        var formAction = document.querySelector('#no_assigned_value input').formAction;
+        var address = document.location.href;
+        assert_equals(formAction, address);
+      }, "Check if input.formAction is the document's address when formaction content attribute value is not assigned");
     </script>
   </body>
 </html>

--- a/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
+++ b/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: formAction_document_address</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#dom-fs-formaction">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/dom.html#the-document's-address">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-button-element">
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#the-input-element">
+    <meta name="assert" content="On getting the formAction IDL attribute, when the content attribute is missing or its value is the empty string, the document's address must be returned instead.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div>
+      <form style="display:none">
+        <button id="testButton" type="submit" formaction>Submit</button>
+        <input id="testInput" type="submit" name="submit" formaction>
+      </form>
+    </div>
+    <script>
+        var button = document.getElementById("testButton");
+        var input = document.getElementById("testInput");
+        var url = document.location.href;
+
+        test(function() {
+            assert_equals(button.formAction, url);
+        }, "Check if button.formAction is the document's address when formAction content attribute is missing");
+
+        button.formAction = "";
+        test(function() {
+            assert_equals(button.formAction, url);
+        }, "Check if button.formAction is the document's address when formAction content attribute is empty string");
+
+        test(function() {
+            assert_equals(input.formAction, url);
+        }, "Check if input.formAction is the document's address when formAction content attribute is missing");
+
+        input.formAction = "";
+        test(function() {
+            assert_equals(input.formAction, url);
+        }, "Check if input.formAction is the document's address when formAction content attribute is empty string");
+    </script>
+  </body>
+</html>

--- a/html/semantics/forms/attributes-common-to-form-controls/formaction.html
+++ b/html/semantics/forms/attributes-common-to-form-controls/formaction.html
@@ -3,7 +3,7 @@
         <title>formaction on button element</title>
         <meta content="text/html; charset=UTF-8" http-equiv="content-type">
         <meta content="formaction on button element" name="description">
-    <link href="http://www.w3.org/TR/html5/attributes-common-to-form-controls.html#dom-fs-formaction" rel="help">
+    <link href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#dom-fs-formaction" rel="help">
 </head>
     <body>
         <script src="/resources/testharness.js"></script>

--- a/html/semantics/forms/attributes-common-to-form-controls/formaction.html
+++ b/html/semantics/forms/attributes-common-to-form-controls/formaction.html
@@ -3,7 +3,7 @@
         <title>formaction on button element</title>
         <meta content="text/html; charset=UTF-8" http-equiv="content-type">
         <meta content="formaction on button element" name="description">
-    <link href="http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#dom-fs-formaction" rel="help">
+    <link href="http://www.w3.org/TR/html5/forms.html#dom-fs-formaction" rel="help">
 </head>
     <body>
         <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
This test verifies that on getting the formAction IDL attribute,
when the content attribute is missing or its value is the empty string,
the document's address must be returned instead.

http://www.w3.org/TR/2012/CR-html5-20121217/forms.html#dom-fs-formaction
