### PR TITLE
When updating manifest from a non-checkout put changes into local_changes section

### DIFF
--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -38,7 +38,7 @@ def get_repo_root():
 manifest_name = "MANIFEST.json"
 ref_suffixes = ["_ref", "-ref"]
 wd_pattern = "*.py"
-blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/"]
+blacklist = ["/", "/tools/", "/resources/", "/common/", "/conformance-checkers/", "_certs"]
 
 
 logging.basicConfig()
@@ -243,7 +243,8 @@ class Manifest(object):
                 for path, items in local_paths.iteritems():
                     paths[path] = items
                 for path in self.local_changes.iterdeleted():
-                    del paths[path]
+                    if path in paths:
+                        del paths[path]
 
             yield item_type, paths
 
@@ -275,20 +276,33 @@ class Manifest(object):
             yield item
 
     def __getitem__(self, path):
-        for _, paths in self._data._included_items():
+        for _, paths in self._included_items():
             if path in paths:
                 return paths[path]
         raise KeyError
+
+    def _committed_with_path(self, rel_path):
+        rv = set()
+        for paths_items in self._data.itervalues():
+            rv |= paths_items.get(rel_path, set())
+        return rv
+
+    def _committed_paths(self):
+        rv = set()
+        for paths_items in self._data.itervalues():
+            rv |= set(paths_items.keys())
+        return rv
 
     def update(self,
                tests_root,
                url_base,
                new_rev,
                committed_changes=None,
-               local_changes=None):
+               local_changes=None,
+               remove_missing_local=False):
 
         if local_changes is None:
-            local_changes = {}
+            local_changes = []
 
         if committed_changes is not None:
             for rel_path, status in committed_changes:
@@ -302,17 +316,29 @@ class Manifest(object):
                     self.extend(manifest_items)
 
         self.local_changes = LocalChanges(self)
-        for rel_path, status in local_changes.iteritems():
+
+        local_paths = set()
+        for rel_path, status in local_changes:
+            local_paths.add(rel_path)
+
             if status == "modified":
-                items = set(get_manifest_items(tests_root,
-                                               rel_path,
-                                               url_base,
-                                               use_committed=False))
-                self.local_changes.extend(items)
+                existing_items = self._committed_with_path(rel_path)
+                local_items = set(get_manifest_items(tests_root,
+                                                     rel_path,
+                                                     url_base,
+                                                     use_committed=False))
+
+                updated_items = local_items - existing_items
+                self.local_changes.extend(updated_items)
             else:
                 self.local_changes.add_deleted(path)
 
-        self.rev = new_rev
+        if remove_missing_local:
+            for path in self._committed_paths() - local_paths:
+                self.local_changes.add_deleted(path)
+
+        if new_rev is not None:
+            self.rev = new_rev
         self.url_base = url_base
 
     def to_json(self):
@@ -702,7 +728,7 @@ class GitTree(TestTree):
         return rv
 
 class NoVCSTree(TestTree):
-    """Subclass that doesn't depend on git but assumes that all changes are comitted"""
+    """Subclass that doesn't depend on git"""
 
     ignore = ["*.py[c|0]", "*~", "#*"]
 
@@ -710,11 +736,8 @@ class NoVCSTree(TestTree):
         return None
 
     def local_changes(self):
-        return None
-
-    def committed_changes(self, base_rev=None):
-        if base_rev is not None:
-            raise ValueError("Tried to update a tree with no VCS against a base_rev")
+        # Put all files into local_changes and rely on Manifest.update to de-dupe
+        # changes that in fact comitted at the base rev.
 
         rv = []
         for dir_path, dir_names, filenames in os.walk(self.tests_root):
@@ -727,6 +750,9 @@ class NoVCSTree(TestTree):
                     continue
                 rv.append((rel_path, "modified"))
         return rv
+
+    def committed_changes(self, base_rev=None):
+        return None
 
 
 def load(manifest_path):
@@ -756,8 +782,10 @@ def update(tests_root, url_base, manifest, ignore_local=False):
 
     if is_git_repo(tests_root):
         tests_tree = GitTree(tests_root, url_base)
+        remove_missing_local = False
     else:
         tests_tree = NoVCSTree(tests_root, url_base)
+        remove_missing_local = not ignore_local
 
     if not ignore_local:
         local_changes = tests_tree.local_changes()
@@ -768,7 +796,8 @@ def update(tests_root, url_base, manifest, ignore_local=False):
                     url_base,
                     tests_tree.current_rev(),
                     tests_tree.committed_changes(manifest.rev),
-                    local_changes)
+                    local_changes,
+                    remove_missing_local=remove_missing_local)
 
 
 def write(manifest, manifest_path):

--- a/tools/scripts/manifest.py
+++ b/tools/scripts/manifest.py
@@ -318,7 +318,7 @@ class Manifest(object):
         self.local_changes = LocalChanges(self)
 
         local_paths = set()
-        for rel_path, status in local_changes:
+        for rel_path, status in local_changes.iteritems():
             local_paths.add(rel_path)
 
             if status == "modified":
@@ -749,7 +749,7 @@ class NoVCSTree(TestTree):
                 if is_blacklisted(rel_path_to_url(rel_path, self.url_base)):
                     continue
                 rv.append((rel_path, "modified"))
-        return rv
+        return dict(rv)
 
     def committed_changes(self, base_rev=None):
         return None


### PR DESCRIPTION
Instead of overwriting manifest entries when updating against a local copy (not clone) of
the tests, put differences into the local_changes section, rather than overwriting the
data about upstream. This makes resyncing changes with upstream easier.
