### PR TITLE
patch 2 - Make searchParams attribute readonly,

### DIFF
--- a/url/interfaces.html
+++ b/url/interfaces.html
@@ -30,7 +30,7 @@ interface URLUtils {
            attribute ScalarValueString port;
            attribute ScalarValueString pathname;
            attribute ScalarValueString search;
-           attribute URLSearchParams searchParams;
+           readonly attribute URLSearchParams searchParams;
            attribute ScalarValueString hash;
 };
 


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1174731
