### PR TITLE
Fix signature of NoSSLEnvironment.

### DIFF
--- a/tools/sslutils/base.py
+++ b/tools/sslutils/base.py
@@ -7,7 +7,7 @@ def get_logger(name="ssl"):
 class NoSSLEnvironment(object):
     ssl_enabled = False
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         pass
 
     def __enter__(self):


### PR DESCRIPTION
Previously this would throw because it was being passed an unexpected logger.
