### PR TITLE
Fix IndexedDB tests to expect InvalidStateError rather than TransactionInactiveError when touching a deleted IDBObjectStore or IDBIndex object, r=janv.

### DIFF
--- a/IndexedDB/idbindex_get7.htm
+++ b/IndexedDB/idbindex_get7.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("TransactionInactiveError", function(){
+        assert_throws("InvalidStateError", function(){
             index.get("data");
         });
         t.done();

--- a/IndexedDB/idbindex_getKey7.htm
+++ b/IndexedDB/idbindex_getKey7.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("TransactionInactiveError", function(){
+        assert_throws("InvalidStateError", function(){
             index.getKey("data");
         });
         t.done();

--- a/IndexedDB/idbindex_openCursor2.htm
+++ b/IndexedDB/idbindex_openCursor2.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("TransactionInactiveError", function(){
+        assert_throws("InvalidStateError", function(){
             index.openCursor();
         });
         t.done();

--- a/IndexedDB/idbindex_openKeyCursor3.htm
+++ b/IndexedDB/idbindex_openKeyCursor3.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("TransactionInactiveError", function(){
+        assert_throws("InvalidStateError", function(){
             index.openKeyCursor();
         });
         t.done();


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1149815
