### PR TITLE
Update template contents owner tests to match spec changes

### DIFF
--- a/html-templates/definitions/template-contents-owner-test-001.html
+++ b/html-templates/definitions/template-contents-owner-test-001.html
@@ -3,7 +3,7 @@
 <head>
 <title>HTML Templates: The template contents owner document (no browsing context)</title>
 <meta name="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<meta name="assert" content="If template's enclosing document has no browsing context, it must be template contents owner">
+<meta name="assert" content="Even if template's enclosing document has no browsing context, it gets its own template contents owner">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-html-templates-20130214/#definitions">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -21,7 +21,7 @@ test(function() {
 
     doc.body.appendChild(template);
 
-    assert_equals(template.content.ownerDocument, doc, 'Wrong template content owner');
+    assert_not_equals(template.content.ownerDocument, doc, 'Wrong template content owner');
 
 }, 'Test the template contents owner document when enclosing document has '
     + 'no browsing content. Template element is created by createElement()');
@@ -35,7 +35,7 @@ test(function() {
 
     var template = doc.querySelector('template');
 
-    assert_equals(template.content.ownerDocument, doc, 'Wrong template content owner');
+    assert_not_equals(template.content.ownerDocument, doc, 'Wrong template content owner');
 
 }, 'Test the template contents owner document when enclosing document has '
     + 'no browsing content. Template element is created by innerHTML');

--- a/html-templates/template-element/node-document-changes.html
+++ b/html-templates/template-element/node-document-changes.html
@@ -21,7 +21,7 @@ test(function() {
     var template = doc1.createElement('template');
 
     assert_equals(template.ownerDocument, doc1, 'Wrong template node owner document');
-    assert_equals(template.content.ownerDocument, doc1,
+    assert_not_equals(template.content.ownerDocument, doc1,
             'Wrong template content owner document');
 
     var doc2 = newHTMLDocument();
@@ -45,7 +45,7 @@ test(function() {
 
     assert_equals(template.ownerDocument, doc1,
             'Wrong template node owner document');
-    assert_equals(template.content.ownerDocument, doc1,
+    assert_not_equals(template.content.ownerDocument, doc1,
             'Wrong template content owner document');
 
     var doc2 = newHTMLDocument();
@@ -75,14 +75,14 @@ test(function() {
     var template = doc1.querySelector('#tmpl');
 
     assert_equals(template.ownerDocument, doc1, 'Wrong template node owner document');
-    assert_equals(template.content.ownerDocument, doc1,
+    assert_not_equals(template.content.ownerDocument, doc1,
             'Wrong template content owner document');
 
     var nestedTemplate = template.content.querySelector('#tmpl2');
 
-    assert_equals(nestedTemplate.ownerDocument, doc1,
+    assert_equals(nestedTemplate.ownerDocument, template.content.ownerDocument,
             'Wrong nested template node owner document');
-    assert_equals(nestedTemplate.content.ownerDocument, doc1,
+    assert_equals(nestedTemplate.content.ownerDocument, template.content.ownerDocument,
             'Wrong nested template content owner document');
 
     var doc2 = newHTMLDocument();

--- a/html-templates/template-element/template-content-node-document.html
+++ b/html-templates/template-element/template-content-node-document.html
@@ -18,36 +18,10 @@
 test(function() {
     var doc = newHTMLDocument();
     var template = doc.createElement('template');
-
-    // document have no browsing context, therefore it is the template contents owner
-    assert_equals(template.content.ownerDocument, doc,
-            'Wrong node document of the template content attribute');
-
-}, 'Node document of the template content attribute must be template contents owner. ' +
-    'Template element created by createElement');
-
-
-test(function() {
-    var doc = newHTMLDocument();
-    doc.body.innerHTML = '<template></template>';
-    var template = doc.querySelector('template');
-
-    // document have no browsing context, therefore it is the template contents owner
-    assert_equals(template.content.ownerDocument, doc,
-            'Wrong node document of the template content attribute');
-
-}, 'Node document of the template content attribute must be template contents owner. ' +
-    'Template element created via innerHTML');
-
-
-test(function() {
-    var doc = newHTMLDocument();
-    var template = doc.createElement('template');
     var nestedTemplate = doc.createElement('template');
     template.appendChild(nestedTemplate);
 
-    // document have no browsing context, therefore it is the template contents owner
-    assert_equals(nestedTemplate.content.ownerDocument, doc,
+    assert_equals(nestedTemplate.content.ownerDocument, template.content.ownerDocument,
             'Wrong node document of the template content attribute');
 
 }, 'Node document of the template content attribute must be template contents owner. ' +
@@ -60,8 +34,7 @@ test(function() {
     var template = doc.querySelector('template');
     var nestedTemplate = template.content.querySelector('template');
 
-    // document have no browsing context, therefore it is the template contents owner
-    assert_equals(nestedTemplate.content.ownerDocument, doc,
+    assert_equals(nestedTemplate.content.ownerDocument, template.content.ownerDocument,
             'Wrong node document of the template content attribute');
 
 }, 'Node document of the template content attribute must be template contents owner. ' +


### PR DESCRIPTION
After https://github.com/w3c/html/commit/57c545df7d03f7afd60208fac35b907e3f2635cf, every template content DocumentFragment gets a new ownerDocument unless that template's ownerDocument was created for some other template (i.e., for another template in the same document or for a nested template).

See spec bug at https://www.w3.org/Bugs/Public/show_bug.cgi?id=23990 for more discussion of this change.
