### PR TITLE
Update the test for setting document.title to the empty string.

### DIFF
--- a/html/dom/documents/dom-tree-accessors/document.title-06.html
+++ b/html/dom/documents/dom-tree-accessors/document.title-06.html
@@ -1,24 +1,19 @@
 <!doctype html>
 <title>document.title and the empty string</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="http://www.whatwg.org/html5/#document.title">
-<meta name="assert" content="On setting document.title, a text node must be created.">
-<link rel="stylesheet" href="/resources/testharness.css">
+<link rel="help" href="http://www.whatwg.org/html/#document.title">
+<meta name="assert" content="On setting document.title to the empty string, no text node must be created.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
 test(function() {
-  document.documentElement.firstChild.removeChild(
-    document.documentElement.firstChild.firstChild);
+  var head = document.documentElement.firstChild;
+  head.removeChild(head.firstChild);
   assert_equals(document.title, "");
   document.title = "";
   assert_equals(document.title, "");
-  assert_true(document.documentElement.firstChild.lastChild instanceof
-              HTMLTitleElement, "Need a title element.");
-  var title = document.documentElement.firstChild.lastChild.firstChild;
-  assert_true(title, "Need a node.");
-  assert_true(title instanceof Text, "Should be a text node");
-  assert_equals(title.value, "");
+  assert_true(head.lastChild instanceof HTMLTitleElement, "Need a title element.");
+  assert_equals(head.lastChild.firstChild, null);
 });
 </script>


### PR DESCRIPTION
This was changed in https://www.w3.org/Bugs/Public/show_bug.cgi?id=24224 http://html5.org/tools/web-apps-tracker?from=8403&to=8404

Gecko/Trident match the new specification, WebKit/Blink match the old specification.
