### PR TITLE
got/lostpointercapture must fire asynchronously

### DIFF
--- a/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
+++ b/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
@@ -21,7 +21,7 @@
 
             var target0;
             var listener;
-            var pointerover_event;
+            var pointerdown_event;
             var detected_pointerEvents = new Array();
             var eventRcvd = false;
 
@@ -46,14 +46,14 @@
                             }
                             test_pointerEvent.step(function () {
                                 assert_false(eventRcvd, "no other events should be received before gotpointercapture." + eventsRcvd_str);
-                                assert_equals(event.pointerId, pointerover_event.pointerId, "pointerID is same for pointerdown and gotpointercapture");
+                                assert_equals(event.pointerId, pointerdown_event.pointerId, "pointerID is same for pointerdown and gotpointercapture");
                             });
 
                             detected_pointertypes[event.pointerType] = true;
                             test_pointerEvent.done(); // complete test
                         }
                         else {
-                            if (pointerover_event.pointerId === event.pointerId) {
+                            if (pointerdown_event.pointerId === event.pointerId) {
                                 detected_pointerEvents.push(event.type);
                                 eventRcvd = true;
                             }
@@ -63,8 +63,8 @@
 
                 // set pointer capture
                 on_event(target0, "pointerdown", function (event) {
-                pointerover_event = event;
-                listener.setPointerCapture(event.pointerId);
+                    pointerdown_event = event;
+                    listener.setPointerCapture(event.pointerId);
                 });
             }
         </script>

--- a/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
+++ b/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
@@ -24,6 +24,7 @@
             var pointerdown_event;
             var detected_pointerEvents = new Array();
             var eventRcvd = false;
+            var isAsync = false;
 
 
             function run() {
@@ -36,6 +37,7 @@
                     on_event(listener, All_Pointer_Events[i], function (event) {
                         if (event.type == "gotpointercapture") {
                             check_PointerEvent(event);
+                            assert_true(isAsync, "gotpointercapture must be fired asynchronously");
                             // if any events have been received with same pointerId before gotpointercapture, then fail
                             var eventsRcvd_str = "";
                             if (eventRcvd) {
@@ -65,6 +67,9 @@
                 on_event(target0, "pointerdown", function (event) {
                     pointerdown_event = event;
                     listener.setPointerCapture(event.pointerId);
+                    setTimeout(function() {
+                        isAsync = true;
+                    });
                 });
             }
         </script>

--- a/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
+++ b/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <title>Pointer Event: gotpiontercapture is fired first.</title>
+        <title>Pointer Event: gotpiontercapture is fired first and asynchronously.</title>
         <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <meta name="assert" content="After setting capture, the gotpointercapture dispatched to the capturing element before any other event is fired." />
@@ -81,7 +81,7 @@
         <h1>Pointer Event: Dispatch gotpointercapture event</h1>
         <h4>Test Description:
             After pointer capture is set for a pointer, and prior to dispatching the first event for the pointer, the gotpointercapture
-            event must be dispatched to the element that is receiving the pointer capture.
+            event must be dispatched to the element that is receiving the pointer capture. The gotpointercapture event must be dispatched asynchronously.
         </h4>
         <br />
         <div id="target0">

--- a/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
+++ b/pointerevents/pointerevent_gotpointercapture_before_first_pointerevent-manual.html
@@ -37,7 +37,10 @@
                     on_event(listener, All_Pointer_Events[i], function (event) {
                         if (event.type == "gotpointercapture") {
                             check_PointerEvent(event);
+
+                            // TA: 10.2
                             assert_true(isAsync, "gotpointercapture must be fired asynchronously");
+
                             // if any events have been received with same pointerId before gotpointercapture, then fail
                             var eventsRcvd_str = "";
                             if (eventRcvd) {

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -75,7 +75,9 @@
                     testStarted = false;
 
                     test(function() {
+                        // TA: 11.2
                         assert_true(isAsync, "lostpointercapture must be fired asynchronously");
+
                         assert_true((pointeroverReceived == false)&&
                         (pointeroutReceived == false)&&
                         (pointerdownReceived == false)&&

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <title>Lostpointercapture triggers first</title>
+        <title>Lostpointercapture triggers first and asynchronously</title>
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -12,7 +12,7 @@
         <h1>Pointer Events capture test - lostpointercapture order</h1>
         <h4>
             Test Description:
-            This test checks if lostpointercapture is handled prior to all subsequent events.
+            This test checks if lostpointercapture is handled asynchronously and prior to all subsequent events.
             Complete the folowing actions:
             <ol>
                 <li> Press and hold left mouse button over "Set Capture" button. "gotpointercapture" should be logged inside of the black rectangle

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -33,6 +33,7 @@
                 pointerenterReceived;
 
             var testStarted = false;
+            var isAsync = false;
 
             var target0 = document.getElementById('target0');
             var target1 = document.getElementById('target1');
@@ -49,6 +50,9 @@
                     }
                     else {
                         rPointerCapture(e);
+                        setTimeout(function() {
+                            isAsync = true;
+                        });
                     }
                  });
 
@@ -71,6 +75,7 @@
                     testStarted = false;
 
                     test(function() {
+                        assert_true(isAsync, "lostpointercapture must be fired asynchronously");
                         assert_true((pointeroverReceived == false)&&
                         (pointeroutReceived == false)&&
                         (pointerdownReceived == false)&&


### PR DESCRIPTION
TA 10.2 and 11.2

These tests fail in IE, but I believe that's expected.
