### PR TITLE
Fixed incorrect type in asserts

### DIFF
--- a/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
+++ b/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
@@ -31,7 +31,7 @@ test(unit(function (ctx) {
 	var s = createSR(host);
 
 	assert_true(s.styleSheets != null, 'ShadowRoot styleSheets attribute shouldn\'t be null');
-    assert_equals(s.styleSheets.length, '0', 'attribute must return the shadow root style sheets only');
+    assert_equals(s.styleSheets.length, 0, 'attribute must return the shadow root style sheets only');
 
 }), 'A_10_01_01_05_01_T01');
 
@@ -48,7 +48,7 @@ test(unit(function (ctx) {
 	s.appendChild(style);
 
 	assert_true(s.styleSheets != null, 'ShadowRoot styleSheets attribute shouldn\'t be null');
-    assert_equals(s.styleSheets.length, '1', 'attribute must return the shadow root style sheets');
+    assert_equals(s.styleSheets.length, 1, 'attribute must return the shadow root style sheets');
 
 }), 'A_10_01_01_05_01_T02');
 </script>


### PR DESCRIPTION
Asserts were using strings instead of number for checking
styleSheets.length resulting in failing tests.
