### PR TITLE
Added test for Element's custom attributes

### DIFF
--- a/html/dom/elements/global-attributes/custom-attrs.html
+++ b/html/dom/elements/global-attributes/custom-attrs.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Element Custom Attributes</title>
+        <link rel="author" title="Bruno de Oliveira Abinader" href="mailto:bruno.d@partner.samsung.com">
+        <link rel="help" href="https://html.spec.whatwg.org/multipage/dom.html#dom-dataset">
+        <link rel="help" href="https://html.spec.whatwg.org/multipage/#xml">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="/dom/nodes/attributes.js"</script>
+    </head>
+    <body>
+        <h1>Element Custom Attributes</h1>
+        <div id="log"></div>
+        <script>
+            test(function() {
+                var div = document.createElement("div");
+                div.setAttributeNS("foo", "data-my-custom-attr", "first");
+                div.setAttributeNS("bar", "data-my-custom-attr", "second");
+                div.dataset.myCustomAttr = "third";
+
+                assert_equals(div.attributes.length, 3);
+                attributes_are(div, [["data-my-custom-attr", "first", "foo"],
+                                     ["data-my-custom-attr", "second", "bar"],
+                                     ["data-my-custom-attr", "third", null]]);
+            }, "Setting an Element's dataset property should not interfere with namespaced attributes with same name");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Based on a discussion in [1], this tests ensures that Element's dataset
properties does not interfere with namespaced attributes with the same
name, but in different namespaces (in the former case, all Element's
dataset properties are stored as attributes with no namespace).

[1] https://critic.hoppipolla.co.uk/showcomment?chain=8907
