### PR TITLE
WebAudio: Fix for WaveShaper "huge curve" test

### DIFF
--- a/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
+++ b/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
@@ -96,9 +96,9 @@
 		*/
 		(function() {
 			var bigCurve=[];
-			for(var i=0;i<60000;i++) { bigCurve.push(i/3.5435); }
+			for(var i=0;i<=60000;i++) { bigCurve.push(i/3.5435); }
 			var inputData=[-1.0, 0, 1.0];
-			var expectedData=[bigCurve[0], bigCurve[30000], bigCurve[59999]];
+			var expectedData=[bigCurve[0], bigCurve[30000], bigCurve[60000]];
 			executeTest(bigCurve, inputData, expectedData, "Testing a huge curve");
 		})();
 


### PR DESCRIPTION
The test previously had an even number of elements so the centre of the
curve was actually mid-way between 2 elements (so I was using the wrong
value used as the centre).  I have now changed the curve to be an odd
number of elements.

Firefox nightly now has 100% passes.

This Pull Request replaces #1041.  @chrislo requested that I spin-up a new branch and pull just a single commit.
