### PR TITLE
XMLHttpRequest test fixes 2

### DIFF
--- a/XMLHttpRequest/getresponseheader-special-characters.htm
+++ b/XMLHttpRequest/getresponseheader-special-characters.htm
@@ -17,7 +17,7 @@
             if(client.readyState == 4) {
               assert_equals(client.getResponseHeader("x-custom-header "), null)
               assert_equals(client.getResponseHeader(" x-custom-header"), null)
-              assert_equals(client.getResponseHeader("x-custom-header-bytes"), "\u2026")
+              assert_equals(client.getResponseHeader("x-custom-header-bytes"), "\xE2\x80\xA6")
               assert_equals(client.getResponseHeader("x¾"), null)
               assert_equals(client.getResponseHeader("x-custom-header\n"), null)
               assert_equals(client.getResponseHeader("\nx-custom-header"), null)

--- a/XMLHttpRequest/getresponseheader-special-characters.htm
+++ b/XMLHttpRequest/getresponseheader-special-characters.htm
@@ -17,7 +17,7 @@
             if(client.readyState == 4) {
               assert_equals(client.getResponseHeader("x-custom-header "), null)
               assert_equals(client.getResponseHeader(" x-custom-header"), null)
-              assert_equals(client.getResponseHeader("x-custom-header-bytes"), "\xE2\x80\xA6")
+              assert_equals(client.getResponseHeader("x-custom-header-bytes"), "\u2026")
               assert_equals(client.getResponseHeader("x¾"), null)
               assert_equals(client.getResponseHeader("x-custom-header\n"), null)
               assert_equals(client.getResponseHeader("\nx-custom-header"), null)

--- a/XMLHttpRequest/open-after-setrequestheader.htm
+++ b/XMLHttpRequest/open-after-setrequestheader.htm
@@ -21,10 +21,10 @@
             }
           })
         }
-        client.open("GET", "resources/inspect-headers.php?filter=bar")
+        client.open("GET", "resources/inspect-headers.php?filter_name=X-foo")
         assert_equals(client.readyState, 1)
         client.setRequestHeader('X-foo', 'bar')
-        client.open("GET", "resources/inspect-headers.php?filter=bar")
+        client.open("GET", "resources/inspect-headers.php?filter_name=X-foo")
         assert_equals(client.readyState, 1)
         client.send()
       })


### PR DESCRIPTION
- getresponseheader-special-characters.htm: horizontal ellipsis (…) can be specified by UTF-8 hex value string in PHP but in JavaScript UTF-8 charset might have to be specified \uXXXX format rather than \xXX which denotes Latin-1 charset. UAs actually interpret "\xE2\x80\xA6" as "â¦". getResponseHeader() in Firefox returns "â¦" instead of "\u2026". It may be decoding the unicode charset in the header field value with Latin-1 charset rule?
- open-after-setrequestheader.htm: corrected the query string of the request URL to make it work correctly with the inspect-headers.php which requires "filter_name" instead of "filter". 
