### PR TITLE
Only prefix url with `resources/` if not in a worker context

### DIFF
--- a/XMLHttpRequest/resources/xmlhttprequest-timeout.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout.js
@@ -21,7 +21,7 @@ var TIME_DELAY = 200;
 /*
  * This should point to a resource that responds with a text/plain resource after a delay of TIME_XHR_LOAD milliseconds.
  */
-var STALLED_REQUEST_URL = "resources/delay.py?ms=" + (TIME_XHR_LOAD);
+var STALLED_REQUEST_URL = "delay.py?ms=" + (TIME_XHR_LOAD);
 
 var inWorker = false;
 try {
@@ -29,6 +29,9 @@ try {
 } catch (e) {
   inWorker = true;
 }
+
+if (!inWorker)
+  STALLED_REQUEST_URL = "resources/" + STALLED_REQUEST_URL;
 
 function message(obj) {
   if (inWorker)


### PR DESCRIPTION
Workers base url is already in the resources directory, so you resolve the url
incorrectly if it is prefixed with "resources/".

Good news, this gets the test passing in Gecko, Blink and Safari.

Closes #975
