### PR TITLE
Update webdriver methods to latest

### DIFF
--- a/webdriver/element_state/method_test.py
+++ b/webdriver/element_state/method_test.py
@@ -9,12 +9,12 @@ import base_test
 class GetElementAttributeTest(base_test.WebDriverBaseTest):
     def test_get_element_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-id-attribute.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertEqual("myId", el.get_attribute("id"))
 
     def test_style_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-style-attribute.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         expected_style = """
                          font-family: \"Gill Sans Extrabold\",Helvetica,sans-serif;
                          line-height: 1.2; font-weight: bold;
@@ -23,47 +23,47 @@ class GetElementAttributeTest(base_test.WebDriverBaseTest):
 
     def test_color_serialization_of_style_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-color-style-attribute.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertEqual("color: rgba(255, 0, 0, 1.0);", el.get_attribute("style"))
 
     def test_true_if_boolean_attribute_present(self):
         self.driver.get(self.webserver.where_is("element_state/res/input-with-checked-attribute.html"))
-        el = self.driver.find_element_by_css("input")
+        el = self.driver.find_element_by_css_selector("input")
         self.assertEqual("true", el.get_attribute("checked"))
 
     def test_none_if_boolean_attribute_absent(self):
         self.driver.get(self.webserver.where_is("element_state/res/input-without-checked-attribute.html"))
-        el = self.driver.find_element_by_css("input")
+        el = self.driver.find_element_by_css_selector("input")
         self.assertIsNone(el.get_attribute("checked"))
 
     def test_option_with_attribute_value(self):
         self.driver.get(self.webserver.where_is("element_state/res/option-with-value-attribute.html"))
-        el = self.driver.find_element_by_css("option")
+        el = self.driver.find_element_by_css_selector("option")
         self.assertEqual("value1", el.get_attribute("value"))
 
     def test_option_without_value_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/option-without-value-attribute.html"))
-        el = self.driver.find_element_by_css("option")
+        el = self.driver.find_element_by_css_selector("option")
         self.assertEqual("Value 1", el.get_attribute("value"))
 
     def test_a_href_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/a-with-href-attribute.html"))
-        el = self.driver.find_element_by_css("a")
+        el = self.driver.find_element_by_css_selector("a")
         self.assertEqual("http://web-platform.test:8000/path#fragment", el.get_attribute("href"))
 
     def test_img_src_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/img-with-src-attribute.html"))
-        el = self.driver.find_element_by_css("img")
+        el = self.driver.find_element_by_css_selector("img")
         self.assertEqual("http://web-platform.test:8000/images/blue.png", el.get_attribute("src"))
 
     def test_custom_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-custom-attribute.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertEqual("attribute value", el.get_attribute("webdriver-custom-attribute"))
 
     def test_attribute_not_present(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-without-attribute.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertIsNone(el.get_attribute("class"))
 
 

--- a/webdriver/element_state/visibility_test.py
+++ b/webdriver/element_state/visibility_test.py
@@ -9,17 +9,17 @@ import base_test
 class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
     def test_0x0_pixel_element_is_not_visible(self):
         self.driver.get(self.webserver.where_is("element_state/res/0x0-pixels.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertFalse(el.is_displayed())
 
     def test_0x0_pixel_text_node_is_visible(self):
         self.driver.get(self.webserver.where_is("element_state/res/0x0-pixels-text-node.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertTrue(el.is_displayed())
 
     def test_1x1_pixel_element(self):
         self.driver.get(self.webserver.where_is("element_state/res/1x1-pixels.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertTrue(el.is_displayed())
 
     def test_zero_sized_element_is_shown_if_decendant_has_size(self):
@@ -32,12 +32,12 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_input_type_hidden_is_never_visible(self):
         self.driver.get(self.webserver.where_is("element_state/res/input-type-hidden.html"))
-        input = self.driver.find_element_by_css("input")
+        input = self.driver.find_element_by_css_selector("input")
         self.assertFalse(input.is_displayed())
 
     def test_input_morphs_into_hidden(self):
         self.driver.get(self.webserver.where_is("element_state/res/input-morphs-into-hidden.html"))
-        input = self.driver.find_element_by_css("input")
+        input = self.driver.find_element_by_css_selector("input")
         self.assertFalse(input.is_displayed())
 
     def test_parent_node_visible_when_all_children_are_absolutely_positioned_and_overflow_is_hidden(self):
@@ -103,12 +103,12 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_element_outside_viewport(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-outside-viewport.html"))
-        hidden = self.driver.find_element_by_css("div")
+        hidden = self.driver.find_element_by_css_selector("div")
         self.assertFalse(hidden.is_displayed())
 
     def test_element_dynamically_moved_outside_viewport(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-dynamically-moved-outside-viewport.html"))
-        hidden = self.driver.find_element_by_css("div")
+        hidden = self.driver.find_element_by_css_selector("div")
         self.assertFalse(hidden.is_displayed())
 
     def test_element_hidden_by_other_element(self):
@@ -134,7 +134,7 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_element_moved_outside_viewport_by_transform(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-moved-outside-viewport-by-transform.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertFalse(el.is_displayed())
 
     def test_element_moved_behind_other_element_by_transform(self):
@@ -147,22 +147,22 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_text_with_same_color_as_background(self):
         self.driver.get(self.webserver.where_is("element_state/res/text-with-same-color-as-background.html"))
-        p = self.driver.find_element_by_css("p")
+        p = self.driver.find_element_by_css_selector("p")
         self.assertFalse(p.is_displayed())
 
     def test_text_with_same_color_as_parent_background(self):
         self.driver.get(self.webserver.where_is("element_state/res/text-with-same-color-as-parent-background.html"))
-        p = self.driver.find_element_by_css("p")
+        p = self.driver.find_element_by_css_selector("p")
         self.assertFalse(p.is_displayed())
 
     def test_text_with_matching_color_and_background(self):
         self.driver.get(self.webserver.where_is("element_state/res/text-with-matching-color-and-background.html"))
-        p = self.driver.find_element_by_css("p")
+        p = self.driver.find_element_by_css_selector("p")
         self.assertTrue(p.is_displayed())
 
     def test_element_with_same_color_as_background(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-same-color-as-background.html"))
-        el = self.driver.find_element_by_css("div")
+        el = self.driver.find_element_by_css_selector("div")
         self.assertFalse(el.is_displayed())
 
     def test_element_with_same_color_as_parent_background(self):
@@ -174,7 +174,7 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 class BodyElementIsAlwaysDisplayedTest(base_test.WebDriverBaseTest):
     def assert_body_is_displayed_on(self, page):
         self.driver.get(self.webserver.where_is(page))
-        body = self.driver.find_element_by_css("body")
+        body = self.driver.find_element_by_css_selector("body")
         assert body.is_displayed()
 
     def test_implicit(self):
@@ -193,12 +193,12 @@ class BodyElementIsAlwaysDisplayedTest(base_test.WebDriverBaseTest):
 class DisplayTest(base_test.WebDriverBaseTest):
     def test_display_block(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-block.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertTrue(el.is_displayed())
 
     def test_display_none(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertFalse(el.is_displayed())
 
     def test_display_none_hides_child_node(self):
@@ -238,12 +238,12 @@ class DisplayTest(base_test.WebDriverBaseTest):
 class VisibilityTest(base_test.WebDriverBaseTest):
     def test_element_state_hidden(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-hidden.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertFalse(el.is_displayed())
 
     def test_element_state_visible(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-visible.html"))
-        el = self.driver.find_element_by_css("p")
+        el = self.driver.find_element_by_css_selector("p")
         self.assertTrue(el.is_displayed())
 
     def test_visibility_hidden_hides_child_node(self):
@@ -295,21 +295,21 @@ class VisibilityTest(base_test.WebDriverBaseTest):
 class VisibilityInteractionTest(base_test.WebDriverBaseTest):
     def test_input_hidden_is_unclickable(self):
         self.driver.get(self.webserver.where_is("element_state/res/input-type-hidden-unclickable.html"))
-        input = self.driver.find_element_by_css("input")
+        input = self.driver.find_element_by_css_selector("input")
 
         with self.assertRaises(exceptions.ElementNotVisibleException):
             input.click()
 
     def test_hidden_input_checkbox_is_untogglable(self):
         self.driver.get(self.webserver.where_is("element_state/res/hidden-input-type-checkbox-untogglable.html"))
-        checkbox = self.driver.find_element_by_css("input")
+        checkbox = self.driver.find_element_by_css_selector("input")
 
         with self.assertRaises(exceptions.ElementNotVisibleException):
             checkbox.click()
 
     def test_typing_in_hidden_input_is_impossible(self):
         self.driver.get(self.webserver.where_is("element_state/res/hidden-input-type-text-writing.html"))
-        textfield = self.driver.find_element_by_css("input")
+        textfield = self.driver.find_element_by_css_selector("input")
 
         with self.assertRaises(exceptions.ElementNotVisibleException):
             textfield.send_keys("Koha is a popular Indian cheese")

--- a/webdriver/modal/alerts_test.py
+++ b/webdriver/modal/alerts_test.py
@@ -22,19 +22,19 @@ class AlertsTest(base_test.WebDriverBaseTest):
         self.driver.find_element_by_id('alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
-        self.driver.get_current_url()
+        self.driver.current_url
 
     def test_should_allow_user_to_accept_an_alert_with_no_text(self):
         self.driver.find_element_by_id('empty-alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
-        self.driver.get_current_url()
+        self.driver.current_url
 
     def test_should_allow_user_to_dismiss_an_alert(self):
         self.driver.find_element_by_id('alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.dismiss()
-        self.driver.get_current_url()
+        self.driver.current_url
 
     def test_should_allow_user_to_get_text_of_an_alert(self):
         self.driver.find_element_by_id('alert').click()

--- a/webdriver/navigation/forward.py
+++ b/webdriver/navigation/forward.py
@@ -11,12 +11,12 @@ class ForwardTest(base_test.WebDriverBaseTest):
     def test_forward(self):
         self.driver.get(self.webserver.where_is('navigation/res/forwardStart.html'))
         self.driver.get(self.webserver.where_is('navigation/res/forwardNext.html'))
-        nextbody = self.driver.find_element_by_css("body").get_text()
+        nextbody = self.driver.find_element_by_css_selector("body").get_text()
         self.driver.go_back()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css_selector("body").get_text()
         self.assertNotEqual(nextbody, currbody)
         self.driver.go_forward()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css_selector("body").get_text()
         self.assertEqual(nextbody, currbody)
 
 

--- a/webdriver/navigation/forwardToNothing.py
+++ b/webdriver/navigation/forwardToNothing.py
@@ -10,9 +10,9 @@ class ForwardToNothingTest(base_test.WebDriverBaseTest):
     # Get a static page that must be the same upon refresh
     def test_forwardToNothing(self):
         self.driver.get(self.webserver.where_is('navigation/forwardStart.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css_selector("body").get_text()
         self.driver.go_forward()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css_selector("body").get_text()
         self.assertEqual(body, currbody)
 
 

--- a/webdriver/navigation/get_from_http_test.py
+++ b/webdriver/navigation/get_from_http_test.py
@@ -10,7 +10,7 @@ class GetFromHttpTest(base_test.WebDriverBaseTest):
     def testGetUrlWithNoRedirectionOverHttp(self):
         page = self.webserver.where_is('navigation/res/empty.html')
         self.driver.get(page)
-        url = self.driver.get_current_url()
+        url = self.driver.current_url
         self.assertEquals(page, url)
 
 
@@ -18,7 +18,7 @@ class GetFromHttpTest(base_test.WebDriverBaseTest):
         page = self.webserver.where_is('navigation/redirect')
         self.driver.get(page)
         expected = self.webserver.where_is('navigation/res/empty.html')
-        url = self.driver.get_current_url()
+        url = self.driver.current_url
         self.assertEquals(expected, url)
 
 
@@ -26,7 +26,7 @@ class GetFromHttpTest(base_test.WebDriverBaseTest):
         page = self.webserver.where_is('navigation/res/instant-meta-redirect.html')
         self.driver.get(page)
         expected = self.webserver.where_is('navigation/res/empty.html')
-        url = self.driver.get_current_url()
+        url = self.driver.current_url
         self.assertEquals(expected, url)
 
 
@@ -34,14 +34,14 @@ class GetFromHttpTest(base_test.WebDriverBaseTest):
         page = self.webserver.where_is('navigation/res/1s-meta-redirect.html')
         self.driver.get(page)
         expected = self.webserver.where_is('navigation/res/empty.html')
-        url = self.driver.get_current_url()
+        url = self.driver.current_url
         self.assertEquals(expected, url)
 
 
     def testGetWillNotFollowMetaRefreshThatRefreshesAfterMoreThanOneSecond(self):
         page = self.webserver.where_is('navigation/res/60s-meta-redirect.html')
         self.driver.get(page)
-        url = self.driver.get_current_url()
+        url = self.driver.current_url
         self.assertEquals(page, url)
 
 

--- a/webdriver/navigation/invalid_cert_test.py
+++ b/webdriver/navigation/invalid_cert_test.py
@@ -21,7 +21,7 @@ class InvalidCertTest(base_test.WebDriverBaseTest):
             'navigation/res/empty.html').replace('http:', 'https:', 1)
 
         self.driver.get(expected)
-        self.assertEquals(expected, self.driver.get_current_url())
+        self.assertEquals(expected, self.driver.current_url)
 
 
 if __name__ == '__main__':

--- a/webdriver/navigation/refresh-page.py
+++ b/webdriver/navigation/refresh-page.py
@@ -10,16 +10,16 @@ class RefreshPageTest(base_test.WebDriverBaseTest):
     # Get a static page that must be the same upon refresh
     def test_refreshPage(self):
         self.driver.get(self.webserver.where_is('navigation/res/refreshPageStatic.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css_selector("body").get_text()
         self.driver.execute_script("document.getElementById('body').innerHTML=''")
         self.driver.refresh()
-        newbody = self.driver.find_element_by_css("body").get_text()
+        newbody = self.driver.find_element_by_css_selector("body").get_text()
         self.assertEqual(body, newbody)
 
         self.driver.get(self.webserver.where_is('navigation/res/refreshPageDynamic.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css_selector("body").get_text()
         self.driver.refresh()
-        newbody = self.driver.find_element_by_css("body").get_text()
+        newbody = self.driver.find_element_by_css_selector("body").get_text()
         self.assertNotEqual(body, newbody)
 
 


### PR DESCRIPTION
- Some methods of webdriver have been changed to latest in Selenium 2.41.0
- Change find_element_by_css() method to find_element_by_css_selector() method
- Change get_current_url() method to current_url attribute
