### PR TITLE
Test expects response when browser sees 401 from webserver, per section 5.2

### DIFF
--- a/webdriver/navigation/auth_tests.py
+++ b/webdriver/navigation/auth_tests.py
@@ -12,19 +12,19 @@ from selenium import webdriver
 
 class WebDriverAuthTest(unittest.TestCase):
 
-	# Response functions to test different Authentication Responses
-	
-
+	# Set up class to start HTTP Server that responds to 
+	# test URLs with various 401 responses
 	@classmethod
 	def setUpClass(cls):
 		config = ConfigParser.ConfigParser()
 		config.read('webdriver.cfg')
 		cls.driver_class = getattr(webdriver, config.get("Default", 'browser'))
 		cls.driver = cls.driver_class()
+
 		def basic_response_func( request, *args ):
 				print "basic_response_func!!!"
 				return (401, {"WWW-Authenticate" : "Basic"}, None)
-		
+
 		basic_auth_handler = { 'method': 'GET',
 							'path' : '/navigation/auth_required_basic',
 							'function' : basic_response_func }
@@ -35,23 +35,20 @@ class WebDriverAuthTest(unittest.TestCase):
 
 	@classmethod
 	def tearDownClass(cls):
-	    cls.driver.quit()
-	    cls.webserver.stop()
+		cls.driver.quit()
+		cls.webserver.stop()
 
+	# Test that when 401 is seen by browser, a WebDriver response is still sent
 	def test_response_401_auth_basic(self):
-
 		page = self.webserver.where_is('navigation/auth_required_basic')
-		print( "page url = " + page )
-
-#
 		resp = self.driver.execute( "get", params={"url" : page})
-
 		print("resp = " + str(resp))
 		url = self.driver.current_url
 		print("URL = " + url)
+		self.assertTrue(True)
 
-	#	self.driver.execute( { })
-#		self.assertTrue(False)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webdriver/navigation/auth_tests.py
+++ b/webdriver/navigation/auth_tests.py
@@ -1,0 +1,57 @@
+# -*- mode: python; fill-column: 100; comment-column: 100; -*-
+
+import os
+import sys
+import unittest
+import ConfigParser
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+
+from webserver import Httpd
+from selenium import webdriver
+
+class WebDriverAuthTest(unittest.TestCase):
+
+	# Response functions to test different Authentication Responses
+	
+
+	@classmethod
+	def setUpClass(cls):
+		config = ConfigParser.ConfigParser()
+		config.read('webdriver.cfg')
+		cls.driver_class = getattr(webdriver, config.get("Default", 'browser'))
+		cls.driver = cls.driver_class()
+		def basic_response_func( request, *args ):
+				print "basic_response_func!!!"
+				return (401, {"WWW-Authenticate" : "Basic"}, None)
+		
+		basic_auth_handler = { 'method': 'GET',
+							'path' : '/navigation/auth_required_basic',
+							'function' : basic_response_func }
+		urlhandlers = [ basic_auth_handler ]
+
+		cls.webserver = Httpd( urlhandlers=urlhandlers )
+		cls.webserver.start()
+
+	@classmethod
+	def tearDownClass(cls):
+	    cls.driver.quit()
+	    cls.webserver.stop()
+
+	def test_response_401_auth_basic(self):
+
+		page = self.webserver.where_is('navigation/auth_required_basic')
+		print( "page url = " + page )
+
+#
+		resp = self.driver.execute( "get", params={"url" : page})
+
+		print("resp = " + str(resp))
+		url = self.driver.current_url
+		print("URL = " + url)
+
+	#	self.driver.execute( { })
+#		self.assertTrue(False)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webdriver/navigation/auth_tests.py
+++ b/webdriver/navigation/auth_tests.py
@@ -13,43 +13,43 @@ from selenium.common.exceptions import TimeoutException
 
 class WebDriverAuthTest(unittest.TestCase):
 
-	# Set up class to start HTTP Server that responds to 
-	# test URLs with various 401 responses
-	@classmethod
-	def setUpClass(cls):
-		config = ConfigParser.ConfigParser()
-		config.read('webdriver.cfg')
-		cls.driver_class = getattr(webdriver, config.get("Default", 'browser'))
-		cls.driver = cls.driver_class()
+    # Set up class to start HTTP Server that responds to 
+    # test URLs with various 401 responses
+    @classmethod
+    def setUpClass(cls):
+        config = ConfigParser.ConfigParser()
+        config.read('webdriver.cfg')
+        cls.driver_class = getattr(webdriver, config.get("Default", 'browser'))
+        cls.driver = cls.driver_class()
 
-		def basic_response_func( request, *args ):
-				return (401, {"WWW-Authenticate" : "Basic"}, None)
+        def basic_response_func( request, *args ):
+            return (401, {"WWW-Authenticate" : "Basic"}, None)
 
-		basic_auth_handler = { 'method': 'GET',
-							'path' : '/navigation/auth_required_basic',
-							'function' : basic_response_func }
-		urlhandlers = [ basic_auth_handler ]
+        basic_auth_handler = { 'method': 'GET',
+                               'path' : '/navigation/auth_required_basic',
+                               'function' : basic_response_func }
+        urlhandlers = [ basic_auth_handler ]
 
-		cls.webserver = Httpd( urlhandlers=urlhandlers )
-		cls.webserver.start()
+        cls.webserver = Httpd( urlhandlers=urlhandlers )
+        cls.webserver.start()
 
-	@classmethod
-	def tearDownClass(cls):
-		cls.driver.quit()
-		cls.webserver.stop()
+    @classmethod
+    def tearDownClass(cls):
+        cls.driver.quit()
+        cls.webserver.stop()
 
-	# Test that when 401 is seen by browser, a WebDriver response is still sent
-	def test_response_401_auth_basic(self):
-		page = self.webserver.where_is('navigation/auth_required_basic')
-		self.driver.set_page_load_timeout(5)
-		try:		
-			self.driver.get( page )
-			# if we got a responses instead of timeout, that's success
-			self.assertTrue(True)
-		except TimeoutException:
-			self.fail("Did not get response from browser.")
-		except:
-			self.fail("Unexpected failure. Please investigate.")
+    # Test that when 401 is seen by browser, a WebDriver response is still sent
+    def test_response_401_auth_basic(self):
+        page = self.webserver.where_is('navigation/auth_required_basic')
+        self.driver.set_page_load_timeout(5)
+        try:
+            self.driver.get( page )
+            # if we got a responses instead of timeout, that's success
+            self.assertTrue(True)
+        except TimeoutException:
+            self.fail("Did not get response from browser.")
+        except:
+            self.fail("Unexpected failure. Please investigate.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/webdriver/navigation/auth_tests.py
+++ b/webdriver/navigation/auth_tests.py
@@ -9,6 +9,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.
 
 from webserver import Httpd
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 
 class WebDriverAuthTest(unittest.TestCase):
 
@@ -22,7 +23,6 @@ class WebDriverAuthTest(unittest.TestCase):
 		cls.driver = cls.driver_class()
 
 		def basic_response_func( request, *args ):
-				print "basic_response_func!!!"
 				return (401, {"WWW-Authenticate" : "Basic"}, None)
 
 		basic_auth_handler = { 'method': 'GET',
@@ -41,14 +41,15 @@ class WebDriverAuthTest(unittest.TestCase):
 	# Test that when 401 is seen by browser, a WebDriver response is still sent
 	def test_response_401_auth_basic(self):
 		page = self.webserver.where_is('navigation/auth_required_basic')
-		resp = self.driver.execute( "get", params={"url" : page})
-		print("resp = " + str(resp))
-		url = self.driver.current_url
-		print("URL = " + url)
-		self.assertTrue(True)
-
-
-
+		self.driver.set_page_load_timeout(5)
+		try:		
+			self.driver.get( page )
+			# if we got a responses instead of timeout, that's success
+			self.assertTrue(True)
+		except TimeoutException:
+			self.fail("Did not get response from browser.")
+		except:
+			self.fail("Unexpected failure. Please investigate.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fails on Firefox, as expected. 
Uses Selenium set_page_load_timeout() as simple way to catch error case, since WebDriver server (aka browser) MUST respond
