### PR TITLE
Support running tests with SSL.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *~
 MANIFEST.json
 \#*
+_certs
 config.json
 node_modules
 scratch

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ the Web Apps Security Working Group.
 Running the Tests
 =================
 
-The tests are designed to be run from your local computer. The test environment
-requires Python 2.7+ (but not Python 3.x).
+The tests are designed to be run from your local computer. The test
+environment requires Python 2.7+ (but not Python 3.x). You will also
+need a copy of OpenSSL. For users on Windows this is available from
+[the openssl website](https://www.openssl.org/related/binaries.html).
 
-To get the tests running, you need to set up the test domains in your 
+To get the tests running, you need to set up the test domains in your
 [`hosts` file](http://en.wikipedia.org/wiki/Hosts_%28file%29%23Location_in_the_file_system). The following entries are required:
 
 ```
@@ -50,6 +52,15 @@ to some port of your choice e.g.
 
 ```
 "http":[1234, "auto"]
+```
+
+If you installed OpenSSL in such a way that running `openssl` at a
+command line doesn't work, you also need to adjust the path to the
+OpenSSL binary. This can be done by adding a section to `config.json`
+like:
+
+```
+"ssl": {"openssl": {"binary": "/path/to/openssl"}}
 ```
 
 Test Runner

--- a/config.default.json
+++ b/config.default.json
@@ -1,8 +1,21 @@
 {"host": "web-platform.test",
  "external_host": null,
  "ports":{"http":[8000, "auto"],
-          "https":[],
+          "https":[8443],
           "ws":["auto"]},
  "check_subdomains": true,
  "log_level":"debug",
- "bind_hostname": true}
+ "bind_hostname": true,
+ "ssl": {"type": "openssl",
+         "openssl": {
+             "openssl_binary": "openssl",
+             "base_path": "_certs",
+             "force_regenerate": false
+         },
+         "pregenerated": {
+             "host_key_path": null,
+             "host_cert_path": null
+         },
+         "none": {}
+        }
+}

--- a/config.default.json
+++ b/config.default.json
@@ -7,6 +7,7 @@
  "log_level":"debug",
  "bind_hostname": true,
  "ssl": {"type": "openssl",
+         "encrypt_after_connect": false,
          "openssl": {
              "openssl_binary": "openssl",
              "base_path": "_certs",

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -13,7 +13,16 @@
 
 var counter = 0;
 
-function cors(desc, url) {
+function cors(desc, scheme, subdomain, port) {
+    if (!scheme) {
+        var url = "";
+    } else {
+        if (!port) {
+            port = location.port;
+        }
+        var url = scheme + "://" + (subdomain ? subdomain + "." : "") + location.hostname + ":" + port + dirname(location.pathname)
+    }
+    console.log(url)
     async_test(desc).step(function() {
         var client = new XMLHttpRequest();
         this.count = counter++;
@@ -42,31 +51,14 @@ function cors(desc, url) {
     });
 }
 
-cors("Same domain basic usage", "");
-cors("Cross domain basic usage", CROSSDOMAIN);
-cors("Same domain different port",
-        "http://" + location.hostname + ":" + PORT + dirname(location.pathname));
+cors("Same domain basic usage");
+cors("Cross domain basic usage", "http", "www1");
+cors("Same domain different port", "http", undefined, PORT);
 
-cors("Cross domain different port",
-        "http://" + SUBDOMAIN + "." + location.hostname + ":"
-        + PORT + dirname(location.pathname));
+cors("Cross domain different port", "http", "www1", PORT);
 
-/* Disable HTTPS tests until this is better supported
+cors("Cross domain different protocol", "https", "www1", PORTS);
 
-XXX HTTPS
-
-cors("Same domain different protocol",
-        'https://' + location.host + dirname(location.pathname));
-
-cors("Cross domain different protocol",
-        CROSSDOMAIN.replace("http:", "https:"));
-
-cors("Same domain different protocol different port",
-        "https://" + location.hostname + ":" + PORTS + dirname(location.pathname));
-
-cors("Cross domain different protocol different port",
-        "https://" + SUBDOMAIN + "." + location.hostname + ":"
-        + PORTS + dirname(location.pathname));
-*/
+cors("Same domain different protocol different port", "https", undefined, PORTS);
 
 </script>

--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -22,7 +22,6 @@ function cors(desc, scheme, subdomain, port) {
         }
         var url = scheme + "://" + (subdomain ? subdomain + "." : "") + location.hostname + ":" + port + dirname(location.pathname)
     }
-    console.log(url)
     async_test(desc).step(function() {
         var client = new XMLHttpRequest();
         this.count = counter++;

--- a/cors/support.js
+++ b/cors/support.js
@@ -20,7 +20,7 @@ var SUBDOMAIN = 'www1'
 var SUBDOMAIN2 = 'www2'
 var PORT = {{ports[http][1]}}
 //XXX HTTPS
-//var PORTS = ports[https][0]
+var PORTS = {{ports[https][0]}}
 
 /* Changes http://example.com/abc/def/cool.htm to http://www1.example.com/abc/def/ */
 var CROSSDOMAIN     = dirname(location.href)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,7 @@ the web-platform-tests repository.
 
  * [git](http://git-scm.com/)
  * [Python 2.7](http://python.org)
+ * [OpenSSL](https://www.openssl.org)
 
 ## Hosts configuration
 
@@ -65,4 +66,13 @@ to some port of your choice e.g.
 
 ```
 "http": [1234, "auto"]
+```
+
+If you installed OpenSSL in such a way that running `openssl` at a
+command line doesn't work, you also need to adjust the path to the
+OpenSSL binary. This can be done by adding a section to `config.json`
+like:
+
+```
+"ssl": {"openssl": {"binary": "/path/to/openssl"}}
 ```

--- a/serve.py
+++ b/serve.py
@@ -21,8 +21,12 @@ from wptserve.logger import set_logger
 
 from mod_pywebsocket import standalone as pywebsocket
 
+sys.path.insert(1, os.path.join(repo_root, "tools"))
+import sslutils
+
 routes = [("GET", "/tools/runner/*", handlers.file_handler),
           ("POST", "/tools/runner/update_manifest.py", handlers.python_script_handler),
+          (any_method, "/_certs/*", handlers.ErrorHandler(404)),
           (any_method, "/tools/*", handlers.ErrorHandler(404)),
           (any_method, "{spec}/tools/*", handlers.ErrorHandler(404)),
           (any_method, "/serve.py", handlers.ErrorHandler(404)),
@@ -46,6 +50,7 @@ def setup_logger(level):
     logging.basicConfig(level=getattr(logging, level.upper()))
     set_logger(logger)
 
+
 def open_socket(port):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if port != 0:
@@ -53,6 +58,7 @@ def open_socket(port):
     sock.bind(('127.0.0.1', port))
     sock.listen(5)
     return sock
+
 
 def get_port():
     free_socket = open_socket(0)
@@ -68,17 +74,19 @@ class ServerProc(object):
         self.daemon = None
         self.stop = Event()
 
-    def start(self, init_func, host, port, paths, bind_hostname, external_config, **kwargs):
+    def start(self, init_func, host, port, paths, bind_hostname, external_config, ssl_config,
+              **kwargs):
         self.proc = Process(target=self.create_daemon,
                             args=(init_func, host, port, paths, bind_hostname,
-                                  external_config), kwargs=kwargs)
+                                  external_config, ssl_config))
         self.proc.daemon = True
         self.proc.start()
 
-    def create_daemon(self, init_func, host, port, paths, bind_hostname, external_config,
+    def create_daemon(self, init_func, host, port, paths, bind_hostname, external_config, ssl_config,
                       **kwargs):
         try:
-            self.daemon = init_func(host, port, paths, bind_hostname, external_config, **kwargs)
+            self.daemon = init_func(host, port, paths, bind_hostname, external_config, 
+                                    ssl_config, **kwargs)
         except socket.error:
             print >> sys.stderr, "Socket error on port %s" % port
             raise
@@ -87,11 +95,15 @@ class ServerProc(object):
             raise
 
         if self.daemon:
-            self.daemon.start(block=False)
             try:
-                self.stop.wait()
-            except KeyboardInterrupt:
-                pass
+                self.daemon.start(block=False)
+                try:
+                    self.stop.wait()
+                except KeyboardInterrupt:
+                    pass
+            except:
+                print >> sys.stderr, traceback.format_exc()
+                raise
 
     def wait(self):
         self.stop.set()
@@ -105,12 +117,13 @@ class ServerProc(object):
     def is_alive(self):
         return self.proc.is_alive()
 
-def check_subdomains(host, paths, bind_hostname):
+
+def check_subdomains(host, paths, bind_hostname, ssl_config):
     port = get_port()
     subdomains = get_subdomains(host)
 
     wrapper = ServerProc()
-    wrapper.start(start_http_server, host, port, paths, bind_hostname, None)
+    wrapper.start(start_http_server, host, port, paths, bind_hostname, None, ssl_config)
 
     connected = False
     for i in range(10):
@@ -135,17 +148,21 @@ def check_subdomains(host, paths, bind_hostname):
 
     wrapper.wait()
 
+
 def get_subdomains(host):
     #This assumes that the tld is ascii-only or already in punycode
     return {subdomain: (subdomain.encode("idna"), host)
             for subdomain in subdomains}
 
-def start_servers(host, ports, paths, bind_hostname, external_config, **kwargs):
+
+def start_servers(host, ports, paths, bind_hostname, external_config, ssl_config, **kwargs):
     servers = defaultdict(list)
     for scheme, ports in ports.iteritems():
         assert len(ports) == {"http":2}.get(scheme, 1)
 
         for port  in ports:
+            if port is None:
+                continue
             init_func = {"http":start_http_server,
                          "https":start_https_server,
                          "ws":start_ws_server,
@@ -153,12 +170,14 @@ def start_servers(host, ports, paths, bind_hostname, external_config, **kwargs):
 
             server_proc = ServerProc()
             server_proc.start(init_func, host, port, paths, bind_hostname,
-                              external_config, **kwargs)
+                              external_config, ssl_config, **kwargs)
             servers[scheme].append((port, server_proc))
 
     return servers
 
-def start_http_server(host, port, paths, bind_hostname, external_config, **kwargs):
+
+def start_http_server(host, port, paths, bind_hostname, external_config, ssl_config,
+                      **kwargs):
     return wptserve.WebTestHttpd(host=host,
                                  port=port,
                                  doc_root=paths["doc_root"],
@@ -167,14 +186,29 @@ def start_http_server(host, port, paths, bind_hostname, external_config, **kwarg
                                  bind_hostname=bind_hostname,
                                  config=external_config,
                                  use_ssl=False,
+                                 key_file=None,
                                  certificate=None,
                                  latency=kwargs.get("latency"))
 
-def start_https_server(host, port, paths, bind_hostname, external_config, **kwargs):
-    return
+
+def start_https_server(host, port, paths, bind_hostname, external_config, ssl_config,
+                       **kwargs):
+    return wptserve.WebTestHttpd(host=host,
+                                 port=port,
+                                 doc_root=paths["doc_root"],
+                                 routes=routes,
+                                 rewrites=rewrites,
+                                 bind_hostname=bind_hostname,
+                                 config=external_config,
+                                 use_ssl=True,
+                                 key_file=ssl_config["key_path"],
+                                 certificate=ssl_config["cert_path"],
+                                 latency=kwargs.get("latency"))
+
 
 class WebSocketDaemon(object):
-    def __init__(self, host, port, doc_root, handlers_root, log_level, bind_hostname):
+    def __init__(self, host, port, doc_root, handlers_root, log_level, bind_hostname,
+                 ssl_config):
         self.host = host
         cmd_args = ["-p", port,
                     "-d", doc_root,
@@ -218,21 +252,29 @@ class WebSocketDaemon(object):
             self.started = False
         self.server = None
 
-def start_ws_server(host, port, paths, bind_hostname, external_config, **kwargs):
+
+def start_ws_server(host, port, paths, bind_hostname, external_config, ssl_config, 
+                    **kwargs):
     return WebSocketDaemon(host,
                            str(port),
                            repo_root,
                            paths["ws_doc_root"],
                            "debug",
-                           bind_hostname)
+                           bind_hostname,
+                           ssl_config)
 
-def start_wss_server(host, port, path, bind_hostname, external_config, **kwargs):
+
+def start_wss_server(host, port, path, bind_hostname, external_config, ssl_config,
+                     **kwargs):
     return
 
-def get_ports(config):
+
+def get_ports(config, ssl_enabled):
     rv = defaultdict(list)
     for scheme, ports in config["ports"].iteritems():
         for i, port in enumerate(ports):
+            if scheme in ["http", "https"] and not ssl_enabled:
+                port = None
             if port == "auto":
                 port = get_port()
             else:
@@ -240,9 +282,14 @@ def get_ports(config):
             rv[scheme].append(port)
     return rv
 
+
+
 def normalise_config(config, ports):
     host = config["external_host"] if config["external_host"] else config["host"]
     domains = get_subdomains(host)
+    ports_ = {}
+    for scheme, ports_used in ports.iteritems():
+        ports_[scheme] = ports_used
 
     for key, value in domains.iteritems():
         domains[key] = ".".join(value)
@@ -257,21 +304,31 @@ def normalise_config(config, ports):
             "domains": domains,
             "ports": ports_}
 
-def start(config, **kwargs):
+
+def get_ssl_config(external_domains, ssl_environment):
+    key_path, cert_path = ssl_environment.host_cert_path(external_domains)
+    return {"key_path": key_path,
+            "cert_path": cert_path}
+
+
+def start(config, ssl_environment, **kwargs):
     host = config["host"]
     domains = get_subdomains(host)
-    ports = get_ports(config)
+    ports = get_ports(config, ssl_environment)
     bind_hostname = config["bind_hostname"]
 
     paths = {"doc_root": config["doc_root"],
              "ws_doc_root": config["ws_doc_root"]}
 
-    if config["check_subdomains"]:
-        check_subdomains(host, paths, bind_hostname)
-
     external_config = normalise_config(config, ports)
 
-    servers = start_servers(host, ports, paths, bind_hostname, external_config, **kwargs)
+    ssl_config = get_ssl_config(external_config["domains"].values(), ssl_environment)
+
+    if config["check_subdomains"]:
+        check_subdomains(host, paths, bind_hostname, ssl_config)
+
+    servers = start_servers(host, ports, paths, bind_hostname, external_config, ssl_config,
+                            **kwargs)
 
     return external_config, servers
 
@@ -281,8 +338,10 @@ def iter_procs(servers):
         for port, server in servers:
             yield server.proc
 
+
 def value_set(config, key):
     return key in config and config[key] is not None
+
 
 def set_computed_defaults(config):
     if not value_set(config, "ws_doc_root"):
@@ -307,6 +366,16 @@ def merge_json(base_obj, override_obj):
             else:
                 rv[key] = override_obj[key]
     return rv
+
+
+def get_ssl_environment(config):
+    implementation_type = config["ssl"]["type"]
+    cls = {"none": sslutils.NoSSLEnvironment,
+           "openssl": sslutils.OpenSSLEnvironment,
+           "pregenerated": sslutils.PregeneratedSSLEnvironment}[implementation_type]
+    kwargs = config["ssl"][implementation_type].copy()
+    return cls(logger, **kwargs)
+
 
 def load_config(default_path, override_path=None, **kwargs):
     if os.path.exists(default_path):
@@ -344,6 +413,7 @@ def get_parser():
                         help="Path to external config file")
     return parser
 
+
 def main():
     kwargs = vars(get_parser().parse_args())
     config = load_config("config.default.json",
@@ -352,14 +422,18 @@ def main():
 
     setup_logger(config["log_level"])
 
-    config_, servers = start(config, **kwargs)
+    ssl_env = get_ssl_environment(config)
 
-    try:
-        while any(item.is_alive() for item in iter_procs(servers)):
-            for item in iter_procs(servers):
-                item.join(1)
-    except KeyboardInterrupt:
-        logger.info("Shutting down")
+    with get_ssl_environment(config) as ssl_env:
+        config_, servers = start(config, ssl_env, **kwargs)
+
+        try:
+            while any(item.is_alive() for item in iter_procs(servers)):
+                for item in iter_procs(servers):
+                    item.join(1)
+        except KeyboardInterrupt:
+            logger.info("Shutting down")
+
 
 if __name__ == "__main__":
     main()

--- a/serve.py
+++ b/serve.py
@@ -203,6 +203,7 @@ def start_https_server(host, port, paths, bind_hostname, external_config, ssl_co
                                  use_ssl=True,
                                  key_file=ssl_config["key_path"],
                                  certificate=ssl_config["cert_path"],
+                                 encrypt_after_connect=ssl_config["encrypt_after_connect"],
                                  latency=kwargs.get("latency"))
 
 
@@ -253,7 +254,7 @@ class WebSocketDaemon(object):
         self.server = None
 
 
-def start_ws_server(host, port, paths, bind_hostname, external_config, ssl_config, 
+def start_ws_server(host, port, paths, bind_hostname, external_config, ssl_config,
                     **kwargs):
     return WebSocketDaemon(host,
                            str(port),
@@ -305,10 +306,11 @@ def normalise_config(config, ports):
             "ports": ports_}
 
 
-def get_ssl_config(external_domains, ssl_environment):
+def get_ssl_config(config, external_domains, ssl_environment):
     key_path, cert_path = ssl_environment.host_cert_path(external_domains)
     return {"key_path": key_path,
-            "cert_path": cert_path}
+            "cert_path": cert_path,
+            "encrypt_after_connect": config["ssl"]["encrypt_after_connect"]}
 
 
 def start(config, ssl_environment, **kwargs):
@@ -322,7 +324,7 @@ def start(config, ssl_environment, **kwargs):
 
     external_config = normalise_config(config, ports)
 
-    ssl_config = get_ssl_config(external_config["domains"].values(), ssl_environment)
+    ssl_config = get_ssl_config(config, external_config["domains"].values(), ssl_environment)
 
     if config["check_subdomains"]:
         check_subdomains(host, paths, bind_hostname, ssl_config)

--- a/serve.py
+++ b/serve.py
@@ -85,7 +85,7 @@ class ServerProc(object):
     def create_daemon(self, init_func, host, port, paths, bind_hostname, external_config, ssl_config,
                       **kwargs):
         try:
-            self.daemon = init_func(host, port, paths, bind_hostname, external_config, 
+            self.daemon = init_func(host, port, paths, bind_hostname, external_config,
                                     ssl_config, **kwargs)
         except socket.error:
             print >> sys.stderr, "Socket error on port %s" % port

--- a/serve.py
+++ b/serve.py
@@ -370,7 +370,7 @@ def merge_json(base_obj, override_obj):
 
 def get_ssl_environment(config):
     implementation_type = config["ssl"]["type"]
-    sslutils.environments[implementation_type]
+    cls = sslutils.environments[implementation_type]
     kwargs = config["ssl"][implementation_type].copy()
     return cls(logger, **kwargs)
 

--- a/serve.py
+++ b/serve.py
@@ -370,9 +370,7 @@ def merge_json(base_obj, override_obj):
 
 def get_ssl_environment(config):
     implementation_type = config["ssl"]["type"]
-    cls = {"none": sslutils.NoSSLEnvironment,
-           "openssl": sslutils.OpenSSLEnvironment,
-           "pregenerated": sslutils.PregeneratedSSLEnvironment}[implementation_type]
+    sslutils.environments[implementation_type]
     kwargs = config["ssl"][implementation_type].copy()
     return cls(logger, **kwargs)
 

--- a/serve.py
+++ b/serve.py
@@ -373,7 +373,10 @@ def merge_json(base_obj, override_obj):
 def get_ssl_environment(config):
     implementation_type = config["ssl"]["type"]
     cls = sslutils.environments[implementation_type]
-    kwargs = config["ssl"][implementation_type].copy()
+    try:
+        kwargs = config["ssl"][implementation_type].copy()
+    except KeyError:
+        raise ValueError("%s is not a vaid ssl type." % implementation_type)
     return cls(logger, **kwargs)
 
 

--- a/tools/sslutils/__init__.py
+++ b/tools/sslutils/__init__.py
@@ -1,0 +1,22 @@
+import openssl
+import pregenerated
+from openssl import OpenSSLEnvironment
+from pregenerated import PregeneratedSSLEnvironment
+
+class NoSSLEnvironment(object):
+    ssl_enabled = False
+
+    def __init__(self, logger):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def host_cert_path(self, host):
+        return None
+
+    def ca_cert_path(self):
+        return None

--- a/tools/sslutils/__init__.py
+++ b/tools/sslutils/__init__.py
@@ -1,25 +1,8 @@
 import openssl
 import pregenerated
+from base import NoSSLEnvironment
 from openssl import OpenSSLEnvironment
 from pregenerated import PregeneratedSSLEnvironment
-
-class NoSSLEnvironment(object):
-    ssl_enabled = False
-
-    def __init__(self, logger):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args, **kwargs):
-        pass
-
-    def host_cert_path(self, host):
-        return None
-
-    def ca_cert_path(self):
-        return None
 
 environments = {"none": NoSSLEnvironment,
                 "openssl": OpenSSLEnvironment,

--- a/tools/sslutils/__init__.py
+++ b/tools/sslutils/__init__.py
@@ -20,3 +20,7 @@ class NoSSLEnvironment(object):
 
     def ca_cert_path(self):
         return None
+
+environments = {"none": NoSSLEnvironment,
+                "openssl": OpenSSLEnvironment,
+                "pregenerated": PregeneratedSSLEnvironment}

--- a/tools/sslutils/base.py
+++ b/tools/sslutils/base.py
@@ -1,0 +1,23 @@
+def get_logger(name="ssl"):
+    logger = structured.get_default_logger(name)
+    if logger is None:
+        logger = structured.structuredlog.StructuredLogger(name)
+    return logger
+
+class NoSSLEnvironment(object):
+    ssl_enabled = False
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def host_cert_path(self, host):
+        return None, None
+
+    def ca_cert_path(self):
+        return None

--- a/tools/sslutils/openssl.py
+++ b/tools/sslutils/openssl.py
@@ -12,8 +12,8 @@ class OpenSSL(object):
 
         :param logger: stdlib logger or python structured logger
         :param binary: path to openssl binary
-        :param base_path: path for storing certificates
-        :param conf_path: path for storing configuration data
+        :param base_path: path to directory for storing certificates
+        :param conf_path: path for configuration file storing configuration data
         :param hosts: list of hosts to include in configuration (or None if not
                       generating host certificates)
         :param duration: Certificate duration in days"""

--- a/tools/sslutils/openssl.py
+++ b/tools/sslutils/openssl.py
@@ -1,0 +1,385 @@
+import functools
+import os
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime
+
+class OpenSSL(object):
+    def __init__(self, logger, binary, base_path, conf_path, hosts):
+        """Context manager for interacting with OpenSSL.
+        Creates a config file for the duration of the context.
+
+        :param logger: stdlib logger or python structured logger
+        :param binary: path to openssl binary
+        :param base_path: path for storing certificates
+        :param conf_path: path for storing configuration data
+        :param hosts: list of hosts to include in configuration (or None if not
+                      generating host certificates)"""
+
+        self.base_path = base_path
+        self.binary = binary
+        self.conf_path = conf_path
+        self.logger = logger
+        self.proc = None
+        self.cmd = []
+        self.hosts = hosts
+
+    def __enter__(self):
+        with open(self.conf_path, "w") as f:
+            f.write(get_config(self.base_path, self.hosts))
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        os.unlink(self.conf_path)
+
+    def log(self, line):
+        if hasattr(self.logger, "process_output"):
+            self.logger.process_output(self.proc.pid if self.proc is not None else None,
+                                       line.decode("utf8", "replace"),
+                                       command=" ".join(self.cmd))
+        else:
+            self.logger.debug(line)
+
+    def __call__(self, cmd, *args, **kwargs):
+        """Run a command using OpenSSL in the current context.
+
+        :param cmd: The openssl subcommand to run
+        :param *args: Additional arguments to pass to the command
+        """
+        self.cmd = [self.binary, cmd]
+        if cmd != "x509":
+            self.cmd += ["-config", self.conf_path]
+        self.cmd += list(args)
+        self.proc = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        stdout, stderr = self.proc.communicate()
+        self.log(stdout)
+        if self.proc.returncode != 0:
+            raise subprocess.CalledProcessError(self.proc.returncode, self.cmd,
+                                                output=stdout)
+
+        self.cmd = []
+        self.proc = None
+        return stdout
+
+
+def make_subject(common_name,
+                 country=None,
+                 state=None,
+                 locality=None,
+                 organization=None,
+                 organization_unit=None):
+    args = [("country", "C"),
+            ("state", "ST"),
+            ("locality", "L"),
+            ("organization", "O"),
+            ("organization_unit", "OU"),
+            ("common_name", "CN")]
+
+    rv = []
+
+    for var, key in args:
+        value = locals()[var]
+        if value is not None:
+            rv.append("/%s=%s" % (key, value.replace("/", "\\/")))
+
+    return "".join(rv)
+
+def make_alt_names(hosts):
+    rv = []
+    for i, name in enumerate(hosts):
+        rv.append("DNS.%i = %s" % (i+1, name))
+    return "\n".join(rv)
+
+def get_config(root_dir, hosts, duration=30):
+    if hosts is None:
+        san_line = ""
+        san_section = ""
+    else:
+        san_line = "subjectAltName = @alt_name"
+        san_section = "[ alt_name ]\n%s\n" % make_alt_names(hosts)
+
+    print san_line, san_section
+
+    return """[ ca ]
+default_ca = CA_default
+
+[ CA_default ]
+dir = %(root_dir)s
+certs = $dir
+new_certs_dir = $certs
+crl_dir = $dir/crl
+database = $dir/index.txt
+private_key = $dir/cakey.pem
+certificate = $dir/cacert.pem
+serial = $dir/serial
+crldir = $dir/crl
+crlnumber = $dir/crlnumber
+crl = $crldir/crl.pem
+RANDFILE = $dir/private/.rand
+x509_extensions = usr_cert
+name_opt        = ca_default
+cert_opt        = ca_default
+default_days = %(duration)d
+default_crl_days = 1
+default_md = sha256
+preserve = no
+policy = policy_anything
+
+[ policy_anything ]
+countryName = optional
+stateOrProvinceName = optional
+localityName = optional
+organizationName = optional
+organizationalUnitName = optional
+commonName = supplied
+emailAddress = optional
+
+[ req ]
+default_bits = 2048
+default_keyfile  = privkey.pem
+distinguished_name = req_distinguished_name
+attributes = req_attributes
+x509_extensions = v3_ca
+
+# Passwords for private keys if not present they will be prompted for
+# input_password = secret
+# output_password = secret
+string_mask = utf8only
+req_extensions = v3_req
+
+[ req_distinguished_name ]
+countryName = Country Name (2 letter code)
+countryName_default = AU
+countryName_min = 2
+countryName_max = 2
+stateOrProvinceName = State or Province Name (full name)
+stateOrProvinceName_default =
+localityName = Locality Name (eg, city)
+0.organizationName = Organization Name
+0.organizationName_default = Web Platform Tests
+organizationalUnitName = Organizational Unit Name (eg, section)
+#organizationalUnitName_default =
+commonName = Common Name (e.g. server FQDN or YOUR name)
+commonName_max = 64
+emailAddress = Email Address
+emailAddress_max = 64
+
+[ req_attributes ]
+
+[ usr_cert ]
+basicConstraints=CA:false
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+
+[ v3_req ]
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+%(san_line)s
+
+[ v3_ca ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints = CA:true
+#crlDistributionPoints = URI:http://web-platform.test:8000/wpt_ca.crl
+
+%(san_section)s
+""" % {"root_dir": root_dir,
+       "san_line": san_line,
+       "san_section": san_section,
+       "duration": duration}
+
+class OpenSSLEnvironment(object):
+    ssl_enabled = True
+
+    def __init__(self, logger, openssl_binary="openssl", base_path=None,
+                 password="web-platform-tests", force_regenerate=False):
+        """SSL environment that creates a local CA and host certificate using OpenSSL.
+
+        By default this will look in base_path for existing certificates that are still
+        valid and only create new certificates if there aren't any. This behaviour can
+        be adjusted using the force_regenerate option.
+
+        :param logger: a stdlib logging compatible logger or mozlog structured logger
+        :param openssl_binary: Path to the OpenSSL binary
+        :param base_path: Path in which certificates will be stored. If None, a temporary
+                          directory will be used and removed when the server shuts down
+        :param password: Password to use
+        :param force_regenerate: Always create a new certificate even if one already exists.
+        """
+        self.logger = logger
+
+        self.temporary = False
+        if base_path is None:
+            base_path = tempfile.mkdtemp()
+            self.temporary = True
+
+        self.base_path = os.path.abspath(base_path)
+        self.password = password
+        self.force_regenerate = force_regenerate
+
+        self.path = None
+        self.binary = openssl_binary
+        self.openssl = None
+
+        self._ca_cert_path = None
+        self._ca_key_path = None
+        self.host_certificates = {}
+
+    def __enter__(self):
+        if not os.path.exists(self.base_path):
+            os.makedirs(self.base_path)
+
+        path = functools.partial(os.path.join, self.base_path)
+
+        with open(path("index.txt"), "w"):
+            pass
+        with open(path("serial"), "w") as f:
+            f.write("01")
+
+        self.path = path
+
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        if self.temporary:
+            shutil.rmtree(self.base_path)
+
+    def _config_openssl(self, hosts):
+        conf_path = self.path("openssl.cfg")
+        return OpenSSL(self.logger, self.binary, self.base_path, conf_path, hosts)
+
+    def ca_cert_path(self):
+        """Get the path to the CA certificate file, generating a
+        new one if needed"""
+        if self._ca_cert_path is None and not self.force_regenerate:
+            self._load_ca_cert()
+        if self._ca_cert_path is None:
+            self._generate_ca()
+        return self._ca_cert_path
+
+    def _load_ca_cert(self):
+        key_path = self.path("cakey.pem")
+        cert_path = self.path("cacert.pem")
+
+        if self.check_key_cert(key_path, cert_path, None):
+            self.logger.info("Using existing CA cert")
+            self._ca_key_path, self._ca_cert_path = key_path, cert_path
+
+    def check_key_cert(self, key_path, cert_path, hosts):
+        """Check that a key and cert file exist and are valid"""
+        if not os.path.exists(key_path) or not os.path.exists(cert_path):
+            return False
+
+        with self._config_openssl(hosts) as openssl:
+            end_date_str = openssl("x509",
+                                   "-noout",
+                                   "-enddate",
+                                   "-in", cert_path).split("=", 1)[1].strip()
+            # Not sure if this works in other locales
+            end_date = datetime.strptime(end_date_str, "%b %d %H:%M:%S %Y %Z")
+            # Should have some buffer here e.g. 1 hr
+            if end_date < datetime.now():
+                return False
+
+        #TODO: check the key actually signed the cert.
+        return True
+
+    def _generate_ca(self):
+        path = self.path
+        self.logger.info("Generating new CA in %s" % self.base_path)
+
+        key_path = path("cakey.pem")
+        req_path = path("careq.pem")
+        cert_path = path("cacert.pem")
+
+        with self._config_openssl(None) as openssl:
+            openssl("req",
+                    "-batch",
+                    "-new",
+                    "-newkey", "rsa:2048",
+                    "-keyout", key_path,
+                    "-out", req_path,
+                    "-subj", make_subject("web-platform-tests"),
+                    "-passout", "pass:%s" % self.password)
+
+            openssl("ca",
+                    "-batch",
+                    "-create_serial",
+                    "-days", "1",
+                    "-keyfile", key_path,
+                    "-passin", "pass:%s" % self.password,
+                    "-selfsign",
+                    "-extensions", "v3_ca",
+                    "-in", req_path,
+                    "-out", cert_path)
+
+        os.unlink(req_path)
+
+        self._ca_key_path, self._ca_cert_path = key_path, cert_path
+
+    def host_cert_path(self, hosts):
+        """Get a tuple of (private key path, certificate path) for a host,
+        generating new ones if necessary.
+
+        hosts must be a list of all hosts to appear on the certificate, with
+        the primary hostname first."""
+        hosts = tuple(hosts)
+        if hosts not in self.host_certificates:
+            if not self.force_regenerate:
+                key_cert = self._load_host_cert(hosts)
+            else:
+                key_cert = None
+            if key_cert is None:
+                key, cert = self._generate_host_cert(hosts)
+            else:
+                key, cert = key_cert
+            self.host_certificates[hosts] = key, cert
+
+        return self.host_certificates[hosts]
+
+    def _load_host_cert(self, hosts):
+        host = hosts[0]
+        key_path = self.path("%s.key" % host)
+        cert_path = self.path("%s.pem" % host)
+
+        # TODO: check that this cert was signed by the CA cert
+        if self.check_key_cert(key_path, cert_path, hosts):
+            self.logger.info("Using existing host cert")
+            return key_path, cert_path
+
+    def _generate_host_cert(self, hosts):
+        host = hosts[0]
+        if self._ca_key_path is None:
+            self._generate_ca()
+        ca_key_path = self._ca_key_path
+
+        assert os.path.exists(ca_key_path)
+
+        path = self.path
+
+        req_path = path("wpt.req")
+        cert_path = path("%s.pem" % host)
+        key_path = path("%s.key" % host)
+
+        self.logger.info("Generating new host cert")
+
+        with self._config_openssl(hosts) as openssl:
+            openssl("req",
+                    "-batch",
+                    "-newkey", "rsa:2048",
+                    "-keyout", key_path,
+                    "-in", ca_key_path,
+                    "-nodes",
+                    "-out", req_path)
+
+            openssl("ca",
+                    "-batch",
+                    "-in", req_path,
+                    "-passin", "pass:%s" % self.password,
+                    "-subj", make_subject(host),
+                    "-out", cert_path)
+
+        os.unlink(req_path)
+
+        return key_path, cert_path

--- a/tools/sslutils/openssl.py
+++ b/tools/sslutils/openssl.py
@@ -97,7 +97,7 @@ def get_config(root_dir, hosts, duration=30):
     else:
         san_line = "subjectAltName = %s" % make_alt_names(hosts)
 
-    return """[ ca ]
+    rv = """[ ca ]
 default_ca = CA_default
 
 [ CA_default ]
@@ -176,12 +176,15 @@ extendedKeyUsage = serverAuth
 %(san_line)s
 
 [ v3_ca ]
+basicConstraints = CA:true
 subjectKeyIdentifier=hash
 authorityKeyIdentifier=keyid:always,issuer:always
-basicConstraints = CA:true
+keyUsage = keyCertSign
 """ % {"root_dir": root_dir,
        "san_line": san_line,
        "duration": duration}
+
+    return rv
 
 class OpenSSLEnvironment(object):
     ssl_enabled = True

--- a/tools/sslutils/pregenerated.py
+++ b/tools/sslutils/pregenerated.py
@@ -1,8 +1,3 @@
-def get_kwargs(kwargs):
-    return {"ca_cert_path": kwargs["ca_cert_path"],
-            "host_key_path": kwargs["host_key_path"],
-            "host_cert_path": kwargs["host_cert_path"]}
-
 class PregeneratedSSLEnvironment(object):
     """SSL environment to use with existing key/certificate files
     e.g. when running on a server with a public domain name

--- a/tools/sslutils/pregenerated.py
+++ b/tools/sslutils/pregenerated.py
@@ -1,0 +1,31 @@
+def get_kwargs(kwargs):
+    return {"ca_cert_path": kwargs["ca_cert_path"],
+            "host_key_path": kwargs["host_key_path"],
+            "host_cert_path": kwargs["host_cert_path"]}
+
+class PregeneratedSSLEnvironment(object):
+    """SSL environment to use with existing key/certificate files
+    e.g. when running on a server with a public domain name
+    """
+    ssl_enabled = True
+
+    def __init__(self, logger, host_key_path, host_cert_path,
+                 ca_cert_path=None):
+        self._ca_cert_path = ca_cert_path
+        self._host_key_path = host_key_path
+        self._host_cert_path = host_cert_path
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        pass
+
+    def host_cert_path(self, hosts):
+        """Return the key and certificate paths for the host"""
+        return self._host_key_path, self._host_cert_path
+
+    def ca_cert_path(self):
+        """Return the certificate path of the CA that signed the
+        host certificates, or None if that isn't known"""
+        return self._ca_cert_path


### PR DESCRIPTION
This adds support for launching a https server either using a
real CA-issued certificate, or a self-signed certificate generated
using OpenSSL. The latter in intended for most testing use cases.
