### PR TITLE
minor fix to single-byte-encoder.html

### DIFF
--- a/encoding/single-byte-decoder.html
+++ b/encoding/single-byte-decoder.html
@@ -121,8 +121,8 @@
  }
 
  // For TextDecoder tests
- var buffer = ArrayBuffer(255),
-     view = Uint8Array(buffer)
+ var buffer = new ArrayBuffer(255),
+     view = new Uint8Array(buffer)
  for(var i = 0, l = view.byteLength; i < l; i++) {
    view[i] = i
  }


### PR DESCRIPTION
Apparently ES requires new for these, but browsers haven’t been updated
yet.
