### PR TITLE
event.path should include Window object as per W3C bug 21066

### DIFF
--- a/shadow-dom/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
+++ b/shadow-dom/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
@@ -35,13 +35,14 @@ t.step(unit(function(ctx) {
     shadowRoot.appendChild(child);
 
     child.addEventListener('click', t.step_func(function(e) {
-        assert_equals(e.path.length, 6, 'path.length');
+        assert_equals(e.path.length, 7, 'path.length');
         assert_equals(e.path[0], child, 'path[0] should be child');
         assert_equals(e.path[1], shadowRoot, 'path[1] should be shadowRoot');
         assert_equals(e.path[2], host, 'path[2] should be host');
         assert_equals(e.path[3], doc.body, 'path[3] should be body');
         assert_equals(e.path[4], doc.documentElement, 'path[4] should be html');
         assert_equals(e.path[5], doc, 'path[5] should be document');
+        assert_equals(e.path[6], window, 'path[6] should be window');
 
         t.done();
     }));

--- a/shadow-dom/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
+++ b/shadow-dom/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
@@ -42,7 +42,7 @@ t.step(unit(function(ctx) {
         assert_equals(e.path[3], doc.body, 'path[3] should be body');
         assert_equals(e.path[4], doc.documentElement, 'path[4] should be html');
         assert_equals(e.path[5], doc, 'path[5] should be document');
-        assert_equals(e.path[6], window, 'path[6] should be window');
+        assert_equals(e.path[6], ctx.iframes[0].contentWindow, 'path[6] should be window');
 
         t.done();
     }));


### PR DESCRIPTION
[Comment 35 of bug 21066](https://www.w3.org/Bugs/Public/show_bug.cgi?id=21066#c35) pointed out that `event.path` should include `Window` when it's in the path.
