### PR TITLE
Use movie_5.* instead of movie_300.* wherever possible

### DIFF
--- a/html/semantics/embedded-content/media-elements/event_canplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplay.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplay_noautoplay.html
@@ -29,7 +29,7 @@ test(function () {
   v.addEventListener("canplay", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/event_canplaythrough.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplaythrough");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_canplaythrough_noautoplay.html
@@ -29,7 +29,7 @@ test(function() {
   v.addEventListener("canplaythrough", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplaythrough");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/event_loadeddata.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadeddata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
@@ -29,7 +29,7 @@ test(function() {
   v.addEventListener("loadeddata", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadeddata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
+++ b/html/semantics/embedded-content/media-elements/event_loadedmetadata.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   });
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadedmetadata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadedmetadata_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadedmetadata_noautoplay.html
@@ -29,7 +29,7 @@ test(function() {
   v.addEventListener("loadedmetadata", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events, loadedmetadata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadstart.html
+++ b/html/semantics/embedded-content/media-elements/event_loadstart.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadstart");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_loadstart_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadstart_noautoplay.html
@@ -29,7 +29,7 @@ test(function() {
   v.addEventListener("loadstart", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadstart");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/event_order_canplay_canplaythrough.html
@@ -45,7 +45,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay, then canplaythrough");
  </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
+++ b/html/semantics/embedded-content/media-elements/event_order_canplay_playing.html
@@ -45,7 +45,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - canplay, then playing");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/event_order_loadedmetadata_loadeddata.html
@@ -45,7 +45,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadedmetadata, then loadeddata");
  </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
+++ b/html/semantics/embedded-content/media-elements/event_order_loadstart_progress.html
@@ -45,7 +45,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadstart, then progress");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_pause.html
+++ b/html/semantics/embedded-content/media-elements/event_pause.html
@@ -41,7 +41,7 @@ test(function() {
   v.addEventListener("play", function() {
     v.pause(); // pause right after play
   });
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - pause");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_pause_noautoplay.html
@@ -31,7 +31,7 @@ test(function() {
   v.addEventListener("pause", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
   v.pause();
 }, "video events - pause");

--- a/html/semantics/embedded-content/media-elements/event_play.html
+++ b/html/semantics/embedded-content/media-elements/event_play.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - play");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_play_noautoplay.html
@@ -32,7 +32,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
 }, "video events - play");
   </script>

--- a/html/semantics/embedded-content/media-elements/event_playing.html
+++ b/html/semantics/embedded-content/media-elements/event_playing.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - playing");
  </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_playing_noautoplay.html
@@ -32,7 +32,7 @@ test(function() {
     t.done();
     v.pause();
   });
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
 }, "video events - playing");
   </script>

--- a/html/semantics/embedded-content/media-elements/event_progress.html
+++ b/html/semantics/embedded-content/media-elements/event_progress.html
@@ -31,7 +31,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - progress");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_progress_noautoplay.html
@@ -29,7 +29,7 @@ test(function() {
   v.addEventListener("progress", function() {
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - progress");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/event_timeupdate.html
+++ b/html/semantics/embedded-content/media-elements/event_timeupdate.html
@@ -28,7 +28,7 @@ v.addEventListener("timeupdate", function() {
   tv.done();
   v.pause();
 }, false);
-v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   </script>
  </body>
 </html>

--- a/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
@@ -32,7 +32,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
 }, "video events - timeupdate");
   </script>

--- a/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
+++ b/html/semantics/embedded-content/media-elements/networkState_during_loadstart.html
@@ -36,7 +36,7 @@ v.addEventListener("loadstart", function() {
   tv.done();
   v.pause();
 }, false);
-v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   </script>
  </body>
 </html>

--- a/html/semantics/embedded-content/media-elements/networkState_during_progress.html
+++ b/html/semantics/embedded-content/media-elements/networkState_during_progress.html
@@ -36,7 +36,7 @@ v.addEventListener("progress", function() {
   tv.done();
   v.pause();
 }, false);
-v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   </script>
  </body>
 </html>

--- a/html/semantics/embedded-content/media-elements/paused_false_during_play.html
+++ b/html/semantics/embedded-content/media-elements/paused_false_during_play.html
@@ -37,7 +37,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - paused property");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/paused_true_during_pause.html
+++ b/html/semantics/embedded-content/media-elements/paused_true_during_pause.html
@@ -37,7 +37,7 @@ test(function() {
     });
     t.done();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
   v.pause();
 }, "video events - paused property");

--- a/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_canplay.html
@@ -37,7 +37,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during canplay");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_canplaythrough.html
@@ -39,7 +39,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during canplaythrough");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_loadeddata.html
@@ -37,7 +37,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during loadeddata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_loadedmetadata.html
@@ -37,7 +37,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during loadedmetadata");
   </script>
  </body>

--- a/html/semantics/embedded-content/media-elements/readyState_during_playing.html
+++ b/html/semantics/embedded-content/media-elements/readyState_during_playing.html
@@ -37,7 +37,7 @@ test(function() {
     t.done();
     v.pause();
   }, false);
-  v.src = getVideoURI("/media/movie_300") + "?" + new Date() + Math.random();
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - readyState property during playing");
   </script>
  </body>


### PR DESCRIPTION
movie_5.\* is faster to load, so is preferable where possible. All of the
tests already also use audio_5.*, which are even smaller, so this ought
not to expose any new problems. None of the test descriptions seem to
indicate that a big or slow-loading resource is required.
