### PR TITLE
Update TA11.1-11.2 to use All_Pointer_Events pattern and eliminate timer

### DIFF
--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -65,8 +65,7 @@
                             log("gotpointercapture", target0);
                             return;
                         }
-
-                        if (event.type == "lostpointercapture") {
+                        else if (event.type == "lostpointercapture") {
                             log("lostpointercapture", target0);
                             captureButton.value = 'Set Capture';
                             isPointerCapture = false;

--- a/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
+++ b/pointerevents/pointerevent_lostpointercapture_is_first-manual.html
@@ -2,13 +2,14 @@
 <html>
     <head>
         <title>Lostpointercapture triggers first and asynchronously</title>
+        <meta name="assert" content="TA11.1: After pointer capture is released for a pointer, and prior to any subsequent events for the pointer, the lostpointercapture event must be dispatched to the element from which pointer capture was removed; TA11.2: lostpointercapture must be dispatched asynchronously.">
         <meta name="viewport" content="width=device-width">
         <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="pointerevent_support.js"></script>
     </head>
-    <body>
+    <body onload="run()">
         <h1>Pointer Events capture test - lostpointercapture order</h1>
         <h4>
             Test Description:
@@ -24,117 +25,79 @@
         <br>
         <input type="button" id="btnCapture" value="Set Capture">
         <script type='text/javascript'>
+            var detected_pointertypes = {};
+            var detected_pointerEvents = new Array();
+            var pointerdown_event = null;
+
+            var test_pointerEvent = async_test("lostpointercapture is dispatched prior to subsequent events"); // set up test harness
+
             var isPointerCapture = false;
             var count=0;
 
-            var pointeroverReceived, pointeroutReceived,
-                pointermoveReceived, pointerdownReceived,
-                pointerupReceived, pointerleaveReceived,
-                pointerenterReceived;
-
             var testStarted = false;
+            var eventRcvd = false;
             var isAsync = false;
 
             var target0 = document.getElementById('target0');
-            var target1 = document.getElementById('target1');
             var captureButton = document.getElementById('btnCapture');
 
-            window.onload = function() {
-
+            function run() {
                 on_event(captureButton, 'pointerdown', function(e) {
+                    pointerdown_event = e;
                     if(isPointerCapture == false) {
                         isPointerCapture = true;
                         captureButton.value = 'Release Capture';
                         sPointerCapture(e);
-                        setTimeout(function() {
-                            pointeroverReceived = false;
-                            pointeroutReceived = false;
-                            pointermoveReceived = false;
-                            pointerdownReceived = false;
-                            pointerupReceived = false;
-                            pointerleaveReceived = false;
-                            pointerenterReceived = false;
-                            rPointerCapture(e);
-                            isAsync = true;
-                        });
                     }
-                 });
-
-                on_event(target0, 'gotpointercapture', function(e) {
-                    log("gotpointercapture", document.getElementById('target0'));
                 });
 
-                on_event(target0, 'lostpointercapture', function(e) {
-                    log("lostpointercapture", document.getElementById('target0'));
-                    captureButton.value = 'Set Capture';
-                    isPointerCapture = false;
-
-                    testStarted = false;
-
-                    test(function() {
-                        // TA: 11.2
-                        assert_true(isAsync, "lostpointercapture must be fired asynchronously");
-
-                        assert_true((pointeroverReceived == false)&&
-                        (pointeroutReceived == false)&&
-                        (pointerdownReceived == false)&&
-                        (pointerupReceived == false)&&
-                        (pointermoveReceived ==false)&&
-                        (pointerenterReceived == false)&&
-                        (pointerleaveReceived == false)
-                        , "lostpointercapture is dispatched prior to subsequent events");
-                    }, "lostpointercapture is dispatched prior to subsequent events");
-                });
-
-                run();
-            }
-
-            function run() {
                 // After pointer capture is released for a pointer, and prior to any subsequent events for the pointer,
                 // the lostpointercapture event must be dispatched to the element from which pointer capture was removed.
                 // TA: 11.1
-                on_event(target0, "pointerover", function (event) {
-                    if(testStarted == true) {
-                        pointeroverReceived = true;
-                    }
-                });
+                // listen to all events
+                for (var i = 0; i < All_Pointer_Events.length; i++) {
+                    on_event(target0, All_Pointer_Events[i], function (event) {
+                        // if the event was gotpointercapture, just log it and return
+                        if (event.type == "gotpointercapture") {
+                            testStarted = true;
+                            rPointerCapture(event);
+                            isAsync = true;
+                            log("gotpointercapture", target0);
+                            return;
+                        }
 
-                on_event(target0, "pointerout", function (event) {
-                    if(testStarted == true) {
-                        pointeroutReceived = true;
-                    }
-                });
+                        if (event.type == "lostpointercapture") {
+                            log("lostpointercapture", target0);
+                            captureButton.value = 'Set Capture';
+                            isPointerCapture = false;
 
-                on_event(target0, "pointerdown", function (event) {
-                    if(testStarted == true) {
-                        pointerdownReceived = true;
-                    }
-                });
+                            // TA: 11.2
+                            assert_true(isAsync, "lostpointercapture must be fired asynchronously");
 
-                on_event(target0, "pointerup", function (event) {
-                    if(testStarted == true) {
-                        pointerupReceived = true;
-                    }
-                    testStarted = true;
-                });
+                            // if any events have been received with same pointerId before lostpointercapture, then fail
+                            var eventsRcvd_str = "";
+                            if (eventRcvd) {
+                                eventsRcvd_str = "Events received before lostpointercapture: ";
+                                for (var i = 0; i < detected_pointerEvents.length; i++) {
+                                    eventsRcvd_str += detected_pointerEvents[i] + ", ";
+                                }
+                            }
+                            test_pointerEvent.step(function () {
+                                assert_false(eventRcvd, "no other events should be received before lostpointercapture." + eventsRcvd_str);
+                                assert_equals(event.pointerId, pointerdown_event.pointerId, "pointerID is same for pointerdown and lostpointercapture");
+                            });
 
-                on_event(target0, "pointermove", function (event) {
-                    if(testStarted == true) {
-                        pointermoveReceived = true;
-                    }
-                });
-
-                on_event(target0, "pointerenter", function (event) {
-                    if(testStarted == true) {
-                        pointerenterReceived = true;
-                    }
-                });
-
-                on_event(target0, "pointerleave", function (event) {
-                    if(testStarted == true) {
-                        pointerleaveReceived = true;
-                    }
-                });
+                            detected_pointertypes[event.pointerType] = true;
+                            test_pointerEvent.done(); // complete test
+                        }
+                        else {
+                            if (testStarted && pointerdown_event != null && pointerdown_event.pointerId === event.pointerId) {
+                                detected_pointerEvents.push(event.type);
+                                eventRcvd = true;
+                            }
+                        }
+                    });
+                }
             }
         </script>
         <h1>Pointer Events Capture Test</h1>


### PR DESCRIPTION
This updates pointerevent_lostpointercapture_is_first-manual.html to use the All_Pointer_Events array used in other tests to verify no other events are fired before lostpointercapture. Also removes the timer that isn't needed to verify isAsync.
