### PR TITLE
Revlin/html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ scratch
 \#*
 config.json
 MANIFEST.json
+
+9820061067-245043313-tickets.pdf

--- a/html/semantics/embedded-content-0/the-video-element/event_loadstart.html
+++ b/html/semantics/embedded-content-0/the-video-element/event_loadstart.html
@@ -3,7 +3,7 @@
  <head>
   <title>video events - loadstart</title>
   <script src="/resources/testharness.js"></script>
-  <script /resources/testharnessreport.js></script>
+  <script src="/resources/testharnessreport.js"></script>
   <script src="../../../../common/media.js"></script>
  </head>
  <body>

--- a/html/semantics/tabular-data/the-caption-element/caption_001.html
+++ b/html/semantics/tabular-data/the-caption-element/caption_001.html
@@ -26,11 +26,11 @@
       <caption>first caption</caption>
     </table>
     <script>
-      test(function () {
+      test(function () { /* 1st Assertion */
         assert_equals(document.getElementById('table1').caption.innerHTML, "first caption");
       }, "first caption element child of the first table element");
 
-      test(function () {
+      test(function () {  /* 2nd Assertion */
         var caption = document.createElement("caption");
         caption.innerHTML = "new caption";
         var table = document.getElementById('table1');
@@ -45,18 +45,18 @@
         assert_equals(captions[1].innerHTML, "second caption");
       }, "setting caption on a table");
 
-      test(function () {
+      test(function () { /* 3rd Assertion */
         assert_equals(document.getElementById('table2').caption, null);
       }, "caption IDL attribute is null");
 
-      test(function () {
+      test(function () { /* 4th Assertion */
         var table = document.getElementById('table3');
         var caption = document.createElement("caption")
         table.rows[0].appendChild(caption);
         assert_equals(table.caption, null);
       }, "caption of the third table element should be null");
 
-      test(function () {
+      test(function () { /* 5th Assertion */
         assert_not_equals(document.getElementById('table4').caption, null);
 
         var parent = document.getElementById('table4').caption.parentNode;


### PR DESCRIPTION
I found a typo in "html/semantics/embedded-content-0/the-video-element/event_loadstart.html" so here's an update.

Oh, yeah, I also added some comments to "html/semantics/tabular-data/the-caption-element/caption_001.html"... nothing functional, just keeping track of the number of assertions
