### PR TITLE
Fix requestAnimationFrame timestamps in queue

### DIFF
--- a/animation-timing/same-dispatch-time.html
+++ b/animation-timing/same-dispatch-time.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <title>requestAnimationFrame in queue get the same timestamp</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="http://w3c.github.io/animation-timing/#dfn-invoke-callbacks-algorithm"/>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      test(function (t) {
+        var a = 0, b = 0;
+
+        /* REASONING:
+        * These two methods that will be called with a timestamp. Because
+        * they execute right after eachother, they're added to the same
+        * queue and SHOULD be timestamped with the same value.
+        */
+        window.requestAnimationFrame(function() { a = arguments[0]; });
+        window.requestAnimationFrame(function() { b = arguments[0]; });
+
+        setTimeout(function() {
+            assert_true(a != 0);
+            assert_true(b != 0);
+            assert_true(a == b);
+        }, 100);
+      }, "requestAnimationFrame will timestamp events in the same queue with the same time");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This resolves #7044 which involved callbacks
in a queue not receiving the same timestamp despite
the specification saying they should. An extra test
was added to verify the correct behavior.
