### PR TITLE
Remove existing console.* instances in the suite.

### DIFF
--- a/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_9.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_canvas_9.html
@@ -38,7 +38,6 @@ try {
     destCtx.fillRect(0, 0,  destCanvas.width, destCanvas.height);
 }
 catch(err) {
-  console.err("Exception Thrown");
 }
 
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_13.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_13.html
@@ -33,7 +33,6 @@ try {
     destCtx.fillRect(0, 0,  destCanvas.width, destCanvas.height);
 }
 catch(err) {
-  console.log("Exception: " + err.message);
 }
 
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_9.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_9.html
@@ -32,7 +32,6 @@ try {
     destCtx.fillRect(0, 0,  destCanvas.width, destCanvas.height);
 }
 catch(err) {
-  console.err("Exception Thrown");
 }
 
 </script>

--- a/conformance-checkers/html-aria/_functional/tree/js/aria.js
+++ b/conformance-checkers/html-aria/_functional/tree/js/aria.js
@@ -20,7 +20,6 @@ var Aria = {
 Aria.Tree = Class.create();
 Aria.Tree.prototype = {
 	initialize: function(inNode){
-		if(!$(inNode) && console.error) console.error('Error from aria.js: Aria.Tree instance initialized with invalid element, '+ inNode);
 		this.el = $(inNode);
 		this.index = Aria.Trees.length; // each tree should know its index in the Aria singleton's list, in order to concatenate id strings
 		this.strActiveDescendant = this.el.getAttribute('aria-activedescendant');
@@ -112,8 +111,7 @@ Aria.Tree.prototype = {
 			case Event.KEY_UP:       this.keyUp();    break;
 			case Event.KEY_RIGHT:    this.keyRight(); break;
 			case Event.KEY_DOWN:     this.keyDown();  break;
-			default: 
-				//console.log(inEvent.keyCode);
+			default:
 				return;
 		}
 		Event.stop(inEvent);

--- a/cors/credentials-flag.htm
+++ b/cors/credentials-flag.htm
@@ -77,7 +77,6 @@ async_test(function () {
     client.open("GET", url + id, true)
     client.withCredentials = false
     client.onload = this.step_func(function() {
-        console.log(client.response + '_', client.response)
         assert_equals(client.response, "NO_COOKIE", "first");
 
         /* Sets the cookie */

--- a/cors/remote-origin.htm
+++ b/cors/remote-origin.htm
@@ -49,7 +49,6 @@ function reverseOrigin(expect_pass, origin)
     else
     {
         t.callback = t.step_func(function(e) {
-            if (e.response) console.log(e.response);
             assert_equals(e.state, "error");
             assert_equals(e.response, "");
             this.done();

--- a/dom/nodes/ParentNode-querySelector-All.js
+++ b/dom/nodes/ParentNode-querySelector-All.js
@@ -160,7 +160,7 @@ function runValidSelectorTest(type, root, selectors, testType, docType) {
       nodeType = "fragment";
       break;
     default:
-      console.log("Reached unreachable code path.");
+      assert_unreached();
       nodeType = "unknown"; // This should never happen.
   }
 
@@ -172,7 +172,6 @@ function runValidSelectorTest(type, root, selectors, testType, docType) {
 
     if ((!s["exclude"] || (s["exclude"].indexOf(nodeType) === -1 && s["exclude"].indexOf(docType) === -1))
      && (s["testType"] & testType) ) {
-      //console.log("Running tests " + nodeType + ": " + s["testType"] + "&" + testType + "=" + (s["testType"] & testType) + ": " + JSON.stringify(s))
       var foundall, found;
 
       test(function() {
@@ -199,8 +198,6 @@ function runValidSelectorTest(type, root, selectors, testType, docType) {
           assert_equals(found, null, "The method should not match anything.");
         }
       }, type + ".querySelector: " + n + ": " + q);
-    } else {
-      //console.log("Excluding for " + nodeType + ": " + s["testType"] + "&" + testType + "=" + (s["testType"] & testType) + ": " + JSON.stringify(s))
     }
   }
 }
@@ -249,7 +246,7 @@ function getNodeType(node) {
     case Node.DOCUMENT_FRAGMENT_NODE:
       return "fragment";
     default:
-      console.log("Reached unreachable code path.");
+      assert_unreached();
       return "unknown"; // This should never happen.
   }
 }

--- a/html-imports/fetching/already-in-import-map.html
+++ b/html-imports/fetching/already-in-import-map.html
@@ -20,7 +20,6 @@ test(function() {
 }, 'If LOCATION is already in the import map, let IMPORT be the imported document for LOCATION and stop. (1)');
 
 test(function() {
-   console.log(window.parentOfFirst);
    assert_true(window.first.import === window.parentOfFirst.import.getElementById('child').import);
 }, 'If LOCATION is already in the import map, let IMPORT be the imported document for LOCATION and stop. (2)');
 </script>

--- a/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
+++ b/mediacapture-streams/stream-api/mediastream/mediastream-removetrack.html
@@ -27,9 +27,7 @@ t.step(function () {
   }
 
   function gotVideo(stream) {
-    console.log(stream);
     var video = stream;
-    console.log(video);
     video.onremovetrack = function () {
        assert_unreached("onremovetrack is not triggered when removal of track is triggered by the script itself");
     };

--- a/old-tests/submission/Opera/script_scheduling/083.html
+++ b/old-tests/submission/Opera/script_scheduling/083.html
@@ -18,7 +18,7 @@
 		}
 		var doc = frames[0].document;
 		doc.open('text/html');
-		doc.write('<script>top.log("IFRAME script");top.document.addEventListener("foo", function(e){ console.log(e+ " "+top+" "+self.location.href); top.log("event: "+e.type); }, false)<\/script>');
+		doc.write('<script>top.log("IFRAME script");top.document.addEventListener("foo", function(e){ top.log("event: "+e.type); }, false)<\/script>');
 		log('end script #1');
 	</script>
 	<script>

--- a/selectors-api/tests/submissions/Opera/ParentNode-query-queryAll.js
+++ b/selectors-api/tests/submissions/Opera/ParentNode-query-queryAll.js
@@ -109,7 +109,6 @@ function runValidSelectorTest(type, root, selectors, docType) {
     var ref = s["ref"];
 
     if (!s["exclude"] || (s["exclude"].indexOf(nodeType) === -1 && s["exclude"].indexOf(docType) === -1)) {
-      //console.log("Running tests " + nodeType + ": " + s["testType"] + "&" + testType + "=" + (s["testType"] & testType) + ": " + JSON.stringify(s))
       var foundall, found, context, refNodes, refArray;
 
       if (s["testType"] & TEST_FIND) {
@@ -225,8 +224,6 @@ function runValidSelectorTest(type, root, selectors, docType) {
           }, type + ".query: " + n + " (with no refNodes): " + q);
         }
       }
-    } else {
-      //console.log("Excluding for " + nodeType + ": " + s["testType"] + "&" + testType + "=" + (s["testType"] & testType) + ": " + JSON.stringify(s))
     }
   }
 }

--- a/shadow-dom/testcommon.js
+++ b/shadow-dom/testcommon.js
@@ -180,8 +180,6 @@ function unit(f) {
         var ctx = newContext();
         try {
             f(ctx);
-        } catch(e) {
-            console.log(e.getMessage());
         } finally {
             cleanContext(ctx);
         }


### PR DESCRIPTION
Fixes #1976.
This removes also console.\* instances in the suite except for the ones that
recently got added to the content-security-policy tree through PR #1935.
