### PR TITLE
Additional Tests for DOM Parsing and Serialization

### DIFF
--- a/domparsing/domparser.html
+++ b/domparsing/domparser.html
@@ -20,7 +20,7 @@
   test(function() {
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     var xhtmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "application/xhtml+xml" );
-    
+
     assert_equals(htmldocDOMParsed.location, xhtmldocDOMParsed.location);
     assert_equals(htmldocDOMParsed.URL, xhtmldocDOMParsed.URL);
     assert_equals(htmldocDOMParsed.documentURI, xhtmldocDOMParsed.documentURI);
@@ -38,7 +38,7 @@
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     assert_equals(htmldocDOMParsed.documentURI, document.URL);
   }, "DOMParser parsed documents have a documentURL equal to the document's URL [DOM4]");
-  
+
   </script>
   <div id="log"></div>
  </body>

--- a/domparsing/domparser.html
+++ b/domparsing/domparser.html
@@ -2,8 +2,8 @@
 <html>
  <head>
   <title>DOM Parser</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <script>

--- a/domparsing/domparser.html
+++ b/domparsing/domparser.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <title>DOM Parser</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <script>
+  var emptyHTML = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>empty</title></head><body></body></html>";
+  var soup = "<!DOCTYPE foo></><foo></multiple></>";
+  var emptyXML = "<!DOCTYPE foo><foo xmlns=\"test_ns\" />";
+  test(function() {
+    var htmldoc = new DOMParser().parseFromString(soup, "text/html");
+    assert_equals(htmldoc.documentElement.namespaceURI, "http://www.w3.org/1999/xhtml");
+  }, "DOMParser parses HTML tag soup with no problems");
+  test(function() {
+    assert_throws(new SyntaxError(), function() { new DOMParser().parseFromString(soup, "application/xml"); });
+  }, "DOMParser throws an exception when parsing tag soup as XML.");
+  test(function() {
+    var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
+    var xhtmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "application/xhtml+xml" );
+    
+    assert_equals(htmldocDOMParsed.location, xhtmldocDOMParsed.location);
+    assert_equals(htmldocDOMParsed.URL, xhtmldocDOMParsed.URL);
+    assert_equals(htmldocDOMParsed.documentURI, xhtmldocDOMParsed.documentURI);
+  }, "Documents parsed as HTML or XML have the same origin properties regardless");
+  // Test what happens when unknown string is provided!
+  test(function() {
+    var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
+    assert_equals(htmldocDOMParsed.URL, document.URL);
+  }, "DOMParser parsed documents have a URL property equal to the document's URL");
+  test(function() {
+    var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
+    assert_equals(htmldocDOMParsed.location, null);
+  }, "DOMParser parsed documents have a location equal to null [HTML5]");
+  test(function() {
+    var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
+    assert_equals(htmldocDOMParsed.documentURI, document.URL);
+  }, "DOMParser parsed documents have a documentURL equal to the document's URL [DOM4]");
+  
+  </script>
+  <div id="log"></div>
+ </body>
+</html>

--- a/domparsing/domparser.html
+++ b/domparsing/domparser.html
@@ -10,35 +10,39 @@
   var emptyHTML = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>empty</title></head><body></body></html>";
   var soup = "<!DOCTYPE foo></><foo></multiple></>";
   var emptyXML = "<!DOCTYPE foo><foo xmlns=\"test_ns\" />";
+
   test(function() {
     var htmldoc = new DOMParser().parseFromString(soup, "text/html");
     assert_equals(htmldoc.documentElement.namespaceURI, "http://www.w3.org/1999/xhtml");
   }, "DOMParser parses HTML tag soup with no problems");
+
   test(function() {
     assert_throws(new SyntaxError(), function() { new DOMParser().parseFromString(soup, "application/xml"); });
   }, "DOMParser throws an exception when parsing tag soup as XML.");
+
   test(function() {
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     var xhtmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "application/xhtml+xml" );
-
     assert_equals(htmldocDOMParsed.location, xhtmldocDOMParsed.location);
     assert_equals(htmldocDOMParsed.URL, xhtmldocDOMParsed.URL);
     assert_equals(htmldocDOMParsed.documentURI, xhtmldocDOMParsed.documentURI);
   }, "Documents parsed as HTML or XML have the same origin properties regardless");
+
   // Test what happens when unknown string is provided!
   test(function() {
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     assert_equals(htmldocDOMParsed.URL, document.URL);
   }, "DOMParser parsed documents have a URL property equal to the document's URL");
+
   test(function() {
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     assert_equals(htmldocDOMParsed.location, null);
   }, "DOMParser parsed documents have a location equal to null [HTML5]");
+
   test(function() {
     var htmldocDOMParsed = new DOMParser().parseFromString(emptyHTML, "text/html");
     assert_equals(htmldocDOMParsed.documentURI, document.URL);
   }, "DOMParser parsed documents have a documentURL equal to the document's URL [DOM4]");
-
   </script>
   <div id="log"></div>
  </body>

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -20,19 +20,23 @@
     assert_equals(document.getElementById("text").innerHTML,
                   "This is a &lt;test&gt; &amp; special text");
   }, "Parsed text with '<', '>', and '&' is serialized correctly");
+
   test(function(){
     assert_equals(document.getElementById("cdata-bogus-comment").innerHTML,
                   "<!--[CDATA[This is a <test & special text]]-->");
   }, "Parsed CDATA as bogus comment in HTML");
+
   test(function(){
     assert_equals(document.getElementById("pi-bogus-comment").innerHTML,
                   "<!--?thingy value with <test & special text?-->");
   }, "Parsed PI as bogus comment in HTML");
+
   test(function(){
     var t = document.getElementById("attr-escaping").firstChild;
     assert_equals(document.getElementById("attr-escaping").innerHTML,
                   "<elem foo=\"ba&quot;r\"></elem>");
   }, "Attribute value with quote character inserted is escaped per spec");
+
   test(function(){
     var t = document.getElementById("attr-escaping2").firstChild;
     assert_equals(document.getElementById("attr-escaping2").innerHTML,

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -2,8 +2,8 @@
 <html>
  <head>
   <title>DOM Serialization in HTML</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -13,8 +13,8 @@
   <div id="text" style="display:none">This is a &lt;test> &amp; special text</div>
   <div id="cdata-bogus-comment" style="display:none"><![CDATA[This is a <test & special text]]></div>
   <div id="pi-bogus-comment" style="display:none"><?thingy value with <test & special text?></div>
-  <div id="attr-escaping" style="display:none"><elem></elem></div>
-  <div id="attr-escaping2" style="display:none"><elem></elem></div>
+  <div id="attr-escaping" style="display:none"><elem foo='ba"r'></elem></div>
+  <div id="attr-escaping2" style="display:none"><elem foo='ba&r'></elem></div>
   <script>
   test(function(){
     assert_equals(document.getElementById("text").innerHTML,
@@ -30,13 +30,11 @@
   }, "Parsed PI as bogus comment in HTML");
   test(function(){
     var t = document.getElementById("attr-escaping").firstChild;
-    t.setAttribute('foo', 'ba"r');
     assert_equals(document.getElementById("attr-escaping").innerHTML,
                   "<elem foo=\"ba&quot;r\"></elem>");
   }, "Attribute value with quote character inserted is escaped per spec");
   test(function(){
     var t = document.getElementById("attr-escaping2").firstChild;
-    t.setAttribute('foo', 'ba&r');
     assert_equals(document.getElementById("attr-escaping2").innerHTML,
                   "<elem foo=\"ba&amp;r\"></elem>");
   }, "Attribute value with & character inserted is escaped per spec");

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -17,31 +17,31 @@
   <div id="attr-escaping2" style="display:none"><elem></elem></div>
   <script>
   test(function(){
-    assert_equals(document.getElementById("text").innerHTML, 
+    assert_equals(document.getElementById("text").innerHTML,
                   "This is a &lt;test&gt; &amp; special text");
   }, "Parsed text with '<', '>', and '&' is serialized correctly");
   test(function(){
-    assert_equals(document.getElementById("cdata-bogus-comment").innerHTML, 
+    assert_equals(document.getElementById("cdata-bogus-comment").innerHTML,
                   "<!--[CDATA[This is a <test & special text]]-->");
   }, "Parsed CDATA as bogus comment in HTML");
-  test(function(){    
-    assert_equals(document.getElementById("pi-bogus-comment").innerHTML, 
+  test(function(){
+    assert_equals(document.getElementById("pi-bogus-comment").innerHTML,
                   "<!--?thingy value with <test & special text?-->");
   }, "Parsed PI as bogus comment in HTML");
   test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+    assert_equals(new XMLSerializer().serializeToString(document.doctype),
                   "<!DOCTYPE html>");
   }, "Parsed DOCTYPE serialized correctly");
   test(function(){
     var t = document.getElementById("attr-escaping").firstChild;
     t.setAttribute('foo', 'ba"r');
-    assert_equals(document.getElementById("attr-escaping").innerHTML, 
+    assert_equals(document.getElementById("attr-escaping").innerHTML,
                   "<elem foo=\"ba&quot;r\"></elem>");
   }, "Attribute value with quote character inserted is escaped per spec");
   test(function(){
     var t = document.getElementById("attr-escaping2").firstChild;
     t.setAttribute('foo', 'ba&r');
-    assert_equals(document.getElementById("attr-escaping2").innerHTML, 
+    assert_equals(document.getElementById("attr-escaping2").innerHTML,
                   "<elem foo=\"ba&amp;r\"></elem>");
   }, "Attribute value with & character inserted is escaped per spec");
   // Basic Test of XMLSerializer

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -1,0 +1,59 @@
+<!docTYPE   htmL >
+<html>
+ <head>
+  <title>DOM Serialization in HTML</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <!-- Static parsed content -->
+  <div id="self-close-element" style="display:none"><myelement /></div>
+  <div id="open-close-element" style="display:none"><myelement></myelement></div>
+  <div id="text" style="display:none">This is a &lt;test> &amp; special text</div>
+  <div id="cdata-bogus-comment" style="display:none"><![CDATA[This is a <test & special text]]></div>
+  <div id="pi-bogus-comment" style="display:none"><?thingy value with <test & special text?></div>
+  <div id="attr-escaping" style="display:none"><elem></elem></div>
+  <div id="attr-escaping2" style="display:none"><elem></elem></div>
+  <script>
+  test(function(){
+    assert_equals(document.getElementById("text").innerHTML, 
+                  "This is a &lt;test&gt; &amp; special text");
+  }, "Parsed text with '<', '>', and '&' is serialized correctly");
+  test(function(){
+    assert_equals(document.getElementById("cdata-bogus-comment").innerHTML, 
+                  "<!--[CDATA[This is a <test & special text]]-->");
+  }, "Parsed CDATA as bogus comment in HTML");
+  test(function(){    
+    assert_equals(document.getElementById("pi-bogus-comment").innerHTML, 
+                  "<!--?thingy value with <test & special text?-->");
+  }, "Parsed PI as bogus comment in HTML");
+  test(function(){
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+                  "<!DOCTYPE html>");
+  }, "Parsed DOCTYPE serialized correctly");
+  test(function(){
+    var t = document.getElementById("attr-escaping").firstChild;
+    t.setAttribute('foo', 'ba"r');
+    assert_equals(document.getElementById("attr-escaping").innerHTML, 
+                  "<elem foo=\"ba&quot;r\"></elem>");
+  }, "Attribute value with quote character inserted is escaped per spec");
+  test(function(){
+    var t = document.getElementById("attr-escaping2").firstChild;
+    t.setAttribute('foo', 'ba&r');
+    assert_equals(document.getElementById("attr-escaping2").innerHTML, 
+                  "<elem foo=\"ba&amp;r\"></elem>");
+  }, "Attribute value with & character inserted is escaped per spec");
+  // Basic Test of XMLSerializer
+  test(function() {
+    var doc = document.implementation.createHTMLDocument("test title");
+    doc.body.appendChild(document.createElement("foo:bar"));
+    doc.body.appendChild(document.createTextNode("text test"));
+    var serializedStr = new XMLSerializer().serializeToString(doc);
+    
+    alert(serializedStr);
+    assert_equals("foo", "");
+  }, "XML Serializer creates an HTML serialization of a document in an HTML-based document");
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_html.html
+++ b/domparsing/serializing_html.html
@@ -29,10 +29,6 @@
                   "<!--?thingy value with <test & special text?-->");
   }, "Parsed PI as bogus comment in HTML");
   test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype),
-                  "<!DOCTYPE html>");
-  }, "Parsed DOCTYPE serialized correctly");
-  test(function(){
     var t = document.getElementById("attr-escaping").firstChild;
     t.setAttribute('foo', 'ba"r');
     assert_equals(document.getElementById("attr-escaping").innerHTML,
@@ -44,16 +40,6 @@
     assert_equals(document.getElementById("attr-escaping2").innerHTML,
                   "<elem foo=\"ba&amp;r\"></elem>");
   }, "Attribute value with & character inserted is escaped per spec");
-  // Basic Test of XMLSerializer
-  test(function() {
-    var doc = document.implementation.createHTMLDocument("test title");
-    doc.body.appendChild(document.createElement("foo:bar"));
-    doc.body.appendChild(document.createTextNode("text test"));
-    var serializedStr = new XMLSerializer().serializeToString(doc);
-    
-    alert(serializedStr);
-    assert_equals("foo", "");
-  }, "XML Serializer creates an HTML serialization of a document in an HTML-based document");
   </script>
  </body>
 </html>

--- a/domparsing/serializing_html_doctypevariation.html
+++ b/domparsing/serializing_html_doctypevariation.html
@@ -9,7 +9,7 @@
   <div id="log"></div>
   <script>
   test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+    assert_equals(new XMLSerializer().serializeToString(document.doctype),
                   "<!DOCTYPE html SYSTEM \" external.dtd \">");
   }, "Parsed DOCTYPE serialized correctly in HTML");
   </script>

--- a/domparsing/serializing_html_doctypevariation.html
+++ b/domparsing/serializing_html_doctypevariation.html
@@ -2,8 +2,8 @@
 <html>
  <head>
   <title>DOCTYPE Serialization in HTML - variation 1</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_html_doctypevariation.html
+++ b/domparsing/serializing_html_doctypevariation.html
@@ -1,0 +1,17 @@
+<!DoCtYpE hTmL  SyStEm     " external.dtd " [  <!ENTITY   blah    "val-value "&gt; ]>
+<html>
+ <head>
+  <title>DOCTYPE Serialization in HTML - variation 1</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script>
+  test(function(){
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+                  "<!DOCTYPE html SYSTEM \" external.dtd \">");
+  }, "Parsed DOCTYPE serialized correctly in HTML");
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml.xhtml
+++ b/domparsing/serializing_xhtml.xhtml
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>DOM Serialization in XHTML</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_xhtml.xhtml
+++ b/domparsing/serializing_xhtml.xhtml
@@ -149,10 +149,6 @@
     assert_equals(document.getElementById("pi").innerHTML,
                   "<?thingy value with <test> & special text?>");
   }, "Parsed PI with '<', '>', and '&' is serialized correctly");
-  test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype),
-                  "<!DOCTYPE blaHH>");
-  }, "Parsed DOCTYPE serialized correctly");
   // InnerHTML
   test(function() {
     var xmldoc = new DOMParser().parseFromString("<!DOCTYPE foo><foo xmlns=\"myfoo\"/>", "application/xml");
@@ -177,23 +173,6 @@
      assert_equals(xmldoc.documentElement.firstChild.nodeType, Node.CDATA_SECTION_NODE);
      assert_equals(htmldoc.documentElement.firstChild.nodeType, Node.COMMENT_NODE);
   }, "innerHTML parses using an XML or HTML depending on whether the node's document is an XML or HTML document");
-  // Basic Test of XMLSerializer
-  test(function() {
-    var doc = document.implementation.createHTMLDocument("test title");
-    //doc.body.appendChild(document.createCDATASection("cdata test"));
-    var serializedStr = new XMLSerializer().serializeToString(doc);
-    var expected = "<!DOCTYPE html>"+
-                    "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
-                      "<head>" +
-                        "<title>test title</title>" +
-                      "</head>" +
-                      "<body>" +
-                      "</body>" +
-                    "</html>";
-    assert_equals(serializedStr, expected);
-
-  }, "XML Serializer makes an XML serialization of an HTML-based document");
-
   // ]]>
   </script>
  </body>

--- a/domparsing/serializing_xhtml.xhtml
+++ b/domparsing/serializing_xhtml.xhtml
@@ -1,0 +1,200 @@
+<!DOCTYPE   blaHH   >
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <!-- Static parsed content -->
+  <div id="html-simple" style="display:none"><meta /></div>
+  <div id="self-close-element" style="display:none"><x xmlns="test_ns" /></div>
+  <div id="self-close-element1" style="display:none"><myelement /></div>
+  <div id="open-close-element2" style="display:none"><c><d/><e/></c></div>
+  <div id="open-close-element3" style="display:none" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:other="test_ns"><html:a/><html:input/><other:foo/></div>
+  <div id="element-nested-ns" style="display:none"><myelement><foo xmlns="test_ns" /></myelement></div>
+  <div id="element-nested-ns2" style="display:none"><c xmlns:one="test_ns"><d xmlns="test2_ns"><one:e/></d></c></div>
+  <div id="element-nested-ns3" style="display:none"><c xmlns="test_ns" xmlns:Two="test2_ns" xmlns:Three="test3_ns" ><Two:d><Two:e></Two:e></Two:d><Three:f><Three:g></Three:g></Three:f></c></div>
+  <div id="element-nested-ns4" style="display:none"><one:c xmlns:one="test_ns"><one:d><one:e><one:f/></one:e></one:d></one:c></div>
+  <div id="element-nested-ns5" style="display:none" xmlns:x="test_ns_x" xmlns:y="test_ns_y" xmlns:z="test_ns_z"><container><x:one/><x:two/><y:one/><y:two/><z:one/><z:two/></container></div>
+  <div id="text" style="display:none">This is a &lt;test> &amp; special text</div>
+  <div id="cdata" style="display:none"><![CDATA[This is a <test> & special text]]></div>
+  <div id="pi" style="display:none"><?thingy value with <test> & special text?></div>
+  <script><![CDATA[
+  // ELEMENTs ---------------------------
+  test(function(){
+    // source: <meta />
+    assert_equals(document.getElementById("html-simple").innerHTML, 
+                  "<meta xmlns=\"http://www.w3.org/1999/xhtml\" />");
+  }, "XHTML self-closing element is serialized per spec");
+  test(function(){
+    assert_equals(document.getElementById("self-close-element").innerHTML, 
+                  "<x xmlns=\"test_ns\"/>");
+  }, "Generic XML element is serialized per spec");
+  test(function(){
+    // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
+    //                     |
+    //                     |--{prefix:null, local:myelement, ns:xhtml, attrs:[]}
+    assert_equals(document.getElementById("self-close-element1").innerHTML, 
+                  "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"></myelement>");
+  }, "Unknown element in XHTML namespace is serialized with open/close tags");
+  test(function(){
+    // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
+    //                     |
+    //                     |--{prefix:null, local:c, ns:xhtml, attrs:[]}
+    //                        |
+    //                        |--{prefix:null, local:d, ns:xhtml, attrs:[]}
+    //                        |--{prefix:null, local:e, ns:xhtml, attrs:[]}
+    assert_equals(document.getElementById("open-close-element2").innerHTML, 
+                  "<c xmlns=\"http://www.w3.org/1999/xhtml\"><d></d><e></e></c>");
+  }, "Namespace declarations are not re-serialized on nested element subtrees");
+  test(function(){
+    // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[xmlns:html=xhtml, xmlns:other=test_ns]}
+    //                     |
+    //                     |--{prefix:html, local:a, ns:xhtml, attrs:[]}
+    //                     |--{prefix:html, local:input, ns:xhtml, attrs:[]}
+    //                     |--{prefix:other, local:foo, ns:test_ns, attrs:[]}
+    assert_equals(document.getElementById("open-close-element3").innerHTML, 
+                  "<html:a xmlns:html=\"http://www.w3.org/1999/xhtml\"></html:a>" +
+                  "<html:input xmlns:html=\"http://www.w3.org/1999/xhtml\" />" + // Note the space after the last attribute
+                  "<other:foo xmlns:other=\"test_ns\"/>");
+  }, "Some specific XHTML elements use self-closing serialization syntax, other xml namespaces serialize to self-closing syntax when childless");
+  test(function(){
+    // <myelement><foo xmlns="test_ns" /></myelement>
+    // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
+    //                     |
+    //                     |--{prefix:null, local:myelement, ns:xhtml, attrs:[]}
+    //                        |
+    //                        |--{prefix:null, local:foo, ns:test_ns, attrs:[xmlns=test_ns]}
+    assert_equals(document.getElementById("element-nested-ns").innerHTML, 
+                  "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"><foo xmlns=\"test_ns\"/></myelement>");
+  }, "Default namespace change in an element subtree is serialized per spec");
+  // TODO: test the case where the actual element's namespace doesn't match the attribute definition...
+  test(function(){
+    // Source: <c xmlns:one="test_ns"><d xmlns="test2_ns"><one:e/></d></c>
+    assert_equals(document.getElementById("element-nested-ns2").innerHTML, 
+                  "<c xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:one=\"test_ns\">" +
+                  "<d xmlns=\"test2_ns\">" +
+                  "<one:e/></d></c>");
+  }, "Interleaved namespace prefixed elements with namespace context definitions are serialized per spec");
+  test(function(){
+    // Source (sans white-space): 
+    // <c xmlns="test_ns" xmlns:Two="test2_ns" xmlns:Three="test3_ns" >
+    //   <Two:d>
+    //     <Two:e></Two:e>
+    //   </Two:d>
+    //   <Three:f>
+    //     <Three:g></Three:g>
+    //   </Three:f>
+    // </c>
+    assert_equals(document.getElementById("element-nested-ns3").innerHTML, 
+                  "<c xmlns=\"test_ns\" xmlns:Two=\"test2_ns\" xmlns:Three=\"test3_ns\">" +
+                  "<Two:d><Two:e/></Two:d>" +
+                  "<Three:f><Three:g/></Three:f>" +
+                  "</c>");
+  }, "Namespace prefix definitions in attributes are recognized during serialization to avoid re-declaration later");
+  test(function(){
+     var root = document.getElementById("element-nested-ns4");
+     var top = root.firstChild;
+     var futureTop = top.firstChild.firstChild.firstChild;
+     // Re-arrange the tree so that futureTop is the new top.
+     root.removeChild(top);
+     root.appendChild(futureTop);
+     futureTop.appendChild(top);
+     // Post re-arranged "source":
+     //   <one:f>
+     //    <one:c xmlns:one="test_ns">
+     //     <one:d>
+     //      <one:e/>
+     //     </one:d>
+     //    </one:c>
+     //   </one:f>
+     assert_equals(root.innerHTML, "<one:f xmlns:one=\"test_ns\">" +
+                                     "<one:c xmlns:one=\"test_ns\">" + // because it's in the attribute list
+                                      "<one:d><one:e/></one:d></one:c></one:f>");
+  }, "Attributes (even those containing prefix definitions) are serialized in due process (even when not technically necessary)");
+  test(function(){
+    // Source:
+    // (pre-established context): xmlns:x="test_ns_x" xmlns:y="test_ns_y" xmlns:z="test_ns_z"
+    //    <container><x:one/><x:two/><y:one/><y:two/><z:one/><z:two/></container>
+    assert_equals(document.getElementById("element-nested-ns5").innerHTML, 
+                  "<container xmlns=\"http://www.w3.org/1999/xhtml\">" +
+                   "<x:one xmlns:x=\"test_ns_x\"/>" +
+                   "<x:two xmlns:x=\"test_ns_x\"/>" +
+                   "<y:one xmlns:y=\"test_ns_y\"/>" +
+                   "<y:two xmlns:y=\"test_ns_y\"/>" +
+                   "<z:one xmlns:z=\"test_ns_z\"/>" +
+                   "<z:two xmlns:z=\"test_ns_z\"/>" +
+                   "</container>");
+  }, "Namespaced elements without attributes (but with prefixes) cause synthetic prefix declarations to be serialized as needed");
+  var ns_one = "test_ns";
+  var ns_two = "test2_ns";
+  test(function(){
+     var root = document.createElementNS(ns_one, "c");
+     assert_true(typeof root.outerHTML != "undefined", "outerHTML needs to exist for this test"); 
+     root.appendChild(document.createElementNS(ns_two, "d"));
+     assert_equals(root.outerHTML, "<c xmlns=\""+ns_one+"\"><d xmlns=\""+ns_two+"\"/></c>");
+  }, "Dynamic element creation w/namespaces are serialized per spec");
+  // TEXT ------------------------------
+  test(function(){
+    assert_equals(document.getElementById("text").innerHTML, 
+                  "This is a &lt;test&gt; &amp; special text");
+  }, "Parsed text with '<', '>', and '&' is serialized correctly");
+  test(function(){
+    assert_equals(document.getElementById("cdata").innerHTML, 
+                  "<![CDATA[This is a <test> & special text]" + "]>");
+  }, "Parsed CDATA with '<', '>', and '&' is serialized correctly");
+  test(function(){    
+    assert_equals(document.getElementById("pi").innerHTML, 
+                  "<?thingy value with <test> & special text?>");
+  }, "Parsed PI with '<', '>', and '&' is serialized correctly");
+  test(function(){
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+                  "<!DOCTYPE blaHH>");
+  }, "Parsed DOCTYPE serialized correctly");
+  // InnerHTML
+  test(function() {
+    var xmldoc = new DOMParser().parseFromString("<!DOCTYPE foo><foo xmlns=\"myfoo\"/>", "application/xml");
+    assert_equals(xmldoc.documentElement.namespaceURI, "myfoo", "Ensure an XML parser was used in DOMParser");
+    assert_equals(typeof xmldoc.documentElement.innerHTML, "string");
+  }, "innerHTML exists for pure XML nodes (of type Element)");
+  test(function() {
+    var controlString = "<!DOCTYPE html>" +
+                        "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
+                         "<head><title></title></head>" +
+                         "<body>" + 
+                          "<foo xmlns=\"myfoo\"/>" +
+                         "</body>" +
+                        "</html>";
+    var xmldoc = new DOMParser().parseFromString(controlString, "application/xhtml+xml");
+    assert_equals(xmldoc.documentElement.lastChild.firstChild.namespaceURI, "myfoo", "Ensure an XML parser was used in DOMParser");
+    var htmldoc = new DOMParser().parseFromString(controlString, "text/html");
+     assert_equals(htmldoc.documentElement.lastChild.firstChild.namespaceURI, "http://www.w3.org/1999/xhtml", "Ensure an HTML parser was used in DOMParser");
+     // innerHTML will parse using XML or HTML based on the type of document
+     xmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
+     htmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
+     assert_equals(xmldoc.documentElement.firstChild.nodeType, Node.CDATA_SECTION_NODE);
+     assert_equals(htmldoc.documentElement.firstChild.nodeType, Node.COMMENT_NODE);
+  }, "innerHTML parses using an XML or HTML depending on whether the node's document is an XML or HTML document");
+  // Basic Test of XMLSerializer
+  test(function() {
+    var doc = document.implementation.createHTMLDocument("test title");
+    //doc.body.appendChild(document.createCDATASection("cdata test"));
+    var serializedStr = new XMLSerializer().serializeToString(doc);
+    var expected = "<!DOCTYPE html>"+
+                    "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
+                      "<head>" +
+                        "<title>test title</title>" +
+                      "</head>" + 
+                      "<body>" +
+                      "</body>" +
+                    "</html>";
+    assert_equals(serializedStr, expected);
+    
+  }, "XML Serializer makes an XML serialization of an HTML-based document");
+  
+  // ]]>
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml.xhtml
+++ b/domparsing/serializing_xhtml.xhtml
@@ -28,10 +28,12 @@
     assert_equals(document.getElementById("html-simple").innerHTML,
                   "<meta xmlns=\"http://www.w3.org/1999/xhtml\" />");
   }, "XHTML self-closing element is serialized per spec");
+
   test(function(){
     assert_equals(document.getElementById("self-close-element").innerHTML,
                   "<x xmlns=\"test_ns\"/>");
   }, "Generic XML element is serialized per spec");
+
   test(function(){
     // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
     //                     |
@@ -39,6 +41,7 @@
     assert_equals(document.getElementById("self-close-element1").innerHTML,
                   "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"></myelement>");
   }, "Unknown element in XHTML namespace is serialized with open/close tags");
+
   test(function(){
     // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
     //                     |
@@ -49,6 +52,7 @@
     assert_equals(document.getElementById("open-close-element2").innerHTML,
                   "<c xmlns=\"http://www.w3.org/1999/xhtml\"><d></d><e></e></c>");
   }, "Namespace declarations are not re-serialized on nested element subtrees");
+
   test(function(){
     // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[xmlns:html=xhtml, xmlns:other=test_ns]}
     //                     |
@@ -60,6 +64,7 @@
                   "<html:input xmlns:html=\"http://www.w3.org/1999/xhtml\" />" + // Note the space after the last attribute
                   "<other:foo xmlns:other=\"test_ns\"/>");
   }, "Some specific XHTML elements use self-closing serialization syntax, other xml namespaces serialize to self-closing syntax when childless");
+
   test(function(){
     // <myelement><foo xmlns="test_ns" /></myelement>
     // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
@@ -70,7 +75,7 @@
     assert_equals(document.getElementById("element-nested-ns").innerHTML,
                   "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"><foo xmlns=\"test_ns\"/></myelement>");
   }, "Default namespace change in an element subtree is serialized per spec");
-  // TODO: test the case where the actual element's namespace doesn't match the attribute definition...
+
   test(function(){
     // Source: <c xmlns:one="test_ns"><d xmlns="test2_ns"><one:e/></d></c>
     assert_equals(document.getElementById("element-nested-ns2").innerHTML,
@@ -78,6 +83,7 @@
                   "<d xmlns=\"test2_ns\">" +
                   "<one:e/></d></c>");
   }, "Interleaved namespace prefixed elements with namespace context definitions are serialized per spec");
+
   test(function(){
     // Source (sans white-space):
     // <c xmlns="test_ns" xmlns:Two="test2_ns" xmlns:Three="test3_ns" >
@@ -94,6 +100,7 @@
                   "<Three:f><Three:g/></Three:f>" +
                   "</c>");
   }, "Namespace prefix definitions in attributes are recognized during serialization to avoid re-declaration later");
+
   test(function(){
      var root = document.getElementById("element-nested-ns4");
      var top = root.firstChild;
@@ -114,6 +121,7 @@
                                      "<one:c xmlns:one=\"test_ns\">" + // because it's in the attribute list
                                       "<one:d><one:e/></one:d></one:c></one:f>");
   }, "Attributes (even those containing prefix definitions) are serialized in due process (even when not technically necessary)");
+
   test(function(){
     // Source:
     // (pre-established context): xmlns:x="test_ns_x" xmlns:y="test_ns_y" xmlns:z="test_ns_z"
@@ -128,33 +136,40 @@
                    "<z:two xmlns:z=\"test_ns_z\"/>" +
                    "</container>");
   }, "Namespaced elements without attributes (but with prefixes) cause synthetic prefix declarations to be serialized as needed");
+
   var ns_one = "test_ns";
   var ns_two = "test2_ns";
+
   test(function(){
      var root = document.createElementNS(ns_one, "c");
      assert_true(typeof root.outerHTML != "undefined", "outerHTML needs to exist for this test");
      root.appendChild(document.createElementNS(ns_two, "d"));
      assert_equals(root.outerHTML, "<c xmlns=\""+ns_one+"\"><d xmlns=\""+ns_two+"\"/></c>");
   }, "Dynamic element creation w/namespaces are serialized per spec");
+
   // TEXT ------------------------------
   test(function(){
     assert_equals(document.getElementById("text").innerHTML,
                   "This is a &lt;test&gt; &amp; special text");
   }, "Parsed text with '<', '>', and '&' is serialized correctly");
+
   test(function(){
     assert_equals(document.getElementById("cdata").innerHTML,
                   "<![CDATA[This is a <test> & special text]" + "]>");
   }, "Parsed CDATA with '<', '>', and '&' is serialized correctly");
+
   test(function(){
     assert_equals(document.getElementById("pi").innerHTML,
                   "<?thingy value with <test> & special text?>");
   }, "Parsed PI with '<', '>', and '&' is serialized correctly");
+
   // InnerHTML
   test(function() {
     var xmldoc = new DOMParser().parseFromString("<!DOCTYPE foo><foo xmlns=\"myfoo\"/>", "application/xml");
     assert_equals(xmldoc.documentElement.namespaceURI, "myfoo", "Ensure an XML parser was used in DOMParser");
     assert_equals(typeof xmldoc.documentElement.innerHTML, "string");
   }, "innerHTML exists for pure XML nodes (of type Element)");
+
   test(function() {
     var controlString = "<!DOCTYPE html>" +
                         "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
@@ -166,12 +181,12 @@
     var xmldoc = new DOMParser().parseFromString(controlString, "application/xhtml+xml");
     assert_equals(xmldoc.documentElement.lastChild.firstChild.namespaceURI, "myfoo", "Ensure an XML parser was used in DOMParser");
     var htmldoc = new DOMParser().parseFromString(controlString, "text/html");
-     assert_equals(htmldoc.documentElement.lastChild.firstChild.namespaceURI, "http://www.w3.org/1999/xhtml", "Ensure an HTML parser was used in DOMParser");
-     // innerHTML will parse using XML or HTML based on the type of document
-     xmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
-     htmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
-     assert_equals(xmldoc.documentElement.firstChild.nodeType, Node.CDATA_SECTION_NODE);
-     assert_equals(htmldoc.documentElement.firstChild.nodeType, Node.COMMENT_NODE);
+    assert_equals(htmldoc.documentElement.lastChild.firstChild.namespaceURI, "http://www.w3.org/1999/xhtml", "Ensure an HTML parser was used in DOMParser");
+    // innerHTML will parse using XML or HTML based on the type of document
+    xmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
+    htmldoc.documentElement.innerHTML = "<![CDATA[parsertype]" + "]>";
+    assert_equals(xmldoc.documentElement.firstChild.nodeType, Node.CDATA_SECTION_NODE);
+    assert_equals(htmldoc.documentElement.firstChild.nodeType, Node.COMMENT_NODE);
   }, "innerHTML parses using an XML or HTML depending on whether the node's document is an XML or HTML document");
   // ]]>
   </script>

--- a/domparsing/serializing_xhtml.xhtml
+++ b/domparsing/serializing_xhtml.xhtml
@@ -25,18 +25,18 @@
   // ELEMENTs ---------------------------
   test(function(){
     // source: <meta />
-    assert_equals(document.getElementById("html-simple").innerHTML, 
+    assert_equals(document.getElementById("html-simple").innerHTML,
                   "<meta xmlns=\"http://www.w3.org/1999/xhtml\" />");
   }, "XHTML self-closing element is serialized per spec");
   test(function(){
-    assert_equals(document.getElementById("self-close-element").innerHTML, 
+    assert_equals(document.getElementById("self-close-element").innerHTML,
                   "<x xmlns=\"test_ns\"/>");
   }, "Generic XML element is serialized per spec");
   test(function(){
     // DOM Context Object: {prefix:null, local:div, ns:xhtml, attrs:[]}
     //                     |
     //                     |--{prefix:null, local:myelement, ns:xhtml, attrs:[]}
-    assert_equals(document.getElementById("self-close-element1").innerHTML, 
+    assert_equals(document.getElementById("self-close-element1").innerHTML,
                   "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"></myelement>");
   }, "Unknown element in XHTML namespace is serialized with open/close tags");
   test(function(){
@@ -46,7 +46,7 @@
     //                        |
     //                        |--{prefix:null, local:d, ns:xhtml, attrs:[]}
     //                        |--{prefix:null, local:e, ns:xhtml, attrs:[]}
-    assert_equals(document.getElementById("open-close-element2").innerHTML, 
+    assert_equals(document.getElementById("open-close-element2").innerHTML,
                   "<c xmlns=\"http://www.w3.org/1999/xhtml\"><d></d><e></e></c>");
   }, "Namespace declarations are not re-serialized on nested element subtrees");
   test(function(){
@@ -55,7 +55,7 @@
     //                     |--{prefix:html, local:a, ns:xhtml, attrs:[]}
     //                     |--{prefix:html, local:input, ns:xhtml, attrs:[]}
     //                     |--{prefix:other, local:foo, ns:test_ns, attrs:[]}
-    assert_equals(document.getElementById("open-close-element3").innerHTML, 
+    assert_equals(document.getElementById("open-close-element3").innerHTML,
                   "<html:a xmlns:html=\"http://www.w3.org/1999/xhtml\"></html:a>" +
                   "<html:input xmlns:html=\"http://www.w3.org/1999/xhtml\" />" + // Note the space after the last attribute
                   "<other:foo xmlns:other=\"test_ns\"/>");
@@ -67,19 +67,19 @@
     //                     |--{prefix:null, local:myelement, ns:xhtml, attrs:[]}
     //                        |
     //                        |--{prefix:null, local:foo, ns:test_ns, attrs:[xmlns=test_ns]}
-    assert_equals(document.getElementById("element-nested-ns").innerHTML, 
+    assert_equals(document.getElementById("element-nested-ns").innerHTML,
                   "<myelement xmlns=\"http://www.w3.org/1999/xhtml\"><foo xmlns=\"test_ns\"/></myelement>");
   }, "Default namespace change in an element subtree is serialized per spec");
   // TODO: test the case where the actual element's namespace doesn't match the attribute definition...
   test(function(){
     // Source: <c xmlns:one="test_ns"><d xmlns="test2_ns"><one:e/></d></c>
-    assert_equals(document.getElementById("element-nested-ns2").innerHTML, 
+    assert_equals(document.getElementById("element-nested-ns2").innerHTML,
                   "<c xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:one=\"test_ns\">" +
                   "<d xmlns=\"test2_ns\">" +
                   "<one:e/></d></c>");
   }, "Interleaved namespace prefixed elements with namespace context definitions are serialized per spec");
   test(function(){
-    // Source (sans white-space): 
+    // Source (sans white-space):
     // <c xmlns="test_ns" xmlns:Two="test2_ns" xmlns:Three="test3_ns" >
     //   <Two:d>
     //     <Two:e></Two:e>
@@ -88,7 +88,7 @@
     //     <Three:g></Three:g>
     //   </Three:f>
     // </c>
-    assert_equals(document.getElementById("element-nested-ns3").innerHTML, 
+    assert_equals(document.getElementById("element-nested-ns3").innerHTML,
                   "<c xmlns=\"test_ns\" xmlns:Two=\"test2_ns\" xmlns:Three=\"test3_ns\">" +
                   "<Two:d><Two:e/></Two:d>" +
                   "<Three:f><Three:g/></Three:f>" +
@@ -118,7 +118,7 @@
     // Source:
     // (pre-established context): xmlns:x="test_ns_x" xmlns:y="test_ns_y" xmlns:z="test_ns_z"
     //    <container><x:one/><x:two/><y:one/><y:two/><z:one/><z:two/></container>
-    assert_equals(document.getElementById("element-nested-ns5").innerHTML, 
+    assert_equals(document.getElementById("element-nested-ns5").innerHTML,
                   "<container xmlns=\"http://www.w3.org/1999/xhtml\">" +
                    "<x:one xmlns:x=\"test_ns_x\"/>" +
                    "<x:two xmlns:x=\"test_ns_x\"/>" +
@@ -132,25 +132,25 @@
   var ns_two = "test2_ns";
   test(function(){
      var root = document.createElementNS(ns_one, "c");
-     assert_true(typeof root.outerHTML != "undefined", "outerHTML needs to exist for this test"); 
+     assert_true(typeof root.outerHTML != "undefined", "outerHTML needs to exist for this test");
      root.appendChild(document.createElementNS(ns_two, "d"));
      assert_equals(root.outerHTML, "<c xmlns=\""+ns_one+"\"><d xmlns=\""+ns_two+"\"/></c>");
   }, "Dynamic element creation w/namespaces are serialized per spec");
   // TEXT ------------------------------
   test(function(){
-    assert_equals(document.getElementById("text").innerHTML, 
+    assert_equals(document.getElementById("text").innerHTML,
                   "This is a &lt;test&gt; &amp; special text");
   }, "Parsed text with '<', '>', and '&' is serialized correctly");
   test(function(){
-    assert_equals(document.getElementById("cdata").innerHTML, 
+    assert_equals(document.getElementById("cdata").innerHTML,
                   "<![CDATA[This is a <test> & special text]" + "]>");
   }, "Parsed CDATA with '<', '>', and '&' is serialized correctly");
-  test(function(){    
-    assert_equals(document.getElementById("pi").innerHTML, 
+  test(function(){
+    assert_equals(document.getElementById("pi").innerHTML,
                   "<?thingy value with <test> & special text?>");
   }, "Parsed PI with '<', '>', and '&' is serialized correctly");
   test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+    assert_equals(new XMLSerializer().serializeToString(document.doctype),
                   "<!DOCTYPE blaHH>");
   }, "Parsed DOCTYPE serialized correctly");
   // InnerHTML
@@ -163,7 +163,7 @@
     var controlString = "<!DOCTYPE html>" +
                         "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
                          "<head><title></title></head>" +
-                         "<body>" + 
+                         "<body>" +
                           "<foo xmlns=\"myfoo\"/>" +
                          "</body>" +
                         "</html>";
@@ -186,14 +186,14 @@
                     "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
                       "<head>" +
                         "<title>test title</title>" +
-                      "</head>" + 
+                      "</head>" +
                       "<body>" +
                       "</body>" +
                     "</html>";
     assert_equals(serializedStr, expected);
-    
+
   }, "XML Serializer makes an XML serialization of an HTML-based document");
-  
+
   // ]]>
   </script>
  </body>

--- a/domparsing/serializing_xhtml_doctypevariation1.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation1.xhtml
@@ -13,7 +13,7 @@
     var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
         "<!DOCTYPE html SYSTEM \" external.dtd \" [  <!ENTITY   blah    \"val-value \"> ]>" :
         "<!DOCTYPE html SYSTEM \" external.dtd \">";
-    
+
     assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
   }, "Parsed DOCTYPE serialized correctly");
   // ]]>

--- a/domparsing/serializing_xhtml_doctypevariation1.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation1.xhtml
@@ -13,7 +13,6 @@
     var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
         "<!DOCTYPE html SYSTEM \" external.dtd \" [  <!ENTITY   blah    \"val-value \"> ]>" :
         "<!DOCTYPE html SYSTEM \" external.dtd \">";
-
     assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
   }, "Parsed DOCTYPE serialized correctly");
   // ]]>

--- a/domparsing/serializing_xhtml_doctypevariation1.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation1.xhtml
@@ -1,0 +1,22 @@
+<!DOCTYPE html  SYSTEM     " external.dtd " [  <!ENTITY   blah    "val-value "> ]>
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML - variation 1</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script><![CDATA[
+  test(function(){
+    // Set testing expectations based on platform capability
+    var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
+        "<!DOCTYPE html SYSTEM \" external.dtd \" [  <!ENTITY   blah    \"val-value \"> ]>" :
+        "<!DOCTYPE html SYSTEM \" external.dtd \">";
+    
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
+  }, "Parsed DOCTYPE serialized correctly");
+  // ]]>
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml_doctypevariation1.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation1.xhtml
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>DOM Serialization in XHTML - variation 1</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_xhtml_doctypevariation2.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation2.xhtml
@@ -1,0 +1,18 @@
+<!DOCTYPE  foo  SYSTEM "external.dtd"  >
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML - variation 2</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script><![CDATA[
+  test(function(){
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+                  "<!DOCTYPE foo SYSTEM \"external.dtd\">");
+  }, "Parsed DOCTYPE serialized correctly");
+  // ]]>
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml_doctypevariation2.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation2.xhtml
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>DOM Serialization in XHTML - variation 2</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_xhtml_doctypevariation2.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation2.xhtml
@@ -9,7 +9,7 @@
   <div id="log"></div>
   <script><![CDATA[
   test(function(){
-    assert_equals(new XMLSerializer().serializeToString(document.doctype), 
+    assert_equals(new XMLSerializer().serializeToString(document.doctype),
                   "<!DOCTYPE foo SYSTEM \"external.dtd\">");
   }, "Parsed DOCTYPE serialized correctly");
   // ]]>

--- a/domparsing/serializing_xhtml_doctypevariation3.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation3.xhtml
@@ -9,10 +9,10 @@
   <div id="log"></div>
   <script><![CDATA[
   test(function(){
-    // Note: line endings are not interoperable (for windows-systems, some 
-    // browsers let literal \r\n through their XML parser, while others 
+    // Note: line endings are not interoperable (for windows-systems, some
+    // browsers let literal \r\n through their XML parser, while others
     // convert \r\n to \n.
-    
+
     // Set testing expectations based on platform capability
     var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
         "<!DOCTYPE Html PUBLIC \"  xxx test  -//TEST /Little Test  EN  \" \" external.dtd \" [   <!ELEMENT  myelement ( #PCDATA)>   ]>" :

--- a/domparsing/serializing_xhtml_doctypevariation3.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation3.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE  HTml  PUBLIC    "  xxx test  -//TEST /Little Test  EN  "     " external.dtd " [   <!ELEMENT  myelement ( #PCDATA)>   ]  >
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML - variation 3</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script><![CDATA[
+  test(function(){
+    // Note: line endings are not interoperable (for windows-systems, some 
+    // browsers let literal \r\n through their XML parser, while others 
+    // convert \r\n to \n.
+    
+    // Set testing expectations based on platform capability
+    var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
+        "<!DOCTYPE Html PUBLIC \"  xxx test  -//TEST /Little Test  EN  \" \" external.dtd \" [   <!ELEMENT  myelement ( #PCDATA)>   ]>" :
+        "<!DOCTYPE Html PUBLIC \"  xxx test  -//TEST /Little Test  EN  \" \" external.dtd \">";
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
+  }, "Parsed DOCTYPE serialized correctly");
+
+  // ]]>
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml_doctypevariation3.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation3.xhtml
@@ -12,14 +12,12 @@
     // Note: line endings are not interoperable (for windows-systems, some
     // browsers let literal \r\n through their XML parser, while others
     // convert \r\n to \n.
-
     // Set testing expectations based on platform capability
     var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
         "<!DOCTYPE Html PUBLIC \"  xxx test  -//TEST /Little Test  EN  \" \" external.dtd \" [   <!ELEMENT  myelement ( #PCDATA)>   ]>" :
         "<!DOCTYPE Html PUBLIC \"  xxx test  -//TEST /Little Test  EN  \" \" external.dtd \">";
     assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
   }, "Parsed DOCTYPE serialized correctly");
-
   // ]]>
   </script>
  </body>

--- a/domparsing/serializing_xhtml_doctypevariation3.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation3.xhtml
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>DOM Serialization in XHTML - variation 3</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_xhtml_doctypevariation4.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation4.xhtml
@@ -9,8 +9,8 @@
   <div id="log"></div>
   <script><![CDATA[
   test(function(){
-    // Note: line endings are not interoperable (for windows-systems, some 
-    // browsers let literal \r\n through their XML parser, while others 
+    // Note: line endings are not interoperable (for windows-systems, some
+    // browsers let literal \r\n through their XML parser, while others
     // convert \r\n to \n.
 
     // Set testing expectations based on platform capability

--- a/domparsing/serializing_xhtml_doctypevariation4.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation4.xhtml
@@ -1,0 +1,26 @@
+<!DOCTYPE  MyName  [   <!ELEMENT  e ( #PCDATA)>   ]  >
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML - variation 4</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script><![CDATA[
+  test(function(){
+    // Note: line endings are not interoperable (for windows-systems, some 
+    // browsers let literal \r\n through their XML parser, while others 
+    // convert \r\n to \n.
+
+    // Set testing expectations based on platform capability
+    var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
+        "<!DOCTYPE MyName [   <!ELEMENT  e ( #PCDATA)>   ]>" :
+        "<!DOCTYPE MyName>";
+    assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
+  }, "Parsed DOCTYPE serialized correctly");
+
+  // ]]>
+  </script>
+ </body>
+</html>

--- a/domparsing/serializing_xhtml_doctypevariation4.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation4.xhtml
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
  <head>
   <title>DOM Serialization in XHTML - variation 4</title>
-  <script src="../resources/testharness.js"></script>
-  <script src="../resources/testharnessreport.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
  </head>
  <body>
   <div id="log"></div>

--- a/domparsing/serializing_xhtml_doctypevariation4.xhtml
+++ b/domparsing/serializing_xhtml_doctypevariation4.xhtml
@@ -12,14 +12,12 @@
     // Note: line endings are not interoperable (for windows-systems, some
     // browsers let literal \r\n through their XML parser, while others
     // convert \r\n to \n.
-
     // Set testing expectations based on platform capability
     var expectedSerialization = (typeof document.doctype.internalSubset != undefined) ?
         "<!DOCTYPE MyName [   <!ELEMENT  e ( #PCDATA)>   ]>" :
         "<!DOCTYPE MyName>";
     assert_equals(new XMLSerializer().serializeToString(document.doctype), expectedSerialization);
   }, "Parsed DOCTYPE serialized correctly");
-
   // ]]>
   </script>
  </body>

--- a/domparsing/xmlserializer_html.html
+++ b/domparsing/xmlserializer_html.html
@@ -19,9 +19,9 @@
     doc.body.appendChild(document.createElement("foo:bar"));
     doc.body.appendChild(document.createTextNode("text test"));
     var serializedStr = new XMLSerializer().serializeToString(doc);
-    alert(serializedStr);
-    assert_equals("foo", "");
-  }, "XML Serializer creates an HTML serialization of a document in an HTML-based document");
+    assert_equals(serializedStr, "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>test title</title></head>" +
+									"<body><foo:bar></foo:bar>text test</body></html>");
+  }, "XML Serializer creates an HTML serialization of a document with XML-like tags");
   </script>
  </body>
 </html>

--- a/domparsing/xmlserializer_html.html
+++ b/domparsing/xmlserializer_html.html
@@ -1,0 +1,27 @@
+<!docTYPE   htmL >
+<html>
+ <head>
+  <title>DOM Serialization in HTML via XMLSerializer</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script>
+  test(function(){
+    assert_equals(new XMLSerializer().serializeToString(document.doctype),
+                  "<!DOCTYPE html>");
+  }, "Parsed DOCTYPE serialized correctly");
+  // Basic Test of XMLSerializer
+  test(function() {
+    var doc = document.implementation.createHTMLDocument("test title");
+    doc.body.appendChild(document.createElement("foo:bar"));
+    doc.body.appendChild(document.createTextNode("text test"));
+    var serializedStr = new XMLSerializer().serializeToString(doc);
+    
+    alert(serializedStr);
+    assert_equals("foo", "");
+  }, "XML Serializer creates an HTML serialization of a document in an HTML-based document");
+  </script>
+ </body>
+</html>

--- a/domparsing/xmlserializer_html.html
+++ b/domparsing/xmlserializer_html.html
@@ -12,13 +12,13 @@
     assert_equals(new XMLSerializer().serializeToString(document.doctype),
                   "<!DOCTYPE html>");
   }, "Parsed DOCTYPE serialized correctly");
+
   // Basic Test of XMLSerializer
   test(function() {
     var doc = document.implementation.createHTMLDocument("test title");
     doc.body.appendChild(document.createElement("foo:bar"));
     doc.body.appendChild(document.createTextNode("text test"));
     var serializedStr = new XMLSerializer().serializeToString(doc);
-    
     alert(serializedStr);
     assert_equals("foo", "");
   }, "XML Serializer creates an HTML serialization of a document in an HTML-based document");

--- a/domparsing/xmlserializer_xhtml.xhtml
+++ b/domparsing/xmlserializer_xhtml.xhtml
@@ -22,9 +22,7 @@
                       "</body>" +
                     "</html>";
     assert_equals(serializedStr, expected);
-
   }, "XML Serializer makes an XML serialization of an HTML-based document");
-
   // ]]>
   </script>
  </body>

--- a/domparsing/xmlserializer_xhtml.xhtml
+++ b/domparsing/xmlserializer_xhtml.xhtml
@@ -1,0 +1,31 @@
+<!DOCTYPE   blaHH   >
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>DOM Serialization in XHTML</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id="log"></div>
+  <script><![CDATA[
+  // Basic Test of XMLSerializer
+  test(function() {
+    var doc = document.implementation.createHTMLDocument("test title");
+    //doc.body.appendChild(document.createCDATASection("cdata test"));
+    var serializedStr = new XMLSerializer().serializeToString(doc);
+    var expected = "<!DOCTYPE html>"+
+                    "<html xmlns=\"http://www.w3.org/1999/xhtml\">" +
+                      "<head>" +
+                        "<title>test title</title>" +
+                      "</head>" +
+                      "<body>" +
+                      "</body>" +
+                    "</html>";
+    assert_equals(serializedStr, expected);
+
+  }, "XML Serializer makes an XML serialization of an HTML-based document");
+
+  // ]]>
+  </script>
+ </body>
+</html>


### PR DESCRIPTION
Tests focus on element and doctype serialization, with a little bit of
DOMParser behaviors thrown in. These tests are primarily for new spec prose recently added to the W3C editor's draft spec.