### PR TITLE
Should disable the manual/refer harness after click pause button 

### DIFF
--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -259,6 +259,7 @@ function ManualUI(elem, runner) {
     this.hide();
 
     this.runner.test_start_callbacks.push(this.on_test_start.bind(this));
+    this.runner.test_pause_callbacks.push(this.hide.bind(this));
     this.runner.done_callbacks.push(this.on_done.bind(this));
 
     this.pass_button.onclick = function() {
@@ -466,6 +467,7 @@ function Runner(manifest_path) {
 
     this.start_callbacks = [];
     this.test_start_callbacks = [];
+    this.test_pause_callbacks = [];
     this.result_callbacks = [];
     this.done_callbacks = [];
 
@@ -517,6 +519,9 @@ Runner.prototype = {
 
     pause: function() {
         this.pause_flag = true;
+        this.test_pause_callbacks.forEach(function(callback) {
+            callback(this.current_test);
+        }.bind(this));
     },
 
     unpause: function() {


### PR DESCRIPTION
During the test, when we press the pause button,the test paused,but for the manual/refer harness ,we also can press passed or failed on the dialog. the progress bar will be wrong.So the diaolg should hide or disabled
