### PR TITLE
Fix cache-put.https.html to expect Response.text() to set body used.

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -313,12 +313,22 @@ cache_test(function(cache) {
                  '[https://fetch.spec.whatwg.org/#dom-body-bodyused] ' +
                  'Response.bodyUsed should be initially false.');
     return response.text().then(function() {
-      assert_false(
+      assert_true(
         response.bodyUsed,
         '[https://fetch.spec.whatwg.org/#concept-body-consume-body] ' +
-          'The text() method should not set "body passed" flag.');
+          'The text() method should set "body used" flag.');
       return cache.put(new Request(test_url), response);
-    });
+      })
+    .then(function() {
+        assert_unreached('Cache put should reject when Response body ' +
+                         'is already used');
+      })
+    .catch(function(err) {
+        assert_equals(err.name, 'TypeError',
+                      '[https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cache-put] ' +
+                      'Cache put should reject with TypeError when Response ' +
+                      'body is already used.');
+      });
   }, 'Cache.put with a used response body');
 
 done();

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -317,17 +317,12 @@ cache_test(function(cache) {
         response.bodyUsed,
         '[https://fetch.spec.whatwg.org/#concept-body-consume-body] ' +
           'The text() method should set "body used" flag.');
-      return cache.put(new Request(test_url), response);
-      })
-    .then(function() {
-        assert_unreached('Cache put should reject when Response body ' +
-                         'is already used');
-      })
-    .catch(function(err) {
-        assert_equals(err.name, 'TypeError',
-                      '[https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cache-put] ' +
-                      'Cache put should reject with TypeError when Response ' +
-                      'body is already used.');
+      return assert_promise_rejects(
+        cache.put(new Request(test_url), response),
+        new TypeError,
+        '[https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cache-put] ' +
+        'Cache put should reject with TypeError when Response ' +
+        'body is already used.');
       });
   }, 'Cache.put with a used response body');
 


### PR DESCRIPTION
See step 3 of:

  https://fetch.spec.whatwg.org/#concept-body-consume-body
