### PR TITLE
Remove obsolete check for non-support of Attr#textContent.

### DIFF
--- a/dom/nodes/attributes.html
+++ b/dom/nodes/attributes.html
@@ -25,7 +25,6 @@ test(function() {
   assert_throws(new TypeError(), function() { attr.appendChild(null) })
   assert_equals(attr.value, "pass")
   assert_false("childNodes" in attr, "Should not have childNodes")
-  assert_false("textContent" in attr, "Should not have textContent")
 }, "AttrExodus")
 
 // setAttribute exhaustive tests


### PR DESCRIPTION
It has been reinstated as an alias for Attr#value.
