### PR TITLE
Implement Generic CSP 1.0 test for wildcard host.

### DIFF
--- a/content-security-policy/generic/generic-0_8.html
+++ b/content-security-policy/generic/generic-0_8.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>test wildcard host name matching (*.web-platform.test is good)</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='wildcardHostTest.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://www." + location.hostname + ":" + location.port + "/content-security-policy/generic/wildcardHostTestSuceeds.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>test wildcard host name matching (*.web-platform.test is good)</h1>
+    <div id='log'></div>
+
+    <script async defer src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_8.html.sub.headers
+++ b/content-security-policy/generic/generic-0_8.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_8={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' *.{{host}}:{{ports[http][0]}} 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/generic-0_8_1.sub.html
+++ b/content-security-policy/generic/generic-0_8_1.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>test wildcard host name matching (www*.web-platform.test is bad, *www.web-platform.test is bad)</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='wildcardHostTestFailure.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://www." + location.hostname + ":" + location.port + "/content-security-policy/generic/wildcardHostTestSuceeds.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>test wildcard host name matching (www*.web-platform.test is bad, *www.web-platform.test is bad)</h1>
+    <div id='log'></div>
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27%20*w.{{host}}:{{ports[http][0]}}%20w*.{{host}}:{{ports[http][0]}}%20%27unsafe-inline%27'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_8_1.sub.html.sub.headers
+++ b/content-security-policy/generic/generic-0_8_1.sub.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_8_1={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' *w.{{host}}:{{ports[http][0]}} w*.{{host}}:{{ports[http][0]}} 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/wildcardHostTest.js
+++ b/content-security-policy/generic/wildcardHostTest.js
@@ -1,0 +1,8 @@
+wildcardHostTestRan = false;
+
+onload = function() {
+  test(function() {
+        assert_true(wildcardHostTestRan, 'Script should have ran.')},
+        "Wildcard host matching works."
+    );
+}

--- a/content-security-policy/generic/wildcardHostTestFailure.js
+++ b/content-security-policy/generic/wildcardHostTestFailure.js
@@ -1,0 +1,8 @@
+wildcardHostTestRan = false;
+
+onload = function() {
+  test(function() {
+        assert_false(wildcardHostTestRan, 'Script should not have ran.')},
+        "Wildcard host matching works."
+    );
+}

--- a/content-security-policy/generic/wildcardHostTestSuceeds.js
+++ b/content-security-policy/generic/wildcardHostTestSuceeds.js
@@ -1,0 +1,1 @@
+wildcardHostTestRan = true;


### PR DESCRIPTION
This branch implements test 0.8 for host wildcards of the "Generic Test Assertions for CSP 1.0" test plan.

See http://www.w3.org/Security/wiki/Test_Assertions_For_Content_Security_Policy for the entire test plan.
