### PR TITLE
Remove the requirement to implement showModalDialog from window-properties.html.

### DIFF
--- a/html/browsers/the-window-object/window-properties.html
+++ b/html/browsers/the-window-object/window-properties.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <meta charset=utf-8>
 <title>Properties of the window object</title>
-<link rel="author" title="Ms2ger" href="ms2ger@gmail.com">
+<link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
 <link rel="help" href="http://ecma-international.org/ecma-262/5.1/#sec-15.1">
-<link rel="help" href="http://dev.w3.org/2006/webapi/WebIDL/#interface-prototype-object">
-<link rel="help" href="http://dev.w3.org/2006/webapi/WebIDL/#es-attributes">
-<link rel="help" href="http://dev.w3.org/2006/webapi/WebIDL/#es-operations">
-<link rel="help" href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#eventtarget">
+<link rel="help" href="http://heycam.github.io/webidl/#interface-prototype-object">
+<link rel="help" href="http://heycam.github.io/webidl/#es-attributes">
+<link rel="help" href="http://heycam.github.io/webidl/#es-operations">
+<link rel="help" href="http://dom.spec.whatwg.org/#eventtarget">
 <link rel="help" href="http://www.whatwg.org/html/#window">
 <link rel="help" href="http://www.whatwg.org/html/#windowtimers">
 <link rel="help" href="http://www.whatwg.org/html/#windowbase64">
@@ -64,7 +64,7 @@ var methods = [
   "confirm",
   "prompt",
   "print",
-  "showModalDialog",
+  // See below: "showModalDialog",
   "postMessage",
 
   // WindowBase64
@@ -89,6 +89,12 @@ var methods = [
   "scrollTo",
   "scrollBy"
 ];
+
+// We would like to remove showModalDialog from the platform,
+// see <https://www.w3.org/Bugs/Public/show_bug.cgi?id=26437>.
+if ("showModalDialog" in window) {
+  methods.push("showModalDialog");
+}
 
 var readonlyAttributes = [
   "history",


### PR DESCRIPTION
The future of this feature is uncertain, and there is no good reason for this
test to require it. However, if it is implemented, we'll still test that it's
implemented correctly.
