### PR TITLE
Add a test with an explicit content type header to send-entity-body-none.

### DIFF
--- a/XMLHttpRequest/send-entity-body-none.htm
+++ b/XMLHttpRequest/send-entity-body-none.htm
@@ -16,7 +16,17 @@
         client.send(null)
         assert_equals(client.getResponseHeader("x-request-content-length"), "0")
         assert_equals(client.getResponseHeader("x-request-content-type"), "NO")
-      })
+      }, "No content type")
+
+      test(function() {
+        var client = new XMLHttpRequest()
+        client.open("POST", "resources/content.py", false)
+        var content_type = 'application/x-foo'
+        client.setRequestHeader('Content-Type', content_type)
+        client.send(null)
+        assert_equals(client.getResponseHeader("x-request-content-length"), "0")
+        assert_equals(client.getResponseHeader("x-request-content-type"), content_type)
+      }, "Explicit content type")
     </script>
   </body>
 </html>


### PR DESCRIPTION
This is based on send-entity-body-none-explicit.htm from presto-testo.
