### PR TITLE
Adding tests for DOM APIs before, after, replaceWith, append and prepend

### DIFF
--- a/dom/nodes/ChildNode-after.html
+++ b/dom/nodes/ChildNode-after.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ChildNode.after</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-childnode-after">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_after(child, nodeName, innerHTML) {
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after();
+        assert_equals(parent.innerHTML, innerHTML);
+    }, nodeName + '.after() without any argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after(null);
+        var expected = innerHTML + 'null';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with null as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after(undefined);
+        var expected = innerHTML + 'undefined';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with undefined as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after('');
+        assert_equals(parent.lastChild.data, '');
+    }, nodeName + '.after() with the empty string as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after('text');
+        var expected = innerHTML + 'text';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with only text as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.after(x);
+        var expected = innerHTML + '<x></x>';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with only one element as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.after(x, 'text');
+        var expected = innerHTML + '<x></x>text';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with one element and text as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.after('text', child);
+        var expected = 'text' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with context object itself as the argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        var z = document.createElement('z');
+        parent.appendChild(y);
+        parent.appendChild(child);
+        parent.appendChild(x);
+        child.after(x, y, z);
+        var expected = innerHTML + '<x></x><y></y><z></z>';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with all siblings of child as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(child);
+        parent.appendChild(x);
+        parent.appendChild(y);
+        child.after(y, x);
+        var expected = innerHTML + '<y></y><x></x>';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() when pre-insert behaves like append.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(child);
+        parent.appendChild(x);
+        parent.appendChild(document.createTextNode('1'));
+        parent.appendChild(y);
+        child.after(x, '2');
+        var expected = innerHTML + '<x></x>12<y></y>';
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.after() with one sibling of child and text as arguments.');
+
+    test(function() {
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        x.after(y);
+        assert_equals(x.nextSibling, null);
+    }, nodeName + '.after() on a child without any parent.');
+}
+
+test_after(document.createComment('test'), 'Comment', '<!--test-->');
+test_after(document.createElement('test'), 'Element', '<test></test>');
+test_after(document.createTextNode('test'), 'Text', 'test');
+
+</script>
+</html>

--- a/dom/nodes/ChildNode-before.html
+++ b/dom/nodes/ChildNode-before.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ChildNode.before</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-childnode-before">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_before(child, nodeName, innerHTML) {
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before();
+        assert_equals(parent.innerHTML, innerHTML);
+    }, nodeName + '.before() without any argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before(null);
+        var expected = 'null' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with null as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before(undefined);
+        var expected = 'undefined' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with undefined as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before('');
+        assert_equals(parent.firstChild.data, '');
+    }, nodeName + '.before() with the empty string as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before('text');
+        var expected = 'text' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with only text as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.before(x);
+        var expected = '<x></x>' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with only one element as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.before(x, 'text');
+        var expected = '<x></x>text' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with one element and text as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.before('text', child);
+        var expected = 'text' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with context object itself as the argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        var z = document.createElement('z');
+        parent.appendChild(y);
+        parent.appendChild(child);
+        parent.appendChild(x);
+        child.before(x, y, z);
+        var expected = '<x></x><y></y><z></z>' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with all siblings of child as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(x);
+        parent.appendChild(y);
+        parent.appendChild(child);
+        child.before(y, x);
+        var expected = '<y></y><x></x>' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() when pre-insert behaves like prepend.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(x);
+        parent.appendChild(document.createTextNode('1'));
+        var y = document.createElement('y');
+        parent.appendChild(y);
+        parent.appendChild(child);
+        child.before(x, '2');
+        var expected = '1<y></y><x></x>2' + innerHTML;
+        assert_equals(parent.innerHTML, expected);
+    }, nodeName + '.before() with one sibling of child and text as arguments.');
+
+    test(function() {
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        x.before(y);
+        assert_equals(x.previousSibling, null);
+    }, nodeName + '.before() on a child without any parent.');
+}
+
+test_before(document.createComment('test'), 'Comment', '<!--test-->');
+test_before(document.createElement('test'), 'Element', '<test></test>');
+test_before(document.createTextNode('test'), 'Text', 'test');
+
+</script>
+</html>

--- a/dom/nodes/ChildNode-replaceWith.html
+++ b/dom/nodes/ChildNode-replaceWith.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ChildNode.replaceWith</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-childnode-replaceWith">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_replaceWith(child, nodeName, innerHTML) {
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.replaceWith();
+        assert_equals(parent.innerHTML, '');
+    }, nodeName + '.replaceWith() without any argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.replaceWith(null);
+        assert_equals(parent.innerHTML, 'null');
+    }, nodeName + '.replaceWith() with null as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.replaceWith(undefined);
+        assert_equals(parent.innerHTML, 'undefined');
+    }, nodeName + '.replaceWith() with undefined as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.replaceWith('');
+        assert_equals(parent.innerHTML, '');
+    }, nodeName + '.replaceWith() with empty string as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        parent.appendChild(child);
+        child.replaceWith('text');
+        assert_equals(parent.innerHTML, 'text');
+    }, nodeName + '.replaceWith() with only text as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.replaceWith(x);
+        assert_equals(parent.innerHTML, '<x></x>');
+    }, nodeName + '.replaceWith() with only one element as an argument.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        var z = document.createElement('z');
+        parent.appendChild(y);
+        parent.appendChild(child);
+        parent.appendChild(x);
+        child.replaceWith(x, y, z);
+        assert_equals(parent.innerHTML, '<x></x><y></y><z></z>');
+    }, nodeName + '.replaceWith() with sibling of child as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        parent.appendChild(x);
+        parent.appendChild(document.createTextNode('1'));
+        child.replaceWith(x, '2');
+        assert_equals(parent.innerHTML, '<x></x>21');
+    }, nodeName + '.replaceWith() with one sibling of child and text as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        parent.appendChild(x);
+        parent.appendChild(document.createTextNode('text'));
+        child.replaceWith(x, child);
+        assert_equals(parent.innerHTML, '<x></x>' + innerHTML + 'text');
+    }, nodeName + '.replaceWith() with one sibling of child and child itself as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        parent.appendChild(child);
+        child.replaceWith(x, 'text');
+        assert_equals(parent.innerHTML, '<x></x>text');
+    }, nodeName + '.replaceWith() with one element and text as arguments.');
+
+    test(function() {
+        var parent = document.createElement('div');
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(x);
+        parent.appendChild(y);
+        child.replaceWith(x, y);
+        assert_equals(parent.innerHTML, '<x></x><y></y>');
+    }, nodeName + '.replaceWith() on a parentless child with two elements as arguments.');
+}
+
+test_replaceWith(document.createComment('test'), 'Comment', '<!--test-->');
+test_replaceWith(document.createElement('test'), 'Element', '<test></test>');
+test_replaceWith(document.createTextNode('test'), 'Text', 'test');
+
+</script>
+</html>

--- a/dom/nodes/ParentNode-append.html
+++ b/dom/nodes/ParentNode-append.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ParentNode.append</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-parentnode-append">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_append(node, nodeName) {
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.append();
+        assert_array_equals(parent.childNodes, []);
+    }, nodeName + '.append() without any argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.append(null);
+        assert_equals(parent.childNodes[0].textContent, 'null');
+    }, nodeName + '.append() with null as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.append(undefined);
+        assert_equals(parent.childNodes[0].textContent, 'undefined');
+    }, nodeName + '.append() with undefined as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.append('text');
+        assert_equals(parent.childNodes[0].textContent, 'text');
+    }, nodeName + '.append() with only text as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        parent.append(x);
+        assert_array_equals(parent.childNodes, [x]);
+    }, nodeName + '.append() with only one element as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var child = document.createElement('test');
+        parent.appendChild(child);
+        parent.append(null);
+        assert_equals(parent.childNodes[0], child);
+        assert_equals(parent.childNodes[1].textContent, 'null');
+    }, nodeName + '.append() with null as an argument, on a parent having a child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var child = document.createElement('test');
+        parent.appendChild(child);
+        parent.append(x, 'text');
+        assert_equals(parent.childNodes[0], child);
+        assert_equals(parent.childNodes[1], x);
+        assert_equals(parent.childNodes[2].textContent, 'text');
+    }, nodeName + '.append() with one element and text as argument, on a parent having a child.');
+}
+
+test_append(document.createElement('div'), 'Element');
+test_append(document.createDocumentFragment(), 'DocumentFrgment');
+</script>
+</html>

--- a/dom/nodes/ParentNode-prepend.html
+++ b/dom/nodes/ParentNode-prepend.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>ParentNode.prepend</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-parentnode-prepend">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_prepend(node, nodeName) {
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.prepend();
+        assert_array_equals(parent.childNodes, []);
+    }, nodeName + '.prepend() without any argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.prepend(null);
+        assert_equals(parent.childNodes[0].textContent, 'null');
+    }, nodeName + '.prepend() with null as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.prepend(undefined);
+        assert_equals(parent.childNodes[0].textContent, 'undefined');
+    }, nodeName + '.prepend() with undefined as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        parent.prepend('text');
+        assert_equals(parent.childNodes[0].textContent, 'text');
+    }, nodeName + '.prepend() with only text as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        parent.prepend(x);
+        assert_array_equals(parent.childNodes, [x]);
+    }, nodeName + '.prepend() with only one element as an argument, on a parent having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var child = document.createElement('test');
+        parent.appendChild(child);
+        parent.prepend(null);
+        assert_equals(parent.childNodes[0].textContent, 'null');
+        assert_equals(parent.childNodes[1], child);
+    }, nodeName + '.prepend() with null as an argument, on a parent having a child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var child = document.createElement('test');
+        parent.appendChild(child);
+        parent.prepend(x, 'text');
+        assert_equals(parent.childNodes[0], x);
+        assert_equals(parent.childNodes[1].textContent, 'text');
+        assert_equals(parent.childNodes[2], child);
+    }, nodeName + '.prepend() with one element and text as argument, on a parent having a child.');
+}
+
+test_prepend(document.createElement('div'), 'Element');
+test_prepend(document.createDocumentFragment(), 'DocumentFrgment');
+</script>
+</html>

--- a/dom/nodes/append-on-Document.html
+++ b/dom/nodes/append-on-Document.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>DocumentType.append</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-parentnode-append">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_append_on_Document() {
+
+    var node = document.implementation.createDocument(null, null);
+    test(function() {
+        var parent = node.cloneNode();
+        parent.append();
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.append() without any argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        parent.append(x);
+        assert_array_equals(parent.childNodes, [x]);
+    }, 'Document.append() with only one element as an argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(x);
+        assert_throws('HierarchyRequestError', function() { parent.append(y); });
+        assert_array_equals(parent.childNodes, [x]);
+    }, 'Document.append() with only one element as an argument, on a Document having one child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        assert_throws('HierarchyRequestError', function() { parent.append('text'); });
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.append() with text as an argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        assert_throws('HierarchyRequestError', function() { parent.append(x, y); });
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.append() with two elements as the argument, on a Document having no child.');
+
+}
+
+test_append_on_Document();
+
+</script>
+</html>

--- a/dom/nodes/prepend-on-Document.html
+++ b/dom/nodes/prepend-on-Document.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>DocumentType.prepend</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-parentnode-prepend">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function test_prepend_on_Document() {
+
+    var node = document.implementation.createDocument(null, null);
+    test(function() {
+        var parent = node.cloneNode();
+        parent.prepend();
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.prepend() without any argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        parent.prepend(x);
+        assert_array_equals(parent.childNodes, [x]);
+    }, 'Document.prepend() with only one element as an argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        parent.appendChild(x);
+        assert_throws('HierarchyRequestError', function() { parent.prepend(y); });
+        assert_array_equals(parent.childNodes, [x]);
+    }, 'Document.append() with only one element as an argument, on a Document having one child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        assert_throws('HierarchyRequestError', function() { parent.prepend('text'); });
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.prepend() with text as an argument, on a Document having no child.');
+
+    test(function() {
+        var parent = node.cloneNode();
+        var x = document.createElement('x');
+        var y = document.createElement('y');
+        assert_throws('HierarchyRequestError', function() { parent.prepend(x, y); });
+        assert_array_equals(parent.childNodes, []);
+    }, 'Document.prepend() with two elements as the argument, on a Document having no child.');
+
+}
+
+test_prepend_on_Document();
+
+</script>
+</html>


### PR DESCRIPTION
Adding tests for DOM convenience APIs
- ChildNode.after(),
- ChildNode.before(),
- ChildNode.replaceWith(),
- ParentNode.append() and
- ParentNode.prepend().

These tests are basically taken from https://codereview.chromium.org/1085843002.

Fixes #1968.
