### PR TITLE
Fix subresource-integrity.html 'use-credential' test case failure

### DIFF
--- a/subresource-integrity/crossorigin-creds-script.js.sub.headers
+++ b/subresource-integrity/crossorigin-creds-script.js.sub.headers
@@ -1,2 +1,2 @@
-Access-Control-Allow-Origin: http://{{domains[]}}:{{ports[http][0]}}
+Access-Control-Allow-Origin: {{location[scheme]}}://{{domains[]}}:{{location[port]}}
 Access-Control-Allow-Credentials: true


### PR DESCRIPTION
The 'use-credentials' test cases were failing when the tests were hosted on HTTPS sites. This was because the headers encoded the Access-Control-Allow-Origin: origin to be HTTP. This fix makes the protocol match wherever the request came from.
