### PR TITLE
fixing tests by correcting imports

### DIFF
--- a/tools/webdriver/webdriver/searchcontext.py
+++ b/tools/webdriver/webdriver/searchcontext.py
@@ -11,14 +11,6 @@ class SearchContext(object):
         """Find all elements matching a css selector."""
         return self._find_elements('css selector', selector)
 
-    def find_element_by_id(self, id):
-        """Find the first element with the given id."""
-        return self._find_element('id', id)
-
-    def find_elements_by_id(self, id):
-        """Find all elements with the given id."""
-        return self._find_elements('id', id)
-
     def find_element_by_link_text(self, text):
         """Find the first link with the given text."""
         return self._find_element('link text', text)

--- a/tools/webdriver/webdriver/webelement.py
+++ b/tools/webdriver/webdriver/webelement.py
@@ -28,9 +28,15 @@ class WebElement(searchcontext.SearchContext):
         """Get the value of an element property or attribute."""
         return self.execute('GET', '/attribute/%s' % name, 'getElementAttribute')
 
-    def get_text(self):
+    @property
+    def text(self):
         """Get the visible text for this element."""
         return self.execute('GET', '/text', 'text')
+
+    @property
+    def tag_name(self):
+        """Get the tag name for this element"""
+        return self.execute('GET', '/name', 'getElementTagName')
 
     def click(self):
         """Click on this element."""

--- a/webdriver/base_test.py
+++ b/webdriver/base_test.py
@@ -10,7 +10,6 @@ from network import get_lan_ip
 repo_root = os.path.abspath(os.path.join(__file__, "../.."))
 sys.path.insert(1, os.path.join(repo_root, "tools", "webdriver"))
 from webdriver.driver import WebDriver
-from webdriver import exceptions, wait
 
 
 class WebDriverBaseTest(unittest.TestCase):

--- a/webdriver/cookie/cookie_test.py
+++ b/webdriver/cookie/cookie_test.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions
 
 
 class CookieTest(base_test.WebDriverBaseTest):
@@ -44,7 +45,7 @@ class CookieTest(base_test.WebDriverBaseTest):
             self.driver.add_cookie({ 'name': invalid_name, 'value': value })
             self.fail( 'should have thrown exceptions.' )
 
-        except UnableToSetCookieException:
+        except exceptions.UnableToSetCookieException:
             pass
         except exceptions.InvalidCookieDomainException:
             pass

--- a/webdriver/element_location/element_location_test.py
+++ b/webdriver/element_location/element_location_test.py
@@ -7,19 +7,14 @@ import base_test
 
 
 class ElementLocationTest(base_test.WebDriverBaseTest):
-    def test_find_element_by_id(self):
-        self.driver.get(self.webserver.where_is("element_location/res/elements.html"))
-        e = self.driver.find_element_by_id("id")
-        self.assertEquals("id", e.text)
-
     def test_find_element_by_name(self):
         self.driver.get(self.webserver.where_is("element_location/res/elements.html"))
-        e = self.driver.find_element_by_name("name")
+        e = self.driver.find_element_by_css("*[name='name']")
         self.assertEquals("name", e.text)
 
     def test_find_element_by_css_selector(self):
         self.driver.get(self.webserver.where_is("element_location/res/elements.html"))
-        e = self.driver.find_element_by_css_selector("#id")
+        e = self.driver.find_element_by_css("#id")
         self.assertEquals("id", e.text)
 
     def test_find_element_by_link_text(self):

--- a/webdriver/element_state/visibility_test.py
+++ b/webdriver/element_state/visibility_test.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions
 
 
 class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
@@ -24,8 +25,8 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_zero_sized_element_is_shown_if_decendant_has_size(self):
         self.driver.get(self.webserver.where_is("element_state/res/zero-sized-element-with-sizable-decendant.html"))
-        parent = self.driver.find_element_by_id("parent")
-        child = self.driver.find_element_by_id("child")
+        parent = self.driver.find_element_by_css("#parent")
+        child = self.driver.find_element_by_css("#child")
 
         self.assertTrue(parent.is_displayed())
         self.assertTrue(child.is_displayed())
@@ -53,7 +54,7 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
         children = self.driver.find_elements_by_css(".child")
         assert all(child.is_displayed() for child in children)
 
-        parent = self.driver.find_element_by_id("parent")
+        parent = self.driver.find_element_by_css("#parent")
         assert parent.is_displayed()
 
     def test_element_hidden_by_overflow_x_is_not_visible(self):
@@ -65,8 +66,8 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
         for page in pages:
             self.driver.get(self.webserver.where_is(page))
-            right = self.driver.find_element_by_id("right")
-            bottom_right = self.driver.find_element_by_id("bottom-right")
+            right = self.driver.find_element_by_css("#right")
+            bottom_right = self.driver.find_element_by_css("#bottom-right")
 
             self.assertFalse(right.is_displayed())
             self.assertFalse(bottom_right.is_displayed())
@@ -80,8 +81,8 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
         for page in pages:
             self.driver.get(self.webserver.where_is(page))
-            bottom = self.driver.find_element_by_id("bottom")
-            bottom_right = self.driver.find_element_by_id("bottom-right")
+            bottom = self.driver.find_element_by_css("#bottom")
+            bottom_right = self.driver.find_element_by_css("#bottom-right")
 
             self.assertFalse(bottom.is_displayed())
             self.assertFalse(bottom_right.is_displayed())
@@ -113,21 +114,21 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_element_hidden_by_other_element(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-hidden-by-other-element.html"))
-        overlay = self.driver.find_element_by_id("overlay")
-        hidden = self.driver.find_element_by_id("hidden")
+        overlay = self.driver.find_element_by_css("#overlay")
+        hidden = self.driver.find_element_by_css("#hidden")
 
         self.assertTrue(overlay.is_displayed())
         self.assertFalse(hidden.is_displayed())
 
     def test_element_partially_hidden_by_other_element(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-partially-hidden-by-other-element.html"))
-        partial = self.driver.find_element_by_id("partial")
+        partial = self.driver.find_element_by_css("#partial")
         self.assertTrue(partial.is_displayed())
 
     def test_element_hidden_by_z_index(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-hidden-by-z-index.html"))
-        overlay = self.driver.find_element_by_id("overlay")
-        hidden = self.driver.find_element_by_id("hidden")
+        overlay = self.driver.find_element_by_css("#overlay")
+        hidden = self.driver.find_element_by_css("#hidden")
 
         self.assertTrue(overlay.is_displayed())
         self.assertFalse(hidden.is_displayed())
@@ -139,8 +140,8 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_element_moved_behind_other_element_by_transform(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-moved-behind-other-element-by-transform.html"))
-        overlay = self.driver.find_element_by_id("overlay")
-        hidden = self.driver.find_element_by_id("hidden")
+        overlay = self.driver.find_element_by_css("#overlay")
+        hidden = self.driver.find_element_by_css("#hidden")
 
         self.assertTrue(overlay.is_displayed())
         self.assertFalse(hidden.is_displayed())
@@ -167,7 +168,7 @@ class NaturalNonVisibleElementsTest(base_test.WebDriverBaseTest):
 
     def test_element_with_same_color_as_parent_background(self):
         self.driver.get(self.webserver.where_is("element_state/res/element-with-same-color-as-parent-background.html"))
-        hidden = self.driver.find_element_by_id("hidden")
+        hidden = self.driver.find_element_by_css("#hidden")
         self.assertFalse(hidden.is_displayed())
 
 
@@ -203,35 +204,35 @@ class DisplayTest(base_test.WebDriverBaseTest):
 
     def test_display_none_hides_child_node(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-child.html"))
-        parent = self.driver.find_element_by_id("parent")
-        child = self.driver.find_element_by_id("child")
+        parent = self.driver.find_element_by_css("#parent")
+        child = self.driver.find_element_by_css("#child")
 
         self.assertFalse(parent.is_displayed())
         self.assertFalse(child.is_displayed())
 
     def test_display_none_hides_child_node_link(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-child-link.html"))
-        child = self.driver.find_element_by_id("child")
+        child = self.driver.find_element_by_css("#child")
         self.assertFalse(child.is_displayed())
 
     def test_display_none_hides_child_node_paragraph(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-child-paragraph.html"))
-        child = self.driver.find_element_by_id("child")
+        child = self.driver.find_element_by_css("#child")
         self.assertFalse(child.is_displayed())
 
     def test_display_none_on_parent_takes_presedence(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-parent-presedence.html"))
-        child = self.driver.find_element_by_id("child")
+        child = self.driver.find_element_by_css("#child")
         self.assertFalse(child.is_displayed())
 
     def test_display_none_on_parent_takes_presedence_over_visibility_visible(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-parent-presedence-visibility.html"))
-        child = self.driver.find_element_by_id("child")
+        child = self.driver.find_element_by_css("#child")
         self.assertFalse(child.is_displayed())
 
     def test_display_none_hidden_dynamically(self):
         self.driver.get(self.webserver.where_is("element_state/res/display-none-dynamic.html"))
-        hidden = self.driver.find_element_by_id("hidden")
+        hidden = self.driver.find_element_by_css("#hidden")
         self.assertFalse(hidden.is_displayed())
 
 
@@ -248,34 +249,34 @@ class VisibilityTest(base_test.WebDriverBaseTest):
 
     def test_visibility_hidden_hides_child_node(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-child.html"))
-        parent = self.driver.find_element_by_id("parent")
-        child = self.driver.find_element_by_id("child")
+        parent = self.driver.find_element_by_css("#parent")
+        child = self.driver.find_element_by_css("#child")
 
         self.assertFalse(parent.is_displayed())
         self.assertFalse(child.is_displayed())
 
     def test_visibility_hidden_hides_child_node_link(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-child-link.html"))
-        parent = self.driver.find_element_by_id("parent")
-        child = self.driver.find_element_by_id("child")
+        parent = self.driver.find_element_by_css("#parent")
+        child = self.driver.find_element_by_css("#child")
 
         self.assertFalse(parent.is_displayed())
         self.assertFalse(child.is_displayed())
 
     def test_visibility_hidden_hides_child_node_paragraph(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-child-paragraph.html"))
-        parent = self.driver.find_element_by_id("parent")
-        child = self.driver.find_element_by_id("child")
+        parent = self.driver.find_element_by_css("#parent")
+        child = self.driver.find_element_by_css("#child")
 
         self.assertFalse(parent.is_displayed())
         self.assertFalse(child.is_displayed())
 
-    def test_visibility_hidden_on_child_takes_presedence(self):
+    def test_visibility_hidden_on_child_takes_precedence(self):
         self.driver.get(self.webserver.where_is("element_state/res/visibility-child-presedence.html"))
-        child = self.driver.find_element_by_id("child")
+        child = self.driver.find_element_by_css("#child")
         self.assertTrue(child.is_displayed())
 
-    def test_visibility_hidden_on_parent_takes_presedence_over_display_block(self):
+    def test_visibility_hidden_on_parent_takes_precedence_over_display_block(self):
         pass
 
     def test_visibility_hidden_set_dynamically(self):
@@ -283,12 +284,12 @@ class VisibilityTest(base_test.WebDriverBaseTest):
 
     def test_should_show_element_not_visible_with_hidden_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/hidden.html"))
-        singleHidden = self.driver.find_element('id', 'singleHidden')
+        singleHidden = self.driver.find_element_by_css('#singleHidden')
         self.assertFalse(singleHidden.is_displayed())
 
     def test_should_show_element_not_visible_when_parent_element_has_hidden_attribute(self):
         self.driver.get(self.webserver.where_is("element_state/res/hidden.html"))
-        child = self.driver.find_element('id', 'child')
+        child = self.driver.find_element_by_css('#child')
         self.assertFalse(child.is_displayed())
 
 

--- a/webdriver/modal/alerts_quit_test.py
+++ b/webdriver/modal/alerts_quit_test.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions, wait
 
 
 class AlertsQuitTest(base_test.WebDriverBaseTest):
@@ -12,7 +13,7 @@ class AlertsQuitTest(base_test.WebDriverBaseTest):
         self.driver.get(self.webserver.where_is('modal/res/alerts.html'))
 
     def test_can_quit_when_an_alert_is_present(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         self.driver.quit()
         with self.assertRaises(Exception):

--- a/webdriver/modal/alerts_test.py
+++ b/webdriver/modal/alerts_test.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions, wait
 
 
 class AlertsTest(base_test.WebDriverBaseTest):
@@ -19,39 +20,39 @@ class AlertsTest(base_test.WebDriverBaseTest):
 
     # Alerts
     def test_should_allow_user_to_accept_an_alert(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
         self.driver.get_current_url()
 
     def test_should_allow_user_to_accept_an_alert_with_no_text(self):
-        self.driver.find_element_by_id('empty-alert').click()
+        self.driver.find_element_by_css('#empty-alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
         self.driver.get_current_url()
 
     def test_should_allow_user_to_dismiss_an_alert(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.dismiss()
         self.driver.get_current_url()
 
     def test_should_allow_user_to_get_text_of_an_alert(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         value = alert.get_text()
         alert.accept()
         self.assertEquals('cheese', value)
 
     def test_setting_the_value_of_an_alert_throws(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
 	with self.assertRaises(exceptions.ElementNotVisibleException):
 	    alert.send_keys('cheese')
         alert.accept()
 
     def test_alert_should_not_allow_additional_commands_if_dismissed(self):
-        self.driver.find_element_by_id('alert').click()
+        self.driver.find_element_by_css('#alert').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
         with self.assertRaises(exceptions.NoSuchAlertException):
@@ -59,79 +60,79 @@ class AlertsTest(base_test.WebDriverBaseTest):
 
     # Prompts
     def test_should_allow_user_to_accept_a_prompt(self):
-        self.driver.find_element_by_id('prompt').click()
+        self.driver.find_element_by_css('#prompt').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == '')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == '')
 
     def test_should_allow_user_to_dismiss_a_prompt(self):
-        self.driver.find_element_by_id('prompt').click()
+        self.driver.find_element_by_css('#prompt').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.dismiss()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'null')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'null')
 
     def test_should_allow_user_to_set_the_value_of_a_prompt(self):
-        self.driver.find_element_by_id('prompt').click()
+        self.driver.find_element_by_css('#prompt').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.send_keys('cheese')
         alert.accept()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'cheese')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'cheese')
 
     def test_should_allow_user_to_get_text_of_a_prompt(self):
-        self.driver.find_element_by_id('prompt').click()
+        self.driver.find_element_by_css('#prompt').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         value = alert.get_text()
         alert.accept()
         self.assertEquals('Enter something', value)
 
     def test_prompt_should_not_allow_additional_commands_if_dismissed(self):
-        self.driver.find_element_by_id('prompt').click()
+        self.driver.find_element_by_css('#prompt').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
         with self.assertRaises(exceptions.NoSuchAlertException):
             alert.get_text()
 
     def test_prompt_should_use_default_value_if_no_keys_sent(self):
-        self.driver.find_element_by_id('prompt-with-default').click()
+        self.driver.find_element_by_css('#prompt-with-default').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'This is a default value')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'This is a default value')
 
     def test_prompt_should_have_null_value_if_dismissed(self):
-        self.driver.find_element_by_id('prompt-with-default').click()
+        self.driver.find_element_by_css('#prompt-with-default').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.dismiss()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'null')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'null')
 
     # Confirmations
     def test_should_allow_user_to_accept_a_confirm(self):
-        self.driver.find_element_by_id('confirm').click()
+        self.driver.find_element_by_css('#confirm').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'true')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'true')
 
     def test_should_allow_user_to_dismiss_a_confirm(self):
-        self.driver.find_element_by_id('confirm').click()
+        self.driver.find_element_by_css('#confirm').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.dismiss()
-        self.wait.until(lambda x: x.find_element_by_id('text').get_text() == 'false')
+        self.wait.until(lambda x: x.find_element_by_css('#text').text == 'false')
 
     def test_setting_the_value_of_a_confirm_throws(self):
-        self.driver.find_element_by_id('confirm').click()
+        self.driver.find_element_by_css('#confirm').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         with self.assertRaises(exceptions.ElementNotVisibleException):
             alert.send_keys('cheese')
         alert.accept()
 
     def test_should_allow_user_to_get_text_of_a_confirm(self):
-        self.driver.find_element_by_id('confirm').click()
+        self.driver.find_element_by_css('#confirm').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         value = alert.get_text()
         alert.accept()
         self.assertEquals('cheese', value)
 
     def test_confirm_should_not_allow_additional_commands_if_dismissed(self):
-        self.driver.find_element_by_id('confirm').click()
+        self.driver.find_element_by_css('#confirm').click()
         alert = self.wait.until(lambda x: x.switch_to_alert())
         alert.accept()
         with self.assertRaises(exceptions.NoSuchAlertException):

--- a/webdriver/navigation/auth_tests.py
+++ b/webdriver/navigation/auth_tests.py
@@ -6,6 +6,7 @@ import ConfigParser
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
 from webserver import Httpd
+from webdriver import exceptions
 
 
 class WebDriverAuthTest(unittest.TestCase):

--- a/webdriver/navigation/forward.py
+++ b/webdriver/navigation/forward.py
@@ -11,12 +11,12 @@ class ForwardTest(base_test.WebDriverBaseTest):
     def test_forward(self):
         self.driver.get(self.webserver.where_is('navigation/res/forwardStart.html'))
         self.driver.get(self.webserver.where_is('navigation/res/forwardNext.html'))
-        nextbody = self.driver.find_element_by_css("body").get_text()
+        nextbody = self.driver.find_element_by_css("body").text
         self.driver.go_back()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css("body").text
         self.assertNotEqual(nextbody, currbody)
         self.driver.go_forward()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css("body").text
         self.assertEqual(nextbody, currbody)
 
 

--- a/webdriver/navigation/forwardToNothing.py
+++ b/webdriver/navigation/forwardToNothing.py
@@ -10,9 +10,9 @@ class ForwardToNothingTest(base_test.WebDriverBaseTest):
     # Get a static page that must be the same upon refresh
     def test_forwardToNothing(self):
         self.driver.get(self.webserver.where_is('navigation/forwardStart.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css("body").text
         self.driver.go_forward()
-        currbody = self.driver.find_element_by_css("body").get_text()
+        currbody = self.driver.find_element_by_css("body").text
         self.assertEqual(body, currbody)
 
 

--- a/webdriver/navigation/refresh-page.py
+++ b/webdriver/navigation/refresh-page.py
@@ -10,16 +10,16 @@ class RefreshPageTest(base_test.WebDriverBaseTest):
     # Get a static page that must be the same upon refresh
     def test_refreshPage(self):
         self.driver.get(self.webserver.where_is('navigation/res/refreshPageStatic.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css("body").text
         self.driver.execute_script("document.getElementById('body').innerHTML=''")
         self.driver.refresh()
-        newbody = self.driver.find_element_by_css("body").get_text()
+        newbody = self.driver.find_element_by_css("body").text
         self.assertEqual(body, newbody)
 
         self.driver.get(self.webserver.where_is('navigation/res/refreshPageDynamic.html'))
-        body = self.driver.find_element_by_css("body").get_text()
+        body = self.driver.find_element_by_css("body").text
         self.driver.refresh()
-        newbody = self.driver.find_element_by_css("body").get_text()
+        newbody = self.driver.find_element_by_css("body").text
         self.assertNotEqual(body, newbody)
 
 

--- a/webdriver/timeouts/implicit_waits_tests.py
+++ b/webdriver/timeouts/implicit_waits_tests.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions
 
 
 class ImplicitWaitsTests(base_test.WebDriverBaseTest):
@@ -11,15 +12,15 @@ class ImplicitWaitsTests(base_test.WebDriverBaseTest):
         self.driver.get(self.webserver.where_is('timeouts/res/implicit_waits_tests.html'))
 
     def test_find_element_by_id(self):
-        add = self.driver.find_element_by_id("adder")
-        self.driver.implicitly_wait(3)
+        add = self.driver.find_element_by_css("#adder")
+        self.driver.set_implicit_timeout(3)
         add.click()
-        self.driver.find_element_by_id("box0")  # All is well if this doesn't throw.
+        self.driver.find_element_by_css("#box0")  # All is well if this doesn't throw.
 
     def test_should_still_fail_to_find_an_element_when_implicit_waits_are_enabled(self):
-        self.driver.implicitly_wait(0.5)
+        self.driver.set_implicit_timeout(0.5)
         try:
-            self.driver.find_element_by_id("box0")
+            self.driver.find_element_by_css("#box0")
             self.fail("Expected NoSuchElementException to have been thrown")
         except exceptions.NoSuchElementException as e:
             pass
@@ -27,10 +28,10 @@ class ImplicitWaitsTests(base_test.WebDriverBaseTest):
             self.fail("Expected NoSuchElementException but got " + str(e))
 
     def test_should_return_after_first_attempt_to_find_one_after_disabling_implicit_waits(self):
-        self.driver.implicitly_wait(3)
-        self.driver.implicitly_wait(0)
+        self.driver.set_implicit_timeout(3)
+        self.driver.set_implicit_timeout(0)
         try:
-            self.driver.find_element_by_id("box0")
+            self.driver.find_element_by_css("#box0")
             self.fail("Expected NoSuchElementException to have been thrown")
         except exceptions.NoSuchElementException as e:
             pass
@@ -38,24 +39,24 @@ class ImplicitWaitsTests(base_test.WebDriverBaseTest):
             self.fail("Expected NoSuchElementException but got " + str(e))
 
     def test_should_implicitly_wait_until_at_least_one_element_is_found_when_searching_for_many(self):
-        add = self.driver.find_element_by_id("adder")
-        self.driver.implicitly_wait(2)
+        add = self.driver.find_element_by_css("#adder")
+        self.driver.set_implicit_timeout(2)
         add.click()
         add.click()
-        elements = self.driver.find_elements_by_class_name("redbox")
+        elements = self.driver.find_elements_by_css(".redbox")
         self.assertTrue(len(elements) >= 1)
 
     def test_should_still_fail_to_find_an_element_by_class_when_implicit_waits_are_enabled(self):
-        self.driver.implicitly_wait(0.5)
-        elements = self.driver.find_elements_by_class_name("redbox")
+        self.driver.set_implicit_timeout(0.5)
+        elements = self.driver.find_elements_by_css(".redbox")
         self.assertEqual(0, len(elements))
 
     def test_should_return_after_first_attempt_to_find_many_after_disabling_implicit_waits(self):
-        add = self.driver.find_element_by_id("adder")
-        self.driver.implicitly_wait(1.1)
-        self.driver.implicitly_wait(0)
+        add = self.driver.find_element_by_css("#adder")
+        self.driver.set_implicit_timeout(1.1)
+        self.driver.set_implicit_timeout(0)
         add.click()
-        elements = self.driver.find_elements_by_class_name("redbox")
+        elements = self.driver.find_elements_by_css(".redbox")
         self.assertEqual(0, len(elements))
 
 

--- a/webdriver/timeouts/page_load_timeouts_tests.py
+++ b/webdriver/timeouts/page_load_timeouts_tests.py
@@ -4,6 +4,7 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions
 
 
 class PageLoadTimeoutTest(base_test.WebDriverBaseTest):

--- a/webdriver/user_input/clear_test.py
+++ b/webdriver/user_input/clear_test.py
@@ -6,44 +6,45 @@ import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
 import base_test
+from webdriver import exceptions
 
 
 class ElementClearTest(base_test.WebDriverBaseTest):
     def test_writable_text_input_element_should_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_writable_input_page.html"))
-        e = self.driver.find_element_by_id("writableTextInput")
+        e = self.driver.find_element_by_css("#writableTextInput")
         e.clear()
         self.assertEquals("", e.get_attribute("value"))
 
     def test_disabled_text_input_element_should_not_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_disabled_input_page.html"))
-        e = self.driver.find_element_by_id("disabledTextInput")
+        e = self.driver.find_element_by_css("#disabledTextInput")
         self.assertRaises(exceptions.InvalidElementStateException, lambda: e.clear())
 
     def test_read_only_text_input_element_should_not_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_readonly_input_page.html"))
-        e = self.driver.find_element_by_id("readOnlyTextInput")
+        e = self.driver.find_element_by_css("#readOnlyTextInput")
         self.assertRaises(exceptions.InvalidElementStateException, lambda: e.clear())
 
     def test_writable_text_area_element_should_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_writable_textarea_page.html"))
-        e = self.driver.find_element_by_id("writableTextArea")
+        e = self.driver.find_element_by_css("#writableTextArea")
         e.clear()
         self.assertEquals("", e.get_attribute("value"))
 
     def test_disabled_text_area_element_should_not_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_disabled_textarea_page.html"))
-        e = self.driver.find_element_by_id("disabledTextArea")
+        e = self.driver.find_element_by_css("#disabledTextArea")
         self.assertRaises(exceptions.InvalidElementStateException, lambda: e.clear())
 
     def test_read_only_text_input_element_should_not_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_readonly_textarea_page.html"))
-        e = self.driver.find_element_by_id("readOnlyTextArea")
+        e = self.driver.find_element_by_css("#readOnlyTextArea")
         self.assertRaises(exceptions.InvalidElementStateException, lambda: e.clear())
 
     def test_content_editable_area_should_clear(self):
         self.driver.get(self.webserver.where_is("user_input/res/element_clear_contenteditable_page.html"))
-        e = self.driver.find_element_by_id("contentEditableElement")
+        e = self.driver.find_element_by_css("#contentEditableElement")
         e.clear()
         self.assertEquals("", e.text)
 


### PR DESCRIPTION
find element by id does not exist in the spec anymore, also correcting other removed locators

make element.text consistent (changing to property access)
