### PR TITLE
Fail on ICE failure

### DIFF
--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -86,6 +86,8 @@ This test uses the legacy callback API with no media, and thus does not require 
 
   var onIceConnectionStateChange = test.step_func(function(event) {
     assert_equals(event.type, 'iceconnectionstatechange');
+    assert_not_equals(gFirstConnection.iceConnectionState, "failed", "iceConnectionState of first connection");
+    assert_not_equals(gSecondConnection.iceConnectionState, "failed", "iceConnectionState of second connection");
     var stateinfo = document.getElementById('stateinfo');
     stateinfo.innerHTML = 'First: ' + gFirstConnection.iceConnectionState
                         + '<br>Second: ' + gSecondConnection.iceConnectionState;

--- a/webrtc/no-media-call.html
+++ b/webrtc/no-media-call.html
@@ -20,8 +20,7 @@ This test uses the legacy callback API with no media, and thus does not require 
   <script src="/common/vendor-prefix.js"
           data-prefixed-objects=
               '[{"ancestors":["window"], "name":"RTCPeerConnection"},
-                {"ancestors":["window"], "name":"RTCSessionDescription"},
-                {"ancestors":["window"], "name":"RTCIceCandidate"}]'
+                {"ancestors":["window"], "name":"RTCSessionDescription"}]'
     >
   </script>
   <script type="text/javascript">


### PR DESCRIPTION
In the WebRTC no-media call, fail when ICE fails rather than wait for the timeout.
