### PR TITLE
Test that 'directory' and 'mod' elements get the HTMLUnknownElement interface.

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -3009,6 +3009,8 @@ setup(function() {
 			'document.createElement("rb")',
 			'document.createElement("spacer")',
 			'document.createElement("basefont")',
+			'document.createElement("directory")',
+			'document.createElement("mod")',
 		],
 		HTMLHtmlElement: ['document.createElement("html")'],
 		HTMLHeadElement: ['document.createElement("head")'],


### PR DESCRIPTION
These were broken in Servo.
