### PR TITLE
Ignore window.onerror spew from some implementations

### DIFF
--- a/IndexedDB/idbobjectstore_createIndex6-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex6-event_order.htm
@@ -11,6 +11,9 @@
 <script src=support.js></script>
 
 <script>
+    // Transaction may fire window.onerror in some implementations.
+    setup({allow_uncaught_exception:true});
+
     var db,
       events = [],
       t = async_test(document.title, {timeout: 10000})

--- a/IndexedDB/idbobjectstore_createIndex7-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex7-event_order.htm
@@ -13,6 +13,9 @@
 <script src="support.js"></script>
 
 <script>
+    // Transaction may fire window.onerror in some implementations.
+    setup({allow_uncaught_exception:true});
+
     var db,
       events = [],
       t = async_test(document.title, {timeout: 10000})


### PR DESCRIPTION
Following normal propagation of IDBRequest `error` events and IDBTransaction `abort` events, Firefox fires global error handlers (i.e. `window.onerror`) as a debugging/logging convenience, with the creation point of the request/transaction as the source info and error name as the message.

Error events can be cancelled (via `preventDefault()`). but (per spec) abort events cannot so they will always hit the global error handlers. To avoid harness errors when these go uncaught, tweak the `allow_uncaught_exception` testharness setting.

(Both affected tests currently fail in Firefox due to unrelated reasons, but other implementations are experimenting with `onerror` support for IDB. Tweaking the tests locally to pass in FF shows that the harness error is reported w/o this setup change.)
