### PR TITLE
port test for script-src 1.9 from php tests

### DIFF
--- a/content-security-policy/script-src/10_1_support_1.js
+++ b/content-security-policy/script-src/10_1_support_1.js
@@ -1,0 +1,1 @@
+var dataScriptRan = false;

--- a/content-security-policy/script-src/10_1_support_2.js
+++ b/content-security-policy/script-src/10_1_support_2.js
@@ -1,0 +1,3 @@
+test(function () {
+            assert_true(dataScriptRan, "data script ran");
+        }, "Verify that data: as script src runs with this policy");

--- a/content-security-policy/script-src/buildInlineWorker.js
+++ b/content-security-policy/script-src/buildInlineWorker.js
@@ -1,0 +1,19 @@
+(function () 
+{ 
+ var workerSource = document.getElementById('inlineWorker');
+
+ var blob = new Blob([workerSource.textContent]);
+
+ // can I create a new script tag like this? ack...
+ var url = window.URL.createObjectURL(blob);
+
+ var worker = new Worker(url);
+
+ worker.addEventListener('message', function(e) {
+    test(function () { 
+ 	assert_not_equals(e.data, 'fail', 'inline script ran'); 
+	})
+ }, false);
+
+ worker.postMessage('');
+})();

--- a/content-security-policy/script-src/buildInlineWorker.js
+++ b/content-security-policy/script-src/buildInlineWorker.js
@@ -1,5 +1,6 @@
-(function () 
-{ 
+(function ()
+{
+ var test = new async_test("test inline worker");
  var workerSource = document.getElementById('inlineWorker');
 
  var blob = new Blob([workerSource.textContent]);
@@ -10,9 +11,10 @@
  var worker = new Worker(url);
 
  worker.addEventListener('message', function(e) {
-    test(function () { 
- 	assert_not_equals(e.data, 'fail', 'inline script ran'); 
-	})
+    test.step(function () {
+        assert_not_equals(e.data, 'fail', 'inline script ran');
+        test.done();
+    })
  }, false);
 
  worker.postMessage('');

--- a/content-security-policy/script-src/script-src-1_9.html
+++ b/content-security-policy/script-src/script-src-1_9.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Worker created from inline text and loaded via blob URI should not run with policy default-src *</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+    <h1>Worker created from inline text and loaded via blob URI should not run with policy default-src *</h1>
+    <div id='log'></div>
+
+	<script id="inlineWorker" type="app/worker">
+	  addEventListener('message', function() {
+	      postMessage('fail');
+	    }, false);
+	</script>
+
+        <script src="buildInlineWorker.js"></script>
+    <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=default-src%20*'></script>
+
+</body>
+</html>

--- a/content-security-policy/script-src/script-src-1_9.html
+++ b/content-security-policy/script-src/script-src-1_9.html
@@ -9,13 +9,13 @@
     <h1>Worker created from inline text and loaded via blob URI should not run with policy default-src *</h1>
     <div id='log'></div>
 
-	<script id="inlineWorker" type="app/worker">
-	  addEventListener('message', function() {
-	      postMessage('fail');
-	    }, false);
-	</script>
+    <script id="inlineWorker" type="app/worker">
+    addEventListener('message', function() {
+        postMessage('fail');
+    }, false);
+    </script>
 
-        <script src="buildInlineWorker.js"></script>
+    <script src="buildInlineWorker.js"></script>
     <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=default-src%20*'></script>
 
 </body>

--- a/content-security-policy/script-src/script-src-1_9.html.sub.headers
+++ b/content-security-policy/script-src/script-src-1_9.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: script-src-1_9={{$id:uuid()}}; Path=/content-security-policy/script-src/
+Content-Security-Policy: default-src *; report-uri  ../support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
CSP test for script-src 1-9 - script running from blobs should not be allowed unless blob: is a whitelisted source for script-src
