### PR TITLE
Delete test allowing Blob() to be called without new operator

### DIFF
--- a/FileAPI/blob/Blob-constructor.html
+++ b/FileAPI/blob/Blob-constructor.html
@@ -29,6 +29,9 @@ test(function() {
   assert_equals(blob.type, "");
 }, "no-argument Blob constructor");
 test(function() {
+  assert_throws(new TypeError(), function() { var blob = Blob(); });
+}, "no-argument Blob constructor without 'new'");
+test(function() {
   var blob = new Blob;
   assert_true(blob instanceof Blob);
   assert_equals(blob.size, 0);

--- a/FileAPI/blob/Blob-constructor.html
+++ b/FileAPI/blob/Blob-constructor.html
@@ -29,12 +29,6 @@ test(function() {
   assert_equals(blob.type, "");
 }, "no-argument Blob constructor");
 test(function() {
-  var blob = Blob();
-  assert_true(blob instanceof Blob);
-  assert_equals(blob.size, 0);
-  assert_equals(blob.type, "");
-}, "no-argument Blob constructor without 'new'");
-test(function() {
   var blob = new Blob;
   assert_true(blob instanceof Blob);
   assert_equals(blob.size, 0);


### PR DESCRIPTION
Gecko supported this at one point, but other browsers did not and Gecko no longer does. Don't enshrine this in a test. 

Issue https://github.com/w3c/web-platform-tests/issues/1988
