### PR TITLE
Fixed eventsource/format-utf-8.htm

### DIFF
--- a/eventsource/format-utf-8.htm
+++ b/eventsource/format-utf-8.htm
@@ -14,7 +14,7 @@
         var source = new EventSource("resources/message.php?mime=text/event-stream;charset=windows-1252&message=data%3A%E2%80%A6")
         source.onmessage = function(e) {
           test.step(function() {
-            assert_unreached()
+            // assert_unreached()
             this.close()
           }, this)
           test.done()


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=869878

As discussion in the above bug, an event stream's
(http://www.w3.org/TR/eventsource/#text-event-stream)
charset parameter serves no purpose; it is only allowed
for compatibility with legacy servers.

Moreover, since the spec says nothing about "the charset
parameter is present and the value is not utf-8", this
fixing just comments out the assert_unreached() called
by onmessage().

Signed-off-by: wanmingx.lin wanmingx.lin@intel.com
