### PR TITLE
Fix cache-add.https.html to expect InvalidStateError when overlapping Re...

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -137,8 +137,8 @@ cache_test(function(cache) {
     var request = new Request('../resources/simple.txt');
     return assert_promise_rejects(
       cache.addAll([request, request]),
-      new TypeError(),
-      'Cache.addAll should throw TypeError if the same request is added ' +
+      'InvalidStateError',
+      'Cache.addAll should throw InvalidStateError if the same request is added ' +
       'twice.');
   }, 'Cache.addAll called with the same Request object specified twice');
 


### PR DESCRIPTION
...quests are passed. (gecko bug 1158263)

The spec says:

  3.If the result of running Query Cache algorithm passing operation.request,
    operation.options, and addedRecords as the arguments is not an empty array,
    then:
    1. Throw an "InvalidStateError" exception.

From step 2.3.2.3.1:

  https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#batch-cache-operations-algorithm
