### PR TITLE
Missing .length causing the test to fail

### DIFF
--- a/shadow-dom/elements-and-dom-objects/csshostrule-interface/csshostrule-attributes/test-001.html
+++ b/shadow-dom/elements-and-dom-objects/csshostrule-interface/csshostrule-attributes/test-001.html
@@ -61,7 +61,7 @@ test(unit(function (ctx) {
 			'}';
 	s.appendChild(style);
 
-	assert_equals(s.styleSheets[0].cssRules[1].cssRules, 1,	'Wrong cssRules collection size');
+	assert_equals(s.styleSheets[0].cssRules[1].cssRules.length, 1,	'Wrong cssRules collection size');
 
 }), 'A_10_03_01_01_T02');
 </script>


### PR DESCRIPTION
Added the .length attribute to fix a failing test in Shadow DOM's
csshostrule-attributes test.
