### PR TITLE
Fix POST Request handling in cache-storage tests. (gecko bug 1158262)

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -27,7 +27,7 @@ cache_test(function(cache) {
   }, 'Cache.add called with non-HTTP/HTTPS URL');
 
 cache_test(function(cache) {
-    var request = new Request('../resources/simple.txt', {method: 'POST', body: 'Hello'});
+    var request = new Request('../resources/simple.txt');
     return cache.add(request)
       .then(function(result) {
           assert_equals(result, undefined,
@@ -36,28 +36,18 @@ cache_test(function(cache) {
   }, 'Cache.add called with Request object');
 
 cache_test(function(cache) {
-    var request = new Request('../resources/simple.txt', {method: 'POST', body: 'Hello'});
-    return request.text()
-      .then(function() {
-          assert_false(request.bodyUsed);
-        })
-      .then(function() {
-          return cache.add(request);
-        });
-  }, 'Cache.add called with Request object with a used body');
-
-cache_test(function(cache) {
-    var request = new Request('../resources/simple.txt', {method: 'POST', body: 'Hello'});
+    var request = new Request('../resources/simple.txt');
     return cache.add(request)
       .then(function(result) {
           assert_equals(result, undefined,
                         'Cache.add should resolve with undefined on success.');
         })
       .then(function() {
-          return assert_promise_rejects(
-            cache.add(request),
-            new TypeError(),
-            'Cache.add should throw TypeError if same request is added twice.');
+          return cache.add(request);
+        })
+      .then(function(result) {
+          assert_equals(result, undefined,
+                        'Cache.add should resolve with undefined on success.');
         });
   }, 'Cache.add called twice with the same Request object');
 

--- a/service-workers/cache-storage/script-tests/cache-delete.js
+++ b/service-workers/cache-storage/script-tests/cache-delete.js
@@ -43,8 +43,8 @@ cache_test(function(cache) {
   }, 'Cache.delete called with a string URL');
 
 cache_test(function(cache) {
-    var request = new Request(test_url, { method: 'POST', body: 'Abc' });
-    return cache.put(request.clone(), new_test_response())
+    var request = new Request(test_url);
+    return cache.put(request, new_test_response())
       .then(function() {
           return cache.delete(request);
         })
@@ -52,32 +52,8 @@ cache_test(function(cache) {
           assert_true(result,
                       'Cache.delete should resolve with "true" if an entry ' +
                       'was successfully deleted.');
-          assert_false(request.bodyUsed,
-                       'Cache.delete should not consume request body.');
         });
   }, 'Cache.delete called with a Request object');
-
-cache_test(function(cache) {
-    var request = new Request(test_url, { method: 'POST', body: 'Abc' });
-    return cache.put(request.clone(), new_test_response())
-      .then(function() {
-          return request.text();
-        })
-      .then(function() {
-          assert_true(request.bodyUsed,
-                      '[https://fetch.spec.whatwg.org/#body-mixin] ' +
-                      'Request.bodyUsed should be true after text() method ' +
-                      'resolves.');
-        })
-      .then(function() {
-          return cache.delete(request);
-        })
-      .then(function(result) {
-          assert_true(result,
-                      'Cache.delete should resolve with "true" if an entry ' +
-                      'was successfully deleted.');
-        });
-  }, 'Cache.delete with a Request object containing used body');
 
 cache_test(function(cache) {
     return cache.delete(test_url)

--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -442,8 +442,8 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
     var request = new Request(entries.a.request, { method: 'POST' });
     return cache.match(request)
       .then(function(result) {
-          assert_object_equals(result, undefined,
-                               'Cache.match should not find a match');
+          assert_equals(result, undefined,
+                        'Cache.match should not find a match');
         });
   }, 'Cache.match with POST Request');
 

--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -181,32 +181,6 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
         });
   }, 'Cache.match with new Request');
 
-cache_test(function(cache) {
-    var request = new Request('https://example.com/foo', {
-        method: 'POST',
-        body: 'Hello world!'
-      });
-    var response = new Response('Booyah!', {
-        status: 200,
-        headers: {'Content-Type': 'text/plain'}
-      });
-
-    return cache.put(request.clone(), response.clone())
-      .then(function() {
-          assert_false(
-            request.bodyUsed,
-            '[https://fetch.spec.whatwg.org/#concept-body-used-flag] ' +
-            'Request.bodyUsed flag should be initially false.');
-        })
-      .then(function() {
-          return cache.match(request);
-        })
-      .then(function(result) {
-          assert_false(request.bodyUsed,
-                       'Cache.match should not consume Request body.');
-        });
-  }, 'Cache.match with Request containing non-empty body');
-
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.a.request,
                           {ignoreSearch: true})
@@ -463,6 +437,15 @@ cache_test(function(cache) {
                         'valid body each time it is called.');
         });
   }, 'Cache.match invoked multiple times for the same Request/Response');
+
+prepopulated_cache_test(simple_entries, function(cache, entries) {
+    var request = new Request(entries.a.request, { method: 'POST' });
+    return cache.match(request)
+      .then(function(result) {
+          assert_object_equals(result, undefined,
+                               'Cache.match should not find a match');
+        });
+  }, 'Cache.match with POST Request');
 
 // Helpers ---
 

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -68,29 +68,6 @@ cache_test(function(cache) {
   }, 'Cache.put with Response without a body');
 
 cache_test(function(cache) {
-    var request = new Request(test_url, {
-        method: 'POST',
-        body: 'Hello'
-      });
-    var response = new Response(test_body);
-    assert_false(request.bodyUsed,
-                 '[https://fetch.spec.whatwg.org/#dom-body-bodyused] ' +
-                 'Request.bodyUsed should be initially false.');
-    return cache.put(request, response.clone())
-      .then(function() {
-          assert_true(request.bodyUsed,
-                       'Cache.put should consume Request body.');
-        })
-      .then(function() {
-          return cache.match(request);
-        })
-      .then(function(result) {
-          assert_object_equals(result, response,
-                               'Cache.put should store response body.');
-        });
-  }, 'Cache.put with Request containing a body');
-
-cache_test(function(cache) {
     var request = new Request(test_url);
     var response = new Response(test_body);
     return cache.put(request, response.clone())
@@ -294,18 +271,11 @@ cache_test(function(cache) {
 
 cache_test(function(cache) {
     var request = new Request(test_url, {method: 'POST', body: test_body});
-    assert_false(request.bodyUsed,
-                 '[https://fetch.spec.whatwg.org/#dom-body-bodyused] ' +
-                 'Request.bodyUsed should be initially false.');
-    var copy = new Request(request);
-    assert_true(request.bodyUsed,
-                '[https://fetch.spec.whatwg.org/#dom-request] ' +
-                'Request constructor should set input\'s used flag.');
     return assert_promise_rejects(
       cache.put(request, new Response(test_body)),
       new TypeError(),
-      'Cache.put should throw a TypeError for a request with used body.');
-  }, 'Cache.put with a used request body');
+      'Cache.put should throw a TypeError for a POST request.');
+  }, 'Cache.put with a POST request');
 
 cache_test(function(cache) {
     var response = new Response(test_body);


### PR DESCRIPTION
The Cache API spec previously allowed storing POST Requests with a body,
but no longer does.  This means that Request bodies cannot be stored at
all any more in Cache.

For example:

  "If r's url's scheme is not one of "http" and "https", or r's method is not `GET`, return a promise rejected with a TypeError."

In step 2.2 here:

  https://slightlyoff.github.io/ServiceWorker/spec/service_worker/index.html#cache-put
