### PR TITLE
fix typo in caption_001.html

### DIFF
--- a/html/semantics/embedded-content-0/the-video-element/event_loadstart.html
+++ b/html/semantics/embedded-content-0/the-video-element/event_loadstart.html
@@ -3,7 +3,7 @@
  <head>
   <title>video events - loadstart</title>
   <script src="/resources/testharness.js"></script>
-  <script /resources/testharnessreport.js></script>
+  <script src="/resources/testharnessreport.js"></script>
   <script src="../../../../common/media.js"></script>
  </head>
  <body>


### PR DESCRIPTION
K, made the same fix to the typo in "html/semantics/tabular-data/the-caption-element/caption_001.html"
