### PR TITLE
Test that abort and emptied events are not fired sync during load()

### DIFF
--- a/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
+++ b/html/semantics/embedded-content-0/media-elements/loading-the-media-resource/039.html
@@ -27,6 +27,8 @@ function load_test(t, v) {
   });
 
   v.load();
+
+  assert_array_equals(actual_events, [], 'events should be fired in queued tasks');
 }
 
 async_test(function(t) {


### PR DESCRIPTION
Firefox currently does, and fails the test.
