### PR TITLE
Make worker navigation tests more reliable.

### DIFF
--- a/workers/semantics/navigation/001-1.html
+++ b/workers/semantics/navigation/001-1.html
@@ -5,12 +5,18 @@ setInterval(function() { postMessage(new Date()) }, 10)
 <!doctype html>
 <title>001-1</title>
 <script>
-var worker = new Worker('#');
-worker.onmessage = function(e) {
-  parent.date = e.data;
+onload = function() {
+  var worker = new Worker('#');
+  worker.onmessage = function(e) {
+    var started = !!parent.date;
+    parent.date = e.data;
+    if (!started) {
+      parent.start_test()
+    }
+  }
 }
 </script>
-<a href='data:text/html,<title>foo</title>foo'>link</a>
+<a href='data:text/html,<title>foo</title><script>onload=function(){parent.after_load()}</script>'>link</a>
 <!--
 */
 //-->

--- a/workers/semantics/navigation/001.html
+++ b/workers/semantics/navigation/001.html
@@ -11,24 +11,24 @@
 var date;
 var newDate;
 </script>
-<iframe src="001-1.html"></iframe>
+<iframe></iframe>
 <script>
 var t = async_test();
+var iframe = document.querySelector('iframe');
 onload = t.step_func(function() {
-  var iframe = document.querySelector('iframe');
+  iframe.src = "001-1.html?" + Math.random();
+});
+start_test = t.step_func(function() {
+  window[0].document.links[0].click();
+});
+after_load = t.step_func(function() {
+  history.back();
+  newDate = new Date();
   setTimeout(this.step_func(function() {
-    window[0].document.links[0].click();
-    iframe.onload = this.step_func(function() {
-      this.onload = null;
-      history.back();
-      newDate = new Date();
-      setTimeout(this.step_func(function() {
-        assert_greater_than(Number(date), Number(newDate));
-        assert_equals(window[0].document.title, '001-1');
-        this.done();
-      }), 300);
-    });
-  }), 150);
+      assert_greater_than(Number(date), Number(newDate));
+      assert_equals(window[0].document.title, '001-1');
+      this.done();
+  }), 500);
 });
 </script>
 <!--

--- a/workers/semantics/navigation/001.html
+++ b/workers/semantics/navigation/001.html
@@ -18,16 +18,16 @@ var iframe = document.querySelector('iframe');
 onload = t.step_func(function() {
   iframe.src = "001-1.html?" + Math.random();
 });
-start_test = t.step_func(function() {
+var start_test = t.step_func(function() {
   window[0].document.links[0].click();
 });
-after_load = t.step_func(function() {
+var after_load = t.step_func(function() {
   history.back();
   newDate = new Date();
   setTimeout(this.step_func(function() {
-      assert_greater_than(Number(date), Number(newDate));
-      assert_equals(window[0].document.title, '001-1');
-      this.done();
+    assert_greater_than(Number(date), Number(newDate));
+    assert_equals(window[0].document.title, '001-1');
+    this.done();
   }), 500);
 });
 </script>

--- a/workers/semantics/navigation/002.html
+++ b/workers/semantics/navigation/002.html
@@ -11,23 +11,23 @@
 var date;
 var newDate;
 </script>
-<iframe src="001-1.html"></iframe>
+<iframe></iframe>
 <script>
 var t = async_test();
+var iframe = document.querySelector('iframe');
 onload = t.step_func(function() {
-  var iframe = document.querySelector('iframe');
+  iframe.src = "001-1.html?" + Math.random();
+});
+var start_test = t.step_func(function() {
+  window[0].document.links[0].click();
+});
+var after_load = t.step_func(function() {
+  newDate = new Date();
   setTimeout(this.step_func(function() {
-    window[0].document.links[0].click();
-    iframe.onload = this.step_func(function() {
-      this.onload = null;
-      newDate = new Date();
-      setTimeout(this.step_func(function() {
-        assert_less_than(Number(date), Number(newDate));
-        assert_equals(window[0].document.title, 'foo');
-        this.done();
-      }), 300);
-    });
-  }), 150);
+    assert_less_than(Number(date), Number(newDate));
+    assert_equals(window[0].document.title, 'foo');
+    this.done();
+  }), 500);
 });
 </script>
 <!--


### PR DESCRIPTION
Stop depending on timing where possible and depend on events instead.
Don't get confused by load event of about:blank iframe
