### PR TITLE
postMessage with zero or one argument shall throw SyntaxError

### DIFF
--- a/webmessaging/without-ports/008.html
+++ b/webmessaging/without-ports/008.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
 test(function() {
-  assert_throws('NOT_SUPPORTED_ERR', function() {
+  assert_throws('SYNTAX_ERR', function() {
     postMessage('');
   });
 });

--- a/webmessaging/without-ports/008.html
+++ b/webmessaging/without-ports/008.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
 test(function() {
-  assert_throws('SYNTAX_ERR', function() {
+  assert_throws(new TypeError(), function() {
     postMessage('');
   });
 });

--- a/webmessaging/without-ports/009.html
+++ b/webmessaging/without-ports/009.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
 test(function() {
-  assert_throws('NOT_SUPPORTED_ERR', function() {
+  assert_throws('SYNTAX_ERR', function() {
     postMessage();
   });
 });

--- a/webmessaging/without-ports/009.html
+++ b/webmessaging/without-ports/009.html
@@ -5,7 +5,7 @@
 <div id="log"></div>
 <script>
 test(function() {
-  assert_throws('SYNTAX_ERR', function() {
+  assert_throws(new TypeError(), function() {
     postMessage();
   });
 });


### PR DESCRIPTION
per the spec https://html.spec.whatwg.org/multipage/comms.html#dom-window-postmessage
