### PR TITLE
Remove references to webidl2.js.

### DIFF
--- a/animation-timing/idlharness.html
+++ b/animation-timing/idlharness.html
@@ -7,7 +7,7 @@
 <link rel="help" href="http://www.w3.org/TR/animation-timing/#definitions"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/webidl2/lib/webidl2.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 </head>
 <body>

--- a/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-init.html
+++ b/mediacapture-streams/stream-api/mediastreamtrack/mediastreamtrack-init.html
@@ -19,7 +19,7 @@ object returned by the success callback in getUserMedia is correctly initialized
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/webidl2/lib/webidl2.js></script>
+<script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>

--- a/mediacapture-streams/stream-api/video-and-audio-tracks/audiostreamtrack.html
+++ b/mediacapture-streams/stream-api/video-and-audio-tracks/audiostreamtrack.html
@@ -13,7 +13,7 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/webidl2/lib/webidl2.js></script>
+<script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <script>
 var idl_array = new IdlArray();

--- a/mediacapture-streams/stream-api/video-and-audio-tracks/videostreamtrack.html
+++ b/mediacapture-streams/stream-api/video-and-audio-tracks/videostreamtrack.html
@@ -13,7 +13,7 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/webidl2/lib/webidl2.js></script>
+<script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <script>
 var idl_array = new IdlArray();

--- a/navigation-timing/idlharness.html
+++ b/navigation-timing/idlharness.html
@@ -9,7 +9,7 @@
 <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-window.performance-attribute"/>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/webidl2/lib/webidl2.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 </head>
 <body>

--- a/proximity/idlharness.html
+++ b/proximity/idlharness.html
@@ -5,7 +5,7 @@
 <link rel="help" href="http://www.w3.org/TR/proximity/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/webidl2/lib/webidl2.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <style>
   pre {

--- a/web-animations/animation-node/idlharness.html
+++ b/web-animations/animation-node/idlharness.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Aleksei Yu. Semenov" href="mailto:a.semenov@unipro.ru">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/webidl2/lib/webidl2.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <body>
 <div id="log"></div>

--- a/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
@@ -2,7 +2,7 @@
 <html class="a">
 <head>
 <title>AudioBuffer IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/webidl2/lib/webidl2.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
     #event-target-idl,
     #audio-context-idl
     { visibility:hidden; height: 0px;}

--- a/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
@@ -2,7 +2,7 @@
 <html class="a">
 <head>
 <title>AudioDestinationNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/webidl2/lib/webidl2.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
     #event-target-idl,
     #audio-context-idl,
     #audio-node-idl

--- a/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
@@ -2,7 +2,7 @@
 <html class="a">
 <head>
 <title>DelayNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/webidl2/lib/webidl2.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
     #event-target-idl,
     #audio-context-idl,
     #audio-node-idl,

--- a/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
@@ -2,7 +2,7 @@
 <html class="a">
 <head>
 <title>GainNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/webidl2/lib/webidl2.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
     #event-target-idl,
     #audio-context-idl,
     #audio-node-idl,

--- a/websockets/interfaces.html
+++ b/websockets/interfaces.html
@@ -2,7 +2,7 @@
 <title>Web Sockets IDL tests</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src=/resources/webidl2/lib/webidl2.js></script>
+<script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 
 <h1>Web Sockets IDL tests</h1>


### PR DESCRIPTION
The canonical location of the WebIDL parser is /resources/WebIDLParser.js.
