### PR TITLE
shadow-dom: Provide proper arguments to DOMImplementation.createDocument().

### DIFF
--- a/shadow-dom/elements-and-dom-objects/extensions-to-element-interface/methods/non-element-nodes-001.html
+++ b/shadow-dom/elements-and-dom-objects/extensions-to-element-interface/methods/non-element-nodes-001.html
@@ -24,6 +24,8 @@ policies and contribution forms [3].
 <body>
 <div id="log"></div>
 <script>
+var XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+
 function createTextNode() {
     var doc = document.implementation.createHTMLDocument('Test Document');
     var node = doc.createTextNode('Text Node');
@@ -39,42 +41,42 @@ function createCommentNode() {
 }
 
 function createCDATASectionNode() {
-    var doc = document.implementation.createDocument();
+    var doc = document.implementation.createDocument(XHTML_NAMESPACE, 'html');
     var node = doc.createCDATASection('CDATA Section Node');
     doc.documentElement.appendChild(node);
     return node;
 }
 
 function createAttributeNode() {
-    var doc = document.implementation.createDocument();
+    var doc = document.implementation.createDocument(XHTML_NAMESPACE, 'html');
     var node = doc.createAttribute('attribute-node');
     doc.documentElement.setAttributeNode(node);
     return node;
 }
 
 function createDocumentFragmentNode() {
-    var doc = document.implementation.createDocument();
+    var doc = document.implementation.createDocument(XHTML_NAMESPACE, 'html');
     var node = doc.createDocumentFragment();
     doc.documentElement.appendChild(node);
     return node;
 }
 
 function createEntityReferenceNode() {
-    var doc = document.implementation.createDocument();
+    var doc = document.implementation.createDocument(XHTML_NAMESPACE, 'html');
     var node = doc.createEntityReference('entity-reference-node');
     doc.documentElement.appendChild(node);
     return node;
 }
 
 function createProcessingInstructionNode() {
-    var doc = document.implementation.createDocument();
+    var doc = document.implementation.createDocument(XHTML_NAMESPACE, 'html');
     var node = doc.createProcessingInstruction('processing-instruction-node');
     doc.documentElement.appendChild(node);
     return node;
 }
 
 function createDocumentNode() {
-    return document.implementation.createDocument();
+    return document.implementation.createDocument(XHTML_NAMESPACE, 'html');
 }
 
 var factories = [

--- a/shadow-dom/testcommon.js
+++ b/shadow-dom/testcommon.js
@@ -127,7 +127,8 @@ function rethrowInternalErrors(e) {
 }
 
 function newDocument() {
-    var d = document.implementation.createDocument();
+    var d = document.implementation.createDocument(
+        'http://www.w3.org/1999/xhtml', 'html');
     //FIXME remove the call below when non-prefixed API is used
     addDocumentPrefixed(d);
     return d;        


### PR DESCRIPTION
Existing code did not give an argument to DOMImplementation.createDocument().
However, this is incorrect according to the definition of createDocument(),
which requires at least two arguments.

It seems that Chromium has recently tightened up a certain kind of invocations
to DOM APIs. Some tests started to fail on Chromium for this reason.
