### PR TITLE
Define a strigifier on the URLUtils interfaces.

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -13,8 +13,12 @@
 
 <!-- URLUtils* stubs -->
 <script type=text/plain class=untested>
-interface URLUtils {};
-interface URLUtilsReadOnly {};
+interface URLUtils {
+  stringifier;
+};
+interface URLUtilsReadOnly {
+  stringifier;
+};
 </script>
 <!-- DOM IDLs -->
 <script type=text/plain class=untested>


### PR DESCRIPTION
This ensures we don't test String() behaviour incorrectly.
