### PR TITLE
insertRow should insert a tr element even in a table with blank lines

### DIFF
--- a/html/semantics/tabular-data/the-table-element/insertRow-method-03.html
+++ b/html/semantics/tabular-data/the-table-element/insertRow-method-03.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>insertRow(): Empty table</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<link rel="help" href="http://www.whatwg.org/html5/#dom-table-insertrow">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<div id="test">
+<table>
+    
+    
+</table>
+</div>
+<script>
+var HTML = "http://www.w3.org/1999/xhtml";
+test(function() {
+  var table = document.getElementById("test").getElementsByTagName("table")[0];
+
+  var tr;
+  test(function() {
+    tr = table.insertRow(0);
+    assert_equals(tr.localName, "tr");
+    assert_equals(tr.namespaceURI, HTML);
+  }, "insertRow should insert a tr element even in a table with blank lines")
+});
+</script>


### PR DESCRIPTION
Will you please confirm that this is the expected behaviour?
