### PR TITLE
Test relative URLs with unknown schemes

### DIFF
--- a/url/a-element.html
+++ b/url/a-element.html
@@ -39,7 +39,7 @@ function runURLTests(raw) {
       if(expected.protocol === ':' && url.protocol !== ':')
         assert_unreached('Expected URL to fail parsing')
       assert_equals(url.protocol, expected.protocol, "scheme")
-      assert_equals(url.hostname, expected.host, "host")
+      assert_equals(url.hostname, expected.hostname, "host")
       assert_equals(url.port, expected.port, "port")
       assert_equals(url.pathname, expected.path, "path")
       assert_equals(url.search, expected.search, "search")

--- a/url/a-element.xhtml
+++ b/url/a-element.xhtml
@@ -47,7 +47,7 @@
           if(expected.protocol === ':' && url.protocol !== ':')
             assert_unreached('Expected URL to fail parsing')
           assert_equals(url.protocol, expected.protocol, "scheme")
-          assert_equals(url.hostname, expected.host, "host")
+          assert_equals(url.hostname, expected.hostname, "host")
           assert_equals(url.port, expected.port, "port")
           assert_equals(url.pathname, expected.path, "path")
           assert_equals(url.search, expected.search, "search")

--- a/url/url-constructor.html
+++ b/url/url-constructor.html
@@ -35,7 +35,7 @@ function runURLTests(raw) {
 
       var url = bURL(expected.input, expected.base)
       assert_equals(url.protocol, expected.protocol, "scheme")
-      assert_equals(url.hostname, expected.host, "host")
+      assert_equals(url.hostname, expected.hostname, "host")
       assert_equals(url.port, expected.port, "port")
       assert_equals(url.pathname, expected.path, "path")
       assert_equals(url.search, expected.search, "search")

--- a/url/urltestdata.txt
+++ b/url/urltestdata.txt
@@ -175,7 +175,7 @@ http://%25DOMAIN:foobar@foodomain.com/  s:http u:%25DOMAIN pass:foobar h:foodoma
 http:\\\\www.google.com\\foo  s:http h:www.google.com p:/foo
 http://foo:80/  s:http h:foo p:/
 http://foo:81/  s:http h:foo port:81 p:/
-httpa://foo:80/  s:httpa p://foo:80/
+httpa://foo:80/  s:httpa h:foo port:80 p:/
 http://foo:-80/
 https://foo:443/  s:https h:foo p:/
 https://foo:80/  s:https h:foo port:80 p:/
@@ -341,9 +341,6 @@ http://[google.com]
 # Misc Unicode
 http://foo:\uD83D\uDCA9@example.com/bar  s:http h:example.com p:/bar u:foo pass:%F0%9F%92%A9
 
-# resolving a relative reference against an unknown scheme results in an error
-x test:test
-
 # resolving a fragment against any scheme succeeds
 \# test:test s:test p:test f:#
 \#x mailto:x@x.com s:mailto p:x@x.com f:#x
@@ -362,3 +359,42 @@ http://`{}:`{}@h/`{}?`{}  s:http u:%60%7B%7D pass:%60%7B%7D h:h p:/%60%7B%7D q:?
 /some/path http://user@example.org/smth s:http u:user h:example.org p:/some/path
  http://user:pass@example.org:21/smth s:http u:user pass:pass h:example.org port:21 p:/smth
 /some/path http://user:pass@example.org:21/smth s:http u:user pass:pass h:example.org port:21 p:/some/path
+
+# a set of tests designed by zcorpan for relative URLs with unknown schemes
+i sc:sd
+i sc:sd/sd
+i sc:/pa/pa s:sc p:/pa/i
+i sc://ho/pa s:sc h:ho p:/i
+i sc:///pa/pa s:sc h: p:/pa/i
+../i sc:sd
+../i sc:sd/sd
+../i sc:/pa/pa s:sc p:/i
+../i sc://ho/pa s:sc h:ho p:/i
+../i sc:///pa/pa s:sc h: p:/i
+/i sc:sd
+/i sc:sd/sd
+/i sc:/pa/pa s:sc p:/i
+/i sc://ho/pa s:sc h:ho p:/i
+/i sc:///pa/pa s:sc h: p:/i
+?i sc:sd
+?i sc:sd/sd
+?i sc:/pa/pa s:sc p:/pa/pa q:?i
+?i sc://ho/pa s:sc h:ho p:/pa q:?i
+?i sc:///pa/pa s:sc h: p:/pa/pa q:?i
+\#i sc:sd s:sc p:sd f:#i
+\#i sc:sd/sd s:sc p:sd/sd f:#i
+\#i sc:/pa/pa s:sc p:/pa/pa f:#i
+\#i sc://ho/pa s:sc h:ho p:/pa f:#i
+\#i sc:///pa/pa s:sc h: p:/pa/pa f:#i
+
+# make sure that relative URL logic works on known typically non-relative schemes too
+about:/../ about:blank s:about p:/
+data:/../ about:blank s:data p:/
+javascript:/../ about:blank s:javascript p:/
+mailto:/../ about:blank s:mailto p:/
+
+# unknown schemes and non-ASCII domains
+sc://ñ.test/ about:blank s:sc h:xn--ida.test p:/
+
+# unknown schemes and backslashes
+sc:\\../ about:blank s:sc p:\\../

--- a/url/urltestparser.js
+++ b/url/urltestparser.js
@@ -1,5 +1,5 @@
 function URLTestParser(input) {
-  var relativeSchemes = ["ftp", "file", "gopher", "http", "https", "ws", "wss"],
+  var specialSchemes = ["ftp", "file", "gopher", "http", "https", "ws", "wss"],
       tokenMap = { "\\": "\\", "#": "#", n: "\n", r: "\r", s: " ", t: "\t", f: "\f" }
       resultMap = { s: "scheme", u: "username", pass: "password", h: "host", port: "port", p: "path", q: "query", f: "fragment" },
       results = []
@@ -9,7 +9,7 @@ function URLTestParser(input) {
     this.scheme = ""
     this.username = ""
     this.password = null
-    this.host = ""
+    this.host = null
     this.port = ""
     this.path = ""
     this.query = ""
@@ -17,16 +17,17 @@ function URLTestParser(input) {
     Object.defineProperties(this, {
       "href": { get: function() {
         return !this.scheme ? this.input : this.protocol + (
-          relativeSchemes.indexOf(this.scheme) != -1 ? "//" + (
+          this.host != null ? "//" + (
             ("" != this.username || null != this.password) ? this.username + (
               null != this.password ? ":" + this.password : ""
             ) + "@" : ""
-          ) + this.host : ""
-        ) + (this.port ? ":" + this.port : "") + this.path + this.query + this.fragment
+          ) + this.host + (this.port ? ":" + this.port : "") : ""
+        ) + this.path + this.query + this.fragment
       } },
       "protocol": { get: function() { return this.scheme + ":" } },
       "search": { get: function() { return "?" == this.query ? "" : this.query } },
-      "hash": { get: function() { return "#" == this.fragment ? "" : this.fragment } }
+      "hash": { get: function() { return "#" == this.fragment ? "" : this.fragment } },
+      "hostname": { get: function() { return null == this.host ? "" : this.host } }
     })
   }
   function normalize(input) {


### PR DESCRIPTION
This was added to the specification with
https://github.com/whatwg/url/commit/b266a43fc9df0e8607074bd4d336a517e20
10009 and sorely needs some tests.

This also changes the urltestparser.js and those that use it due to the
new semantics.
