### PR TITLE
evaluate assertions immediately after xhr.abort()

### DIFF
--- a/XMLHttpRequest/abort-event-order.htm
+++ b/XMLHttpRequest/abort-event-order.htm
@@ -33,13 +33,14 @@
                     if (readyState == 1)
                     {
                         xhr.abort();
+                        VerifyResult();
                     }else{
                         assert_unreached('Loadstart event should not fire in readyState '+readyState);
                     }
                 });
             };
 
-            xhr.onloadend          = function(e){ actual.push(e.type); VerifyResult(); };
+            xhr.onloadend          = function(e){ actual.push(e.type); };
             xhr.onabort            = function(e){ actual.push(e.type); };
 
             xhr.upload.onloadend   = function(e){ actual.push("upload." + e.type); };
@@ -50,12 +51,8 @@
                 test.step(function()
                 {
                     assert_array_equals(actual, expect);
-                    setTimeout(function() {
-                      test.step(function() {
-                        assert_equals(xhr.readyState, 0, 'state should be UNSENT');
-                        test.done();
-                      });
-                    });
+                    assert_equals(xhr.readyState, 0, 'state should be UNSENT');
+                    test.done();
                 });
             };
 


### PR DESCRIPTION
Anne has made a good point that it's more appropriate to perform assertions
here, rather than in one of the other event listeners, because
XMLHttpRequest#abort() should be synchronous, and the abort and loadend events
are dispatched synchronously.

So, this simplifies the test and avoids relying on setTimeout(), which is
nice, and potentially avoids missing assertions in non-compliant browsers.
