### PR TITLE
Fix typos in the Document#getElementById test.

### DIFF
--- a/dom/nodes/Document-getElementById.html
+++ b/dom/nodes/Document-getElementById.html
@@ -31,7 +31,7 @@
     var element = document.createElement("div");
     element.setAttribute("id", "null");
     document.body.appendChild(element);
-    this.add_cleanup(function() { document.body.removeChild(element);
+    this.add_cleanup(function() { document.body.removeChild(element) });
     assert_equals(document.getElementById(null), element);
   }, "Calling document.getElementById with a null argument.");
 
@@ -39,7 +39,7 @@
     var element = document.createElement("div");
     element.setAttribute("id", "undefined");
     document.body.appendChild(element);
-    this.add_cleanup(function() { document.body.removeChild(element);
+    this.add_cleanup(function() { document.body.removeChild(element) });
     assert_equals(document.getElementById(undefined), element);
   }, "Calling document.getElementById with an undefined argument.");
 


### PR DESCRIPTION
The fixes bugs introduced in 0082d4e75add20e6512600ffb540f80538abe355.
