### PR TITLE
SRI: s/w3c-test.org/example.test/g

### DIFF
--- a/subresource-integrity/refresh-header.js.headers
+++ b/subresource-integrity/refresh-header.js.headers
@@ -1,1 +1,1 @@
-Refresh: 0; url=http://w3c-test.org/
+Refresh: 0; url=http://example.test/


### PR DESCRIPTION
`refresh-header.js.headers` contains a `refresh` header which should have no effect on the outcome
of the test (the header will be ignored). The linting script doesn't appreciate that it contains
`w3c-test.org`; this patch changes the URL to the non-existent `example.test` to make it clear that
the URL doesn't matter to the outcome of the test.
