### PR TITLE
add option to just dump JSON to a textarea

### DIFF
--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -76,7 +76,7 @@
           </div>
         </div>
         <div class="form-group">
-          <label for="dumpit" class="col-sm-3 control-label">Dump JSON</label>
+          <label for="dumpit" class="col-sm-3 control-label">Dump JSON (debug)</label>
           <div class="col-sm-9">
             <input type=checkbox id='dumpit'>
           </div>

--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -78,7 +78,7 @@
         <div class="form-group">
           <label for="dumpit" class="col-sm-3 control-label">Dump JSON</label>
           <div class="col-sm-9">
-            <input type=checkbox value="yeah ok" id='dumpit'>
+            <input type=checkbox id='dumpit'>
           </div>
         </div>
         <div class="form-group" style='padding-top: 20px'>

--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -54,25 +54,31 @@
         <div class="form-group">
           <label for="th" class="col-sm-3 control-label">JavaScript tests</label>
           <div class="col-sm-9">
-            <input type=checkbox checked value="testharness" id='th'>
+            <input type=checkbox checked value="testharness" id='th' class='test-type'>
           </div>
         </div>
         <div class="form-group">
           <label for="ref" class="col-sm-3 control-label">Reference tests</label>
           <div class="col-sm-9">
-            <input type=checkbox checked value="reftest" id='ref'>
+            <input type=checkbox checked value="reftest" id='ref' class='test-type'>
           </div>
         </div>
         <div class="form-group">
           <label for="man" class="col-sm-3 control-label">Manual tests</label>
           <div class="col-sm-9">
-            <input type=checkbox checked value="manual" id='man'>
+            <input type=checkbox checked value="manual" id='man' class='test-type'>
           </div>
         </div>
         <div class="form-group">
           <label for="path" class="col-sm-3 control-label">Run tests under path</label>
           <div class="col-sm-9">
             <input value="/" id='path' class='path form-control' disabled>
+          </div>
+        </div>
+        <div class="form-group">
+          <label for="dumpit" class="col-sm-3 control-label">Dump JSON</label>
+          <div class="col-sm-9">
+            <input type=checkbox value="yeah ok" id='dumpit'>
           </div>
         </div>
         <div class="form-group" style='padding-top: 20px'>

--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -192,7 +192,9 @@ VisualOutput.prototype = {
         var a = this.elem.querySelector(".jsonResults");
         var json = this.runner.results.to_json();
         var ta = this.elem.querySelector("textarea");
-        if (ta) ta.parentNode.removeChild(ta);
+        if (ta) {
+            ta.parentNode.removeChild(ta);
+        }
         if (document.getElementById("dumpit").checked) {
             ta = document.createElement("textarea");
             ta.style.width = "100%";

--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -190,7 +190,17 @@ VisualOutput.prototype = {
         this.meter.classList.remove("progress-striped", "active");
         //add the json serialization of the results
         var a = this.elem.querySelector(".jsonResults");
-        var blob = new Blob([this.runner.results.to_json()], { type: "application/json" });
+        var json = this.runner.results.to_json();
+        var ta = this.elem.querySelector("textarea");
+        if (ta) ta.parentNode.removeChild(ta);
+        if (document.getElementById("dumpit").checked) {
+            ta = document.createElement("textarea");
+            ta.style.width = "100%";
+            ta.setAttribute("rows", "50");
+            this.elem.appendChild(ta);
+            ta.textContent = json;
+        }
+        var blob = new Blob([json], { type: "application/json" });
         a.href = window.URL.createObjectURL(blob);
         a.download = "runner-results.json";
         a.textContent = "Download JSON results";
@@ -309,7 +319,7 @@ function TestControl(elem, runner) {
     this.pause_button = this.elem.querySelector("button.togglePause");
     this.start_button = this.elem.querySelector("button.toggleStart");
     this.type_checkboxes = Array.prototype.slice.call(
-        this.elem.querySelectorAll("input[type=checkbox]"));
+        this.elem.querySelectorAll("input[type=checkbox].test-type"));
     this.runner = runner;
     this.runner.done_callbacks.push(this.on_done.bind(this));
     this.set_start();


### PR DESCRIPTION
This adds a runner option to have the JSON dumped to a big textarea. It is meant as a last recourse option when that's the only way that any JSON will get produced by the tool.
