### PR TITLE
Implement Generic CSP 1.0 tests for the 'self' keyword.

### DIFF
--- a/content-security-policy/generic/generic-0_2.html
+++ b/content-security-policy/generic/generic-0_2.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>'self' keyword positive test</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='positiveTest.js'></script>
+</head>
+<body>
+    <h1>'self' keyword positive test</h1>
+    <div id='log'></div>
+
+
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_2.html
+++ b/content-security-policy/generic/generic-0_2.html
@@ -10,6 +10,6 @@
     <h1>'self' keyword positive test</h1>
     <div id='log'></div>
 
-
+    <script async defer src='../support/checkReport.sub.js?reportExists=false'></script>
 </body>
 </html>

--- a/content-security-policy/generic/generic-0_2.html.sub.headers
+++ b/content-security-policy/generic/generic-0_2.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_2={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/generic-0_2_2.html
+++ b/content-security-policy/generic/generic-0_2_2.html
@@ -17,6 +17,6 @@
     <h1>'self' fails with a different port</h1>
     <div id='log'></div>
 
-    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27'></script>
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27%20%27unsafe-inline%27'></script>
 </body>
 </html>

--- a/content-security-policy/generic/generic-0_2_2.html
+++ b/content-security-policy/generic/generic-0_2_2.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>'self' fails with a different port</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='negativeTests.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://" + location.hostname + ":44403/content-security-policy/generic/unreached.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>'self' fails with a different port</h1>
+    <div id='log'></div>
+
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_2_2.html.sub.headers
+++ b/content-security-policy/generic/generic-0_2_2.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_2_2={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/generic-0_2_3.html
+++ b/content-security-policy/generic/generic-0_2_3.html
@@ -17,6 +17,6 @@
     <h1>'self' fails with a different host (including sub-host e.g. foo.com as self with content from bar.foo.com)</h1>
     <div id='log'></div>
 
-    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27'></script>
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27%20%27unsafe-inline%27'></script>
 </body>
 </html>

--- a/content-security-policy/generic/generic-0_2_3.html
+++ b/content-security-policy/generic/generic-0_2_3.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>'self' fails with a different host (including sub-host e.g. foo.com as self with content from bar.foo.com)</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='negativeTests.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://www." + location.hostname + ":" + location.port + "/content-security-policy/generic/unreached.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>'self' fails with a different host (including sub-host e.g. foo.com as self with content from bar.foo.com)</h1>
+    <div id='log'></div>
+
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_2_3.html.sub.headers
+++ b/content-security-policy/generic/generic-0_2_3.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_2_3={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/negativeTests.js
+++ b/content-security-policy/generic/negativeTests.js
@@ -1,0 +1,3 @@
+var t1 = async_test("'self' keyword prevents access to external scripts.");
+
+onload = function() {t1.done();}

--- a/content-security-policy/generic/positiveTest.js
+++ b/content-security-policy/generic/positiveTest.js
@@ -1,0 +1,6 @@
+onload = function() {
+  test(function() {
+        assert_true(true, 'Script ran.')},
+        "'self' keyword allows scripts from the same host."
+    );
+}

--- a/content-security-policy/generic/unreached.js
+++ b/content-security-policy/generic/unreached.js
@@ -1,0 +1,3 @@
+onload = function() {
+      t1.step(function() {assert_unreached("Script should not have ran.");});
+}


### PR DESCRIPTION
This branch implements tests 0.2, 0.2.2 and 0.2.3 of the "Generic Test Assertions for CSP 1.0" test plan.

See http://www.w3.org/Security/wiki/Test_Assertions_For_Content_Security_Policy for the entire test plan.
