### PR TITLE
CSP: Asterisk (*) wildcard should not allow blob:, data:, or filesystem: when matching source expressions - web platform test update (r=sstamm,jgraham)

### DIFF
--- a/content-security-policy/script-src/buildInlineWorker.js
+++ b/content-security-policy/script-src/buildInlineWorker.js
@@ -1,20 +1,20 @@
 (function ()
 {
- var test = new async_test("test inline worker");
  var workerSource = document.getElementById('inlineWorker');
-
  var blob = new Blob([workerSource.textContent]);
 
  // can I create a new script tag like this? ack...
  var url = window.URL.createObjectURL(blob);
 
- var worker = new Worker(url);
+ try {
+   var worker = new Worker(url);
+ }
+ catch (e) {
+   done();
+ }
 
  worker.addEventListener('message', function(e) {
-    test.step(function () {
-        assert_not_equals(e.data, 'fail', 'inline script ran');
-        test.done();
-    })
+   assert_unreached("script ran");
  }, false);
 
  worker.postMessage('');


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1086999
