### PR TITLE
Remove SRI header tests

### DIFF
--- a/subresource-integrity/refresh-header.js
+++ b/subresource-integrity/refresh-header.js
@@ -1,1 +1,0 @@
-refresh_header=true;

--- a/subresource-integrity/refresh-header.js.headers
+++ b/subresource-integrity/refresh-header.js.headers
@@ -1,1 +1,0 @@
-Refresh: 0; url=http://example.test/

--- a/subresource-integrity/subresource-integrity.html
+++ b/subresource-integrity/subresource-integrity.html
@@ -148,20 +148,6 @@
     ).execute();
 
     new SRIScriptTest(
-        false,
-        "Resource with Refresh header",
-        "refresh-header.js",
-        "sha256-ieQAXii4cMmZFLxSRnxfZ1KSyzCjOb+N2rQ6OaVBWyM="
-    ).execute();
-
-    new SRIScriptTest(
-        false,
-        "Resource with WWW-Authenticate header",
-        "www-authenticate-header.js",
-        "sha256-ztNCkGU1fBB5II5wihGTbFb9F2TIMaHldkbnMlp7G/M="
-    ).execute();
-
-    new SRIScriptTest(
         true,
         "Same-origin script with correct hash, options.",
         "matching-digest.js",

--- a/subresource-integrity/www-authenticate-header.js
+++ b/subresource-integrity/www-authenticate-header.js
@@ -1,1 +1,0 @@
-www_authenticate_header=true;

--- a/subresource-integrity/www-authenticate-header.js.headers
+++ b/subresource-integrity/www-authenticate-header.js.headers
@@ -1,1 +1,0 @@
-WWW-Authenticate: Basic


### PR DESCRIPTION
If I'm not mistaken, we removed the SRI eligibility requirement to not have WWW-Authenticate and Refresh headers, as unnecessary. Thus, these tests cause an inappropriate failure on Chrome. @hillbrad, can you take a look at this for me? And can one of @fmarier @devd @mozfreddyb just sanity check that this is the correct spec behavior?
