### PR TITLE
Test should be for compliance with actual spec

### DIFF
--- a/XMLHttpRequest/setrequestheader-bogus-name.htm
+++ b/XMLHttpRequest/setrequestheader-bogus-name.htm
@@ -15,7 +15,8 @@
           var client = new XMLHttpRequest()
           client.open("GET", "...")
           // Per https://www.w3.org/Bugs/Public/show_bug.cgi?id=23346 TypeError is the right error for this test.
-          assert_throws(new TypeError(), function() { client.setRequestHeader(name, 'x-value') })
+          // However, the literature currently specifies that SyntaxError is thrown
+          assert_throws(new SyntaxError(), function() { client.setRequestHeader(name, 'x-value') })
         })
       }
       try_name("")


### PR DESCRIPTION
Though the specification may change in the future, the current literature says to throw a SyntaxError here.

Since these tests verify that a user agent complies with the actual literature, and not a proposed future literature, it is appropriate to assert that the thrown assertion is a SyntaxError rather than a TypeError, for the time being.
