### PR TITLE
Pass the path from the command line into update_manifest.

### DIFF
--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -597,5 +597,6 @@ if __name__ == "__main__":
         sys.exit(1)
     opts = create_parser().parse_args()
     update_manifest(get_repo_root(),
+                    path=opts.path,
                     rebuild=opts.rebuild,
                     local_changes=opts.experimental_include_local_changes)


### PR DESCRIPTION
Until acbcad1cb71c6eebd2a63c5cf16ea7f366812f48, update_manifest directly
accessed the global 'opts' variable; this passes the path through the
arguments instead.
