### PR TITLE
Update the reflection test to convert values to a string correctly.

### DIFF
--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -334,7 +334,7 @@ ReflectionTests.typeMap = {
                      {toString:function() {return 2;}, valueOf: null},
                      {valueOf:function() {return 3;}}],
         "domExpected": function(val) {
-            var parsed = ReflectionTests.parseInt(val + "");
+            var parsed = ReflectionTests.parseInt(String(val));
             if (parsed === false || parsed > maxInt || parsed < minInt) {
                 return null;
             }


### PR DESCRIPTION
Per the Web IDL spec, the conversion to DOMString is done by invoking ToString
as defined at
http://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring.  This is
also what
http://people.mozilla.org/~jorendorff/es6-draft.html#sec-string-constructor-string-value
does when called without new.

On the other hand, ""+v as currently used in the test invokes ToPrimitive on
both sides of the addition before invoking ToString on the right-hand side.

For the particular value { valueOf:function() {return 3;} }, ToPrimitive
returns the number 3, so ""+{ valueOf:function() {return 3;} } == "3".

But ToString() on that same value invokes ToPrimitive with the "String" hint,
which will try toString() before trying valueOf().  So ToString({
valueOf:function() {return 3;} }) is "[object Object]", which is not at all the
same thing as "3".
