### PR TITLE
Replace assert_null and assert_not_null with assert_equals and assert_not_equals.

### DIFF
--- a/html-templates/additions-to-the-steps-to-clone-a-node/template-clone-children.html
+++ b/html-templates/additions-to-the-steps-to-clone-a-node/template-clone-children.html
@@ -24,14 +24,14 @@ test(function () {
     var template = doc.querySelector('#tmpl1');
     var copy = template.cloneNode(true);
 
-    assert_not_undefined(copy.content, 'Template clone content attribute should not be undefined');
-    assert_not_null(copy.content, 'Template clone content attribute should not be null');
+    assert_not_equals(copy.content, undefined, 'Template clone content attribute should not be undefined');
+    assert_not_equals(copy.content, null, 'Template clone content attribute should not be null');
 
     assert_equals(copy.content.childNodes.length, 2,
             'Wrong number of template content\'s copy child nodes');
-    assert_not_null(copy.content.querySelector('#div1'),
+    assert_not_equals(copy.content.querySelector('#div1'), null,
             'Template child node should be copied');
-    assert_not_null(copy.content.querySelector('#div2'),
+    assert_not_equals(copy.content.querySelector('#div2'), null,
             'Template child node should be copied');
 
 }, 'Clone template node. Test call to cloneNode(true)');
@@ -48,18 +48,14 @@ test(function () {
     var template = doc.querySelector('#tmpl1');
     var copy = template.cloneNode();
 
-    assert_not_undefined(copy.content, 'Template clone content attribute should not be undefined');
-    assert_not_null(copy.content, 'Template clone content attribute should not be null');
+    assert_not_equals(copy.content, undefined, 'Template clone content attribute should not be undefined');
+    assert_not_equals(copy.content, null, 'Template clone content attribute should not be null');
 
-    assert_equals(copy.content.childNodes.length, 2,
+    assert_equals(copy.content.childNodes.length, 0,
             'Wrong number of template content\'s copy child nodes');
-    assert_not_null(copy.content.querySelector('#div1'),
-            'Template child node should be copied');
-    assert_not_null(copy.content.querySelector('#div2'),
-            'Template child node should be copied');
 
 }, 'Clone template node. Test call to cloneNode() with the default parameter '
-    + '(true by default)');
+    + '(false by default)');
 
 
 
@@ -73,8 +69,8 @@ test(function () {
     var template = doc.querySelector('#tmpl1');
     var copy = template.cloneNode(false);
 
-    assert_not_undefined(copy.content, 'Template clone content attribute is undefined');
-    assert_not_null(copy.content, 'Template clone content attribute is null');
+    assert_not_equals(copy.content, undefined, 'Template clone content attribute is undefined');
+    assert_not_equals(copy.content, null, 'Template clone content attribute is null');
 
     assert_equals(copy.content.childNodes.length, 0,
             'Wrong number of template content\'s copy child nodes');

--- a/html-templates/additions-to-the-steps-to-clone-a-node/templates-copy-document-owner.html
+++ b/html-templates/additions-to-the-steps-to-clone-a-node/templates-copy-document-owner.html
@@ -79,12 +79,12 @@ test(function () {
     var template = doc.querySelector('#tmpl1');
     var copy = template.cloneNode();
 
-    assert_equals(copy.content.childNodes.length, 2,
+    assert_equals(copy.content.childNodes.length, 0,
             'Wrong number of template content\'s copy child nodes');
     checkOwnerDocument(copy.content, template.content.ownerDocument);
 
 }, 'ownerDocument of cloned template content is set to template content owner. '
-      + 'Test cloneNode() with no arguments (true by default)');
+      + 'Test cloneNode() with no arguments (false by default)');
 
 
 

--- a/html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
+++ b/html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
@@ -42,7 +42,7 @@ function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum, foote
     assert_equals(table.rows.length, 1, 'Wrong number of table rows');
     assert_equals(table.rows[0].cells.length, 1, 'Wrong number of table cells');
     if (id !== null) {
-        assert_not_null(template.content.querySelector('#' + id),
+        assert_not_equals(template.content.querySelector('#' + id), null,
                 'Element should present in the template content');
     }
     if (tagName !== null) {
@@ -50,21 +50,21 @@ function doTest(doc, tagToTest, templateInnerHTML, id, tagName, bodiesNum, foote
                 'Wrong element in the template content');
     }
 
-    assert_null(table.caption, 'Table should have no caption');
+    assert_equals(table.caption, null, 'Table should have no caption');
 
     if (bodiesNum) {
         assert_equals(table.tBodies.length, bodiesNum, 'Table should have '
                 + bodiesNum + ' body');
     }
     if (footerIsNull) {
-        assert_null(table.tFoot, 'Table should have no footer');
+        assert_equals(table.tFoot, null, 'Table should have no footer');
     }
     if (footerId) {
         assert_not_equals(table.tFoot.id, footerId,
                 'Table should have no footer with id="' + footerId + '"');
     }
     if (headerIsNull) {
-        assert_null(table.tHead, 'Table should have no header');
+        assert_equals(table.tHead, null, 'Table should have no header');
     }
     if (headerId) {
         assert_not_equals(table.tHead.id, headerId,

--- a/html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-row-context.html
+++ b/html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-row-context.html
@@ -39,7 +39,7 @@ function doTest(doc, templateInnerHTML, id, tagName, elementId) {
     assert_equals(table.rows[0].cells.length, 1, 'Wrong number of table cells');
     assert_equals(template.parentNode, tr, 'Wrong template parent');
     if (id !== null) {
-        assert_not_null(template.content.querySelector('#' + id),
+        assert_not_equals(template.content.querySelector('#' + id), null,
                     'Element should present in the template content');
     }
     if (tagName !== null) {
@@ -47,7 +47,7 @@ function doTest(doc, templateInnerHTML, id, tagName, elementId) {
                 'Wrong element in the template content');
     }
     if (elementId) {
-        assert_null(doc.querySelector('#' + elementId),
+        assert_equals(doc.querySelector('#' + elementId), null,
                 'Table should have no element with ID ' + elementId);
     }
 }


### PR DESCRIPTION
Without this change,
html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-body-context.html
and
html-templates/parsing-html-templates/clearing-the-stack-back-to-a-given-context/clearing-stack-back-to-a-table-row-context.html
fails with exceptions.
