### PR TITLE
Switch back to using firefox as the default test browser in the webdrive...

### DIFF
--- a/webdriver/webdriver.cfg
+++ b/webdriver/webdriver.cfg
@@ -1,2 +1,2 @@
 [Default]
-browser: Chrome
+browser: Firefox


### PR DESCRIPTION
Restore Firefox as the default browser for tests run in the webdriver suite.
