### PR TITLE
Fix tests for parsing template elements inside XHTML documents

### DIFF
--- a/html-templates/additions-to-parsing-xhtml-documents/node-document.html
+++ b/html-templates/additions-to-parsing-xhtml-documents/node-document.html
@@ -19,6 +19,7 @@
 
 test(function() {
     var doc = newXHTMLDocument();
+    doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     doc.body = doc.createElement('body');
     doc.body.innerHTML = '<template id="tmpl"></template>';
 
@@ -42,7 +43,7 @@ test(function() {
 
 test(function() {
     var doc = newXHTMLDocument();
-
+    doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     doc.body = doc.createElement('body');
     doc.body.innerHTML = '<template id="tmpl"><div>Div content</div></template>';
 
@@ -68,6 +69,7 @@ test(function() {
 
 test(function() {
     var doc = newXHTMLDocument();
+    doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     doc.body = doc.createElement('body');
     doc.body.innerHTML = ''
             + '<template id="tmpl"><div>Div content</div> And some more text'

--- a/html-templates/additions-to-parsing-xhtml-documents/template-child-nodes.html
+++ b/html-templates/additions-to-parsing-xhtml-documents/template-child-nodes.html
@@ -18,7 +18,7 @@
 
 test(function() {
     var doc = newXHTMLDocument();
-
+    doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     doc.body = doc.createElement('body');
     doc.body.innerHTML = '<template id="tmpl1">'
             + '<div id="div1">This is div inside template</div>'
@@ -38,6 +38,7 @@ test(function() {
 
 test(function() {
     var doc = newXHTMLDocument();
+    doc.documentElement.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
     doc.body = doc.createElement('body');
     doc.body.innerHTML = '<template id="tmpl1">'
             + '<div id="div1">This is div inside template</div>'

--- a/html-templates/resources/template-child-nodes-div.xhtml
+++ b/html-templates/resources/template-child-nodes-div.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>Template tag with children div tags inside</title>
-    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru">
+    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru"/>
 </head>
 <body>
 	<p>Template tag with div tags inside</p>

--- a/html-templates/resources/template-child-nodes-nested.xhtml
+++ b/html-templates/resources/template-child-nodes-nested.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>Template tag with children div tags inside another template tag</title>
-    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru">
+    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru"/>
 </head>
 <body>
 	<p>Template tag with children div tags inside another template tag</p>


### PR DESCRIPTION
Because XML documents used in node-document.html and template-child-nodes.html to parse template elements
didn't have the default namespace set by xmlns, template elements were being parsed as elements outside
of the html namespace. Fixed the tests by explicitly setting xmlns attribute on the document element to
the html's namespace URI.

Also self-closed link elements in two XHTML documents inside the resource directory under html-templates
as they were encountering parser errors.
