### PR TITLE
Correct IndexedDB test issues

### DIFF
--- a/IndexedDB/idbdatabase_close2.htm
+++ b/IndexedDB/idbdatabase_close2.htm
@@ -15,7 +15,7 @@ open_rq.onupgradeneeded = function() {}
 open_rq.onsuccess = function(e) {
     db = e.target.result;
 
-    var rq = window.indexedDB.deleteDatabase(databaseName);
+    var rq = window.indexedDB.deleteDatabase(db.name);
     rq.onblocked = t.step_func(function (e) {
         blocked_fired = true;
         db.close();

--- a/IndexedDB/idbdatabase_close2.htm
+++ b/IndexedDB/idbdatabase_close2.htm
@@ -8,12 +8,17 @@
 
 var db;
 var blocked_fired = false;
+var versionchange_fired = false;
 var t = async_test();
 var open_rq = createdb(t);
 
-open_rq.onupgradeneeded = function() {}
-open_rq.onsuccess = function(e) {
+open_rq.onupgradeneeded = t.step_func(function() {});
+open_rq.onsuccess = t.step_func(function(e) {
     db = e.target.result;
+
+    db.onversionchange = t.step_func(function (e) {
+      versionchange_fired = true;
+    });
 
     var rq = window.indexedDB.deleteDatabase(db.name);
     rq.onblocked = t.step_func(function (e) {
@@ -21,11 +26,12 @@ open_rq.onsuccess = function(e) {
         db.close();
     });
     rq.onsuccess = t.step_func(function (e) {
+        assert_true(versionchange_fired, "versionchange event fired")
         assert_true(blocked_fired, "block event fired")
         t.done();
     });
     rq.onerror = fail(t, 'Unexpected database deletion error');
-};
+});
 
 </script>
 

--- a/IndexedDB/idbdatabase_createObjectStore9-invalidparameters.htm
+++ b/IndexedDB/idbdatabase_createObjectStore9-invalidparameters.htm
@@ -10,7 +10,7 @@
         var t = async_test(document.title + " - " + desc);
 
         createdb(t).onupgradeneeded = function(e) {
-            assert_throws('InvalidAccessError', function() {
+            assert_throws(null, function() {
                 e.target.result.createObjectStore("store", params);
             });
 
@@ -26,5 +26,3 @@
 </script>
 
 <div id=log></div>
-
-<p>XXX: Ordering is not defined for all of these, so it should be updated when <a href=https://www.w3.org/Bugs/Public/show_bug.cgi?id=17681>bug 17681</a> is resolved.

--- a/IndexedDB/idbindex-multientry-big.htm
+++ b/IndexedDB/idbindex-multientry-big.htm
@@ -10,46 +10,48 @@
 <script>
     var db,
         t_add = async_test("Adding one item with 1000 multiEntry keys", { timeout: 10000 }),
-        t_get = async_test("Getting the one item by 1000 indeced keys ", { timeout: 10000 })
+        t_get = async_test("Getting the one item by 1000 indeced keys ", { timeout: 10000 });
 
-    var open_rq = createdb(t_add)
-    var obj = { test: 'yo', idxkeys: [] }
+    var open_rq = createdb(t_add);
+    var obj = { test: 'yo', idxkeys: [] };
 
     for (var i = 0; i < 1000; i++)
-        obj.idxkeys.push('index_no_' + i)
+        obj.idxkeys.push('index_no_' + i);
 
 
     open_rq.onupgradeneeded = function(e) {
-        db = e.target.result
+        db = e.target.result;
 
         db.createObjectStore('store')
-          .createIndex('index', 'idxkeys', { multiEntry: true })
-    }
+          .createIndex('index', 'idxkeys', { multiEntry: true });
+    };
     open_rq.onsuccess = function(e) {
-        db.transaction('store', 'readwrite')
-          .objectStore('store')
+        var tx = db.transaction('store', 'readwrite');
+        tx.objectStore('store')
           .put(obj, 1)
           .onsuccess = t_add.step_func(function(e)
         {
-            assert_equals(e.target.result, 1, "put'd key")
-            this.done()
-        })
-
-        var idx = db.transaction('store').objectStore('store').index('index')
-
-        for (var i = 0; i < 1000; i++)
-        {
-            idx.get('index_no_' + i).onsuccess = t_get.step_func(function(e) {
-                assert_equals(e.target.result.test, "yo")
-            })
-        }
-
-        idx.get('index_no_999').onsuccess = t_get.step_func(function(e) {
-            assert_equals(e.target.result.test, "yo")
-            assert_equals(e.target.result.idxkeys.length, 1000)
+            assert_equals(e.target.result, 1, "put'd key");
             this.done();
-        })
-    }
+        });
+
+        tx.oncomplete = t_get.step_func(function() {
+            var idx = db.transaction('store').objectStore('store').index('index')
+
+            for (var i = 0; i < 1000; i++)
+            {
+                idx.get('index_no_' + i).onsuccess = t_get.step_func(function(e) {
+                    assert_equals(e.target.result.test, "yo");
+                });
+            }
+
+            idx.get('index_no_999').onsuccess = t_get.step_func(function(e) {
+                assert_equals(e.target.result.test, "yo");
+                assert_equals(e.target.result.idxkeys.length, 1000);
+                this.done();
+            });
+        });
+    };
 </script>
 
 <div id="log"></div>

--- a/IndexedDB/idbobjectstore_createIndex6-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex6-event_order.htm
@@ -53,7 +53,7 @@
                                        "transaction.abort: ConstraintError",
                                        "db.abort: ConstraintError",
 
-                                       "open_rq.error: ConstraintError" ],
+                                       "open_rq.error: AbortError" ],
                             "events");
         t.done();
     }


### PR DESCRIPTION
This contains fixes for:

idbdatabase_close2.htm -  test assumed no versionchange, spec requires it
idbdatabase_createObjectStore9-invalidparameters.htm - was assuming exception priority (unspecified)
idbindex-multientry-big.htm - was assuming transaction sequencing (spec allows UA flexibility)
idbobjectstore_createIndex6-event_order.htm - correct expected exception type per spec
