### PR TITLE
Correct initiatorType of iframe element

### DIFF
--- a/resource-timing/test_resource_timing.js
+++ b/resource-timing/test_resource_timing.js
@@ -151,9 +151,6 @@ function resource_load(expected)
     t["simple_attrs"].step(function() {
         var actual = window.performance.getEntriesByName(expected.name)[0];
         var expected_type = expected.initiatorType;
-        if (expected.initiatorType == "iframe") {
-            expected_type = "subdocument";
-        }
         assert_equals(actual.name, expected.name);
         assert_equals(actual.initiatorType, expected_type);
         assert_equals(actual.entryType, "resource");


### PR DESCRIPTION
If the initiator is an element, on getting, the initiatorType attribute MUST return a DOMString with the same value as the localName of that element [DOM].
The iframe.localName should be "iframe", not "subdocument".
