### PR TITLE
Some assertions generate always changing messages when failing

### DIFF
--- a/XMLHttpRequest/responsexml-document-properties.htm
+++ b/XMLHttpRequest/responsexml-document-properties.htm
@@ -43,7 +43,7 @@
       }
 
       test(function() {
-        assert_equals((new Date(client.getResponseHeader('Last-Modified'))).getTime(), (new Date(client.responseXML.lastModified)).getTime()) 
+        assert_true((new Date(client.getResponseHeader('Last-Modified'))).getTime() == (new Date(client.responseXML.lastModified)).getTime(), 'responseXML.lastModified time shoud be equal to time in response Last-Modified header')
       }, 'lastModified set according to HTTP header')
 
       test(function() {

--- a/XMLHttpRequest/send-authentication-basic-setrequestheader-existing-session.htm
+++ b/XMLHttpRequest/send-authentication-basic-setrequestheader-existing-session.htm
@@ -25,7 +25,7 @@
         client.setRequestHeader('X-User', open_user)
         // initial request - this will get a 401 response and re-try with HTTP auth
         client.send(null)
-        assert_equals(client.responseText, open_user + '\nopen-pass')
+        assert_true(client.responseText == (open_user + '\nopen-pass'), 'responseText should contain the right user and password')
         assert_equals(client.status, 200)
         assert_equals(client.getResponseHeader('x-challenge'), 'DID')
         // Another request, this time user,pass is omitted and an Authorization header set explicitly

--- a/XMLHttpRequest/send-authentication-competing-names-passwords.htm
+++ b/XMLHttpRequest/send-authentication-competing-names-passwords.htm
@@ -34,7 +34,7 @@
           client.open("GET", urlstart + "resources/authentication.py", false, user2, pass2)
           client.setRequestHeader("x-user", userwin)
           client.send(null)
-          assert_equals(client.responseText, (userwin||'') + "\n" + (passwin||''))
+          assert_true(client.responseText == ((userwin||'') + "\n" + (passwin||'')), 'responseText should contain the right user and password')
 
           // We want to send multiple requests to the same realm here, so we try to make the UA forget its (cached) credentials between each test..
           // forcing a 401 response to (hopefully) "log out"

--- a/XMLHttpRequest/send-authentication-cors-basic-setrequestheader.htm
+++ b/XMLHttpRequest/send-authentication-cors-basic-setrequestheader.htm
@@ -25,7 +25,7 @@
         client.onreadystatechange = function () {
           if (client.readyState < 4) {return}
           test.step( function () {
-            assert_equals(client.responseText, user + '\npass')
+            assert_true(client.responseText == (user + '\npass'), 'responseText should contain the right user and password')
             assert_equals(client.status, 200)
             assert_equals(client.getResponseHeader('x-challenge'), 'DID-NOT')
             test.done()


### PR DESCRIPTION
When failing, some assertions dump token values which always change test run after test run.
This defeats WebKit test infrastructure which is checking text output against expected text output.
