### PR TITLE
Correct open-during-abort.htm.

### DIFF
--- a/XMLHttpRequest/open-during-abort.htm
+++ b/XMLHttpRequest/open-during-abort.htm
@@ -12,8 +12,7 @@
         var client = new XMLHttpRequest(),
             abort_flag = false,
             result = [],
-            expected = [1, 1, 4, 1] // open() => 1, send() => 1,
-                                    // abort => 4, open => 1
+            expected = [1, 4, 1] // open() => 1, abort() => 4, open() => 1
 
         client.onreadystatechange = this.step_func(function() {
           result.push(client.readyState)


### PR DESCRIPTION
It expected a synchronous readystatechange event from the send() method,
which is not dispatched by the specification. (Gecko, Servo and Blink all
pass the test with this change.)
