### PR TITLE
Add URL IDL tests & drop stale (untested) URL IDLs

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -10,42 +10,10 @@
 <h1>HTML IDL tests</h1>
 <div id=log></div>
 
-<!-- URL IDLs -->
+<!-- URLUtils* stubs -->
 <script type=text/plain class=untested>
-[Constructor(DOMString url, optional (URL or DOMString) base = "about:blank")]
-interface URL {
-};
-URL implements URLUtils;
-
-[NoInterfaceObject]
-interface URLUtils {
-  stringifier attribute DOMString href;
-  readonly attribute DOMString origin;
-
-           attribute DOMString protocol;
-           attribute DOMString username;
-           attribute DOMString password;
-           attribute DOMString host;
-           attribute DOMString hostname;
-           attribute DOMString port;
-           attribute DOMString pathname;
-           attribute DOMString search;
-           attribute URLQuery? query;
-           attribute DOMString hash;
-};
-
-[NoInterfaceObject]
-interface URLUtilsReadOnly {
-  stringifier readonly attribute DOMString href;
-
-  readonly attribute DOMString protocol;
-  readonly attribute DOMString host;
-  readonly attribute DOMString hostname;
-  readonly attribute DOMString port;
-  readonly attribute DOMString pathname;
-  readonly attribute DOMString search;
-  readonly attribute DOMString hash;
-};
+interface URLUtils {};
+interface URLUtilsReadOnly {};
 </script>
 <!-- DOM IDLs -->
 <script type=text/plain class=untested>

--- a/url/interfaces.html
+++ b/url/interfaces.html
@@ -8,7 +8,7 @@
 <h1>URL IDL tests</h1>
 <div id=log></div>
 
-<script type=text/plain class=untested>
+<script type=text/plain>
 [Constructor(DOMString url, optional DOMString base = "about:blank"),
  Exposed=Window,Worker]
 interface URL {

--- a/url/interfaces.html
+++ b/url/interfaces.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<title>URL IDL tests</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+
+<h1>URL IDL tests</h1>
+<div id=log></div>
+
+<script type=text/plain class=untested>
+[Constructor(DOMString url, optional DOMString base = "about:blank"),
+ Exposed=Window,Worker]
+interface URL {
+  static DOMString domainToASCII(ScalarValueString domain);
+  static DOMString domainToUnicode(ScalarValueString domain);
+};
+URL implements URLUtils;
+
+[NoInterfaceObject]
+interface URLUtils {
+  stringifier attribute ScalarValueString href;
+  readonly attribute DOMString origin;
+
+           attribute ScalarValueString protocol;
+           attribute ScalarValueString username;
+           attribute ScalarValueString password;
+           attribute ScalarValueString host;
+           attribute ScalarValueString hostname;
+           attribute ScalarValueString port;
+           attribute ScalarValueString pathname;
+           attribute ScalarValueString search;
+           attribute URLSearchParams searchParams;
+           attribute ScalarValueString hash;
+};
+
+[NoInterfaceObject]
+interface URLUtilsReadOnly {
+  stringifier readonly attribute DOMString href;
+  readonly attribute DOMString origin;
+
+  readonly attribute DOMString protocol;
+  readonly attribute DOMString host;
+  readonly attribute DOMString hostname;
+  readonly attribute DOMString port;
+  readonly attribute DOMString pathname;
+  readonly attribute DOMString search;
+  readonly attribute DOMString hash;
+};
+interface URLSearchParams {
+  void append(ScalarValueString name, ScalarValueString value);
+  void delete(ScalarValueString name);
+  DOMString? get(ScalarValueString name);
+  sequence<DOMString> getAll(ScalarValueString name);
+  boolean has(ScalarValueString name);
+  void set(ScalarValueString name, ScalarValueString value);
+  stringifier;
+};
+typedef DOMString ScalarValueString;
+</script>
+<script>
+"use strict";
+var idlArray;
+setup(function() {
+	idlArray = new IdlArray();
+	[].forEach.call(document.querySelectorAll("script[type=text\\/plain]"), function(node) {
+		if (node.className == "untested") {
+			idlArray.add_untested_idls(node.textContent);
+		} else {
+			idlArray.add_idls(node.textContent);
+		}
+	});
+}, {explicit_done:true});
+window.onload = function() {
+	idlArray.add_objects({
+		URL: ['new URL("http://foo")']
+	});
+	idlArray.test();
+	done();
+};
+</script>


### PR DESCRIPTION
This change:

  [x] adds URL & URLUtils\* IDL tests (up-to-date with current URL spec)
  [x] drops untested URL & URLUtils\* IDLs from html/dom/interfaces.html
  [x] replaces old untested html/dom/interfaces.html URLUtils\* IDLs w/ stubs

(Nothing in html/dom/interfaces.html references the URL interface anyway,
so there's no reason to include it there. And the URLUtils\* IDLs that were
in there were out-of-date with the current URL spec, and regardless there's
no need to include the actual whole interfaces for them there, so instead
let's just put (untested) stubs for them there.)
