### PR TITLE
add webdriver back tests

### DIFF
--- a/webdriver/navigation/back.py
+++ b/webdriver/navigation/back.py
@@ -1,0 +1,23 @@
+import unittest
+import sys
+import os
+
+sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
+import base_test
+
+
+class BackTest(base_test.WebDriverBaseTest):
+    # Get a static page that must be the same upon refresh
+    def test_back(self):
+        self.driver.get(self.webserver.where_is('navigation/res/backStart.html'))
+        body = self.driver.find_element_by_css("body").text
+	self.driver.get(self.webserver.where_is('navigation/res/backNext.html'))
+	currbody = self.driver.find_element_by_css("body").text
+	self.assertNotEqual(body, currbody)
+        self.driver.go_back()
+        backbody = self.driver.find_element_by_css("body").text
+        self.assertEqual(body, backbody)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webdriver/navigation/back.py
+++ b/webdriver/navigation/back.py
@@ -10,13 +10,13 @@ class BackTest(base_test.WebDriverBaseTest):
     # Get a static page that must be the same upon refresh
     def test_back(self):
         self.driver.get(self.webserver.where_is('navigation/res/backStart.html'))
-        body = self.driver.find_element_by_css("body").text
+	body = self.driver.find_element_by_css("body").text
 	self.driver.get(self.webserver.where_is('navigation/res/backNext.html'))
 	currbody = self.driver.find_element_by_css("body").text
 	self.assertNotEqual(body, currbody)
-        self.driver.go_back()
-        backbody = self.driver.find_element_by_css("body").text
-        self.assertEqual(body, backbody)
+	self.driver.go_back()
+	backbody = self.driver.find_element_by_css("body").text
+	self.assertEqual(body, backbody)
 
 
 if __name__ == '__main__':

--- a/webdriver/navigation/backToNothing.py
+++ b/webdriver/navigation/backToNothing.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(1, os.path.abspath(os.path.join(__file__, "../..")))
+import base_test
+
+
+class BackToNothingTest(base_test.WebDriverBaseTest):
+
+    def test_backToNothing(self):
+        self.driver.get(self.webserver.where_is('navigation/res/backNothing.html'))
+        body = self.driver.find_element_by_css("body").text
+        self.driver.go_back()
+        currbody = self.driver.find_element_by_css("body").text
+        self.assertEqual(body, currbody)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webdriver/navigation/res/backNext.html
+++ b/webdriver/navigation/res/backNext.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body id=body>
+This is the "back next" page.
+</body>
+</html>

--- a/webdriver/navigation/res/backNothing.html
+++ b/webdriver/navigation/res/backNothing.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+This is the "back nothing" page.
+</body>
+</html>

--- a/webdriver/navigation/res/backStart.html
+++ b/webdriver/navigation/res/backStart.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+This is the "back start" page.
+</body>
+</html>


### PR DESCRIPTION
This adds two simple tests for "Back" button functionality within WebDriver which parallel the existing ones for "Forward".

These tests are suggested here: http://www.w3.org/wiki/WebDriver/Test_suite#back
