### PR TITLE
Add iframe support for test runner

### DIFF
--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -17,7 +17,12 @@ Include test types:<br>
 <label><input type=checkbox checked value="reftest">Reftests</label><br>
 <label><input type=checkbox checked value="manual">Manual tests</label>
 <p><label>Run tests under path <input value="/" class="path"><button class="togglePause" disabled>Pause</button><button class="toggleStart">Start</button></label>
-</header>
+
+<p>Run tests in: <label><input name="runMode" type=checkbox value="iframe">iframe</label>
+</div>
+
+<div id="runMode">
+<iframe id="testFrame"></iframe>
 </div>
 
 <div id="output">

--- a/tools/runner/runner.css
+++ b/tools/runner/runner.css
@@ -38,4 +38,5 @@ html.done section + section { border-top: none; }
 
 body > p { text-align: center; }
 body > p > textarea { width: 90%; height: 20em; }
+iframe {width: 100%; height: 400px; frameborder: no; border: 0; marginwidth: 0; marginheight: 0; }
 


### PR DESCRIPTION
This is to add test runner an optional feature of running tests in an iframe while keeping running tests in a top-level browsing context as default.
It makes the test runner work smoothly in Web Runtime, and benefits reftests and manual tests running on mobile devices by saving tab/window switching operations
