### PR TITLE
Avoid content type sniffing snafus

### DIFF
--- a/encoding/resources/text-plain-charset.py
+++ b/encoding/resources/text-plain-charset.py
@@ -1,0 +1,3 @@
+def main(request, response):
+  response.headers.set("Content-Type", "text/plain;charset=" + request.GET.first("label"))
+  response.content = "hello encoding"

--- a/encoding/single-byte-decoder.html
+++ b/encoding/single-byte-decoder.html
@@ -86,7 +86,7 @@
      async_test(function(t) {
        var frame = document.createElement("iframe"),
            name = compatibility_names[encoding.name] || encoding.name;
-       frame.src = "resources/single-byte-raw.py?label=" + label
+       frame.src = "resources/text-plain-charset.py?label=" + label
        frame.onload = t.step_func_done(function() {
          assert_equals(frame.contentDocument.characterSet, name)
          assert_equals(frame.contentDocument.inputEncoding, name)


### PR DESCRIPTION
The single-byte-raw.py returns a response body that's a sequence of 256 bytes [0x00, 0x01, ... 0xFE, 0xFF] in a text/plain. When attempting to load the content in a frame, Chrome applies logic akin to https://mimesniff.spec.whatwg.org/#sniffing-a-mislabeled-binary-resource which recognizes that payload as containing binary data bytes and  application/octet-stream, and prompts the user to download the binary file instead.

Since the document.characterSet/document.inputEncoding test doesn't actually care about the content, this change just introduces another python file which returns a textual payload.

Notes to reviewers:
- If the intent of this test was to detect encoding sniffing by the UA, then this is all moot (but we should make that clear)
- text-plain-charset.py returns an ASCII response body. It does not attempt to encode it, so this could lead to confusing behavior if re-used in the future in another test with UTF-16. (Asking python to encode the string fails for some labels unknown to python.)
- We could add a query param flag to single-byte-raw.py instead of adding a new file. I'm happy with either.
