### PR TITLE
Add a test for empty names for Element.children.

### DIFF
--- a/dom/collections/HTMLCollection-empty-name.html
+++ b/dom/collections/HTMLCollection-empty-name.html
@@ -54,4 +54,12 @@ test(function() {
   assert_equals(c[""], undefined, "Named getter should return undefined for empty string.");
   assert_equals(c.namedItem(""), null, "namedItem should return null for empty string.");
 }, "Empty string as a name for Element.getElementsByClassName");
+
+test(function() {
+  var div = document.getElementById("test");
+  var c = div.children;
+  assert_false("" in c, "Empty string should not be in the collection.");
+  assert_equals(c[""], undefined, "Named getter should return undefined for empty string.");
+  assert_equals(c.namedItem(""), null, "namedItem should return null for empty string.");
+}, "Empty string as a name for Element.children");
 </script>


### PR DESCRIPTION
Missed this one earlier.
