### PR TITLE
Implement generic CSP 1.0 Tests for implicit port numbers

### DIFF
--- a/content-security-policy/generic/generic-0_10.html
+++ b/content-security-policy/generic/generic-0_10.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>test implicit port number matching (requires port 80)</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://www." + location.hostname + "/content-security-policy/generic/positiveTest.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>test implicit port number matching (requires port 80)</h1>
+    <div id='log'></div>
+
+    <script async defer src='../support/checkReport.sub.js?reportExists=false'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_10.html.sub.headers
+++ b/content-security-policy/generic/generic-0_10.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_10={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' www.{{host}} 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/generic-0_10_1.sub.html
+++ b/content-security-policy/generic/generic-0_10_1.sub.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>implicit port number matching fails with a different port</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+    <script src='negativeTests.js'></script>
+    <script>
+      var head = document.getElementsByTagName('head')[0];
+      var script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.src = "http://www." + location.hostname + ":{{ports[http][1]}}/content-security-policy/generic/unreached.js";
+      head.appendChild(script);
+    </script>
+</head>
+<body>
+    <h1>implicit port number matching fails with a different port</h1>
+    <div id='log'></div>
+
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27self%27%20www.{{host}}%20%27unsafe-inline%27'></script>
+</body>
+</html>

--- a/content-security-policy/generic/generic-0_10_1.sub.html.sub.headers
+++ b/content-security-policy/generic/generic-0_10_1.sub.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: generic-0_10_1={{$id:uuid()}}; Path=/content-security-policy/generic/
+Content-Security-Policy: script-src 'self' www.{{host}} 'unsafe-inline'; report-uri  ../support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/generic/negativeTests.js
+++ b/content-security-policy/generic/negativeTests.js
@@ -1,3 +1,3 @@
-var t1 = async_test("'self' keyword prevents access to external scripts.");
+var t1 = async_test("Prevents access to external scripts.");
 
 onload = function() {t1.done();}

--- a/content-security-policy/generic/positiveTest.js
+++ b/content-security-policy/generic/positiveTest.js
@@ -1,6 +1,6 @@
 onload = function() {
   test(function() {
         assert_true(true, 'Script ran.')},
-        "'self' keyword allows scripts from the same host."
+        "Allows scripts from the same host."
     );
 }


### PR DESCRIPTION
This branch implements test 0.10 for implicit port numbers from the CSP Test Plan.

See http://www.w3.org/Security/wiki/Test_Assertions_For_Content_Security_Policy for more information.
