### PR TITLE
Order is apparently wrong making the test fail.

### DIFF
--- a/shadow-dom/user-interaction/focus-navigation/test-004.html
+++ b/shadow-dom/user-interaction/focus-navigation/test-004.html
@@ -157,7 +157,7 @@ A_07_02_04_T02.step(unit(function (ctx) {
 	chb2.setAttribute('class', 'shadow');
 	chb2.setAttribute('tabindex', '3');
 	chb2.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
-		assert_equals(counter++, 3, 'Point 2: wrong focus navigation order');
+		assert_equals(counter++, 4, 'Point 2: wrong focus navigation order');
 		invoked[2] = true;
 	}), false);
 	invoked[2] = false;
@@ -165,11 +165,11 @@ A_07_02_04_T02.step(unit(function (ctx) {
 
 	var chb3 = d.createElement('input');
 	chb3.setAttribute('type', 'checkbox');
-	chb3.setAttribute('id', 'chb2');
+	chb3.setAttribute('id', 'chb3');
 	chb3.setAttribute('class', 'shadow');
 	chb3.setAttribute('tabindex', '2');
 	chb3.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
-		assert_equals(counter++, 2, 'Point 3: wrong focus navigation order');
+		assert_equals(counter++, 1, 'Point 3: wrong focus navigation order');
 		invoked[3] = true;
 	}), false);
 	invoked[3] = false;
@@ -187,7 +187,7 @@ A_07_02_04_T02.step(unit(function (ctx) {
 	inp1.setAttribute('value', 'Input 1');
 	inp1.setAttribute('tabindex', '4');
 	inp1.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
-		assert_equals(counter++, 4, 'Point 4: wrong focus navigation order');
+		assert_equals(counter++, 3, 'Point 4: wrong focus navigation order');
 		invoked[4] = true;
 	}), false);
 	invoked[4] = false;
@@ -207,10 +207,10 @@ A_07_02_04_T02.step(unit(function (ctx) {
 
 	var chb4 = d.createElement('input');
 	chb4.setAttribute('type', 'checkbox');
-	chb4.setAttribute('id', 'chb2');
+	chb4.setAttribute('id', 'chb4');
 	chb4.setAttribute('tabindex', '2');
 	chb4.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
-		assert_equals(counter++, 1, 'Point 6: wrong focus navigation order');
+		assert_equals(counter++, 2, 'Point 6: wrong focus navigation order');
 		invoked[6] = true;
 	}), false);
 	invoked[6] = false;
@@ -219,10 +219,10 @@ A_07_02_04_T02.step(unit(function (ctx) {
 	chb1.focus();
 
 	//simulate TAB clicks
-	//Expected order: chb1, chb4, chb3, chb2, inp1, inp2
+	//Expected order: chb1, chb3, chb4, chb2, inp1, inp2
 	fireKeyboardEvent(d, chb1, 'U+0009');
-	fireKeyboardEvent(d, chb4, 'U+0009');
 	fireKeyboardEvent(d, chb3, 'U+0009');
+	fireKeyboardEvent(d, chb4, 'U+0009');
 	fireKeyboardEvent(d, chb2, 'U+0009');
 	fireKeyboardEvent(d, inp1, 'U+0009');
 	fireKeyboardEvent(d, inp2, 'U+0009');
@@ -231,7 +231,7 @@ A_07_02_04_T02.step(unit(function (ctx) {
 
 	for (var i = 1; i < invoked.length; i++) {
 		if (!invoked[i]) {
-			assert_true(false, 'Piont ' + i + ' event listener was not invoked');
+			assert_true(false, 'Point ' + i + ' event listener was not invoked');
 		}
 	}
 


### PR DESCRIPTION
Based on my understanding of the tabindex behavior as explained in the
html5 living standard: pre-order, depth first tree order ("before any
element whose tabindex attribute has a value equal to the value of the
tabindex attribute on the element but that is later in the document in
tree order than the element").
