### PR TITLE
navigator.getBattery() test

### DIFF
--- a/battery-status/battery-promise.html
+++ b/battery-status/battery-promise.html
@@ -8,7 +8,7 @@
     function returnBattery() {
         return navigator.getBattery();
     }
-    
+
     promise_test(function () {
         return returnBattery()
           .then(function (result) {

--- a/battery-status/battery-promise.html
+++ b/battery-status/battery-promise.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>navigator.getBattery() - navigator.getBattery()'s returnvalue is Promise<BatteryManager>. </title>
+<link rel="author" title="YuichiNukiyama" href="https://github.com/YuichiNukiyama">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+    function returnBattery() {
+        return navigator.getBattery();
+    }
+    
+    promise_test(function () {
+        return returnBattery()
+          .then(function (result) {
+              assert_class_string(result, "BatteryManager", "getBattery should return BatteryManager Object.");
+          });
+    }, "navigator.getBattery() return BatteryManager");
+
+</script>
+
+<div id="log"></div>


### PR DESCRIPTION
According to Battery Status API CR on 09 December 2014, pepole who want
to use Battery API should use getBattery method. But existing tests are
based on WD and don't use getBattery method. So, I try to test this
method.
