### PR TITLE
Stop using /resources/media/sunflower.*

### DIFF
--- a/html/editing/dnd/media/001.xhtml
+++ b/html/editing/dnd/media/001.xhtml
@@ -18,13 +18,14 @@ function start(event)
 	draggedFrame = canvas.toDataURL('image/png');
 	event.dataTransfer.setData('text/uri-list',draggedFrame);}
 </script>
+<script src="/common/media.js"></script>
 </head>
 <body dropzone="copy string:text/uri-list" ondrop="dropIt(event)">
 <p>
 	<video draggable="true" ondragstart="start(event)" controls="true"/>
  <script>
   var video = document.querySelector('video');
-  video.src = '/resources/media/sunflower.' + (video.canPlayType('video/webm') ? 'webm' : 'mp4');
+  video.src = getVideoURI('/media/movie_5');
  </script>
 </p>
 <p>Drag video and drop it somewhere on the page. Dragged frame should be copied to the canvas below and you should see word PASS once you drop video.</p>

--- a/html/semantics/embedded-content-0/media-elements/interfaces/TextTrack/activeCues.html
+++ b/html/semantics/embedded-content-0/media-elements/interfaces/TextTrack/activeCues.html
@@ -2,6 +2,7 @@
 <title>TextTrack.activeCues</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=/common/media.js></script>
 <div id=log></div>
 <script>
 setup(function(){
@@ -98,6 +99,6 @@ test1.step(function(){
         video.play();
         test1.done();
     });
-    video.src = '/resources/media/sunflower.' + (video.canPlayType('video/webm') ? 'webm' : 'mp4');
+    video.src = getVideoURI("/media/movie_5");
 });
 </script>


### PR DESCRIPTION
The other media resources are in /media/ and it would be nice to remove
sunflower.\* from this odd location. The two modified tests didn't
actually need a moving video, the static movie_5.\* is enough.
