### PR TITLE
Various minor fixes to IndexedDB tests

### DIFF
--- a/IndexedDB/idbcursor_advance_index.htm
+++ b/IndexedDB/idbcursor_advance_index.htm
@@ -16,7 +16,7 @@
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
-        db = event.target.result;
+        db = e.target.result;
         var store = db.createObjectStore("test", {keyPath:"pKey"});
         store.createIndex("idx", "iKey");
 

--- a/IndexedDB/idbcursor_advance_objectstore.htm
+++ b/IndexedDB/idbcursor_advance_objectstore.htm
@@ -16,7 +16,7 @@
 
     var open_rq = createdb(t);
     open_rq.onupgradeneeded = function(e) {
-        db = event.target.result;
+        db = e.target.result;
         var store = db.createObjectStore("test", {keyPath:"pKey"});
 
         for(var i = 0; i < records.length; i++) {

--- a/IndexedDB/idbdatabase_close.htm
+++ b/IndexedDB/idbdatabase_close.htm
@@ -29,7 +29,7 @@ open_rq.onsuccess = function(e) {
         upgradeneeded_fired = counter++;
     });
     rq.onsuccess = t.step_func(function (e) {
-        assert_equals(versionchange_fired, 0, 'block event fired #')
+        assert_equals(versionchange_fired, 0, 'versionchange event fired #')
         assert_equals(blocked_fired, 1, 'block event fired #')
         assert_equals(upgradeneeded_fired, 2, 'second upgradeneeded event fired #')
 

--- a/IndexedDB/idbdatabase_createObjectStore11.htm
+++ b/IndexedDB/idbdatabase_createObjectStore11.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>IDBDatabase.createObjectStore() - Attampt Create Exsists Object Store With Difference keyPath throw ConstraintError </title>
+<title>IDBDatabase.createObjectStore() - attempting to create an existing object store with a different keyPath throw ConstraintError </title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#widl-IDBDatabase-createObjectStore-IDBObjectStore-DOMString-name-IDBObjectStoreParameters-optionalParameters">
 <script src="/resources/testharness.js"></script>

--- a/IndexedDB/idbfactory_open9.htm
+++ b/IndexedDB/idbfactory_open9.htm
@@ -47,7 +47,7 @@ should_throw({
 
 function should_work(val) {
     var t = async_test("Calling open() with version argument 1.5 should not throw.")
-    var rq = createdb(t)
+    var rq = createdb(t, val)
     rq.onupgradeneeded = function() {
         t.done()
     }

--- a/IndexedDB/idbobjectstore_openCursor.htm
+++ b/IndexedDB/idbobjectstore_openCursor.htm
@@ -25,11 +25,14 @@
         txn.objectStore("store")
            .openCursor().onsuccess = this.step_func(function(e)
         {
-            if (e.target.result)
+            if (e.target.result) {
+                count += 1;
                 e.target.result.continue()
+            }
         })
 
         txn.oncomplete = this.step_func(function() {
+            assert_equals(count, 100);
             this.done()
         })
     }

--- a/IndexedDB/idbtransaction_abort.htm
+++ b/IndexedDB/idbtransaction_abort.htm
@@ -7,7 +7,6 @@
 <script src=support.js></script>
 
 <script>
-    // TODO XXX DO THE IDBTransaction abort test here here
     var db, aborted,
       t = async_test(document.title, {timeout: 10000}),
       record = { indexedProperty: "bar" };

--- a/IndexedDB/idbversionchangeevent.htm
+++ b/IndexedDB/idbversionchangeevent.htm
@@ -36,7 +36,7 @@
 
             // Errors
             db.onerror = fail(t, "db.error");
-            db.abort = fail(t, "db.abort");
+            db.onabort = fail(t, "db.abort");
 
             setTimeout(t.step_func(deleteDB), 10);
         });


### PR DESCRIPTION
This fixes a few minor problems I noticed when making https://github.com/dumbmatter/fakeIndexedDB

A couple tests weren't actually testing what they seemed intended to test (idbfactory_open9.htm and idbobjectstore_openCursor.htm). And there were a few typos that probably only affect clarity and error cases.
