### PR TITLE
Fix Worker_terminate_event_queue erroneous failure

### DIFF
--- a/workers/support/WorkerTerminate.js
+++ b/workers/support/WorkerTerminate.js
@@ -2,7 +2,7 @@ onmessage = function(evt)
 {
     for (var i=0; true; i++)
     {
-        if (i%1000 == 1)
+        if (i%1000 == 0)
         {
             postMessage(i);
         }


### PR DESCRIPTION
The Worker_terminate_event_queue test checks that the last message received has the value 10,000 (see [https://github.com/w3c/web-platform-tests/blob/master/workers/Worker_terminate_event_queue.htm](Worker_terminate_event_queue.htm)). However, the messages posted took values which are powers of 1,000 + 1 causing Worker_terminate_event_queue to always fail. This patch fixes the worker to emit values at exact powers of 1,000.
