### PR TITLE
Test for abort and emptied events in HTMLMediaElement.load()

### DIFF
--- a/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
+++ b/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<title>load() fires abort/emptied events when networkState is not NETWORK_EMPTY</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/media.js"></script>
+<div id=log></div>
+<script>
+function load_test(t, v) {
+  assert_not_equals(v.networkState, v.NETWORK_EMPTY);
+
+  var expected_events = [];
+  if (v.networkState == v.NETWORK_LOADING || v.networkState == v.NETWORK_IDLE) {
+    expected_events.push('abort');
+  }
+  if (v.networkState != v.NETWORK_EMPTY) {
+    expected_events.push('emptied');
+  }
+
+  var actual_events = [];
+  v.onabort = v.onemptied = t.step_func(function(e) {
+    actual_events.push(e.type);
+  });
+
+  v.onloadstart = t.step_func(function() {
+    assert_array_equals(actual_events, expected_events);
+    t.done();
+  });
+
+  v.load();
+}
+async_test(function(t) {
+  var v = document.createElement('video');
+  // suspend is fired optionally "if the user agent intends to not attempt to
+  // fetch the resource" or "once the entire media resource has been fetched"
+  v.preload = 'none';
+  v.src = getAudioURI('/media/sound_5');
+  v.onsuspend = t.step_func(function() {
+    v.onsuspend = null;
+    assert_equals(v.networkState, v.NETWORK_IDLE);
+    load_test(t, v);
+  });
+}, 'NETWORK_IDLE');
+async_test(function(t) {
+  var v = document.createElement('video');
+  v.src = 'resources/delayed-broken-video.py';
+  v.onloadstart = t.step_func(function() {
+    v.onloadstart = null;
+    assert_equals(v.networkState, v.NETWORK_LOADING);
+    load_test(t, v);
+  });
+}, 'NETWORK_LOADING');
+async_test(function(t) {
+  var v = document.createElement('video');
+  v.src = 'data:,';
+  v.onerror = t.step_func(function() {
+    v.onerror = null;
+    assert_equals(v.networkState, v.NETWORK_NO_SOURCE);
+    load_test(t, v);
+  });
+  assert_equals(v.networkState, v.NETWORK_NO_SOURCE);
+}, 'NETWORK_NO_SOURCE');
+</script>

--- a/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
+++ b/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
@@ -28,6 +28,7 @@ function load_test(t, v) {
 
   v.load();
 }
+
 async_test(function(t) {
   var v = document.createElement('video');
   // suspend is fired optionally "if the user agent intends to not attempt to
@@ -40,6 +41,7 @@ async_test(function(t) {
     load_test(t, v);
   });
 }, 'NETWORK_IDLE');
+
 async_test(function(t) {
   var v = document.createElement('video');
   v.src = 'resources/delayed-broken-video.py';
@@ -49,6 +51,7 @@ async_test(function(t) {
     load_test(t, v);
   });
 }, 'NETWORK_LOADING');
+
 async_test(function(t) {
   var v = document.createElement('video');
   v.src = 'data:,';


### PR DESCRIPTION
Thanks to Revlin John who submitted a similar test:
https://github.com/w3c/web-platform-tests/pull/571

This started out as improvments to that test, but quickly morphed beyond
recognition in an attempt to provide full coverage.

There's plenty of load() left to test, but that is better left to
dedicated tests since they will require more complex setup to e.g. get
in-band text tracks or seek in the video.
