### PR TITLE
Referrer-Policy: Debug/Release mode generator templates

### DIFF
--- a/referrer-policy/README.md
+++ b/referrer-policy/README.md
@@ -27,12 +27,16 @@ The ```spec.src.json``` defines all the test scenarios for the referrer policy.
 
 Invoking ```./generic/tools/generate.py``` will parse the spec JSON and determine which tests to generate (or skip) while using templates.
 
+
 The spec can be validated by running ```./generic/tools/spec_validator.py```. This is specially important when you're making changes to  ```spec.src.json```. Make sure it's a valid JSON (no comments or trailing commas). The validator should be informative and very specific on any issues.
 
 For details about the spec JSON, see **Overview of the spec JSON** below.
 
 
-## Generating the tests
+## Generating and running the tests
+
+The repository already contains generated tests, so if you're making changes,
+see the **Removing all generated tests** section below, on how to remove them before you start generating tests which include your changes.
 
 Start from the command line:
 
@@ -58,6 +62,18 @@ Run tests under path: ```/referrer-policy```.
 
 Click start.
 
+
+## Options for generating tests
+
+The generator script ```./generic/tools/generate.py``` has two targets: ```release``` and ```debug```.
+
+* Using **release** for the target will produce tests using a template for optimizing size and performance. The release template is intended for the official web-platform-tests and possibly other test suites. No sanity checking is done in release mode. Use this option whenever you're checking into web-platform-tests.
+
+* When generating for ```debug```, the produced tests will contain more verbosity and sanity checks. Use this target to identify problems with the test suite when making changes locally. Make sure you don't check in tests generated with the debug target.
+
+Note that **release** is the default target when invoking ```generate.py```.
+
+
 ## Removing all generated tests
 
 ```bash
@@ -76,6 +92,7 @@ git add * && git commit -m "Remove generated tests"
 
 **Important:**
 The ```./generic/tools/clean.py``` utility will only work if there is a valid ```spec.src.json``` and previously generated directories match the specification requirement names. So make sure you run ```clean.py``` before you alter the specification section of the spec JSON.
+
 
 ## Updating the tests
 
@@ -124,6 +141,7 @@ git add * && git commit -m "Update generated tests"
 
 ```
 
+
 ## Overview of the spec JSON
 
 **Main sections:**
@@ -151,6 +169,7 @@ git add * && git commit -m "Update generated tests"
 
   A 1:1 mapping of a **subresource type** to the URL path of the sub-resource.
   When adding a new sub-resource, a path to an existing file for it also must be specified.
+
 
 ### Test Expansion Patterns
 
@@ -206,6 +225,7 @@ var scenario = {
   "source_protocol": "http",
   "target_protocol": "http",
   "subresource": "iframe-tag",
+  "subresource_path": "/referrer-policy/generic/subresource/document.py",
   "referrer_url": "origin"
 };
 ```
@@ -218,5 +238,4 @@ Taking the spec JSON, the generator follows this algorithm:
 * Expand all ```excluded_tests``` to create a blacklist of selections
 
 * For each specification requirement: Expand the ```test_expansion``` pattern into selections and check each against the blacklist, if not marked as suppresed, generate the test resources for the selection
-
 

--- a/referrer-policy/generic/sanity-checker.js
+++ b/referrer-policy/generic/sanity-checker.js
@@ -1,0 +1,52 @@
+// The SanityChecker is used in debug mode to identify problems with the
+// structure of the testsuite. In release mode it is mocked out to do nothing.
+
+function SanityChecker()  {}
+
+SanityChecker.prototype.checkScenario = function(scenario) {
+  // Check if scenario is valid.
+  // TODO(kristijanburnik): Move to a sanity-checks.js for debug mode only.
+  test(function() {
+
+    // We extend the exsiting test_expansion_schema not to kill performance by
+    // copying.
+    var expectedFields = SPEC_JSON["test_expansion_schema"];
+    expectedFields["referrer_policy"] = SPEC_JSON["referrer_policy_schema"];
+
+    assert_own_property(scenario, "subresource_path",
+                        "Scenario has the path to the subresource.");
+
+    for (var field in expectedFields) {
+      assert_own_property(scenario, field,
+                          "The scenario contains field " + field)
+      assert_in_array(scenario[field], expectedFields[field],
+                      "Scenario's " + field + " is one of: " +
+                      expectedFields[field].join(", ")) + "."
+    }
+
+    // Check if the protocol is matched.
+    assert_equals(scenario["source_protocol"] + ":", location.protocol,
+                  "Protocol of the test page should match the scenario.")
+
+  }, "[ReferrerPolicyTestCase] The test scenario is valid.");
+}
+
+SanityChecker.prototype.checkSubresourceResult = function(test,
+                                                          scenario,
+                                                          subresourceUrl,
+                                                          result) {
+  test.step(function() {
+    assert_equals(Object.keys(result).length, 3);
+    assert_own_property(result, "location");
+    assert_own_property(result, "referrer");
+    assert_own_property(result, "headers");
+
+    // Skip location check for scripts.
+    if (scenario.subresource == "script-tag")
+      return;
+
+    // Sanity check: location of sub-resource matches reported location.
+    assert_equals(result.location, subresourceUrl,
+                  "Subresource reported location.");
+  }, "Running a valid test scenario.");
+};

--- a/referrer-policy/generic/template/document.html.template
+++ b/referrer-policy/generic/template/document.html.template
@@ -2,13 +2,8 @@
 <html>
   <head>
     <title>This page reports back it's request details to the parent frame</title>
-    <!-- Common global functions for referrer-policy tests. -->
-    <script src="/referrer-policy/generic/common.js"></script>
   </head>
   <body>
-    <h2>This page reports back it's request details to the parent frame</h2>
-    <pre>%(headers)s</pre>
-
     <script>
       var SERVER_REQUEST_HEADERS = %(headers)s;
       var result = {
@@ -18,6 +13,5 @@
       };
       parent.postMessage(result, "*");
     </script>
-
   </body>
 </html>

--- a/referrer-policy/generic/template/script.js.template
+++ b/referrer-policy/generic/template/script.js.template
@@ -1,3 +1,2 @@
 var SERVER_REQUEST_HEADERS = %(headers)s;
-
 postMessage(SERVER_REQUEST_HEADERS, '*');

--- a/referrer-policy/generic/template/test.debug.html.template
+++ b/referrer-policy/generic/template/test.debug.html.template
@@ -1,18 +1,21 @@
 <!DOCTYPE html>
 %(generated_disclaimer)s
-<!-- TODO(kristijanburnik): Create a template for automated tests:
-http://testthewebforward.org/docs/test-templates.html#script-test-with-metadata
--->
 <html>
   <head>
-    <title>Referrer-Policy: %(spec_title)s</title>
-    <meta name="description" content="%(spec_description)s">%(meta_delivery_method)s
+    <title>Referrer-Policy: %(spec_title)s</title>%(meta_delivery_method)s
+    <meta name="description" content="%(spec_description)s">
+    <meta name="assert" content="The referrer URL is %(referrer_url)s when a
+        document served over %(source_protocol)s requires an %(target_protocol)s
+        sub-resource via %(subresource)s using the %(delivery_method)s
+        delivery method and when the target request is %(origin)s.">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <!-- Common global functions for referrer-policy tests. -->
     <script src="/referrer-policy/generic/common.js"></script>
     <!-- The original specification JSON for validating the scenario. -->
     <script src="/referrer-policy/spec_json.js"></script>
+    <!-- Internal checking of the tests -->
+    <script src="/referrer-policy/generic/sanity-checker.js"></script>
     <!-- Simple wrapper API for all referrer-policy test cases. -->
     <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
   </head>
@@ -20,10 +23,12 @@ http://testthewebforward.org/docs/test-templates.html#script-test-with-metadata
     <h1>%(spec_title)s</h1>
     <h2>%(spec_description)s</h2>
 
-    <p id="description">The referrer URL is %(referrer_url)s when a document
-      served over %(source_protocol)s requires an %(target_protocol)s
-      sub-resource via %(subresource)s using the %(delivery_method)s delivery
-      method and when the target request is %(origin)s.</p>
+    <p>
+      <script>
+        // Show the detailed assertion description of the test.
+        document.write(document.querySelector("meta[name=assert]").content);
+      </script>
+    </p>
 
     <p>See <a href="%(spec_specification_url)s" target="_blank">specification</a>
        details for this test.</p>
@@ -53,19 +58,7 @@ http://testthewebforward.org/docs/test-templates.html#script-test-with-metadata
       <tbody>
     </table>
 
-    <script>
-      var scenario = {
-        "referrer_policy": %(referrer_policy_json)s,
-        "delivery_method": "%(delivery_method)s",
-        "origin": "%(origin)s",
-        "source_protocol": "%(source_protocol)s",
-        "target_protocol": "%(target_protocol)s",
-        "subresource": "%(subresource)s",
-        "referrer_url": "%(referrer_url)s"
-      };
-      var description = document.getElementById("description").innerHTML;
-      ReferrerPolicyTestCase(scenario, description).start();
-    </script>
+    <script>%(test_js)s</script>
 
     <div id="log"></div>
   </body>

--- a/referrer-policy/generic/template/test.js.template
+++ b/referrer-policy/generic/template/test.js.template
@@ -1,0 +1,14 @@
+ReferrerPolicyTestCase(
+  {
+    "referrer_policy": %(referrer_policy_json)s,
+    "delivery_method": "%(delivery_method)s",
+    "origin": "%(origin)s",
+    "source_protocol": "%(source_protocol)s",
+    "target_protocol": "%(target_protocol)s",
+    "subresource": "%(subresource)s",
+    "subresource_path": "%(subresource_path)s",
+    "referrer_url": "%(referrer_url)s"
+  },
+  document.querySelector("meta[name=assert]").content,
+  new SanityChecker()
+).start();

--- a/referrer-policy/generic/template/test.release.html.template
+++ b/referrer-policy/generic/template/test.release.html.template
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+%(generated_disclaimer)s
+<html>
+  <head>
+    <title>Referrer-Policy: %(spec_title)s</title>
+    <meta name="description" content="%(spec_description)s">%(meta_delivery_method)s
+    <link rel="author" title="Kristijan Burnik" href="burnik@chromium.org">
+    <link rel="help" href="%(spec_specification_url)s">
+    <meta name="assert" content="The referrer URL is %(referrer_url)s when a
+        document served over %(source_protocol)s requires an %(target_protocol)s
+        sub-resource via %(subresource)s using the %(delivery_method)s
+        delivery method and when the target request is %(origin)s.">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <!-- TODO(kristijanburnik): Minify and merge both: -->
+    <script src="/referrer-policy/generic/common.js"></script>
+    <script src="/referrer-policy/generic/referrer-policy-test-case.js?pipe=sub"></script>
+  </head>
+  <body>
+    <script>%(test_js)s</script>
+    <div id="log"></div>
+  </body>
+</html>


### PR DESCRIPTION
In this PR:
- introduce support for generating debug/release templates
- release mode reduces verbosity, size of the test and number of resources being loaded
- NOOP for sanity checking in release mode, full checking in debug mode
- move JS test invocation to a separate template
- refactor and optimize image decoding
- update README.md

Stats:
- run-time reduced by ~ 10 sec (11 %)
- size of generated tests reduced by ~ 1.2 M (13%)

@mikewest 
