### PR TITLE
Adding more bogus header values

### DIFF
--- a/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
+++ b/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>XMLHttpRequest: setRequestHeader() - header value with whitespace</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]/p[contains(@class,'note')] /following::ol/li[6]" />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      function request(value) {
+        test(function() {
+          var client = new XMLHttpRequest()
+          client.open("POST", "resources/inspect-headers.py?filter_name=X-Empty", false)
+          client.setRequestHeader('X-Empty', value)
+          client.send(null)
+          assert_equals(client.responseText, 'x-empty: '+ String(value.trim()).toLowerCase()+'\n' )
+        }, document.title + " (" + value + ")")
+      }
+      request(" ")
+      request(" t")
+      request("t ")
+      request(" t ")
+    </script>
+  </body>
+</html>

--- a/XMLHttpRequest/setrequestheader-bogus-value.htm
+++ b/XMLHttpRequest/setrequestheader-bogus-value.htm
@@ -19,6 +19,11 @@
       }
       try_value("t\rt")
       try_value("t\nt")
+      try_value(" ");
+      try_value(" t");
+      try_value("t ");
+      try_value("t\bt");
+      try_value("\x7f");
       try_value("ﾃｽﾄ")
 
       test(function() {

--- a/XMLHttpRequest/setrequestheader-bogus-value.htm
+++ b/XMLHttpRequest/setrequestheader-bogus-value.htm
@@ -19,9 +19,6 @@
       }
       try_value("t\rt")
       try_value("t\nt")
-      try_value(" ");
-      try_value(" t");
-      try_value("t ");
       try_value("t\bt");
       try_value("\x7f");
       try_value("ﾃｽﾄ")

--- a/XMLHttpRequest/setrequestheader-content-type.htm
+++ b/XMLHttpRequest/setrequestheader-content-type.htm
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>XMLHttpRequest: setRequestHeader() - Content-Type header</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]/p[contains(@class,'note')] /following::ol/li[6]" />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      function request(value) {
+        test(function() {
+          var client = new XMLHttpRequest()
+          client.open("POST", "resources/inspect-headers.py?filter_name=Content-Type", false)
+          client.setRequestHeader('Content-Type', value)
+          client.send("")
+          assert_equals(client.responseText, 'content-type: '+ String(value ? value.trim() : value).toLowerCase()+'\n' )
+        }, document.title + " (" + value + ")")
+      }
+      request("")
+      request(" ")
+      request(null)
+      request(undefined)
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
WebKit tightened a bit header values checking based on RFC 7230 rules.
Related bug entry is https://bugs.webkit.org/show_bug.cgi?id=128593.
The " " header value specific case is discussed in https://bugs.webkit.org/show_bug.cgi?id=147445 as some sites actually use it.
