### PR TITLE
Adjusted queryselector to operate on the SR

### DIFF
--- a/shadow-dom/styles/test-011.html
+++ b/shadow-dom/styles/test-011.html
@@ -188,7 +188,7 @@ test(unit(function (ctx) {
 	assert_equals(d.querySelector('#li5').offsetHeight, defHeight5, 'Point 43: Inherited ' +
 			'element style should be reset');
 
-	assert_equals(d.querySelector('#spn1').offsetHeight, spnHeight, 'Element shouldn\'t ' +
+	assert_equals(s2.querySelector('#spn1').offsetHeight, spnHeight, 'Element shouldn\'t ' +
 		'be affected by resetStyleInheritance flag');
 
 }), 'A_06_00_12_T02');


### PR DESCRIPTION
I assume that querying from document into a Shadow Root isn't expected
to work. Made the query to operate on the SR which fixes the failing
test(s).
