### PR TITLE
Use the built-in harness timeout for failing relevant mutations tests ra...

### DIFF
--- a/html/semantics/embedded-content/the-img-element/relevant-mutations.html
+++ b/html/semantics/embedded-content/the-img-element/relevant-mutations.html
@@ -107,10 +107,9 @@ function t(desc, func, expect) {
     var img = document.querySelector('[data-desc="' + desc + '"]');
     img.onload = img.onerror = this.unreached_func('update the image data was run');
     if (expect == 'timeout') {
-      setTimeout(this.step_func_done(), 250);
+      setTimeout(this.step_func_done(), 1000);
     } else {
       img['on' + expect] = this.step_func_done(function() {});
-      setTimeout(this.unreached_func('update the image data was not run'), 250)
     }
     func.call(this, img);
   }, desc);


### PR DESCRIPTION
...ther than an artifically short one.

This test was rather unstable on our infrastructure, and this change is hoped to help with that.
