### PR TITLE
Tag Window as [PrimaryGlobal] to get correct attribute assertion

### DIFF
--- a/IndexedDB/interfaces.html
+++ b/IndexedDB/interfaces.html
@@ -20,7 +20,7 @@ setup(function() {
   request.onload = function() {
     var idls = request.responseText;
 
-    idlArray.add_untested_idls("interface Window { };");
+    idlArray.add_untested_idls("[PrimaryGlobal] interface Window { };");
     idlArray.add_untested_idls("interface Event { };");
     idlArray.add_untested_idls("interface EventTarget { };");
 


### PR DESCRIPTION
Without the [PrimaryGlobal] extended attribute on interface Window, the test fails in Firefox with:

Fail    Window interface: attribute indexedDB   assert_true: The prototype object must have a property "indexedDB" expected true got false

... since attributes on the PrimaryGlobal interface should be on the object themselves, but on prototypes for other interfaces. With the extended attribute, the test passes: 100% in Firefox 36! In Chrome (Canary, ~43) that assertion passes, although the test case still fails but due to the attribute not being an accessor (WIP)
