### PR TITLE
Indexed DB: Add Event interface stub

### DIFF
--- a/IndexedDB/interfaces.html
+++ b/IndexedDB/interfaces.html
@@ -166,6 +166,8 @@ interface Window { };
 
 interface WorkerUtils { };
 
+interface Event { };
+
 interface EventTarget { };
 </script>
 
@@ -200,4 +202,3 @@ setup(function() {
   idlArray.test();
 });
 </script>
-


### PR DESCRIPTION
A missing untested IDL stub for "Event" was causing two "Cannot read property...." exceptions to be thrown, hiding actual test case results.
