### PR TITLE
adding test for calling open() to terminate the abort() algorithm

### DIFF
--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -18,7 +18,12 @@
         log.push('upload.onloadstart')
         client.abort() // This will trigger an abort event
       }
-
+      /*
+      The following code runs from upload.onabort because per spec the abort event
+      fires first on the upload, then on the xhr object. Hence, we can assert in
+      client.onabort that the listener should not run at all - client.upload.onabort
+      should fire first, and calling open() should interrupt abort processing.
+      */
       client.upload.onabort = test.step_func(function () {
         // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
         //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
@@ -29,11 +34,10 @@
       })
 
       client.onabort = test.step_func(function () {
-        assert_unreached('abort() algorithm should have been terminated by open() in the handler')
+        assert_unreached('abort() algorithm should have been terminated by open() in the upload.abort handler')
       })
 
       client.onload = test.step_func(function(){
-        alert(log)
         assert_array_equals(log, ['upload.onloadstart', 'upload.onabort'])
         test.done()
       })

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -12,11 +12,23 @@
     <div id="log"></div>
     <script>
       var test = async_test()
-      var client = new XMLHttpRequest(), log = []
+      var client = new XMLHttpRequest(), log = [], lastTest = false
+      var expected = [
+        'readyState before abort() 1' /* we abort from onloadstart - still OPENED state */,
+        "upload.onabort - before open() 4", /* onabort fires first on upload, now in DONE state due to "request error steps" algo */
+        "client.onabort 4", /* open question: should open() stop this? Should readyState now be 1? */
+        "client.onloadend 4", /* ditto open questions.. */
+        "readyState after open() 1", /* no-brainer */
+        "readyState after abort() 1", /* the abort() call now returns, readyState was already set by open() */
+        "client.onload 4", /* These are logged by the second request completing successfully */
+        "client.onloadend 4"
+        ]
 
       client.upload.onloadstart = function(){
-        log.push('upload.onloadstart')
+        log.push('readyState before abort() '+client.readyState)
         client.abort() // This will trigger an abort event
+        log.push('readyState after abort() '+client.readyState)
+
       }
       /*
       The following code runs from upload.onabort because per spec the abort event
@@ -27,22 +39,31 @@
       client.upload.onabort = test.step_func(function () {
         // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
         //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
-        log.push('upload.onabort')
-        client.open("GET", "resources/well-formed.xml")
-        assert_equals(client.readyState, client.OPENED, 'readyState after open()')
+        log.push('upload.onabort - before open() ' + client.readyState)
+        client.open("GET", "resources/content.py")
+        log.push('readyState after open() ' + client.readyState)
+        lastTest = true
         client.send(null)
       })
 
       client.onabort = test.step_func(function () {
-        assert_unreached('abort() algorithm should have been terminated by open() in the upload.abort handler')
+        log.push('client.onabort ' + client.readyState)
+      })
+
+      client.onloadend = test.step_func(function () {
+        log.push('client.onloadend ' + client.readyState)
+        if(lastTest){
+          console.log(log)
+          assert_array_equals(log, expected)
+          test.done()
+        }
       })
 
       client.onload = test.step_func(function(){
-        assert_array_equals(log, ['upload.onloadstart', 'upload.onabort'])
-        test.done()
+        log.push('client.onload ' + client.readyState)
       })
 
-      client.open("POST", "resources/well-formed.xml")
+      client.open("POST", "resources/content.py")
       client.send(document)
     </script>
   </body>

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: open() during abort event - abort() called from upload.onloadstart</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-open()-method" data-tested-assertations="following::ol/li[15] following::ol/li[15]/ol/li[1] following::ol/li[15]/ol/li[2]" />
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-abort" data-tested-assertations="following::ol/li[2]/ol/li[3]" />
+    <!-- TODO: no suitable assertation in spec yet for the main point of this test - see https://www.w3.org/Bugs/Public/show_bug.cgi?id=27033#c5 -->
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var test = async_test()
+      var client = new XMLHttpRequest(), log = []
+
+      client.upload.onloadstart = function(){
+        log.push('upload.onloadstart')
+        client.abort() // This will trigger an abort event
+      }
+
+      client.upload.onabort = test.step_func(function () {
+        // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
+        //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
+        log.push('upload.onabort')
+        client.open("GET", "resources/well-formed.xml")
+        assert_equals(client.readyState, client.OPENED, 'readyState after open()')
+        client.send(null)
+      })
+
+      client.onabort = test.step_func(function () {
+        assert_unreached('abort() algorithm should have been terminated by open() in the handler')
+      })
+
+      client.onload = test.step_func(function(){
+        alert(log)
+        assert_array_equals(log, ['upload.onloadstart', 'upload.onabort'])
+        test.done()
+      })
+
+      client.open("POST", "resources/well-formed.xml")
+      client.send(document)
+    </script>
+  </body>
+</html>

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -4,9 +4,11 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-      var test = async_test()
-      var client = new XMLHttpRequest(), log = [], lastTest = false
-      var expected = [
+async_test(t => {
+  let client = new XMLHttpRequest(),
+      log = [],
+      lastTest = false,
+      expected = [
         'readyState before abort() 1' /* we abort from onloadstart - still OPENED state */,
         "upload.onabort - before open() 4", /* onabort fires first on upload, now in DONE state due to "request error steps" algo */
         "client.onabort 4", /* open question: should open() stop this? Should readyState now be 1? */
@@ -15,46 +17,46 @@
         "readyState after abort() 1", /* the abort() call now returns, readyState was already set by open() */
         "client.onload 4", /* These are logged by the second request completing successfully */
         "client.onloadend 4"
-        ]
+      ]
 
-      client.upload.onloadstart = function(){
-        log.push('readyState before abort() '+client.readyState)
-        client.abort() // This will trigger an abort event
-        log.push('readyState after abort() '+client.readyState)
+  client.upload.onloadstart = t.step_func(() => {
+    log.push('readyState before abort() '+client.readyState)
+    client.abort() // This will trigger an abort event
+    log.push('readyState after abort() '+client.readyState)
+  })
+  /*
+  The following code runs from upload.onabort because per spec the abort event
+  fires first on the upload, then on the xhr object. Hence, we can assert in
+  client.onabort that the listener should not run at all - client.upload.onabort
+  should fire first, and calling open() should interrupt abort processing.
+  */
+  client.upload.onabort = t.step_func(() => {
+    // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
+    //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
+    log.push('upload.onabort - before open() ' + client.readyState)
+    client.open("GET", "resources/content.py")
+    log.push('readyState after open() ' + client.readyState)
+    lastTest = true
+    client.send(null)
+  })
 
-      }
-      /*
-      The following code runs from upload.onabort because per spec the abort event
-      fires first on the upload, then on the xhr object. Hence, we can assert in
-      client.onabort that the listener should not run at all - client.upload.onabort
-      should fire first, and calling open() should interrupt abort processing.
-      */
-      client.upload.onabort = test.step_func(function () {
-        // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
-        //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
-        log.push('upload.onabort - before open() ' + client.readyState)
-        client.open("GET", "resources/content.py")
-        log.push('readyState after open() ' + client.readyState)
-        lastTest = true
-        client.send(null)
-      })
+  client.onabort = t.step_func(() => {
+    log.push('client.onabort ' + client.readyState)
+  })
 
-      client.onabort = test.step_func(function () {
-        log.push('client.onabort ' + client.readyState)
-      })
+  client.onloadend = t.step_func(() => {
+    log.push('client.onloadend ' + client.readyState)
+    if(lastTest) {
+      assert_array_equals(log, expected)
+      test.done()
+    }
+  })
 
-      client.onloadend = test.step_func(function () {
-        log.push('client.onloadend ' + client.readyState)
-        if(lastTest){
-          assert_array_equals(log, expected)
-          test.done()
-        }
-      })
+  client.onload = t.step_func(() => {
+    log.push('client.onload ' + client.readyState)
+  })
 
-      client.onload = test.step_func(function(){
-        log.push('client.onload ' + client.readyState)
-      })
-
-      client.open("POST", "resources/content.py")
-      client.send(document)
-    </script>
+  client.open("POST", "resources/content.py")
+  client.send(document)
+})
+</script>

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -1,16 +1,9 @@
 <!doctype html>
-<html>
-  <head>
-    <title>XMLHttpRequest: open() during abort event - abort() called from upload.onloadstart</title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-open()-method" data-tested-assertations="following::ol/li[15] following::ol/li[15]/ol/li[1] following::ol/li[15]/ol/li[2]" />
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-abort" data-tested-assertations="following::ol/li[2]/ol/li[3]" />
-    <!-- TODO: no suitable assertation in spec yet for the main point of this test - see https://www.w3.org/Bugs/Public/show_bug.cgi?id=27033#c5 -->
-  </head>
-  <body>
-    <div id="log"></div>
-    <script>
+<title>XMLHttpRequest: open() during abort event - abort() called from upload.onloadstart</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
       var test = async_test()
       var client = new XMLHttpRequest(), log = [], lastTest = false
       var expected = [
@@ -53,7 +46,6 @@
       client.onloadend = test.step_func(function () {
         log.push('client.onloadend ' + client.readyState)
         if(lastTest){
-          console.log(log)
           assert_array_equals(log, expected)
           test.done()
         }
@@ -66,5 +58,3 @@
       client.open("POST", "resources/content.py")
       client.send(document)
     </script>
-  </body>
-</html>

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -32,7 +32,8 @@ async_test(t => {
     client.send(null)
   })
 
-  client.onabort = t.step_func(() => { // happens immediately after all of upload.onabort, so readyState is 1
+  client.onabort = t.step_func(() => {
+    // happens immediately after all of upload.onabort, so readyState is 1
     log.push('client.onabort ' + client.readyState)
   })
 

--- a/XMLHttpRequest/open-during-abort-event.htm
+++ b/XMLHttpRequest/open-during-abort-event.htm
@@ -9,38 +9,30 @@ async_test(t => {
       log = [],
       lastTest = false,
       expected = [
-        'readyState before abort() 1' /* we abort from onloadstart - still OPENED state */,
-        "upload.onabort - before open() 4", /* onabort fires first on upload, now in DONE state due to "request error steps" algo */
-        "client.onabort 4", /* open question: should open() stop this? Should readyState now be 1? */
-        "client.onloadend 4", /* ditto open questions.. */
-        "readyState after open() 1", /* no-brainer */
-        "readyState after abort() 1", /* the abort() call now returns, readyState was already set by open() */
-        "client.onload 4", /* These are logged by the second request completing successfully */
+        'readyState before abort() 1',
+        "upload.onabort - before open() 4",
+        "readyState after open() 1",
+        "client.onabort 1",
+        "client.onloadend 1",
+        "readyState after abort() 1",
+        "client.onload 4",
         "client.onloadend 4"
       ]
 
   client.upload.onloadstart = t.step_func(() => {
     log.push('readyState before abort() '+client.readyState)
-    client.abort() // This will trigger an abort event
+    client.abort()
     log.push('readyState after abort() '+client.readyState)
   })
-  /*
-  The following code runs from upload.onabort because per spec the abort event
-  fires first on the upload, then on the xhr object. Hence, we can assert in
-  client.onabort that the listener should not run at all - client.upload.onabort
-  should fire first, and calling open() should interrupt abort processing.
-  */
+
   client.upload.onabort = t.step_func(() => {
-    // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
-    //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
     log.push('upload.onabort - before open() ' + client.readyState)
     client.open("GET", "resources/content.py")
     log.push('readyState after open() ' + client.readyState)
-    lastTest = true
     client.send(null)
   })
 
-  client.onabort = t.step_func(() => {
+  client.onabort = t.step_func(() => { // happens immediately after all of upload.onabort, so readyState is 1
     log.push('client.onabort ' + client.readyState)
   })
 
@@ -48,8 +40,9 @@ async_test(t => {
     log.push('client.onloadend ' + client.readyState)
     if(lastTest) {
       assert_array_equals(log, expected)
-      test.done()
+      t.done()
     }
+    lastTest = true
   })
 
   client.onload = t.step_func(() => {
@@ -57,6 +50,6 @@ async_test(t => {
   })
 
   client.open("POST", "resources/content.py")
-  client.send(document)
+  client.send("non-empty")
 })
 </script>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -1,0 +1,50 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: open() during abort processing - abort() called from onloadstart</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-open()-method" data-tested-assertations="following::ol/li[15] following::ol/li[15]/ol/li[1] following::ol/li[15]/ol/li[2]" />
+    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-abort" data-tested-assertations="following::ol/li[2]/ol/li[3]" />
+    <!-- TODO: no suitable assertation in spec yet for the main point of this test - see https://www.w3.org/Bugs/Public/show_bug.cgi?id=27033#c5 -->
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var test = async_test()
+      var client = new XMLHttpRequest(), test_state = 0
+
+      client.upload.onabort = test.step_func(function () {
+        assert_unreached('abort() algorithm should have been terminated by open() in the readystatechange handler')
+      })
+
+      client.onabort = test.step_func(function () {
+        assert_unreached('abort() algorithm should have been terminated by open() in the readystatechange handler')
+      })
+
+      client.onloadstart = function(){
+        test_state = 1
+        client.abort() // This will trigger an abort event
+      }
+
+      client.onload = test.step_func(function(){
+        test.done()
+      })
+
+      client.onreadystatechange = test.step_func(function() {
+          if(test_state === 1){ // this readystatechange event is fired due to the abort() algorithm
+            client.onreadystatechange = null // must kill this event handler to avoid a very strange recursion problem
+            // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
+            //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
+            test_state = 2
+            client.open("GET", "resources/well-formed.xml")
+            assert_equals(client.readyState, client.OPENED, 'readyState after open()')
+            client.send(null)
+          }
+      })
+
+      client.open("GET", "resources/well-formed.xml")
+      client.send('abcd')
+    </script>
+  </body>
+</html>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -12,38 +12,60 @@
     <div id="log"></div>
     <script>
       var test = async_test()
-      var client = new XMLHttpRequest(), test_state = 0
+      var client = new XMLHttpRequest(), test_state = 1, log = []
+      var expected = [
+        "onloadstart readyState before abort() 1",
+        "onreadystatechange readyState before open() 4", /* this event is triggered from the abort(), readyState is now 4 */
+        "onreadystatechange readyState after open() 1",
+        "onloadstart readyState 1", /* should this fire *after* abort() returns, like IE does? Or at this point, like Gecko does? */
+        "client.onabort 1", /* open question whether this should fire at all.. and if it does, so should upload.onabort - no? */
+        "readyState after abort() 1", /* abort() call returns when open() has already set readyState to 1 */
+        "client.onload 4" /* second request succeeds */
+      ]
 
       client.upload.onabort = test.step_func(function () {
-        assert_unreached('abort() algorithm should have been terminated by open() in the readystatechange handler')
+        log.push('upload.onabort ' + client.readyState)
+      })
+
+      client.upload.onloadend = test.step_func(function () {
+        log.push('upload.onloadend ' + client.readyState)
       })
 
       client.onabort = test.step_func(function () {
-        assert_unreached('abort() algorithm should have been terminated by open() in the readystatechange handler')
+        log.push('client.onabort ' + client.readyState)
       })
 
       client.onloadstart = function(){
-        test_state = 1
-        client.abort() // This will trigger an abort event
+        if(test_state === 1){
+          test_state = 2
+          log.push('onloadstart readyState before abort() ' + client.readyState)
+          client.abort() // This will trigger an abort event
+          log.push('readyState after abort() ' + client.readyState)
+        }else{
+          log.push('onloadstart readyState ' + client.readyState)
+        }
       }
 
       client.onload = test.step_func(function(){
+        log.push('client.onload ' + client.readyState)
+        console.log(log)
+        assert_array_equals(log, expected)
         test.done()
       })
 
       client.onreadystatechange = test.step_func(function() {
-          if(test_state === 1){ // this readystatechange event is fired due to the abort() algorithm
-            client.onreadystatechange = null // must kill this event handler to avoid a very strange recursion problem
+          if(test_state === 2){ // this readystatechange event is fired due to the abort() algorithm
             // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
             //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
-            test_state = 2
-            client.open("GET", "resources/well-formed.xml")
-            assert_equals(client.readyState, client.OPENED, 'readyState after open()')
+            test_state = 3
+            log.push('onreadystatechange readyState before open() ' + client.readyState)
+            client.open("GET", "resources/content.py")
+            log.push('onreadystatechange readyState after open() ' + client.readyState)
             client.send(null)
           }
       })
 
-      client.open("POST", "resources/well-formed.xml")
+      client.open("POST", "resources/content.py")
       client.send('abcd')
     </script>
   </body>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -43,7 +43,7 @@
           }
       })
 
-      client.open("GET", "resources/well-formed.xml")
+      client.open("POST", "resources/well-formed.xml")
       client.send('abcd')
     </script>
   </body>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -1,16 +1,9 @@
 <!doctype html>
-<html>
-  <head>
-    <title>XMLHttpRequest: open() during abort processing - abort() called from onloadstart</title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#the-open()-method" data-tested-assertations="following::ol/li[15] following::ol/li[15]/ol/li[1] following::ol/li[15]/ol/li[2]" />
-    <link rel="help" href="http://dvcs.w3.org/hg/xhr/raw-file/tip/Overview.html#dom-xmlhttprequest-abort" data-tested-assertations="following::ol/li[2]/ol/li[3]" />
-    <!-- TODO: no suitable assertation in spec yet for the main point of this test - see https://www.w3.org/Bugs/Public/show_bug.cgi?id=27033#c5 -->
-  </head>
-  <body>
-    <div id="log"></div>
-    <script>
+<title>XMLHttpRequest: open() during abort processing - abort() called from onloadstart</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
       var test = async_test()
       var client = new XMLHttpRequest(), test_state = 1, log = []
       var expected = [
@@ -48,7 +41,6 @@
 
       client.onload = test.step_func(function(){
         log.push('client.onload ' + client.readyState)
-        console.log(log)
         assert_array_equals(log, expected)
         test.done()
       })
@@ -68,5 +60,3 @@
       client.open("POST", "resources/content.py")
       client.send('abcd')
     </script>
-  </body>
-</html>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -4,9 +4,11 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-      var test = async_test()
-      var client = new XMLHttpRequest(), test_state = 1, log = []
-      var expected = [
+async_test(t => {
+  let client = new XMLHttpRequest(),
+      test_state = 1,
+      log = [],
+      expected = [
         "onloadstart readyState before abort() 1",
         "onreadystatechange readyState before open() 4", /* this event is triggered from the abort(), readyState is now 4 */
         "onreadystatechange readyState after open() 1",
@@ -16,47 +18,47 @@
         "client.onload 4" /* second request succeeds */
       ]
 
-      client.upload.onabort = test.step_func(function () {
-        log.push('upload.onabort ' + client.readyState)
-      })
+  client.upload.onabort = t.step_func(() => {
+    log.push('upload.onabort ' + client.readyState)
+  })
 
-      client.upload.onloadend = test.step_func(function () {
-        log.push('upload.onloadend ' + client.readyState)
-      })
+  client.upload.onloadend = t.step_func(() => {
+    log.push('upload.onloadend ' + client.readyState)
+  })
 
-      client.onabort = test.step_func(function () {
-        log.push('client.onabort ' + client.readyState)
-      })
+  client.onabort = t.step_func(() => {
+    log.push('client.onabort ' + client.readyState)
+  })
 
-      client.onloadstart = function(){
-        if(test_state === 1){
-          test_state = 2
-          log.push('onloadstart readyState before abort() ' + client.readyState)
-          client.abort() // This will trigger an abort event
-          log.push('readyState after abort() ' + client.readyState)
-        }else{
-          log.push('onloadstart readyState ' + client.readyState)
-        }
+  client.onloadstart = t.step_func(() => {
+    if(test_state === 1){
+      test_state = 2
+      log.push('onloadstart readyState before abort() ' + client.readyState)
+      client.abort() // This will trigger an abort event
+      log.push('readyState after abort() ' + client.readyState)
+    }else{
+      log.push('onloadstart readyState ' + client.readyState)
+    }
+  })
+
+  client.onload = t.step_func_done(() => {
+    log.push('client.onload ' + client.readyState)
+    assert_array_equals(log, expected)
+  })
+
+  client.onreadystatechange = t.step_func(() => {
+      if(test_state === 2){ // this readystatechange event is fired due to the abort() algorithm
+        // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
+        //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
+        test_state = 3
+        log.push('onreadystatechange readyState before open() ' + client.readyState)
+        client.open("GET", "resources/content.py")
+        log.push('onreadystatechange readyState after open() ' + client.readyState)
+        client.send(null)
       }
+  })
 
-      client.onload = test.step_func(function(){
-        log.push('client.onload ' + client.readyState)
-        assert_array_equals(log, expected)
-        test.done()
-      })
-
-      client.onreadystatechange = test.step_func(function() {
-          if(test_state === 2){ // this readystatechange event is fired due to the abort() algorithm
-            // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
-            //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
-            test_state = 3
-            log.push('onreadystatechange readyState before open() ' + client.readyState)
-            client.open("GET", "resources/content.py")
-            log.push('onreadystatechange readyState after open() ' + client.readyState)
-            client.send(null)
-          }
-      })
-
-      client.open("POST", "resources/content.py")
-      client.send('abcd')
-    </script>
+  client.open("POST", "resources/content.py")
+  client.send('abcd')
+})
+</script>

--- a/XMLHttpRequest/open-during-abort-processing.htm
+++ b/XMLHttpRequest/open-during-abort-processing.htm
@@ -10,52 +10,52 @@ async_test(t => {
       log = [],
       expected = [
         "onloadstart readyState before abort() 1",
-        "onreadystatechange readyState before open() 4", /* this event is triggered from the abort(), readyState is now 4 */
+        "onreadystatechange readyState before open() 4",
         "onreadystatechange readyState after open() 1",
-        "onloadstart readyState 1", /* should this fire *after* abort() returns, like IE does? Or at this point, like Gecko does? */
-        "client.onabort 1", /* open question whether this should fire at all.. and if it does, so should upload.onabort - no? */
-        "readyState after abort() 1", /* abort() call returns when open() has already set readyState to 1 */
-        "client.onload 4" /* second request succeeds */
+        "onloadstart readyState 1",
+        "upload.onabort 1",
+        "upload.onloadend 1",
+        "client.onabort 1",
+        "readyState after abort() 1",
+        "client.onload 4"
       ]
 
-  client.upload.onabort = t.step_func(() => {
-    log.push('upload.onabort ' + client.readyState)
-  })
-
-  client.upload.onloadend = t.step_func(() => {
-    log.push('upload.onloadend ' + client.readyState)
-  })
-
-  client.onabort = t.step_func(() => {
-    log.push('client.onabort ' + client.readyState)
+  client.onreadystatechange = t.step_func(() => {
+    if(test_state === 2){
+      test_state = 3
+      log.push('onreadystatechange readyState before open() ' + client.readyState)
+      client.open("GET", "resources/content.py")
+      log.push('onreadystatechange readyState after open() ' + client.readyState)
+      client.send(null)
+    }
   })
 
   client.onloadstart = t.step_func(() => {
     if(test_state === 1){
       test_state = 2
       log.push('onloadstart readyState before abort() ' + client.readyState)
-      client.abort() // This will trigger an abort event
+      client.abort()
       log.push('readyState after abort() ' + client.readyState)
     }else{
       log.push('onloadstart readyState ' + client.readyState)
     }
   })
 
+  client.upload.onabort = t.step_func(() => {
+    log.push('upload.onabort ' + client.readyState)
+  })
+
+  client.onabort = t.step_func(() => {
+    log.push('client.onabort ' + client.readyState)
+  })
+
+  client.upload.onloadend = t.step_func(() => {
+    log.push('upload.onloadend ' + client.readyState)
+  })
+
   client.onload = t.step_func_done(() => {
     log.push('client.onload ' + client.readyState)
     assert_array_equals(log, expected)
-  })
-
-  client.onreadystatechange = t.step_func(() => {
-      if(test_state === 2){ // this readystatechange event is fired due to the abort() algorithm
-        // this, if enabled, would also test #dom-xmlhttprequest-abort step following::ol/li[2]/ol/li[1]
-        //assert_equals(client.readyState, client.DONE, 'abort() should first set readyState to DONE')
-        test_state = 3
-        log.push('onreadystatechange readyState before open() ' + client.readyState)
-        client.open("GET", "resources/content.py")
-        log.push('onreadystatechange readyState after open() ' + client.readyState)
-        client.send(null)
-      }
   })
 
   client.open("POST", "resources/content.py")


### PR DESCRIPTION
Two tests based on comments here:
https://www.w3.org/Bugs/Public/show_bug.cgi?id=27033
open-during-abort-event calls open() from an upload.abort event listener. abort() is called from the xhr.loadstart event. Note that Webkit-based browsers do not currently fire abort events here. Per the spec, they should. Firefox fails this test too, because the test (tentatively) asserts that open() in xhr.upload.onabort should terminate abort processing so that xhr.onabort should not fire.

open-during-abort-processing calls open() from a readystatechange fired due to an abort() call.
