### PR TITLE
this fixes work of the checkDirection function in Firefox

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -146,7 +146,7 @@ function rPointerCapture(e) {
 
 // declare the follwoing variables to use this function: previousPointerX, previousPointerY, currentPointerX, currentPointerY;
 // init previousPointerX, previousPointerY before calling of the function; in "pointerdown" event handler for example
-function checkDirection(testToStep, isVertical, currentMoveCount, moveCountToPass, delta) {
+function checkDirection(testToStep, isVertical, currentMoveCount, moveCountToPass, delta, event) {
     if(!isVertical) {
         if(currentMoveCount > moveCountToPass / 2) { // avoid immediate triggering while vertical scroll is still performed
                 testToStep.step( function() {

--- a/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch-manual.html
@@ -105,7 +105,7 @@
                 // Scrollable-Parent, Child: `auto`, Grand-Child: `none`
                 // TA: 15.5
                 on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta);
+                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
 
                     moveCount++;
                     if(moveCount >= countToPass) {

--- a/pointerevents/pointerevent_touch-action-inherit_child-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-none_touch-manual.html
@@ -94,7 +94,7 @@
                 //
                 // TA: 15.
                 on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta);
+                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
 
                     moveCount++;
                     if(moveCount >= countToPass) {

--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
@@ -107,7 +107,7 @@
                 });
 
                 on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, true, moveCount, countToPass, moveDelta);
+                    checkDirection(test_touchaction, true, moveCount, countToPass, moveDelta, event);
 
                     moveCount++;
                     if(moveCount >= countToPass) {

--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch-manual.html
@@ -104,7 +104,7 @@
                 // Scrollable-Parent, Child: `pan-x`, Grand-Child: `pan-y`
                 // TA: 15.6
                 on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta);
+                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
 
                     moveCount++;
                     if(moveCount >= countToPass) {

--- a/pointerevents/pointerevent_touch-action-inherit_parent-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_parent-none_touch-manual.html
@@ -100,7 +100,7 @@
                 //
                 // TA: 15.
                 on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta);
+                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
                     moveCount++;
                     if(moveCount >= countToPass) {
                         updateDescriptionNextStep();


### PR DESCRIPTION
Firefox in contrast to IE has "event" as local variable. So we have to pass "event" as parameter for checkDirection function to make this tests work properly on Firefox. The changes affect tests related to specs 15.5, 15.6, 15.8, 15.9, 15.13
