### PR TITLE
Remove bogus assertion from IndexedDB invalid key test

### DIFF
--- a/IndexedDB/key_invalid.htm
+++ b/IndexedDB/key_invalid.htm
@@ -23,7 +23,6 @@
         // set the current test, and run it
         db.setTest(t).onupgradeneeded = function(e) {
             objStore = objStore || e.target.result.createObjectStore("store");
-            try { objStore.add("value", key); } catch(e) { assert_unreached(e); };
             assert_throws('DataError', function() {
                 objStore.add("value", key);
             });


### PR DESCRIPTION
The test case is asserting that get() with an invalid key doesn't throw, which defeats the purpose of the test since it is expected to throw. It's followed by a correct assertion, which is just getting skipped.
