### PR TITLE
Hillbrad/new format sri

### DIFF
--- a/subresource-integrity/crossorigin-anon.js
+++ b/subresource-integrity/crossorigin-anon.js
@@ -1,0 +1,1 @@
+crossorigin_anon=true;

--- a/subresource-integrity/crossorigin-anon.js.headers
+++ b/subresource-integrity/crossorigin-anon.js.headers
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *

--- a/subresource-integrity/crossorigin-creds.js
+++ b/subresource-integrity/crossorigin-creds.js
@@ -1,0 +1,1 @@
+crossorigin_creds=true;

--- a/subresource-integrity/crossorigin-creds.js.sub.headers
+++ b/subresource-integrity/crossorigin-creds.js.sub.headers
@@ -1,0 +1,2 @@
+Access-Control-Allow-Origin: http://{{domains[]}}:{{ports[http][0]}}
+Access-Control-Allow-Credentials: true

--- a/subresource-integrity/crossorigin-ineligible.js
+++ b/subresource-integrity/crossorigin-ineligible.js
@@ -1,0 +1,1 @@
+crossorigin_ineligible=true;

--- a/subresource-integrity/loads-scripts-with-base64-encoded-sha-digests.js
+++ b/subresource-integrity/loads-scripts-with-base64-encoded-sha-digests.js
@@ -1,1 +1,0 @@
-loads_scripts_with_base64_encoded_sha_digests=true;

--- a/subresource-integrity/loads-scripts-with-correct-content-type.js
+++ b/subresource-integrity/loads-scripts-with-correct-content-type.js
@@ -1,1 +1,0 @@
-loads_scripts_with_correct_content_type=true;

--- a/subresource-integrity/loads-scripts-with-improper-integrity-uri-scheme.js
+++ b/subresource-integrity/loads-scripts-with-improper-integrity-uri-scheme.js
@@ -1,1 +1,0 @@
-loads_scripts_with_improper_integrity_uri_scheme=true;

--- a/subresource-integrity/loads-scripts-with-incorrect-content-type.js
+++ b/subresource-integrity/loads-scripts-with-incorrect-content-type.js
@@ -1,1 +1,0 @@
-loads_scripts_with_incorrect_content_type=true;

--- a/subresource-integrity/loads-scripts-with-matching-digest.js
+++ b/subresource-integrity/loads-scripts-with-matching-digest.js
@@ -1,1 +1,0 @@
-loads_scripts_with_matching_digest=true;

--- a/subresource-integrity/loads-scripts-with-non-matching-digest.js
+++ b/subresource-integrity/loads-scripts-with-non-matching-digest.js
@@ -1,1 +1,0 @@
-loads_scripts_with_non_matching_digest=true;

--- a/subresource-integrity/loads-scripts-with-unhyphenated-digest-name.js
+++ b/subresource-integrity/loads-scripts-with-unhyphenated-digest-name.js
@@ -1,1 +1,0 @@
-loads_scripts_with_unhyphenated_digest_name=true;

--- a/subresource-integrity/loads-scripts-with-weak-digest-algorithms.js
+++ b/subresource-integrity/loads-scripts-with-weak-digest-algorithms.js
@@ -1,1 +1,0 @@
-loads_scripts_with_weak_digest_algorithms=true;

--- a/subresource-integrity/matching-digest.js
+++ b/subresource-integrity/matching-digest.js
@@ -1,0 +1,1 @@
+matching_digest=true;

--- a/subresource-integrity/non-matching-digest.js
+++ b/subresource-integrity/non-matching-digest.js
@@ -1,0 +1,1 @@
+non_matching_digest=true;

--- a/subresource-integrity/refresh-header.js
+++ b/subresource-integrity/refresh-header.js
@@ -1,0 +1,1 @@
+refresh_header=true;

--- a/subresource-integrity/refresh-header.js.headers
+++ b/subresource-integrity/refresh-header.js.headers
@@ -1,0 +1,1 @@
+Refresh: 0; url=http://w3c-test.org/

--- a/subresource-integrity/subresource-integrity.html
+++ b/subresource-integrity/subresource-integrity.html
@@ -6,74 +6,176 @@
 <div id="log"></div>
 
 <script>
-  var loads_scripts_with_badly_encoded_digest;
-  var loads_scripts_with_correct_content_type;
-  var loads_scripts_with_improper_integrity_uri_scheme;
-  var loads_scripts_with_incorrect_content_type;
-  var loads_scripts_with_matching_digest;
-  var loads_scripts_with_non_matching_digest;
-  var loads_scripts_with_weak_digest_algorithms;
+  var xorigin_anon = location.protocol
+    + '//www1.' + location.hostname + ':' + location.port 
+    + '/subresource-integrity/crossorigin-anon.js';
+
+  var xorigin_creds = location.protocol
+    + '//www1.' + location.hostname + ':' + location.port 
+    + '/subresource-integrity/crossorigin-creds.js';
+
+  var xorigin_ineligible = location.protocol
+    + '//www1.' + location.hostname + ':' + location.port 
+    + '/subresource-integrity/crossorigin-ineligible.js';
+
+    var SRIScriptTest = function(pass, name, src, integrityValue, crossoriginValue) {
+        this.pass = pass;
+        this.name = name;
+        this.src = src;
+        this.integrityValue = integrityValue;
+        this.crossoriginValue = crossoriginValue;
+    }
+
+    SRIScriptTest.prototype.execute = function() {
+        var test = async_test(this.name);
+        var e = document.createElement("script");
+        e.src = this.src;
+        e.setAttribute("integrity", this.integrityValue);
+        if(this.crossoriginValue) {
+            e.setAttribute("crossorigin", this.crossoriginValue);
+        }
+        if(this.pass) {
+            e.addEventListener("load", function() {test.done()});
+            e.addEventListener("error", function() {
+                test.step(function(){ assert_unreached("Good load fired error handler.") })
+            });
+        } else {
+           e.addEventListener("load", function() {
+                test.step(function() { assert_unreached("Bad load succeeded.") })
+            });
+           e.addEventListener("error", function() {test.done()});
+        }
+        document.body.appendChild(e);
+    };
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with correct hash.",
+        "matching-digest.js",
+        "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E="
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "Same-origin script with incorrect hash.",
+        "non-matching-digest.js",
+        "sha256-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with multiple sha256 hashes, including correct.",
+        "matching-digest.js",
+        "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E= sha256-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with multiple sha256 hashes, including unknown algorithm.",
+        "matching-digest.js",
+        "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E= foo666-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"
+    ).execute();
+    
+    // TODO may need to change these to hash-source prefix, e.g. 'sha256' instead of 'SHA-256'
+
+    test(function() {assert_equals(getPrioritizedHashFunction('SHA-512', 'SHA-256'), 'SHA-512')},
+        "SHA-512 preferred to SHA-256.");
+
+    test(function() {assert_equals(getPrioritizedHashFunction('SHA-384', 'SHA-512'), 'SHA-512')},
+        "SHA-512 preferred to SHA-384.");
+
+    test(function() {assert_equals(getPrioritizedHashFunction('SHA-384', 'SHA-256'), 'SHA-384')},
+        "SHA-384 preferred to SHA-256.");
+
+    test(function() {assert_equals(getPrioritizedHashFunction('MD5', 'SHA-256'), 'SHA-256')},
+        "SHA-256 preferred to MD5.");
+
+    test(function() {assert_equals(getPrioritizedHashFunction('SHA-256', 'SHA-256'), '')},
+        "getPrioritizedHashFunction('SHA-256', 'SHA-256') returns empty string");
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with sha256 mismatch, sha512 match",
+        "matching-digest.js",
+        "sha512-geByvIIRspbnUnwooKGNNCb39nvg+EW0O9hDScTXeo/9pVZztLSUYU3LNV6H0lZapo8bCJUpyPPLAzE9fDzpxg== sha256-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "Same-origin script with sha256 match, sha512 mismatch",
+        "matching-digest.js",
+        "sha512-deadbeefspbnUnwooKGNNCb39nvg+EW0O9hDScTXeo/9pVZztLSUYU3LNV6H0lZapo8bCJUpyPPLAzE9fDzpxg== sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E="
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "<crossorigin='anonymous'> with correct hash, ACAO: *",
+        xorigin_anon,
+        "sha256-r6KBpvzfcSLlbFZCj1OACLxTxVck2TOrBTEdUbwz1yU=",
+        "anonymous"
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "<crossorigin='anonymous'> with incorrect hash, ACAO: *",
+        xorigin_anon,
+        "sha256-deadbeefcSLlbFZCj1OACLxTxVck2TOrBTEdUbwz1yU=",
+        "anonymous"
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "<crossorigin='use-credentials'> with correct hash, CORS-eligible",
+        xorigin_creds,
+        "sha256-sPICZvGN2S+pTRZgiw3DWrhC6JLDlt2zRyGpwH7unU8=",
+        "use-credentials"
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "<crossorigin='use-credentials'> with incorrect hash CORS-eligible",
+        xorigin_creds,
+        "sha256-deadbeef2S+pTRZgiw3DWrhC6JLDlt2zRyGpwH7unU8=",
+        "use-credentials"
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "<crossorigin='anonymous'> with CORS-ineligible resource",
+        xorigin_ineligible,
+        "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E=",
+        "anonymous"
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "Resource with Refresh header",
+        "refresh-header.js",
+        "sha256-ieQAXii4cMmZFLxSRnxfZ1KSyzCjOb+N2rQ6OaVBWyM="
+    ).execute();
+
+    new SRIScriptTest(
+        false,
+        "Resource with WWW-Authenticate header",
+        "www-authenticate-header.js",
+        "sha256-ztNCkGU1fBB5II5wihGTbFb9F2TIMaHldkbnMlp7G/M="
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with correct hash, options.",
+        "matching-digest.js",
+        "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E=?foo=bar?spam=eggs"
+    ).execute();
+
+    new SRIScriptTest(
+        true,
+        "Same-origin script with unknown algorithm only.",
+        "matching-digest.js",
+        "foo666-foolUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E="
+    ).execute();
+
 </script>
-
-<!-- Should load -->
-<script src="loads-scripts-with-correct-content-type.js" integrity="ni:///sha-256;ZrrvOG-Kjz4R-FDFrfSQCQC_oMDfc0kQ3DJNd5URlrY?ct=application/javascript"></script>
-
-<!-- Shouldn't load. Correct URI is ni:///sha-256;J9PNsSFLX168LnQhGZeryaLZDmTLy_fMdx4pO-LhjW4 -->
-<script src="loads-scripts-with-improper-integrity-uri-scheme.js" integrity="wrong:///sha-256;J9PNsSFLX168LnQhGZeryaLZDmTLy_fMdx4pO-LhjW4"></script>
-
-<!-- Shouldn't load. Correct URI is ni:///sha-256;LiWoBTgUHmhVG6gn0dO9R0lBEItHgny2pnvLtBOc0tI?ct=application/javascript -->
-<script src="loads-scripts-with-incorrect-content-type.js" integrity="ni:///sha-256;LiWoBTgUHmhVG6gn0dO9R0lBEItHgny2pnvLtBOc0tI?ct=text/plain"></script>
-
-<!-- Should load -->
-<script src="loads-scripts-with-matching-digest.js" integrity="ni:///sha-256;EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT_E"></script>
-
-<!-- Shouldn't load. Correct URI is ni:///sha-256;mmx3g0H5KnIi_lnkuMJzYK7q6ss-Wnp-7zoGvgiQVtU -->
-<script src="loads-scripts-with-non-matching-digest.js" integrity="ni:///sha-256;EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT_E"></script>
-
-<!-- Shouldn't load. MD5 is considered to be a weak algorithm -->
-<script src="loads-scripts-with-weak-digest-algorithms.js" integrity="ni:///md5;XHzXKrCo5jhDN4BvNhs-4A"></script>
-
-<!-- Should load -->
-<script src="loads-scripts-with-base64-encoded-sha-digests.js" integrity="ni:///sha-256;+xc7GxEqWw6VtSIsI5W90RQtOrfjeGD+6WFgxZgiuOw="></script>
-
-<!-- Should load -->
-<script src="loads-scripts-with-unhyphenated-digest-name.js" integrity="ni:///sha256;ZR6E3E_G_B3WNdop4bYFtnXaj5bH02S3znD__KOC8Io"></script>
-
-
-<script>
-  function assert_undefined(actual) {
-    assert_equals(actual, undefined, "Should be undefined.");
-  }
-
-  test(function() {
-    assert_true(loads_scripts_with_correct_content_type)
-  }, "Loads scripts with correct content type");
-
-  test(function() {
-    assert_undefined(loads_scripts_with_improper_integrity_uri_scheme)
-  }, "Doesn't load scripts with improper integrity URI scheme");
-
-  test(function() {
-    assert_undefined(loads_scripts_with_incorrect_content_type)
-  }, "Doesn't load scripts with incorrect content-type");
-
-  test(function() {
-    assert_true(loads_scripts_with_matching_digest)
-  }, "Loads scripts with matching digest");
-
-  test(function() {
-    assert_undefined(loads_scripts_with_non_matching_digest)
-  }, "Doesn't load scripts with non-matching digest");
-
-  test(function() {
-    assert_undefined(loads_scripts_with_weak_digest_algorithms)
-  }, "Doesn't load scripts using weak digest algorithm");
-
-  test(function() {
-    assert_true(loads_scripts_with_base64_encoded_sha_digests)
-  }, "Loads scripts with base64 encoded sha digests");
-
-  test(function() {
-    assert_true(loads_scripts_with_unhyphenated_digest_name)
-  }, "Loads scripts with unhyphenated digest names");
-</script>
+<!--TODO check cache-poisoned resources, transfer-encoding, 3xx redirect
+   to resource with matching hash, cross-origin leakage test as in sec5.3
+   and <link> tags -->

--- a/subresource-integrity/subresource-integrity.html
+++ b/subresource-integrity/subresource-integrity.html
@@ -7,15 +7,15 @@
 
 <script>
   var xorigin_anon = location.protocol
-    + '//www1.' + location.hostname + ':' + location.port 
+    + '//www1.' + location.hostname + ':' + location.port
     + '/subresource-integrity/crossorigin-anon.js';
 
   var xorigin_creds = location.protocol
-    + '//www1.' + location.hostname + ':' + location.port 
+    + '//www1.' + location.hostname + ':' + location.port
     + '/subresource-integrity/crossorigin-creds.js';
 
   var xorigin_ineligible = location.protocol
-    + '//www1.' + location.hostname + ':' + location.port 
+    + '//www1.' + location.hostname + ':' + location.port
     + '/subresource-integrity/crossorigin-ineligible.js';
 
     var SRIScriptTest = function(pass, name, src, integrityValue, crossoriginValue) {
@@ -75,7 +75,7 @@
         "matching-digest.js",
         "sha256-EKclUXH9SRRUv3FmL7bIEV0z2s3EvzHFxzHKCnfHT/E= foo666-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdead"
     ).execute();
-    
+
     // TODO may need to change these to hash-source prefix, e.g. 'sha256' instead of 'SHA-256'
 
     test(function() {assert_equals(getPrioritizedHashFunction('SHA-512', 'SHA-256'), 'SHA-512')},

--- a/subresource-integrity/tools/generate_javascript.py
+++ b/subresource-integrity/tools/generate_javascript.py
@@ -1,6 +1,6 @@
 from os import path, listdir
-from hashlib import sha256, md5
-from base64 import urlsafe_b64encode
+from hashlib import sha512, sha256, md5
+from base64 import b64encode
 import re
 
 JS_DIR = path.normpath(path.join(__file__, "..", ".."))
@@ -17,19 +17,25 @@ def js_files():
 URL-safe base64 encode a binary digest and strip any padding.
 '''
 def format_digest(digest):
-  return urlsafe_b64encode(digest).rstrip("=")
+  return b64encode(digest)
+
+'''
+Generate an encoded sha512 URI.
+'''
+def sha512_uri(content):
+  return "sha512-%s" % format_digest(sha512(content).digest())
 
 '''
 Generate an encoded sha256 URI.
 '''
 def sha256_uri(content):
-  return "ni:///sha-256;%s" % format_digest(sha256(content).digest())
+  return "sha256-%s" % format_digest(sha256(content).digest())
 
 '''
 Generate an encoded md5 digest URI.
 '''
 def md5_uri(content):
-  return "ni:///md5;%s" % format_digest(md5(content).digest())
+  return "md5-%s" % format_digest(md5(content).digest())
 
 def main():
   for file in js_files():
@@ -38,6 +44,7 @@ def main():
     var_name = re.sub(r"[^a-z0-9]", "_", base)
     content = "%s=true;" % var_name
     with open(file, "w") as f: f.write(content)
+    print "\tSHA512 integrity: %s" % sha512_uri(content)
     print "\tSHA256 integrity: %s" % sha256_uri(content)
     print "\tMD5 integrity:    %s" % md5_uri(content)
 

--- a/subresource-integrity/www-authenticate-header.js
+++ b/subresource-integrity/www-authenticate-header.js
@@ -1,0 +1,1 @@
+www_authenticate_header=true;

--- a/subresource-integrity/www-authenticate-header.js.headers
+++ b/subresource-integrity/www-authenticate-header.js.headers
@@ -1,0 +1,1 @@
+WWW-Authenticate: Basic


### PR DESCRIPTION
Update of Subresource Integrity tests to use new integrity format and crossorigin rules.  Contains some 'stub' tests for algorithm priority that won't pass anywhere yet and will need updating in the future.  No <link> tests yet, just <script>
