### PR TITLE
Update pointerevent_support.js to match the spec

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -31,8 +31,8 @@ function check_PointerEvent(event) {
     };
     [
         ["readonly", "long", "pointerId"],
-        ["readonly", "long", "width"],
-        ["readonly", "long", "height"],
+        ["readonly", "float", "width"],
+        ["readonly", "float", "height"],
         ["readonly", "float", "pressure"],
         ["readonly", "long", "tiltX"],
         ["readonly", "long", "tiltY"],


### PR DESCRIPTION
Change data type of width and height attributes of a pointer event from long to float to match the spec.
