### PR TITLE
Turn off input password autocomplete to enhance security

### DIFF
--- a/conformance-checkers/html-aria/accessible-name-input/password-title.html
+++ b/conformance-checkers/html-aria/accessible-name-input/password-title.html
@@ -5,6 +5,6 @@
       <title>Password input with title attribute and no other labeling mechanism</title>
    </head>
    <body>
-   	<input type="password" id="test" title="foo" />
+   	<input type="password" id="test" title="foo" autocomplete="off"/>  <!-- turn off autocomplete to enhance security -->
    </body>
 </html>

--- a/conformance-checkers/html-aria/name-computation-input/612.html
+++ b/conformance-checkers/html-aria/name-computation-input/612.html
@@ -5,6 +5,6 @@
       <title>Input with type="password" label/for without wai-aria</title>
    </head>
    <body>
-<input type="password" id="test">
+<input type="password" id="test" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 <label for="test">foo</label></body>
 </html>

--- a/conformance-checkers/html-aria/name-computation-input/660.html
+++ b/conformance-checkers/html-aria/name-computation-input/660.html
@@ -10,7 +10,7 @@
    </head>
    <body>
       <form>
-         <label for="test" title="bar"><input id="test" type="password" name="test" title="bar"></label> 
+         <label for="test" title="bar"><input id="test" type="password" name="test" title="bar" autocomplete="off"></label>  <!-- turn off autocomplete to enhance security -->
       </form>
    </body>
 </html>

--- a/conformance-checkers/html-aria/name-computation-input/721.html
+++ b/conformance-checkers/html-aria/name-computation-input/721.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <label for="test">States:</label>
-<input type="password" id="test"/>
+<input type="password" id="test" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 </body>
 </html>
 

--- a/conformance-checkers/html-aria/name-computation-input/748.html
+++ b/conformance-checkers/html-aria/name-computation-input/748.html
@@ -5,7 +5,7 @@
 <title>An INPUT type=text, password, checkbox, radio, file, or image , with id="test", with no aria-labelledby and no aria-label, does not have a role=presentation, is not referenced by a LABEL element, and has a title.</title>
 </head>
 <body>
-<input type="password" id="test" title="crazy" value="baz"/>
+<input type="password" id="test" title="crazy" value="baz" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 </body>
 </html>
 

--- a/conformance-checkers/html-aria/name-computation-input/753.html
+++ b/conformance-checkers/html-aria/name-computation-input/753.html
@@ -13,7 +13,7 @@ content:"fancy ";
 </head>
 <body>
 <label for="test">fruit</label>
-<input type="password" id="test"/>
+<input type="password" id="test" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 </body>
 </html>
 

--- a/conformance-checkers/html-aria/name-computation-input/758.html
+++ b/conformance-checkers/html-aria/name-computation-input/758.html
@@ -13,7 +13,7 @@ content:" fruit"
 </head>
 <body>
 <label for="test">fancy</label>
-<input type="password" id="test"/>
+<input type="password" id="test" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 </body>
 </html>
 

--- a/html/editing/dnd/selection/008.xhtml
+++ b/html/editing/dnd/selection/008.xhtml
@@ -14,7 +14,7 @@ div[ondragenter]
 </head>
 <body onload="document.querySelector('input').select()">
 <p>You should not be able to drag and drop selection from password field to the blue box.</p>
-<p><input type="password" value="FAIL"/></p>
+<p><input type="password" value="FAIL" autocomplete="off"/></p>  <!-- turn off autocomplete to enhance security -->
 <div
 	ondragenter="event.preventDefault()"
 	ondragover="return false"

--- a/html/editing/dnd/selection/018.xhtml
+++ b/html/editing/dnd/selection/018.xhtml
@@ -12,7 +12,7 @@ textarea
 </head>
 <body onload="document.querySelector('input').select()">
 <p>You should not be able to drag and drop selection from password field to the textarea.</p>
-<p><input type="password" value="FAIL"/></p>
+<p><input type="password" value="FAIL" autocomplete="off"/></p>  <!-- turn off autocomplete to enhance security -->
 <p><textarea placeholder="Drop selection here"/></p>
 </body>
 </html>

--- a/html/editing/dnd/selection/028.xhtml
+++ b/html/editing/dnd/selection/028.xhtml
@@ -14,7 +14,7 @@ div[contenteditable]
 </head>
 <body onload="document.querySelector('input').select()">
 <p>You should not be able to drag and drop selection from password field to the blue box.</p>
-<p><input type="password" value="FAIL"/></p>
+<p><input type="password" value="FAIL" autocomplete="off"/></p> <!-- turn off autocomplete to enhance security -->
 <div contenteditable="true"/>
 </body>
 </html>

--- a/html/editing/dnd/selection/078.xhtml
+++ b/html/editing/dnd/selection/078.xhtml
@@ -11,7 +11,7 @@ input[placeholder]
 </head>
 <body onload="document.querySelector('input').select()">
 <p>You should not be able to drag and drop selection from password field to the input below.</p>
-<p><input type="password" value="FAIL"/></p>
+<p><input type="password" value="FAIL" autocomplete="off"/></p>  <!-- turn off autocomplete to enhance security -->
 <p><input placeholder="Drop selection here"/></p>
 </body>
 </html>

--- a/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
@@ -13,7 +13,7 @@
 <input type=search id=search value="foobar">
 <input type=tel id=tel value="foobar">
 <input type=url id=url value="foobar">
-<input type=password id=password value="foobar">
+<input type=password id=password value="foobar" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 <input id=display_none value="foobar">
 <textarea id=textarea>foobar</textarea>
 <script>

--- a/html/semantics/forms/the-form-element/form-nameditem.html
+++ b/html/semantics/forms/the-form-element/form-nameditem.html
@@ -23,7 +23,7 @@
 <input type=tel name=l6>
 <input type=url name=l7>
 <input type=email name=l8>
-<input type=password name=l9>
+<input type=password name=l9 autocomplete=off> <!-- turn off autocomplete to enhance security -->
 <input type=datetime name=l10>
 <input type=date name=l11>
 <input type=month name=l12>

--- a/html/semantics/forms/the-input-element/password.html
+++ b/html/semantics/forms/the-input-element/password.html
@@ -7,9 +7,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <div style="display: none">
-<input id="password" type="password" />
-<input id=password2 type=password value="password">
-<input id="password_with_value" type="password" value="foobar" />
+<input id="password" type="password" autocomplete="off" /> <!-- turn off autocomplete to enhance security -->
+<input id=password2 type=password value="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
+<input id="password_with_value" type="password" value="foobar" autocomplete="off" /> <!-- turn off autocomplete to enhance security -->
 </div>
 <script type="text/javascript">
     setup(function() {

--- a/selectors-api/level1-content.html
+++ b/selectors-api/level1-content.html
@@ -63,7 +63,7 @@
 
 		<form id="attr-value-form1">
 			<input id="attr-value-input1" type="text">
-			<input id="attr-value-input2" type="password">
+			<input id="attr-value-input2" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 			<input id="attr-value-input3" type="hidden">
 			<input id="attr-value-input4" type="radio">
 			<input id="attr-value-input5" type="checkbox">
@@ -243,7 +243,7 @@
 
 	<div id="pseudo-ui">
 		<input id="pseudo-ui-input1" type="text">
-		<input id="pseudo-ui-input2" type="password">
+		<input id="pseudo-ui-input2" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input3" type="radio">
 		<input id="pseudo-ui-input4" type="radio" checked="checked">
 		<input id="pseudo-ui-input5" type="checkbox">
@@ -255,7 +255,7 @@
 		<button id="pseudo-ui-button1">Enabled</button>
 
 		<input id="pseudo-ui-input10" disabled="disabled" type="text">
-		<input id="pseudo-ui-input11" disabled="disabled" type="password">
+		<input id="pseudo-ui-input11" disabled="disabled" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input12" disabled="disabled" type="radio">
 		<input id="pseudo-ui-input13" disabled="disabled" type="radio" checked="checked">
 		<input id="pseudo-ui-input14" disabled="disabled" type="checkbox">

--- a/selectors-api/level1-content.xht
+++ b/selectors-api/level1-content.xht
@@ -58,7 +58,7 @@
 
 		<form id="attr-value-form1">
 			<input id="attr-value-input1" type="text"/>
-			<input id="attr-value-input2" type="password"/>
+			<input id="attr-value-input2" type="password" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 			<input id="attr-value-input3" type="hidden"/>
 			<input id="attr-value-input4" type="radio"/>
 			<input id="attr-value-input5" type="checkbox"/>
@@ -238,7 +238,7 @@
 
 	<div id="pseudo-ui">
 		<input id="pseudo-ui-input1" type="text"/>
-		<input id="pseudo-ui-input2" type="password"/>
+		<input id="pseudo-ui-input2" type="password" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input3" type="radio"/>
 		<input id="pseudo-ui-input4" type="radio" checked="checked"/>
 		<input id="pseudo-ui-input5" type="checkbox"/>
@@ -250,7 +250,7 @@
 		<button id="pseudo-ui-button1">Enabled</button>
 
 		<input id="pseudo-ui-input10" disabled="disabled" type="text"/>
-		<input id="pseudo-ui-input11" disabled="disabled" type="password"/>
+		<input id="pseudo-ui-input11" disabled="disabled" type="password" autocomplete="off"/> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input12" disabled="disabled" type="radio"/>
 		<input id="pseudo-ui-input13" disabled="disabled" type="radio" checked="checked"/>
 		<input id="pseudo-ui-input14" disabled="disabled" type="checkbox"/>

--- a/selectors-api/tests/submissions/Opera/level2-content.html
+++ b/selectors-api/tests/submissions/Opera/level2-content.html
@@ -63,7 +63,7 @@
 
 		<form id="attr-value-form1">
 			<input id="attr-value-input1" type="text">
-			<input id="attr-value-input2" type="password">
+			<input id="attr-value-input2" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 			<input id="attr-value-input3" type="hidden">
 			<input id="attr-value-input4" type="radio">
 			<input id="attr-value-input5" type="checkbox">
@@ -243,7 +243,7 @@
 
 	<div id="pseudo-ui">
 		<input id="pseudo-ui-input1" type="text">
-		<input id="pseudo-ui-input2" type="password">
+		<input id="pseudo-ui-input2" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input3" type="radio">
 		<input id="pseudo-ui-input4" type="radio" checked="checked">
 		<input id="pseudo-ui-input5" type="checkbox">
@@ -255,7 +255,7 @@
 		<button id="pseudo-ui-button1">Enabled</button>
 
 		<input id="pseudo-ui-input10" disabled="disabled" type="text">
-		<input id="pseudo-ui-input11" disabled="disabled" type="password">
+		<input id="pseudo-ui-input11" disabled="disabled" type="password" autocomplete="off"> <!-- turn off autocomplete to enhance security -->
 		<input id="pseudo-ui-input12" disabled="disabled" type="radio">
 		<input id="pseudo-ui-input13" disabled="disabled" type="radio" checked="checked">
 		<input id="pseudo-ui-input14" disabled="disabled" type="checkbox">


### PR DESCRIPTION
- AUTOCOMPLETE attribute is not disabled in HTML FORM/INPUT element containing password type input. Passwords may be stored in browsers and retrieved. Turn off AUTOCOMPLETE attribute in form or individual input elements containing password by using AUTOCOMPLETE='OFF'.
