### PR TITLE
Use hostname rather than host when appending a port manually.

### DIFF
--- a/websockets/constructor/017.html
+++ b/websockets/constructor/017.html
@@ -13,6 +13,6 @@ var tests = [
 ];
 //Pass condition is to not throw
 for (var i = 0; i < tests.length; ++i) {
-  test(function(){new WebSocket(tests[i][0] + location.host + ':' + tests[i][1] + '/echo')}, tests[i][0]);
+  test(function(){new WebSocket(tests[i][0] + location.hostname + ':' + tests[i][1] + '/echo')}, tests[i][0]);
 }
 </script>


### PR DESCRIPTION
The host attribute returns the port as well as the hostname.
