### PR TITLE
fix structured-cloning with getter properties

### DIFF
--- a/webmessaging/without-ports/026.html
+++ b/webmessaging/without-ports/026.html
@@ -11,7 +11,6 @@ async_test(function() {
    assert_throws(new Error("getter_should_propagate_exceptions"), function() {
      postMessage(obj, '*');
   });
-  
   this.done();
 });
 </script>

--- a/webmessaging/without-ports/026.html
+++ b/webmessaging/without-ports/026.html
@@ -6,12 +6,12 @@
 <script>
 async_test(function() {
    var obj = {};
-   Object.defineProperty(obj, "field", { get: this.step_func(function(){ assert_unreached(); })});
+   obj.__defineGetter__( "field", function(){ throw new Error("getter_should_propagate_exceptions"); });
 
-   postMessage(obj, '*');
-   onmessage = this.step_func(function(e) {
-     assert_not_exists(e.data, "field");
-     this.done();
+   assert_throws(new Error("getter_should_propagate_exceptions"), function() {
+     postMessage(obj, '*');
   });
+  
+  this.done();
 });
 </script>

--- a/webmessaging/without-ports/029.html
+++ b/webmessaging/without-ports/029.html
@@ -1,16 +1,19 @@
 <!doctype html>
-<title>Cloning objects with getter properties</title>
+<title>Check that getters don't linger after deletion wrt cloning</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
 async_test(function() {
    var obj = {};
-   Object.defineProperty(obj, "field", { get: this.step_func(function(){ assert_unreached(); })});
+   obj.__defineGetter__( "a", function(){ return 2; } );
+   obj.__defineSetter__( "a", function(v){ return; } );
+   delete obj.a;
+   obj.a = 2;
 
    postMessage(obj, '*');
    onmessage = this.step_func(function(e) {
-     assert_not_exists(e.data, "field");
+     assert_equals(e.data.a, 2);
      this.done();
   });
 });


### PR DESCRIPTION
Getter property would not be copied during structured-cloning, no Error
is mentioned in the spec (infrastructure.html#structured-clone). The
original case contained 2 independent cases, which can be separated.
