### PR TITLE
Wrong order for some nodes unrelated to shadow dom

### DIFF
--- a/shadow-dom/user-interaction/focus-navigation/test-003.html
+++ b/shadow-dom/user-interaction/focus-navigation/test-003.html
@@ -152,7 +152,7 @@ A_07_02_03_T02.step(unit(function (ctx) {
 	chb2.setAttribute('class', 'shadow');
 	chb2.setAttribute('tabindex', '3');
 	chb2.addEventListener('focus', A_07_02_03_T02.step_func(function(event) {
-		assert_equals(counter++, 3, 'Point 2: wrong focus navigation order');
+		assert_equals(counter++, 2, 'Point 2: wrong focus navigation order');
 		invoked[2] = true;
 	}), false);
 	invoked[2] = false;
@@ -160,11 +160,11 @@ A_07_02_03_T02.step(unit(function (ctx) {
 
 	var chb3 = d.createElement('input');
 	chb3.setAttribute('type', 'checkbox');
-	chb3.setAttribute('id', 'chb2');
+	chb3.setAttribute('id', 'chb3');
 	chb3.setAttribute('class', 'shadow');
 	chb3.setAttribute('tabindex', '2');
 	chb3.addEventListener('focus', A_07_02_03_T02.step_func(function(event) {
-		assert_equals(counter++, 2, 'Point 3: wrong focus navigation order');
+		assert_equals(counter++, 1, 'Point 3: wrong focus navigation order');
 		invoked[3] = true;
 	}), false);
 	invoked[3] = false;
@@ -202,10 +202,10 @@ A_07_02_03_T02.step(unit(function (ctx) {
 
 	var chb4 = d.createElement('input');
 	chb4.setAttribute('type', 'checkbox');
-	chb4.setAttribute('id', 'chb2');
+	chb4.setAttribute('id', 'chb4');
 	chb4.setAttribute('tabindex', '6');
 	chb4.addEventListener('focus', A_07_02_03_T02.step_func(function(event) {
-		assert_equals(counter++, 1, 'Point 6: wrong focus navigation order');
+		assert_equals(counter++, 3, 'Point 6: wrong focus navigation order');
 		invoked[6] = true;
 	}), false);
 	invoked[6] = false;
@@ -214,11 +214,11 @@ A_07_02_03_T02.step(unit(function (ctx) {
 	chb1.focus();
 
 	//simulate TAB clicks
-	//Expected order: chb1, chb4, chb3, chb2, inp1, inp2
+	//Expected order: chb1, chb3, chb2, chb4, inp1, inp2
 	fireKeyboardEvent(d, chb1, 'U+0009');
-	fireKeyboardEvent(d, chb4, 'U+0009');
 	fireKeyboardEvent(d, chb3, 'U+0009');
 	fireKeyboardEvent(d, chb2, 'U+0009');
+	fireKeyboardEvent(d, chb4, 'U+0009');
 	fireKeyboardEvent(d, inp1, 'U+0009');
 	fireKeyboardEvent(d, inp2, 'U+0009');
 


### PR DESCRIPTION
The expected order of nodes outside of the shadow root was wrong. Since
there is no identical tabindex in use, the order is simply tabindex.
"before any element whose tabindex attribute has a value greater than
the value of the tabindex attribute on the element."
