### PR TITLE
Adding a basic no-media call that uses promises.

### DIFF
--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -90,7 +90,7 @@ This test uses data only, and thus does not require fake media devices.
     // The createDataChannel is necessary and sufficient to make
     // sure the ICE connection be attempted.
     gFirstConnection.createDataChannel('channel');
-    
+
     var atStep = 'createOffer first';
     var offerSdp = null;
     var answerSdp = null;
@@ -126,7 +126,7 @@ This test uses data only, and thus does not require fake media devices.
       atStep = 'negotiation completed';
     })
     .catch(test.step_func(function(e) {
-      assert_unreached('Error ' + e.name + ':' + e.message + 
+      assert_unreached('Error ' + e.name + ':' + e.message +
                        ' happened at step ' + atStep);
     }));
   });

--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -91,30 +91,22 @@ This test uses data only, and thus does not require fake media devices.
     // sure the ICE connection be attempted.
     gFirstConnection.createDataChannel('channel');
 
-    var atStep = 'createOffer first';
+    var atStep = 'Create offer';
 
     gFirstConnection.createOffer()
     .then(function(offer) {
-      atStep = 'setLocalDescription first';
-      return gFirstConnection.setLocalDescription(offer);
+      atStep = 'Handle offer';
+      return Promise.all([gFirstConnection.setLocalDescription(offer),
+                          gSecondConnection.setRemoteDescription(offer)])
     })
     .then(function() {
-      atStep = 'setRemoteDescription at second';
-      return gSecondConnection.setRemoteDescription(
-         gFirstConnection.localDescription)
-    })
-    .then(function() {
-      atStep = 'createAnswer';
+      atStep = 'Create answer';
       return gSecondConnection.createAnswer()
     })
     .then(function(answer) {
-      atStep = 'setLocalDescription second';
-      return gSecondConnection.setLocalDescription(answer);
-    })
-    .then(function() {
-      atStep = 'setRemoteDescription first';
-      return gFirstConnection.setRemoteDescription(
-          gSecondConnection.localDescription);
+      atStep = 'Handle answer';
+      return Promise.all([gSecondConnection.setLocalDescription(answer),
+                          gFirstConnection.setRemoteDescription(answer)])
     })
     .then(function() {
       atStep = 'negotiation completed';

--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -95,21 +95,29 @@ This test uses data only, and thus does not require fake media devices.
 
     gFirstConnection.createOffer()
     .then(function(offer) {
-      atStep = 'Handle offer';
-      return Promise.all([gFirstConnection.setLocalDescription(offer),
-                          gSecondConnection.setRemoteDescription(offer)])
+      atStep = 'Set local description at first';
+      return gFirstConnection.setLocalDescription(offer);
+    })
+    .then(function() {
+      atStep = 'Set remote description at second';
+      return gSecondConnection.setRemoteDescription(
+          gFirstConnection.localDescription);
     })
     .then(function() {
       atStep = 'Create answer';
       return gSecondConnection.createAnswer()
     })
     .then(function(answer) {
-      atStep = 'Handle answer';
-      return Promise.all([gSecondConnection.setLocalDescription(answer),
-                          gFirstConnection.setRemoteDescription(answer)])
+      atStep = 'Set local description at second';
+      return gSecondConnection.setLocalDescription(answer);
     })
     .then(function() {
-      atStep = 'negotiation completed';
+      atStep = 'Set remote description at first';
+      return gFirstConnection.setRemoteDescription(
+          gSecondConnection.localDescription);
+    })
+    .then(function() {
+      atStep = 'Negotiation completed';
     })
     .catch(test.step_func(function(e) {
       assert_unreached('Error ' + e.name + ': ' + e.message +

--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<!--
+This test uses no media, and thus does not require fake media devices.
+-->
+
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>RTCPeerConnection No-Media Connection Test</title>
+</head>
+<body>
+  <div id="log"></div>
+  <h2>iceConnectionState info</h2>
+  <div id="stateinfo">
+  </div>
+
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/vendor-prefix.js"
+          data-prefixed-objects=
+              '[{"ancestors":["window"], "name":"RTCPeerConnection"},
+                {"ancestors":["window"], "name":"RTCSessionDescription"},
+                {"ancestors":["window"], "name":"RTCIceCandidate"}]'
+    >
+  </script>
+  <script type="text/javascript">
+  var test = async_test('Can set up a basic WebRTC call with no data using promises.');
+
+  var gFirstConnection = null;
+  var gSecondConnection = null;
+
+  var onOfferCreated = test.step_func(function(offer) {
+    // TODO: Switch to promise-based interface.
+    gFirstConnection.setLocalDescription(offer)
+        .catch(failed('setLocalDescription first'));
+
+    // This would normally go across the application's signaling solution.
+    // In our case, the "signaling" is to call this function.
+    receiveCall(offer.sdp);
+  });
+
+  function receiveCall(offerSdp) {
+
+    var parsedOffer = new RTCSessionDescription({ type: 'offer',
+                                                  sdp: offerSdp });
+    gSecondConnection.setRemoteDescription(parsedOffer)
+       .then(function() {
+          gSecondConnection.createAnswer().then(onAnswerCreated,
+                                                failed('createAnswer'));
+      },
+      failed('setRemoteDescription second'));
+  };
+
+  var onAnswerCreated = test.step_func(function(answer) {
+    gSecondConnection.setLocalDescription(answer)
+        .catch(failed('setLocalDescription second'));
+
+    // Similarly, this would go over the application's signaling solution.
+    handleAnswer(answer.sdp);
+  });
+
+  function handleAnswer(answerSdp) {
+    var parsedAnswer = new RTCSessionDescription({ type: 'answer',
+                                                   sdp: answerSdp });
+    gFirstConnection.setRemoteDescription(parsedAnswer)
+       .catch(failed('setRemoteDescription first'));
+  };
+
+  var onIceCandidateToFirst = test.step_func(function(event) {
+    // If event.candidate is null = no more candidates.
+    if (event.candidate) {
+      var candidate = new RTCIceCandidate(event.candidate);
+      gSecondConnection.addIceCandidate(candidate);
+    }
+  });
+
+  var onIceCandidateToSecond = test.step_func(function(event) {
+    if (event.candidate) {
+      var candidate = new RTCIceCandidate(event.candidate);
+      gFirstConnection.addIceCandidate(candidate);
+    }
+  });
+
+  var onRemoteStream = test.step_func(function(event) {
+    assert_unreached('WebRTC received a stream when there was none');
+  });
+
+  var onIceConnectionStateChange = test.step_func(function(event) {
+    assert_equals(event.type, 'iceconnectionstatechange');
+    var stateinfo = document.getElementById('stateinfo');
+    stateinfo.innerHTML = 'First: ' + gFirstConnection.iceConnectionState
+                        + '<br>Second: ' + gSecondConnection.iceConnectionState;
+    // Note: All these combinations are legal states indicating that the
+    // call has connected. All browsers should end up in completed/completed,
+    // but as of this moment, we've chosen to terminate the test early.
+    // TODO: Revise test to ensure completed/completed is reached.
+    if (gFirstConnection.iceConnectionState == 'connected' &&
+        gSecondConnection.iceConnectionState == 'connected') {
+      test.done()
+    }
+    if (gFirstConnection.iceConnectionState == 'connected' &&
+        gSecondConnection.iceConnectionState == 'completed') {
+      test.done()
+    }
+    if (gFirstConnection.iceConnectionState == 'completed' &&
+        gSecondConnection.iceConnectionState == 'connected') {
+      test.done()
+    }
+    if (gFirstConnection.iceConnectionState == 'completed' &&
+        gSecondConnection.iceConnectionState == 'completed') {
+      test.done()
+    }
+  });
+
+  // Returns a suitable error callback.
+  function failed(function_name) {
+    return test.step_func(function() {
+      assert_unreached('WebRTC called error callback for ' + function_name);
+    });
+  }
+
+  // Returns a suitable do-nothing.
+  function ignoreSuccess(function_name) {
+  }
+
+  // This function starts the test.
+  test.step(function() {
+    gFirstConnection = new RTCPeerConnection(null);
+    gFirstConnection.onicecandidate = onIceCandidateToFirst;
+    gFirstConnection.oniceconnectionstatechange = onIceConnectionStateChange;
+
+    gSecondConnection = new RTCPeerConnection(null);
+    gSecondConnection.onicecandidate = onIceCandidateToSecond;
+    gSecondConnection.onaddstream = onRemoteStream;
+    gSecondConnection.oniceconnectionstatechange = onIceConnectionStateChange;
+
+    // The offerToReceiveVideo is necessary and sufficient to make
+    // an actual connection.
+    // TODO: Use a promise-based API. This is legacy.
+    gFirstConnection.createOffer({offerToReceiveVideo: true})
+        .then(onOfferCreated, failed('createOffer'));
+       
+  });
+</script>
+
+</body>
+</html>

--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -25,7 +25,7 @@ This test uses data only, and thus does not require fake media devices.
     >
   </script>
   <script type="text/javascript">
-  var test = async_test('Can set up a basic WebRTC call with no data using promises.');
+  var test = async_test('Can set up a basic WebRTC call with only data using promises.');
 
   var gFirstConnection = null;
   var gSecondConnection = null;
@@ -92,20 +92,16 @@ This test uses data only, and thus does not require fake media devices.
     gFirstConnection.createDataChannel('channel');
 
     var atStep = 'createOffer first';
-    var offerSdp = null;
-    var answerSdp = null;
 
     gFirstConnection.createOffer()
     .then(function(offer) {
-      offerSdp = offer.sdp;
       atStep = 'setLocalDescription first';
       return gFirstConnection.setLocalDescription(offer);
     })
     .then(function() {
       atStep = 'setRemoteDescription at second';
-      var parsedOffer = new RTCSessionDescription({ type: 'offer',
-                                                    sdp: offerSdp });
-      return gSecondConnection.setRemoteDescription(parsedOffer)
+      return gSecondConnection.setRemoteDescription(
+         gFirstConnection.localDescription)
     })
     .then(function() {
       atStep = 'createAnswer';
@@ -113,20 +109,18 @@ This test uses data only, and thus does not require fake media devices.
     })
     .then(function(answer) {
       atStep = 'setLocalDescription second';
-      answerSdp = answer.sdp
       return gSecondConnection.setLocalDescription(answer);
     })
     .then(function() {
-      var parsedAnswer = new RTCSessionDescription({ type: 'answer',
-                                                     sdp: answerSdp });
       atStep = 'setRemoteDescription first';
-      return gFirstConnection.setRemoteDescription(parsedAnswer);
+      return gFirstConnection.setRemoteDescription(
+          gSecondConnection.localDescription);
     })
     .then(function() {
       atStep = 'negotiation completed';
     })
     .catch(test.step_func(function(e) {
-      assert_unreached('Error ' + e.name + ':' + e.message +
+      assert_unreached('Error ' + e.name + ': ' + e.message +
                        ' happened at step ' + atStep);
     }));
   });

--- a/webrtc/promises-call.html
+++ b/webrtc/promises-call.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <!--
-This test uses no media, and thus does not require fake media devices.
+This test uses data only, and thus does not require fake media devices.
 -->
 
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>RTCPeerConnection No-Media Connection Test</title>
+  <title>RTCPeerConnection Data-Only Connection Test with Promises</title>
 </head>
 <body>
   <div id="log"></div>
@@ -29,43 +29,6 @@ This test uses no media, and thus does not require fake media devices.
 
   var gFirstConnection = null;
   var gSecondConnection = null;
-
-  var onOfferCreated = test.step_func(function(offer) {
-    // TODO: Switch to promise-based interface.
-    gFirstConnection.setLocalDescription(offer)
-        .catch(failed('setLocalDescription first'));
-
-    // This would normally go across the application's signaling solution.
-    // In our case, the "signaling" is to call this function.
-    receiveCall(offer.sdp);
-  });
-
-  function receiveCall(offerSdp) {
-
-    var parsedOffer = new RTCSessionDescription({ type: 'offer',
-                                                  sdp: offerSdp });
-    gSecondConnection.setRemoteDescription(parsedOffer)
-       .then(function() {
-          gSecondConnection.createAnswer().then(onAnswerCreated,
-                                                failed('createAnswer'));
-      },
-      failed('setRemoteDescription second'));
-  };
-
-  var onAnswerCreated = test.step_func(function(answer) {
-    gSecondConnection.setLocalDescription(answer)
-        .catch(failed('setLocalDescription second'));
-
-    // Similarly, this would go over the application's signaling solution.
-    handleAnswer(answer.sdp);
-  });
-
-  function handleAnswer(answerSdp) {
-    var parsedAnswer = new RTCSessionDescription({ type: 'answer',
-                                                   sdp: answerSdp });
-    gFirstConnection.setRemoteDescription(parsedAnswer)
-       .catch(failed('setRemoteDescription first'));
-  };
 
   var onIceCandidateToFirst = test.step_func(function(event) {
     // If event.candidate is null = no more candidates.
@@ -113,17 +76,6 @@ This test uses no media, and thus does not require fake media devices.
     }
   });
 
-  // Returns a suitable error callback.
-  function failed(function_name) {
-    return test.step_func(function() {
-      assert_unreached('WebRTC called error callback for ' + function_name);
-    });
-  }
-
-  // Returns a suitable do-nothing.
-  function ignoreSuccess(function_name) {
-  }
-
   // This function starts the test.
   test.step(function() {
     gFirstConnection = new RTCPeerConnection(null);
@@ -135,12 +87,48 @@ This test uses no media, and thus does not require fake media devices.
     gSecondConnection.onaddstream = onRemoteStream;
     gSecondConnection.oniceconnectionstatechange = onIceConnectionStateChange;
 
-    // The offerToReceiveVideo is necessary and sufficient to make
-    // an actual connection.
-    // TODO: Use a promise-based API. This is legacy.
-    gFirstConnection.createOffer({offerToReceiveVideo: true})
-        .then(onOfferCreated, failed('createOffer'));
-       
+    // The createDataChannel is necessary and sufficient to make
+    // sure the ICE connection be attempted.
+    gFirstConnection.createDataChannel('channel');
+    
+    var atStep = 'createOffer first';
+    var offerSdp = null;
+    var answerSdp = null;
+
+    gFirstConnection.createOffer()
+    .then(function(offer) {
+      offerSdp = offer.sdp;
+      atStep = 'setLocalDescription first';
+      return gFirstConnection.setLocalDescription(offer);
+    })
+    .then(function() {
+      atStep = 'setRemoteDescription at second';
+      var parsedOffer = new RTCSessionDescription({ type: 'offer',
+                                                    sdp: offerSdp });
+      return gSecondConnection.setRemoteDescription(parsedOffer)
+    })
+    .then(function() {
+      atStep = 'createAnswer';
+      return gSecondConnection.createAnswer()
+    })
+    .then(function(answer) {
+      atStep = 'setLocalDescription second';
+      answerSdp = answer.sdp
+      return gSecondConnection.setLocalDescription(answer);
+    })
+    .then(function() {
+      var parsedAnswer = new RTCSessionDescription({ type: 'answer',
+                                                     sdp: answerSdp });
+      atStep = 'setRemoteDescription first';
+      return gFirstConnection.setRemoteDescription(parsedAnswer);
+    })
+    .then(function() {
+      atStep = 'negotiation completed';
+    })
+    .catch(test.step_func(function(e) {
+      assert_unreached('Error ' + e.name + ':' + e.message + 
+                       ' happened at step ' + atStep);
+    }));
   });
 </script>
 


### PR DESCRIPTION
This tests the basic promise machinery in PeerConnection.

Tested and works in Firefox; asking @jan-ivar to take a look because he's probably most passionate about how Promises usage should be styled.
