### PR TITLE
URLUtils.search returns empty string, not '?'

### DIFF
--- a/workers/WorkerLocation_search_empty.htm
+++ b/workers/WorkerLocation_search_empty.htm
@@ -11,7 +11,7 @@
     
     var FileName = "./support/WorkerLocation.js";
     var SearchString = "?";
-    var ExpectedResult = SearchString;
+    var ExpectedResult = "";
     var description = "WorkerLocation.search Getter Condition: input is a hierarchical URL, "
                     + "and contained a &lt;query&gt; component (possibly an empty one).";
     


### PR DESCRIPTION
From the latest draft http://url.spec.whatwg.org/#dom-url-search:

> The search attribute must run these steps:
> 
> If url is null, or its query is either null or the empty string, return the empty string.
> 
> Return "?" concatenated with query.

And from 2012 https://dvcs.w3.org/hg/url/raw-file/tip/Overview.html#dom-url-search

> The search attribute must run these steps:
> 
> If the fatal error flag is set, or query is either null or the empty string, return the empty string.
> 
> Return "?" concatenated with query.

In each of these cases, the expected result of `location.search` for url `./support/WorkerLocation.js?` is the empty string.
