### PR TITLE
Moved/Updated obsolete test for olderShadowRoot

### DIFF
--- a/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-014.html
+++ b/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-014.html
@@ -10,10 +10,10 @@ policies and contribution forms [3].
 -->
 <html>
 <head>
-<title>Shadow DOM Test: A_10_05_05</title>
-<link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-element">
-<meta name="assert" content="The shadow HTML element: olderShadowRoot attribute">
+<title>Shadow DOM Test: ShadowRoot olderShadowRoot</title>
+<link rel="author" title="Kenji Baheux" href="mailto:kenjibaheux@google.com">
+<link rel="help" href="http://w3c.github.io/webcomponents/spec/shadow/#widl-ShadowRoot-olderShadowRoot">
+<meta name="assert" content="The ShadowRoot element: olderShadowRoot attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -35,13 +35,12 @@ test(unit(function (ctx) {
 	var div = d.createElement('div');
 	div.innerHTML = '' +
 		'<span id="spandex">This is a shadow root content</span>' +
-		'<shadow><span id="shadowId">This is a shadow fallback content</span></shadow>';
+		'<content><span id="contentId">This is the content fallback</span></content>';
 	s.appendChild(div);
 
-	assert_equals(s.querySelector('#shadowId').olderShadowRoot, null, 'If shadow tree does not exist, ' +
-			'return null');
+	assert_equals(s.olderShadowRoot, null, 'If the context object is the oldest shadow root, return null');
 
-}), 'A_10_05_05_T01');
+}), 'ShadowRoot.olderShadowRoot_T01');
 </script>
 </body>
 </html>


### PR DESCRIPTION
The test was using olderShadowRoot on the Shadow element. This attribute
is now part of the ShadowRoot interface.
