### PR TITLE
Check disabled-video at next frame

### DIFF
--- a/mediacapture-streams/stream-api/introduction/disabled-video-black.html
+++ b/mediacapture-streams/stream-api/introduction/disabled-video-black.html
@@ -27,8 +27,12 @@ t.step(function() {
       {video: true},
       t.step_func(function (stream) {
         var testOncePlaying = function() {
+          if (stream.getVideoTracks()[0].enabled) {
+            stream.getVideoTracks()[0].enabled = false;
+            return;
+          }
+
           vid.removeEventListener("timeupdate", testOncePlaying, false);
-          stream.getVideoTracks()[0].enabled = false;
           cv.width = vid.offsetWidth;
           cv.height = vid.offsetHeight;
           var ctx = cv.getContext("2d");


### PR DESCRIPTION
If test checks pixels of video element at same frame, video element has
privious frame not blackness, because video element wasn't rederred after track
was disabled.
