### PR TITLE
adjust explict revoke test to fail if revocation fails

### DIFF
--- a/media-source/URL-createObjectURL-revoke.html
+++ b/media-source/URL-createObjectURL-revoke.html
@@ -9,13 +9,20 @@
 <body>
 <div id="log"></div>
 <script>
-var video = document.createElement('video');
-test(function() {
+async_test(function(t) {
     var mediaSource = new MediaSource();
     var url = window.URL.createObjectURL(mediaSource);
     window.URL.revokeObjectURL(url);
+    mediaSource.addEventListener('sourceopen',
+                                 t.unreached_func("url should not reference MediaSource."));
+    var video = document.createElement('video');
     video.src = url;
-    assert_equals(mediaSource.readyState, 'closed');
+    video.addEventListener('error', t.step_func_done(function(e) {
+        assert_equals(e.target.error.code,
+                      MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
+                      'Expected error code');
+        assert_equals(mediaSource.readyState, 'closed');
+    }));
 }, "Check revoking behavior of URL.revokeObjectURL(url).");
 </script>
 </body>


### PR DESCRIPTION
Previously this test would pass even without the revokeObjectURL().

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1116382
