### PR TITLE
Make some writable cssom-view attributes that we only allow setting from chrome act the way readonly replaceables would when called from content.

### DIFF
--- a/html/browsers/the-window-object/window-properties.html
+++ b/html/browsers/the-window-object/window-properties.html
@@ -61,6 +61,12 @@ var replaceableAttributes = [
   "scrollY",
   "pageXOffset",
   "pageYOffset",
+  "innerWidth",
+  "innerHeight",
+  "screenX",
+  "screenY",
+  "outerWidth",
+  "outerHeight",
 ];
 
 var methods = [
@@ -116,14 +122,6 @@ var readonlyAttributes = [
 
   // WindowLocalStorage
   "localStorage",
-
-  // CSSOM-View
-  "innerWidth",
-  "innerHeight",
-  "screenX",
-  "screenY",
-  "outerWidth",
-  "outerHeight"
 ];
 
 var writableAttributes = [


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1151940
