### PR TITLE
Remove assert_object_equals usage from Cache Storage API tests

### DIFF
--- a/service-workers/cache-storage/resources/testharness-helpers.js
+++ b/service-workers/cache-storage/resources/testharness-helpers.js
@@ -32,132 +32,69 @@ function assert_promise_rejects(promise, code, description) {
     });
 }
 
-// Asserts that two objects |actual| and |expected| are weakly equal under the
-// following definition:
-//
-// |a| and |b| are weakly equal if any of the following are true:
-//   1. If |a| is not an 'object', and |a| === |b|.
-//   2. If |a| is an 'object', and all of the following are true:
-//     2.1 |a.p| is weakly equal to |b.p| for all own properties |p| of |a|.
-//     2.2 Every own property of |b| is an own property of |a|.
-//
-// This is a replacement for the the version of assert_object_equals() in
-// testharness.js. The latter doesn't handle own properties correctly. I.e. if
-// |a.p| is not an own property, it still requires that |b.p| be an own
-// property.
-//
-// Note that |actual| must not contain cyclic references.
-self.assert_object_equals = function(actual, expected, description) {
-  var object_stack = [];
-
-  function _is_equal(actual, expected, prefix) {
-    if (typeof actual !== 'object') {
-      assert_equals(actual, expected, prefix);
-      return;
-    }
-    assert_true(typeof expected === 'object', prefix);
-    assert_equals(object_stack.indexOf(actual), -1,
-                  prefix + ' must not contain cyclic references.');
-
-    object_stack.push(actual);
-
-    Object.getOwnPropertyNames(expected).forEach(function(property) {
-        assert_own_property(actual, property, prefix);
-        _is_equal(actual[property], expected[property],
-                  prefix + '.' + property);
-      });
-    Object.getOwnPropertyNames(actual).forEach(function(property) {
-        assert_own_property(expected, property, prefix);
-      });
-
-    object_stack.pop();
-  }
-
-  function _brand(object) {
-    return Object.prototype.toString.call(object).match(/^\[object (.*)\]$/)[1];
-  }
-
-  _is_equal(actual, expected,
-            (description ? description + ': ' : '') + _brand(expected));
-};
-
-// Equivalent to assert_in_array, but uses a weaker equivalence relation
-// (assert_object_equals) than '==='.
-function assert_object_in_array(actual, expected_array, description) {
-  assert_true(expected_array.some(function(element) {
-      try {
-        assert_object_equals(actual, element);
-        return true;
-      } catch (e) {
-        return false;
-      }
-    }), description);
+// Helper for testing with Headers objects. Compares Headers instances
+// by serializing |expected| and |actual| to arrays and comparing.
+function assert_header_equals(actual, expected, description) {
+    assert_class_string(actual, "Headers", description);
+    var header, actual_headers = [], expected_headers = [];
+    for (header of actual)
+        actual_headers.push(header[0] + ": " + header[1]);
+    for (header of expected)
+        expected_headers.push(header[0] + ": " + header[1]);
+    assert_array_equals(actual_headers, expected_headers,
+                        description + " Headers differ.");
 }
 
-// Assert that the two arrays |actual| and |expected| contain the same set of
-// elements as determined by assert_object_equals. The order is not significant.
+// Helper for testing with Response objects. Compares simple
+// attributes defined on the interfaces, as well as the headers. It
+// does not compare the response bodies.
+function assert_response_equals(actual, expected, description) {
+    assert_class_string(actual, "Response", description);
+    ["type", "url", "status", "ok", "statusText"].forEach(function(attribute) {
+        assert_equals(actual[attribute], expected[attribute],
+                      description + " Attributes differ: " + attribute + ".");
+    });
+    assert_header_equals(actual.headers, expected.headers, description);
+}
+
+// Assert that the two arrays |actual| and |expected| contain the same
+// set of Responses as determined by assert_response_equals. The order
+// is not significant.
 //
-// |expected| is assumed to not contain any duplicates as determined by
-// assert_object_equals().
-function assert_array_equivalent(actual, expected, description) {
-  assert_true(Array.isArray(actual), description);
-  assert_equals(actual.length, expected.length, description);
-  expected.forEach(function(expected_element) {
-      // assert_in_array treats the first argument as being 'actual', and the
-      // second as being 'expected array'. We are switching them around because
-      // we want to be resilient against the |actual| array containing
-      // duplicates.
-      assert_object_in_array(expected_element, actual, description);
+// |expected| is assumed to not contain any duplicates.
+function assert_response_array_equivalent(actual, expected, description) {
+    assert_true(Array.isArray(actual), description);
+    assert_equals(actual.length, expected.length, description);
+    expected.forEach(function(expected_element) {
+        // assert_response_in_array treats the first argument as being
+        // 'actual', and the second as being 'expected array'. We are
+        // switching them around because we want to be resilient
+        // against the |actual| array containing duplicates.
+        assert_response_in_array(expected_element, actual, description);
     });
 }
 
-// Asserts that two arrays |actual| and |expected| contain the same set of
-// elements as determined by assert_object_equals(). The corresponding elements
-// must occupy corresponding indices in their respective arrays.
-function assert_array_objects_equals(actual, expected, description) {
-  assert_true(Array.isArray(actual), description);
-  assert_equals(actual.length, expected.length, description);
-  actual.forEach(function(value, index) {
-      assert_object_equals(value, expected[index],
-                           description + ' : object[' + index + ']');
+// Asserts that two arrays |actual| and |expected| contain the same
+// set of Responses as determined by assert_response_equals(). The
+// corresponding elements must occupy corresponding indices in their
+// respective arrays.
+function assert_response_array_equals(actual, expected, description) {
+    assert_true(Array.isArray(actual), description);
+    assert_equals(actual.length, expected.length, description);
+    actual.forEach(function(value, index) {
+        assert_response_equals(value, expected[index],
+                               description + " : object[" + index + "]");
     });
 }
 
-// Asserts that |object| that is an instance of some interface has the attribute
-// |attribute_name| following the conditions specified by WebIDL, but it's
-// acceptable that the attribute |attribute_name| is an own property of the
-// object because we're in the middle of moving the attribute to a prototype
-// chain.  Once we complete the transition to prototype chains,
-// assert_will_be_idl_attribute must be replaced with assert_idl_attribute
-// defined in testharness.js.
-//
-// FIXME: Remove assert_will_be_idl_attribute once we complete the transition
-// of moving the DOM attributes to prototype chains.  (http://crbug.com/43394)
-function assert_will_be_idl_attribute(object, attribute_name, description) {
-  assert_true(typeof object === "object", description);
-
-  assert_true("hasOwnProperty" in object, description);
-
-  // Do not test if |attribute_name| is not an own property because
-  // |attribute_name| is in the middle of the transition to a prototype
-  // chain.  (http://crbug.com/43394)
-
-  assert_true(attribute_name in object, description);
-}
-
-// Stringifies a DOM object.  This function stringifies not only own properties
-// but also DOM attributes which are on a prototype chain.  Note that
-// JSON.stringify only stringifies own properties.
-function stringifyDOMObject(object)
-{
-    function deepCopy(src) {
-        if (typeof src != "object")
-            return src;
-        var dst = Array.isArray(src) ? [] : {};
-        for (var property in src) {
-            dst[property] = deepCopy(src[property]);
+// Equivalent to assert_in_array, but uses assert_response_equals.
+function assert_response_in_array(actual, expected_array, description) {
+    assert_true(expected_array.some(function(element) {
+        try {
+            assert_response_equals(actual, element);
+            return true;
+        } catch (e) {
+            return false;
         }
-        return dst;
-    }
-    return JSON.stringify(deepCopy(object));
+    }), description);
 }

--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -109,7 +109,7 @@ var vary_entries = [
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll('not-present-in-the-cache')
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result, [],
             'Cache.matchAll should resolve with an empty array on failure.');
         });
@@ -126,23 +126,23 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.a.request.url)
       .then(function(result) {
-          assert_array_objects_equals(result, [entries.a.response],
-                                      'Cache.matchAll should match by URL.');
+          assert_response_array_equals(result, [entries.a.response],
+                                       'Cache.matchAll should match by URL.');
         });
   }, 'Cache.matchAll with URL');
 
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.a.request.url)
       .then(function(result) {
-          assert_object_equals(result, entries.a.response,
-                               'Cache.match should match by URL.');
+          assert_response_equals(result, entries.a.response,
+                                 'Cache.match should match by URL.');
         });
   }, 'Cache.match with URL');
 
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.a.request)
       .then(function(result) {
-          assert_array_objects_equals(
+          assert_response_array_equals(
             result, [entries.a.response],
             'Cache.matchAll should match by Request.');
         });
@@ -151,15 +151,15 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.a.request)
       .then(function(result) {
-          assert_object_equals(result, entries.a.response,
-                               'Cache.match should match by Request.');
+          assert_response_equals(result, entries.a.response,
+                                 'Cache.match should match by Request.');
         });
   }, 'Cache.match with Request');
 
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(new Request(entries.a.request.url))
       .then(function(result) {
-          assert_array_objects_equals(
+          assert_response_array_equals(
             result, [entries.a.response],
             'Cache.matchAll should match by Request.');
         });
@@ -168,8 +168,8 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(new Request(entries.a.request.url))
       .then(function(result) {
-          assert_object_equals(result, entries.a.response,
-                               'Cache.match should match by Request.');
+          assert_response_equals(result, entries.a.response,
+                                 'Cache.match should match by Request.');
         });
   }, 'Cache.match with new Request');
 
@@ -177,7 +177,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.a.request,
                           {ignoreSearch: true})
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
               entries.a.response,
@@ -194,7 +194,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.a.request,
                        {ignoreSearch: true})
       .then(function(result) {
-          assert_object_in_array(
+          assert_response_in_array(
             result,
             [
               entries.a.response,
@@ -211,7 +211,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.a_with_query.request,
                           {ignoreSearch: true})
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
               entries.a.response,
@@ -227,7 +227,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.a_with_query.request,
                        {ignoreSearch: true})
       .then(function(result) {
-          assert_object_in_array(
+          assert_response_in_array(
             result,
             [
               entries.a.response,
@@ -242,7 +242,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.cat.request.url + '#mouse')
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
               entries.cat.response,
@@ -254,15 +254,15 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.cat.request.url + '#mouse')
       .then(function(result) {
-          assert_object_equals(result, entries.cat.response,
-                               'Cache.match should ignore URL fragment.');
+          assert_response_equals(result, entries.cat.response,
+                                 'Cache.match should ignore URL fragment.');
         });
   }, 'Cache.match with URL containing fragment');
 
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll('http')
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result, [],
             'Cache.matchAll should treat query as a URL and not ' +
             'just a string fragment.');
@@ -282,7 +282,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.matchAll(entries.secret_cat.request.url)
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result, [entries.secret_cat.response],
             'Cache.matchAll should not ignore embedded credentials');
         });
@@ -291,7 +291,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(simple_entries, function(cache, entries) {
     return cache.match(entries.secret_cat.request.url)
       .then(function(result) {
-          assert_object_equals(
+          assert_response_equals(
             result, entries.secret_cat.response,
             'Cache.match should not ignore embedded credentials');
         });
@@ -300,7 +300,7 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
 prepopulated_cache_test(vary_entries, function(cache, entries) {
     return cache.matchAll('http://example.com/c')
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
               entries.vary_cookie_absent.response
@@ -316,7 +316,7 @@ prepopulated_cache_test(vary_entries, function(cache, entries) {
                         {headers: {'Cookies': 'none-of-the-above'}}));
         })
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
             ],
@@ -331,7 +331,7 @@ prepopulated_cache_test(vary_entries, function(cache, entries) {
                         {headers: {'Cookies': 'is-for-cookie'}}));
         })
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [entries.vary_cookie_is_cookie.response],
             'Cache.matchAll should match the entire header if a vary header ' +
@@ -342,7 +342,7 @@ prepopulated_cache_test(vary_entries, function(cache, entries) {
 prepopulated_cache_test(vary_entries, function(cache, entries) {
     return cache.match('http://example.com/c')
       .then(function(result) {
-          assert_object_in_array(
+          assert_response_in_array(
             result,
             [
               entries.vary_cookie_absent.response
@@ -355,7 +355,7 @@ prepopulated_cache_test(vary_entries, function(cache, entries) {
     return cache.matchAll('http://example.com/c',
                           {ignoreVary: true})
       .then(function(result) {
-          assert_array_equivalent(
+          assert_response_array_equivalent(
             result,
             [
               entries.vary_cookie_is_cookie.response,
@@ -383,7 +383,7 @@ cache_test(function(cache) {
           return cache.match(request.url);
         })
       .then(function(result) {
-          assert_object_equals(
+          assert_response_equals(
             result, response,
             'Cache.match should return a Response object that has the same ' +
             'properties as the stored response.');

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -30,9 +30,9 @@ cache_test(function(cache) {
           return cache.match(test_url);
         })
       .then(function(result) {
-          assert_object_equals(result, response,
-                               'Cache.put should update the cache with ' +
-                               'new request and response.');
+          assert_response_equals(result, response,
+                                 'Cache.put should update the cache with ' +
+                                 'new request and response.');
           return result.text();
         })
       .then(function(body) {
@@ -75,9 +75,9 @@ cache_test(function(cache) {
           return cache.match(test_url);
         })
       .then(function(result) {
-          assert_object_equals(result, response,
-                               'Cache.put should update the cache with ' +
-                               'new Request and Response.');
+          assert_response_equals(result, response,
+                                 'Cache.put should update the cache with ' +
+                                 'new Request and Response.');
         });
   }, 'Cache.put with a Response containing an empty URL');
 
@@ -118,9 +118,9 @@ cache_test(function(cache) {
           return cache.match(test_url);
         })
       .then(function(result) {
-          assert_object_equals(result, response,
-                               'Cache.put should update the cache with ' +
-                               'new request and response.');
+          assert_response_equals(result, response,
+                                 'Cache.put should update the cache with ' +
+                                 'new request and response.');
           return result.text();
         })
       .then(function(body) {
@@ -142,9 +142,9 @@ cache_test(function(cache) {
           return cache.match(test_url);
         })
       .then(function(result) {
-          assert_object_equals(result, alternate_response,
-                               'Cache.put should replace existing ' +
-                               'response with new response.');
+          assert_response_equals(result, alternate_response,
+                                 'Cache.put should replace existing ' +
+                                 'response with new response.');
           return result.text();
         })
       .then(function(body) {
@@ -168,9 +168,9 @@ cache_test(function(cache) {
           return cache.match(test_url);
         })
       .then(function(result) {
-          assert_object_equals(result, alternate_response,
-                               'Cache.put should replace existing ' +
-                               'response with new response.');
+          assert_response_equals(result, alternate_response,
+                                 'Cache.put should replace existing ' +
+                                 'response with new response.');
           return result.text();
         })
       .then(function(body) {
@@ -248,9 +248,9 @@ cache_test(function(cache) {
           return cache.match(new URL('relative-url', location.href).href);
         })
       .then(function(result) {
-          assert_object_equals(result, response,
-                               'Cache.put should accept a relative URL ' +
-                               'as the request.');
+          assert_response_equals(result, response,
+                                 'Cache.put should accept a relative URL ' +
+                                 'as the request.');
         });
   }, 'Cache.put with a relative URL');
 

--- a/service-workers/cache-storage/script-tests/cache-storage-match.js
+++ b/service-workers/cache-storage/script-tests/cache-storage-match.js
@@ -30,8 +30,8 @@ cache_test(function(cache) {
           return self.caches.match(transaction.request);
         })
       .then(function(response) {
-          assert_object_equals(response, transaction.response,
-                               'The response should not have changed.');
+          assert_response_equals(response, transaction.response,
+                                 'The response should not have changed.');
         });
 }, 'CacheStorageMatch with no cache name provided');
 
@@ -49,8 +49,8 @@ cache_test(function(cache) {
           return self.caches.match(transaction.request);
         })
       .then(function(response) {
-          assert_object_equals(response, transaction.response,
-                               'The response should not have changed.');
+          assert_response_equals(response, transaction.response,
+                                 'The response should not have changed.');
         });
 }, 'CacheStorageMatch from one of many caches');
 
@@ -70,8 +70,8 @@ promise_test(function(test) {
           return self.caches.match(transaction.request, {cacheName: 'x'});
         })
       .then(function(response) {
-          assert_object_equals(response, transaction.response,
-                               'The response should not have changed.');
+          assert_response_equals(response, transaction.response,
+                                 'The response should not have changed.');
         })
       .then(function() {
           return self.caches.match(transaction.request, {cacheName: 'y'});
@@ -89,8 +89,8 @@ cache_test(function(cache) {
           return self.caches.match(transaction.request);
         })
       .then(function(response) {
-          assert_object_equals(response, transaction.response,
-                               'The response should not have changed.');
+          assert_response_equals(response, transaction.response,
+                                 'The response should not have changed.');
         });
 }, 'CacheStorageMatch a string request');
 


### PR DESCRIPTION
Following on from a discussion in https://critic.hoppipolla.co.uk/r/5479 which identifies assert_object_equals as broken for DOM objects and undesirable in general, this eliminates the function's problematic use by the serviceworker/cachestorage tests in favor of dedicated helpers.
