### PR TITLE
Avoid timeouts in quota tests by putting bigger data chunks

### DIFF
--- a/webstorage/storage_local_setitem_quotaexceedederr.html
+++ b/webstorage/storage_local_setitem_quotaexceedederr.html
@@ -15,12 +15,12 @@
 
             var index = 0;
             var key = "name";
-            var val = "user";
+            var val = "x".repeat(1024);
 
             assert_throws("QUOTA_EXCEEDED_ERR", function() {
                 while (true) {
                     index++;
-                    localStorage.setItem("" + key + index, "" + index);
+                    localStorage.setItem("" + key + index, "" + val + index);
                 }
             });
 

--- a/webstorage/storage_session_setitem_quotaexceedederr.html
+++ b/webstorage/storage_session_setitem_quotaexceedederr.html
@@ -15,12 +15,12 @@
 
             var index = 0;
             var key = "name";
-            var val = "user";
+            var val = "x".repeat(1024);
 
             assert_throws("QUOTA_EXCEEDED_ERR", function() {
                 while (true) {
                     index++;
-                    sessionStorage.setItem("" + key + index, "" + index);
+                    sessionStorage.setItem("" + key + index, "" + val + index);
                 }
             });
 


### PR DESCRIPTION
Putting small key/value pairs can take longer than the timeout threshold to hit quota limits. Put at least 1k (depending on string representation, etc) at a time to hit the limit more quickly.
