### PR TITLE
Add a test for an edge case resource selection invocation in Blink

### DIFF
--- a/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/038.html
+++ b/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/038.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>NOT invoking resource selection by inserting into other document with src set</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<iframe hidden></iframe>
+<script>
+async_test(function(t) {
+  onload = t.step_func(function() {
+    var v = document.createElement('video');
+    v.src = 'data:,';
+    v.onerror = t.step_func(function() {
+      assert_equals(v.readyState, v.HAVE_NOTHING);
+      assert_equals(v.networkState, v.NETWORK_NO_SOURCE);
+      var iframe = document.querySelector('iframe');
+      iframe.contentDocument.body.appendChild(v);
+      v.onloadstart = t.step_func(function() { assert_unreached(); });
+      // wait for an event after the above
+      var v2 = document.createElement('video');
+      v2.src = 'data:,';
+      v2.onloadstart = t.step_func(function() { t.done(); });
+    });
+  });
+});
+</script>


### PR DESCRIPTION
In current Blink, inserting a media element with a src attribute and
networkState NETWORK_EMPTY will trigger resource selection. Normally the
src attribute and NETWORK_EMPTY don't go together, but when a media
element is moved between documents its networkState is reset. None of
this is per spec, of course.
