### PR TITLE
Update MediaSource tests with new cases from Blink.

### DIFF
--- a/media-source/manifest.txt
+++ b/media-source/manifest.txt
@@ -1,6 +1,5 @@
 mediasource-addsourcebuffer.html
 mediasource-append-buffer.html
-mediasource-append-stream.html
 mediasource-appendwindow.html
 mediasource-buffered.html
 mediasource-closed.html

--- a/media-source/mediasource-addsourcebuffer.html
+++ b/media-source/mediasource-addsourcebuffer.html
@@ -11,11 +11,28 @@
         <script>
           mediasource_test(function(test, mediaElement, mediaSource)
           {
+              mediaSource.endOfStream();
+              assert_throws("InvalidStateError",
+                          function() { mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE); },
+                          "addSourceBuffer() threw an exception when in 'ended' state.");
+              test.done();
+          }, "Test addSourceBuffer() in 'ended' state.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
               assert_throws("InvalidAccessError",
                           function() { mediaSource.addSourceBuffer(""); },
                           "addSourceBuffer() threw an exception when passed an empty string.");
               test.done();
           }, "Test addSourceBuffer() with empty type");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              assert_throws("NotSupportedError",
+                          function() { mediaSource.addSourceBuffer(null); },
+                          "addSourceBuffer() threw an exception when passed null.");
+              test.done();
+          }, "Test addSourceBuffer() with null");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
@@ -58,6 +75,32 @@
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
+              var mimetype = MediaSourceUtil.VIDEO_ONLY_TYPE;
+
+              assert_true(MediaSource.isTypeSupported(mimetype), mimetype + " is supported");
+
+              var sourceBuffer = mediaSource.addSourceBuffer(mimetype);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+              assert_equals(mediaSource.sourceBuffers[0], sourceBuffer, "SourceBuffer is in mediaSource.sourceBuffers");
+              assert_equals(mediaSource.activeSourceBuffers.length, 0, "SourceBuffer is in mediaSource.activeSourceBuffers");
+              test.done();
+          }, "Test addSourceBuffer() video only");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var mimetype = MediaSourceUtil.AUDIO_ONLY_TYPE;
+
+              assert_true(MediaSource.isTypeSupported(mimetype), mimetype + " is supported");
+
+              var sourceBuffer = mediaSource.addSourceBuffer(mimetype);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+              assert_equals(mediaSource.sourceBuffers[0], sourceBuffer, "SourceBuffer is in mediaSource.sourceBuffers");
+              assert_equals(mediaSource.activeSourceBuffers.length, 0, "SourceBuffer is in mediaSource.activeSourceBuffers");
+              test.done();
+          }, "Test addSourceBuffer() audio only");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
               var mimetype = 'video/mp4;codecs="avc1.4D4001,mp4a.40.2"';
 
               assert_true(MediaSource.isTypeSupported(mimetype), mimetype + " is supported");
@@ -85,6 +128,26 @@
               assert_equals(mediaSource.activeSourceBuffers.length, 0, "SourceBufferB is not in mediaSource.activeSourceBuffers");
               test.done();
           }, "Test addSourceBuffer() with AAC and H.264 in separate SourceBuffers");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var reachedLimit = false;
+
+             // The 20 here is an arbitrary upper limit to make sure the test terminates. This test
+             // assumes that implementations won't support more than 20 SourceBuffers simultaneously.
+             for (var i = 0; i < 20; ++i) {
+                 try {
+                     mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+                 } catch(e) {
+                     assert_equals(e.name, "QuotaExceededError");
+                     reachedLimit = true;
+                     break;
+                 }
+             }
+             assert_true(reachedLimit, "Reached SourceBuffer limit.");
+             test.done();
+          }, "Test addSourceBuffer() QuotaExceededError.");
+
         </script>
     </body>
 </html>

--- a/media-source/mediasource-append-buffer.html
+++ b/media-source/mediasource-append-buffer.html
@@ -316,7 +316,7 @@
               test.expectEvent(sourceBuffer, "update", "Append success.");
               test.expectEvent(sourceBuffer, "updateend", "Append ended.");
 
-              var arrayBuffer = mediaData.buffer.slice();
+              var arrayBuffer = mediaData.buffer.slice(0);
 
               assert_equals(arrayBuffer.byteLength, mediaData.buffer.byteLength, "arrayBuffer.byteLength before transfer.");
 

--- a/media-source/mediasource-append-buffer.html
+++ b/media-source/mediasource-append-buffer.html
@@ -116,6 +116,45 @@
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
+              test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+              test.expectEvent(sourceBuffer, "update", "Append success.");
+              test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+              sourceBuffer.appendBuffer(mediaData);
+              assert_true(sourceBuffer.updating, "updating attribute is true");
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_false(sourceBuffer.updating, "updating attribute is false");
+
+                  test.expectEvent(mediaSource, "sourceended", "MediaSource sourceended event");
+                  mediaSource.endOfStream();
+                  assert_equals(mediaSource.readyState, "ended", "MediaSource readyState is 'ended'");
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaSource.readyState, "ended", "MediaSource readyState is 'ended'");
+
+                  test.expectEvent(mediaSource, "sourceopen", "MediaSource sourceopen event");
+                  test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+                  test.expectEvent(sourceBuffer, "update", "Append success.");
+                  test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+                  sourceBuffer.appendBuffer(new Uint8Array(0));
+
+                  assert_equals(mediaSource.readyState, "open", "MediaSource readyState is 'open'");
+                  assert_true(sourceBuffer.updating, "updating attribute is true");
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaSource.readyState, "open", "MediaSource readyState is 'open'");
+                  assert_false(sourceBuffer.updating, "updating attribute is false");
+                  test.done();
+              });
+          }, "Test zero byte SourceBuffer.appendBuffer() call triggering an 'ended' to 'open' transition.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
               test.failOnEvent(mediaElement, 'error');
 
               test.expectEvent(sourceBuffer, "updatestart", "Append started.");
@@ -227,6 +266,31 @@
               });
           }, "Test appending an empty ArrayBufferView.");
 
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+              test.expectEvent(sourceBuffer, "update", "Append success.");
+              test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+
+              var arrayBufferView = new Uint8Array(mediaData);
+
+              assert_equals(arrayBufferView.length, mediaData.length, "arrayBufferView.length before transfer.");
+
+              // Send the buffer as in a message so it gets neutered.
+              window.postMessage( "test", "*", [arrayBufferView.buffer]);
+
+              assert_equals(arrayBufferView.length, 0, "arrayBufferView.length after transfer.");
+
+              sourceBuffer.appendBuffer(arrayBufferView);
+
+              assert_true(sourceBuffer.updating, "updating attribute is true");
+
+              test.waitForExpectedEvents(function()
+              {
+                 assert_false(sourceBuffer.updating, "updating attribute is false");
+                 test.done();
+              });
+          }, "Test appending a neutered ArrayBufferView.");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
@@ -245,6 +309,229 @@
                   test.done();
               });
           }, "Test appending an empty ArrayBuffer.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+              test.expectEvent(sourceBuffer, "update", "Append success.");
+              test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+
+              var arrayBuffer = mediaData.buffer.slice();
+
+              assert_equals(arrayBuffer.byteLength, mediaData.buffer.byteLength, "arrayBuffer.byteLength before transfer.");
+
+              // Send the buffer as in a message so it gets neutered.
+              window.postMessage( "test", "*", [arrayBuffer]);
+
+              assert_equals(arrayBuffer.byteLength, 0, "arrayBuffer.byteLength after transfer.");
+
+              sourceBuffer.appendBuffer(arrayBuffer);
+
+              assert_true(sourceBuffer.updating, "updating attribute is true");
+
+              test.waitForExpectedEvents(function()
+              {
+                 assert_false(sourceBuffer.updating, "updating attribute is false");
+                 test.done();
+              });
+          }, "Test appending a neutered ArrayBuffer.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var halfIndex = (initSegment.length + 1) / 2;
+              var partialInitSegment = initSegment.subarray(0, halfIndex);
+              var remainingInitSegment = initSegment.subarray(halfIndex);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+              test.expectEvent(sourceBuffer, "updateend", "partialInitSegment append ended.");
+              sourceBuffer.appendBuffer(partialInitSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaElement.readyState, mediaElement.HAVE_NOTHING);
+                  assert_equals(mediaSource.duration, Number.NaN);
+                  test.expectEvent(sourceBuffer, "updateend", "remainingInitSegment append ended.");
+                  test.expectEvent(mediaElement, "loadedmetadata", "loadedmetadata event received.");
+                  sourceBuffer.appendBuffer(remainingInitSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaElement.readyState, mediaElement.HAVE_METADATA);
+                  assert_equals(mediaSource.duration, segmentInfo.duration);
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  test.expectEvent(mediaElement, "loadeddata", "loadeddata fired.");
+                  sourceBuffer.appendBuffer(mediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_greater_than_equal(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA);
+                  assert_equals(sourceBuffer.updating, false);
+                  assert_equals(mediaSource.readyState, "open");
+                  test.done();
+              });
+          }, "Test appendBuffer with partial init segments.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+              var halfIndex = (mediaSegment.length + 1) / 2;
+              var partialMediaSegment = mediaSegment.subarray(0, halfIndex);
+              var remainingMediaSegment = mediaSegment.subarray(halfIndex);
+
+              test.expectEvent(sourceBuffer, "updateend", "InitSegment append ended.");
+              test.expectEvent(mediaElement, "loadedmetadata", "loadedmetadata done.");
+              sourceBuffer.appendBuffer(initSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaElement.readyState, mediaElement.HAVE_METADATA);
+                  assert_equals(mediaSource.duration, segmentInfo.duration);
+                  test.expectEvent(sourceBuffer, "updateend", "partial media segment append ended.");
+                  sourceBuffer.appendBuffer(partialMediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  test.expectEvent(mediaElement, "loadeddata", "loadeddata fired.");
+                  sourceBuffer.appendBuffer(remainingMediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_greater_than_equal(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA);
+                  assert_equals(mediaSource.readyState, "open");
+                  assert_equals(sourceBuffer.updating, false);
+                  test.done();
+              });
+          }, "Test appendBuffer with partial media segments.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var partialInitSegment = initSegment.subarray(0, initSegment.length / 2);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+              test.expectEvent(sourceBuffer, "updateend", "partialInitSegment append ended.");
+              sourceBuffer.appendBuffer(partialInitSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  // Call abort to reset the parser.
+                  sourceBuffer.abort();
+
+                  // Append the full intiialization segment.
+                  test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+                  sourceBuffer.appendBuffer(initSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  test.expectEvent(mediaElement, "loadeddata", "loadeddata fired.");
+                  sourceBuffer.appendBuffer(mediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.done();
+              });
+          }, "Test abort in the middle of an initialization segment.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              test.expectEvent(mediaSource.sourceBuffers, "removesourcebuffer", "SourceBuffer removed.");
+              mediaSource.removeSourceBuffer(sourceBuffer);
+              test.waitForExpectedEvents(function()
+              {
+                  assert_throws("InvalidStateError",
+                      function() { sourceBuffer.abort(); },
+                      "sourceBuffer.abort() throws an exception for InvalidStateError.");
+
+                  test.done();
+              });
+          }, "Test abort after removing sourcebuffer.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+              test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+              sourceBuffer.appendBuffer(initSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaSource.readyState, "open", "readyState is open after init segment appended.");
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  sourceBuffer.appendBuffer(mediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(sourceBuffer.buffered.length, 1, "sourceBuffer has a buffered range");
+                  assert_equals(mediaSource.readyState, "open", "readyState is open after media segment appended.");
+                  test.expectEvent(mediaSource, "sourceended", "source ended");
+                  mediaSource.endOfStream();
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaSource.readyState, "ended", "readyState is ended.");
+                  assert_throws("InvalidStateError",
+                      function() { sourceBuffer.abort(); },
+                      "sourceBuffer.abort() throws an exception for InvalidStateError.");
+                  test.done();
+              });
+
+          }, "Test abort after readyState is ended following init segment and media segment.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+              test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+              sourceBuffer.appendWindowStart = 1;
+              sourceBuffer.appendWindowEnd = 100;
+              sourceBuffer.appendBuffer(mediaData);
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_false(sourceBuffer.updating, "updating attribute is false");
+                  sourceBuffer.abort();
+                  assert_equals(sourceBuffer.appendWindowStart, 0, "appendWindowStart is reset to 0");
+                  assert_equals(sourceBuffer.appendWindowEnd, Number.POSITIVE_INFINITY, 
+                      "appendWindowEnd is reset to +INFINITY");
+                  test.done();
+              });
+          }, "Test abort after appendBuffer update ends.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.VIDEO_ONLY_TYPE);
+
+              test.expectEvent(sourceBuffer, "updatestart", "Append started.");
+              test.expectEvent(sourceBuffer, "update", "Append success.");
+              test.expectEvent(sourceBuffer, "updateend", "Append ended.");
+
+              assert_throws( { name: "TypeError"} ,
+                  function() { sourceBuffer.appendBuffer(null); },
+                  "appendBuffer(null) throws an exception.");
+              test.done();
+          }, "Test appending null.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              mediaSource.removeSourceBuffer(sourceBuffer);
+
+              assert_throws( { name: "InvalidStateError"} ,
+                  function() { sourceBuffer.appendBuffer(mediaData); },
+                  "appendBuffer() throws an exception when called after removeSourceBuffer().");
+              test.done();
+          }, "Test appending after removeSourceBuffer().");
 
         </script>
     </body>

--- a/media-source/mediasource-appendwindow.html
+++ b/media-source/mediasource-appendwindow.html
@@ -49,14 +49,66 @@
                   "set appendWindowStart throws an exception when greater than appendWindowEnd.");
 
               assert_throws("InvalidAccessError",
+                  function() { sourceBuffer.appendWindowStart = sourceBuffer.appendWindowEnd; },
+                  "set appendWindowStart throws an exception when equal to appendWindowEnd.");
+
+              assert_throws("InvalidAccessError",
+                  function() { sourceBuffer.appendWindowEnd = sourceBuffer.appendWindowStart; },
+                  "set appendWindowEnd throws an exception when equal to appendWindowStart.");
+
+              assert_throws("InvalidAccessError",
+                  function() { sourceBuffer.appendWindowEnd = sourceBuffer.appendWindowStart - 1; },
+                  "set appendWindowEnd throws an exception if less than appendWindowStart.");
+
+              assert_throws("InvalidAccessError",
                   function() { sourceBuffer.appendWindowStart = -100.0; },
                   "set appendWindowStart throws an exception when less than 0.");
 
               assert_throws("InvalidAccessError",
+                  function() { sourceBuffer.appendWindowEnd = -100.0; },
+                  "set appendWindowEnd throws an exception when less than 0.");
+
+              assert_throws("InvalidAccessError",
                   function() { sourceBuffer.appendWindowEnd = Number.NaN; },
                   "set appendWindowEnd throws an exception if NaN.");
+
+              assert_throws("InvalidAccessError",
+                  function() { sourceBuffer.appendWindowEnd = undefined; },
+                  "set appendWindowEnd throws an exception if undefined.");
+
+              assert_throws({name: "TypeError"},
+                  function() { sourceBuffer.appendWindowStart = undefined; },
+                  "set appendWindowStart throws an exception if undefined.");
+
               test.done();
           }, "Test set wrong values to appendWindowStart and appendWindowEnd.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+
+              sourceBuffer.appendWindowStart = "";
+              assert_true(sourceBuffer.appendWindowStart == 0, "appendWindowStart is 0");
+
+              sourceBuffer.appendWindowStart = "10";
+              assert_true(sourceBuffer.appendWindowStart == 10, "appendWindowStart is 10");
+
+              sourceBuffer.appendWindowStart = null;
+              assert_true(sourceBuffer.appendWindowStart == 0, "appendWindowStart is 0");
+
+              sourceBuffer.appendWindowStart = true;
+              assert_true(sourceBuffer.appendWindowStart == 1, "appendWindowStart is 1");
+
+              sourceBuffer.appendWindowStart = false;
+              assert_true(sourceBuffer.appendWindowStart == 0, "appendWindowStart is 0");
+
+              sourceBuffer.appendWindowEnd = "100";
+              assert_true(sourceBuffer.appendWindowEnd == 100, "appendWindowEnd is 100");
+
+              test.done();
+
+          }, "Test set correct values to appendWindowStart and appendWindowEnd.");
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
@@ -109,6 +161,14 @@
                   test.done();
               });
           }, "Test appendWindowStart and appendWindowEnd value after a sourceBuffer.abort().");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+               assert_equals(sourceBuffer.appendWindowStart, 0, "appendWindowStart is 0 initially");
+               assert_equals(sourceBuffer.appendWindowEnd, Number.POSITIVE_INFINITY,
+                            "appendWindowStart is POSITIVE_INFINITY initially");
+               test.done();
+          }, "Test read appendWindowStart and appendWindowEnd initial values.");
 
        </script>
     </body>

--- a/media-source/mediasource-buffered.html
+++ b/media-source/mediasource-buffered.html
@@ -66,6 +66,7 @@
             }
 
             mediaSourceDemuxedTest(function(test, mediaElement, mediaSource, dataA, dataB) {
+                test.expectEvent(mediaElement, "loadedmetadata");
                 appendData(test, mediaSource, dataA, dataB, function()
                 {
                     assertBufferedEquals(mediaSource.activeSourceBuffers[0], expectationsA[subType], "mediaSource.activeSourceBuffers[0]");
@@ -116,13 +117,14 @@
                         test.done();
                     });
                 });
-            }, "Muxed tracks with different lengths");
+            }, "Muxed content with different lengths");
 
             mediaSourceDemuxedTest(function(test, mediaElement, mediaSource, dataA, dataB) {
                 var dataBSize = {
                     webm: 318,
                     mp4: 835,
                 };
+                test.expectEvent(mediaElement, "loadedmetadata");
                 appendData(test, mediaSource, dataA, dataB.subarray(0, dataBSize[subType]), function()
                 {
                     assertBufferedEquals(mediaSource.activeSourceBuffers[0], expectationsA[subType], "mediaSource.activeSourceBuffers[0]");
@@ -148,6 +150,7 @@
                 MediaSourceUtil.fetchManifestAndData(test, subType + "/test-av-384k-44100Hz-1ch-320x240-30fps-10kfr-manifest.json", function(type, data)
                 {
                     var sourceBuffer = mediaSource.addSourceBuffer(type);
+                    test.expectEvent(mediaElement, "loadedmetadata");
                     test.expectEvent(sourceBuffer, "update");
                     test.expectEvent(sourceBuffer, "updateend");
                     sourceBuffer.appendBuffer(data.subarray(0, 4052));
@@ -167,6 +170,50 @@
                 });
             }, "Muxed content empty buffered ranges.");
 
+            mediasource_test(function(test, mediaElement, mediaSource)
+            {
+                mediaElement.pause();
+                test.failOnEvent(mediaElement, "error");
+                test.endOnEvent(mediaElement, "ended");
+
+                var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+
+                assertBufferedEquals(mediaSource.sourceBuffers[0], "{ }", "mediaSource.sourceBuffers[0]");
+                assertBufferedEquals(mediaElement, "{ }", "mediaElement.buffered");
+                test.done();
+
+            }, "Get buffered range when sourcebuffer is empty.");
+
+            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+            {
+                var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+
+                test.expectEvent(mediaElement, "loadedmetadata");
+                test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+                sourceBuffer.appendBuffer(initSegment);
+                test.waitForExpectedEvents(function()
+                {
+                    assertBufferedEquals(mediaSource.sourceBuffers[0], "{ }", "mediaSource.sourceBuffers[0]");
+                    assertBufferedEquals(mediaSource.activeSourceBuffers[0], "{ }", "mediaSource.activeSourceBuffers[0]");
+                    assertBufferedEquals(mediaElement, "{ }", "mediaElement.buffered");
+                    test.done();
+                });
+
+            }, "Get buffered range when only init segment is appended.");
+
+            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+            {
+                test.expectEvent(mediaSource.sourceBuffers, "removesourcebuffer", "SourceBuffer removed.");
+                mediaSource.removeSourceBuffer(sourceBuffer);
+
+                test.waitForExpectedEvents(function()
+                {
+                    assert_throws("InvalidStateError",
+                        function() { sourceBuffer.buffered; },
+                        "get sourceBuffer.buffered throws an exception for InvalidStateError.");
+                    test.done();
+                });
+            }, "Get buffered range after removing sourcebuffer.");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-closed.html
+++ b/media-source/mediasource-closed.html
@@ -15,7 +15,7 @@
               assert_equals(mediaSource.sourceBuffers.length, 0, "sourceBuffers is empty");
               assert_equals(mediaSource.activeSourceBuffers.length, 0, "activeSourceBuffers is empty");
               assert_equals(mediaSource.readyState, "closed", "readyState is 'closed'");
-              assert_true(Number.isNaN(mediaSource.duration), "duration is NaN");
+              assert_true(isNaN(mediaSource.duration), "duration is NaN");
           }, "Test attribute values on a closed MediaSource object.");
 
           test(function ()
@@ -106,7 +106,7 @@
               mediaSource.addEventListener("sourceclose", test.step_func(function (event)
               {
                   assert_equals(mediaSource.readyState, "closed", "readyState is 'closed'");
-                  assert_true(Number.isNaN(mediaSource.duration), "duration is NaN");
+                  assert_true(isNaN(mediaSource.duration), "duration is NaN");
                   test.done();
               }));
 

--- a/media-source/mediasource-closed.html
+++ b/media-source/mediasource-closed.html
@@ -54,6 +54,21 @@
                   "endOfStream() throws an exception when closed.");
           }, "Test endOfStream() while closed.");
 
+          test(function ()
+          {
+              var mediaSource = new MediaSource();
+              assert_throws("InvalidStateError",
+                  function() { mediaSource.endOfStream("decode"); },
+                  "endOfStream(decode) throws an exception when closed.");
+          }, "Test endOfStream(decode) while closed.");
+
+          test(function ()
+          {
+              var mediaSource = new MediaSource();
+              assert_throws("InvalidStateError",
+                  function() { mediaSource.endOfStream("network"); },
+                  "endOfStream(network) throws an exception when closed.");
+          }, "Test endOfStream(network) while closed.");
 
           test(function ()
           {
@@ -62,6 +77,62 @@
                   function() { mediaSource.duration = 10; },
                   "Setting duration throws an exception when closed.");
           }, "Test setting duration while closed.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+
+              assert_equals(mediaSource.readyState, "open", "readyState is 'open'");
+              // Setup a handler to run when the MediaSource closes.
+              mediaSource.addEventListener("sourceclose", test.step_func(function (event)
+              {
+                  assert_equals(mediaSource.readyState, "closed", "readyState is 'closed'");
+                  assert_throws("InvalidStateError",
+                      function() { mediaSource.duration = 10; },
+                      "Setting duration when closed throws an exception");
+                  test.done();
+              }));
+
+              // Trigger the MediaSource to close.
+              mediaElement.src = "";
+          }, "Test setting duration while open->closed.");
+
+           mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+
+              assert_equals(mediaSource.readyState, "open", "readyState is 'open'");
+              // Setup a handler to run when the MediaSource closes.
+              mediaSource.addEventListener("sourceclose", test.step_func(function (event)
+              {
+                  assert_equals(mediaSource.readyState, "closed", "readyState is 'closed'");
+                  assert_true(Number.isNaN(mediaSource.duration), "duration is NaN");
+                  test.done();
+              }));
+
+              // Trigger the MediaSource to close.
+              mediaElement.src = "";
+          }, "Test getting duration while open->closed.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+
+              assert_equals(mediaSource.readyState, "open", "readyState is open");
+
+              // Setup a handler to run when the MediaSource closes.
+              mediaSource.addEventListener("sourceclose", test.step_func(function (event)
+              {
+                  assert_equals(mediaSource.readyState, "closed", "readyState is closed");
+                  assert_throws("InvalidStateError",
+                    function() { sourceBuffer.abort(); },
+                    "sourceBuffer.abort() throws INVALID_STATE_ERROR");
+                  test.done();
+              }));
+
+              // Trigger the MediaSource to close.
+              mediaElement.src = "";
+          }, "Test sourcebuffer.abort when closed.");
 
         </script>
     </body>

--- a/media-source/mediasource-duration-boundaryconditions.html
+++ b/media-source/mediasource-duration-boundaryconditions.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>MediaSource.duration boundary condition test cases.</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          function DurationBoundaryConditionTest(testDurationValue, expectedError, description)
+          {
+              return mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+              {
+                  // Append initialization segment.
+                  test.expectEvent(sourceBuffer, "updateend", "sourceBuffer");
+                  test.expectEvent(mediaElement, "loadedmetadata", "mediaElement");
+                  sourceBuffer.appendBuffer(MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init));
+                  test.waitForExpectedEvents(function()
+                  {
+                      if (expectedError) {
+                          assert_throws(expectedError,
+                              function() { mediaSource.duration = testDurationValue; },
+                              "mediaSource.duration assignment throws an exception for " + testDurationValue);
+                          test.done();
+                          return;
+                      }
+
+                      mediaSource.duration = testDurationValue;
+
+                      assert_equals(mediaSource.duration, testDurationValue, "mediaSource.duration");
+                      assert_equals(mediaElement.duration, testDurationValue, "mediaElement.duration");
+
+                      test.expectEvent(mediaElement, "durationchange", "mediaElement");
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_equals(mediaSource.duration, testDurationValue, "mediaSource.duration");
+                          assert_equals(mediaElement.duration, testDurationValue, "mediaElement.duration");
+                          test.done();
+                      });
+                  });
+
+              }, description);
+          }
+
+          DurationBoundaryConditionTest(Math.pow(2, 31) - 1, null, "Set duration to 2^31 - 1");
+          DurationBoundaryConditionTest(1, null, "Set duration to 1");
+          DurationBoundaryConditionTest(Number.MAX_VALUE, null, "Set duration to Number.MAX_VALUE");
+          DurationBoundaryConditionTest(Number.MIN_VALUE, null, "Set duration to Number.MIN_VALUE");
+          DurationBoundaryConditionTest(Number.MAX_VALUE - 1, null, "Set duration to Number.MAX_VALUE - 1");
+          DurationBoundaryConditionTest(Number.MIN_VALUE - 1, "InvalidAccessError", "Set duration to Number.MIN_VALUE - 1");
+          DurationBoundaryConditionTest(Number.POSITIVE_INFINITY, null, "Set duration to Number.POSITIVE_INFINITY");
+          DurationBoundaryConditionTest(Number.NEGATIVE_INFINITY, "InvalidAccessError", "Set duration to Number.NEGATIVE_INFINITY");
+          DurationBoundaryConditionTest(-1 * Number.MAX_VALUE, "InvalidAccessError", "Set duration to lowest value.");
+          DurationBoundaryConditionTest(-101.9, "InvalidAccessError", "Set duration to a negative double.");
+          DurationBoundaryConditionTest(101.9, null, "Set duration to a positive double.");
+          DurationBoundaryConditionTest(0, null, "Set duration to zero");
+          DurationBoundaryConditionTest(NaN, "InvalidAccessError", "Set duration to NaN");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-is-type-supported.html
+++ b/media-source/mediasource-is-type-supported.html
@@ -30,6 +30,8 @@
               'video/webm;codecs="',
               'video/webm;codecs=""',
               'video/webm;codecs=","',
+              '',
+              null
           ], false, 'Test invalid MIME format');
 
           test_type_support([
@@ -59,6 +61,7 @@
               'video/webm;codecs="vp8,vorbis"',
               'video/webm;codecs="vorbis, vp8"',
               'audio/webm;codecs="vorbis"',
+              'AUDIO/WEBM;CODECS="vorbis"',
           ], true, 'Test valid WebM type');
 
           test_type_support([

--- a/media-source/mediasource-remove.html
+++ b/media-source/mediasource-remove.html
@@ -21,6 +21,20 @@
               test.done();
           }, "Test remove with an negative start.");
 
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+
+              [ undefined, NaN, Infinity, -Infinity ].forEach(function(item)
+              {
+                  assert_throws(new TypeError(), function()
+                  {
+                      sourceBuffer.remove(item, 2);
+                  }, "remove");
+              });
+
+              test.done();
+          }, "Test remove with non-finite start.");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
@@ -50,6 +64,29 @@
               test.done();
           }, "Test remove with a start larger than the end.");
 
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+
+              assert_throws("InvalidAccessError", function()
+              {
+                  sourceBuffer.remove(0, Number.NEGATIVE_INFINITY);
+              }, "remove");
+
+              test.done();
+          }, "Test remove with a NEGATIVE_INFINITY end.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+
+              assert_throws("InvalidAccessError", function()
+              {
+                  sourceBuffer.remove(0, Number.NaN);
+              }, "remove");
+
+              test.done();
+          }, "Test remove with a NaN end.");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
@@ -115,6 +152,34 @@
               });
           }, "Test aborting a remove operation.");
 
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              sourceBuffer.appendBuffer(mediaData);
+
+              test.expectEvent(sourceBuffer, "updatestart");
+              test.expectEvent(sourceBuffer, "update");
+              test.expectEvent(sourceBuffer, "updateend");
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_less_than(mediaSource.duration, 10)
+
+                  mediaSource.duration = 10;
+
+                  sourceBuffer.remove(mediaSource.duration, mediaSource.duration + 2);
+
+                  assert_true(sourceBuffer.updating, "updating");
+                  test.expectEvent(sourceBuffer, "updatestart");
+                  test.expectEvent(sourceBuffer, "update");
+                  test.expectEvent(sourceBuffer, "updateend");
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.done();
+              });
+
+          }, "Test remove with a start at the duration.");
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
@@ -159,7 +224,7 @@
                       mediaSource.endOfStream();
                       assert_false(sourceBuffer.updating, "updating");
 
-                      var duration = segmentInfo.duration.toFixed(3);
+                      var duration = mediaElement.duration.toFixed(3);
                       var subType = MediaSourceUtil.getSubType(segmentInfo.type);
 
                       assertBufferedEquals(sourceBuffer, "{ [0.000, " + duration + ") }", "Initial buffered range.");

--- a/media-source/mediasource-removesourcebuffer.html
+++ b/media-source/mediasource-removesourcebuffer.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>MediaSource.removeSourceBuffer() test cases.</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+
+              mediaSource.removeSourceBuffer(sourceBuffer);
+
+              var sourceBuffer2 = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer2 != null, "New SourceBuffer returned");
+              assert_true(sourceBuffer != sourceBuffer2, "SourceBuffers are different instances.");
+              assert_equals(mediaSource.sourceBuffers.length, 1, "sourceBuffers.length == 1");
+
+              test.done();
+          }, "Test addSourceBuffer(), removeSourceBuffer(), addSourceBuffer() sequence.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              assert_throws(new TypeError(),
+                          function() { mediaSource.removeSourceBuffer(null); },
+                          "removeSourceBuffer() threw an exception when passed null.");
+              test.done();
+          }, "Test removeSourceBuffer() with null");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+
+              mediaSource.removeSourceBuffer(sourceBuffer);
+
+              assert_throws("NotFoundError",
+                  function() { mediaSource.removeSourceBuffer(sourceBuffer); },
+                  "removeSourceBuffer() threw an exception when a SourceBuffer that was already removed.");
+
+              test.done();
+          }, "Test calling removeSourceBuffer() twice with the same object.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+
+              mediaSource.endOfStream();
+              assert_true(mediaSource.readyState == "ended", "MediaSource in ended state");
+              mediaSource.removeSourceBuffer(sourceBuffer);
+
+              assert_true(mediaSource.sourceBuffers.length == 0, "MediaSource.sourceBuffers is empty");
+              assert_true(mediaSource.activeSourceBuffers.length == 0, "MediaSource.activesourceBuffers is empty");
+
+              test.done();
+          }, "Test calling removeSourceBuffer() in ended state.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+
+              test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+              test.expectEvent(mediaElement, "loadedmetadata", "loadedmetadata done.");
+              sourceBuffer.appendBuffer(initSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_true(mediaSource.sourceBuffers.length == 1, "MediaSource.sourceBuffers is not empty");
+                  assert_true(mediaSource.activeSourceBuffers.length == 1, "MediaSource.activesourceBuffers is not empty");
+                  assert_equals(mediaElement.readyState, mediaElement.HAVE_METADATA);
+                  assert_equals(mediaSource.duration, segmentInfo.duration);
+                  test.expectEvent(mediaSource.activeSourceBuffers, "removesourcebuffer", "SourceBuffer removed from activeSourceBuffers.");
+                  test.expectEvent(mediaSource.sourceBuffers, "removesourcebuffer", "SourceBuffer removed.");
+                  mediaSource.removeSourceBuffer(sourceBuffer);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_true(mediaSource.sourceBuffers.length == 0, "MediaSource.sourceBuffers is empty");
+                  assert_true(mediaSource.activeSourceBuffers.length == 0, "MediaSource.activesourceBuffers is empty");
+                  test.done();
+              });
+          }, "Test removesourcebuffer event on activeSourceBuffers.");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-sequencemode-append-buffer.html
+++ b/media-source/mediasource-sequencemode-append-buffer.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>SourceBuffer.mode == "sequence" test cases.</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          function mediasource_sequencemode_test(testFunction, description, options)
+          {
+              return mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+              {
+                  assert_greater_than(segmentInfo.media.length, 3, "at least 3 media segments for supported type");
+                  test.failOnEvent(mediaElement, "error");
+                  sourceBuffer.mode = "sequence";
+                  assert_equals(sourceBuffer.mode, "sequence", "mode after setting it to \"sequence\"");
+
+                  var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+                  test.expectEvent(sourceBuffer, "updatestart", "initSegment append started.");
+                  test.expectEvent(sourceBuffer, "update", "initSegment append success.");
+                  test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+                  sourceBuffer.appendBuffer(initSegment);
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_equals(sourceBuffer.timestampOffset, 0, "timestampOffset initially 0");
+                      testFunction(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData);
+                  });
+              }, description, options);
+          }
+
+          function append_segment(test, sourceBuffer, mediaData, info, callback)
+          {
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, info);
+              test.expectEvent(sourceBuffer, "updatestart", "media segment append started.");
+              test.expectEvent(sourceBuffer, "update", "media segment append success.");
+              test.expectEvent(sourceBuffer, "updateend", "media segment append ended.");
+              sourceBuffer.appendBuffer(mediaSegment);
+              test.waitForExpectedEvents(callback);
+          }
+
+          function threeDecimalPlaces(number)
+          {
+              return Number(number.toFixed(3));
+          }
+
+          // Verifies expected times to 3 decimal places before and after mediaSource.endOfStream(),
+          // and calls |callback| on success.
+          function verify_offset_and_buffered(test, mediaSource, sourceBuffer,
+                                              expectedTimestampOffset, expectedBufferedRangeStartTime,
+                                              expectedBufferedRangeMaxEndTimeBeforeEOS,
+                                              expectedBufferedRangeEndTimeAfterEOS,
+                                              callback) {
+              assert_equals(threeDecimalPlaces(sourceBuffer.timestampOffset),
+                            threeDecimalPlaces(expectedTimestampOffset),
+                            "expectedTimestampOffset");
+
+              // Prior to EOS, the buffered range end time may not have fully reached the next media
+              // segment's timecode (adjusted by any timestampOffset). It should not exceed it though.
+              // Therefore, an exact assertBufferedEquals() will not work here.
+              assert_equals(sourceBuffer.buffered.length, 1, "sourceBuffer.buffered has 1 range before EOS");
+              assert_equals(threeDecimalPlaces(sourceBuffer.buffered.start(0)),
+                            threeDecimalPlaces(expectedBufferedRangeStartTime),
+                            "sourceBuffer.buffered range begins where expected before EOS");
+              assert_less_than_equal(threeDecimalPlaces(sourceBuffer.buffered.end(0)),
+                                     threeDecimalPlaces(expectedBufferedRangeMaxEndTimeBeforeEOS),
+                                     "sourceBuffer.buffered range ends at or before expected upper bound before EOS");
+
+              test.expectEvent(mediaSource, "sourceended", "mediaSource endOfStream");
+              mediaSource.endOfStream();
+              test.waitForExpectedEvents(function()
+              {
+                  assertBufferedEquals(sourceBuffer,
+                                       "{ [" + expectedBufferedRangeStartTime.toFixed(3) + ", " + expectedBufferedRangeEndTimeAfterEOS.toFixed(3) + ") }",
+                                       "sourceBuffer.buffered after EOS");
+                  callback();
+              });
+          }
+
+          mediasource_sequencemode_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_equals(segmentInfo.media[0].timecode, 0, "segment starts at time 0");
+              append_segment(test, sourceBuffer, mediaData, segmentInfo.media[0], function()
+              {
+                  verify_offset_and_buffered(test, mediaSource, sourceBuffer,
+                                             0, 0,
+                                             segmentInfo.media[1].timecode + sourceBuffer.timestampOffset,
+                                             segmentInfo.media[0].highest_end_time + sourceBuffer.timestampOffset,
+                                             test.done);
+              });
+          }, "Test sequence AppendMode appendBuffer(first media segment)");
+
+          mediasource_sequencemode_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_greater_than(segmentInfo.media[1].timecode, 0, "segment starts after time 0");
+              append_segment(test, sourceBuffer, mediaData, segmentInfo.media[1], function()
+              {
+                  verify_offset_and_buffered(test, mediaSource, sourceBuffer,
+                                             -segmentInfo.media[1].timecode, 0,
+                                             segmentInfo.media[2].timecode + sourceBuffer.timestampOffset,
+                                             segmentInfo.media[1].highest_end_time + sourceBuffer.timestampOffset,
+                                             test.done);
+              });
+          }, "Test sequence AppendMode appendBuffer(second media segment)");
+
+          mediasource_sequencemode_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_greater_than(segmentInfo.media[1].timecode, 0, "segment starts after time 0");
+              append_segment(test, sourceBuffer, mediaData, segmentInfo.media[1], function()
+              {
+                  assert_equals(segmentInfo.media[0].timecode, 0, "segment starts at time 0");
+                  append_segment(test, sourceBuffer, mediaData, segmentInfo.media[0], function()
+                  {
+                      // Current timestampOffset should reflect offset required to put media[0]
+                      // immediately after media[1]'s highest frame end timestamp (as was adjusted
+                      // by an earlier timestampOffset).
+                      verify_offset_and_buffered(test, mediaSource, sourceBuffer,
+                                                 segmentInfo.media[1].highest_end_time - segmentInfo.media[1].timecode, 0,
+                                                 segmentInfo.media[1].timecode + sourceBuffer.timestampOffset,
+                                                 segmentInfo.media[0].highest_end_time + sourceBuffer.timestampOffset,
+                                                 test.done);
+                  })
+              });
+          }, "Test sequence AppendMode appendBuffer(second media segment, then first media segment)");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-timestamp-offset.html
+++ b/media-source/mediasource-timestamp-offset.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>SourceBuffer.timestampOffset test cases.</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          function simpleTimestampOffsetTest(value, expected, description)
+          {
+              mediasource_test(function(test, mediaElement, mediaSource)
+              {
+                  var segmentInfo = MediaSourceUtil.SEGMENT_INFO;
+                  var sourceBuffer = mediaSource.addSourceBuffer(segmentInfo.type);
+
+                  if (expected == "TypeError")  {
+                      assert_throws({name: "TypeError"},
+                          function() { sourceBuffer.timestampOffset = value; },
+                          "setting timestampOffset to " + description + " throws an exception.");
+                  } else {
+                      sourceBuffer.timestampOffset = value;
+                      assert_equals(sourceBuffer.timestampOffset, expected);
+                  }
+
+                  test.done();
+              }, "Test setting SourceBuffer.timestampOffset to " + description + ".");
+          }
+
+          simpleTimestampOffsetTest(10.5, 10.5, "a positive number");
+          simpleTimestampOffsetTest(-10.4, -10.4, "a negative number");
+          simpleTimestampOffsetTest(0, 0, "zero");
+          simpleTimestampOffsetTest(Number.POSITIVE_INFINITY, "TypeError", "positive infinity");
+          simpleTimestampOffsetTest(Number.NEGATIVE_INFINITY, "TypeError", "negative infinity");
+          simpleTimestampOffsetTest(Number.NaN, "TypeError", "NaN");
+          simpleTimestampOffsetTest(undefined, "TypeError", "undefined");
+          simpleTimestampOffsetTest(null, 0, "null");
+          simpleTimestampOffsetTest(false, 0, "false");
+          simpleTimestampOffsetTest(true, 1, "true");
+          simpleTimestampOffsetTest("10.5", 10.5, "a number string");
+          simpleTimestampOffsetTest("", 0, "an empty string");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+              test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+              sourceBuffer.appendBuffer(initSegment);
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  sourceBuffer.appendBuffer(mediaSegment);
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  mediaSource.endOfStream();
+
+                  assert_equals(mediaSource.readyState, "ended");
+
+                  mediaSource.sourceBuffers[0].timestampOffset = 2;
+
+                  assert_equals(mediaSource.readyState, "open");
+
+                  test.expectEvent(mediaSource, "sourceopen", "mediaSource fired 'sourceopen' event.");
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.done();
+              });
+          }, "Test setting timestampOffset in 'ended' state causes a transition to 'open'.");
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+              var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+              test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+              sourceBuffer.appendBuffer(initSegment);
+              assert_equals(mediaSource.sourceBuffers[0].timestampOffset, 0, "read initial value");
+
+              test.waitForExpectedEvents(function()
+              {
+                  test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+                  sourceBuffer.appendBuffer(mediaSegment);
+                  assert_equals(mediaSource.sourceBuffers[0].timestampOffset, 0,
+                      "No change to timestampoffset after segments mode init segment append");
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(mediaSource.sourceBuffers[0].timestampOffset, 0,
+                      "No change to timestampoffset after segments mode media segment append");
+                  test.done();
+              });
+          }, "Test getting the initial value of timestampOffset.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+
+              mediaSource.removeSourceBuffer(sourceBuffer);
+              assert_true(mediaSource.sourceBuffers.length == 0, "MediaSource.sourceBuffers is empty");
+              assert_true(mediaSource.activeSourceBuffers.length == 0, "MediaSource.activesourceBuffers is empty");
+
+              assert_throws("InvalidStateError", function()
+              {
+                  sourceBuffer.timestampOffset = 10;
+              });
+
+              test.done();
+          }, "Test setting timestampoffset after removing the sourcebuffer.");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Here are a bunch of new test cases that have been in Blink for a while but were not part of the original test import. Most of these tests just cover various boundary conditions and edge cases.
