### PR TITLE
Update Audio constructor test to match specs

### DIFF
--- a/html/semantics/embedded-content-0/the-audio-element/audio_constructor.html
+++ b/html/semantics/embedded-content-0/the-audio-element/audio_constructor.html
@@ -11,14 +11,12 @@ test(function() {
     valueOf: function() { throw Error() }
   };
   var tests = [
-    [function() { return Audio() }, null, "No arguments, without new"],
-    [function() { return new Audio() }, null, "No arguments, with new"],
-    [function() { return Audio("") }, "", "Empty string argument, without new"],
-    [function() { return new Audio("") }, "", "Empty string argument, with new"],
-    [function() { return Audio("src") }, "src", "Non-empty string argument, without new"],
-    [function() { return new Audio("src") }, "src", "Non-empty string argument, with new"],
-    [function() { return Audio("", throwingObject) }, "", "Extra argument, without new"],
-    [function() { return new Audio("", throwingObject) }, "", "Extra argument, with new"],
+    [function() { return new Audio() }, null, "No arguments"],
+    [function() { return new Audio("") }, "", "Empty string argument"],
+    [function() { return new Audio("src") }, "src", "Non-empty string argument"],
+    [function() { return new Audio(null) }, "null", "Null argument"],
+    [function() { return new Audio(undefined) }, null, "Undefined argument"],
+    [function() { return new Audio("", throwingObject) }, "", "Extra argument"],
   ];
   tests.forEach(function(t) {
     var fn = t[0], expectedSrc = t[1], description = t[2];
@@ -34,6 +32,11 @@ test(function() {
     }, description);
   });
 });
+test(function() {
+  assert_throws(new TypeError(), function() {
+    Audio();
+  });
+}, "Calling Audio should throw");
 test(function() {
   assert_throws(new TypeError(), function() {
     HTMLAudioElement();


### PR DESCRIPTION
Neither HTML nor WebIDL seem to say anything that would make Audio()
without new work. Even the very first revision of Web Apps 1.0 from
2006 says "The Audio() _constructor_ takes a single argument" and
nothing about calling it as a function. Ad-hoc testing found that
presently Gecko, Presto, and Trident support calling Audio() without
new, while Blink and WebKit do not.

Also test null and undefined as the arguments, since an undefined
optional argument should be treated as a missing argument per WebIDL,
but isn't in all implementations.
