### PR TITLE
Update window-properties.html to current WebIDL.

### DIFF
--- a/html/browsers/the-window-object/window-properties.html
+++ b/html/browsers/the-window-object/window-properties.html
@@ -253,6 +253,8 @@ test(function() {
       assert_equals(window[id], EventTargetProto[id]);
       assert_data_propdesc(Object.getOwnPropertyDescriptor(EventTargetProto, id),
                            true, true, true);
+      assert_data_propdesc(Object.getOwnPropertyDescriptor(window, id),
+                           true, true, true);
     }, "EventTarget method: " + id);
   });
 }, "EventTarget interface");
@@ -262,9 +264,8 @@ test(function() {
     test(function() {
       var WindowProto = Window.prototype;
       assert_true(id in window, id + " in window");
-      assert_true(id in WindowProto, id + " in Window.prototype");
-      assert_equals(window[id], WindowProto[id]);
-      assert_data_propdesc(Object.getOwnPropertyDescriptor(WindowProto, id),
+      assert_false(id in WindowProto, id + " in Window.prototype");
+      assert_data_propdesc(Object.getOwnPropertyDescriptor(window, id),
                            true, true, true);
     }, "Window method: " + id);
   });
@@ -272,8 +273,8 @@ test(function() {
     test(function() {
       var WindowProto = Window.prototype;
       assert_true(id in window, id + " in window");
-      assert_true(id in WindowProto, id + " in Window.prototype");
-      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(WindowProto, id),
+      assert_false(id in WindowProto, id + " in Window.prototype");
+      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(window, id),
                                false, true, true);
     }, "Window readonly attribute: " + id);
   });
@@ -281,8 +282,8 @@ test(function() {
     test(function() {
       var WindowProto = Window.prototype;
       assert_true(id in window, id + " in window");
-      assert_true(id in WindowProto, id + " in Window.prototype");
-      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(WindowProto, id),
+      assert_false(id in WindowProto, id + " in Window.prototype");
+      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(window, id),
                                true, true, true);
     }, "Window attribute: " + id);
   });
@@ -290,18 +291,18 @@ test(function() {
     test(function() {
       var WindowProto = Window.prototype;
       assert_true(id in window, id + " in window");
+      assert_false(id in WindowProto, id + " in Window.prototype");
       // location has a [PutForwards] extended attribute.
       assert_accessor_propdesc(Object.getOwnPropertyDescriptor(window, id),
                                id === "location", true, false);
-      assert_false(id in WindowProto, id + " in Window.prototype");
     }, "Window unforgeable attribute: " + id);
   });
   replacableAttributes.forEach(function(id) {
     test(function() {
       var WindowProto = Window.prototype;
       assert_true(id in window, id + " in window");
-      assert_true(id in WindowProto, id + " in Window.prototype");
-      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(WindowProto, id),
+      assert_false(id in WindowProto, id + " in Window.prototype");
+      assert_accessor_propdesc(Object.getOwnPropertyDescriptor(window, id),
                                true, true, true);
     }, "Window replaceable attribute: " + id);
   });


### PR DESCRIPTION
In particular, WebIDL now defines that members of the global object end up on the object itself; see http://dev.w3.org/2006/webapi/WebIDL/#es-attributes (second bullet, second and third sub-bullets).
