### PR TITLE
Updates and new tests for TAs 2.4.1, 3.6, 3.6.1, 4.3, 4.3.1

### DIFF
--- a/pointerevents/pointerevent_pointerenter_nohover-manual.html
+++ b/pointerevents/pointerevent_pointerenter_nohover-manual.html
@@ -22,6 +22,7 @@ or one of its descendants as a result of a pointerdown event, the pointerenter e
 
             var test_pointerEnter;
             var f_pointerenter_rcvd = false;
+            var pointerenter_event;
 
             function run() {
                 var target0 = document.getElementById("target0");
@@ -31,11 +32,14 @@ or one of its descendants as a result of a pointerdown event, the pointerenter e
                     test_pointerEvent.step(function () {
                         assert_equals(event.type, "pointerdown", "pointer event received" + event.type);
                         assert_true(f_pointerenter_rcvd, "pointerenter event should have been received before pointerdown");
+                        assert_equals(event.pointerType, pointerenter_event.pointerType, "pointerType is same for pointerenter and pointerdown");
+                        assert_equals(event.isPrimary, pointerenter_event.isPrimary, "isPrimary is same for pointerenter and pointerdown");
                     });
                     test_pointerEvent.done(); // complete test
                 });
 
                 on_event(target0, "pointerenter", function (event) {
+                    pointerenter_event = event;
                     check_PointerEvent(event);
                     test_pointerEvent.step(function () {
                         assert_not_equals(event.pointerType, "mouse", "Test should be run using a pen or touch as input");

--- a/pointerevents/pointerevent_pointerenter_nohover-manual.html
+++ b/pointerevents/pointerevent_pointerenter_nohover-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
     <head>
-        <title>Pointer Event: Dispatch pointerenter. (touch)</title>
+        <title>Pointer Event: Dispatch pointerenter. (nohover)</title>
         <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/"/>
         <meta name="assert" content="When a pointing device that does not support hover is moved into the hit test boundaries of an element
@@ -28,31 +28,34 @@ or one of its descendants as a result of a pointerdown event, the pointerenter e
                 var target0 = document.getElementById("target0");
 
                 on_event(target0, "pointerdown", function (event) {
-                    check_PointerEvent(event);
-                    test_pointerEvent.step(function () {
-                        assert_equals(event.type, "pointerdown", "pointer event received" + event.type);
-                        assert_true(f_pointerenter_rcvd, "pointerenter event should have been received before pointerdown");
-                        assert_equals(event.pointerType, pointerenter_event.pointerType, "pointerType is same for pointerenter and pointerdown");
-                        assert_equals(event.isPrimary, pointerenter_event.isPrimary, "isPrimary is same for pointerenter and pointerdown");
-                    });
-                    test_pointerEvent.done(); // complete test
+                    if(event.pointerType == 'touch') {
+                        check_PointerEvent(event);
+                        test_pointerEvent.step(function () {
+                            assert_equals(event.type, "pointerdown", "pointer event received" + event.type);
+                            assert_true(f_pointerenter_rcvd, "pointerenter event should have been received before pointerdown");
+                            assert_equals(event.pointerType, pointerenter_event.pointerType, "pointerType is same for pointerenter and pointerdown");
+                            assert_equals(event.isPrimary, pointerenter_event.isPrimary, "isPrimary is same for pointerenter and pointerdown");
+                        });
+                        test_pointerEvent.done(); // complete test
+                    }
                 });
 
                 on_event(target0, "pointerenter", function (event) {
-                    pointerenter_event = event;
-                    check_PointerEvent(event);
-                    test_pointerEvent.step(function () {
-                        assert_not_equals(event.pointerType, "mouse", "Test should be run using a pen or touch as input");
-                        assert_equals(event.type, "pointerenter", "pointer event received" + event.type);
-                    });
-                    f_pointerenter_rcvd = true;
-                    detected_pointertypes[event.pointerType] = true;
+                    if(event.pointerType == 'touch') {
+                        pointerenter_event = event;
+                        check_PointerEvent(event);
+                        test_pointerEvent.step(function () {
+                            assert_equals(event.type, "pointerenter", "pointer event received" + event.type);
+                        });
+                        f_pointerenter_rcvd = true;
+                        detected_pointertypes[event.pointerType] = true;
+                    }
                 });
             }
         </script>
     </head>
     <body onload="run()">
-        <h1>Pointer Event: Dispatch pointerenter (touch)</h1>
+        <h1>Pointer Event: Dispatch pointerenter (nohover)</h1>
         <h4>
             Test Description:
             When a pointing device that does not support hover is moved into the hit test boundaries of an element or one of its
@@ -60,7 +63,7 @@ or one of its descendants as a result of a pointerdown event, the pointerenter e
         </h4>
         <br />
         <div id="target0">
-            Use touch to tap here.
+            Tap here.
         </div>
         <div id="complete-notice">
             <p>Test complete: Scroll to Summary to view Pass/Fail Results.</p>

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -35,21 +35,23 @@
                 // After firing the pointercancel event the pointerleave event must be dispatched.
                 // TA: 4.3.1
                 on_event(target0, "pointerleave", function (event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    if(pointercancel_event != null) {
-                        if(eventTested == false) {
-                            test_pointerleave.step(function() {
-                                assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");
-                                assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerleave");
-                            });
-                            eventTested = true;
-                            test_pointerleave.done();
+                    if(event.pointerType == 'touch') {
+                        detected_pointertypes[event.pointerType] = true;
+                        if(pointercancel_event != null) {
+                            if(eventTested == false) {
+                                test_pointerleave.step(function() {
+                                    assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");
+                                    assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerleave");
+                                });
+                                eventTested = true;
+                                test_pointerleave.done();
+                            }
                         }
-                    }
-                    else {
-                        test_pointerleave.step(function() {
-                            assert_unreached("pointerleave received before pointercancel");
-                        }, "pointerleave received before pointercancel");
+                        else {
+                            test_pointerleave.step(function() {
+                                assert_unreached("pointerleave received before pointercancel");
+                            }, "pointerleave received before pointercancel");
+                        }
                     }
                 });
             }

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -36,7 +36,7 @@
                 // TA: 4.3.1
                 on_event(target0, "pointerleave", function (event) {
                     detected_pointertypes[event.pointerType] = true;
-                    if(pointercancel_event) {
+                    if(pointercancel_event != null) {
                         if(eventTested == false) {
                             test_pointerleave.step(function() {
                                 assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -48,9 +48,8 @@
                     }
                     else {
                         test_pointerleave.step(function() {
-                            assert_true(false,
-                            "pointercancel received before pointerleave");
-                        }, "pointercancel received before pointerleave");
+                            assert_unreached("pointercancel should be received after pointerleave");
+                        }, "pointercancel should be received after pointerleave");
                     }
                 });
             }

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -38,18 +38,18 @@
                     detected_pointertypes[event.pointerType] = true;
                     if(pointercancel_event) {
                         if(eventTested == false) {
-							test_pointerleave.step(function() {
-								assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");
-								assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerleave");
-							});
+                            test_pointerleave.step(function() {
+                                assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");
+                                assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerleave");
+                            });
                             eventTested = true;
                             test_pointerleave.done();
                         }
                     }
                     else {
                         test_pointerleave.step(function() {
-                            assert_unreached("pointercancel should be received after pointerleave");
-                        }, "pointercancel should be received after pointerleave");
+                            assert_unreached("pointerleave received before pointercancel");
+                        }, "pointerleave received before pointercancel");
                     }
                 });
             }

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -9,9 +9,9 @@
         <!-- Additional helper script for common checks across event types -->
         <script type="text/javascript" src="pointerevent_support.js"></script>
     </head>
-    <body onload="run()">
+    <body class="scrollable" onload="run()">
         <h2>pointerleave after pointercancel</h2>
-        <h4>Test Description: This test checks if pointerleave event triggers after pointercancel. Start touch on the black rectangle and move your touch like you're scrolling in any direction. </h4>
+        <h4>Test Description: This test checks if pointerleave event triggers after pointercancel. Start touch on the black rectangle and move your touch to scroll in any direction. </h4>
         <p>Note: this test is for touch devices only</p>
         <div id="target0"></div>
         <script>

--- a/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+    <head>
+        <title>pointerleave after pointercancel</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <!-- Additional helper script for common checks across event types -->
+        <script type="text/javascript" src="pointerevent_support.js"></script>
+    </head>
+    <body onload="run()">
+        <h2>pointerleave after pointercancel</h2>
+        <h4>Test Description: This test checks if pointerleave event triggers after pointercancel. Start touch on the black rectangle and move your touch like you're scrolling in any direction. </h4>
+        <p>Note: this test is for touch devices only</p>
+        <div id="target0"></div>
+        <script>
+            var test_pointerleave = async_test("pointerleave event received");
+            // showPointerTypes is defined in pointerevent_support.js
+            // Requirements: the callback function will reference the test_pointerEvent object and
+            // will fail unless the async_test is created with the var name "test_pointerEvent".
+            add_completion_callback(showPointerTypes);
+
+            var eventTested = false;
+            var pointercancel_event = null;
+            var detected_pointertypes = {};
+
+            function run() {
+                var target0 = document.getElementById("target0");
+
+                on_event(target0, "pointercancel", function (event) {
+                    pointercancel_event = event;
+                });
+
+                // After firing the pointercancel event the pointerleave event must be dispatched.
+                // TA: 4.3.1
+                on_event(target0, "pointerleave", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    if(pointercancel_event) {
+                        if(eventTested == false) {
+							test_pointerleave.step(function() {
+								assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerleave");
+								assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerleave");
+							});
+                            eventTested = true;
+                            test_pointerleave.done();
+                        }
+                    }
+                    else {
+                        test_pointerleave.step(function() {
+                            assert_true(false,
+                            "pointercancel received before pointerleave");
+                        }, "pointercancel received before pointerleave");
+                    }
+                });
+            }
+
+        </script>
+        <h1>Pointer Events pointerleave tests</h1>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+    <head>
+        <title>pointerleave after pointerup</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <!-- Additional helper script for common checks across event types -->
+        <script type="text/javascript" src="pointerevent_support.js"></script>
+    </head>
+    <body onload="run()">
+        <h2>pointerleave after pointerup</h2>
+        <h4>Test Description: This test checks if pointerleave event triggers for devices that don't support hover. Tap the black rectangle. </h4>
+        <p>Note: this test is only for devices that do not support hover.</p>
+        <div id="target0"></div>
+        <script>
+            var test_pointerleave = async_test("pointerleave event received");
+            // showPointerTypes is defined in pointerevent_support.js
+            // Requirements: the callback function will reference the test_pointerEvent object and
+            // will fail unless the async_test is created with the var name "test_pointerEvent".
+            add_completion_callback(showPointerTypes);
+
+            var eventTested = false;
+            var isPointerupReceived = false;
+			var pointerup_event = null;
+            var detected_pointertypes = {};
+
+            function run() {
+                var target0 = document.getElementById("target0");
+
+                on_event(target0, "pointerup", function (event) {
+					pointerup_event = event;
+                });
+
+                // For input devices that do not support hover, a pointerleave event must follow the pointerup event.
+                // TA: 3.6
+                on_event(target0, "pointerleave", function (event) {
+                    if(event.pointerType == 'touch') {
+                        detected_pointertypes[event.pointerType] = true;
+                        if(pointerup_event) {
+                            if(eventTested == false) {
+                                eventTested = true;
+                                test_pointerleave.step(function() {
+                                    assert_equals(event.pointerType, pointerup_event.pointerType, "pointerType is same for pointerup and pointerleave");
+                                    assert_equals(event.isPrimary, pointerup_event.isPrimary, "isPrimary is same for pointerup and pointerleave");
+                                });
+                                test_pointerleave.done();
+                            }
+                        }
+                        else {
+                            test_pointerleave.step(function() {
+                                assert_true(false,
+                                "pointerup received before pointerleave");
+                            }, "pointerup received before pointerleave");
+                        }
+                    }
+                });
+            }
+
+        </script>
+        <h1>Pointer Events pointerleave tests</h1>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+            <p>Refresh the page to run the tests again with a different pointer type.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
@@ -38,7 +38,7 @@
                 on_event(target0, "pointerleave", function (event) {
                     if(event.pointerType == 'touch') {
                         detected_pointertypes[event.pointerType] = true;
-                        if(pointerup_event) {
+                        if(pointerup_event != null) {
                             if(eventTested == false) {
                                 eventTested = true;
                                 test_pointerleave.step(function() {

--- a/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
@@ -23,14 +23,14 @@
 
             var eventTested = false;
             var isPointerupReceived = false;
-			var pointerup_event = null;
+            var pointerup_event = null;
             var detected_pointertypes = {};
 
             function run() {
                 var target0 = document.getElementById("target0");
 
                 on_event(target0, "pointerup", function (event) {
-					pointerup_event = event;
+                    pointerup_event = event;
                 });
 
                 // For input devices that do not support hover, a pointerleave event must follow the pointerup event.

--- a/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerleave_after_pointerup_nohover.html
@@ -50,9 +50,8 @@
                         }
                         else {
                             test_pointerleave.step(function() {
-                                assert_true(false,
-                                "pointerup received before pointerleave");
-                            }, "pointerup received before pointerleave");
+                                assert_unreached("pointerleave received before pointerup");
+                            }, "pointerleave received before pointerup");
                         }
                     }
                 });

--- a/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
@@ -22,22 +22,26 @@
             add_completion_callback(showPointerTypes);
 
             var eventTested = false;
-            var isPointercancelReceived = false;
+            var pointercancel_event = null;
             var detected_pointertypes = {};
 
             function run() {
                 var target0 = document.getElementById("target0");
 
                 on_event(target0, "pointercancel", function (event) {
-                    isPointercancelReceived = true;
+                    pointercancel_event = event;
                 });
 
                 // After firing the pointercancel event the pointerout event must be dispatched.
-                // TA: 7.6
+                // TA: 4.3
                 on_event(target0, "pointerout", function (event) {
                     detected_pointertypes[event.pointerType] = true;
-                    if(isPointercancelReceived) {
+                    if(pointercancel_event) {
                         if (eventTested == false) {
+							test_pointerout.step(function() {
+								assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
+								assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
+							});
                             eventTested = true;
                             test_pointerout.done();
                         }

--- a/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
@@ -35,22 +35,24 @@
                 // After firing the pointercancel event the pointerout event must be dispatched.
                 // TA: 4.3
                 on_event(target0, "pointerout", function (event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    if(pointercancel_event != null) {
-                        if (eventTested == false) {
-                            test_pointerout.step(function() {
-                                assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
-                                assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
-                            });
-                            eventTested = true;
-                            test_pointerout.done();
+                    if(event.pointerType == 'touch') {
+                        detected_pointertypes[event.pointerType] = true;
+                        if(pointercancel_event != null) {
+                            if (eventTested == false) {
+                                test_pointerout.step(function() {
+                                    assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
+                                    assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
+                                });
+                                eventTested = true;
+                                test_pointerout.done();
+                            }
                         }
-                    }
-                    else {
-                        test_pointerout.step(function() {
-                            assert_true(false,
-                            "pointercancel received before pointerout");
-                        }, "pointercancel received before pointerout");
+                        else {
+                            test_pointerout.step(function() {
+                                assert_true(false,
+                                "pointercancel received before pointerout");
+                            }, "pointercancel received before pointerout");
+                        }
                     }
                 });
             }

--- a/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
@@ -38,7 +38,7 @@
                     detected_pointertypes[event.pointerType] = true;
                     if(pointercancel_event) {
                         if (eventTested == false) {
-							test_pointerout.step(function() {
+				            test_pointerout.step(function() {
 								assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
 								assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
 							});
@@ -59,7 +59,6 @@
         <h1>Pointer Events pointerout tests</h1>
         <div id="complete-notice">
             <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
-            <p>Refresh the page to run the tests again with a different pointer type.</p>
         </div>
         <div id="log"></div>
     </body>

--- a/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
+++ b/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html
@@ -36,12 +36,12 @@
                 // TA: 4.3
                 on_event(target0, "pointerout", function (event) {
                     detected_pointertypes[event.pointerType] = true;
-                    if(pointercancel_event) {
+                    if(pointercancel_event != null) {
                         if (eventTested == false) {
-				            test_pointerout.step(function() {
-								assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
-								assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
-							});
+                            test_pointerout.step(function() {
+                                assert_equals(event.pointerType, pointercancel_event.pointerType, "pointerType is same for pointercancel and pointerout");
+                                assert_equals(event.isPrimary, pointercancel_event.isPrimary, "isPrimary is same for pointercancel and pointerout");
+                            });
                             eventTested = true;
                             test_pointerout.done();
                         }

--- a/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
@@ -22,14 +22,14 @@
             add_completion_callback(showPointerTypes);
 
             var eventTested = false;
-            var isPointerupReceived = false;
+            var pointerup_event = null;
             var detected_pointertypes = {};
 
             function run() {
                 var target0 = document.getElementById("target0");
 
                 on_event(target0, "pointerup", function (event) {
-                    isPointerupReceived = true;
+                    pointerup_event = event;
                 });
 
                 // For input devices that do not support hover, a pointerout event must follow the pointerup event.
@@ -37,8 +37,12 @@
                 on_event(target0, "pointerout", function (event) {
                     if(event.pointerType == 'touch') {
                         detected_pointertypes[event.pointerType] = true;
-                        if(isPointerupReceived) {
+                        if(pointerup_event) {
                             if(eventTested == false) {
+                                test_pointerout.step(function() {
+                                    assert_equals(event.pointerType, pointerup_event.pointerType, "pointerType is same for pointerup and pointerout");
+                                    assert_equals(event.isPrimary, pointerup_event.isPrimary, "isPrimary is same for pointerup and pointerout");
+                                });
                                 eventTested = true;
                                 test_pointerout.done();
                             }

--- a/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
@@ -32,8 +32,8 @@
                     isPointerupReceived = true;
                 });
 
-                // When touch, a device that does not support hover, after firing the pointerup event the pointerout event must be dispatched.
-                // TA: 7.5
+                // For input devices that do not support hover, a pointerout event must follow the pointerup event.
+                // TA: 3.6
                 on_event(target0, "pointerout", function (event) {
                     if(event.pointerType == 'touch') {
                         detected_pointertypes[event.pointerType] = true;

--- a/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
+++ b/pointerevents/pointerevent_pointerout_after_pointerup_nohover.html
@@ -37,7 +37,7 @@
                 on_event(target0, "pointerout", function (event) {
                     if(event.pointerType == 'touch') {
                         detected_pointertypes[event.pointerType] = true;
-                        if(pointerup_event) {
+                        if(pointerup_event != null) {
                             if(eventTested == false) {
                                 test_pointerout.step(function() {
                                     assert_equals(event.pointerType, pointerup_event.pointerType, "pointerType is same for pointerup and pointerout");


### PR DESCRIPTION
Added attribute checking for TA 2.4.1, 3.6 and 4.3.
Created tests for TAs 3.6.1 and 4.3.1.

Note: IE11 fails pointerevent_pointerleave_after_pointercancel_touch.html as it does pointerevent_pointerout_after_pointercancel_touch.html.
