### PR TITLE
Confirm Object.prototype.hasOwnProperty doesn't trace prototype chain.

### DIFF
--- a/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
+++ b/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<!--
+Distributed under both the W3C Test Suite License [1] and the W3C
+3-clause BSD License [2]. To contribute to a W3C Test Suite, see the
+policies and contribution forms [3].
+
+[1] http://www.w3.org/Consortium/Legal/2008/04-testsuite-license
+[2] http://www.w3.org/Consortium/Legal/2008/03-bsd-license
+[3] http://www.w3.org/2004/10/27-testcases
+-->
+<html>
+<head>
+<meta charset="utf-8">
+<title>Object.prototype.hasOwnProperty: Check prototype chain</title>
+<link rel="author" title="Masaya Iseki" href="mailto:iseki.m.aa@gmail.com">
+<link rel="help" href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.5">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+test(function() {
+  var obj = new Object();
+
+  obj.prop = 'exists';
+  assert_true(Object.hasOwnProperty.call(obj, 'prop'));
+  assert_true('hasOwnProperty' in obj);
+  assert_false(Object.hasOwnProperty.call(obj, 'hasOwnProperty'));
+});
+</script>
+
+</body>
+</html>

--- a/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
+++ b/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
@@ -34,12 +34,8 @@ test(function() {
 
 test(function() {
   [null, undefined].forEach(function(that) {
-  	try {
-  	  that.hasOwnProperty('hasOwnProperty');  
-  	}
-  	catch(err) {
-  	  assert_equals('TypeError', err.name);
-  	}
+    assert_throws(new TypeError(),
+        function() { that.hasOwnProperty('hasOwnProperty'); });
   });
 });
 </script>

--- a/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
+++ b/js/builtins/Object.prototype.hasOwnProperty-prototype-chain.html
@@ -13,17 +13,34 @@ policies and contribution forms [3].
 <meta charset="utf-8">
 <title>Object.prototype.hasOwnProperty: Check prototype chain</title>
 <link rel="author" title="Masaya Iseki" href="mailto:iseki.m.aa@gmail.com">
-<link rel="help" href="http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.4.5">
+<link rel="help" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.prototype.hasownproperty">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
 test(function() {
-  var obj = new Object();
+  [{}, []].forEach(function(that) {
+  	that.prop = 'exists';
+  	assert_true(that.hasOwnProperty('prop'));
+  	assert_true('hasOwnProperty' in that);
+  	assert_false(that.hasOwnProperty('hasOwnProperty'));
+  });
+});
 
-  obj.prop = 'exists';
-  assert_true(Object.hasOwnProperty.call(obj, 'prop'));
-  assert_true('hasOwnProperty' in obj);
-  assert_false(Object.hasOwnProperty.call(obj, 'hasOwnProperty'));
+test(function() {
+  ['foo', 42].forEach(function(that) {
+  	assert_false(that.hasOwnProperty('hasOwnProperty'));
+  });
+});
+
+test(function() {
+  [null, undefined].forEach(function(that) {
+  	try {
+  	  that.hasOwnProperty('hasOwnProperty');  
+  	}
+  	catch(err) {
+  	  assert_equals('TypeError', err.name);
+  	}
+  });
 });
 </script>
 


### PR DESCRIPTION
Add test case to confirm that Object.prototype.hasOwnProperty doesn't trace prototype chain.

Please take a look.
