### PR TITLE
Use webidl2.js instead of WebIDLParser.js

### DIFF
--- a/dom/interfaces.html
+++ b/dom/interfaces.html
@@ -3,7 +3,7 @@
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/webidl2.js></script>
 <script src=/resources/idlharness.js></script>
 <script type=text/plain>
 exception DOMException {

--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -4,7 +4,7 @@
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/webidl2.js></script>
 <script src=/resources/idlharness.js></script>
 <!-- URL IDLs -->
 <script type=text/plain class=untested>


### PR DESCRIPTION
I'm pretty sure we don't want to use WebIDLParser.js anymore.  It's obsolete, right?  The files seem to work locally with this change (no exceptions thrown or anything), although I didn't test if it caused any changes in test failures.
