### PR TITLE
test opening referenced MediaSource after URL.revokeObjectURL()

### DIFF
--- a/media-source/URL-createObjectURL-revoke.html
+++ b/media-source/URL-createObjectURL-revoke.html
@@ -24,6 +24,20 @@ async_test(function(t) {
         assert_equals(mediaSource.readyState, 'closed');
     }));
 }, "Check revoking behavior of URL.revokeObjectURL(url).");
+async_test(function(t) {
+    var mediaSource = new MediaSource();
+    var url = window.URL.createObjectURL(mediaSource);
+    var video = document.createElement('video');
+    var unexpectedErrorHandler = t.unreached_func("Unexpected error.")
+    video.addEventListener('error', unexpectedErrorHandler);
+    video.src = url;
+    window.URL.revokeObjectURL(url);
+    mediaSource.addEventListener('sourceopen', t.step_func_done(function(e) {
+        assert_equals(mediaSource.readyState, 'open');
+        mediaSource.endOfStream();
+        video.removeEventListener('error', unexpectedErrorHandler);
+    }));
+}, "Check referenced MediaSource can open after URL.revokeObjectURL(url).");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1116382
