### PR TITLE
Compact runner UI & add manifest update animation.

### DIFF
--- a/tools/runner/index.html
+++ b/tools/runner/index.html
@@ -20,55 +20,28 @@
 </header>
 
 <div class="container">
-  <h2>Running Tests</h2>
-  <p>
-    This <em>Test Runner</em> runs some set of
-    <a href="https://github.com/w3c/web-platform-tests/blob/master/README.md">web-platform-tests</a>
-    tests. The set of tests run is configurable via the <em>path</em> field below. Some examples
-    path values are:
-  <ul>
-    <li><code>/</code> - runs all of the tests from the root down</li>
-    <li><code>/websockets</code> - runs all of the
-        <a href="http://w3c-test.org/websockets/">websockets</a> tests</li>
-    <li><code>/websockets/constructor</code> - runs all of the
-        <a href="http://w3c-test.org/websockets/constructor/">websockets/constructor</a> tests</li>
-    <li><code>/html/syntax/parsing</code> - runs all of the HTML syntax parsing tests
-        <a href="http://w3c-test.org/html/syntax/parsing/">html/syntax/parsing</a> tests</li>
-  </ul>
-  <p>
-    If the test runner is run online, the set of tests available to run can be found in the
-    <a href="http://w3c-test.org/">w3c-test.org</a> test repository.
-  <p>
-    Tests will run in a new window. For reftests and manual tests it is recommended to have that
-    window and this window side by side.
-
-
-
   <div id="testControl" class="panel panel-default">
-    <div class='panel-heading'>
-      <h2 class='panel-title'>Runner Options</h2>
-    </div>
     <div class="panel-body">
       <form id='options' class='horizontal-form' onsubmit='return false;'>
-        <p>Include test types:</p>
+
         <div class="form-group">
-          <label for="th" class="col-sm-3 control-label">JavaScript tests</label>
+          <label class="col-sm-3 control-label">Test types to include</label>
           <div class="col-sm-9">
-            <input type=checkbox checked value="testharness" id='th' class='test-type'>
+            <label>
+              <input type=checkbox checked value="testharness" id='th' class='test-type'>
+              JavaScript tests
+            </label>
+            <label>
+              <input type=checkbox checked value="reftest" id='ref' class='test-type'>
+              Reftests
+            </label>
+            <label>
+              <input type=checkbox checked value="manual" id='man' class='test-type'>
+              Manual tests
+            </label>
           </div>
         </div>
-        <div class="form-group">
-          <label for="ref" class="col-sm-3 control-label">Reference tests</label>
-          <div class="col-sm-9">
-            <input type=checkbox checked value="reftest" id='ref' class='test-type'>
-          </div>
-        </div>
-        <div class="form-group">
-          <label for="man" class="col-sm-3 control-label">Manual tests</label>
-          <div class="col-sm-9">
-            <input type=checkbox checked value="manual" id='man' class='test-type'>
-          </div>
-        </div>
+
         <div class="form-group">
           <label for="path" class="col-sm-3 control-label">Run tests under path</label>
           <div class="col-sm-9">
@@ -77,27 +50,27 @@
         </div>
 
         <div class="form-group">
-          <label for="timeout_multiplier" class="col-sm-3 control-label">Timeout Multiplier</label>
+          <label for="timeout_multiplier" class="col-sm-3 control-label">Timeout multiplier</label>
           <div class="col-sm-9">
             <input type=number value="1" id='timeout_multiplier' class='timeout_multiplier form-control'>
           </div>
         </div>
 
         <div class="form-group">
-          <label for="render" class="col-sm-3 control-label">Show output (debug)</label>
+          <label class="col-sm-3 control-label">Debug options</label>
           <div class="col-sm-9">
-            <input type=checkbox id='render' value='render' class='render'>
+            <label>
+              <input type=checkbox id='render' value='render' class='render'>
+              Show output
+            </label>
+            <label>
+              <input type=checkbox id='dumpit'>
+              Dump JSON
+            </label>
           </div>
         </div>
 
         <div class="form-group">
-          <label for="dumpit" class="col-sm-3 control-label">Dump JSON (debug)</label>
-          <div class="col-sm-9">
-            <input type=checkbox id='dumpit'>
-          </div>
-        </div>
-
-        <div class="form-group" style='padding-top: 20px'>
           <div class="col-sm-offset-3 col-sm-9">
             <button type="submit" class="btn btn-success toggleStart" disabled>Start</button>
             <button type='submit' class="btn btn-info togglePause" disabled>Pause</button>
@@ -107,10 +80,33 @@
     </div>
   </div>
 
+  <div class="instructions">
+    <p>
+      To run a set of
+      <a href="https://github.com/w3c/web-platform-tests/blob/master/README.md">web-platform-tests</a>
+      tests, specify a path value in the <b>Run tests under path</b> field above. Example paths:
+    <ul>
+      <li><code>/</code> - runs all of the tests from the root down</li>
+      <li><code>/websockets</code> - runs all of the
+          <a href="http://w3c-test.org/websockets/">websockets</a> tests</li>
+      <li><code>/websockets/constructor</code> - runs all of the
+          <a href="http://w3c-test.org/websockets/constructor/">websockets/constructor</a> tests</li>
+      <li><code>/html/syntax/parsing</code> - runs all of the
+          <a href="http://w3c-test.org/html/syntax/parsing/">html/syntax/parsing</a> tests</li>
+    </ul>
+    <p>
+      If the test runner is run online, the set of tests available to run can be found in the
+      <a href="http://w3c-test.org/">w3c-test.org</a> test repository.
+    <p>
+      Tests will run in a new window. For reftests and manual tests it’s best
+      to put that window side-by-side with this one.
+  </div>
+
   <div id="output">
     <div class="summary clearfix">
-      <h4>Progress</h4>
-      <div id="manifest">Updating and loading test manifest</div>
+      <h4>Progress
+        <span id="manifest">updating and loading test manifest; this may take several minutes</span>
+      </h4>
       <div class="progress">
         <div class="progress-bar" role="progressbar"
              aria-valuenow="0" aria-valuemin="0" aria-valuemax="0" style="width: 0">

--- a/tools/runner/runner.css
+++ b/tools/runner/runner.css
@@ -130,7 +130,7 @@ body {
 }
 
 .horizontal-form .form-group {
-    padding-bottom: 15px;
+    padding: 6px;
 }
 
 header.navbar-inverse {
@@ -159,4 +159,35 @@ td.ERROR {
 }
 .stopped {
     background-image: linear-gradient(to bottom, #fc0000 0, #770000 100%);
+}
+
+.col-sm-9 label {
+    margin-right: 20px;
+}
+
+.instructions {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+@keyframes alert_updating {
+  from {
+    background-color: inherit;
+  }
+  to {
+    background-color: #ffc;
+  }
+}
+
+#manifest {
+  padding-left: 6px;
+  padding-right: 6px;
+  font-size: 80%;
+  font-weight: normal;
+  font-style: italic;
+  color: #999;
+  animation-duration: 1.5s;
+  animation-name: alert_updating;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
 }

--- a/tools/runner/runner.js
+++ b/tools/runner/runner.js
@@ -131,6 +131,7 @@ function VisualOutput(elem, runner) {
     this.meter = this.progress.querySelector(".progress-bar");
     this.result_count = null;
     this.json_results_area = this.elem.querySelector("textarea");
+    this.instructions = document.querySelector(".instructions");
 
     this.elem.style.display = "none";
     this.runner.manifest_wait_callbacks.push(this.on_manifest_wait.bind(this));
@@ -163,12 +164,14 @@ VisualOutput.prototype = {
 
     on_manifest_wait: function() {
         this.clear();
+        this.instructions.style.display = "none";
         this.elem.style.display = "block";
-        this.manifest_status.style.display = "block";
+        this.manifest_status.style.display = "inline";
     },
 
     on_start: function() {
         this.clear();
+        this.instructions.style.display = "none";
         this.elem.style.display = "block";
         this.meter.classList.remove("stopped");
         this.meter.classList.add("progress-striped", "active");


### PR DESCRIPTION
The instructions at the top of the browser-based runner page take up a lot of vertical space and only really need to be shown to users when the page first loads. So this PR moves the instructions to follow the runner (form) controls. After the user starts a test run, the instructions are hidden and just the progress/results are then shown after the runner controls. This seems like better UX to me than showing the instructions all the time.

Also, this PR adds some simple background-color animation to the "updating and loading test manifest" text so that the user knows the runner isn't just hanging. That's to address https://github.com/w3c/web-platform-tests/issues/1372. Again, it seems like better UX to give some kind of progress indicator during that phase.
