### PR TITLE
IndexedDB support: Make fail() output clearer if request is still pending

### DIFF
--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -46,7 +46,7 @@ function fail(test, desc) {
             assert_unreached(desc + " (" + e.target.error.name + ": " + e.message + ")");
         else if (e && e.message)
             assert_unreached(desc + " (" + e.message + ")");
-        else if (e && e.target.error)
+        else if (e && e.target.readyState === 'done' && e.target.error)
             assert_unreached(desc + " (" + e.target.error.name + ")");
         else
             assert_unreached(desc);


### PR DESCRIPTION
If the `fail()` event listener is triggered due to an unexpected event, it peeks at `e.target.error` to see if that value would be a good thing to report. But if `e.target` is a request and the request's `readyState` is `'pending'`, accessing `.error` will throw, making `fail()` give unhelpful output.

So check `e.target.readyState` before accessing `e.target.error`
