### PR TITLE
Remove the timeout calls from media-source tests.

### DIFF
--- a/media-source/mediasource-config-changes.js
+++ b/media-source/mediasource-config-changes.js
@@ -97,5 +97,5 @@ function mediaSourceConfigChangeTest(directory, idA, idB, description)
                 });
             });
         });
-    }, description, { timeout: 10000 } );
+    }, description);
 };

--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -211,7 +211,7 @@
                       test.done();
                   });
               });
-          }, 'Test setting same duration multiple times does not fire duplicate durationchange', {timeout: 2500});
+          }, 'Test setting same duration multiple times does not fire duplicate durationchange');
         </script>
     </body>
 </html>

--- a/media-source/mediasource-getvideoplaybackquality.html
+++ b/media-source/mediasource-getvideoplaybackquality.html
@@ -65,7 +65,7 @@
                   assert_greater_than(timeUpdateCount, 2, "timeUpdateCount");
                   test.done();
               });
-          }, "Test HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API", {timeout: 5000});
+          }, "Test HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-play.html
+++ b/media-source/mediasource-play.html
@@ -38,7 +38,7 @@
                   mediaSource.endOfStream();
                   mediaElement.play();
               });
-          }, "Test normal playback case with MediaSource API", {timeout: 5000});
+          }, "Test normal playback case with MediaSource API");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-seek-during-pending-seek.html
+++ b/media-source/mediasource-seek-during-pending-seek.html
@@ -63,7 +63,7 @@
                   test.done();
               });
 
-          }, 'Test seeking to a new location before transitioning beyond HAVE_METADATA.', {timeout: 10000} );
+          }, 'Test seeking to a new location before transitioning beyond HAVE_METADATA.');
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
@@ -136,7 +136,7 @@
                   assert_greater_than(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA, 'Greater than HAVE_CURRENT_DATA');
                   test.done();
               });
-          }, 'Test seeking to a new location during a pending seek.', {timeout: 10000} );
+          }, 'Test seeking to a new location during a pending seek.');
         </script>
     </body>
 </html>

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -1,6 +1,4 @@
 (function(window) {
-    setup({ timeout: 12000 });
-
     var SEGMENT_INFO_LIST = [
 	{
 	    url: 'mp4/test.mp4',


### PR DESCRIPTION
These only evere reduce the timeout, never increase it, so they are unnecessary
now.
