### PR TITLE
Fix CharRangesArray.prototype

### DIFF
--- a/custom-elements/testcommon.js
+++ b/custom-elements/testcommon.js
@@ -159,7 +159,6 @@ CharRangesArray.prototype.testEach = function(namingFunction, checkFunction) {
             var rangeEnd = getCharCode(this.array[i+1]);
             for (var c = rangeStart; c <= rangeEnd; c++) {
                 checkFunction(namingFunction(c));
-                testCharCode(c, namingFunction, checkFunction);
             }
         }
     }


### PR DESCRIPTION
Check function is getting called twice, which is causing the TypeAlreadyRegistered error.
Removed extra call from CharRangesArray.prototype
