### PR TITLE
Increase the timeout for cache-storage tests, a=testonly

### DIFF
--- a/service-workers/cache-storage/serviceworker/cache-match.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.match and Cache.matchAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/serviceworker/cache-put.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-put.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.put</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-match.https.html
+++ b/service-workers/cache-storage/window/cache-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.match and Cache.matchAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-put.https.html
+++ b/service-workers/cache-storage/window/cache-put.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.put</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/worker/cache-match.https.html
+++ b/service-workers/cache-storage/worker/cache-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.match and Cache.matchAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/service-workers/cache-storage/worker/cache-put.https.html
+++ b/service-workers/cache-storage/worker/cache-put.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.put</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-put">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1153521
