### PR TITLE
Throw RangeErrors in TextEncoder/TextDecoder constructors.

### DIFF
--- a/encoding/api-invalid-label.html
+++ b/encoding/api-invalid-label.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Encoding API: invalid label</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var invalidLabel = "invalid-invalidLabel"
+
+test(function() {
+    assert_throws({name: 'RangeError'}, function() { new TextEncoder(invalidLabel); });
+    assert_throws({name: 'RangeError'}, function() { new TextDecoder(invalidLabel); });
+}, 'Invalid label "' + invalidLabel + '" should be rejected by API.');
+
+</script>


### PR DESCRIPTION
Fixes #5620.
Fix the TODOs and FIXMEs to comply with the spec.
Add test case for passing invalid invalid labels.
Update test metadata; three test cases have been resolved upstream and
will be fixed whenever the rust-encoding dependency is sufficiently upgraded.
