### PR TITLE
testing override URL for javascript:'markup' - generated documents

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-<p id="log">FAILED (test did not run)</p>
+<div id="log">FAILED (test did not run)</div>
 
 <iframe src="about:blank" name="ifr1"></iframe>
 <iframe src="" name="ifr2"></iframe>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
@@ -1,0 +1,56 @@
+<!DOCTYPE html><html><head><title>javascript: URL creating a document in an about:blank iframe</title>
+<link rel="help" href="http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<p id="log">FAILED (test did not run)</p>
+
+<iframe src="about:blank" name="ifr1"></iframe>
+<iframe src="" name="ifr2"></iframe>
+<iframe src="./" name="ifr3"></iframe>
+
+<script>
+setup({'explicit_done':true})
+var results = {};
+var expected = {
+    ifr1:{url:"about:blank", sameDom: true},
+    ifr2:{url:"about:blank", sameDom: true},
+    ifr3:{url: location.href.replace(/\/[^\/]*$/, '/'), sameDom: true },
+    ifr4:{url:"about:blank", sameDom: true}
+}
+
+var js_url = 'javascript:"<html><script>var sameDom = false; try{var cn = top.document.body.className;sameDom = true;}catch(e){}; parent.postMessage( {url: document.URL, name: name, sameDom: sameDom}, \'*\')<\/script><body><p>JS-generated document</p></body></<html>";'
+window.addEventListener('message', function(e){ console.log(e.data);
+    var ifr = e.data.name;
+    results[ifr] = e.data;
+    test(function(){
+        assert_equals(results[ifr].url, expected[ifr].url);
+        assert_equals(results[ifr].sameDom, expected[ifr].sameDom);
+    }, 'Testing URL and details of IFRAME ' + ifr);
+    if(Object.keys(results).length === Object.keys(expected).length){
+        done();
+    }
+}, false);
+
+var ifr = document.createElement('iframe');
+ifr.name = 'ifr4';
+document.body.appendChild(ifr);
+
+window.onload = function () {
+    for (var i = 0, frame, frames = document.getElementsByTagName('iframe'); frame = frames[i]; i++) {
+        try{
+            console.log('setting src on ' + i);
+            frame.src = js_url;
+            console.log('done');
+        }catch(e){
+            console.log('exception')
+            results[frame.name] = 'Exception on setting!';
+            console.log('could read name')
+        }
+    };
+}
+
+</script>
+</body>
+</html>

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
@@ -11,7 +11,7 @@
 <iframe src="./" name="ifr3"></iframe>
 
 <script>
-setup({'explicit_done':true})
+var test = async_test();
 var results = {};
 var expected = {
     ifr1:{url:"about:blank", sameDom: true},
@@ -21,15 +21,15 @@ var expected = {
 }
 
 var js_url = 'javascript:"<html><script>var sameDom = false; try{var cn = top.document.body.className;sameDom = true;}catch(e){}; parent.postMessage( {url: document.URL, name: name, sameDom: sameDom}, \'*\')<\/script><body><p>JS-generated document</p></body></<html>";'
-window.addEventListener('message', function(e){ console.log(e.data);
+window.addEventListener('message', function(e){
     var ifr = e.data.name;
     results[ifr] = e.data;
-    test(function(){
+    test.step(function(){
         assert_equals(results[ifr].url, expected[ifr].url);
         assert_equals(results[ifr].sameDom, expected[ifr].sameDom);
     }, 'Testing URL and details of IFRAME ' + ifr);
     if(Object.keys(results).length === Object.keys(expected).length){
-        done();
+        test.done();
     }
 }, false);
 
@@ -40,13 +40,9 @@ document.body.appendChild(ifr);
 window.onload = function () {
     for (var i = 0, frame, frames = document.getElementsByTagName('iframe'); frame = frames[i]; i++) {
         try{
-            console.log('setting src on ' + i);
             frame.src = js_url;
-            console.log('done');
         }catch(e){
-            console.log('exception')
             results[frame.name] = 'Exception on setting!';
-            console.log('could read name')
         }
     };
 }

--- a/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_javascript_url_01.htm
@@ -1,5 +1,8 @@
 <!DOCTYPE html><html><head><title>javascript: URL creating a document in an about:blank iframe</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-iframe-element">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/embedded-content.html#process-the-iframe-attributes">
 <link rel="help" href="http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#the-iframe-element">
+<link rel="help" href="http://www.w3.org/html/wg/drafts/html/CR/embedded-content-0.html#process-the-iframe-attributes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>


### PR DESCRIPTION
When a document is generated from a javascript: URL, per the spec its document.URL property should be the URL of the previous document in that window.
