### PR TITLE
some tests in websockets/constructor does not refer constants.js

### DIFF
--- a/websockets/constants.js
+++ b/websockets/constants.js
@@ -1,4 +1,4 @@
-//FIXME: 
+//FIXME:
 var DOMAIN_FOR_WS_TESTS = location.hostname;
 var DOMAIN_FOR_WSS_TESTS = location.hostname;
 

--- a/websockets/constructor/002.html
+++ b/websockets/constructor/002.html
@@ -5,14 +5,16 @@
 <script src=../constants.js></script>
 <div id=log></div>
 <script>
+var domain = SCHEME_DOMAIN_PORT.split('://')[1];
+
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("/test")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://foo bar.com/")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("wss://foo bar.com/")})});
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("http://"+location.hostname+"/")})});
+test(function() {assert_throws("SyntaxError", function(){new WebSocket("http://"+domain+"/")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("mailto:example@example.org")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("about:blank")})});
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/#")})});
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/#test")})});
+test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/#")})});
+test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/#test")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("?test")})});
 test(function() {assert_throws("SyntaxError", function(){new WebSocket("#test")})});
 </script>

--- a/websockets/constructor/004.html
+++ b/websockets/constructor/004.html
@@ -5,19 +5,21 @@
 <script src=../constants.js></script>
 <div id=log></div>
 <script>
+var domain = SCHEME_DOMAIN_PORT.split('://')[1];
+
 // empty string
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/", "")})});
+test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/", "")})});
 
 // chars below U+0020 except U+0000; U+0000 is tested in a separate test
 for (var i = 1; i < 0x20; ++i) {
 test(function() {
-  assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/", "a"+String.fromCharCode(i)+"b")}, 'char code '+i);
+  assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/", "a"+String.fromCharCode(i)+"b")}, 'char code '+i);
 })
 }
 // some chars above U+007E
 for (var i = 0x7F; i < 0x100; ++i) {
 test(function() {
-  assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/", "a"+String.fromCharCode(i)+"b")}, 'char code '+i);
+  assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/", "a"+String.fromCharCode(i)+"b")}, 'char code '+i);
 })
 }
 </script>

--- a/websockets/constructor/005.html
+++ b/websockets/constructor/005.html
@@ -5,7 +5,9 @@
 <script src=../constants.js></script>
 <div id=log></div>
 <script>
+var domain = SCHEME_DOMAIN_PORT.split('://')[1];
+
 test(function() {
-  assert_true(new WebSocket("ws://"+location.hostname+"/") instanceof WebSocket);
+  assert_true(new WebSocket("ws://"+domain+"/") instanceof WebSocket);
 });
 </script>

--- a/websockets/constructor/007.html
+++ b/websockets/constructor/007.html
@@ -5,5 +5,6 @@
 <script src=../constants.js></script>
 <div id=log></div>
 <script>
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+location.hostname+"/", 'a'+String.fromCharCode(0)+'b')})});
+var domain = SCHEME_DOMAIN_PORT.split('://')[1];
+test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://"+domain+"/", 'a'+String.fromCharCode(0)+'b')})});
 </script>

--- a/websockets/constructor/017.html
+++ b/websockets/constructor/017.html
@@ -6,8 +6,10 @@
 <div id=log></div>
 <script>
 var tests = ['ws:', 'ws:/', 'wss:', 'wss:/'];
+var domain = SCHEME_DOMAIN_PORT.split('://')[1];
+
 //Pass condition is to not throw
 for (var i = 0; i < tests.length; ++i) {
-  test(function(){new WebSocket(tests[i]+location.hostname+'/ws/echo')}, tests[i]);
+  test(function(){new WebSocket(tests[i]+domain+'/ws/echo')}, tests[i]);
 }
 </script>

--- a/websockets/constructor/021.html
+++ b/websockets/constructor/021.html
@@ -5,5 +5,9 @@
 <script src=../constants.js></script>
 <div id=log></div>
 <script>
-test(function() {assert_throws("SyntaxError", function(){new WebSocket("ws://certo2.oslo.osa/ws/protocol_array",["foobar, foobar"])})});
+test(function() {
+	assert_throws("SyntaxError", function(){
+		new WebSocket(SCHEME_DOMAIN_PORT+"/ws/protocol_array",["foobar", "foobar"])
+	})
+});
 </script>


### PR DESCRIPTION
TestTWF Tokyo Meetup : needs review

I found that several tests in websockets/constructor doesn't refer constants.js for new WebSocket(). (location.hostname or specific site)

For above, it is hard to check in local development while switch DOMAIN_FOR_WS_TESTS to "w3c-test.org" in constants.js.

So, I've fixed to refer constants.js completely for tests in constructor directory.
