### PR TITLE
Set httponly for cookies to enhance security

### DIFF
--- a/XMLHttpRequest/resources/headers.py
+++ b/XMLHttpRequest/resources/headers.py
@@ -3,8 +3,8 @@
 def main(request, response):
     response.headers.set("Content-Type", "text/plain")
     response.headers.set("X-Custom-Header", "test")
-    response.headers.set("Set-Cookie", "test")
-    response.headers.set("Set-Cookie2", "test")
+    response.headers.set("Set-Cookie", "test;httponly")
+    response.headers.set("Set-Cookie2", "test;httponly")
     response.headers.set("X-Custom-Header-Empty", "")
     response.headers.set("X-Custom-Header-Comma", "1")
     response.headers.append("X-Custom-Header-Comma", "2")

--- a/eventsource/resources/status-reconnect.py
+++ b/eventsource/resources/status-reconnect.py
@@ -11,7 +11,7 @@ def main(request, response):
         response.delete_cookie(cookie_name)
         body = "data: data\n\n"
     else:
-        response.set_cookie(cookie_name, status_code);
+        response.set_cookie(cookie_name, status_code + ";httponly");
         status = (int(status_code), "TEST")
         body = "retry: 2\n"
         if "ok_first" in request.GET:

--- a/websockets/cookies/support/set-cookie.py
+++ b/websockets/cookies/support/set-cookie.py
@@ -1,5 +1,5 @@
 import urllib
 
 def main(request, response):
-    response.headers.set('Set-Cookie', urllib.unquote(request.url_parts.query))
+    response.headers.set('Set-Cookie', urllib.unquote(request.url_parts.query) + ";httponly")
     return [("Content-Type", "text/plain")], ""


### PR DESCRIPTION
- A cookie without the HttpOnly flag means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.
