### PR TITLE
Fix worker onerror tests to catch window.onerror; expect 5 arguments; ex...

### DIFF
--- a/workers/semantics/reporting-errors/001.html
+++ b/workers/semantics/reporting-errors/001.html
@@ -40,7 +40,7 @@ onconnect = function (e) {
 setup({allow_uncaught_exception:true});
 async_test(function() {
   window.onerror = this.step_func(function(a) {
-    assert_unreached('window.onerror invoked: '+a);
+    assert_unreached('window.onerror invoked: ' + a);
   });
   var worker = new SharedWorker('#', '');
   worker.port.onmessage = this.step_func_done(function(e) {

--- a/workers/semantics/reporting-errors/001.html
+++ b/workers/semantics/reporting-errors/001.html
@@ -1,13 +1,15 @@
 <!--
 var port;
-onerror = function(a,b,c,d) {
+var timeout;
+onerror = function(a,b,c,d,e) {
   // will return undefined, thus the error is "not handled"
   // so error should be reported to the user, but this test doesn't check
   // that.
-  // just make sure that this method is invoked with four arguments
+  // just make sure that this method is invoked with five arguments
+  clearTimeout(timeout);
   var log = '';
-  if (arguments.length != 4)
-    log += 'got ' + arguments.length + ' arguments, expected 4. ';
+  if (arguments.length != 5)
+    log += 'got ' + arguments.length + ' arguments, expected 5. ';
   if (typeof a != 'string')
     log += 'first argument wasn\'t a string. ';
   if (b != location.href)
@@ -16,11 +18,14 @@ onerror = function(a,b,c,d) {
     log += 'third argument wasn\'t a number. ';
   if (typeof d != 'number')
     log += 'fourth argument wasn\'t a number. ';
+  if (e != 42)
+    log += 'fifth argument wasn\'t the thrown exception. ';
   port.postMessage(log);
 }
 onconnect = function (e) {
   port = e.ports[0];
-  y(); // will "report the error"
+  timeout = setTimeout(function() { port.postMessage('self.onerror was not invoked'); }, 0);
+  throw 42; // will "report the error"
 }
 
 
@@ -32,11 +37,14 @@ onconnect = function (e) {
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({allow_uncaught_exception:true});
 async_test(function() {
+  window.onerror = this.step_func(function(a) {
+    assert_unreached('window.onerror invoked: '+a);
+  });
   var worker = new SharedWorker('#', '');
-  worker.port.onmessage = this.step_func(function(e) {
+  worker.port.onmessage = this.step_func_done(function(e) {
     assert_equals(e.data, '');
-    this.done();
   });
 });
 </script>

--- a/workers/semantics/reporting-errors/001.html
+++ b/workers/semantics/reporting-errors/001.html
@@ -24,7 +24,7 @@ onerror = function(a,b,c,d,e) {
 }
 onconnect = function (e) {
   port = e.ports[0];
-  timeout = setTimeout(function() { port.postMessage('self.onerror was not invoked'); }, 0);
+  timeout = setTimeout(function() { port.postMessage('self.onerror was not invoked'); }, 250);
   throw 42; // will "report the error"
 }
 

--- a/workers/semantics/reporting-errors/002.html
+++ b/workers/semantics/reporting-errors/002.html
@@ -46,7 +46,7 @@ onconnect = function (e) {
 setup({allow_uncaught_exception:true});
 async_test(function() {
   window.onerror = this.step_func(function(a) {
-    assert_unreached('window.onerror invoked: '+a);
+    assert_unreached('window.onerror invoked: ' + a);
   });
   var worker = new SharedWorker('#', '');
   worker.port.onmessage = this.step_func_done(function(e) {

--- a/workers/semantics/reporting-errors/002.html
+++ b/workers/semantics/reporting-errors/002.html
@@ -1,16 +1,37 @@
 <!--
 var port;
-addEventListener('error', function() {
-  // this function is not the .onerror function, so won't be invoked as
-  // part of "report the error". thus the error will be "not handled"
-  // and should be reported to the user, but this test doesn't check that
-  // make sure that this function doesn't run at all
-  port.postMessage('error event');
+var timeout;
+addEventListener('error', function(e) {
+  // event is not canceled, thus the error is "not handled"
+  // so error should be reported to the user, but this test doesn't check
+  // that.
+  // just make sure that this event has the right properties
+  clearTimeout(timeout);
+  var log = '';
+  if (!self.ErrorEvent || Object.getPrototypeOf(e) != ErrorEvent.prototype)
+    log += 'event should be an ErrorEvent. ';
+  if (e.bubbles)
+    log += 'event should not bubble. ';
+  if (!e.cancelable)
+    log += 'event should be cancelable. ';
+  if (!e.isTrusted)
+    log += 'event should be trusted. ';
+  if (typeof e.message != 'string')
+    log += 'message wasn\'t a string. ';
+  if (e.filename != location.href)
+    log += 'filename was ' + e.filename + ', expected ' + location.href + '. ';
+  if (typeof e.lineno != 'number')
+    log += 'lineno wasn\'t a number. ';
+  if (typeof e.colno != 'number')
+    log += 'colno argument wasn\'t a number. ';
+  if (e.error != 42)
+    log += 'fifth argument wasn\'t the thrown exception. ';
+  port.postMessage(log);
 }, false);
 onconnect = function (e) {
   port = e.ports[0];
-  port.postMessage('control');
-  y(); // will "report the error"
+  timeout = setTimeout(function() { port.postMessage('No error event fired'); }, 0);
+  throw 42; // will "report the error"
 }
 
 
@@ -22,17 +43,15 @@ onconnect = function (e) {
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({allow_uncaught_exception:true});
 async_test(function() {
-  var worker = new SharedWorker('#', '');
-  var i = 0;
-  worker.port.onmessage = this.step_func(function(e) {
-    i++;
-    assert_equals(e.data, 'control');
+  window.onerror = this.step_func(function(a) {
+    assert_unreached('window.onerror invoked: '+a);
   });
-  setTimeout(this.step_func(function() {
-    assert_equals(i, 1, 'number of message events');
-    this.done();
-  }), 100);
+  var worker = new SharedWorker('#', '');
+  worker.port.onmessage = this.step_func_done(function(e) {
+    assert_equals(e.data, '');
+  });
 });
 </script>
 <!--

--- a/workers/semantics/reporting-errors/002.html
+++ b/workers/semantics/reporting-errors/002.html
@@ -30,7 +30,7 @@ addEventListener('error', function(e) {
 }, false);
 onconnect = function (e) {
   port = e.ports[0];
-  timeout = setTimeout(function() { port.postMessage('No error event fired'); }, 0);
+  timeout = setTimeout(function() { port.postMessage('No error event fired'); }, 250);
   throw 42; // will "report the error"
 }
 

--- a/workers/semantics/reporting-errors/003.html
+++ b/workers/semantics/reporting-errors/003.html
@@ -20,7 +20,7 @@ onconnect = function (e) {
 setup({allow_uncaught_exception:true});
 async_test(function() {
   window.onerror = this.step_func(function(a) {
-    assert_unreached('window.onerror invoked: '+a);
+    assert_unreached('window.onerror invoked: ' + a);
   });
   var worker = new SharedWorker('#', '');
   worker.addEventListener('error', this.step_func(function(e) {

--- a/workers/semantics/reporting-errors/003.html
+++ b/workers/semantics/reporting-errors/003.html
@@ -1,6 +1,6 @@
 <!--
 onconnect = function (e) {
-  setTimeout(function() { e.ports[0].postMessage(''); }, 50);
+  setTimeout(function() { e.ports[0].postMessage(''); }, 250);
   y(); // will "report the error"
   // onerror is null so it'll be "not handled", and the error should be
   // reported to the user, although we don't test that here

--- a/workers/semantics/reporting-errors/003.html
+++ b/workers/semantics/reporting-errors/003.html
@@ -1,5 +1,6 @@
 <!--
 onconnect = function (e) {
+  setTimeout(function() { e.ports[0].postMessage(''); }, 50);
   y(); // will "report the error"
   // onerror is null so it'll be "not handled", and the error should be
   // reported to the user, although we don't test that here
@@ -16,7 +17,11 @@ onconnect = function (e) {
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
+setup({allow_uncaught_exception:true});
 async_test(function() {
+  window.onerror = this.step_func(function(a) {
+    assert_unreached('window.onerror invoked: '+a);
+  });
   var worker = new SharedWorker('#', '');
   worker.addEventListener('error', this.step_func(function(e) {
     assert_unreached('error on worker');
@@ -24,9 +29,9 @@ async_test(function() {
   worker.port.addEventListener('error', this.step_func(function(e) {
     assert_unreached('error on port');
   }), false);
-  setTimeout(this.step_func(function() {
-    this.done();
-  }), 500);
+  worker.port.onmessage = this.step_func_done(function(e) {
+    assert_equals(e.data, '');
+  });
 });
 </script>
 <!--

--- a/workers/semantics/reporting-errors/004-1.html
+++ b/workers/semantics/reporting-errors/004-1.html
@@ -2,7 +2,7 @@
 <script>
 parent.t.step(function() {
   window.onerror = this.step_func(function(a) {
-    assert_unreached('(inner) window.onerror invoked: '+a);
+    assert_unreached('(inner) window.onerror invoked: ' + a);
   });
   var worker = new SharedWorker('004.html#', '');
   worker.addEventListener('error', this.step_func(function(e) {

--- a/workers/semantics/reporting-errors/004-1.html
+++ b/workers/semantics/reporting-errors/004-1.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<script>
+parent.t.step(function() {
+  window.onerror = this.step_func(function(a) {
+    assert_unreached('(inner) window.onerror invoked: '+a);
+  });
+  var worker = new SharedWorker('004.html#', '');
+  worker.addEventListener('error', this.step_func(function(e) {
+    parent.assert_unreached('(inner) error on worker');
+  }), false);
+  worker.port.addEventListener('error', this.step_func(function(e) {
+    parent.assert_unreached('(inner) error on port');
+  }), false);
+  worker.port.onmessage = this.step_func_done(function(e) {
+    parent.assert_equals(e.data, 2);
+  });
+});
+</script>

--- a/workers/semantics/reporting-errors/004.html
+++ b/workers/semantics/reporting-errors/004.html
@@ -1,0 +1,39 @@
+<!--
+var i = 0;
+onconnect = function (e) {
+  i++;
+  setTimeout(function() { e.ports[0].postMessage(i); }, 10);
+  y(); // will "report the error"
+}
+
+/*
+-->
+<!doctype html>
+<title>shared worker in two documents and window.onerror</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+setup({allow_uncaught_exception:true});
+var t = async_test(function() {
+  window.onerror = this.step_func(function(a) {
+    assert_unreached('(outer) window.onerror invoked: '+a);
+  });
+  var worker = new SharedWorker('#', '');
+  worker.addEventListener('error', this.step_func(function(e) {
+    assert_unreached('(outer) error on worker');
+  }), false);
+  worker.port.addEventListener('error', this.step_func(function(e) {
+    assert_unreached('(outer) error on port');
+  }), false);
+  worker.port.onmessage = this.step_func(function(e) {
+    assert_equals(e.data, 1);
+    var iframe = document.createElement('iframe');
+    iframe.src = '004-1.html';
+    document.body.appendChild(iframe);
+  });
+});
+</script>
+<!--
+*/
+//-->

--- a/workers/semantics/reporting-errors/004.html
+++ b/workers/semantics/reporting-errors/004.html
@@ -17,7 +17,7 @@ onconnect = function (e) {
 setup({allow_uncaught_exception:true});
 var t = async_test(function() {
   window.onerror = this.step_func(function(a) {
-    assert_unreached('(outer) window.onerror invoked: '+a);
+    assert_unreached('(outer) window.onerror invoked: ' + a);
   });
   var worker = new SharedWorker('#', '');
   worker.addEventListener('error', this.step_func(function(e) {

--- a/workers/semantics/reporting-errors/004.html
+++ b/workers/semantics/reporting-errors/004.html
@@ -2,7 +2,7 @@
 var i = 0;
 onconnect = function (e) {
   i++;
-  setTimeout(function() { e.ports[0].postMessage(i); }, 10);
+  setTimeout(function() { e.ports[0].postMessage(i); }, 250);
   y(); // will "report the error"
 }
 


### PR DESCRIPTION
...pect addEventListener to work; add a new test involving two documents.
