### PR TITLE
Fix worker ErrorEvent test should use constructor and test non-support f...

### DIFF
--- a/workers/Worker_dispatchEvent_ErrorEvent.htm
+++ b/workers/Worker_dispatchEvent_ErrorEvent.htm
@@ -1,44 +1,52 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title> ErrorEvent.initErrorEvent() and Worker.dispatchEvent() </title>
+<title> ErrorEvent and Worker.dispatchEvent() </title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id=log></div>
 <script>
-    
+
     var EVENT = "error";
     var FILENAME = './support/ErrorEvent.js';
     var MESSAGE = 'Hello Worker';
     var LINENO = 5;
-    var description = "ErrorEvent.initErrorEvent() and Worker.dispatchEvent()";
-    
+    var COLNO = 6;
+    var ERROR = new Error("test");
+    var description = "ErrorEvent and Worker.dispatchEvent()";
+
     var t = async_test("Test Description: " + description);
 
-    var worker = new Worker(FILENAME);
-    
-    worker.addEventListener(EVENT, t.step_func(TestErrorEvent), true);
-    
-    var evt = document.createEvent("ErrorEvent");
+    t.step(function() {
+        var worker = new Worker(FILENAME);
 
-    evt.initErrorEvent(EVENT,    /* type */
-                       true,     /* bubbles */
-                       true,     /* cancelable */
-                       MESSAGE,  /* message */
-                       FILENAME, /* filename */
-                       LINENO    /* lineno */ );
-                       
-    worker.dispatchEvent(evt);
-    
-    function TestErrorEvent(evt)
-    {
-        var ExpectedResult = [EVENT, MESSAGE, FILENAME, LINENO];
-        var ActualResult = [evt.type, evt.message, evt.filename, evt.lineno];
-        assert_array_equals(ActualResult, ExpectedResult);
-        t.done();
-    }
+        worker.addEventListener(EVENT, t.step_func(TestErrorEvent), true);
+
+        var evt = new ErrorEvent(EVENT, {bubbles:true, cancelable:true, message:MESSAGE, filename:FILENAME, lineno:LINENO, colno:COLNO, error:ERROR});
+
+        worker.dispatchEvent(evt);
+
+        function TestErrorEvent(evt)
+        {
+            var ExpectedResult = [EVENT, MESSAGE, FILENAME, LINENO, COLNO, ERROR];
+            var ActualResult = [evt.type, evt.message, evt.filename, evt.lineno, evt.colno, evt.error];
+            assert_array_equals(ActualResult, ExpectedResult);
+            t.done();
+        }
+    });
+
+    test(function() {
+        assert_throws("NotSupportedError", function() {
+            document.createEvent("ErrorEvent");
+        }, "should not be supported");
+    }, "document.createEvent('ErrorEvent')");
+
+    test(function() {
+        var evt = new ErrorEvent("error");
+        assert_false("initErrorEvent" in evt, "should not be supported");
+    }, "initErrorEvent");
 </script>
 </body>
 </html>

--- a/workers/Worker_dispatchEvent_ErrorEvent.htm
+++ b/workers/Worker_dispatchEvent_ErrorEvent.htm
@@ -30,9 +30,12 @@
 
         function TestErrorEvent(evt)
         {
-            var ExpectedResult = [EVENT, MESSAGE, FILENAME, LINENO, COLNO, ERROR];
-            var ActualResult = [evt.type, evt.message, evt.filename, evt.lineno, evt.colno, evt.error];
-            assert_array_equals(ActualResult, ExpectedResult);
+            assert_equals(evt.type, EVENT, 'type');
+            assert_equals(evt.message, MESSAGE, 'message');
+            assert_equals(evt.filename, FILENAME, 'filename');
+            assert_equals(evt.lineno, LINENO, 'lineno');
+            assert_equals(evt.colno, COLNO, 'colno');
+            assert_equals(evt.error, ERROR, 'error');
             t.done();
         }
     });


### PR DESCRIPTION
...or legacy. Fixes #492
