### PR TITLE
Split FileAPI idlharness test into window and worker tests

### DIFF
--- a/FileAPI/idlharness.html
+++ b/FileAPI/idlharness.html
@@ -15,144 +15,46 @@
 
     <div id="log"></div>
 
-    <pre id="untested_idl" style="display: none">
-      interface ArrayBuffer {
-      };
-
-      interface ArrayBufferView {
-      };
-
-      interface URL {
-      };
-
-      interface EventTarget {
-      };
-
-      interface Event {
-      };
-
-      [TreatNonCallableAsNull]
-      callback EventHandlerNonNull = any (Event event);
-      typedef EventHandlerNonNull? EventHandler;
-    </pre>
-
-    <pre id="idl" style="display: none">
-[Constructor,
- Constructor(sequence<(ArrayBuffer or ArrayBufferView or Blob or DOMString)> blobParts, optional BlobPropertyBag options), Exposed=Window,Worker]
-interface Blob {
-
-  readonly attribute unsigned long long size;
-  readonly attribute DOMString type;
-  readonly attribute boolean isClosed;
-
-  //slice Blob into byte-ranged chunks
-
-  Blob slice([Clamp] optional long long start,
-             [Clamp] optional long long end,
-             optional DOMString contentType);
-  void close();
-
-};
-
-dictionary BlobPropertyBag {
-  DOMString type = "";
-};
-
-[Constructor(sequence<(Blob or DOMString or ArrayBufferView or ArrayBuffer)> fileBits,
-[EnsureUTF16] DOMString fileName, optional FilePropertyBag options), Exposed=Window,Worker]
-interface File : Blob {
-
-  readonly attribute DOMString name;
-  readonly attribute long long lastModified;
-
-};
-
-dictionary FilePropertyBag {
-
-  DOMString type = "";
-  long long lastModified;
-
-};
-
-[Exposed=Window,Worker] interface FileList {
-  getter File? item(unsigned long index);
-  readonly attribute unsigned long length;
-};
-
-[Constructor, Exposed=Window,Worker]
-interface FileReader: EventTarget {
-
-  // async read methods
-  void readAsArrayBuffer(Blob blob);
-  void readAsText(Blob blob, optional DOMString label);
-  void readAsDataURL(Blob blob);
-
-  void abort();
-
-  // states
-  const unsigned short EMPTY = 0;
-  const unsigned short LOADING = 1;
-  const unsigned short DONE = 2;
-
-  readonly attribute unsigned short readyState;
-
-  // File or Blob data
-  readonly attribute (DOMString or ArrayBuffer)? result;
-
-  readonly attribute DOMError? error;
-
-  // event handler attributes
-  attribute EventHandler onloadstart;
-  attribute EventHandler onprogress;
-  attribute EventHandler onload;
-  attribute EventHandler onabort;
-  attribute EventHandler onerror;
-  attribute EventHandler onloadend;
-
-};
-
-[Constructor, Exposed=Worker]
-interface FileReaderSync {
-
-  // Synchronously return strings
-
-  ArrayBuffer readAsArrayBuffer(Blob blob);
-  DOMString readAsText(Blob blob, optional DOMString label);
-  DOMString readAsDataURL(Blob blob);
-};
-
-partial interface URL {
-
-  static DOMString createObjectURL(Blob blob);
-  static DOMString createFor(Blob blob);
-  static void revokeObjectURL(DOMString url);
-
-};
-
-    </pre>
-
     <form name="uploadData">
       <input type="file" id="fileChooser">
     </form>
 
     <script>
-      var idl_array, file_input;
+var file_input;
+setup(function() {
+    var idl_array = new IdlArray();
 
-      setup(function() {
+    var request = new XMLHttpRequest();
+    request.open("GET", "idlharness.idl");
+    request.send();
+    request.onload = function() {
+        var idls = request.responseText;
+
+        idl_array.add_untested_idls("[PrimaryGlobal] interface Window { };");
+
+        idl_array.add_untested_idls("interface ArrayBuffer {};");
+        idl_array.add_untested_idls("interface ArrayBufferView {};");
+        idl_array.add_untested_idls("interface URL {};");
+        idl_array.add_untested_idls("interface EventTarget {};");
+        idl_array.add_untested_idls("interface Event {};");
+        idl_array.add_untested_idls("[TreatNonCallableAsNull] callback EventHandlerNonNull = any (Event event);");
+        idl_array.add_untested_idls("typedef EventHandlerNonNull? EventHandler;");
+
+        idl_array.add_idls(idls);
+
         file_input = document.querySelector("#fileChooser");
-        idl_array = new IdlArray();
-        idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
-        idl_array.add_idls(document.getElementById("idl").textContent);
-
         idl_array.add_objects({
-          Blob: ['new Blob(["TEST"])'],
-          File: ['new File(["myFileBits"], "myFileName")'],
-          FileList: ['file_input.files'],
-          FileReader: ['new FileReader()']
+            Blob: ['new Blob(["TEST"])'],
+            File: ['new File(["myFileBits"], "myFileName")'],
+            FileList: ['file_input.files'],
+            FileReader: ['new FileReader()']
         });
-      });
 
-      idl_array.test();
+        idl_array.test();
+        done();
+  };
+}, {explicit_done: true});
     </script>
+
   </body>
 </html>

--- a/FileAPI/idlharness.idl
+++ b/FileAPI/idlharness.idl
@@ -1,0 +1,81 @@
+[Constructor,
+ Constructor(sequence<(ArrayBuffer or ArrayBufferView or Blob or DOMString)> blobParts, optional BlobPropertyBag options), Exposed=Window,Worker]
+interface Blob {
+
+  readonly attribute unsigned long long size;
+  readonly attribute DOMString type;
+  readonly attribute boolean isClosed;
+
+  //slice Blob into byte-ranged chunks
+
+  Blob slice([Clamp] optional long long start,
+             [Clamp] optional long long end,
+             optional DOMString contentType);
+  void close();
+
+};
+
+dictionary BlobPropertyBag {
+  DOMString type = "";
+};
+
+[Constructor(sequence<(Blob or DOMString or ArrayBufferView or ArrayBuffer)> fileBits,
+[EnsureUTF16] DOMString fileName, optional FilePropertyBag options), Exposed=Window,Worker]
+interface File : Blob {
+
+  readonly attribute DOMString name;
+  readonly attribute long long lastModified;
+
+};
+
+dictionary FilePropertyBag {
+
+  DOMString type = "";
+  long long lastModified;
+
+};
+
+[Exposed=Window,Worker] interface FileList {
+  getter File? item(unsigned long index);
+  readonly attribute unsigned long length;
+};
+
+[Constructor, Exposed=Window,Worker]
+interface FileReader: EventTarget {
+
+  // async read methods
+  void readAsArrayBuffer(Blob blob);
+  void readAsText(Blob blob, optional DOMString label);
+  void readAsDataURL(Blob blob);
+
+  void abort();
+
+  // states
+  const unsigned short EMPTY = 0;
+  const unsigned short LOADING = 1;
+  const unsigned short DONE = 2;
+
+  readonly attribute unsigned short readyState;
+
+  // File or Blob data
+  readonly attribute (DOMString or ArrayBuffer)? result;
+
+  readonly attribute DOMError? error;
+
+  // event handler attributes
+  attribute EventHandler onloadstart;
+  attribute EventHandler onprogress;
+  attribute EventHandler onload;
+  attribute EventHandler onabort;
+  attribute EventHandler onerror;
+  attribute EventHandler onloadend;
+
+};
+
+partial interface URL {
+
+  static DOMString createObjectURL(Blob blob);
+  static DOMString createFor(Blob blob);
+  static void revokeObjectURL(DOMString url);
+
+};

--- a/FileAPI/idlharness.worker.js
+++ b/FileAPI/idlharness.worker.js
@@ -1,0 +1,45 @@
+importScripts("/resources/testharness.js");
+importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
+
+var request = new XMLHttpRequest();
+request.open("GET", "idlharness.idl");
+request.send();
+request.onload = function() {
+    var idl_array = new IdlArray();
+    var idls = request.responseText;
+
+    idl_array.add_untested_idls("[Global] interface Window { };");
+
+    idl_array.add_untested_idls("interface ArrayBuffer {};");
+    idl_array.add_untested_idls("interface ArrayBufferView {};");
+    idl_array.add_untested_idls("interface URL {};");
+    idl_array.add_untested_idls("interface EventTarget {};");
+    idl_array.add_untested_idls("interface Event {};");
+    idl_array.add_untested_idls("[TreatNonCallableAsNull] callback EventHandlerNonNull = any (Event event);");
+    idl_array.add_untested_idls("typedef EventHandlerNonNull? EventHandler;");
+
+
+    var worker_idls =
+            '[Constructor, Exposed=Worker]\n' +
+            'interface FileReaderSync {\n' +
+            '\n' +
+            '  // Synchronously return strings\n' +
+            '\n' +
+            '  ArrayBuffer readAsArrayBuffer(Blob blob);\n' +
+            '  DOMString readAsText(Blob blob, optional DOMString label);\n' +
+            '  DOMString readAsDataURL(Blob blob);\n' +
+            '};';
+
+    idl_array.add_idls(idls);
+    idl_array.add_idls(worker_idls);
+
+    idl_array.add_objects({
+        Blob: ['new Blob(["TEST"])'],
+        File: ['new File(["myFileBits"], "myFileName")'],
+        FileReader: ['new FileReader()'],
+        FileReaderSync: ['new FileReaderSync()']
+    });
+
+    idl_array.test();
+    done();
+};


### PR DESCRIPTION
The existing test was failing trying to use FileReaderSync from a window context even though it's `[Exposed=Worker]`. That's probably an idlharness bug, but regardless we should test in worker contexts as well.

Pull the common IDL itself out into a file, and test worker stuff only in workers.
