### PR TITLE
Self-close link elements in html-templates/resources to avoid hitting XML parser errors.

### DIFF
--- a/html-templates/resources/template-child-nodes-div.xhtml
+++ b/html-templates/resources/template-child-nodes-div.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>Template tag with children div tags inside</title>
-    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru">
+    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru"/>
 </head>
 <body>
 	<p>Template tag with div tags inside</p>

--- a/html-templates/resources/template-child-nodes-nested.xhtml
+++ b/html-templates/resources/template-child-nodes-nested.xhtml
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>Template tag with children div tags inside another template tag</title>
-    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru">
+    <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru"/>
 </head>
 <body>
 	<p>Template tag with children div tags inside another template tag</p>


### PR DESCRIPTION
Self-close link elements in html-templates/resources/template-child-nodes-div.xhtml and html-templates/resources/template-child-nodes-nested.xhtml to avoid hitting XML parser errors.
