### PR TITLE
PointerEvents: update touch-action tests to be more reliable

### DIFF
--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -65,8 +65,7 @@
                             log("gotpointercapture", target0);
                             return;
                         }
-
-                        if (event.type == "lostpointercapture") {
+                        else if (event.type == "lostpointercapture") {
                             log("lostpointercapture", target0);
                             captureButton.value = 'Set Capture';
                             isPointerCapture = false;

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -71,7 +71,9 @@
                             isPointerCapture = false;
 
                             // TA: 11.2
-                            assert_true(isAsync, "lostpointercapture must be fired asynchronously");
+                            test_pointerEvent.step(function () {
+                                assert_true(isAsync, "lostpointercapture must be fired asynchronously");
+                             });
 
                             // if any events have been received with same pointerId before lostpointercapture, then fail
                             var eventsRcvd_str = "";

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -2,13 +2,14 @@
 <html>
     <head>
         <title>Lostpointercapture triggers first and asynchronously</title>
+        <meta name="assert" content="TA11.1: After pointer capture is released for a pointer, and prior to any subsequent events for the pointer, the lostpointercapture event must be dispatched to the element from which pointer capture was removed; TA11.2: lostpointercapture must be dispatched asynchronously.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="pointerevent_support.js"></script>
     </head>
-    <body>
+    <body onload="run()">
         <h1>Pointer Events capture test - lostpointercapture order</h1>
         <h4>
             Test Description:
@@ -24,117 +25,79 @@
         <br>
         <input type="button" id="btnCapture" value="Set Capture">
         <script type='text/javascript'>
+            var detected_pointertypes = {};
+            var detected_pointerEvents = new Array();
+            var pointerdown_event = null;
+
+            var test_pointerEvent = async_test("lostpointercapture is dispatched prior to subsequent events"); // set up test harness
+
             var isPointerCapture = false;
             var count=0;
 
-            var pointeroverReceived, pointeroutReceived,
-                pointermoveReceived, pointerdownReceived,
-                pointerupReceived, pointerleaveReceived,
-                pointerenterReceived;
-
             var testStarted = false;
+            var eventRcvd = false;
             var isAsync = false;
 
             var target0 = document.getElementById('target0');
-            var target1 = document.getElementById('target1');
             var captureButton = document.getElementById('btnCapture');
 
-            window.onload = function() {
-
+            function run() {
                 on_event(captureButton, 'pointerdown', function(e) {
+                    pointerdown_event = e;
                     if(isPointerCapture == false) {
                         isPointerCapture = true;
                         captureButton.value = 'Release Capture';
                         sPointerCapture(e);
-                        setTimeout(function() {
-                            pointeroverReceived = false;
-                            pointeroutReceived = false;
-                            pointermoveReceived = false;
-                            pointerdownReceived = false;
-                            pointerupReceived = false;
-                            pointerleaveReceived = false;
-                            pointerenterReceived = false;
-                            rPointerCapture(e);
-                            isAsync = true;
-                        });
                     }
-                 });
-
-                on_event(target0, 'gotpointercapture', function(e) {
-                    log("gotpointercapture", document.getElementById('target0'));
                 });
 
-                on_event(target0, 'lostpointercapture', function(e) {
-                    log("lostpointercapture", document.getElementById('target0'));
-                    captureButton.value = 'Set Capture';
-                    isPointerCapture = false;
-
-                    testStarted = false;
-
-                    test(function() {
-                        // TA: 11.2
-                        assert_true(isAsync, "lostpointercapture must be fired asynchronously");
-
-                        assert_true((pointeroverReceived == false)&&
-                        (pointeroutReceived == false)&&
-                        (pointerdownReceived == false)&&
-                        (pointerupReceived == false)&&
-                        (pointermoveReceived ==false)&&
-                        (pointerenterReceived == false)&&
-                        (pointerleaveReceived == false)
-                        , "lostpointercapture is dispatched prior to subsequent events");
-                    }, "lostpointercapture is dispatched prior to subsequent events");
-                });
-
-                run();
-            }
-
-            function run() {
                 // After pointer capture is released for a pointer, and prior to any subsequent events for the pointer,
                 // the lostpointercapture event must be dispatched to the element from which pointer capture was removed.
                 // TA: 11.1
-                on_event(target0, "pointerover", function (event) {
-                    if(testStarted == true) {
-                        pointeroverReceived = true;
-                    }
-                });
+                // listen to all events
+                for (var i = 0; i < All_Pointer_Events.length; i++) {
+                    on_event(target0, All_Pointer_Events[i], function (event) {
+                        // if the event was gotpointercapture, just log it and return
+                        if (event.type == "gotpointercapture") {
+                            testStarted = true;
+                            rPointerCapture(event);
+                            isAsync = true;
+                            log("gotpointercapture", target0);
+                            return;
+                        }
 
-                on_event(target0, "pointerout", function (event) {
-                    if(testStarted == true) {
-                        pointeroutReceived = true;
-                    }
-                });
+                        if (event.type == "lostpointercapture") {
+                            log("lostpointercapture", target0);
+                            captureButton.value = 'Set Capture';
+                            isPointerCapture = false;
 
-                on_event(target0, "pointerdown", function (event) {
-                    if(testStarted == true) {
-                        pointerdownReceived = true;
-                    }
-                });
+                            // TA: 11.2
+                            assert_true(isAsync, "lostpointercapture must be fired asynchronously");
 
-                on_event(target0, "pointerup", function (event) {
-                    if(testStarted == true) {
-                        pointerupReceived = true;
-                    }
-                    testStarted = true;
-                });
+                            // if any events have been received with same pointerId before lostpointercapture, then fail
+                            var eventsRcvd_str = "";
+                            if (eventRcvd) {
+                                eventsRcvd_str = "Events received before lostpointercapture: ";
+                                for (var i = 0; i < detected_pointerEvents.length; i++) {
+                                    eventsRcvd_str += detected_pointerEvents[i] + ", ";
+                                }
+                            }
+                            test_pointerEvent.step(function () {
+                                assert_false(eventRcvd, "no other events should be received before lostpointercapture." + eventsRcvd_str);
+                                assert_equals(event.pointerId, pointerdown_event.pointerId, "pointerID is same for pointerdown and lostpointercapture");
+                            });
 
-                on_event(target0, "pointermove", function (event) {
-                    if(testStarted == true) {
-                        pointermoveReceived = true;
-                    }
-                });
-
-                on_event(target0, "pointerenter", function (event) {
-                    if(testStarted == true) {
-                        pointerenterReceived = true;
-                    }
-                });
-
-                on_event(target0, "pointerleave", function (event) {
-                    if(testStarted == true) {
-                        pointerleaveReceived = true;
-                    }
-                });
+                            detected_pointertypes[event.pointerType] = true;
+                            test_pointerEvent.done(); // complete test
+                        }
+                        else {
+                            if (testStarted && pointerdown_event != null && pointerdown_event.pointerId === event.pointerId) {
+                                detected_pointerEvents.push(event.type);
+                                eventRcvd = true;
+                            }
+                        }
+                    });
+                }
             }
         </script>
         <h1>Pointer Events Capture Test</h1>

--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -168,24 +168,3 @@ function rPointerCapture(e) {
     catch(e) {
     }
 }
-
-// declare the follwoing variables to use this function: previousPointerX, previousPointerY, currentPointerX, currentPointerY;
-// init previousPointerX, previousPointerY before calling of the function; in "pointerdown" event handler for example
-function checkDirection(testToStep, isVertical, currentMoveCount, moveCountToPass, delta, event) {
-    if(!isVertical) {
-        if(currentMoveCount > moveCountToPass / 2) { // avoid immediate triggering while vertical scroll is still performed
-                testToStep.step( function() {
-                currentPointerY = event.clientY;
-                assert_approx_equals(previousPointerY, currentPointerY, delta, "scroll move was along horisontal line: ");
-                previousPointerY = currentPointerY;
-            });
-        }
-    }
-    else {
-        testToStep.step( function() {
-            currentPointerX = event.clientX;
-            assert_approx_equals(previousPointerX, currentPointerX, delta, "scroll move was along vertical line: ");
-            previousPointerX = currentPointerX;
-        });
-    }
-}

--- a/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: parent > child: auto > child: none</title>
+        <meta name="assert" content="TA15.5 - when a user touches an element, the effect of that touch is determined by the value of the touch-action property and the default touch behaviors on the element and its ancestors. Scrollable-Parent, Child: `auto`, Grand-Child: `none`">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -18,7 +19,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: no panning.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -78,45 +79,28 @@
                 </div>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var moveCount = 0;
-            var moveDelta = 10;
-            var countToPass = 100;
-            var isFirstScroll = true;
-            // these variables are necessary to use checkDirection() function below
-            var previousPointerX, previousPointerY, currentPointerX, currentPointerY;
-
             add_completion_callback(showPointerTypes);
 
             var test_touchaction = async_test("touch-action attribute test");
 
             function run() {
                 var target0 = document.getElementById("target0");
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    previousPointerX = event.clientX;
-                    previousPointerY = event.clientY;
-                });
+                var btnComplete = document.getElementById("btnComplete");
 
                 // Check if touch-action attribute works properly for embedded divs
                 // Scrollable-Parent, Child: `auto`, Grand-Child: `none`
                 // TA: 15.5
-                on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
-
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        if(!isFirstScroll) {
-                            test_touchaction.done();
-                            updateDescriptionComplete();
-                        }
-                        moveCount = 0;
-                        isFirstScroll = false;
-                    }
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
 
                 on_event(target0, 'scroll', function(event) {

--- a/pointerevents/pointerevent_touch-action-inherit_child-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-none_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: child: none</title>
+        <meta name="assert" content="TA15.9 - when a user touches an element, the effect of that touch is determined by the value of the touch-action property and the default touch behaviors on the element and its ancestors. Scrollable-Parent, Child: `none`">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -15,7 +16,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: no panning</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -73,45 +74,28 @@
                 <p>Lorem ipsum dolor sit amet...</p>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var moveCount = 0;
-            var countToPass = 100;
-			var moveDelta = 10;
-            var isFirstScroll = true;
-            // these variables are necessary to use checkDirection() function below
-            var previousPointerX, previousPointerY, currentPointerX, currentPointerY;
-
             add_completion_callback(showPointerTypes);
 
             var test_touchaction = async_test("touch-action attribute test");
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
                 // Check if touch-action attribute works properly for embedded divs
                 //
-                // TA: 15.
-                on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
-
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        if(!isFirstScroll) {
-                            test_touchaction.done();
-                            updateDescriptionComplete();
-                        }
-                        moveCount = 0;
-                        isFirstScroll = false;
-                    }
-                });
-
-                on_event(target0, 'pointerdown', function(event) {
+                // TA: 15.9
+                on_event(btnComplete, 'click', function(event) {
                     detected_pointertypes[event.pointerType] = true;
-                    previousPointerX = event.clientX;
-                    previousPointerY = event.clientY;
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
 
                 on_event(target0, 'scroll', function(event) {

--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: parent > child: pan-x > child: pan-x</title>
+        <meta name="assert" content="TA15.6 - when a user touches an element, the effect of that touch is determined by the value of the touch-action property and the default touch behaviors on the element and its ancestors. Scrollable-Parent, Child: `pan-x`, Grand-Child: `pan-x`">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -18,7 +19,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: only pans in x direction.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: only pans in x direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -78,64 +79,29 @@
                 </div>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var xCount = 0;
-            var moveCount = 0;
-            var countToPass = 100;
-            var moveDelta = 10;
-            var xScr0, yScr0, xScr1, yScr1;
-            var yMoveReceived = false;
-            // these variables are necessary to use checkDirection() function below
-            var previousPointerX, previousPointerY, currentPointerX, currentPointerY;
 
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
                 var test_touchaction = async_test("touch-action attribute test");
 
-                xScr0 = target0.scrollLeft;
-                yScr0 = target0.scrollTop;
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    previousPointerX = event.clientX;
-                    previousPointerY = event.clientY;
-                });
-
-                on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, true, moveCount, countToPass, moveDelta, event);
-
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        yMoveReceived = true;
-                    }
-                });
-
                 // Check if touch-action attribute works properly for embedded divs
                 //
-                // TA: 15.
-                on_event(target0, 'scroll', function(event) {
-                    xScr1 = target0.scrollLeft;
-                    yScr1 = target0.scrollTop;
-
-                    if(xScr1 != xScr0) {
-                        xCount++;
-                        xScr0 = xScr1;
-                    }
-
-                    if(yScr1 != yScr0) {
-                        test_touchaction.step(failOnScroll, "y-scroll received while pan-x is set");
-                    }
-
-                    if(xCount >= countToPass && yMoveReceived) {
-                        test_touchaction.done();
-                        updateDescriptionComplete();
-                    }
+                // TA: 15.6
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_not_equals(target0.scrollLeft, 0, "scroll x offset should not be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
             }
         </script>

--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch-manual.html
@@ -82,14 +82,12 @@
         <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
+            var test_touchaction = async_test("touch-action attribute test");
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
                 var btnComplete = document.getElementById("btnComplete");
-
-                var test_touchaction = async_test("touch-action attribute test");
 
                 // Check if touch-action attribute works properly for embedded divs
                 //

--- a/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: parent > child: pan-x > child: pan-y</title>
+        <meta name="assert" content="TA15.13 - Touch action inherits child 'pan-x' -> child 'pan-y' test">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -18,7 +19,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning/zooming/etc.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: no panning/zooming/etc.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -78,14 +79,8 @@
                 </div>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
-            var moveCount = 0;
-            var countToPass = 100;
-            var moveDelta = 10;
-            var isFirstScroll = true;
-            // these variables are necessary to use checkDirection() function below
-            var previousPointerX, previousPointerY, currentPointerX, currentPointerY;
-
             var detected_pointertypes = {};
             add_completion_callback(showPointerTypes);
 
@@ -93,29 +88,19 @@
 
             function run() {
                 var target0 = document.getElementById("target0");
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    previousPointerX = event.clientX;
-                    previousPointerY = event.clientY;
-                });
+                var btnComplete = document.getElementById("btnComplete");
 
                 // Check if touch-action attribute works properly for embedded divs
                 // Scrollable-Parent, Child: `pan-x`, Grand-Child: `pan-y`
-                // TA: 15.6
-                on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
-
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        if(!isFirstScroll) {
-                            test_touchaction.done();
-                            updateDescriptionComplete();
-                        }
-                        moveCount = 0;
-                        isFirstScroll = false;
-                    }
+                // TA: 15.13
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
 
                 on_event(target0, 'scroll', function(event) {

--- a/pointerevents/pointerevent_touch-action-inherit_parent-none_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-inherit_parent-none_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: inherit from parent: none</title>
+        <meta name="assert" content="TA15.8 - when a user touches an element, the effect of that touch is determined by the value of the touch-action property and the default touch behaviors on the element and its ancestors. Scrollable-Parent: `none` Child: `auto`">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -15,7 +16,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: no panning</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -73,44 +74,28 @@
                 <p>Lorem ipsum dolor sit amet...</p>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var moveCount = 0;
-            var moveDelta = 10;
-            var isFirstScroll = true;
-            var countToPass = 100;
-            // these variables are necessary to use checkDirection() function below
-            var previousPointerX, previousPointerY, currentPointerX, currentPointerY;
-
             add_completion_callback(showPointerTypes);
 
             var test_touchaction = async_test("touch-action attribute test");
 
             function run() {
                 var target0 = document.getElementById("target0");
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                    previousPointerX = event.clientX;
-                    previousPointerY = event.clientY;
-                });
+                var btnComplete = document.getElementById("btnComplete");
 
                 // Check if touch-action attribute works properly for embedded divs
                 //
-                // TA: 15.
-                on_event(target0, 'pointermove', function(event) {
-                    checkDirection(test_touchaction, isFirstScroll, moveCount, countToPass, moveDelta, event);
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        if(!isFirstScroll) {
-                            test_touchaction.done();
-                            updateDescriptionComplete();
-                        }
-                        moveCount = 0;
-                        isFirstScroll = false;
-                    }
+                // TA: 15.8
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
 
                 on_event(target0, 'scroll', function(event) {

--- a/pointerevents/pointerevent_touch-action-none-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-none-css_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: none</title>
+        <meta name="assert" content="TA15.2 - With `touch-action: none` on a swiped or click/dragged element, `pointerdown+(optional pointermove)+pointerup` must be dispatched.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -17,7 +18,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning/zooming/etc.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: no panning/zooming/etc.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div id="target0">
             <p>
@@ -73,35 +74,27 @@
             <p>Lorem ipsum dolor sit amet...</p>
             <p>Lorem ipsum dolor sit amet...</p>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var moveCount = 0;
-            var countToPass = 100;
-            var isFirstScroll = true;
 
             var test_touchaction = async_test("touch-action attribute test");
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
                 // Check if "touch-action: none" attribute works properly
                 //TA: 15.2
-                on_event(target0, 'pointermove', function(event) {
+                on_event(btnComplete, 'click', function(event) {
                     detected_pointertypes[event.pointerType] = true;
-
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                        if(!isFirstScroll)
-                        {
-                            updateDescriptionComplete();
-                            test_touchaction.done();
-                        }
-                        moveCount = 0;
-                        isFirstScroll = false;
-                    }
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
 
                 on_event(target0, 'scroll', function(event) {

--- a/pointerevents/pointerevent_touch-action-pan-x-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-x-css_touch-manual.html
@@ -77,14 +77,12 @@
         <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
+            var test_touchaction = async_test("touch-action attribute test");
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
                 var btnComplete = document.getElementById("btnComplete");
-
-                var test_touchaction = async_test("touch-action attribute test");
 
                 // Check if "touch-action: pan-x" attribute works properly
                 //TA: 15.3

--- a/pointerevents/pointerevent_touch-action-pan-x-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-x-css_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: pan-x</title>
+        <meta name="assert" content="TA15.3 - With `touch-action: pan-x` on a swiped or click/dragged element, only panning on the x-axis should be possible.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -17,7 +18,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: only pans in x direction.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: only pans in x direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div id="target0">
             <p>
@@ -73,54 +74,28 @@
             <p>Lorem ipsum dolor sit amet...</p>
             <p>Lorem ipsum dolor sit amet...</p>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var xCount = 0;
-            var moveCount = 0;
-            var countToPass = 50;
-            var xScr0, yScr0, xScr1, yScr1;
 
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
                 var test_touchaction = async_test("touch-action attribute test");
 
-                xScr0 = target0.scrollLeft;
-                yScr0 = target0.scrollTop;
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                });
-
-                on_event(target0, 'pointermove', function(event) {
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionNextStep();
-                    }
-                });
-
                 // Check if "touch-action: pan-x" attribute works properly
                 //TA: 15.3
-                on_event(target0, 'scroll', function(event) {
-                    xScr1 = target0.scrollLeft;
-                    yScr1 = target0.scrollTop;
-
-                    if(xScr1 != xScr0) {
-                        xCount++;
-                        xScr0 = xScr1;
-                    }
-
-                    if(yScr1 != yScr0) {
-                        test_touchaction.step(failOnScroll, "y-scroll received while pan-x is set");
-                    }
-
-                    if(xCount >= countToPass) {
-                        test_touchaction.done();
-                        updateDescriptionComplete();
-                    }
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_not_equals(target0.scrollLeft, 0, "scroll x offset should not be 0 in the end of the test");
+                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
             }
         </script>

--- a/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: parent > child: pan-x pan-y > child: pan-y</title>
+        <meta name="assert" content="TA15.17 - Touch action 'pan-x pan-y' 'pan-y' test">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -18,7 +19,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: no panning/zooming/etc.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: only pans in y direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div class="scroller" id="target0">
             <div>
@@ -76,52 +77,28 @@
                 </div>
             </div>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
-            var yCount = 0;
-            var moveCount = 0;
-            var countToPass = 50;
-            var xScr0, yScr0, xScr1, yScr1;
-
             var detected_pointertypes = {};
-
             add_completion_callback(showPointerTypes);
 
             var test_touchaction = async_test("touch-action attribute test");
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
-                xScr0 = target0.scrollLeft;
-                yScr0 = target0.scrollTop;
-
-                on_event(target0, 'pointerdown', function(event) {
+                // Check if touch-action attribute works properly for embedded divs
+                //
+                // TA: 15.17
+                on_event(btnComplete, 'click', function(event) {
                     detected_pointertypes[event.pointerType] = true;
-                });
-
-                on_event(target0, 'pointermove', function(event) {
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        test_touchaction.done();
-                        updateDescriptionComplete();
-                    }
-                });
-
-                on_event(target0, 'scroll', function(event) {
-                    xScr1 = target0.scrollLeft;
-                    yScr1 = target0.scrollTop;
-
-                    if(yScr1 != yScr0) {
-                        yCount++;
-                        yScr0 = yScr1;
-                    }
-
-                    if(xScr1 != xScr0) {
-                        test_touchaction.step(failOnScroll, "x-scroll received while pan-y is set");
-                    }
-
-                    if(yCount >= countToPass) {
-                        updateDescriptionNextStep();
-                    }
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_not_equals(target0.scrollTop, 0, "scroll y offset should not be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
             }
         </script>

--- a/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
@@ -77,14 +77,12 @@
         <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
+            var test_touchaction = async_test("touch-action attribute test");
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
                 var btnComplete = document.getElementById("btnComplete");
-
-                var test_touchaction = async_test("touch-action attribute test");
 
                 // Check if "touch-action: pan-y" attribute works properly
                 //TA: 15.4

--- a/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>touch-action: pan-y</title>
+        <meta name="assert" content="TA15.4 - With `touch-action: pan-y` on a swiped or click/dragged element, only panning in the y-axis should be possible.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
@@ -17,7 +18,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll text DOWN. Wait for description update. Expected: only pans in y direction.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN then RIGHT. Tap Complete button under the rectangle when done. Expected: only pans in y direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div id="target0">
             <p>
@@ -73,54 +74,28 @@
             <p>Lorem ipsum dolor sit amet...</p>
             <p>Lorem ipsum dolor sit amet...</p>
         </div>
+        <input type="button" id="btnComplete" value="Complete test">
         <script type='text/javascript'>
             var detected_pointertypes = {};
-
-            var yCount = 0;
-            var moveCount = 0;
-            var countToPass = 50;
-            var xScr0, yScr0, xScr1, yScr1;
 
             add_completion_callback(showPointerTypes);
 
             function run() {
                 var target0 = document.getElementById("target0");
+                var btnComplete = document.getElementById("btnComplete");
 
                 var test_touchaction = async_test("touch-action attribute test");
 
-                xScr0 = target0.scrollLeft;
-                yScr0 = target0.scrollTop;
-
-                on_event(target0, 'pointerdown', function(event) {
-                    detected_pointertypes[event.pointerType] = true;
-                });
-
-                on_event(target0, 'pointermove', function(event) {
-                    moveCount++;
-                    if(moveCount >= countToPass) {
-                        updateDescriptionComplete();
-                    }
-                });
-
                 // Check if "touch-action: pan-y" attribute works properly
                 //TA: 15.4
-                on_event(target0, 'scroll', function(event) {
-                    xScr1 = target0.scrollLeft;
-                    yScr1 = target0.scrollTop;
-
-                    if(yScr1 != yScr0) {
-                        yCount++;
-                        yScr0 = yScr1;
-                    }
-
-                    if(xScr1 != xScr0) {
-                        test_touchaction.step(failOnScroll, "x-scroll received while pan-y is set");
-                    }
-
-                    if(yCount >= countToPass) {
-                        test_touchaction.done();
-                        updateDescriptionNextStep();
-                    }
+                on_event(btnComplete, 'click', function(event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    test_touchaction.step(function() {
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should not be 0 in the end of the test");
+                        assert_not_equals(target0.scrollTop, 0, "scroll y offset should not be 0 in the end of the test");
+                    });
+                    test_touchaction.done();
+                    updateDescriptionComplete();
                 });
             }
         </script>

--- a/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-y-css_touch-manual.html
@@ -91,7 +91,7 @@
                 on_event(btnComplete, 'click', function(event) {
                     detected_pointertypes[event.pointerType] = true;
                     test_touchaction.step(function() {
-                        assert_equals(target0.scrollLeft, 0, "scroll x offset should not be 0 in the end of the test");
+                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
                         assert_not_equals(target0.scrollTop, 0, "scroll y offset should not be 0 in the end of the test");
                     });
                     test_touchaction.done();


### PR DESCRIPTION
This change (committing on behalf of @EvgenyAgafonchikov ) updates the remaining touch-action tests that were using event counts to try to surmise scroll attempts in regions where touch actions are prohibited. These now use the "Complete" button approach, which makes them much more reliable than a magic number for expected event counts.  
