### PR TITLE
Cache add()/addAll() should expect TypeError for invalid scheme. (gecko ...

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -22,8 +22,8 @@ cache_test(function(cache) {
 cache_test(function(cache) {
     return assert_promise_rejects(
       cache.add('javascript://this-is-not-http-mmkay'),
-      'NetworkError',
-      'Cache.add should throw a NetworkError for non-HTTP/HTTPS URLs.');
+      new TypeError(),
+      'Cache.add should throw a TypeError for non-HTTP/HTTPS URLs.');
   }, 'Cache.add called with non-HTTP/HTTPS URL');
 
 cache_test(function(cache) {


### PR DESCRIPTION
...bug 1158265)

For example:

  "If r's url's scheme is not one of "http" and "https", or r's method is not `GET`, return a promise rejected with a TypeError."

In step 3.2 here:

  https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cache-addAll
