### PR TITLE
Add new test type wdspec to manifest generator

### DIFF
--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -14,13 +14,10 @@ from fnmatch import fnmatch
 
 
 def get_repo_root():
-    file_path = os.path.abspath(__file__)
-    while file_path:
-        if os.path.exists(os.path.join(file_path, ".git")):
-            return file_path
-        else:
-            file_path = os.path.split(file_path)[0]
-    return None
+    try:
+        return subprocess.check_output("git rev-parse --show-toplevel").rstrip()
+    except subprocess.CalledProcessError:
+        return None
 
 
 repo_root = get_repo_root()

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -358,11 +358,12 @@ def get_manifest_items(rel_path):
             #Need to check if this is the right reftype
             ref_list = [RefTest(rel_path, url, ref_url, "==")]
 
-    # wdspec tests are in subdirectories of /webdriver excluding
-    # /webdriver/client and  __init__.py files.
-    if (rel_dir_tree[0] == "webdriver" and len(rel_dir_tree) > 2 and
-            rel_dir_tree[1] != "client" and filename != "__init__.py" and
-            fnmatch(filename, wd_pattern)):
+    # wdspec tests are in subdirectories of /webdriver excluding __init__.py
+    # files.
+    if (rel_dir_tree[0] == "webdriver" and
+        len(rel_dir_tree) > 2 and
+        filename != "__init__.py" and
+        fnmatch(filename, wd_pattern)):
         return [WebdriverSpecTest(rel_path)]
 
     if file_markup_type:

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -15,7 +15,7 @@ from fnmatch import fnmatch
 
 def get_repo_root():
     try:
-        return subprocess.check_output("git rev-parse --show-toplevel").rstrip()
+        return subprocess.check_output(["git", "rev-parse", "--show-toplevel"]).rstrip()
     except subprocess.CalledProcessError:
         return None
 

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -531,13 +531,13 @@ def write(manifest, manifest_path):
         json.dump(manifest.to_json(), f, indent=2)
 
 
-def update_manifest(repo_path, rebuild=False, local_changes=False):
+def update_manifest(repo_path, **kwargs):
     setup_git(repo_path)
-    if not rebuild:
+    if not kwargs.get("rebuild", False):
         manifest = load(opts.path)
     else:
         manifest = Manifest(None)
-    if has_local_changes() and not local_changes:
+    if has_local_changes() and not kwargs.get("local_changes", False):
         logger.info("Not writing manifest because working directory is not clean.")
     else:
         logger.info("Updating manifest")

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -315,6 +315,7 @@ def get_manifest_items(rel_path):
 
     base_path, filename = os.path.split(path)
     name, ext = os.path.splitext(filename)
+    rel_dir_tree = rel_path.split(os.path.sep)
 
     file_markup_type = markup_type(ext)
 
@@ -347,13 +348,10 @@ def get_manifest_items(rel_path):
 
     # wdspec tests are in subdirectories of /webdriver excluding
     # /webdriver/client and  __init__.py files.
-    if rel_path.startswith("webdriver"):
-        if not base_path.endswith("webdriver") and \
-                not base_path.endswith("client") and \
-                filename != "__init__.py" and \
-                fnmatch(filename, wd_pattern):
-            return [WebdriverSpecTest(rel_path)]
-        return []
+    if (rel_dir_tree[0] == "webdriver" and len(rel_dir_tree) > 2 and
+            rel_dir_tree[1] != "client" and filename != "__init__.py" and
+            fnmatch(filename, wd_pattern)):
+        return [WebdriverSpecTest(rel_path)]
 
     if file_markup_type:
         timeout = None


### PR DESCRIPTION
This patch adds a new test type, wdspec, short for WebDriver
specification tests to the manifest generator.

It also makes a number of improvements to tools/scripts/manifest.py.
