### PR TITLE
Fix test of Blob.length

### DIFF
--- a/FileAPI/blob/Blob-constructor.html
+++ b/FileAPI/blob/Blob-constructor.html
@@ -16,7 +16,7 @@ is ongoing that will affect a number of the following tests.</strong>
 <script>
 test(function() {
   assert_true("Blob" in window, "window should have a Blob property.");
-  assert_equals(Blob.length, 2, "Blob.length should be 2.");
+  assert_equals(Blob.length, 0, "Blob.length should be 0.");
   assert_true(Blob instanceof Function, "Blob should be a function.");
 }, "Blob interface object");
 


### PR DESCRIPTION
The length of an interface is the length of the shortest list of arguments from the overload set of its constructor.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/1804)

<!-- Reviewable:end -->
