### PR TITLE
Test for a no-media call.

### DIFF
--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -21,22 +21,19 @@ This test uses no media, and thus does not require fake media devices.
   <script src="/resources/testharnessreport.js"></script>
   <script src="/common/vendor-prefix.js"
           data-prefixed-objects=
-              '[{"ancestors":["navigator"], "name":"getUserMedia"},
-                {"ancestors":["window"], "name":"RTCPeerConnection"},
-                {"ancestors":["window"], "name":"RTCSessionDescription"},
-                {"ancestors":["window"], "name":"RTCIceCandidate"}]'
-          data-prefixed-prototypes=
-               '[{"ancestors":["HTMLMediaElement"],"name":"srcObject"}]'>
+              '[{"ancestors":["window"], "name":"RTCPeerConnection"}]'
+    >
   </script>
   <script type="text/javascript">
-  var test = async_test('Can set up a basic WebRTC call with no data.',
-                        {timeout: 5000});
+  var test = async_test('Can set up a basic WebRTC call with no data.');
 
   var gFirstConnection = null;
   var gSecondConnection = null;
 
   var onOfferCreated = test.step_func(function(offer) {
-    gFirstConnection.setLocalDescription(offer);
+    // TODO: Switch to promise-based interface.
+    gFirstConnection.setLocalDescription(offer, null,
+                                         failed('setLocalDescription first'));
 
     // This would normally go across the application's signaling solution.
     // In our case, the "signaling" is to call this function.
@@ -47,14 +44,17 @@ This test uses no media, and thus does not require fake media devices.
 
     var parsedOffer = new RTCSessionDescription({ type: 'offer',
                                                   sdp: offerSdp });
-    gSecondConnection.setRemoteDescription(parsedOffer);
-
+    // These functions use the legacy interface extensions to RTCPeerConnection.
+    // TODO: Switch to promise-based interfaces.
+    gSecondConnection.setRemoteDescription(parsedOffer, null,
+        failed('setRemoteDescription second'));
     gSecondConnection.createAnswer(onAnswerCreated,
                                    failed('createAnswer'));
   };
 
   var onAnswerCreated = test.step_func(function(answer) {
-    gSecondConnection.setLocalDescription(answer);
+    gSecondConnection.setLocalDescription(answer, null,
+                                          failed('setLocalDescription second'));
 
     // Similarly, this would go over the application's signaling solution.
     handleAnswer(answer.sdp);
@@ -63,32 +63,30 @@ This test uses no media, and thus does not require fake media devices.
   function handleAnswer(answerSdp) {
     var parsedAnswer = new RTCSessionDescription({ type: 'answer',
                                                    sdp: answerSdp });
-    gFirstConnection.setRemoteDescription(parsedAnswer);
+    gFirstConnection.setRemoteDescription(parsedAnswer, null,
+                                          failed('setRemoteDescription first'));
   };
 
-  // Note: the ice candidate handlers are special. We can not wrap them in test
-  // steps since that seems to cause some kind of starvation that prevents the
-  // call of being set up. Unfortunately we cannot report errors in here.
-  var onIceCandidateToFirst = function(event) {
+  var onIceCandidateToFirst = test.step_func(function(event) {
     // If event.candidate is null = no more candidates.
     if (event.candidate) {
       var candidate = new RTCIceCandidate(event.candidate);
       gSecondConnection.addIceCandidate(candidate);
     }
-  };
+  });
 
-  var onIceCandidateToSecond = function(event) {
+  var onIceCandidateToSecond = test.step_func(function(event) {
     if (event.candidate) {
       var candidate = new RTCIceCandidate(event.candidate);
       gFirstConnection.addIceCandidate(candidate);
     }
-  };
+  });
 
   var onRemoteStream = test.step_func(function(event) {
     assert_unreached('WebRTC received a stream when there was none');
   });
 
-  function onIceConnectionStateChange(event) {
+  var onIceConnectionStateChange = test.step_func(function(event) {
     assert_equals(event.type, 'iceconnectionstatechange');
     if (gFirstConnection.iceConnectionState == 'completed' &&
         gSecondConnection.iceConnectionState == 'connected') {
@@ -101,7 +99,7 @@ This test uses no media, and thus does not require fake media devices.
         gSecondConnection.iceConnectionState == 'completed') {
       test.done()
     }
-  }
+  });
 
   // Returns a suitable error callback.
   function failed(function_name) {
@@ -112,17 +110,18 @@ This test uses no media, and thus does not require fake media devices.
 
   // This function starts the test.
   test.step(function() {
-    gFirstConnection = new RTCPeerConnection(null, null);
+    gFirstConnection = new RTCPeerConnection(null);
     gFirstConnection.onicecandidate = onIceCandidateToFirst;
     gFirstConnection.oniceconnectionstatechange = onIceConnectionStateChange;
 
-    gSecondConnection = new RTCPeerConnection(null, null);
+    gSecondConnection = new RTCPeerConnection(null);
     gSecondConnection.onicecandidate = onIceCandidateToSecond;
     gSecondConnection.onaddstream = onRemoteStream;
     gSecondConnection.oniceconnectionstatechange = onIceConnectionStateChange;
 
     // The offerToReceiveVideo is necessary and sufficient to make
     // an actual connection.
+    // TODO: Use a promise-based API. This is legacy.
     gFirstConnection.createOffer(onOfferCreated, failed('createOffer'),
         {offerToReceiveVideo: true});
   });

--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -10,10 +10,8 @@ This test uses no media, and thus does not require fake media devices.
 </head>
 <body>
   <div id="log"></div>
-  <div>
-    <video id="local-view" autoplay="autoplay"></video>
-    <video id="remote-view" autoplay="autoplay"/>
-    </video>
+  <h2>iceConnectionState info</h2>
+  <div id="stateinfo">
   </div>
 
   <!-- These files are in place when executing on W3C. -->
@@ -21,7 +19,8 @@ This test uses no media, and thus does not require fake media devices.
   <script src="/resources/testharnessreport.js"></script>
   <script src="/common/vendor-prefix.js"
           data-prefixed-objects=
-              '[{"ancestors":["window"], "name":"RTCPeerConnection"}]'
+              '[{"ancestors":["window"], "name":"RTCPeerConnection"},
+                {"ancestors":["window"], "name":"RTCSessionDescription"}]'
     >
   </script>
   <script type="text/javascript">
@@ -46,10 +45,12 @@ This test uses no media, and thus does not require fake media devices.
                                                   sdp: offerSdp });
     // These functions use the legacy interface extensions to RTCPeerConnection.
     // TODO: Switch to promise-based interfaces.
-    gSecondConnection.setRemoteDescription(parsedOffer, null,
-        failed('setRemoteDescription second'));
-    gSecondConnection.createAnswer(onAnswerCreated,
-                                   failed('createAnswer'));
+    gSecondConnection.setRemoteDescription(parsedOffer,
+      function() {
+        gSecondConnection.createAnswer(onAnswerCreated,
+                                       failed('createAnswer'));
+      },
+      failed('setRemoteDescription second'));
   };
 
   var onAnswerCreated = test.step_func(function(answer) {
@@ -88,6 +89,20 @@ This test uses no media, and thus does not require fake media devices.
 
   var onIceConnectionStateChange = test.step_func(function(event) {
     assert_equals(event.type, 'iceconnectionstatechange');
+    var stateinfo = document.getElementById('stateinfo');
+    stateinfo.innerHTML = 'First: ' + gFirstConnection.iceConnectionState
+                        + '<br>Second: ' + gSecondConnection.iceConnectionState;
+    // Note: All these combinations are legal states indicating that the
+    // call has connected. All browsers should end up in completed/completed,
+    // but as of this moment, we've chosen to terminate the test early.
+    if (gFirstConnection.iceConnectionState == 'connected' &&
+        gSecondConnection.iceConnectionState == 'connected') {
+      test.done()
+    }
+    if (gFirstConnection.iceConnectionState == 'connected' &&
+        gSecondConnection.iceConnectionState == 'completed') {
+      test.done()
+    }
     if (gFirstConnection.iceConnectionState == 'completed' &&
         gSecondConnection.iceConnectionState == 'connected') {
       test.done()

--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<!--
+This test uses no media, and thus does not require fake media devices.
+-->
+
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>RTCPeerConnection No-Media Connection Test</title>
+</head>
+<body>
+  <div id="log"></div>
+  <div>
+    <video id="local-view" autoplay="autoplay"></video>
+    <video id="remote-view" autoplay="autoplay"/>
+    </video>
+  </div>
+
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/vendor-prefix.js"
+          data-prefixed-objects=
+              '[{"ancestors":["navigator"], "name":"getUserMedia"},
+                {"ancestors":["window"], "name":"RTCPeerConnection"},
+                {"ancestors":["window"], "name":"RTCSessionDescription"},
+                {"ancestors":["window"], "name":"RTCIceCandidate"}]'
+          data-prefixed-prototypes=
+               '[{"ancestors":["HTMLMediaElement"],"name":"srcObject"}]'>
+  </script>
+  <script type="text/javascript">
+  var test = async_test('Can set up a basic WebRTC call with no data.',
+                        {timeout: 5000});
+
+  var gFirstConnection = null;
+  var gSecondConnection = null;
+
+  var onOfferCreated = test.step_func(function(offer) {
+    gFirstConnection.setLocalDescription(offer);
+
+    // This would normally go across the application's signaling solution.
+    // In our case, the "signaling" is to call this function.
+    receiveCall(offer.sdp);
+  });
+
+  function receiveCall(offerSdp) {
+
+    var parsedOffer = new RTCSessionDescription({ type: 'offer',
+                                                  sdp: offerSdp });
+    gSecondConnection.setRemoteDescription(parsedOffer);
+
+    gSecondConnection.createAnswer(onAnswerCreated,
+                                   failed('createAnswer'));
+  };
+
+  var onAnswerCreated = test.step_func(function(answer) {
+    gSecondConnection.setLocalDescription(answer);
+
+    // Similarly, this would go over the application's signaling solution.
+    handleAnswer(answer.sdp);
+  });
+
+  function handleAnswer(answerSdp) {
+    var parsedAnswer = new RTCSessionDescription({ type: 'answer',
+                                                   sdp: answerSdp });
+    gFirstConnection.setRemoteDescription(parsedAnswer);
+  };
+
+  // Note: the ice candidate handlers are special. We can not wrap them in test
+  // steps since that seems to cause some kind of starvation that prevents the
+  // call of being set up. Unfortunately we cannot report errors in here.
+  var onIceCandidateToFirst = function(event) {
+    // If event.candidate is null = no more candidates.
+    if (event.candidate) {
+      var candidate = new RTCIceCandidate(event.candidate);
+      gSecondConnection.addIceCandidate(candidate);
+    }
+  };
+
+  var onIceCandidateToSecond = function(event) {
+    if (event.candidate) {
+      var candidate = new RTCIceCandidate(event.candidate);
+      gFirstConnection.addIceCandidate(candidate);
+    }
+  };
+
+  var onRemoteStream = test.step_func(function(event) {
+    assert_unreached('WebRTC received a stream when there was none');
+  });
+
+  function onIceConnectionStateChange(event) {
+    assert_equals(event.type, 'iceconnectionstatechange');
+    if (gFirstConnection.iceConnectionState == 'completed' &&
+        gSecondConnection.iceConnectionState == 'connected') {
+      test.done()
+    }
+    // Note: This should have been as below.
+    if (gFirstConnection.iceConnectionState == 'completed' &&
+        gSecondConnection.iceConnectionState == 'completed') {
+      test.done()
+    }
+  }
+
+  // Returns a suitable error callback.
+  function failed(function_name) {
+    return test.step_func(function() {
+      assert_unreached('WebRTC called error callback for ' + function_name);
+    });
+  }
+
+  // This function starts the test.
+  test.step(function() {
+    gFirstConnection = new RTCPeerConnection(null, null);
+    gFirstConnection.onicecandidate = onIceCandidateToFirst;
+    gFirstConnection.oniceconnectionstatechange = onIceConnectionStateChange;
+
+    gSecondConnection = new RTCPeerConnection(null, null);
+    gSecondConnection.onicecandidate = onIceCandidateToSecond;
+    gSecondConnection.onaddstream = onRemoteStream;
+    gSecondConnection.oniceconnectionstatechange = onIceConnectionStateChange;
+
+    // The offerToReceiveVideo is necessary and sufficient to make
+    // an actual connection.
+    gFirstConnection.createOffer(onOfferCreated, failed('createOffer'),
+        {offerToReceiveVideo: true});
+  });
+</script>
+
+</body>
+</html>

--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -94,7 +94,9 @@ This test uses no media, and thus does not require fake media devices.
         gSecondConnection.iceConnectionState == 'connected') {
       test.done()
     }
-    // Note: This should have been as below.
+    // Note: This test should have been as below, but second connection
+    // does not reach "completed". This is noted as an issue in the spec.
+    // https://github.com/w3c/webrtc-pc/issues/224
     if (gFirstConnection.iceConnectionState == 'completed' &&
         gSecondConnection.iceConnectionState == 'completed') {
       test.done()

--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -20,7 +20,8 @@ This test uses no media, and thus does not require fake media devices.
   <script src="/common/vendor-prefix.js"
           data-prefixed-objects=
               '[{"ancestors":["window"], "name":"RTCPeerConnection"},
-                {"ancestors":["window"], "name":"RTCSessionDescription"}]'
+                {"ancestors":["window"], "name":"RTCSessionDescription"},
+                {"ancestors":["window"], "name":"RTCIceCandidate"}]'
     >
   </script>
   <script type="text/javascript">
@@ -31,7 +32,7 @@ This test uses no media, and thus does not require fake media devices.
 
   var onOfferCreated = test.step_func(function(offer) {
     // TODO: Switch to promise-based interface.
-    gFirstConnection.setLocalDescription(offer, null,
+    gFirstConnection.setLocalDescription(offer, ignoreSuccess,
                                          failed('setLocalDescription first'));
 
     // This would normally go across the application's signaling solution.
@@ -54,7 +55,7 @@ This test uses no media, and thus does not require fake media devices.
   };
 
   var onAnswerCreated = test.step_func(function(answer) {
-    gSecondConnection.setLocalDescription(answer, null,
+    gSecondConnection.setLocalDescription(answer, ignoreSuccess,
                                           failed('setLocalDescription second'));
 
     // Similarly, this would go over the application's signaling solution.
@@ -64,7 +65,7 @@ This test uses no media, and thus does not require fake media devices.
   function handleAnswer(answerSdp) {
     var parsedAnswer = new RTCSessionDescription({ type: 'answer',
                                                    sdp: answerSdp });
-    gFirstConnection.setRemoteDescription(parsedAnswer, null,
+    gFirstConnection.setRemoteDescription(parsedAnswer, ignoreSuccess,
                                           failed('setRemoteDescription first'));
   };
 
@@ -95,6 +96,7 @@ This test uses no media, and thus does not require fake media devices.
     // Note: All these combinations are legal states indicating that the
     // call has connected. All browsers should end up in completed/completed,
     // but as of this moment, we've chosen to terminate the test early.
+    // TODO: Revise test to ensure completed/completed is reached.
     if (gFirstConnection.iceConnectionState == 'connected' &&
         gSecondConnection.iceConnectionState == 'connected') {
       test.done()
@@ -107,9 +109,6 @@ This test uses no media, and thus does not require fake media devices.
         gSecondConnection.iceConnectionState == 'connected') {
       test.done()
     }
-    // Note: This test should have been as below, but second connection
-    // does not reach "completed". This is noted as an issue in the spec.
-    // https://github.com/w3c/webrtc-pc/issues/224
     if (gFirstConnection.iceConnectionState == 'completed' &&
         gSecondConnection.iceConnectionState == 'completed') {
       test.done()
@@ -121,6 +120,10 @@ This test uses no media, and thus does not require fake media devices.
     return test.step_func(function() {
       assert_unreached('WebRTC called error callback for ' + function_name);
     });
+  }
+
+  // Returns a suitable do-nothing.
+  function ignoreSuccess(function_name) {
   }
 
   // This function starts the test.


### PR DESCRIPTION
This test verifies that a connection is established for a call where
no media is added, but the initiator offers to receive video.

The iceconnectionstate = connected indicator is used to determine
that the connection is established.

(This test submission is also a test on the review process for submitting new tests. Please give feedback as appropriate.)
