### PR TITLE
Fix base URL tests to not self-interfere

### DIFF
--- a/html/infrastructure/urls/terminology-0/document-base-url.html
+++ b/html/infrastructure/urls/terminology-0/document-base-url.html
@@ -25,6 +25,10 @@
         var base = document.createElement("base");
         base.setAttribute("href", "/foo/bar");
         document.head.appendChild(base);
+        t1.add_cleanup(function () {
+          document.head.removeChild(base);
+        });
+
         assert_resolve_url(document, location.href.replace(location.pathname, "/foo"));
         assert_equals(document.baseURI, base.href, "The document base URL should be URL of the first base element that has an href attribute.");
       });


### PR DESCRIPTION
Without this change, the document's base URL is set to "/foo/bar" for the whole testing cycle. This then infects future tests, which assume that window.location is equal to document.baseURI, when they pass the former to assert_resolve_url.
