### PR TITLE
Add doc_root and ws_doc_root defaulting to null in config.default.json.

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,6 @@
 {"host": "web-platform.test",
+ "doc_root": null,
+ "ws_doc_root": null,
  "external_host": null,
  "ports":{"http":[8000, "auto"],
           "https":[8443],


### PR DESCRIPTION
The null (None) will result in using a hardcoded default.

@jgraham
