### PR TITLE
Limit open redirecton in redirect.py to enhance security

### DIFF
--- a/common/redirect.py
+++ b/common/redirect.py
@@ -1,3 +1,5 @@
+from urlparse import urlparse
+
 def main(request, response):
     """Simple handler that causes redirection.
 
@@ -5,15 +7,24 @@ def main(request, response):
     status - The status to use for the redirection. Defaults to 302.
     location - The resource to redirect to.
     """
-    status = 302
-    if "status" in request.GET:
-        try:
-            status = int(request.GET.first("status"))
-        except ValueError:
-            pass
+    try:
+        status = 302
+        if "status" in request.GET:
+            try:
+                status = int(request.GET.first("status"))
+            except ValueError:
+                pass
 
-    response.status = status
+        response.status = status
 
-    location = request.GET.first("location")
+        location = request.GET.first("location")
 
-    response.headers.set("Location", location)
+        local_parsed = urlparse(location)
+        request_parsed = urlparse(request.url)
+        if local_parsed.hostname != None and local_parsed.hostname != request_parsed.hostname:
+            return "illegal redirect url"
+
+        response.headers.set("Location", location)
+
+    except Exception:
+        return "exception thrown"


### PR DESCRIPTION
- The value of the location request parameter is used to perform an HTTP redirect, this will cause a redirection to other website URL by attacker. So limit the open redirection in same domain.
- It will print an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. Add try catch to avoid print sensitive information.
