### PR TITLE
Long timeout for cache-storage/common.https.html due to variable disk…

### DIFF
--- a/service-workers/cache-storage/common.https.html
+++ b/service-workers/cache-storage/common.https.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Cache Storage: Verify that Window and Workers see same storage</title>
 <link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/testharness-helpers.js"></script>


### PR DESCRIPTION
… performance. (gecko bug 1168517)
