### PR TITLE
using alternative method to get host ip address

### DIFF
--- a/webdriver/base_test.py
+++ b/webdriver/base_test.py
@@ -37,7 +37,7 @@ class WebDriverBaseTest(unittest.TestCase):
                 cls.driver = cls.driver_class(desired_capabilities=capabilities)
             else:
                 cls.driver = cls.driver_class()
-        cls.webserver = Httpd(host=get_lan_ip()))
+        cls.webserver = Httpd(host=get_lan_ip())
         cls.webserver.start()
 
     @classmethod

--- a/webdriver/base_test.py
+++ b/webdriver/base_test.py
@@ -2,11 +2,11 @@
 import ConfigParser
 import json
 import os
-import socket
 import unittest
 
 from webserver import Httpd
 from selenium import webdriver
+from network import get_lan_ip
 
 class WebDriverBaseTest(unittest.TestCase):
 
@@ -37,7 +37,7 @@ class WebDriverBaseTest(unittest.TestCase):
                 cls.driver = cls.driver_class(desired_capabilities=capabilities)
             else:
                 cls.driver = cls.driver_class()
-        cls.webserver = Httpd(host=socket.gethostbyname(socket.gethostname()))
+        cls.webserver = Httpd(host=get_lan_ip()))
         cls.webserver.start()
 
     @classmethod

--- a/webdriver/network.py
+++ b/webdriver/network.py
@@ -1,0 +1,30 @@
+# this comes from this stack overflow post:
+# http://stackoverflow.com/a/1947766/725944
+
+# module for getting the lan ip address of the computer
+
+import os
+import socket
+
+if os.name != "nt":
+    import fcntl
+    import struct
+    def get_interface_ip(ifname):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        return socket.inet_ntoa(fcntl.ioctl(
+                s.fileno(),
+                0x8915,  # SIOCGIFADDR
+                struct.pack('256s', ifname[:15])
+            )[20:24])
+
+def get_lan_ip():
+    ip = socket.gethostbyname(socket.gethostname())
+    if ip.startswith("127.") and os.name != "nt":
+        interfaces = ["eth0","eth1","eth2","wlan0","wlan1","wifi0","ath0","ath1","ppp0"]
+        for ifname in interfaces:
+            try:
+                ip = get_interface_ip(ifname)
+                break;
+            except IOError:
+                pass
+    return ip

--- a/webdriver/network.py
+++ b/webdriver/network.py
@@ -10,9 +10,9 @@ if os.name != "nt":
     import fcntl
     import struct
     def get_interface_ip(ifname):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sckt = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         return socket.inet_ntoa(fcntl.ioctl(
-                s.fileno(),
+                sckt.fileno(),
                 0x8915,  # SIOCGIFADDR
                 struct.pack('256s', ifname[:15])
             )[20:24])
@@ -24,7 +24,7 @@ def get_lan_ip():
         for ifname in interfaces:
             try:
                 ip = get_interface_ip(ifname)
-                break;
+                break
             except IOError:
                 pass
     return ip


### PR DESCRIPTION
works on linux too, more reliably than socket.gethostbyname(socket.gethostname()) 
