### PR TITLE
Hillbrad/fix audio source onerror

### DIFF
--- a/content-security-policy/media-src/media-src-7_1.html
+++ b/content-security-policy/media-src/media-src-7_1.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Video element src attribute must match src list - positive test</title>
-    <meta name=timeout content=long>
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
 </head>

--- a/content-security-policy/media-src/media-src-7_2.html
+++ b/content-security-policy/media-src/media-src-7_2.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Audio element src attribute must match src list - positive test</title>
-    <meta name=timeout content=long>
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
 </head>

--- a/content-security-policy/media-src/media-src-7_3.html
+++ b/content-security-policy/media-src/media-src-7_3.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Video track src attribute must match src list - positive test</title>
-    <meta name=timeout content=long>
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
 </head>

--- a/content-security-policy/media-src/media-src-7_3_2.html
+++ b/content-security-policy/media-src/media-src-7_3_2.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <title>Video track src attribute must match src list - negative test</title>
-    <meta name=timeout content=long>
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
 </head>
@@ -11,7 +10,8 @@
     <div id='log'></div>
 
   <script>
-    var source_test = async_test("Disallowed track element");
+    var source_test =
+        async_test("Disallowed track element onerror handler fires.");
 
       var trackURL = location.protocol +
         "//www." +
@@ -33,18 +33,25 @@
   </script>
 
     <video id="videoObject" width="320" height="240" controls
-           onloadeddata="media_loaded(source_test)" crossorigin>
+           onerror="media_error_handler(source_test)"
+           crossorigin>
         <source id="audioSourceObject"
                 type="audio/mpeg"
                 src="/media/white.mp4">
-        <track id="trackObject"
+        <track default
+               id="trackObject"
                kind="subtitles"
                srclang="en"
                label="English"
-               onerror="media_error_handler(source_test)">
+               onerror="media_error_handler(source_test)"
+               onload="media_loaded(source_test)"
+               onloadeddata="media_loaded(source_test)">
     </video>
     <script>
         document.getElementById("trackObject").src = trackURL;
+        source_test.step(function() {
+            source_test.set_status(source_test.FAIL);
+        });
     </script>
 
   <script async defer src="../support/checkReport.sub.js?reportField=violated-directive&reportValue=media-src%20%27self%27">


### PR DESCRIPTION
update to give Firefox chance to fire event handlers on track element, fix timeouts back to short for tests where no report is expected.
