### PR TITLE
Test playing video in a detached document

### DIFF
--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/play-in-detached-document.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/play-in-detached-document.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>play() in detached document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/media.js"></script>
+<div id="log"></div>
+<script>
+// Negative test for failure to play in a detached document.
+async_test(function(t)
+{
+  var doc = document.implementation.createHTMLDocument("");
+  var v = doc.createElement("video");
+  doc.body.appendChild(v);
+  v.src = getVideoURI("/media/movie_5");
+  v.play();
+  v.addEventListener("timeupdate", t.step_func(function() {
+    assert_false(v.paused);
+    if (v.currentTime > 0) {
+      t.done();
+    }
+  }));
+});
+</script>


### PR DESCRIPTION
Many tests don't insert the media element into a document and this
doesn't seem to be a problem. However, all of Opera 20 (Blink), Safari 7
(WebKit), Firefox 30 (Gecko) and IE11 (Trident) fail this test. Only
Opera 12.16 (Presto) passes it, but only after playing to the end; it
seems like timeupdate events aren't being fired correctly.
