### PR TITLE
Added "webdriver" to manifest blacklist.

### DIFF
--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -13,7 +13,7 @@ import argparse
 manifest_name = "MANIFEST.json"
 exclude_php_hack = True
 ref_suffixes = ["_ref", "-ref"]
-blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/", "webdriver"]
+blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/", "/webdriver/"]
 
 logging.basicConfig()
 logger = logging.getLogger("Web platform tests")

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -13,7 +13,7 @@ import argparse
 manifest_name = "MANIFEST.json"
 exclude_php_hack = True
 ref_suffixes = ["_ref", "-ref"]
-blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/"]
+blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/", "webdriver"]
 
 logging.basicConfig()
 logger = logging.getLogger("Web platform tests")


### PR DESCRIPTION
As far as I understand, all of the tests in the webdriver subtree are not going to be testharness.js tests (but instead pretty much written in python) so we should have the runner ignore the whole subtree for now (unless/until some actual testharness.js tests are added in that subtree).
