### PR TITLE
SRI allows base64 and unhyphenated digest names

### DIFF
--- a/subresource-integrity/loads-scripts-with-badly-encoded-digest.js
+++ b/subresource-integrity/loads-scripts-with-badly-encoded-digest.js
@@ -1,1 +1,0 @@
-loads_scripts_with_badly_encoded_digest=true;

--- a/subresource-integrity/loads-scripts-with-base64-encoded-sha-digests.js
+++ b/subresource-integrity/loads-scripts-with-base64-encoded-sha-digests.js
@@ -1,0 +1,1 @@
+loads_scripts_with_base64_encoded_sha_digests=true;

--- a/subresource-integrity/loads-scripts-with-unhyphenated-digest-name.js
+++ b/subresource-integrity/loads-scripts-with-unhyphenated-digest-name.js
@@ -1,0 +1,1 @@
+loads_scripts_with_unhyphenated_digest_name=true;

--- a/subresource-integrity/subresource-integrity.html
+++ b/subresource-integrity/subresource-integrity.html
@@ -15,9 +15,6 @@
   var loads_scripts_with_weak_digest_algorithms;
 </script>
 
-<!-- Shouldn't load. Correct URI is ni:///sha-256;ME12ZWwv8POIkFVSgWFgW3sbnHh0DB-Fyb57zYQAFhs -->
-<script src="loads-scripts-with-badly-encoded-digest.js" integrity="ni:///sha-256;ME12ZWwv8POIkFVSgWFgW3sbnHh0DB+Fyb57zYQAFhs"></script>
-
 <!-- Should load -->
 <script src="loads-scripts-with-correct-content-type.js" integrity="ni:///sha-256;ZrrvOG-Kjz4R-FDFrfSQCQC_oMDfc0kQ3DJNd5URlrY?ct=application/javascript"></script>
 
@@ -36,14 +33,17 @@
 <!-- Shouldn't load. MD5 is considered to be a weak algorithm -->
 <script src="loads-scripts-with-weak-digest-algorithms.js" integrity="ni:///md5;XHzXKrCo5jhDN4BvNhs-4A"></script>
 
+<!-- Should load -->
+<script src="loads-scripts-with-base64-encoded-sha-digests.js" integrity="ni:///sha-256;+xc7GxEqWw6VtSIsI5W90RQtOrfjeGD+6WFgxZgiuOw="></script>
+
+<!-- Should load -->
+<script src="loads-scripts-with-unhyphenated-digest-name.js" integrity="ni:///sha256;ZR6E3E_G_B3WNdop4bYFtnXaj5bH02S3znD__KOC8Io"></script>
+
+
 <script>
   function assert_undefined(actual) {
     assert_equals(actual, undefined, "Should be undefined.");
   }
-
-  test(function() {
-    assert_undefined(loads_scripts_with_badly_encoded_digest)
-  }, "Doesn't load scripts with badly encoded digests");
 
   test(function() {
     assert_true(loads_scripts_with_correct_content_type)
@@ -68,4 +68,12 @@
   test(function() {
     assert_undefined(loads_scripts_with_weak_digest_algorithms)
   }, "Doesn't load scripts using weak digest algorithm");
+
+  test(function() {
+    assert_true(loads_scripts_with_base64_encoded_sha_digests)
+  }, "Loads scripts with base64 encoded sha digests");
+
+  test(function() {
+    assert_true(loads_scripts_with_unhyphenated_digest_name)
+  }, "Loads scripts with unhyphenated digest names");
 </script>

--- a/subresource-integrity/support/generate_javascript.py
+++ b/subresource-integrity/support/generate_javascript.py
@@ -5,45 +5,41 @@ import re
 
 JS_DIR = path.normpath(path.join(__file__, "..", ".."))
 
-
+'''
+Yield each file in the javascript directory
+'''
 def js_files():
-    '''
-    Yield each file in the javascript directory
-    '''
-    for f in listdir(JS_DIR):
-        if path.isfile(f) and f.endswith(".js"):
-            yield f
+  for f in listdir(JS_DIR):
+    if path.isfile(f) and f.endswith(".js"):
+      yield f
 
-
+'''
+URL-safe base64 encode a binary digest and strip any padding.
+'''
 def format_digest(digest):
-    '''
-    URL-safe base64 encode a binary digest and strip any padding.
-    '''
-    return urlsafe_b64encode(digest).rstrip("=")
+  return urlsafe_b64encode(digest).rstrip("=")
 
-
+'''
+Generate an encoded sha256 URI.
+'''
 def sha256_uri(content):
-    '''
-    Generate an encoded sha256 URI.
-    '''
-    return "ni:///sha-256;%s" % format_digest(sha256(content).digest())
+  return "ni:///sha-256;%s" % format_digest(sha256(content).digest())
 
-
+'''
+Generate an encoded md5 digest URI.
+'''
 def md5_uri(content):
-    '''
-    Generate an encoded md5 digest URI.
-    '''
-    return "ni:///md5;%s" % format_digest(md5(content).digest())
-
+  return "ni:///md5;%s" % format_digest(md5(content).digest())
 
 def main():
-    for file in js_files():
-        base = path.splitext(path.basename(file))[0]
-        var_name = re.sub(r"[^a-z]", "_", base)
-        content = "%s=true;" % var_name
-        with open(file, "w") as f:
-            f.write(content)
-
+  for file in js_files():
+    print "Generating content for %s" % file
+    base = path.splitext(path.basename(file))[0]
+    var_name = re.sub(r"[^a-z0-9]", "_", base)
+    content = "%s=true;" % var_name
+    with open(file, "w") as f: f.write(content)
+    print "\tSHA256 integrity: %s" % sha256_uri(content)
+    print "\tMD5 integrity:    %s" % md5_uri(content)
 
 if __name__ == "__main__":
-    main()
+  main()


### PR DESCRIPTION
This PR updates the SRI tests to allow for unhyphenated digest names in the `integrity` attribute and to allow normal base64 encoding for digests in addition to web-safe base64 encoding. These changes are based on the discussion in https://github.com/w3c/webappsec/pull/78.

/cc @mozfreddyb @hillbrad 
