### PR TITLE
Referrer-Policy: Remove dead code in wrapResult.

### DIFF
--- a/referrer-policy/generic/common.js
+++ b/referrer-policy/generic/common.js
@@ -85,8 +85,6 @@ function wrapResult(url, server_data) {
     referrer: server_data.headers.referer,
     headers: server_data.headers
   }
-
-  return result;
 }
 
 function queryIframe(url, callback) {


### PR DESCRIPTION
Refactoring of the generic/common.js in referrer-policy resulted in leaving behind some dead code.

As shown in the Firefox builds:

```
JavaScript warning: http://web-platform.test:8000/referrer-policy/generic/common.js, line 89: unreachable code after return statement
```

http://ftp.mozilla.org/pub/mozilla.org/firefox/try-builds/james@hoppipolla.co.uk-a11f3f8e6398/try-linux/try_ubuntu32_vm_test-web-platform-tests-3-bm01-tests1-linux32-build437.txt.gz

@mikewest 
