### PR TITLE
assert 4th argument is a non-specific number

### DIFF
--- a/workers/WorkerGlobalScope_ErrorEvent_colno.htm
+++ b/workers/WorkerGlobalScope_ErrorEvent_colno.htm
@@ -20,7 +20,7 @@
     worker.onmessage = t.step_func(function(evt)
     {
         var err = evt.data;
-        assert_equals(err.colno, 5);
+        assert_equals(typeof err.colno, "number");
         t.done();        
     });
     


### PR DESCRIPTION
N'either the ECMAScript specification nor the web-apps/workers specifications specify specific rules about what the column number actually points to.

Maybe they should, but they don't. Column 5 (the position of the "throw" keyword) is not necessarily more helpful than the column of the expression being thrown, if any. In any case, since it's not specified anywhere, an exact number should not be asserted. What should be asserted is that the property exists at all
