### PR TITLE
Mark Window as a global in webstorage/idlharness.html.

### DIFF
--- a/webstorage/idlharness.html
+++ b/webstorage/idlharness.html
@@ -15,6 +15,7 @@
 <div id="log"></div>
 
 <pre id='untested_idl' style='display:none'>
+[PrimaryGlobal]
 interface Window {
 };
 


### PR DESCRIPTION
This doesn't do anything right now, but will fix some incorrect expectations
once https://github.com/w3c/testharness.js/pull/104 lands.
