### PR TITLE
Remove no longer necessary Servo workaround

### DIFF
--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -37,11 +37,11 @@ test(function()
     function filter(node)
     {
         if (node.id == "B1")
-            return /*NodeFilter.*/FILTER_SKIP;
-        return /*NodeFilter.*/FILTER_ACCEPT;
+            return NodeFilter.FILTER_SKIP;
+        return NodeFilter.FILTER_ACCEPT;
     }
 
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.currentNode, { type: Element, id: 'A1' });
@@ -51,11 +51,11 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, {
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, {
         acceptNode : function(node) {
             if (node.id == "B1")
-                return /*NodeFilter.*/FILTER_SKIP;
-            return /*NodeFilter.*/FILTER_ACCEPT;
+                return NodeFilter.FILTER_SKIP;
+            return NodeFilter.FILTER_ACCEPT;
         }
     });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
@@ -67,7 +67,7 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, null);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, null);
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.currentNode, { type: Element, id: 'A1' });
@@ -77,7 +77,7 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, undefined);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, undefined);
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.currentNode, { type: Element, id: 'A1' });
@@ -87,7 +87,7 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, {});
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, {});
     assert_throws(new TypeError(), function () { walker.firstChild(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_throws(new TypeError(), function () { walker.nextNode(); });
@@ -96,7 +96,7 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, { acceptNode: "foo" });
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, { acceptNode: "foo" });
     assert_throws(new TypeError(), function () { walker.firstChild(); });
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_throws(new TypeError(), function () { walker.nextNode(); });
@@ -105,9 +105,9 @@ test(function()
 
 test(function()
 {
-    var filter = function() { return /*NodeFilter.*/FILTER_ACCEPT; };
-    filter.acceptNode = function(node) { return /*NodeFilter.*/FILTER_SKIP; };
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var filter = function() { return NodeFilter.FILTER_ACCEPT; };
+    filter.acceptNode = function(node) { return NodeFilter.FILTER_SKIP; };
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.nextNode(), { type: Element, id: 'B1' });
 }, 'Testing with function having acceptNode function');
@@ -116,17 +116,17 @@ test(function()
 {
     var filter = {
         acceptNode: function(node) {
-            return /*NodeFilter.*/FILTER_ACCEPT;
+            return NodeFilter.FILTER_ACCEPT;
         }
     };
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
 }, 'Testing acceptNode callee');
 
 test(function()
 {
     var test_error = { name: "test" };
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT,
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT,
                                            function(node) {
                                                throw test_error;
                                            });
@@ -139,7 +139,7 @@ test(function()
 test(function()
 {
     var test_error = { name: "test" };
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT,
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT,
                                            {
                                                acceptNode : function(node) {
                                                    throw test_error;

--- a/dom/traversal/TreeWalker-currentNode.html
+++ b/dom/traversal/TreeWalker-currentNode.html
@@ -26,7 +26,7 @@ var all = function(node) { return true; }
 
 test(function()
 {
-    var w = document.createTreeWalker(subTree, /*NodeFilter.*/SHOW_ELEMENT, all);
+    var w = document.createTreeWalker(subTree, NodeFilter.SHOW_ELEMENT, all);
     assert_node(w.currentNode, { type: Element, id: 'subTree' });
     assert_equals(w.parentNode(), null);
     assert_node(w.currentNode, { type: Element, id: 'subTree' });
@@ -35,8 +35,8 @@ test(function()
 test(function()
 {
     var w = document.createTreeWalker(subTree,
-                                      /*NodeFilter.*/SHOW_ELEMENT
-                                      | /*NodeFilter.*/SHOW_COMMENT,
+                                      NodeFilter.SHOW_ELEMENT
+                                      | NodeFilter.SHOW_COMMENT,
                                       all);
     w.currentNode = document.documentElement;
     assert_equals(w.parentNode(), null);
@@ -63,7 +63,7 @@ test(function()
 
 test(function()
 {
-    var w = document.createTreeWalker(subTree, /*NodeFilter.*/SHOW_ELEMENT, all);
+    var w = document.createTreeWalker(subTree, NodeFilter.SHOW_ELEMENT, all);
     w.currentNode = subTree.previousSibling;
     assert_equals(w.nextNode(), subTree);
     w.currentNode = document.getElementById("parent");

--- a/dom/traversal/TreeWalker-previousNodeLastChildReject.html
+++ b/dom/traversal/TreeWalker-previousNodeLastChildReject.html
@@ -66,11 +66,11 @@ test(function()
     function filter(node)
     {
         if (node.id == "C2")
-            return /*NodeFilter.*/FILTER_REJECT;
-        return /*NodeFilter.*/FILTER_ACCEPT;
+            return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
     }
 
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.currentNode, { type: Element, id: 'A1' });

--- a/dom/traversal/TreeWalker-previousSiblingLastChildSkip.html
+++ b/dom/traversal/TreeWalker-previousSiblingLastChildSkip.html
@@ -66,11 +66,11 @@ test(function()
     function filter(node)
     {
         if (node.id == "B1")
-            return /*NodeFilter.*/FILTER_SKIP;
-        return /*NodeFilter.*/FILTER_ACCEPT;
+            return NodeFilter.FILTER_SKIP;
+        return NodeFilter.FILTER_ACCEPT;
     }
 
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.currentNode, { type: Element, id: 'root' });
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.currentNode, { type: Element, id: 'A1' });

--- a/dom/traversal/TreeWalker-traversal-reject.html
+++ b/dom/traversal/TreeWalker-traversal-reject.html
@@ -45,24 +45,24 @@ setup(function() {
 var rejectB1Filter = {
   acceptNode: function(node) {
     if (node.id == 'B1')
-      return /*NodeFilter.*/FILTER_REJECT;
+      return NodeFilter.FILTER_REJECT;
 
-    return /*NodeFilter.*/FILTER_ACCEPT;
+    return NodeFilter.FILTER_ACCEPT;
   }
 }
 
 var skipB2Filter = {
   acceptNode: function(node) {
     if (node.id == 'B2')
-      return /*NodeFilter.*/FILTER_SKIP;
+      return NodeFilter.FILTER_SKIP;
 
-    return /*NodeFilter.*/FILTER_ACCEPT;
+    return NodeFilter.FILTER_ACCEPT;
   }
 }
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, rejectB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, rejectB1Filter);
     assert_node(walker.nextNode(), { type: Element, id: 'A1' });
     assert_node(walker.nextNode(), { type: Element, id: 'B2' });
     assert_node(walker.nextNode(), { type: Element, id: 'B3' });
@@ -70,14 +70,14 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, rejectB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, rejectB1Filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.firstChild(), { type: Element, id: 'B2' });
 }, 'Testing firstChild');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB2Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB2Filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.firstChild(), { type: Element, id: 'B1' });
     assert_node(walker.nextSibling(), { type: Element, id: 'B3' });
@@ -85,21 +85,21 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, rejectB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, rejectB1Filter);
     walker.currentNode = testElement.querySelectorAll('#C1')[0];
     assert_node(walker.parentNode(), { type: Element, id: 'A1' });
 }, 'Testing parentNode');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB2Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB2Filter);
     walker.currentNode = testElement.querySelectorAll('#B3')[0];
     assert_node(walker.previousSibling(), { type: Element, id: 'B1' });
 }, 'Testing previousSibling');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, rejectB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, rejectB1Filter);
     walker.currentNode = testElement.querySelectorAll('#B3')[0];
     assert_node(walker.previousNode(), { type: Element, id: 'B2' });
     assert_node(walker.previousNode(), { type: Element, id: 'A1' });

--- a/dom/traversal/TreeWalker-traversal-skip-most.html
+++ b/dom/traversal/TreeWalker-traversal-skip-most.html
@@ -42,22 +42,22 @@ setup(function() {
 var filter = {
   acceptNode: function(node) {
     if (node.className == 'keep')
-      return /*NodeFilter.*/FILTER_ACCEPT;
+      return NodeFilter.FILTER_ACCEPT;
 
-    return /*NodeFilter.*/FILTER_SKIP;
+    return NodeFilter.FILTER_SKIP;
   }
 }
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     assert_node(walker.firstChild(), { type: Element, id: 'B1' });
     assert_node(walker.nextSibling(), { type: Element, id: 'B3' });
 }, 'Testing nextSibling');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, filter);
     walker.currentNode = testElement.querySelectorAll('#B3')[0];
     assert_node(walker.previousSibling(), { type: Element, id: 'B1' });
 }, 'Testing previousSibling');

--- a/dom/traversal/TreeWalker-traversal-skip.html
+++ b/dom/traversal/TreeWalker-traversal-skip.html
@@ -45,24 +45,24 @@ setup(function() {
 var skipB1Filter = {
   acceptNode: function(node) {
     if (node.id == 'B1')
-      return /*NodeFilter.*/FILTER_SKIP;
+      return NodeFilter.FILTER_SKIP;
 
-    return /*NodeFilter.*/FILTER_ACCEPT;
+    return NodeFilter.FILTER_ACCEPT;
   }
 }
 
 var skipB2Filter = {
   acceptNode: function(node) {
     if (node.id == 'B2')
-      return /*NodeFilter.*/FILTER_SKIP;
+      return NodeFilter.FILTER_SKIP;
 
-    return /*NodeFilter.*/FILTER_ACCEPT;
+    return NodeFilter.FILTER_ACCEPT;
   }
 }
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB1Filter);
     assert_node(walker.nextNode(), { type: Element, id: 'A1' });
     assert_node(walker.nextNode(), { type: Element, id: 'C1' });
     assert_node(walker.nextNode(), { type: Element, id: 'B2' });
@@ -71,14 +71,14 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB1Filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.firstChild(), { type: Element, id: 'C1' });
 }, 'Testing firstChild');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB2Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB2Filter);
     assert_node(walker.firstChild(), { type: Element, id: 'A1' });
     assert_node(walker.firstChild(), { type: Element, id: 'B1' });
     assert_node(walker.nextSibling(), { type: Element, id: 'B3' });
@@ -86,21 +86,21 @@ test(function()
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB1Filter);
     walker.currentNode = testElement.querySelectorAll('#C1')[0];
     assert_node(walker.parentNode(), { type: Element, id: 'A1' });
 }, 'Testing parentNode');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB2Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB2Filter);
     walker.currentNode = testElement.querySelectorAll('#B3')[0];
     assert_node(walker.previousSibling(), { type: Element, id: 'B1' });
 }, 'Testing previousSibling');
 
 test(function()
 {
-    var walker = document.createTreeWalker(testElement, /*NodeFilter.*/SHOW_ELEMENT, skipB1Filter);
+    var walker = document.createTreeWalker(testElement, NodeFilter.SHOW_ELEMENT, skipB1Filter);
     walker.currentNode = testElement.querySelectorAll('#B3')[0];
     assert_node(walker.previousNode(), { type: Element, id: 'B2' });
     assert_node(walker.previousNode(), { type: Element, id: 'C1' });

--- a/dom/traversal/traversal-support.js
+++ b/dom/traversal/traversal-support.js
@@ -8,21 +8,3 @@ function assert_node(actual, expected)
     if (typeof(expected.nodeValue) !== 'undefined')
         assert_equals(actual.nodeValue, expected.nodeValue);
 }
-
-// XXX Servo doesn't have these constants in NodeFilter yet
-var FILTER_ACCEPT = 1;
-var FILTER_REJECT = 2;
-var FILTER_SKIP = 3;
-var SHOW_ALL = 0xFFFFFFFF;
-var SHOW_ELEMENT = 0x1;
-var SHOW_ATTRIBUTE = 0x2;
-var SHOW_TEXT = 0x4;
-var SHOW_CDATA_SECTION = 0x8;
-var SHOW_ENTITY_REFERENCE = 0x10;
-var SHOW_ENTITY = 0x20;
-var SHOW_PROCESSING_INSTRUCTION = 0x40;
-var SHOW_COMMENT = 0x80;
-var SHOW_DOCUMENT = 0x100;
-var SHOW_DOCUMENT_TYPE = 0x200;
-var SHOW_DOCUMENT_FRAGMENT = 0x400;
-var SHOW_NOTATION = 0x800;


### PR DESCRIPTION
There were constants defined in dom/traversal/traversal-support.js that
were used to workaround Servo's lack of implementing those constants.
Those constants are now implemented in Servo on NodeFilter, so the
workaround can be removed.
