### PR TITLE
another followup.  Update wpt tests to not expect navigator.taintEnabled() in workers, because we still have a CLOSED TREE

### DIFF
--- a/workers/interfaces.idl
+++ b/workers/interfaces.idl
@@ -96,7 +96,6 @@ interface NavigatorID {
   readonly attribute DOMString appVersion;
   readonly attribute DOMString platform;
   readonly attribute DOMString product; // constant "Gecko"
-  boolean taintEnabled(); // constant false
   readonly attribute DOMString userAgent;
 };
 


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1154878
