### PR TITLE
IndexedDB: Skip keypath tests for non-cloneable values

### DIFF
--- a/IndexedDB/key_invalid.htm
+++ b/IndexedDB/key_invalid.htm
@@ -17,6 +17,15 @@
         objStore  = null,
         objStore2 = null;
 
+    function is_cloneable(o) {
+        try {
+            self.postMessage(o, '*');
+            return true;
+        } catch (ex) {
+            return false;
+        }
+    }
+
     function invalid_key(desc, key) {
         var t = async_test(document.title + " - " + desc);
 
@@ -27,11 +36,12 @@
                 objStore.add("value", key);
             });
 
-            objStore2 = objStore2 || e.target.result.createObjectStore("store2", { keyPath: ["x", "keypath"] });
-            assert_throws('DataError', function() {
-                objStore2.add({ x: "value", keypath: key });
-            });
-
+            if (is_cloneable(key)) {
+                objStore2 = objStore2 || e.target.result.createObjectStore("store2", { keyPath: ["x", "keypath"] });
+                assert_throws('DataError', function() {
+                    objStore2.add({ x: "value", keypath: key });
+                });
+            }
             this.done();
         };
     }


### PR DESCRIPTION
Per discussion in https://www.w3.org/Bugs/Public/show_bug.cgi?id=26492 we probably want to clone before extracting keys using keypaths. Chrome already does this, other implementers seem to agree. The spec is written in a non-algorithmic style, so it's ambiguous.

With this change, all potential key types are still tested as explicit keys. But a secondary test, embedding potential key values into an object and using implicit keys via key paths, is not done if the value is not cloneable, since it could fail with either DataCloneError (if cloning is done before extraction) or DataError (if cloning is done after extraction). 
