### PR TITLE
Tagging all instructions to human testers.

### DIFF
--- a/mediacapture-streams/mediastreams-as-media-elements/video-assignment-manual.html
+++ b/mediacapture-streams/mediastreams-as-media-elements/video-assignment-manual.html
@@ -7,9 +7,11 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the <code>srcObject</code> attribute.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream object returned by
+the success callback in getUserMedia can be properly assigned to a video element
+via the <code>srcObject</code> attribute.</p>
 
 <video id="vid"></video>
 

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/api-present.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/api-present.html
@@ -9,9 +9,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<h1>Description</h1>
-<p>This test checks for the presence of the <code>navigator.getUserMedia</code> method, taking vendor prefixes into account.</p>
-    <div id='log'></div>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks for the presence of the
+<code>navigator.getUserMedia</code> method, taking vendor prefixes into account.</p>
+<div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/deny.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/deny.html
@@ -8,9 +8,11 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, <strong>please deny</strong> access to the video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the error callback is triggered when user denies access to the video stream.</p>
+<p class="instructions">When prompted, <strong>please deny</strong> access to
+the video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the error callback is triggered
+when user denies access to the video stream.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html
@@ -7,8 +7,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<h1>Description</h1>
-<p>This test checks that getUserMedia with no value in the options parameter raises a NOT_SUPPORTED_ERR exception.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that getUserMedia with no value in the
+options parameter raises a NOT_SUPPORTED_ERR exception.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
@@ -8,9 +8,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that setting a trivial mandatory
+constraint (width &gt;=0) in getUserMedia works</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
@@ -7,9 +7,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that setting an optional constraint in getUserMedia is handled as optional</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that setting an optional constraint in
+getUserMedia is handled as optional</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html
@@ -7,9 +7,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that setting a trivial mandatory
+constraint (width &gt;=0) in getUserMedia works</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html
@@ -7,8 +7,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<h1>Description</h1>
-<p>This test checks that getUserMedia with an unknown value in the options parameter raises a NOT_SUPPORTED_ERR exception.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that getUserMedia with an unknown value
+in the options parameter raises a NOT_SUPPORTED_ERR exception.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/introduction/disabled-audio-silence.html
+++ b/mediacapture-streams/stream-api/introduction/disabled-audio-silence.html
@@ -8,9 +8,12 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio stream.</p>
-<h1>Description</h1>
-<p>This test checks that a disabled audio track in a MediaStream is rendered as silence. It relies on the <a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">Web Audio API</a>.</p>
+<p class="instructions">When prompted, accept to share your audio stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that a disabled audio track in a
+MediaStream is rendered as silence. It relies on the
+<a href="https://dvcs.w3.org/hg/audio/raw-file/tip/webaudio/specification.html">
+Web Audio API</a>.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/introduction/disabled-video-black.html
+++ b/mediacapture-streams/stream-api/introduction/disabled-video-black.html
@@ -8,9 +8,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that a disabled video track in a MediaStream is rendered as blackness.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that a disabled video track in a
+MediaStream is rendered as blackness.</p>
 <video id="vid"></video>
 
 <div id='log'></div>

--- a/mediacapture-streams/stream-api/mediastream/audio.html
+++ b/mediacapture-streams/stream-api/mediastream/audio.html
@@ -8,9 +8,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track.</p>
+<p class="instructions">When prompted, accept to share your audio stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream object returned by
+the success callback in getUserMedia has exactly one audio track.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-addtrack.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-addtrack.html
@@ -8,9 +8,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio stream, then your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that adding a track to a MediaStream works as expected.</p>
+<p class="instructions">When prompted, accept to share your audio stream, then your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that adding a track to a MediaStream works as expected.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-finished-add.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-finished-add.html
@@ -8,9 +8,11 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio stream, then your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception.</p>
+<p class="instructions">When prompted, accept to share your audio stream, then
+your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that adding a track to a finished
+MediaStream raises an INVALID_STATE_ERR exception.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-gettrackid.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-gettrackid.html
@@ -7,9 +7,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that MediaStream.getTrackById behaves as expected</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that MediaStream.getTrackById behaves as expected</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-id-manual.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-id-manual.html
@@ -7,9 +7,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream object returned by
+the success callback in getUserMedia has a correct id.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-idl.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-idl.html
@@ -12,9 +12,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video and audio stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream constructor follows the algorithm set in the spec.</p>
+<p class="instructions">When prompted, accept to share your video and audio stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream constructor
+follows the algorithm set in the spec.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
@@ -8,9 +8,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio stream, then your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that removinging a track from a MediaStream works as expected.</p>
+<p class="instructions">When prompted, accept to share your audio stream, then your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that removinging a track from a MediaStream works as expected.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/stream-ended.html
+++ b/mediacapture-streams/stream-api/mediastream/stream-ended.html
@@ -8,9 +8,11 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers "onended" when it is set to true.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream object returned by
+the success callback in getUserMedia has a ended set to false at start, and
+triggers "onended" when it is set to true.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastream/video.html
+++ b/mediacapture-streams/stream-api/mediastream/video.html
@@ -9,9 +9,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the MediaStream object returned by
+the success callback in getUserMedia has exactly one video track and no audio.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-end.html
+++ b/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-end.html
@@ -7,9 +7,12 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video and audio stream, and then revoke that permission.</p>
-<h1>Description</h1>
-<p>This test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked.</p>
+<p class="instructions">When prompted, accept to share your video and audio
+stream, and then revoke that permission.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the video and audio tracks of
+MediaStream object returned by the success callback in getUserMedia are
+correctly set into ended state when permission is revoked.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-id.html
+++ b/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-id.html
@@ -7,9 +7,9 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your audio and video stream.</p>
-<h1>Description</h1>
-<p>This test checks that distinct mediastream tracks have distinct ids </p>
+<p class="instructions">When prompted, accept to share your audio and video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that distinct mediastream tracks have distinct ids.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-init.html
+++ b/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-init.html
@@ -11,9 +11,10 @@
 <link rel='stylesheet' href='/resources/testharness.css' media='all'/>
 </head>
 <body>
-<p>When prompted, accept to share your video stream.</p>
-<h1>Description</h1>
-<p>This test checks that the video track of MediaStream object returned by the success callback in getUserMedia is correctly initialized.</p>
+<p class="instructions">When prompted, accept to share your video stream.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks that the video track of MediaStream
+object returned by the success callback in getUserMedia is correctly initialized.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>

--- a/mediacapture-streams/stream-api/video-and-audio-tracks/audiostreamtrack.html
+++ b/mediacapture-streams/stream-api/video-and-audio-tracks/audiostreamtrack.html
@@ -8,8 +8,8 @@
 </head>
 <body>
 
-<h1>Description</h1>
-<p>This test verifies the availability of the AudioStreamTrack interface.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test verifies the availability of the AudioStreamTrack interface.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>

--- a/mediacapture-streams/stream-api/video-and-audio-tracks/videostreamtrack.html
+++ b/mediacapture-streams/stream-api/video-and-audio-tracks/videostreamtrack.html
@@ -8,8 +8,8 @@
 </head>
 <body>
 
-<h1>Description</h1>
-<p>This test verifies the availability of the VideoStreamTrack interface.</p>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test verifies the availability of the VideoStreamTrack interface.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>


### PR DESCRIPTION
As a part of making the WebRTC tests run as Blink layout tests (https://crbug.com/389134) I'm tagging the manual instructions in the tests with a special class "instructions", as agreed upon with dom@w3.org. Tags with this class will rewritten during import to the layout tests so they're invisible (style="display: none"). This way the test runner will not render the instructions and we don't have to create an expectations file containing only the instructions. Only the testharness output will be printed, which is parsed correctly already by the test runner.
