### PR TITLE
Serve: Remove misleading shebang.

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from tools.serve import serve
 
 def main():


### PR DESCRIPTION
This PR fixes the following issue:

The serve.py script does nothing when invoked and is not marked with an executable bit.
Hashbang is therefore misleading.
This also  [breaks presubmit checks](http://build.chromium.org/p/tryserver.blink/builders/blink_presubmit/builds/36248/steps/presubmit/logs/stdio) in Chromium.

@jgraham, @Ms2ger, @mikewest 
