### PR TITLE
pat 2 - Don't set the 'badInput' state on <input type=email> for punycode encoding failures.

### DIFF
--- a/html/semantics/forms/constraints/form-validation-validity-badInput.html
+++ b/html/semantics/forms/constraints/form-validation-validity-badInput.html
@@ -17,7 +17,7 @@ var testElements = [
         {conditions: {multiple: false, value: ""}, expected: false, name: "[target] The multiple attribute is false and the value attribute is empty"},
         {conditions: {multiple: false, value: "test1@example.com"}, expected: false, name: "[target] The multiple attribute is false and the value attribute is a valid e-mail address"},
         {conditions: {multiple: true, value: "test1@example.com,test2@eample.com"}, expected: false, name: "[target] The multiple attribute is true and the value contains valid e-mail addresses"},
-        {conditions: {multiple: true, value: "test,1@example.com"}, expected: true, name: "[target] The multiple attribute is true and the value attribute contains a ','"}
+        {conditions: {multiple: true, value: "test,1@example.com"}, expected: false, name: "[target] The multiple attribute is true and the value attribute contains a ','"}
         //TODO, the value contains characters that cannot be converted to punycode.
         //Can not find a character that cannot be converted to punycode.
       ]


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1064430
