### PR TITLE
Add a basic TextTrackList.getTrackById test

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/getTrackById.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrackList/getTrackById.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>TextTrackList.getTrackById</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+test(function(){
+    var video = document.createElement('video');
+    var track1 = video.addTextTrack('subtitles');
+    var track2 = video.addTextTrack('subtitles');
+    assert_equals(track1.id, '');
+    assert_equals(track2.id, '');
+    assert_equals(video.textTracks.getTrackById(''), track1);
+    assert_equals(video.textTracks.getTrackById('fake-id'), null);
+});
+</script>


### PR DESCRIPTION
Unfortunately in-band tracks are required to get a non-empty
id, so this is the extent of testing currently possible.
