### PR TITLE
Change crosssite host name to www2

### DIFF
--- a/eventsource/eventsource-cross-origin.htm
+++ b/eventsource/eventsource-cross-origin.htm
@@ -9,7 +9,7 @@
     <div id="log"></div>
     <script>
       var crossdomain = location.href
-                    .replace('://', '://crosssite.')
+                    .replace('://', '://www2.')
                     .replace(/\/[^\/]*$/, '/')
 
       function doCORS(url, title) {

--- a/eventsource/request-cache-control.htm
+++ b/eventsource/request-cache-control.htm
@@ -9,7 +9,7 @@
     <div id="log"></div>
     <script>
       var crossdomain = location.href
-                    .replace('://', '://crosssite.')
+                    .replace('://', '://www2.')
                     .replace(/\/[^\/]*$/, '/')
 
       // running it twice to check whether it stays consistent

--- a/eventsource/request-credentials.htm
+++ b/eventsource/request-credentials.htm
@@ -9,7 +9,7 @@
     <div id="log"></div>
     <script>
       var crossdomain = location.href
-                    .replace('://', '://crosssite.')
+                    .replace('://', '://www2.')
                     .replace(/\/[^\/]*$/, '/')
 
       function testCookie(desc, success, props, id) {


### PR DESCRIPTION
Change hostname from "crosssite" (used by Opera) to "www2" (used by the W3C's test framework).
