### PR TITLE
Add some basic manual tests for Gamepad API.

### DIFF
--- a/gamepad/events-manual.html
+++ b/gamepad/events-manual.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+<title>Manual Gamepad events tests</title>
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#the-gamepadconnected-event">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#the-gamepaddisconnected-event">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({explicit_timeout: true});
+
+function set_instructions(text) {
+  document.getElementById("instructions").textContent = text;
+}
+
+var index = -1;
+addEventListener("gamepadconnected", function (e) {
+  assert_equals(index, -1, "Too many connected events?");
+  assert_class_string(e, "GamepadEvent");
+  assert_class_string(e.gamepad, "Gamepad");
+  index = e.gamepad.index;
+  set_instructions("Found a gamepad. Now disconnect the gamepad.");
+});
+addEventListener("gamepaddisconnected", function (e) {
+  assert_class_string(e, "GamepadEvent");
+  assert_equals(e.gamepad.index, index);
+  done();
+});
+</script>
+</head>
+<body>
+<p id="instructions">This test requires a gamepad. Connect one and press any button to start the test.</p>
+</body>
+</html>

--- a/gamepad/getgamepads-polling-manual.html
+++ b/gamepad/getgamepads-polling-manual.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+<title>Manual Gamepad getGamepads polling tests</title>
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({explicit_timeout: true});
+// Poll until we see a gamepad.
+var id = setInterval(function() {
+  var gamepads = navigator.getGamepads();
+  var found = null;
+  for (var i = 0; i < gamepads.length; i++) {
+    if (gamepads[i]) {
+      found = gamepads[i];
+      break;
+    }
+  }
+  if (found) {
+    clearInterval(id);
+    done();
+  }
+}, 15);
+</script>
+</head>
+<body>
+<p>This test requires a gamepad. Connect one and press any button to start the test.</p>
+</body>
+</html>

--- a/gamepad/idlharness-manual.html
+++ b/gamepad/idlharness-manual.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+<title>Manual Gamepad IDL tests</title>
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepad-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadbutton-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadevent-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script>
+setup({explicit_done: true, explicit_timeout: true});
+
+addEventListener("gamepadconnected", function (e) {
+  var idl_array = new IdlArray();
+  idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+  idl_array.add_idls(document.getElementById("idl").textContent);
+  idl_array.add_objects({
+    GamepadEvent: [e],
+    Gamepad: [e.gamepad],
+    GamepadButton: [e.gamepad.buttons[0]],
+    Navigator: ["navigator"],
+  });
+  idl_array.test();
+  done();
+});
+</script>
+</head>
+<body>
+<pre id="untested_idl" style="display: none">
+interface Navigator {
+};
+
+interface Event {
+};
+</pre>
+<pre id="idl" style="display: none">
+interface Gamepad {
+    readonly    attribute DOMString           id;
+    readonly    attribute long                index;
+    readonly    attribute boolean             connected;
+    readonly    attribute DOMHighResTimeStamp timestamp;
+    readonly    attribute GamepadMappingType  mapping;
+    readonly    attribute double[]            axes;
+    readonly    attribute GamepadButton[]     buttons;
+};
+
+enum GamepadMappingType {
+  "",
+  "standard"
+};
+
+interface GamepadButton {
+    readonly    attribute boolean pressed;
+    readonly    attribute double  value;
+};
+
+[Constructor(DOMString type, optional GamepadEventInit eventInitDict)]
+interface GamepadEvent : Event
+{
+  readonly attribute Gamepad? gamepad;
+};
+
+dictionary GamepadEventInit : EventInit
+{
+  Gamepad? gamepad = null;
+};
+
+partial interface Navigator {
+    Gamepad[] getGamepads();
+};
+</pre>
+<p id="instructions">This test requires a gamepad. Connect one and press any button to start the test.</p>
+<div id="log"></div>
+</body>
+</html>

--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+<title>Gamepad IDL tests</title>
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepad-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadbutton-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadevent-interface">
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+</head>
+<body>
+<pre id="untested_idl" style="display: none">
+interface Navigator {
+};
+
+interface Event {
+};
+</pre>
+<pre id="idl" style="display: none">
+interface Gamepad {
+    readonly    attribute DOMString           id;
+    readonly    attribute long                index;
+    readonly    attribute boolean             connected;
+    readonly    attribute DOMHighResTimeStamp timestamp;
+    readonly    attribute GamepadMappingType  mapping;
+    readonly    attribute double[]            axes;
+    readonly    attribute GamepadButton[]     buttons;
+};
+
+enum GamepadMappingType {
+  "",
+  "standard"
+};
+
+interface GamepadButton {
+    readonly    attribute boolean pressed;
+    readonly    attribute double  value;
+};
+
+[Constructor(DOMString type, optional GamepadEventInit eventInitDict)]
+interface GamepadEvent : Event
+{
+  readonly attribute Gamepad? gamepad;
+};
+
+dictionary GamepadEventInit : EventInit
+{
+  Gamepad? gamepad = null;
+};
+
+partial interface Navigator {
+    Gamepad[] getGamepads();
+};
+</pre>
+<script>
+var idl_array = new IdlArray();
+idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+idl_array.add_idls(document.getElementById("idl").textContent);
+idl_array.add_objects({
+    GamepadEvent: [new GamepadEvent("something")],
+    Navigator: ["navigator"],
+  });
+idl_array.test();
+</script>
+<div id="log"></div>
+</body>
+</html>

--- a/gamepad/timestamp-manual.html
+++ b/gamepad/timestamp-manual.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+<title>Manual Gamepad timestamp tests</title>
+<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#widl-Gamepad-timestamp">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({explicit_timeout: true});
+
+function set_instructions(text) {
+  document.getElementById("instructions").textContent = text;
+}
+
+var index = -1;
+var lastTimestamp = performance.now();
+var id = -1;
+addEventListener("gamepadconnected", function (e) {
+  assert_equals(index, -1, "Too many connected events?");
+  index = e.gamepad.index;
+  assert_greater_than(e.gamepad.timestamp, lastTimestamp, "timestamp should be increasing");
+  lastTimestamp = e.gamepad.timestamp;
+  set_instructions("Found a gamepad. Now release the button you pressed and press it again.");
+  // There may not be a button pressed here, so handle it cleanly either way.
+  if (e.gamepad.buttons.some(function (b) { return b.pressed; })) {
+    id = setInterval(waitForButtonRelease, 15);
+  } else {
+    id = setInterval(waitForButtonPress, 15);
+  }
+});
+
+function waitForButtonRelease() {
+  var gamepad = navigator.getGamepads()[index];
+  assert_true(!!gamepad);
+  if (gamepad.buttons.every(function (b) { return !b.pressed; })) {
+    assert_greater_than(gamepad.timestamp, lastTimestamp, "timestamp should be increasing");
+    lastTimestamp = gamepad.timestamp;
+    clearInterval(id);
+    id = setInterval(waitForButtonPress, 15);
+  }
+}
+
+function waitForButtonPress() {
+  var gamepad = navigator.getGamepads()[index];
+  assert_true(!!gamepad);
+  if (gamepad.buttons.some(function (b) { return b.pressed; })) {
+    assert_greater_than(gamepad.timestamp, lastTimestamp, "timestamp should be increasing");
+    clearInterval(id);
+    done();
+  }
+}
+
+</script>
+</head>
+<body>
+<p id="instructions">This test requires a gamepad. Connect one and press any button to start the test.</p>
+</body>
+</html>


### PR DESCRIPTION
I added some very simple manual tests for the Gamepad API. I've run them in Firefox and Chrome. They seem to not work 100% reliably on Chrome when run via /runner/, I'm not sure if that's a bug in Chrome or if the tests need a change to be more reliable. I'll poke a Chrome engineer on that later. When run standalone all 3 tests pass in Chrome, and 2/3 pass in Firefox (Firefox doesn't have Gamepad.timestamp yet).

I'm planning on writing some more tests, specifically around currently underspecified behavior in the spec that needs to be clarified, but this is my first time writing web-platform-tests so I wanted to make sure I'm not doing anything unreasonable first.
