### PR TITLE
Prevent "global name 'git' is not defined" error.

### DIFF
--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -461,6 +461,7 @@ def get_reference_links(root):
 
 def get_file(base_path, rel_path, use_committed):
     if use_committed:
+        git = get_git_func(os.path.dirname(__file__))
         blob = git("show", "HEAD:%s" % rel_path)
         file_obj = ContextManagerStringIO(blob)
     else:


### PR DESCRIPTION
This appears to be what was causing the manifest-generation step to fail on http://w3c-test.org/tools/runner/index.html
