### PR TITLE
Header files for lang attribute tests

### DIFF
--- a/html/dom/elements/global-attributes/the-lang-attribute-003.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-003.html.headers
@@ -1,1 +1,1 @@
-AddLanguage 'ko' .html
+Content-Language: ko

--- a/html/dom/elements/global-attributes/the-lang-attribute-003.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-003.html.headers
@@ -1,0 +1,1 @@
+AddLanguage 'ko' .html

--- a/html/dom/elements/global-attributes/the-lang-attribute-005.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-005.html.headers
@@ -1,1 +1,1 @@
-AddLanguage 'zh' .html
+Content-Language: zh

--- a/html/dom/elements/global-attributes/the-lang-attribute-005.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-005.html.headers
@@ -1,0 +1,1 @@
+AddLanguage 'zh' .html

--- a/html/dom/elements/global-attributes/the-lang-attribute-006.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-006.html.headers
@@ -1,1 +1,1 @@
-AddLanguage 'zh' .html
+Content-Language: zh

--- a/html/dom/elements/global-attributes/the-lang-attribute-006.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-006.html.headers
@@ -1,0 +1,1 @@
+AddLanguage 'zh' .html

--- a/html/dom/elements/global-attributes/the-lang-attribute-009.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-009.html.headers
@@ -1,1 +1,1 @@
-AddLanguage 'ko' .html
+Content-Language: ko

--- a/html/dom/elements/global-attributes/the-lang-attribute-009.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-009.html.headers
@@ -1,0 +1,1 @@
+AddLanguage 'ko' .html

--- a/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
@@ -1,1 +1,1 @@
-AddLanguage 'ko,zh,ja' .html
+Content-Language: ko,zh,ja

--- a/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
+++ b/html/dom/elements/global-attributes/the-lang-attribute-011.html.headers
@@ -1,0 +1,1 @@
+AddLanguage 'ko,zh,ja' .html


### PR DESCRIPTION
These are the .headers files that were missing for several of the tests with names beginning "the-lang-attribute...".
