### PR TITLE
WebMessaging__3rd param not Transferable should throw TypeError

### DIFF
--- a/webmessaging/with-ports/025.html
+++ b/webmessaging/with-ports/025.html
@@ -5,9 +5,9 @@
 <div id=log></div>
 <script>
 test(function() {
-  assert_throws(new TypeError(), function() {
-    postMessage('', '*', 1);
-  });
+   assert_throws(new TypeError(), function() {
+      postMessage('', '*', 1);
+   });
 });
 </script>
 

--- a/webmessaging/with-ports/025.html
+++ b/webmessaging/with-ports/025.html
@@ -4,11 +4,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
-async_test(function() {
-  postMessage('', '*', 1);
-  onmessage = this.step_func(function(e) {
-    assert_array_equals(e.ports, []);
-    this.done();
+test(function() {
+  assert_throws(new TypeError(), function() {
+    postMessage('', '*', 1);
   });
 });
 </script>

--- a/webmessaging/with-ports/026.html
+++ b/webmessaging/with-ports/026.html
@@ -5,9 +5,9 @@
 <div id=log></div>
 <script>
 test(function() {
-  assert_throws(new TypeError(), function() {
-  	postMessage('', '*', {length:1});
-  });
+   assert_throws(new TypeError(), function() {
+      postMessage('', '*', {length:1});
+   });
 });
 </script>
 

--- a/webmessaging/with-ports/026.html
+++ b/webmessaging/with-ports/026.html
@@ -4,11 +4,9 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
-async_test(function() {
-  postMessage('', '*', {length:1});
-  onmessage = this.step_func(function(e) {
-    assert_array_equals(e.ports, [null]);
-    this.done();
+test(function() {
+  assert_throws(new TypeError(), function() {
+  	postMessage('', '*', {length:1});
   });
 });
 </script>

--- a/webmessaging/without-ports/025.html
+++ b/webmessaging/without-ports/025.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
-async_test(function() { 
+async_test(function() {
    var ch = new MessageChannel();
    assert_true(ch.port1 instanceof MessagePort, "MessageChannel's port not an instance of MessagePort");
    assert_throws(new TypeError(), function () { var p = new MessagePort();}, "MessagePort is [[Callable]]");

--- a/webmessaging/without-ports/025.html
+++ b/webmessaging/without-ports/025.html
@@ -5,7 +5,6 @@
 <div id=log></div>
 <script>
 async_test(function() { 
-   var obj = { f : function() {}};
    var ch = new MessageChannel();
    assert_true(ch.port1 instanceof MessagePort, "MessageChannel's port not an instance of MessagePort");
    assert_throws(new TypeError(), function () { var p = new MessagePort();}, "MessagePort is [[Callable]]");


### PR DESCRIPTION
- with-ports 025, 026 should throw TypeError when the 3rd param isn't
  Transferable;
- without-ports 025, dont mean to fix the case. Remove the unused var
  obj to avoid confusion in the future.
