### PR TITLE
Increase some problematically small timeouts.

### DIFF
--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-aborted.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-aborted.js
@@ -1,4 +1,4 @@
-sif (this.document === undefined)
+if (this.document === undefined)
   importScripts("xmlhttprequest-timeout.js");
 /*
 This sets up three requests:

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-aborted.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-aborted.js
@@ -1,15 +1,15 @@
-if (this.document === undefined)
+sif (this.document === undefined)
   importScripts("xmlhttprequest-timeout.js");
 /*
 This sets up three requests:
-The first request will only be open()ed, not aborted, timeout will be 400 but will never triggered because send() isn't called. 
-After a 1 second delay, the test asserts that no load/error/timeout/abort events fired
+The first request will only be open()ed, not aborted, timeout will be TIME_REGULAR_TIMEOUT but will never triggered because send() isn't called.
+After TIME_NORMAL_LOAD, the test asserts that no load/error/timeout/abort events fired
 
 Second request will be aborted immediately after send(), test asserts that abort fired
 
-Third request is set up to call abort() after a 1 second delay, but it also has a 400ms timeout. Asserts that timeout fired.
-(abort() is called 600ms later and should not fire an abort event per spec. This is untested!)
+Third request is set up to call abort() after TIME_NORMAL_LOAD, but it also has a TIME_REGULAR_TIMEOUT timeout. Asserts that timeout fired.
+(abort() is called later and should not fire an abort event per spec. This is untested!)
 */
 runTestRequests([ new AbortedRequest(false),
-		  new AbortedRequest(true, -1),
-		  new AbortedRequest(true, TIME_NORMAL_LOAD) ]);
+                  new AbortedRequest(true, -1),
+                  new AbortedRequest(true, TIME_NORMAL_LOAD) ]);

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-abortedonmain.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-abortedonmain.js
@@ -1,8 +1,8 @@
 /*
-This test sets up two requests: 
+This test sets up two requests:
 one that gets abort()ed from a 0ms timeout (0ms will obviously be clamped to whatever the implementation's minimal value is), asserts abort event fires
-one that will be aborted after 200ms (TIME_DELAY), (with a timeout at 400ms) asserts abort event fires. Does not assert that the timeout event does *not* fire.
+one that will be aborted after TIME_DELAY, (with a timeout at TIME_REGULAR_TIMEOUT) asserts abort event fires. Does not assert that the timeout event does *not* fire.
 */
 
 runTestRequests([ new AbortedRequest(true, 0),
-		  new AbortedRequest(true, TIME_DELAY) ]);
+                  new AbortedRequest(true, TIME_DELAY) ]);

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-overrides.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-overrides.js
@@ -2,10 +2,10 @@ if (this.document === undefined)
   importScripts("xmlhttprequest-timeout.js");
 /*
 Sets up three requests to a resource that will take 0.6 seconds to load:
-1) timeout first set to 1000ms, after 400ms timeout is set to 0, asserts load fires
-2) timeout first set to 1000ms, after 200ms timeout is set to 400, asserts load fires (race condition..?!?)
-3) timeout first set to 0, after 400ms it is set to 1000, asserts load fires
+1) timeout first set to TIME_NORMAL_LOAD, after TIME_REGULAR_TIMEOUT timeout is set to 0, asserts load fires
+2) timeout first set to TIME_NORMAL_LOAD, after TIME_DELAY timeout is set to TIME_REGULAR_TIMEOUT, asserts load fires (race condition..?!?)
+3) timeout first set to 0, after TIME_REGULAR_TIMEOUT it is set to TIME_REGULAR_TIMEOUT * 10, asserts load fires
 */
 runTestRequests([ new RequestTracker(true, "timeout disabled after initially set", TIME_NORMAL_LOAD, TIME_REGULAR_TIMEOUT, 0),
-		  new RequestTracker(true, "timeout overrides load after a delay", TIME_NORMAL_LOAD, TIME_DELAY, TIME_REGULAR_TIMEOUT),
-		  new RequestTracker(true, "timeout enabled after initially disabled", 0, TIME_REGULAR_TIMEOUT, TIME_NORMAL_LOAD * 10) ]);
+                  new RequestTracker(true, "timeout overrides load after a delay", TIME_NORMAL_LOAD, TIME_DELAY, TIME_REGULAR_TIMEOUT),
+                  new RequestTracker(true, "timeout enabled after initially disabled", 0, TIME_REGULAR_TIMEOUT, TIME_NORMAL_LOAD * 10) ]);

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-overridesexpires.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-overridesexpires.js
@@ -2,11 +2,10 @@ if (this.document === undefined)
   importScripts("xmlhttprequest-timeout.js");
 /*
         Starts three requests:
-        1) XHR to resource which will take a least 600ms with timeout initially set to 1000ms. After 800ms timeout is supposedly reset to 200ms,
+        1) XHR to resource which will take a least TIME_XHR_LOAD ms with timeout initially set to TIME_NORMAL_LOAD ms. After TIME_LATE_TIMEOUT ms timeout is supposedly reset to TIME_DELAY ms,
            but the resource should have finished loading already. Asserts "load" fires.
-        2) XHR with initial timeout set to 1000, after 400ms sets timeout to 300ms. Asserts "timeout" fires.
-           (Originally new value was 200ms. Race condition-y. Setting the new timeout to 300ms would be a better test of the "measured from start of fetching" requirement.)
-        3) XHR with initial timeout set to 200, after 400ms sets timeout to 500ms. Asserts "timeout" fires (the change happens when timeout already fired and the request is done).
+        2) XHR with initial timeout set to TIME_NORMAL_LOAD, after TIME_REGULAR_TIMEOUT sets timeout to TIME_DELAY+100. Asserts "timeout" fires.
+        3) XHR with initial timeout set to TIME_DELAY, after TIME_REGULAR_TIMEOUT sets timeout to 500ms. Asserts "timeout" fires (the change happens when timeout already fired and the request is done).
 */
 runTestRequests([ new RequestTracker(true, "timeout set to expiring value after load fires", TIME_NORMAL_LOAD, TIME_LATE_TIMEOUT, TIME_DELAY),
                   new RequestTracker(true, "timeout set to expired value before load fires", TIME_NORMAL_LOAD, TIME_REGULAR_TIMEOUT, TIME_DELAY+100),

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-overridesexpires.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-overridesexpires.js
@@ -1,13 +1,13 @@
 if (this.document === undefined)
   importScripts("xmlhttprequest-timeout.js");
 /*
-	Starts three requests:
-	1) XHR to resource which will take a least 600ms with timeout initially set to 1000ms. After 800ms timeout is supposedly reset to 200ms, 
-	   but the resource should have finished loading already. Asserts "load" fires.
-	2) XHR with initial timeout set to 1000, after 400ms sets timeout to 300ms. Asserts "timeout" fires. 
-	   (Originally new value was 200ms. Race condition-y. Setting the new timeout to 300ms would be a better test of the "measured from start of fetching" requirement.)
-	3) XHR with initial timeout set to 200, after 400ms sets timeout to 500ms. Asserts "timeout" fires (the change happens when timeout already fired and the request is done).
+        Starts three requests:
+        1) XHR to resource which will take a least 600ms with timeout initially set to 1000ms. After 800ms timeout is supposedly reset to 200ms,
+           but the resource should have finished loading already. Asserts "load" fires.
+        2) XHR with initial timeout set to 1000, after 400ms sets timeout to 300ms. Asserts "timeout" fires.
+           (Originally new value was 200ms. Race condition-y. Setting the new timeout to 300ms would be a better test of the "measured from start of fetching" requirement.)
+        3) XHR with initial timeout set to 200, after 400ms sets timeout to 500ms. Asserts "timeout" fires (the change happens when timeout already fired and the request is done).
 */
 runTestRequests([ new RequestTracker(true, "timeout set to expiring value after load fires", TIME_NORMAL_LOAD, TIME_LATE_TIMEOUT, TIME_DELAY),
-		  new RequestTracker(true, "timeout set to expired value before load fires", TIME_NORMAL_LOAD, TIME_REGULAR_TIMEOUT, TIME_DELAY+100),
-		  new RequestTracker(true, "timeout set to non-expiring value after timeout fires", TIME_DELAY, TIME_REGULAR_TIMEOUT, 500) ]);
+                  new RequestTracker(true, "timeout set to expired value before load fires", TIME_NORMAL_LOAD, TIME_REGULAR_TIMEOUT, TIME_DELAY+100),
+                  new RequestTracker(true, "timeout set to non-expiring value after timeout fires", TIME_DELAY, TIME_REGULAR_TIMEOUT, 500) ]);

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout-runner.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout-runner.js
@@ -1,3 +1,4 @@
+
 function testResultCallbackHandler(event) {
     if (event.data == "done") {
         done();
@@ -16,5 +17,5 @@ function testResultCallbackHandler(event) {
 window.addEventListener("message", testResultCallbackHandler);
 
 // Setting up testharness.js
-setup({ explicit_done: true, timeout: 30 * 1000 });
+setup({ explicit_done: true });
 

--- a/XMLHttpRequest/resources/xmlhttprequest-timeout.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-timeout.js
@@ -11,12 +11,12 @@
    request handlers.
  */
 
-var TIME_NORMAL_LOAD = 1000;
-var TIME_LATE_TIMEOUT = 800;
-var TIME_XHR_LOAD = 600;
-var TIME_REGULAR_TIMEOUT = 400;
-var TIME_SYNC_TIMEOUT = 200;
-var TIME_DELAY = 200;
+var TIME_NORMAL_LOAD = 5000;
+var TIME_LATE_TIMEOUT = 4000;
+var TIME_XHR_LOAD = 3000;
+var TIME_REGULAR_TIMEOUT = 2000;
+var TIME_SYNC_TIMEOUT = 1000;
+var TIME_DELAY = 1000;
 
 /*
  * This should point to a resource that responds with a text/plain resource after a delay of TIME_XHR_LOAD milliseconds.

--- a/XMLHttpRequest/xmlhttprequest-timeout-aborted.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-aborted.html
@@ -12,6 +12,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-abortedonmain.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#event-xhr-abort" data-tested-assertations="../.." />
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol/li[9]"/>
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-overrides.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-overrides.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#timeout-error" data-tested-assertations=".."/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-overridesexpires.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-simple.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-simple.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-synconmain.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-synconmain.html
@@ -6,6 +6,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-timeout-attribute" data-tested-assertations="following::ol[1]/li[1]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::ol[1]/li[10]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-twice.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-twice.html
@@ -10,6 +10,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#timeout-error" data-tested-assertations=".."/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-aborted.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-aborted.html
@@ -12,6 +12,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-overrides.html
@@ -8,6 +8,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#timeout-error" data-tested-assertations=".."/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-overridesexpires.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-overridesexpires.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-simple.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-simple.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>
@@ -19,7 +20,7 @@
     <div id="log"></div>
     <script type="text/javascript">
         var worker = new Worker("resources/xmlhttprequest-timeout-simple.js");
-	worker.onmessage = testResultCallbackHandler;
+        worker.onmessage = testResultCallbackHandler;
     </script>
 </body>
 </html>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-synconworker.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-synconworker.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>

--- a/XMLHttpRequest/xmlhttprequest-timeout-worker-twice.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-worker-twice.html
@@ -9,6 +9,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
     <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
     <link rel="stylesheet" href="/resources/testharness.css" />
+    <meta name=timeout content=long>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="resources/xmlhttprequest-timeout-runner.js"></script>


### PR DESCRIPTION
These tests tend to be intermittent in Firefox debug builds and would probably
also be so on slower hardware.
