### PR TITLE
Fix imported webstorage tests to use async_test(), step_func()

### DIFF
--- a/webstorage/event_basic.js
+++ b/webstorage/event_basic.js
@@ -1,11 +1,11 @@
-test(function() {
+async_test(function(t) {
     var name ;
-    testStorages(runTest);
+    testStorages(t.step_func(runTest));
 
     function runTest(storageString, callback)
     {
         name = storageString;
-        window.completionCallback = callback;
+        window.completionCallback = function() { t.done(); };
 
         assert_true(storageString in window, storageString + " exist");
         window.storage = eval(storageString);
@@ -14,7 +14,7 @@ test(function() {
         storage.clear();
         assert_equals(storage.length, 0, "storage.length");
 
-        runAfterNStorageEvents(step1, 0);
+        runAfterNStorageEvents(t.step_func(step1), 0);
     }
 
     function step1(msg)
@@ -22,7 +22,7 @@ test(function() {
         storageEventList = new Array();
         storage.setItem('FOO', 'BAR');
 
-        runAfterNStorageEvents(step2, 1);
+        runAfterNStorageEvents(t.step_func(step2), 1);
     }
 
     function shouldBeEqualToString(express, expectValue) {
@@ -32,117 +32,90 @@ test(function() {
 
     function step2(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 1);
-            shouldBeEqualToString(storageEventList[0].key, "FOO");
-            assert_equals(storageEventList[0].oldValue, null);
-            shouldBeEqualToString(storageEventList[0].newValue, "BAR");
-        }, name + ": the first storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 1);
+        shouldBeEqualToString(storageEventList[0].key, "FOO");
+        assert_equals(storageEventList[0].oldValue, null);
+        shouldBeEqualToString(storageEventList[0].newValue, "BAR");
 
         storage.setItem('FU', 'BAR');
         storage.setItem('a', '1');
         storage.setItem('b', '2');
         storage.setItem('b', '3');
 
-        runAfterNStorageEvents(step3, 5);
+        runAfterNStorageEvents(t.step_func(step3), 5);
     }
 
     function step3(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 5);
-            shouldBeEqualToString(storageEventList[1].key, "FU");
-            assert_equals(storageEventList[1].oldValue, null);
-            shouldBeEqualToString(storageEventList[1].newValue, "BAR");
-        }, name + ": the second storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 5);
+        shouldBeEqualToString(storageEventList[1].key, "FU");
+        assert_equals(storageEventList[1].oldValue, null);
+        shouldBeEqualToString(storageEventList[1].newValue, "BAR");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[2].key, "a");
-            assert_equals(storageEventList[2].oldValue, null);
-            shouldBeEqualToString(storageEventList[2].newValue, "1");
-        }, name + ": the third storage event properties");
+        shouldBeEqualToString(storageEventList[2].key, "a");
+        assert_equals(storageEventList[2].oldValue, null);
+        shouldBeEqualToString(storageEventList[2].newValue, "1");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[3].key, "b");
-            assert_equals(storageEventList[3].oldValue, null);
-            shouldBeEqualToString(storageEventList[3].newValue, "2");
-        }, name + ": the fourth storage event properties");
+        shouldBeEqualToString(storageEventList[3].key, "b");
+        assert_equals(storageEventList[3].oldValue, null);
+        shouldBeEqualToString(storageEventList[3].newValue, "2");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[4].key, "b");
-            shouldBeEqualToString(storageEventList[4].oldValue, "2");
-            shouldBeEqualToString(storageEventList[4].newValue, "3");
-        }, name + ": the fifth storage event properties");
-
+        shouldBeEqualToString(storageEventList[4].key, "b");
+        shouldBeEqualToString(storageEventList[4].oldValue, "2");
+        shouldBeEqualToString(storageEventList[4].newValue, "3");
 
         storage.removeItem('FOO');
 
-        runAfterNStorageEvents(step4, 6);
+        runAfterNStorageEvents(t.step_func(step4), 6);
     }
 
     function step4(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 6);
-            shouldBeEqualToString(storageEventList[5].key, "FOO");
-            shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
-            assert_equals(storageEventList[5].newValue, null);
-        }, name + ": the sixth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 6);
+        shouldBeEqualToString(storageEventList[5].key, "FOO");
+        shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
+        assert_equals(storageEventList[5].newValue, null);
 
         storage.removeItem('FU');
 
-        runAfterNStorageEvents(step5, 7);
+        runAfterNStorageEvents(t.step_func(step5), 7);
     }
 
     function step5(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 7);
-            shouldBeEqualToString(storageEventList[6].key, "FU");
-            shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
-            assert_equals(storageEventList[6].newValue, null);
-        }, name + ": the seventh storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 7);
+        shouldBeEqualToString(storageEventList[6].key, "FU");
+        shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
+        assert_equals(storageEventList[6].newValue, null);
 
         storage.clear();
 
-        runAfterNStorageEvents(step6, 8);
+        runAfterNStorageEvents(t.step_func(step6), 8);
     }
 
     function step6(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 8);
-            assert_equals(storageEventList[7].key, null);
-            assert_equals(storageEventList[7].oldValue, null);
-            assert_equals(storageEventList[7].newValue, null);
-        }, name + ": the eighth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 8);
+        assert_equals(storageEventList[7].key, null);
+        assert_equals(storageEventList[7].oldValue, null);
+        assert_equals(storageEventList[7].newValue, null);
 
         completionCallback();
     }
 
 }, "DOM Storage mutations fire StorageEvents that are caught by the event listener set via window.onstorage.");
-

--- a/webstorage/event_body_attribute.js
+++ b/webstorage/event_body_attribute.js
@@ -1,11 +1,11 @@
-test(function() {
+async_test(function(t) {
     var name ;
     testStorages(runTest);
 
     function runTest(storageString, callback)
     {
         name = storageString;
-        window.completionCallback = callback;
+        window.completionCallback = function() { t.done(); };
 
         assert_true(storageString in window, storageString + " exist");
         window.storage = eval(storageString);
@@ -13,7 +13,7 @@ test(function() {
         storage.clear();
         assert_equals(storage.length, 0, "storage.length");
 
-        iframe.onload = step1;
+        iframe.onload = t.step_func(step1);
         iframe.src = "iframe/event_body_handler.html";
     }
 
@@ -22,7 +22,7 @@ test(function() {
         storageEventList = new Array();
         storage.setItem('FOO', 'BAR');
 
-        runAfterNStorageEvents(step2, 1);
+        runAfterNStorageEvents(t.step_func(step2), 1);
     }
 
     function shouldBeEqualToString(express, expectValue) {
@@ -32,117 +32,90 @@ test(function() {
 
     function step2(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 1);
-            shouldBeEqualToString(storageEventList[0].key, "FOO");
-            assert_equals(storageEventList[0].oldValue, null);
-            shouldBeEqualToString(storageEventList[0].newValue, "BAR");
-        }, name + ": the first storage event properties");
+        if (msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 1);
+        shouldBeEqualToString(storageEventList[0].key, "FOO");
+        assert_equals(storageEventList[0].oldValue, null);
+        shouldBeEqualToString(storageEventList[0].newValue, "BAR");
 
         storage.setItem('FU', 'BAR');
         storage.setItem('a', '1');
         storage.setItem('b', '2');
         storage.setItem('b', '3');
 
-        runAfterNStorageEvents(step3, 5);
+        runAfterNStorageEvents(t.step_func(step3), 5);
     }
 
     function step3(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 5);
-            shouldBeEqualToString(storageEventList[1].key, "FU");
-            assert_equals(storageEventList[1].oldValue, null);
-            shouldBeEqualToString(storageEventList[1].newValue, "BAR");
-        }, name + ": the second storage event properties");
+        if (msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 5);
+        shouldBeEqualToString(storageEventList[1].key, "FU");
+        assert_equals(storageEventList[1].oldValue, null);
+        shouldBeEqualToString(storageEventList[1].newValue, "BAR");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[2].key, "a");
-            assert_equals(storageEventList[2].oldValue, null);
-            shouldBeEqualToString(storageEventList[2].newValue, "1");
-        }, name + ": the third storage event properties");
+        shouldBeEqualToString(storageEventList[2].key, "a");
+        assert_equals(storageEventList[2].oldValue, null);
+        shouldBeEqualToString(storageEventList[2].newValue, "1");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[3].key, "b");
-            assert_equals(storageEventList[3].oldValue, null);
-            shouldBeEqualToString(storageEventList[3].newValue, "2");
-        }, name + ": the fourth storage event properties");
+        shouldBeEqualToString(storageEventList[3].key, "b");
+        assert_equals(storageEventList[3].oldValue, null);
+        shouldBeEqualToString(storageEventList[3].newValue, "2");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[4].key, "b");
-            shouldBeEqualToString(storageEventList[4].oldValue, "2");
-            shouldBeEqualToString(storageEventList[4].newValue, "3");
-        }, name + ": the fifth storage event properties");
-
+        shouldBeEqualToString(storageEventList[4].key, "b");
+        shouldBeEqualToString(storageEventList[4].oldValue, "2");
+        shouldBeEqualToString(storageEventList[4].newValue, "3");
 
         storage.removeItem('FOO');
 
-        runAfterNStorageEvents(step4, 6);
+        runAfterNStorageEvents(t.step_func(step4), 6);
     }
 
     function step4(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 6);
-            shouldBeEqualToString(storageEventList[5].key, "FOO");
-            shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
-            assert_equals(storageEventList[5].newValue, null);
-        }, name + ": the sixth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 6);
+        shouldBeEqualToString(storageEventList[5].key, "FOO");
+        shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
+        assert_equals(storageEventList[5].newValue, null);
 
         storage.removeItem('FU');
 
-        runAfterNStorageEvents(step5, 7);
+        runAfterNStorageEvents(t.step_func(step5), 7);
     }
 
     function step5(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 7);
-            shouldBeEqualToString(storageEventList[6].key, "FU");
-            shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
-            assert_equals(storageEventList[6].newValue, null);
-        }, name + ": the seventh storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 7);
+        shouldBeEqualToString(storageEventList[6].key, "FU");
+        shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
+        assert_equals(storageEventList[6].newValue, null);
 
         storage.clear();
 
-        runAfterNStorageEvents(step6, 8);
+        runAfterNStorageEvents(t.step_func(step6), 8);
     }
 
     function step6(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 8);
-            assert_equals(storageEventList[7].key, null);
-            assert_equals(storageEventList[7].oldValue, null);
-            assert_equals(storageEventList[7].newValue, null);
-        }, name + ": the eighth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 8);
+        assert_equals(storageEventList[7].key, null);
+        assert_equals(storageEventList[7].oldValue, null);
+        assert_equals(storageEventList[7].newValue, null);
 
         completionCallback();
     }
 
 }, "DOM Storage mutations fire StorageEvents that are caught by the event listener specified as an attribute on the body.");
-

--- a/webstorage/event_case_sensitive.js
+++ b/webstorage/event_case_sensitive.js
@@ -1,11 +1,11 @@
-test(function() {
+async_test(function(t) {
     var name ;
-    testStorages(runTest);
+    testStorages(t.step_func(runTest));
 
     function runTest(storageString, callback)
     {
         name = storageString;
-        window.completionCallback = callback;
+        window.completionCallback = function() { t.done(); };
 
         assert_true(storageString in window, storageString + " exist");
         window.storage = eval(storageString);
@@ -14,7 +14,7 @@ test(function() {
         assert_equals(storage.length, 0, "storage.length");
         storage.foo = "test";
 
-        runAfterNStorageEvents(step1, 1);
+        runAfterNStorageEvents(t.step_func(step1), 1);
     }
 
     function step1(msg)
@@ -22,33 +22,28 @@ test(function() {
         storageEventList = new Array();
         storage.foo = "test";
 
-        runAfterNStorageEvents(step2, 0);
+        runAfterNStorageEvents(t.step_func(step2), 0);
     }
 
     function step2(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 0);
-        }, name + ": The key/value does not change, the event is not fired.");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 0);
 
         storage.foo = "TEST";
 
-        runAfterNStorageEvents(step3, 1);
+        runAfterNStorageEvents(t.step_func(step3), 1);
     }
 
     function step3(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 1);
-        }, name + ": The event is fired when the value case is changed.");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 1);
 
         completionCallback();
     }
 }, "storage events fire even when only the case of the value changes.");
-

--- a/webstorage/event_setattribute.js
+++ b/webstorage/event_setattribute.js
@@ -1,11 +1,11 @@
-test(function() {
+async_test(function(t) {
     var name ;
-    testStorages(runTest);
+    testStorages(t.step_func(runTest));
 
     function runTest(storageString, callback)
     {
         name = storageString;
-        window.completionCallback = callback;
+        window.completionCallback = function() { t.done(); };
 
         assert_true(storageString in window, storageString + " exist");
         window.storage = eval(storageString);
@@ -14,7 +14,7 @@ test(function() {
         storage.clear();
         assert_equals(storage.length, 0, "storage.length");
 
-        iframe.onload = step1;
+        iframe.onload = t.step_func(step1);
         iframe.src = "iframe/event_setattribute_handler.html";
     }
 
@@ -23,7 +23,7 @@ test(function() {
         storageEventList = new Array();
         storage.setItem('FOO', 'BAR');
 
-        runAfterNStorageEvents(step2, 1);
+        runAfterNStorageEvents(t.step_func(step2), 1);
     }
 
     function shouldBeEqualToString(express, expectValue) {
@@ -33,117 +33,90 @@ test(function() {
 
     function step2(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 1);
-            shouldBeEqualToString(storageEventList[0].key, "FOO");
-            assert_equals(storageEventList[0].oldValue, null);
-            shouldBeEqualToString(storageEventList[0].newValue, "BAR");
-        }, name + ": the first storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 1);
+        shouldBeEqualToString(storageEventList[0].key, "FOO");
+        assert_equals(storageEventList[0].oldValue, null);
+        shouldBeEqualToString(storageEventList[0].newValue, "BAR");
 
         storage.setItem('FU', 'BAR');
         storage.setItem('a', '1');
         storage.setItem('b', '2');
         storage.setItem('b', '3');
 
-        runAfterNStorageEvents(step3, 5);
+        runAfterNStorageEvents(t.step_func(step3), 5);
     }
 
     function step3(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 5);
-            shouldBeEqualToString(storageEventList[1].key, "FU");
-            assert_equals(storageEventList[1].oldValue, null);
-            shouldBeEqualToString(storageEventList[1].newValue, "BAR");
-        }, name + ": the second storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 5);
+        shouldBeEqualToString(storageEventList[1].key, "FU");
+        assert_equals(storageEventList[1].oldValue, null);
+        shouldBeEqualToString(storageEventList[1].newValue, "BAR");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[2].key, "a");
-            assert_equals(storageEventList[2].oldValue, null);
-            shouldBeEqualToString(storageEventList[2].newValue, "1");
-        }, name + ": the third storage event properties");
+        shouldBeEqualToString(storageEventList[2].key, "a");
+        assert_equals(storageEventList[2].oldValue, null);
+        shouldBeEqualToString(storageEventList[2].newValue, "1");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[3].key, "b");
-            assert_equals(storageEventList[3].oldValue, null);
-            shouldBeEqualToString(storageEventList[3].newValue, "2");
-        }, name + ": the forth storage event properties");
+        shouldBeEqualToString(storageEventList[3].key, "b");
+        assert_equals(storageEventList[3].oldValue, null);
+        shouldBeEqualToString(storageEventList[3].newValue, "2");
 
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            shouldBeEqualToString(storageEventList[4].key, "b");
-            shouldBeEqualToString(storageEventList[4].oldValue, "2");
-            shouldBeEqualToString(storageEventList[4].newValue, "3");
-        }, name + ": the fifth storage event properties");
-
+        shouldBeEqualToString(storageEventList[4].key, "b");
+        shouldBeEqualToString(storageEventList[4].oldValue, "2");
+        shouldBeEqualToString(storageEventList[4].newValue, "3");
 
         storage.removeItem('FOO');
 
-        runAfterNStorageEvents(step4, 6);
+        runAfterNStorageEvents(t.step_func(step4), 6);
     }
 
     function step4(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 6);
-            shouldBeEqualToString(storageEventList[5].key, "FOO");
-            shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
-            assert_equals(storageEventList[5].newValue, null);
-        }, name + ": the sixth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 6);
+        shouldBeEqualToString(storageEventList[5].key, "FOO");
+        shouldBeEqualToString(storageEventList[5].oldValue, "BAR");
+        assert_equals(storageEventList[5].newValue, null);
 
         storage.removeItem('FU');
 
-        runAfterNStorageEvents(step5, 7);
+        runAfterNStorageEvents(t.step_func(step5), 7);
     }
 
     function step5(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 7);
-            shouldBeEqualToString(storageEventList[6].key, "FU");
-            shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
-            assert_equals(storageEventList[6].newValue, null);
-        }, name + ": the seventh storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 7);
+        shouldBeEqualToString(storageEventList[6].key, "FU");
+        shouldBeEqualToString(storageEventList[6].oldValue, "BAR");
+        assert_equals(storageEventList[6].newValue, null);
 
         storage.clear();
 
-        runAfterNStorageEvents(step6, 8);
+        runAfterNStorageEvents(t.step_func(step6), 8);
     }
 
     function step6(msg)
     {
-        test(function() {
-            if(msg != undefined) {
-                assert_unreached(msg);
-            }
-            assert_equals(storageEventList.length, 8);
-            assert_equals(storageEventList[7].key, null);
-            assert_equals(storageEventList[7].oldValue, null);
-            assert_equals(storageEventList[7].newValue, null);
-        }, name + ": the eighth storage event properties");
+        if(msg != undefined) {
+            assert_unreached(msg);
+        }
+        assert_equals(storageEventList.length, 8);
+        assert_equals(storageEventList[7].key, null);
+        assert_equals(storageEventList[7].oldValue, null);
+        assert_equals(storageEventList[7].newValue, null);
 
         completionCallback();
     }
 
 }, "DOM Storage mutations fire StorageEvents that are caught by the event listener attached via setattribute.");
-


### PR DESCRIPTION
These async tests were imported as a series of nested synchronous test() calls. Rework/simplify to make the outermost an async_test() and wrap the individual steps with step_func(). This matches the behavior of the original Blink tests these were adapted from.
