### PR TITLE
Fix the bug of showing '1/1' of 'Subtest Pass Rate' when the result of the reftest(or manual test) is not 'PASS'.

### DIFF
--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -180,7 +180,11 @@ VisualOutput.prototype = {
         if (subtests_count) {
             subtests_node.textContent = subtest_pass_count + "/" + subtests_count;
         } else {
-            subtests_node.textContent = "1/1";
+            if (status == "PASS") {
+                subtests_node.textContent = "1/1";
+            } else {
+                subtests_node.textContent = "0/1";
+            }
         }
 
         var status_arr = ["PASS", "FAIL", "ERROR", "TIMEOUT"];


### PR DESCRIPTION
I'm very sorry for dropping PR1008 which James Graham also reviewed.
Thanks to James Graham. 
For my wrong git operation, I find the code of pull request1008 would be not update while I have modified trailing whitespace James suggested on my own branch. 
So I dropped PR1008 and repull new request. 
