### PR TITLE
Add Contributing Guidelines with CLA.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Grant of License for Contributed Test Cases
+-------------------------------------------
+
+By contributing to this repository you grant to the W3C, a perpetual, non-exclusive, royalty-free, world-wide right and license under any Contributor copyrights in this contribution to copy, publish, use, and modify the contribution and to distribute the contribution under a BSD License or one with more restrictive terms, as well as a right and license of the same scope to any derivative works prepared by the W3C and based on, or incorporating all or part of the contribution. You further agrees that any derivative works of this contribution prepared by the W3C shall be solely owned by the W3C.
+
+You state, to the best of your knowledge, that you, or the company you represents, has all rights necessary to contribute the Materials.
+
+W3C will retain attribution of initial authorship to you. The W3C makes no a-priori commitment to support or distribute contributions.
+
+Disclaimer
+----------
+
+The contribution is provided as is, and you make no representations or warranties, express or implied, including, but not limited to, warranties of merchantability, fitness for a particular purpose, non-infringement, or title; that the contents of the document are suitable for any purpose. You make no representations, express or implied, that the contribution or the use thereof indicates conformance to a specification; contributions are provided only to help reaching interoperability.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 Grant of License
 ----------------
 
-By contributing to this repository, you grant to the W3C a perpetual,
+By contributing to this repository, you and the company you represent, if the
+company holds any copyrights in the contribution, grant to the W3C a perpetual,
 non-exclusive, royalty-free, world-wide right and license under all of your
 copyrights in this contribution to copy, publish, use, and modify the
 contribution and to distribute the contribution under a BSD License or one with
@@ -11,7 +12,7 @@ of the contribution. You further agree that any derivative works of this
 contribution prepared by the W3C shall be solely owned by the W3C.
 
 You state, to the best of your knowledge, that you, or the company you
-represent, have all rights necessary to contribute the Materials.
+represent, have all rights necessary to contribute the materials.
 
 W3C will retain attribution of initial authorship to you. The W3C makes no
 a-priori commitment to support or distribute contributions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,28 @@
-Grant of License for Contributed Test Cases
--------------------------------------------
+Grant of License
+----------------
 
-By contributing to this repository you grant to the W3C, a perpetual, non-exclusive, royalty-free, world-wide right and license under any Contributor copyrights in this contribution to copy, publish, use, and modify the contribution and to distribute the contribution under a BSD License or one with more restrictive terms, as well as a right and license of the same scope to any derivative works prepared by the W3C and based on, or incorporating all or part of the contribution. You further agrees that any derivative works of this contribution prepared by the W3C shall be solely owned by the W3C.
+By contributing to this repository, you grant to the W3C a perpetual,
+non-exclusive, royalty-free, world-wide right and license under all of your
+copyrights in this contribution to copy, publish, use, and modify the
+contribution and to distribute the contribution under a BSD License or one with
+more restrictive terms, as well as a right and license of the same scope to any
+derivative works prepared by the W3C and based on or incorporating all or part
+of the contribution. You further agree that any derivative works of this
+contribution prepared by the W3C shall be solely owned by the W3C.
 
-You state, to the best of your knowledge, that you, or the company you represents, has all rights necessary to contribute the Materials.
+You state, to the best of your knowledge, that you, or the company you
+represent, have all rights necessary to contribute the Materials.
 
-W3C will retain attribution of initial authorship to you. The W3C makes no a-priori commitment to support or distribute contributions.
+W3C will retain attribution of initial authorship to you. The W3C makes no
+a-priori commitment to support or distribute contributions.
 
 Disclaimer
 ----------
 
-The contribution is provided as is, and you make no representations or warranties, express or implied, including, but not limited to, warranties of merchantability, fitness for a particular purpose, non-infringement, or title; that the contents of the document are suitable for any purpose. You make no representations, express or implied, that the contribution or the use thereof indicates conformance to a specification; contributions are provided only to help reaching interoperability.
+All content from this repository is provided as is, and W3C makes no
+representations or warranties, express or implied, including, but not limited
+to, warranties of merchantability, fitness for a particular purpose,
+non-infringement, or title; nor that the contents of this repository are
+suitable for any purpose. We make no representations, express or implied, that
+the content of this repository or the use thereof indicates conformance to a
+specification. All content is provided as-is to help reach interoperability.

--- a/README.md
+++ b/README.md
@@ -57,59 +57,11 @@ Contributing
 
 Save the Web, Write Some Tests!
 
-Let's get the legalese out of the way:
-
-You may wish to read the details below, but the **simplest thing to know** is
-this:
-
-* if the company you work for is already a member of the Working Group
-  responsible for the specification, then you don't need to worry; you're
-  already covered
-* if not, you will need to [fill out this form](http://www.w3.org/2002/09/wbs/1/testgrants2-200409/)
-
-### Grant of License for Contributed Test Cases Published Outside a W3C Recommendation
-
-By contributing to this repository, you, the Contributor, hereby grant
-to the W3C, a perpetual, non-exclusive, royalty-free, world-wide right
-and license under any Contributor copyrights in this contribution to
-copy, publish, use, and modify the contribution and to distribute the
-contribution under a BSD License (see [1] below) or one with more
-restrictive terms, as well as a right and license of the same scope to
-any derivative works prepared by the W3C and based on, or
-incorporating all or part of the contribution. The Contributor further
-agrees that any derivative works of this contribution prepared by the
-W3C shall be solely owned by the W3C.
-
-The Contributor states, to the best of her/his knowledge, that she/he,
-or the company she/he represents, has all rights necessary to
-contribute the Materials.
-
-W3C will retain attribution of initial authorship to the
-Contributor. The W3C makes no a-priori commitment to support or
-distribute contributions.
-
-Note: We can accept tests contributed under compatible conditions,
-just contact us to ask about it.
-
-[1] http://www.w3.org/Consortium/Legal/2008/03-bsd-license.html
-
-### Disclaimer
-
-THE CONTRIBUTION IS PROVIDED AS IS, AND CONTRIBUTORS MAKE NO
-REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT
-LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT
-ARE SUITABLE FOR ANY PURPOSE. CONTRIBUTORS MAKE NO REPRESENTATIONS,
-EXPRESS OR IMPLIED, THAT THE CONTRIBUTION OR THE USE THEREOF INDICATES
-CONFORMANCE TO A SPECIFICATION; CONTRIBUTIONS ARE PROVIDED ONLY TO
-HELP REACHING INTEROPERABILITY.
-
-*Legalese over*.
-
-Absolutely everyone is welcome (and even encouraged) to contribute to test 
-development, so long as you fulfil the contribution requirements detailed
-above. No test is too small or too simple, especially if it corresponds to
-something for which you've noted an interoperability bug in a browser.
+Absolutely everyone is welcome (and even encouraged) to contribute to test
+development, so long as you fulfill the contribution requirements detailed
+in the [Contributing Guidelines][contributing]. No test is too small or too
+simple, especially if it corresponds to something for which you've noted an
+interoperability bug in a browser.
 
 The way to contribute is just as usual:
 
@@ -131,5 +83,4 @@ If you wish to contribute actively, you're very welcome to join the
 public-html-testsuite@w3.org mailing list (low traffic) by 
 [signing up to our mailing list](mailto:public-html-testsuite-request@w3.org?subject=subscribe).
 
-
-
+[contributing]: https://github.com/w3c/web-platform-tests/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This pull request reflects a change in the contribution process which greatly simplifies accepting contributions from W3C members and non-members alike, as it drops the requirements for filling-in Grant II forms. This has of course been vetted by W3C legal.

You're welcome. :)
