### PR TITLE
Fix a bug in overridemimetype-invalid-mime-type.htm

### DIFF
--- a/XMLHttpRequest/overridemimetype-invalid-mime-type.htm
+++ b/XMLHttpRequest/overridemimetype-invalid-mime-type.htm
@@ -12,13 +12,13 @@
     <script>
       test(function() {
         var client = new XMLHttpRequest();
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text\\plain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text plain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text\nplain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('cahrset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType(null); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType(50212); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType( (new Array(1000)).join('a/b/c/') ); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType('text\\plain;charset=Shift-JIS'); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType('text plain;charset=Shift-JIS'); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType('text\nplain;charset=Shift-JIS'); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType('cahrset=Shift-JIS'); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType(null); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType(50212); });
+        assert_throws(new TypeError(), function() { client.overrideMimeType( (new Array(1000)).join('a/b/c/') ); });
       });
     </script>
   </body>


### PR DESCRIPTION
According to the latest spec, the TypeError should be thrown, not SyntaxError.

Signed-off-by: wanghongjuan hongjuanx.wang@intel.com
