### PR TITLE
Fix createTestMediaPlayer

### DIFF
--- a/shadow-dom/events/event-dispatch/test-001.html
+++ b/shadow-dom/events/event-dispatch/test-001.html
@@ -35,7 +35,7 @@ A_05_05_01_T01.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-slider-thumb relative target	#volume-slider-thumb
+    //For #volume-slider-thumb relative target #volume-slider-thumb
     roots.volumeShadowRoot.querySelector('#volume-slider-thumb').addEventListener('click',
 	    A_05_05_01_T01.step_func(function(event) {
 	    	invoked = true;
@@ -68,7 +68,7 @@ A_05_05_01_T02.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-shadow-root relative target	#volume-slider-thumb
+    //For #volume-shadow-root relative target #volume-slider-thumb
     roots.volumeShadowRoot.addEventListener('click',
     		A_05_05_01_T02.step_func(function(event) {
     			invoked = true;
@@ -101,13 +101,13 @@ A_05_05_01_T03.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-slider relative target #volume-slider
+    //For #volume-slider relative target #volume-shadow-host
     roots.playerShadowRoot.querySelector('#volume-slider').addEventListener('click',
     		A_05_05_01_T03.step_func(function(event) {
     			invoked = true;
-		    	assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 		    			'Wrong target');
-		    	assert_true(event.currentTarget.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.currentTarget.getAttribute('id'), 'volume-slider',
 		    			'Wrong currentTarget');
 	    }), false);
 
@@ -135,13 +135,13 @@ A_05_05_01_T04.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-slider-container relative target #volume-slider
+    //For #volume-slider-container relative target #volume-shadow-host
     roots.playerShadowRoot.querySelector('#volume-slider-container').addEventListener('click',
     		A_05_05_01_T04.step_func(function(event) {
     			invoked = true;
-		    	assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 		    			'Wrong target');
-		    	assert_true(event.currentTarget.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.currentTarget.getAttribute('id'), 'volume-slider-container',
 		    			'Wrong currentTarget');
 	    }), false);
 
@@ -168,13 +168,13 @@ A_05_05_01_T05.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #controls relative target #volume-slider
+    //For #controls relative target #volume-shadow-host
     roots.playerShadowRoot.querySelector('#controls').addEventListener('click',
     		A_05_05_01_T05.step_func(function(event) {
     			invoked = true;
-		    	assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 		    			'Wrong target');
-		    	assert_true(event.currentTarget.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.currentTarget.getAttribute('id'), 'controls',
 		    			'Wrong currentTarget');
 	    }), false);
 
@@ -201,13 +201,13 @@ A_05_05_01_T06.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #player-shadow-root relative target #volume-slider
-    roots.playerShadowRoot.addEventListener('click',
+    //For #player-shadow-host relative target #player-shadow-host
+    d.querySelector('#player-shadow-host').addEventListener('click',
     		A_05_05_01_T06.step_func(function(event) {
     			invoked = true;
-		    	assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.target.getAttribute('id'), 'player-shadow-host',
 		    			'Wrong target');
-		    	assert_true(event.currentTarget.getAttribute('id'), 'volume-slider',
+		    	assert_equals(event.currentTarget.getAttribute('id'), 'player-shadow-host',
 		    			'Wrong currentTarget');
 	    }), false);
 
@@ -235,13 +235,13 @@ A_05_05_01_T07.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #player relative target #player
+    //For #player relative target #player-shadow-host
     d.querySelector('#player').addEventListener('click',
     		A_05_05_01_T07.step_func(function(event) {
     			invoked = true;
-		    	assert_equals(event.target.getAttribute('id'), 'player',
+		    	assert_equals(event.target.getAttribute('id'), 'player-shadow-host',
 		    			'Wrong target');
-		    	assert_true(event.currentTarget.getAttribute('id'), 'player',
+		    	assert_equals(event.currentTarget.getAttribute('id'), 'player',
 		    			'Wrong currentTarget');
 	    }), false);
 

--- a/shadow-dom/events/event-retargeting/test-004.html
+++ b/shadow-dom/events/event-retargeting/test-004.html
@@ -60,11 +60,11 @@ A_05_01_04_T02.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-shadow-root relative target is #volume-slider-thumb
-    roots.volumeShadowRoot.addEventListener('click',
+    //For #volume-shadow-host relative target is #volume-shadow-host
+    roots.playerShadowRoot.querySelector('#volume-shadow-host').addEventListener('click',
     	A_05_01_04_T02.step_func(function (event) {
     		invoked = true;
-	        assert_equals(event.target.getAttribute('id'), 'volume-slider-thumb',
+	        assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
         		'Wrong related target');
     }), false);
 
@@ -90,11 +90,11 @@ A_05_01_04_T03.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-slider relative target is #volume-slider
+    //For #volume-slider relative target is #volume-shadow-host
     roots.playerShadowRoot.querySelector('#volume-slider').addEventListener('click',
     		A_05_01_04_T03.step_func(function (event) {
     			invoked = true;
-	        assert_equals(event.target.getAttribute('id'), 'volume-slider',
+	        assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
         		'Wrong related target');
     }), false);
 
@@ -118,11 +118,11 @@ A_05_01_04_T04.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #volume-slider-container relative target is #volume-slider
+    //For #volume-slider-container relative target is #volume-shadow-host
     roots.playerShadowRoot.querySelector('#volume-slider-container').addEventListener('click',
     		A_05_01_04_T04.step_func(function (event) {
     			invoked = true;
-		        assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		        assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 	        		'Wrong related target');
     }), false);
 
@@ -146,11 +146,11 @@ A_05_01_04_T05.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #controls relative target is #volume-slider
+    //For #controls relative target is #volume-shadow-host
     roots.playerShadowRoot.querySelector('#controls').addEventListener('click',
     		A_05_01_04_T05.step_func(function (event) {
     			invoked = true;
-		        assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		        assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 	        		'Wrong related target');
     }), false);
 
@@ -174,11 +174,11 @@ A_05_01_04_T06.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #player-shadow-root relative target is #volume-slider
+    //For #player-shadow-host relative target is #player-shadow-host
     roots.playerShadowRoot.addEventListener('click',
     		A_05_01_04_T06.step_func(function (event) {
     			invoked = true;
-		        assert_equals(event.target.getAttribute('id'), 'volume-slider',
+		        assert_equals(event.target.getAttribute('id'), 'volume-shadow-host',
 	        		'Wrong related target');
     }), false);
 
@@ -203,11 +203,11 @@ A_05_01_04_T07.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #player relative target is #player
+    //For #player relative target is #player-shadow-host
     d.querySelector('#player').addEventListener('click',
     		A_05_01_04_T07.step_func(function (event) {
     			invoked = true;
-		        assert_equals(event.target.getAttribute('id'), 'player',
+		        assert_equals(event.target.getAttribute('id'), 'player-shadow-host',
 	        		'Wrong related target');
     }), false);
 
@@ -344,11 +344,11 @@ A_05_01_04_T12.step(unit(function (ctx) {
     //expected result of what relative target should be see
     //see at http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 
-    //For #player relative target is #player
+    //For #player relative target is #player-shadow-host
     d.querySelector('#player').addEventListener('click',
     		A_05_01_04_T12.step_func(function (event) {
     			invoked = true;
-		        assert_equals(event.target.getAttribute('id'), 'player',
+		        assert_equals(event.target.getAttribute('id'), 'player-shadow-host',
 	        		'Wrong related target');
     }), false);
 

--- a/shadow-dom/testcommon.js
+++ b/shadow-dom/testcommon.js
@@ -228,30 +228,30 @@ function createTestMediaPlayer(d) {
     d.body.innerHTML = '' +
 	'<div id="player">' +
 		'<input type="checkbox" id="outside-control">' +
-		'<div id="player-shadow-root">' +
+		'<div id="player-shadow-host">' +
 	    '</div>' +
 	'</div>';
 
-	var playerShadowRoot = d.querySelector('#player-shadow-root').createShadowRoot();
+	var playerShadowRoot = d.querySelector('#player-shadow-host').createShadowRoot();
 	playerShadowRoot.innerHTML = '' +
 		'<div id="controls">' +
 			'<button class="play-button">PLAY</button>' +
-			'<input type="range" id="timeline">' +
-				'<div id="timeline-shadow-root">' +
+			'<div tabindex="0" id="timeline">' +
+				'<div id="timeline-shadow-host">' +
 				'</div>' +
-			'</input>' +
+			'</div>' +
 		    '<div class="volume-slider-container" id="volume-slider-container">' +
-		        '<input type="range" class="volume-slider" id="volume-slider">' +
-		            '<div id="volume-shadow-root">' +
+		        '<div tabindex="0" class="volume-slider" id="volume-slider">' +
+		            '<div id="volume-shadow-host">' +
 		            '</div>' +
-		        '</input>' +
+		        '</div>' +
 		    '</div>' +
 		'</div>';
 
-	var timeLineShadowRoot = playerShadowRoot.querySelector('#timeline-shadow-root').createShadowRoot();
+	var timeLineShadowRoot = playerShadowRoot.querySelector('#timeline-shadow-host').createShadowRoot();
 	timeLineShadowRoot.innerHTML =  '<div class="slider-thumb" id="timeline-slider-thumb"></div>';
 
-	var volumeShadowRoot = playerShadowRoot.querySelector('#volume-shadow-root').createShadowRoot();
+	var volumeShadowRoot = playerShadowRoot.querySelector('#volume-shadow-host').createShadowRoot();
 	volumeShadowRoot.innerHTML = '<div class="slider-thumb" id="volume-slider-thumb"></div>';
 
 	return {


### PR DESCRIPTION
Some shadow DOM tests use common "testcommon.js" file, which
contains "createTestMediaPlayer()" function which creates fake
media player with shadow roots for tests to use.

The media player assumed that `<input>` tag can contain some other
tags like `<input type="range"><div>...</div></input>`, which is not
true. Usually `<input>` doesn't require its closing tag, thus
the `<div>` inside `<input>` becomes just a sibling of the `<input>`.

The tests which used `crateTestMediaPlayer()` depended on the
DOM tree structure with the wrong assumption (given above),
so as a 1st step I replaced the `<input>` with `<div tabindex="0">`s
so that we keep the tree structure as is while the element is
clickable.

Now the tree structure looks like:

```
div#player
  input#outside-control (type=checkbox)
  div#player-shadow-host
    #shadow-root
      div#controls
        button.play_button
        div#timeline (used to be <input type=range>)
          div#timeline-shadow-host
            #shadow-root
              div#timeline-slider-thumb
        div#volue-slider-container
          div#volume-slider (used to be <input type=range>)
            div#volume-shadow-host
              #shadow-root
                div#volume-slider-thumb
```

On the 2nd step, I fixed the test expectations.  These tests
(events/event-dispatch/test-001.html and
events/event-retargeting/test-004.html) relied on the fact that
`<input>` is implemented using user-agent shadow, thus e.g.
a click event on `#volume-slider-thumb`, will be retargeted
This is no longer true as all elements inside the whole control
is implemented by plain `<div>`s, and `#timeline` and `#volume-slider`
cannot be a shadow boundary.  These expectations are adjusted.
