### PR TITLE
Add test for setting textContent of LI element

### DIFF
--- a/dom/nodes/Node-textContent.html
+++ b/dom/nodes/Node-textContent.html
@@ -144,6 +144,14 @@ arguments.forEach(function(aValue) {
   }, "Element without children set to " + format_value(argument))
 
   test(function() {
+    var li = document.createElement("li")
+    li.textContent = argument
+    document.body.appendChild(li)
+    check(li)
+    document.body.removeChild(li)
+  }, "HTMLLIElement appended to body with child set to " + format_value(argument))
+
+  test(function() {
     var el = document.createElement("div")
     var text = el.appendChild(document.createTextNode(""))
     el.textContent = argument


### PR DESCRIPTION
Adds a test case for setting and reading back the textContent of a LI element that is attached to the dom.

The dom attachment is significant as some browsers attempt to apply styles to the content when reading back the value. I recently reported this as a regression in IE 11 on Connect.
http://connect.microsoft.com/IE/feedback/details/805580/incorrect-textcontent-for-li-elements
