### PR TITLE
Remove the unused selection variable from dom/common.js.

### DIFF
--- a/dom/common.js
+++ b/dom/common.js
@@ -5,7 +5,6 @@
 
 // Everything is done in functions in this test harness, so we have to declare
 // all the variables before use to make sure they can be reused.
-var selection;
 var testDiv, paras, detachedDiv, detachedPara1, detachedPara2,
 	foreignDoc, foreignPara1, foreignPara2, xmlDoc, xmlElement,
 	detachedXmlElement, detachedTextNode, foreignTextNode,
@@ -17,7 +16,6 @@ var testDiv, paras, detachedDiv, detachedPara1, detachedPara2,
 var testRangesShort, testRanges, testPoints, testNodesShort, testNodes;
 
 function setupRangeTests() {
-	selection = getSelection();
 	testDiv = document.querySelector("#test");
 	if (testDiv) {
 		testDiv.parentNode.removeChild(testDiv);


### PR DESCRIPTION
It does not belong in the DOM test suite, and is not used there.

This also allows Servo to run tests that use it to completion.
