### PR TITLE
Add test-case that if both types of custom element types are provided at...

### DIFF
--- a/custom-elements/custom-element-lifecycle/types-of-callbacks/dettached-callback-test.html
+++ b/custom-elements/custom-element-lifecycle/types-of-callbacks/dettached-callback-test.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Attached callback of a custom element should be called </title>
+<meta name="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
+<meta name="assert" content="attached callback ... must be enqueued whenever custom element is inserted into a document and this document has a browsing context.">
+<link rel="help" href="http://www.w3.org/TR/custom-elements/#types-of-callbacks">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+</head>
+<body>
+<div id="log"></div>
+<script type="text/javascript">
+test(function() {
+    var doc = newHTMLDocument();
+    var proto = newHTMLElementPrototype();
+    var GeneratedConstructor = doc.registerElement('x-a', {prototype: proto});
+    var customElement = new GeneratedConstructor();
+    assert_equals(proto.attachedCallbackCalledCounter, 0, 'Callback attached ' +
+        'should not be called in documents that do not have a browsing context');
+}, 'Test attached callback if custom element is instantiated via constructor. ' +
+    'Document has no browsing context');
+
+
+test(function() {
+    var doc = newHTMLDocument();
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-b', {prototype: proto});
+    doc.body.innerHTML = '<x-b></x-b>';
+    assert_equals(proto.attachedCallbackCalledCounter, 0, 'Callback attached ' +
+        'should not be called in documents that do not have a browsing context');
+}, 'Test attached callback if custom element is created via innerHTML property. ' +
+    'Document has no browsing context');
+
+
+test(function() {
+    var doc = newHTMLDocument();
+    doc.body.innerHTML = '<x-c></x-c>';
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-c', {prototype: proto});
+    assert_equals(proto.attachedCallbackCalledCounter, 0, 'Callback attached ' +
+        'should not be called in documents that do not have a browsing context');
+}, 'Test attached callback if custom element is created via innerHTML property before ' +
+    'registration. Document has no browsing context');
+
+
+test(function() {
+    var doc = newHTMLDocument();
+    doc.body.innerHTML = '<x-d id="x-d"></x-d>';
+    var customElement = doc.querySelector('#x-d');
+
+    var proto = newHTMLElementPrototype();
+    var GeneratedConstructor = doc.registerElement('x-d', {prototype: proto});
+
+    customElement.constructor.prototype = proto;
+    assert_equals(proto.attachedCallbackCalledCounter, 0, 'Callback attached should ' +
+        'not be called for unregistered custom element in document without browsing context');
+}, 'Test attached callback if custom element is unregistered');
+
+
+testInIFrame('../../resources/x-element.html', function(doc) {
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-element', {prototype: proto});
+    assert_equals(proto.attachedCallbackCalledCounter, 1, 'Callback attached should be ' +
+        'called in documents with browsing context');
+}, 'Test attached callback. Document has browsing context');
+
+
+testInIFrame('../../resources/blank.html', function(doc) {
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-element', {prototype: proto});
+
+    var x = doc.createElement('x-element');
+    assert_equals(proto.attachedCallbackCalledCounter, 0, 'Callback attached should not ' +
+        'be called before element is added to document with browsing context');
+
+    doc.body.appendChild(x);
+    assert_equals(proto.attachedCallbackCalledCounter, 1, 'Callback attached should be called ' +
+        'in documents with browsing context');
+}, 'Test attached callback. Registered element is created via document.createElement(). ' +
+    'Document has browsing context');
+
+
+testInIFrame('../../resources/blank.html', function(doc) {
+    var x = doc.createElement('x-element');
+    doc.body.appendChild(x);
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-element', {prototype: proto});
+    assert_equals(proto.attachedCallbackCalledCounter, 1, 'Callback attached should ' +
+        'be called in documents with browsing context');
+}, 'Test attached callback. Unregistered element is created via document.createElement(). ' +
+    'Document has browsing context');
+
+
+testInIFrame('../../resources/blank.html', function(doc) {
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-element', {prototype: proto});
+    doc.body.innerHTML = '<x-element></x-element>';
+    assert_equals(proto.attachedCallbackCalledCounter, 1, 'Callback attached should ' +
+        'be called in documents with browsing context');
+}, 'Test attached callback. Registered element is created via innerHTML property. ' +
+    'Document has browsing context');
+
+
+testInIFrame('../../resources/blank.html', function(doc) {
+    doc.body.innerHTML = '<x-element></x-element>';
+    var proto = newHTMLElementPrototype();
+    doc.registerElement('x-element', {prototype: proto});
+    assert_equals(proto.attachedCallbackCalledCounter, 1, 'Callback attached should ' +
+        'be called in documents with browsing context');
+}, 'Test attached callback. Unresolved element is created via innerHTML property. ' +
+    'Document has browsing context');
+</script>
+</body>
+</html>

--- a/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
+++ b/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>When an HTML Document is loaded in a browsing context, a new registry must be created and associated with this document</title>
+<meta name="author" title="Bon-Yong Lee" href="mailto:bylee78@gmail.com">
+<meta name="assert" content="If both types of custom element types are provided at the time of element's instantiation, the custom tag must win over the type extension.">
+<link rel="help" href="http://www.w3.org/TR/custom-elements/#instantiating-custom-elements">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+</head>
+<body>
+<div id="log"></div>
+<script type="text/javascript">
+test(function() {
+	var Tag = document.registerElement( 'custom-tags' );
+	var Extension= document.registerElement( 'type-extensions', {
+		prototype: Object.create( HTMLButtonElement.prototype ),
+		extends: 'button'
+	} );
+	var instance = document.createElement( 'custom-tags', 'custom-button' );
+	assert_true( instance instanceof Tag );
+
+}, 'If both types of custom element types are provided at the time of element\'s instantiation, the custom tag must win over the type extension. ');
+</script>
+</body>
+</html>

--- a/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
+++ b/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
@@ -19,8 +19,8 @@ test(function() {
 		prototype: Object.create( HTMLButtonElement.prototype ),
 		extends: 'button'
 	} );
-	var instance = document.createElement( 'custom-tags', 'custom-button' );
-	assert_true( instance instanceof Tag );
+	var instance = document.createElement( 'custom-tags', 'type-extensions' );
+	assert_true( instance instanceof Tag, 'A custom-tags wins a type-extensions' );
 
 }, 'If both types of custom element types are provided at the time of element\'s instantiation, the custom tag must win over the type extension. ');
 </script>

--- a/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
+++ b/custom-elements/instantiating-custom-elements/custom-tags-wins-type-extensions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>When an HTML Document is loaded in a browsing context, a new registry must be created and associated with this document</title>
+<title>A custom tag prior to a type extension</title>
 <meta name="author" title="Bon-Yong Lee" href="mailto:bylee78@gmail.com">
 <meta name="assert" content="If both types of custom element types are provided at the time of element's instantiation, the custom tag must win over the type extension.">
 <link rel="help" href="http://www.w3.org/TR/custom-elements/#instantiating-custom-elements">


### PR DESCRIPTION
Add test-case that if both types of custom element types are provided at the time of element's instantiation, the custom tag must win over the type extension.
