### PR TITLE
Use selection object in the same tree.

### DIFF
--- a/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
+++ b/shadow-dom/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
@@ -37,7 +37,7 @@ test(unit(function (ctx) {
 	range.setStart(span.firstChild, 0);
 	range.setEnd(span.firstChild, 3);
 
-	var selection = window.getSelection();
+	var selection = s.getSelection();
     selection.removeAllRanges();
     selection.addRange(range);
 


### PR DESCRIPTION
This test used Selection object from different TreeScope.
At this point the spec has some ambiguity, but at least if the test uses
a Selection object from the same TreeScope, it should work as expected.
