### PR TITLE
Run callbacks whose window is no longer current as long as its document is the active document in the browsing context.

### DIFF
--- a/old-tests/submission/Opera/script_scheduling/094.html
+++ b/old-tests/submission/Opera/script_scheduling/094.html
@@ -8,14 +8,16 @@
 <body>
 
 	<div id="log">FAILED (This TC requires JavaScript enabled)</div>
+	<iframe id="myFrame"></iframe>
 
 	<script>
           var t = async_test(undefined, {timeout:3500});
           onload = t.step_func(function() {
-            document.open();
-            document.write("<title> scheduler: parser-created defer script after document load</title><script src='/resources/testharness.js'><\/script><script src='/resources/testharnessreport.js'><\/script><script src='testlib/testlib.js'><\/script><script>var t=async_test()<\/script><div id=log></div><script defer src='data:text/javascript,t.done();'><\/script>");
-            document.close();
-            setTimeout(t.step_func(function() {assert_unreached()}, 500));
+            var doc = document.getElementById("myFrame").contentDocument;
+            var win = document.getElementById("myFrame").contentWindow;
+            doc.open();
+            doc.write("<title> scheduler: parser-created defer script after document load</title><script src='/resources/testharness.js'><\/script><script src='/resources/testharnessreport.js'><\/script><script src='testlib/testlib.js'><\/script><script>var t=async_test()<\/script><div id=log></div><script defer src='data:text/javascript,parent.t.done();'><\/script>");
+            doc.close();
           })
         </script>
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/101.html
+++ b/old-tests/submission/Opera/script_scheduling/101.html
@@ -8,20 +8,23 @@
 <body>
 
 	<div id="log">FAILED (This TC requires JavaScript enabled)</div>
+	<iframe id="myFrame"></iframe>
 
 	<script>
           var t = async_test();
           onload = t.step_func(
             function() {
-              document.open();
-              document.write("<title> scheduler: defer script after initial onload event</title><script src='/resources/testharness.js'><\/script><script src='/resources/testharnessreport.js'><\/script><script src='testlib/testlib.js'><\/script><div id='log'>document.written content</div><script>log('inline script #1'); t = async_test();<\/script><script src='scripts/include-1.js'><\/script><script defer src='scripts/include-2.js'><\/script>");
-              document.close();
+              var doc = document.getElementById("myFrame").contentDocument;
+              var win = document.getElementById("myFrame").contentWindow;
+              doc.open();
+              doc.write("<title> scheduler: defer script after initial onload event</title><script src='/resources/testharness.js'><\/script><script src='/resources/testharnessreport.js'><\/script><script src='testlib/testlib.js'><\/script><div id='log'>document.written content</div><script>log('inline script #1'); t = async_test();<\/script><script src='scripts/include-1.js'><\/script><script defer src='scripts/include-2.js'><\/script>");
+              doc.close();
               //Note that the *window* object has changed but the *global scope* of the script has not.
-              window.setTimeout(
+              win.setTimeout(
                 function() {
                   window.t.step(
                     function() {
-                      window.assert_array_equals(window.eventOrder, ['inline script #1', 'external script #1', 'external script #2']);
+                      window.assert_array_equals(win.eventOrder, ['inline script #1', 'external script #1', 'external script #2']);
                       window.t.done();
                 })}, 1000);
             });


### PR DESCRIPTION
The distinction only matters when document.open() makes a different
window current without changing the active document.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1180525
