### PR TITLE
Increased timeout to make test more stable

### DIFF
--- a/html/browsers/history/the-history-interface/004.html
+++ b/html/browsers/history/the-history-interface/004.html
@@ -36,7 +36,7 @@ window.onload = function () {
 			assert_equals( location.hash.replace(/^#/,''), 'baz', 'the browser navigated synchronously' );
 		}, '.go commands should be queued until the thread has ended');
 		history.go(-1);
-		setTimeout(checkjumps,100);
+		setTimeout(checkjumps,1000);
 	}
 	function checkjumps() {
 		test(function () {


### PR DESCRIPTION
Because line 39 setTimeout's time is very short, sometimes checkjumps function is run before history.go(-1). 
