### PR TITLE
Fix XHR tests following whatwg/fetch@c103d09

### DIFF
--- a/XMLHttpRequest/send-entity-body-get-head-async.htm
+++ b/XMLHttpRequest/send-entity-body-get-head-async.htm
@@ -23,7 +23,13 @@
         client.upload.addEventListener('loadstart', logEvt)
         client.addEventListener('loadend', function(){
           test.step(function(){
-            assert_equals(client.getResponseHeader("x-request-content-length"), "NO")
+            if (method === "HEAD") {
+              // Fetch 4.4.3 --- Set Content-Length to 0 if method is HEAD and
+              // request's body is null.
+              assert_equals(client.getResponseHeader("x-request-content-length"), "0")
+            } else {
+              assert_equals(client.getResponseHeader("x-request-content-length"), "NO")
+            }
             assert_equals(client.getResponseHeader("x-request-method"), method)
             assert_equals(client.responseText, "")
             assert_array_equals(events, [])

--- a/XMLHttpRequest/send-entity-body-get-head.htm
+++ b/XMLHttpRequest/send-entity-body-get-head.htm
@@ -22,7 +22,14 @@
           client.upload.addEventListener('progress', logEvt)
           client.upload.addEventListener('loadend', logEvt)
           client.upload.addEventListener('loadstart', logEvt)
-          assert_equals(client.getResponseHeader("x-request-content-length"), "NO")
+
+          if (method === "HEAD") {
+            // Fetch 4.4.3 --- Set Content-Length to 0 if method is HEAD and
+            // request's body is null.
+            assert_equals(client.getResponseHeader("x-request-content-length"), "0")
+          } else {
+            assert_equals(client.getResponseHeader("x-request-content-length"), "NO")
+          }
           assert_equals(client.getResponseHeader("x-request-method"), method)
           assert_equals(client.responseText, "")
           assert_array_equals(events, [])


### PR DESCRIPTION
Following whatwg/fetch@c103d09, if method is HEAD and request body is null, Content-Length header should be set to "0".

Closes #980
Closes #981
