### PR TITLE
Use an explicit 'subtest' query parameter to select the subtest, instead...

### DIFF
--- a/dom/ranges/Range-cloneContents.html
+++ b/dom/ranges/Range-cloneContents.html
@@ -2,9 +2,9 @@
 <title>Range.cloneContents() tests</title>
 <link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
 <meta name=timeout content=long>
-<p>To debug test failures, look at the URL of the hidden iframes corresponding
-to the test at the end of the document, load those individually, and use your
-browser's debugging tools.
+<p>To debug test failures, add a query parameter "subtest" with the test id (like
+"?subtest=5").  Only that test will be run.  Then you can look at the resulting
+iframe in the DOM.
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -13,6 +13,14 @@ browser's debugging tools.
 "use strict";
 
 testDiv.parentNode.removeChild(testDiv);
+
+var actualIframe = document.createElement("iframe");
+actualIframe.style.display = "none";
+document.body.appendChild(actualIframe);
+
+var expectedIframe = document.createElement("iframe");
+expectedIframe.style.display = "none";
+document.body.appendChild(expectedIframe);
 
 function myCloneContents(range) {
 	// "Let frag be a new DocumentFragment whose ownerDocument is the same as
@@ -222,35 +230,48 @@ function myCloneContents(range) {
 	return frag;
 }
 
+function restoreIframe(iframe, i) {
+	// Most of this function is designed to work around the fact that Opera
+	// doesn't let you add a doctype to a document that no longer has one, in
+	// any way I can figure out.  I eventually compromised on something that
+	// will still let Opera pass most tests that don't actually involve
+	// doctypes.
+	while (iframe.contentDocument.firstChild
+	&& iframe.contentDocument.firstChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.firstChild);
+	}
+
+	while (iframe.contentDocument.lastChild
+	&& iframe.contentDocument.lastChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.lastChild);
+	}
+
+	if (!iframe.contentDocument.firstChild) {
+		// This will throw an exception in Opera if we reach here, which is why
+		// I try to avoid it.  It will never happen in a browser that obeys the
+		// spec, so it's really just insurance.  I don't think it actually gets
+		// hit by anything.
+		iframe.contentDocument.appendChild(iframe.contentDocument.implementation.createDocumentType("html", "", ""));
+	}
+	iframe.contentDocument.appendChild(referenceDoc.documentElement.cloneNode(true));
+	iframe.contentWindow.setupRangeTests();
+	iframe.contentWindow.testRangeInput = testRanges[i];
+	iframe.contentWindow.run();
+}
+
 function testCloneContents(i) {
-	// We only load the expected once the actual is finished, to avoid race
-	// conditions.  First set the onload to null and the src to the empty
-	// string, so that when we set the src for real we're not just changing the
-	// hash -- otherwise the load event won't fire.  We never do anything after
-	// a src set except in an onload handler, to avoid race conditions.
-	var actual = actualIframes[i];
-	actual.id = i + "-actual";
-	actual.onload = function() { onLoadActual(i); };
-	actual.src = "Range-test-iframe.html#" + testRanges[i];
-}
+	restoreIframe(actualIframe, i);
+	restoreIframe(expectedIframe, i);
 
-function onLoadActual(i) {
-	var expected = expectedIframes[i];
-	expected.id = i + "-expected";
-	expected.onload = function() { onLoadExpected(i); };
-	expected.src = "Range-test-iframe.html#" + testRanges[i];
-}
-
-function onLoadExpected(i) {
-	var actualRange = actualIframes[i].contentWindow.testRange;
-	var expectedRange = expectedIframes[i].contentWindow.testRange;
+	var actualRange = actualIframe.contentWindow.testRange;
+	var expectedRange = expectedIframe.contentWindow.testRange;
 	var actualFrag, expectedFrag;
 	var actualRoots, expectedRoots;
 
 	domTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual cloneContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated cloneContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -325,9 +346,9 @@ function onLoadExpected(i) {
 	domTests[i].done();
 
 	positionTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual cloneContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated cloneContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -372,9 +393,9 @@ function onLoadExpected(i) {
 	positionTests[i].done();
 
 	fragTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual cloneContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated cloneContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -398,24 +419,36 @@ test(function() {
 	assert_array_equals(range.cloneContents().childNodes, []);
 }, "Range.detach()");
 
+var iStart = 0;
+var iStop = testRanges.length;
+
+if (/subtest=[0-9]+/.test(location.search)) {
+	var matches = /subtest=([0-9]+)/.exec(location.search);
+	iStart = Number(matches[1]);
+	iStop = Number(matches[1]) + 1;
+}
+
 var domTests = [];
 var positionTests = [];
 var fragTests = [];
-var actualIframes = [];
-var expectedIframes = [];
-for (var i = 0; i < testRanges.length; i++) {
-	domTests.push(async_test("Resulting DOM for range " + i + " " + testRanges[i]));
-	positionTests.push(async_test("Resulting cursor position for range " + i + " " + testRanges[i]));
-	fragTests.push(async_test("Returned fragment for range " + i + " " + testRanges[i]));
 
-	actualIframes.push(document.createElement("iframe"));
-	actualIframes[i].style.display = "none";
-	document.body.appendChild(actualIframes[i]);
-
-	expectedIframes.push(document.createElement("iframe"));
-	expectedIframes[i].style.display = "none";
-	document.body.appendChild(expectedIframes[i]);
-
-	testCloneContents(i);
+for (var i = iStart; i < iStop; i++) {
+	domTests[i] = async_test("Resulting DOM for range " + i + " " + testRanges[i]);
+	positionTests[i] = async_test("Resulting cursor position for range " + i + " " + testRanges[i]);
+	fragTests[i] = async_test("Returned fragment for range " + i + " " + testRanges[i]);
 }
+
+var referenceDoc = document.implementation.createHTMLDocument("");
+referenceDoc.removeChild(referenceDoc.documentElement);
+
+actualIframe.onload = function() {
+	expectedIframe.onload = function() {
+		for (var i = iStart; i < iStop; i++) {
+			testCloneContents(i);
+		}
+	}
+	expectedIframe.src = "Range-test-iframe.html";
+	referenceDoc.appendChild(actualIframe.contentDocument.documentElement.cloneNode(true));
+}
+actualIframe.src = "Range-test-iframe.html";
 </script>

--- a/dom/ranges/Range-deleteContents.html
+++ b/dom/ranges/Range-deleteContents.html
@@ -2,9 +2,9 @@
 <title>Range.deleteContents() tests</title>
 <link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
 <meta name=timeout content=long>
-<p>To debug test failures, look at the URL of the hidden iframes corresponding
-to the test at the end of the document, load those individually, and use your
-browser's debugging tools.
+<p>To debug test failures, add a query parameter "subtest" with the test id (like
+"?subtest=5").  Only that test will be run.  Then you can look at the resulting
+iframe in the DOM.
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -13,6 +13,43 @@ browser's debugging tools.
 "use strict";
 
 testDiv.parentNode.removeChild(testDiv);
+
+var actualIframe = document.createElement("iframe");
+actualIframe.style.display = "none";
+document.body.appendChild(actualIframe);
+
+var expectedIframe = document.createElement("iframe");
+expectedIframe.style.display = "none";
+document.body.appendChild(expectedIframe);
+
+function restoreIframe(iframe, i) {
+	// Most of this function is designed to work around the fact that Opera
+	// doesn't let you add a doctype to a document that no longer has one, in
+	// any way I can figure out.  I eventually compromised on something that
+	// will still let Opera pass most tests that don't actually involve
+	// doctypes.
+	while (iframe.contentDocument.firstChild
+	&& iframe.contentDocument.firstChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.firstChild);
+	}
+
+	while (iframe.contentDocument.lastChild
+	&& iframe.contentDocument.lastChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.lastChild);
+	}
+
+	if (!iframe.contentDocument.firstChild) {
+		// This will throw an exception in Opera if we reach here, which is why
+		// I try to avoid it.  It will never happen in a browser that obeys the
+		// spec, so it's really just insurance.  I don't think it actually gets
+		// hit by anything.
+		iframe.contentDocument.appendChild(iframe.contentDocument.implementation.createDocumentType("html", "", ""));
+	}
+	iframe.contentDocument.appendChild(referenceDoc.documentElement.cloneNode(true));
+	iframe.contentWindow.setupRangeTests();
+	iframe.contentWindow.testRangeInput = testRanges[i];
+	iframe.contentWindow.run();
+}
 
 function myDeleteContents(range) {
 	// "If the context object's start and end are the same, abort this method."
@@ -110,33 +147,17 @@ function myDeleteContents(range) {
 }
 
 function testDeleteContents(i) {
-	// We only load the expected once the actual is finished, to avoid race
-	// conditions.  First set the onload to null and the src to the empty
-	// string, so that when we set the src for real we're not just changing the
-	// hash -- otherwise the load event won't fire.  We never do anything after
-	// a src set except in an onload handler, to avoid race conditions.
-	var actual = actualIframes[i];
-	actual.id = i + "-actual";
-	actual.onload = function() { onLoadActual(i); };
-	actual.src = "Range-test-iframe.html#" + testRanges[i];
-}
+	restoreIframe(actualIframe, i);
+	restoreIframe(expectedIframe, i);
 
-function onLoadActual(i) {
-	var expected = expectedIframes[i];
-	expected.id = i + "-expected";
-	expected.onload = function() { onLoadExpected(i); };
-	expected.src = "Range-test-iframe.html#" + testRanges[i];
-}
-
-function onLoadExpected(i) {
-	var actualRange = actualIframes[i].contentWindow.testRange;
-	var expectedRange = expectedIframes[i].contentWindow.testRange;
+	var actualRange = actualIframe.contentWindow.testRange;
+	var expectedRange = expectedIframe.contentWindow.testRange;
 	var actualRoots, expectedRoots;
 
 	domTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual deleteContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated deleteContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -221,9 +242,9 @@ function onLoadExpected(i) {
 	domTests[i].done();
 
 	positionTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual deleteContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated deleteContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -277,22 +298,34 @@ test(function() {
 	range.deleteContents();
 }, "Detached Range");
 
+var iStart = 0;
+var iStop = testRanges.length;
+
+if (/subtest=[0-9]+/.test(location.search)) {
+	var matches = /subtest=([0-9]+)/.exec(location.search);
+	iStart = Number(matches[1]);
+	iStop = Number(matches[1]) + 1;
+}
+
 var domTests = [];
 var positionTests = [];
-var actualIframes = [];
-var expectedIframes = [];
-for (var i = 0; i < testRanges.length; i++) {
-	domTests.push(async_test("Resulting DOM for range " + i + " " + testRanges[i]));
-	positionTests.push(async_test("Resulting cursor position for range " + i + " " + testRanges[i]));
 
-	actualIframes.push(document.createElement("iframe"));
-	actualIframes[i].style.display = "none";
-	document.body.appendChild(actualIframes[i]);
-
-	expectedIframes.push(document.createElement("iframe"));
-	expectedIframes[i].style.display = "none";
-	document.body.appendChild(expectedIframes[i]);
-
-	testDeleteContents(i);
+for (var i = iStart; i < iStop; i++) {
+	domTests[i] = async_test("Resulting DOM for range " + i + " " + testRanges[i]);
+	positionTests[i] = async_test("Resulting cursor position for range " + i + " " + testRanges[i]);
 }
+
+var referenceDoc = document.implementation.createHTMLDocument("");
+referenceDoc.removeChild(referenceDoc.documentElement);
+
+actualIframe.onload = function() {
+	expectedIframe.onload = function() {
+		for (var i = iStart; i < iStop; i++) {
+			testDeleteContents(i);
+		}
+	}
+	expectedIframe.src = "Range-test-iframe.html";
+	referenceDoc.appendChild(actualIframe.contentDocument.documentElement.cloneNode(true));
+}
+actualIframe.src = "Range-test-iframe.html";
 </script>

--- a/dom/ranges/Range-extractContents.html
+++ b/dom/ranges/Range-extractContents.html
@@ -2,9 +2,9 @@
 <title>Range.extractContents() tests</title>
 <link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
 <meta name=timeout content=long>
-<p>To debug test failures, look at the URL of the hidden iframes corresponding
-to the test at the end of the document, load those individually, and use your
-browser's debugging tools.
+<p>To debug test failures, add a query parameter "subtest" with the test id (like
+"?subtest=5").  Only that test will be run.  Then you can look at the resulting
+iframe in the DOM.
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -14,35 +14,56 @@ browser's debugging tools.
 
 testDiv.parentNode.removeChild(testDiv);
 
+var actualIframe = document.createElement("iframe");
+actualIframe.style.display = "none";
+document.body.appendChild(actualIframe);
+
+var expectedIframe = document.createElement("iframe");
+expectedIframe.style.display = "none";
+document.body.appendChild(expectedIframe);
+
+function restoreIframe(iframe, i) {
+	// Most of this function is designed to work around the fact that Opera
+	// doesn't let you add a doctype to a document that no longer has one, in
+	// any way I can figure out.  I eventually compromised on something that
+	// will still let Opera pass most tests that don't actually involve
+	// doctypes.
+	while (iframe.contentDocument.firstChild
+	&& iframe.contentDocument.firstChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.firstChild);
+	}
+
+	while (iframe.contentDocument.lastChild
+	&& iframe.contentDocument.lastChild.nodeType != Node.DOCUMENT_TYPE_NODE) {
+		iframe.contentDocument.removeChild(iframe.contentDocument.lastChild);
+	}
+
+	if (!iframe.contentDocument.firstChild) {
+		// This will throw an exception in Opera if we reach here, which is why
+		// I try to avoid it.  It will never happen in a browser that obeys the
+		// spec, so it's really just insurance.  I don't think it actually gets
+		// hit by anything.
+		iframe.contentDocument.appendChild(iframe.contentDocument.implementation.createDocumentType("html", "", ""));
+	}
+	iframe.contentDocument.appendChild(referenceDoc.documentElement.cloneNode(true));
+	iframe.contentWindow.setupRangeTests();
+	iframe.contentWindow.testRangeInput = testRanges[i];
+	iframe.contentWindow.run();
+}
+
 function testExtractContents(i) {
-	// We only load the expected once the actual is finished, to avoid race
-	// conditions.  First set the onload to null and the src to the empty
-	// string, so that when we set the src for real we're not just changing the
-	// hash -- otherwise the load event won't fire.  We never do anything after
-	// a src set except in an onload handler, to avoid race conditions.
-	var actual = actualIframes[i];
-	actual.id = i + "-actual";
-	actual.onload = function() { onLoadActual(i); };
-	actual.src = "Range-test-iframe.html#" + testRanges[i];
-}
+	restoreIframe(actualIframe, i);
+	restoreIframe(expectedIframe, i);
 
-function onLoadActual(i) {
-	var expected = expectedIframes[i];
-	expected.id = i + "-expected";
-	expected.onload = function() { onLoadExpected(i); };
-	expected.src = "Range-test-iframe.html#" + testRanges[i];
-}
-
-function onLoadExpected(i) {
-	var actualRange = actualIframes[i].contentWindow.testRange;
-	var expectedRange = expectedIframes[i].contentWindow.testRange;
+	var actualRange = actualIframe.contentWindow.testRange;
+	var expectedRange = expectedIframe.contentWindow.testRange;
 	var actualFrag, expectedFrag;
 	var actualRoots, expectedRoots;
 
 	domTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual extractContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated extractContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -111,9 +132,9 @@ function onLoadExpected(i) {
 	domTests[i].done();
 
 	positionTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual extractContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated extractContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -166,9 +187,9 @@ function onLoadExpected(i) {
 	positionTests[i].done();
 
 	fragTests[i].step(function() {
-		assert_equals(actualIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(actualIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for actual extractContents()");
-		assert_equals(expectedIframes[i].contentWindow.unexpectedException, null,
+		assert_equals(expectedIframe.contentWindow.unexpectedException, null,
 			"Unexpected exception thrown when setting up Range for simulated extractContents()");
 		assert_equals(typeof actualRange, "object",
 			"typeof Range produced in actual iframe");
@@ -192,24 +213,36 @@ test(function() {
 	assert_array_equals(range.extractContents().childNodes, []);
 }, "Detached Range");
 
+var iStart = 0;
+var iStop = testRanges.length;
+
+if (/subtest=[0-9]+/.test(location.search)) {
+	var matches = /subtest=([0-9]+)/.exec(location.search);
+	iStart = Number(matches[1]);
+	iStop = Number(matches[1]) + 1;
+}
+
 var domTests = [];
 var positionTests = [];
 var fragTests = [];
-var actualIframes = [];
-var expectedIframes = [];
-for (var i = 0; i < testRanges.length; i++) {
-	domTests.push(async_test("Resulting DOM for range " + i + " " + testRanges[i]));
-	positionTests.push(async_test("Resulting cursor position for range " + i + " " + testRanges[i]));
-	fragTests.push(async_test("Returned fragment for range " + i + " " + testRanges[i]));
 
-	actualIframes.push(document.createElement("iframe"));
-	actualIframes[i].style.display = "none";
-	document.body.appendChild(actualIframes[i]);
-
-	expectedIframes.push(document.createElement("iframe"));
-	expectedIframes[i].style.display = "none";
-	document.body.appendChild(expectedIframes[i]);
-
-	testExtractContents(i);
+for (var i = iStart; i < iStop; i++) {
+	domTests[i] = async_test("Resulting DOM for range " + i + " " + testRanges[i]);
+	positionTests[i] = async_test("Resulting cursor position for range " + i + " " + testRanges[i]);
+	fragTests[i] = async_test("Returned fragment for range " + i + " " + testRanges[i]);
 }
+
+var referenceDoc = document.implementation.createHTMLDocument("");
+referenceDoc.removeChild(referenceDoc.documentElement);
+
+actualIframe.onload = function() {
+	expectedIframe.onload = function() {
+		for (var i = iStart; i < iStop; i++) {
+			testExtractContents(i);
+		}
+	}
+	expectedIframe.src = "Range-test-iframe.html";
+	referenceDoc.appendChild(actualIframe.contentDocument.documentElement.cloneNode(true));
+}
+actualIframe.src = "Range-test-iframe.html";
 </script>

--- a/dom/ranges/Range-insertNode.html
+++ b/dom/ranges/Range-insertNode.html
@@ -2,8 +2,8 @@
 <title>Range.insertNode() tests</title>
 <link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
 <meta name=timeout content=long>
-<p>To debug test failures, add a query parameter with the test id (like
-"?5,16").  Only that test will be run.  Then you can look at the resulting
+<p>To debug test failures, add a query parameter "subtest" with the test id (like
+"?subtest=5,16").  Only that test will be run.  Then you can look at the resulting
 iframes in the DOM.
 <div id=log></div>
 <script src=/resources/testharness.js></script>
@@ -241,8 +241,8 @@ var iStop = testRangesShort.length;
 var jStart = 0;
 var jStop = testNodesShort.length;
 
-if (/[0-9]+,[0-9]+/.test(location.search)) {
-	var matches = /([0-9]+),([0-9]+)/.exec(location.search);
+if (/subtest=[0-9]+,[0-9]+/.test(location.search)) {
+	var matches = /subtest=([0-9]+),([0-9]+)/.exec(location.search);
 	iStart = Number(matches[1]);
 	iStop = Number(matches[1]) + 1;
 	jStart = Number(matches[2]) + 0;

--- a/dom/ranges/Range-surroundContents.html
+++ b/dom/ranges/Range-surroundContents.html
@@ -3,9 +3,8 @@
 <title>Range.surroundContents() tests</title>
 <link rel="author" title="Aryeh Gregor" href=ayg@aryeh.name>
 <meta name=timeout content=long>
-
-<p>To debug test failures, add a query parameter with the test id (like
-"?5,16").  Only that test will be run.  Then you can look at the resulting
+<p>To debug test failures, add a query parameter "subtest" with the test id (like
+"?subtest=5,16").  Only that test will be run.  Then you can look at the resulting
 iframes in the DOM.
 <div id=log></div>
 <script src=/resources/testharness.js></script>
@@ -308,8 +307,8 @@ var iStop = testRangesShort.length;
 var jStart = 0;
 var jStop = testNodesShort.length;
 
-if (/[0-9]+,[0-9]+/.test(location.search)) {
-	var matches = /([0-9]+),([0-9]+)/.exec(location.search);
+if (/subtest=[0-9]+,[0-9]+/.test(location.search)) {
+	var matches = /subtest=([0-9]+),([0-9]+)/.exec(location.search);
 	iStart = Number(matches[1]);
 	iStop = Number(matches[1]) + 1;
 	jStart = Number(matches[2]) + 0;


### PR DESCRIPTION
... of just a naked number. Mozilla sometimes appends query parameters to its tests for its own reasons and those parameters should not accidentally trigger selection of a subtest. Also, don't use one or two iframes per subtest; it saves a lot of memory and time to use one or two iframes per test and have the subtests reuse those frames.
