### PR TITLE
Make all CacheStorage tests use long timeout due to variable disk latenc...

### DIFF
--- a/service-workers/cache-storage/serviceworker/cache-add.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-add.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.add and Cache.addAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/serviceworker/cache-delete.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-delete.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.delete</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-storage-keys.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage.keys</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/serviceworker/cache-storage-match.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-storage-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage.match</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/serviceworker/cache-storage.https.html
+++ b/service-workers/cache-storage/serviceworker/cache-storage.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../service-workers/resources/test-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-add.https.html
+++ b/service-workers/cache-storage/window/cache-add.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.add and Cache.addAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-delete.https.html
+++ b/service-workers/cache-storage/window/cache-delete.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Cache.delete</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-storage-keys.https.html
+++ b/service-workers/cache-storage/window/cache-storage-keys.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage.keys</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-storage-match.https.html
+++ b/service-workers/cache-storage/window/cache-storage-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage.match</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/cache-storage.https.html
+++ b/service-workers/cache-storage/window/cache-storage.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: CacheStorage</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/window/sandboxed-iframes.https.html
+++ b/service-workers/cache-storage/window/sandboxed-iframes.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Verify access in sandboxed iframes</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>

--- a/service-workers/cache-storage/worker/cache-add.https.html
+++ b/service-workers/cache-storage/worker/cache-add.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.add and Cache.addAll</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-add">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/service-workers/cache-storage/worker/cache-delete.https.html
+++ b/service-workers/cache-storage/worker/cache-delete.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache.delete</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-delete">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/service-workers/cache-storage/worker/cache-storage-keys.https.html
+++ b/service-workers/cache-storage/worker/cache-storage-keys.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage.keys</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/service-workers/cache-storage/worker/cache-storage-match.https.html
+++ b/service-workers/cache-storage/worker/cache-storage-match.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage.match</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage-match">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/service-workers/cache-storage/worker/cache-storage.https.html
+++ b/service-workers/cache-storage/worker/cache-storage.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>CacheStorage</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>


### PR DESCRIPTION
...y in automation.

We are seeing test timeouts in a number of these tests in automation.  For example:

  https://bugzilla.mozilla.org/show_bug.cgi?id=1161055
  https://bugzilla.mozilla.org/show_bug.cgi?id=1160389

Increasing the timeout to long seems to avoid these failures:

  https://treeherder.mozilla.org/#/jobs?repo=try&revision=3ee720899303

Note, the failures in cache-match.https.html in that run are likely due to a different, legitimate problem in gecko.

I think using a long timeout for all Cache API tests is reasonable since performance will be quite variable in automated tests due to disk performance on things like AWS.
