### PR TITLE
Seperate the host that the server is bound to from the one that's exposed in the frontend

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,5 @@
 {"host": "web-platform.test",
+ "external_host": null,
  "ports":{"http":[8000, "auto"],
           "https":[],
           "ws":["auto"]},


### PR DESCRIPTION
This helps when the server is being accessed through a proxy and .py scripts and templates should access the server through the proxied name.
