### PR TITLE
Added --config option to serve.py.

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -324,14 +324,14 @@ def load_config(default_path, override_path=None, **kwargs):
     rv = merge_json(base_obj, override_obj)
 
     if kwargs.get("config_path"):
-      other_path = os.path.abspath(os.path.expanduser(kwargs.get("config_path")))
-      if os.path.exists(other_path):
-        base_obj = rv
-        with open(other_path) as f:
-            override_obj = json.load(f)
-        rv = merge_json(base_obj, override_obj)
-      else:
-        raise ValueError("Config path %s does not exist" % other_path)
+        other_path = os.path.abspath(os.path.expanduser(kwargs.get("config_path")))
+        if os.path.exists(other_path):
+            base_obj = rv
+            with open(other_path) as f:
+                override_obj = json.load(f)
+            rv = merge_json(base_obj, override_obj)
+        else:
+            raise ValueError("Config path %s does not exist" % other_path)
 
     set_computed_defaults(rv)
     return rv

--- a/serve.py
+++ b/serve.py
@@ -326,7 +326,7 @@ def load_config(default_path, override_path=None, **kwargs):
     if kwargs.get("config_path"):
       other_path = os.path.abspath(os.path.expanduser(kwargs.get("config_path")))
       if os.path.exists(other_path):
-        base_obj =rv
+        base_obj = rv
         with open(other_path) as f:
             override_obj = json.load(f)
         rv = merge_json(base_obj, override_obj)


### PR DESCRIPTION
In addition to reading the standard config.default.json file and any
config.json file in the working directory, this option allows you to
specify a custom location for any additional config file to read.
Meant to be useful for the case of, e.g., you don't want to have to keep
settings in a custom config.json in your working directory due to risk of
it getting blown away by a "git clean" or whatever.
