### PR TITLE
Remove use of assert_object_equals() from IndexedDB tests.

### DIFF
--- a/IndexedDB/idbcursor-key.htm
+++ b/IndexedDB/idbcursor-key.htm
@@ -29,18 +29,18 @@
                 var cursor = e.target.result;
                 assert_equals(cursor.value, "data", "prequisite cursor.value");
 
-                assert_object_equals(cursor.key, key, 'key');
+                assert_key_equals(cursor.key, key, 'key');
                 assert_readonly(cursor, 'key');
 
                 if (key instanceof Array) {
                     cursor.key.push("new");
                     key.push("new");
 
-                    assert_object_equals(cursor.key, key, 'key after array push');
+                    assert_key_equals(cursor.key, key, 'key after array push');
 
                     // But we can not change key (like readonly, just a bit different)
                     cursor.key = 10;
-                    assert_object_equals(cursor.key, key, 'key after assignment');
+                    assert_key_equals(cursor.key, key, 'key after assignment');
                 }
 
                 t.done();

--- a/IndexedDB/idbcursor-primarykey.htm
+++ b/IndexedDB/idbcursor-primarykey.htm
@@ -33,18 +33,18 @@
                 assert_equals(cursor.value, "data", "prequisite cursor.value");
                 assert_equals(cursor.key, "data", "prequisite cursor.key");
 
-                assert_object_equals(cursor.primaryKey, key, 'primaryKey');
+                assert_key_equals(cursor.primaryKey, key, 'primaryKey');
                 assert_readonly(cursor, 'primaryKey');
 
                 if (key instanceof Array) {
                     cursor.primaryKey.push("new");
                     key.push("new");
 
-                    assert_object_equals(cursor.primaryKey, key, 'primaryKey after array push');
+                    assert_key_equals(cursor.primaryKey, key, 'primaryKey after array push');
 
                     // But we can not change key (like readonly, just a bit different)
                     cursor.key = 10;
-                    assert_object_equals(cursor.primaryKey, key, 'key after assignment');
+                    assert_key_equals(cursor.primaryKey, key, 'key after assignment');
                 }
 
                 t.done();

--- a/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
+++ b/IndexedDB/idbdatabase_deleteObjectStore4-not_reused.htm
@@ -33,7 +33,7 @@ open_rq.onupgradeneeded = function(e) {
 }
 
 open_rq.onsuccess = function(e) {
-    assert_object_equals(keys, [5, 6, 1], "keys");
+    assert_array_equals(keys, [5, 6, 1], "keys");
     t.done();
 }
 

--- a/IndexedDB/idbindex-multientry.htm
+++ b/IndexedDB/idbindex-multientry.htm
@@ -44,7 +44,7 @@
         idx.getKey('Bobby').onsuccess = this.step_func(function(e) {
             gotten_keys.push(e.target.result)
 
-            assert_object_equals(gotten_keys, expected_keys);
+            assert_array_equals(gotten_keys, expected_keys);
             this.done();
         });
     }

--- a/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex4-deleteIndex-event_order.htm
@@ -42,13 +42,13 @@
 
     open_rq.onsuccess = function(e) {
         log("open_rq.success")(e);
-        assert_object_equals(events, [ "rq_add1.success",
-                                       "rq_add2.error: ConstraintError",
-                                       "rq_add3.success",
+        assert_array_equals(events, [ "rq_add1.success",
+                                      "rq_add2.error: ConstraintError",
+                                      "rq_add3.success",
 
-                                       "transaction.complete",
+                                      "transaction.complete",
 
-                                       "open_rq.success" ],
+                                      "open_rq.success" ],
                             "events");
         t.done();
     }

--- a/IndexedDB/idbobjectstore_createIndex6-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex6-event_order.htm
@@ -47,17 +47,17 @@
 
     open_rq.onerror = function(e) {
         log("open_rq.error")(e);
-        assert_object_equals(events, [ "rq_add1.success",
-                                       "rq_add2.success",
+        assert_array_equals(events, [ "rq_add1.success",
+                                      "rq_add2.success",
 
-                                       "rq_add3.error: AbortError",
-                                       "transaction.error: AbortError",
-                                       "db.error: AbortError",
+                                      "rq_add3.error: AbortError",
+                                      "transaction.error: AbortError",
+                                      "db.error: AbortError",
 
-                                       "transaction.abort: ConstraintError",
-                                       "db.abort: ConstraintError",
+                                      "transaction.abort: ConstraintError",
+                                      "db.abort: ConstraintError",
 
-                                       "open_rq.error: AbortError" ],
+                                      "open_rq.error: AbortError" ],
                             "events");
         t.done();
     }

--- a/IndexedDB/idbobjectstore_createIndex7-event_order.htm
+++ b/IndexedDB/idbobjectstore_createIndex7-event_order.htm
@@ -49,20 +49,20 @@
 
     open_rq.onerror = function(e) {
         log("open_rq.error")(e);
-        assert_object_equals(events, [ "rq_add1.success",
+        assert_array_equals(events, [ "rq_add1.success",
 
-                                       "rq_add2.error: ConstraintError",
-                                       "transaction.error: ConstraintError",
-                                       "db.error: ConstraintError",
+                                      "rq_add2.error: ConstraintError",
+                                      "transaction.error: ConstraintError",
+                                      "db.error: ConstraintError",
 
-                                       "rq_add3.error: AbortError",
-                                       "transaction.error: AbortError",
-                                       "db.error: AbortError",
+                                      "rq_add3.error: AbortError",
+                                      "transaction.error: AbortError",
+                                      "db.error: AbortError",
 
-                                       "transaction.abort: ConstraintError",
-                                       "db.abort: ConstraintError",
+                                      "transaction.abort: ConstraintError",
+                                      "db.abort: ConstraintError",
 
-                                       "open_rq.error: AbortError" ],
+                                      "open_rq.error: AbortError" ],
                             "events");
         t.done();
     }

--- a/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
+++ b/IndexedDB/idbobjectstore_createIndex8-valid_keys.htm
@@ -38,7 +38,7 @@
         });
         idx.get(ar).onsuccess = t.step_func(function(e) {
             assert_equals(e.target.result.key, 'array', 'key');
-            assert_object_equals(e.target.result.i, ar, 'array is the same');
+            assert_array_equals(e.target.result.i, ar, 'array is the same');
         });
         idx.get(num).onsuccess = t.step_func(function(e) {
             assert_equals(e.target.result.key, 'number', 'key');

--- a/IndexedDB/key_valid.html
+++ b/IndexedDB/key_valid.html
@@ -35,7 +35,8 @@
                            .objectStore("store2")
                            .get(['v', key])
                 rq.onsuccess = t.step_func(function(e) {
-                    assert_object_equals(e.target.result, { x: 'v', keypath: key })
+                    assert_equals(e.target.result.x, 'v');
+                    assert_key_equals(e.target.result.keypath, key);
                     t.done()
                 })
             })

--- a/IndexedDB/keygenerator-constrainterror.htm
+++ b/IndexedDB/keygenerator-constrainterror.htm
@@ -62,10 +62,7 @@
             }
             else {
                 assert_equals(errors, 2, "expected ConstraintError's");
-
-                assert_equals(actual_keys.length, expected.length, "array length");
-                assert_object_equals(actual_keys, expected, "keygenerator array");
-
+                assert_array_equals(actual_keys, expected, "keygenerator array");
                 t.done();
             }
         });

--- a/IndexedDB/keygenerator-overflow.htm
+++ b/IndexedDB/keygenerator-overflow.htm
@@ -58,7 +58,7 @@
             }
             else {
                 assert_true(overflow_error_fired, "error fired on 'current number' overflow");
-                assert_object_equals(actual_keys, expected_keys, "keygenerator array");
+                assert_array_equals(actual_keys, expected_keys, "keygenerator array");
 
                 t.done();
             }

--- a/IndexedDB/keygenerator.htm
+++ b/IndexedDB/keygenerator.htm
@@ -43,9 +43,7 @@
                     cursor.continue();
                 }
                 else {
-                    assert_equals(actual_keys.length, expected_keys.length, "array length");
-                    assert_object_equals(actual_keys, expected_keys, "keygenerator array");
-
+                    assert_key_equals(actual_keys, expected_keys, "keygenerator array");
                     t.done();
                 }
             });

--- a/IndexedDB/keyorder.htm
+++ b/IndexedDB/keyorder.htm
@@ -45,11 +45,11 @@
                 var cursor = e.target.result;
 
                 if (cursor) {
-                    actual_keys.push(cursor.key.valueOf());
+                    actual_keys.push(cursor.key);
                     cursor.continue();
                 }
                 else {
-                    assert_object_equals(actual_keys, expected, "keyorder array");
+                    assert_key_equals(actual_keys, expected, "keyorder array");
                     assert_equals(actual_keys.length, expected.length, "array length");
 
                     t.done();
@@ -60,12 +60,7 @@
         // The IDBKey.cmp test
         test(function () {
             var sorted = unsorted.slice(0).sort(function(a, b) { return indexedDB.cmp(a, b)});
-
-            for (var i in sorted)
-                if (typeof sorted[i] === "object" && 'valueOf' in sorted[i])
-                    sorted[i] = sorted[i].valueOf();
-
-            assert_object_equals(sorted, expected, "sorted array");
+            assert_key_equals(sorted, expected, "sorted array");
 
         }, "IDBKey.cmp sorted - " + desc);
     }
@@ -84,16 +79,16 @@
 
     keysort('float < Date',
         [ now, 0, 9999999999999, -0.22 ],
-        [ -0.22, 0, 9999999999999, now.valueOf() ]);
+        [ -0.22, 0, 9999999999999, now ]);
 
     keysort('float < Date < String < Array',
         [ [], "", now, [0], "-1", 0, 9999999999999, ],
-        [ 0, 9999999999999, now.valueOf(), "", "-1", [], [0] ]);
+        [ 0, 9999999999999, now, "", "-1", [], [0] ]);
 
 
     keysort('Date(1 sec ago) < Date(now) < Date(1 minute in future)',
         [ now, one_sec_ago, one_min_future ],
-        [ one_sec_ago.valueOf(), now.valueOf(), one_min_future.valueOf() ]);
+        [ one_sec_ago, now, one_min_future ]);
 
     keysort('-1.1 < 1 < 1.01337 < 1.013373 < 2',
         [ 1.013373, 2, 1.01337, -1.1, 1 ],
@@ -157,12 +152,12 @@
           1,
           2.55,
           Infinity,
-          one_sec_ago.valueOf(),
-          now.valueOf(),
+          one_sec_ago,
+          now,
           "test",
           [],
           [0 ,2, "c"],
-          [0, now.valueOf()],
+          [0, now],
           [0, "b", "c"],
           [0, []],
           [0, [], 3],

--- a/IndexedDB/keypath.htm
+++ b/IndexedDB/keypath.htm
@@ -41,9 +41,7 @@
                     cursor.continue();
                 }
                 else {
-                    assert_equals(actual_keys.length, expected_keys.length, "array length");
-                    assert_object_equals(actual_keys, expected_keys, "keyorder array");
-
+                    assert_key_equals(actual_keys, expected_keys, "keyorder array");
                     t.done();
                 }
             });

--- a/IndexedDB/keypath_maxsize.htm
+++ b/IndexedDB/keypath_maxsize.htm
@@ -39,9 +39,7 @@
                     actual_keys.push(cursor.key.valueOf());
                     cursor.continue();
                 } else {
-                    assert_equals(actual_keys.length, expected_keys.length, "array length");
-                    assert_object_equals(actual_keys, expected_keys, "keyorder array");
-
+                    assert_array_equals(actual_keys, expected_keys, "keyorder array");
                     t.done();
                 }
             });
@@ -63,4 +61,3 @@
 </script>
 
 <div id=log></log>
-

--- a/IndexedDB/request_bubble-and-capture.htm
+++ b/IndexedDB/request_bubble-and-capture.htm
@@ -29,20 +29,20 @@
 
     open_rq.onsuccess = function(e) {
         log("open_rq.success")(e);
-        assert_object_equals(events, [
-                                       "capture  db.success",
-                                       "capture txn.success",
-                                       "capture rq1.success",
-                                       "bubble  rq1.success",
+        assert_array_equals(events, [
+                                      "capture  db.success",
+                                      "capture txn.success",
+                                      "capture rq1.success",
+                                      "bubble  rq1.success",
 
-                                       "capture  db.error: ConstraintError",
-                                       "capture txn.error: ConstraintError",
-                                       "capture rq2.error: ConstraintError",
-                                       "bubble  rq2.error: ConstraintError",
-                                       "bubble  txn.error: ConstraintError",
-                                       "bubble   db.error: ConstraintError",
+                                      "capture  db.error: ConstraintError",
+                                      "capture txn.error: ConstraintError",
+                                      "capture rq2.error: ConstraintError",
+                                      "bubble  rq2.error: ConstraintError",
+                                      "bubble  txn.error: ConstraintError",
+                                      "bubble   db.error: ConstraintError",
 
-                                       "open_rq.success"
+                                      "open_rq.success"
                                      ],
                             "events");
         this.done();

--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -120,3 +120,7 @@ function createdb_for_multiple_tests(dbname, version) {
 
     return rq_open;
 }
+
+function assert_key_equals(actual, expected, description) {
+    assert_equals(indexedDB.cmp(actual, expected), 0, description);
+}

--- a/IndexedDB/transaction-create_in_versionchange.htm
+++ b/IndexedDB/transaction-create_in_versionchange.htm
@@ -50,18 +50,18 @@
             .addEventListener("success", log("complete2_get.success"))
 
         txn.oncomplete = this.step_func(function(e) {
-            assert_object_equals(events, [
-                                   "versionchange_add.success: 1",
-                                   "versionchange_count.success: 0",
-                                   "versionchange_add2.success: 2",
-                                   "versionchange_txn.complete",
+            assert_array_equals(events, [
+                                  "versionchange_add.success: 1",
+                                  "versionchange_count.success: 0",
+                                  "versionchange_add2.success: 2",
+                                  "versionchange_txn.complete",
 
-                                   "open_rq.success: [object IDBDatabase]",
+                                  "open_rq.success: [object IDBDatabase]",
 
-                                   "complete_count.success: 2",
-                                   "complete2_get.success: 1",
-                                 ],
-                        "events")
+                                  "complete_count.success: 2",
+                                  "complete2_get.success: 1",
+                                ],
+                       "events")
             this.done()
         })
     }

--- a/IndexedDB/transaction-requestqueue.htm
+++ b/IndexedDB/transaction-requestqueue.htm
@@ -23,8 +23,6 @@ open_rq.onupgradeneeded = function(e) {
         os.put({ os: "os" + i, k: i});
         os.add({ os: "os" + i });
     }
-
-//    assert_object_equals(db.objectStoreNames, ["os1", "os2", "os3", "os4", "os5" ], "objectStores");
 }
 
 open_rq.onsuccess = function(e) {
@@ -67,22 +65,22 @@ function finish() {
     if (--finish_to_go)
         return;
 
-    assert_object_equals(keys['txn'], [
-                           "os1: 1",
-                           "os3: 1",
-                           "os1: 2",
-                           "os2: 3",
-                           "os2: 1", "os2: 1", "os2: 1",
-                           "os1: 2",
-                          ], 'transaction keys');
+    assert_array_equals(keys['txn'], [
+        "os1: 1",
+        "os3: 1",
+        "os1: 2",
+        "os2: 3",
+        "os2: 1", "os2: 1", "os2: 1",
+        "os1: 2",
+    ], 'transaction keys');
 
-    assert_object_equals(keys['txn2'], [
-                           "os4: 1", "os4: 5", "os4: 4", "os3: 1",
-                           "os4: 1", "os4: 5", "os4: 4", "os3: 1",
-                           "os4: 1", "os4: 5", "os4: 4", "os3: 1",
-                           "os1: 2",
-                           "os4: 5",
-                          ], 'transaction 2 keys');
+    assert_array_equals(keys['txn2'], [
+        "os4: 1", "os4: 5", "os4: 4", "os3: 1",
+        "os4: 1", "os4: 5", "os4: 4", "os3: 1",
+        "os4: 1", "os4: 5", "os4: 4", "os3: 1",
+        "os1: 2",
+        "os4: 5",
+    ], 'transaction 2 keys');
 
     t.done();
 }

--- a/IndexedDB/transaction_bubble-and-capture.htm
+++ b/IndexedDB/transaction_bubble-and-capture.htm
@@ -37,20 +37,20 @@
 
     open_rq.onsuccess = function(e) {
         log("open_rq.success")(e);
-        assert_object_equals(events, [
-                                       "capture db.success",
-                                       "capture txn.success",
-                                       "capture rq1.success",
-                                       "bubble  rq1.success",
+        assert_array_equals(events, [
+                                      "capture db.success",
+                                      "capture txn.success",
+                                      "capture rq1.success",
+                                      "bubble  rq1.success",
 
-                                       "capture db.error: ConstraintError",
-                                       "capture txn.error: ConstraintError",
-                                       "capture rq2.error: ConstraintError",
-                                       "bubble  rq2.error: ConstraintError",
-                                       "bubble  txn.error: ConstraintError",
-                                       "bubble  db.error: ConstraintError",
+                                      "capture db.error: ConstraintError",
+                                      "capture txn.error: ConstraintError",
+                                      "capture rq2.error: ConstraintError",
+                                      "bubble  rq2.error: ConstraintError",
+                                      "bubble  txn.error: ConstraintError",
+                                      "bubble  db.error: ConstraintError",
 
-                                       "open_rq.success",
+                                      "open_rq.success",
                                      ],
                             "events");
         this.done();


### PR DESCRIPTION
Uses a mix of:
- assert_array_equals() for simple lists (e.g. event sequence)
- assert_key_equals() for IDB keys (or array-of-keys)
- case-by-case logic

Part of https://github.com/w3c/web-platform-tests/issues/2033
