### PR TITLE
Bringing GetUserMedia tests more up to date.

### DIFF
--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html
@@ -25,7 +25,7 @@ t.step( function () {
         t.done();
       }), t.step_func(function (error) {
         assert_unreached("This should never be triggered since the constraints parameter is empty");
-         }));
+      }));
   });
   t.done();
 });

--- a/mediacapture-streams/stream-api/mediastream/audio.html
+++ b/mediacapture-streams/stream-api/mediastream/audio.html
@@ -27,7 +27,8 @@ t.step(function() {
     assert_equals(stream.getAudioTracks()[0].kind, "audio", "getAudioTracks() returns a sequence of tracks whose kind is 'audio'");
     assert_equals(stream.getVideoTracks().length, 0, "the media stream has zero video track");
     t.done();
-  }));
+  }),
+  function(error) {});
 });
 </script>
 </body>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-gettrackid.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-gettrackid.html
@@ -18,7 +18,12 @@
 <script>
 var t = async_test("Tests that MediaStream.getTrackById works as expected", {timeout: 10000});
 t.step(function () {
-  navigator.getUserMedia({video: true}, t.step_func(gotVideo), function(error) {});
+  navigator.getUserMedia(
+      {video: true},
+      t.step_func(gotVideo),
+      t.step_func(function (error) {
+        assert_unreached('Unexpected getUserMedia error: ' + error);
+      }));
   function gotVideo(stream) {
     var track = stream.getVideoTracks()[0];
     assert_equals(track, stream.getTrackById(track.id), "getTrackById returns track of given id");

--- a/mediacapture-streams/stream-api/mediastream/mediastream-id-manual.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-id-manual.html
@@ -25,7 +25,7 @@ if (window.navigator.getUserMedia) {
      assert_regexp_match(stream.id, allowedCharacters, "the media stream id uses the set of allowed characters");
   });
   t.done();
-});
+}, function(error) {});
 }
 </script>
 </body>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-idl.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-idl.html
@@ -19,7 +19,7 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
+<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"},{"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var t = async_test("Tests that a MediaStream constructor follows the algorithm set in the spec", {timeout: 10000});
 t.step(function() {

--- a/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
@@ -20,10 +20,10 @@
 var t = async_test("Tests that a removal from a MediaStream works as expected", {timeout:10000});
 t.step(function () {
   var audio;
-  navigator.getUserMedia({audio:true}, gotAudio, function() {});
+  navigator.getUserMedia({audio:true}, gotAudio, function(error) {});
   function gotAudio(stream) {
      audio = stream;
-     navigator.getUserMedia({video:true}, gotVideo, function() {});
+     navigator.getUserMedia({video:true}, gotVideo, function(error) {});
   }
 
   function gotVideo(stream) {

--- a/mediacapture-streams/stream-api/mediastream/video.html
+++ b/mediacapture-streams/stream-api/mediastream/video.html
@@ -16,7 +16,7 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
+<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var t = async_test("Tests that a MediaStream with at least one video track is returned");
 t.step(function() {


### PR DESCRIPTION
This patch mostly adds error callbacks when appropriate, fixes some indentation and adds prefixes for MediaStream, which is prefixed in Chrome.
