### PR TITLE
Fix ChildNode::after incorrect test

### DIFF
--- a/dom/nodes/ChildNode-after.html
+++ b/dom/nodes/ChildNode-after.html
@@ -106,7 +106,7 @@ function test_after(child, nodeName, innerHTML) {
         parent.appendChild(document.createTextNode('1'));
         parent.appendChild(y);
         child.after(x, '2');
-        var expected = innerHTML + '<x></x>12<y></y>';
+        var expected = innerHTML + '<x></x>21<y></y>';
         assert_equals(parent.innerHTML, expected);
     }, nodeName + '.after() with one sibling of child and text as arguments.');
 


### PR DESCRIPTION
This test was added in
https://github.com/w3c/web-platform-tests/pull/1974

The tests were 'basically taken from https://codereview.chromium.org/1085843002.'

But according to
https://codereview.chromium.org/1085843002/patch/500001/510001
it looks like this test case was copied incorrectly
