### PR TITLE
XMLHttpRequest test fixes

### DIFF
--- a/XMLHttpRequest/abort-event-loadend.htm
+++ b/XMLHttpRequest/abort-event-loadend.htm
@@ -16,7 +16,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.onreadystatechange = function()
+            xhr.onloadstart = function()
             {
                 test.step(function()
                 {

--- a/XMLHttpRequest/getresponseheader-error-state.htm
+++ b/XMLHttpRequest/getresponseheader-error-state.htm
@@ -27,7 +27,7 @@
             }
           })
         }
-        var url = location.protocol + 'www1.' + location.hostname + (location.pathname.replace(/getresponseheader-error-state\.htm/, 'resources/nocors/folder.txt'))
+        var url = location.protocol + "//" + 'www1.' + location.hostname + (location.pathname.replace(/getresponseheader-error-state\.htm/, 'resources/nocors/folder.txt'))
         client.open("GET", url)
         client.send(null)
       })


### PR DESCRIPTION
- abort-event-loadend.htm: changed to call abort() in onloadstart rather than in onreadystatechange; otherwise the test ends up with throwing InvalidStateError in send().
- getresponseheader-error-state.htm: corrected the URL composition part; without "//", location.protocol ("http:") tends to be interpreted as [protoco] + [host] + [path] by user agent, which leads the result to 404 error instead of CORS failure.
