### PR TITLE
Do not try to have the runner window on top

### DIFF
--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -476,7 +476,6 @@ Runner.prototype = {
 
     open_test_window: function() {
         this.test_window = window.open("about:blank", 800, 600);
-        window.focus();
     },
 
     manifest_loaded: function() {


### PR DESCRIPTION
WebKit will strongly throttle what happens in windows that are not the foreground
one. This in turn causes a lot of tests to fail. This window.focus() was largely
ineffective anyway, and were it to work for Safari it would actively break the
results.
