### PR TITLE
resource-timing - allow secureConnectionStart to be 0 OR undefined

### DIFF
--- a/resource-timing/test_resource_timing.html
+++ b/resource-timing/test_resource_timing.html
@@ -286,7 +286,8 @@
 
             pass =  (actualEntry.redirectStart == 0) &&
                     (actualEntry.redirectEnd == 0) &&
-                    (actualEntry.secureConnectionStart == undefined) &&
+                    (actualEntry.secureConnectionStart == undefined ||
+                     actualEntry.secureConnectionStart == 0) &&
                     validate_timeline(actualEntry);
 
             (pass) ? test_true(true,


### PR DESCRIPTION
This change fixes the test assuming secureConnectionStart is undefined.
Fixes bug #1257
