### PR TITLE
picture: Flip pass condition on the media="," test and add a another test

### DIFF
--- a/html/semantics/embedded-content/the-img-element/update-the-source-set.html
+++ b/html/semantics/embedded-content/the-img-element/update-the-source-set.html
@@ -80,7 +80,8 @@ onload = function() {
 <div><picture><source srcset='data:,b' media='not all and !'><img src='data:,a' data-expect='data:,a'></picture></div>
 <div><picture><source srcset='data:,b' media='not all and (!)'><img src='data:,a' data-expect='data:,a'></picture></div>
 <div><picture><source srcset='data:,b' media='all, !'><img src='data:,a' data-expect='data:,b'></picture></div>
-<div><picture><source srcset='data:,b' media=','><img src='data:,a' data-expect='data:,b'></picture></div>
+<div><picture><source srcset='data:,b' media=','><img src='data:,a' data-expect='data:,a'></picture></div>
+<div><picture><source srcset='data:,b' media=', all'><img src='data:,a' data-expect='data:,b'></picture></div>
 
 <!-- <source type> assume support for gif, png, jpg, svg, ico -->
 


### PR DESCRIPTION
I had misunderstood how CSS grammar works.

http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-query-list
http://dev.w3.org/csswg/mediaqueries-4/#typedef-media-query
http://dev.w3.org/csswg/css-values/#comb-one
http://dev.w3.org/csswg/mediaqueries-4/#error-handling

The empty string is not a valid `<media-query>` and so `media=","` is equivalent to `media="not all,not all"`
