### PR TITLE
add timeout tests

### DIFF
--- a/webdriver/timeouts/find_element_test.py
+++ b/webdriver/timeouts/find_element_test.py
@@ -1,0 +1,31 @@
+# -*- mode: python; fill-column: 100; comment-column: 100; -*-
+
+import os
+import sys
+import unittest
+
+from selenium.common.exceptions import NoSuchElementException
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+import base_test
+
+
+class FindElementTest(base_test.WebDriverBaseTest):
+    def test_we_get_timed_out_by_default(self):
+        self.driver.get(self.webserver.where_is("timeouts/res/delayed-element.html"))
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_id("newDiv")
+
+    def test_we_get_timed_out_with_small_wait(self):
+        self.driver.get(self.webserver.where_is("timeouts/res/delayed-element.html"))
+        self.driver.timeouts("implicit", 10)
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element_by_id("newDiv")
+
+    def test_we_wait_for_element(self):
+        self.driver.get(self.webserver.where_is("timeouts/res/delayed-element.html"))
+        self.driver.timeouts("implicit", 10000)
+        self.driver.find_element_by_id("newDiv")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webdriver/timeouts/page_load_test.py
+++ b/webdriver/timeouts/page_load_test.py
@@ -1,0 +1,30 @@
+# -*- mode: python; fill-column: 100; comment-column: 100; -*-
+
+import os
+import sys
+import unittest
+
+from selenium.common.exceptions import TimeoutException
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+import base_test
+
+
+class PageTimeoutsTest(base_test.WebDriverBaseTest):
+    def test_pagetimeout_default_pass(self):
+        self.driver.get(self.webserver.where_is("timeouts/res/pageload.html"))
+        self.assertTrue(self.driver.execute_script("return document.readyState;"), "complete")
+
+    def test_pagetimeout_fail(self):
+        self.driver.timeouts("page load", 0)
+        with self.assertRaises(TimeoutException):
+            self.driver.get(self.webserver.where_is("timeouts/res/pageload.html"))
+
+    def test_pagetimeout_pass(self):
+        self.driver.timeouts("page load", 60000)
+        self.driver.get(self.webserver.where_is("timeouts/res/pageload.html"))
+        self.assertTrue(self.driver.execute_script("return document.readyState;"), "complete")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webdriver/timeouts/res/delayed-element.html
+++ b/webdriver/timeouts/res/delayed-element.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8" />
+  <title>Delayed Element</title>
+  <script>
+    function createElement() {
+      var newDiv = document.createElement("div");
+      newDiv.id = "newDiv";
+      var newContent = document.createTextNode("I am a newly created div!");
+      newDiv.appendChild(newContent);
+      document.body.appendChild(newDiv);
+    }
+    window.setTimeout(createElement, 3000);
+  </script>
+</head>
+<body>
+</body>

--- a/webdriver/timeouts/res/pageload.html
+++ b/webdriver/timeouts/res/pageload.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8" />
+  <title>Page Load Test</title>
+</head>
+<body>
+</body>

--- a/webdriver/timeouts/script_test.py
+++ b/webdriver/timeouts/script_test.py
@@ -1,0 +1,31 @@
+# -*- mode: python; fill-column: 100; comment-column: 100; -*-
+
+import os
+import sys
+import unittest
+
+from selenium.common.exceptions import TimeoutException
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir)))
+import base_test
+
+
+class ScriptTimeoutsTest(base_test.WebDriverBaseTest):
+    def test_default_async_timeout(self):
+        # makes sure we can call async without setting timeout first
+        self.driver.execute_async_script("arguments[arguments.length - 1]();")
+        self.driver.timeouts("script", 0)
+        self.driver.execute_async_script("arguments[arguments.length - 1]();")
+
+    def test_async_pass(self):
+        self.driver.timeouts("script", 3000)
+        self.driver.execute_async_script("window.setTimeout(function(){arguments[arguments.length - 1]();}, 500);")
+
+    def test_async_fail(self):
+        self.driver.timeouts("script", 3000)
+        with self.assertRaises(TimeoutException):
+            self.driver.execute_async_script("window.setTimeout(function(){arguments[arguments.length - 1]();}, 6000);")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
these will fail because selenium 2 doesn't support the timeouts command. To test it, feel free to replace timeouts with implicitly_wait or what not and they should all pass expect for test_async_pass and test_async_fail for reasons that are not clear to me but should work according to spec...
