### PR TITLE
worker postMessage(1, null) should throw, undefined should not. Fixes #491

### DIFF
--- a/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/second-argument-null.html
+++ b/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/second-argument-null.html
@@ -2,7 +2,7 @@
 try {
   postMessage(1, null);
 } catch(e) {
-  postMessage(2);
+  postMessage(e instanceof TypeError);
 }
 /*
 -->
@@ -15,7 +15,7 @@ try {
 (async_test()).step(function() {
   var worker = new Worker('#');
   worker.onmessage = this.step_func(function(e) {
-    assert_equals(e.data, 2);
+    assert_true(e.data);
     this.done();
   });
 });

--- a/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/second-argument-undefined.html
+++ b/workers/interfaces/DedicatedWorkerGlobalScope/postMessage/second-argument-undefined.html
@@ -1,13 +1,13 @@
 <!--
 try {
-  postMessage(1, null);
+  postMessage(1, undefined);
 } catch(e) {
-  postMessage(2);
+  postMessage(''+e);
 }
 /*
 -->
 <!doctype html>
-<title>Using null in postMessage's second argument</title>
+<title>Using undefined in postMessage's second argument</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -15,7 +15,7 @@ try {
 (async_test()).step(function() {
   var worker = new Worker('#');
   worker.onmessage = this.step_func(function(e) {
-    assert_equals(e.data, 2);
+    assert_equals(e.data, 1);
     this.done();
   });
 });


### PR DESCRIPTION
(Omitting the second argument is already tested in e.g. `return-value.html`.)
