### PR TITLE
Anchor, Area & Link elements no longer matches :enabled

### DIFF
--- a/html/semantics/selectors/pseudo-classes/enabled.html
+++ b/html/semantics/selectors/pseudo-classes/enabled.html
@@ -38,5 +38,5 @@
 <fieldset disabled id=fieldset2></fieldset>
 
 <script>
-  testSelector(":enabled", ["link1", "link2", "link6", "link7", "link8", "button1", "input1", "select1", "optgroup1", "option1", "textarea1", "submitbutton", "menuitem1", "fieldset1"], "':enabled' should <a>s/<area>s/<link>s that have an href attribute and elements that are not disabled");
+  testSelector(":enabled", ["button1", "input1", "select1", "optgroup1", "option1", "textarea1", "submitbutton", "menuitem1", "fieldset1"], "':enabled' elements that are not disabled");
 </script>


### PR DESCRIPTION
HTML spec has been modified [1] to disable support for :enabled CSS
selector on Anchor, Area & Link elements, after discussion on W3C
Bugzilla [2].

[1] https://html5.org/r/8818
[2] https://www.w3.org/Bugs/Public/show_bug.cgi?id=26622
