### PR TITLE
Update test size.attributes.parse.whitespace.html

### DIFF
--- a/2dcontext/tools/tests.yaml
+++ b/2dcontext/tools/tests.yaml
@@ -198,7 +198,7 @@
         ("empty", "", None),
         ("onlyspace", "  ", None),
         ("space", "  100", 100),
-        ("whitespace", "\r\n\t\f100", 100),
+        ("whitespace", "\n\t\f100", 100),
         ("plus", "+100", 100),
         ("minus", "-100", None),
         ("octal", "0100", 100),

--- a/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
+++ b/html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
@@ -24,8 +24,8 @@ _addTest(function(canvas, ctx) {
 _assertSame(canvas.width, 100, "canvas.width", "100");
 _assertSame(canvas.height, 100, "canvas.height", "100");
 _assertSame(window.getComputedStyle(canvas, null).getPropertyValue("width"), "100px", "window.getComputedStyle(canvas, null).getPropertyValue(\"width\")", "\"100px\"");
-_assertSame(canvas.getAttribute('width'), '\r\n\t\x0c100', "canvas.getAttribute('width')", "'\\r\\n\\t\\x0c100'");
-_assertSame(canvas.getAttribute('height'), '\r\n\t\x0c100', "canvas.getAttribute('height')", "'\\r\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('width'), '\n\t\x0c100', "canvas.getAttribute('width')", "'\\n\\t\\x0c100'");
+_assertSame(canvas.getAttribute('height'), '\n\t\x0c100', "canvas.getAttribute('height')", "'\\n\\t\\x0c100'");
 
 
 });


### PR DESCRIPTION
On linux, the escape character for wrapping is '\n', but the one used in tests is '\r\n' which cannot be recognized,  just change it.
