### PR TITLE
Fixing comments and indentation, prefixing MediaStream also in audio.html.

### DIFF
--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
@@ -17,14 +17,13 @@
 <script src=/resources/testharnessreport.js></script>
 <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
-var t = async_test("Tests that setting a trivial mandatory constraint in getUserMedia works", {timeout:10000});
+var t = async_test("Tests that setting an impossible constraint in getUserMedia fails", {timeout:10000});
 t.step(function() {
   navigator.getUserMedia({video: {mandatory: {width: {min:Infinity}}}}, t.step_func(function (stream) {
     assert_unreached("a Video stream of infinite width cannot be created");
     t.done();
   }), t.step_func(function(error) {
-    console.log(error);
-    assert_equals(error.name, "ContraintNotSatisfied", "An impossible constraint triggers a ContraintNotSatified error");
+    assert_equals(error.name, "ConstraintNotSatisfiedError", "An impossible constraint triggers a ConstraintNotSatisfiedError");
     assert_equals(error.constraintName, "width", "The name of the not satisfied error is given in error.constraintName");
     t.done();
   }));

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
@@ -18,13 +18,14 @@
 <script>
 var t = async_test("Tests that setting an optional constraint in getUserMedia is handled as optional", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {optional: [{width: {min:1024}}, {width: {max: 800}}]}}, t.step_func(function (stream) {
-    assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
-    t.done();
-  }), t.step_func(function(error) {
-    assert_unreached("an optional constraint can't prevent the obtention of a video stream");
-    t.done();
-  }));
+  navigator.getUserMedia({video: {optional: [{width: {min:1024}}, {width: {max: 800}}]}},
+      t.step_func(function (stream) {
+        assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
+        t.done();
+      }),
+      t.step_func(function(error) {
+        assert_unreached("an optional constraint can't stop us from obtaining a video stream");
+      }));
 });
 </script>
 </body>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html
@@ -16,11 +16,18 @@
 <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 test(function () {
-    // TODO This is no longer what's in the spec, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22211
-  assert_throws("NOT_SUPPORTED_ERR",
-    function () {
-      navigator.getUserMedia({doesnotexist:true}, t.step_func(function (stream) {assert_unreached("This should never be triggered since the constraints parameter is unrecognized");}), t.step_func(function (error) {assert_unreached("This should never be triggered since the constraints parameter is unrecognized");});
-    }
+  // TODO This is no longer what's in the spec, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22211
+  assert_throws(
+      "NOT_SUPPORTED_ERR",
+      function () {
+        navigator.getUserMedia(
+            {doesnotexist:true},
+            t.step_func(function (stream) {
+              assert_unreached("This should never be triggered since the constraints parameter is unrecognized");
+            }), t.step_func(function (error) {
+              assert_unreached("This should never be triggered since the constraints parameter is unrecognized");
+            }));
+      }
   )
   }
 );

--- a/mediacapture-streams/stream-api/introduction/disabled-video-black.html
+++ b/mediacapture-streams/stream-api/introduction/disabled-video-black.html
@@ -22,28 +22,30 @@ var vid = document.getElementById("vid");
 var cv = document.createElement("canvas");
 var t = async_test("Tests that a disabled video track in a MediaStream is rendered as blackness", {timeout: 10000});
 t.step(function() {
-  navigator.getUserMedia({video: true}, t.step_func(function (stream) {
-    var testOncePlaying = function() {
-       vid.removeEventListener("timeupdate", testOncePlaying, false);
-       stream.getVideoTracks()[0].enabled = false;
-       cv.width = vid.offsetWidth;
-       cv.height = vid.offsetHeight;
-       var ctx = cv.getContext("2d");
-       ctx.drawImage(vid,0,0);
-       var imageData = ctx.getImageData(0, 0, cv.width, cv.height);
-       for (var i = 0; i < imageData.data.length; i+=4) {
-	   assert_equals(imageData.data[i], 0, "No red component in pixel #" + i);
-	   assert_equals(imageData.data[i + 1], 0, "No green component in pixel #" + i);
-	   assert_equals(imageData.data[i + 2], 0, "No blue component in pixel #" + i);
-	   assert_equals(imageData.data[i + 3], 255, "No transparency in pixel #" + i);
-       }
-       t.done();
-    }
-    vid.srcObject = stream;
-    vid.play();
-    vid.addEventListener("timeupdate", t.step_func(testOncePlaying), false);
-
-  }), function(error) {});
+  navigator.getUserMedia(
+      {video: true},
+      t.step_func(function (stream) {
+        var testOncePlaying = function() {
+          vid.removeEventListener("timeupdate", testOncePlaying, false);
+          stream.getVideoTracks()[0].enabled = false;
+          cv.width = vid.offsetWidth;
+          cv.height = vid.offsetHeight;
+          var ctx = cv.getContext("2d");
+          ctx.drawImage(vid,0,0);
+          var imageData = ctx.getImageData(0, 0, cv.width, cv.height);
+          for (var i = 0; i < imageData.data.length; i+=4) {
+            assert_equals(imageData.data[i], 0, "No red component in pixel #" + i);
+            assert_equals(imageData.data[i + 1], 0, "No green component in pixel #" + i);
+            assert_equals(imageData.data[i + 2], 0, "No blue component in pixel #" + i);
+            assert_equals(imageData.data[i + 3], 255, "No transparency in pixel #" + i);
+          }
+          t.done();
+        }
+        vid.srcObject = stream;
+        vid.play();
+        vid.addEventListener("timeupdate", t.step_func(testOncePlaying), false);
+      }),
+      function(error) {});
 });
 </script>
 </body>

--- a/mediacapture-streams/stream-api/mediastream/audio.html
+++ b/mediacapture-streams/stream-api/mediastream/audio.html
@@ -15,7 +15,7 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
+<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var astream;
 var t = async_test("Tests that a MediaStream with exactly one audio track is returned", {timeout: 10000});


### PR DESCRIPTION
This is some more errors I found when working to get these running for Chrome layout tests in continuous integration here.

I'm assuming here that wrapping parameters should indent 4 spaces and functions indent 2 spaces after opening brace.
