### PR TITLE
chunked should send chunk-size as hexdigits

### DIFF
--- a/XMLHttpRequest/resources/chunked.py
+++ b/XMLHttpRequest/resources/chunked.py
@@ -10,7 +10,7 @@ def main(request, response):
     response.write_status_headers()
 
     for value in chunks:
-        response.writer.write("%d\r\n" % len(value))
+        response.writer.write("%x\r\n" % len(value))
         response.writer.write(value)
         response.writer.write("\r\n")
     response.writer.write("0\r\n")


### PR DESCRIPTION
This test has been sending chunk-size as decimal, which is incorrect. So, when writing the first chunk size, it's reported as being `13`. The spec says this is read as a HEX, so all parsers read out `0x13`, which is 19. Parsers then read 19 characters and don't find a CRLF after, and so the encoding is tossed. Instead, the first chunk should claim it's chunk-size as `d`.

In effect, this test would not pass on latest Firefox or Chrome. With this change, it does.
