### PR TITLE
IndexedDB: Fix abort-in-initial-upgradeneeded assertions

### DIFF
--- a/IndexedDB/abort-in-initial-upgradeneeded.html
+++ b/IndexedDB/abort-in-initial-upgradeneeded.html
@@ -23,11 +23,10 @@ open_rq.onupgradeneeded = function(e) {
 }
 
 open_rq.onerror = function(e) {
-    assert_true(!!e.target.result, "event.target.result should be non-null");
-    assert_equals(db, e.target.result);
     assert_equals(open_rq, e.target);
+    assert_equals(e.target.result, undefined);
     assert_equals(e.target.error.name, "AbortError");
-    assert_equals(e.target.result.version, 0);
+    assert_equals(db.version, 0);
     assert_equals(open_rq.transaction, null);
     this.done();
 }


### PR DESCRIPTION
Spec says: "result ... is undefined when the request resulted in an error." But the test is asserting that the result is non-null after an error. The test currently fails both in Firefox and Chrome M37+. With this change, the test passes.
