### PR TITLE
Test that the exception doesn't get lost in acceptNode.

### DIFF
--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -123,33 +123,31 @@ test(function()
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
 }, 'Testing acceptNode callee');
 
-// XXX Looks like Servo is doing something wrong when a callback function throws
 test(function()
 {
+    var test_error = { name: "test" };
     var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT,
                                            function(node) {
-                                               throw('filter exception');
-                                               return /*NodeFilter.*/FILTER_ACCEPT;
+                                               throw test_error;
                                            });
-    assert_throws(null, function () { walker.firstChild(); });
+    assert_throws(test_error, function () { walker.firstChild(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
-    assert_throws(null, function () { walker.nextNode(); });
+    assert_throws(test_error, function () { walker.nextNode(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, 'Testing with filter function that throws');
 
-// XXX Looks like Servo is doing something wrong when a callback function throws
 test(function()
 {
+    var test_error = { name: "test" };
     var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT,
                                            {
                                                acceptNode : function(node) {
-                                                   throw('filter exception');
-                                                   return /*NodeFilter.*/FILTER_ACCEPT;
+                                                   throw test_error;
                                                }
                                            });
-    assert_throws(null, function () { walker.firstChild(); });
+    assert_throws(test_error, function () { walker.firstChild(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
-    assert_throws(null, function () { walker.nextNode(); });
+    assert_throws(test_error, function () { walker.nextNode(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
 }, 'Testing with filter object that throws');
 


### PR DESCRIPTION
And it turns out that it does get lost. I have no idea where, but I suspect it
is in SpiderMonkey somewhere. I hope the SpiderMonkey upgrade will fix it.
