### PR TITLE
Drop Workers tests from html/dom/interfaces.html.

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2388,7 +2388,6 @@ interface ImageBitmapFactories {
   void createImageBitmap(ImageBitmapSource image, ImageBitmapCallback _callback, optional long sx, long sy, long sw, long sh);
 };
 Window implements ImageBitmapFactories;
-WorkerGlobalScope implements ImageBitmapFactories;
 
 interface DataTransfer {
            attribute DOMString dropEffect;
@@ -2437,29 +2436,6 @@ dictionary DragEventInit : MouseEventInit {
   DataTransfer? dataTransfer;
 };
 
-interface WorkerGlobalScope : EventTarget {
-  readonly attribute WorkerGlobalScope self;
-  readonly attribute WorkerLocation location;
-
-  void close();
-           attribute EventHandler onerror;
-           attribute EventHandler onoffline;
-           attribute EventHandler ononline;
-
-  // also has obsolete members
-};
-
-interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
-  void postMessage(any message, optional sequence<Transferable> transfer);
-           attribute EventHandler onmessage;
-};
-
-interface SharedWorkerGlobalScope : WorkerGlobalScope {
-  readonly attribute DOMString name;
-  readonly attribute ApplicationCache applicationCache;
-           attribute EventHandler onconnect;
-};
-
 [Constructor(DOMString type, optional ErrorEventInit eventInitDict)]
 interface ErrorEvent : Event {
   readonly attribute DOMString message;
@@ -2474,45 +2450,6 @@ dictionary ErrorEventInit : EventInit {
   unsigned long lineno;
   unsigned long column;
 };
-
-[NoInterfaceObject]
-interface AbstractWorker {
-           attribute EventHandler onerror;
-
-};
-
-[Constructor(DOMString scriptURL)]
-interface Worker : EventTarget {
-  void terminate();
-
-  void postMessage(any message, optional sequence<Transferable> transfer);
-           attribute EventHandler onmessage;
-};
-Worker implements AbstractWorker;
-
-[Constructor(DOMString scriptURL, optional DOMString name)]
-interface SharedWorker : EventTarget {
-  readonly attribute MessagePort port;
-};
-SharedWorker implements AbstractWorker;
-
-[NoInterfaceObject]
-partial interface WorkerGlobalScope {
-  void importScripts(DOMString... urls);
-  readonly attribute WorkerNavigator navigator;
-};
-WorkerGlobalScope implements WindowTimers;
-WorkerGlobalScope implements WindowBase64;
-
-interface WorkerNavigator {};
-WorkerNavigator implements NavigatorID;
-WorkerNavigator implements NavigatorLanguage;
-WorkerNavigator implements NavigatorOnLine;
-
-interface WorkerLocation {
-  stringifier readonly attribute DOMString href;
-};
-WorkerLocation implements URLUtilsReadOnly;
 
 [Constructor(DOMString type, optional MessageEventInit eventInitDict)]
 interface MessageEvent : Event {
@@ -3054,9 +2991,6 @@ window.onload = function() {
 		PeerConnection: [],
 		MediaStreamEvent: [],
 		ErrorEvent: [],
-		AbstractWorker: [],
-		Worker: [],
-		SharedWorker: [],
 		MessageEvent: [],
 		MessageChannel: [],
 		MessagePort: [],


### PR DESCRIPTION
The current Workers IDL tests in html/dom/interfaces.html aren't actually
testing anything usefully. Useful testing is going to require us to addd
some additional workers test infrastructure; see #1020.
