### PR TITLE
Fix event path trimming test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The way to contribute is just as usual:
 * Fork this repository (and make sure you're still relatively in sync
   with it if you forked a while ago).
 * Create a branch for your changes:
-  `git checkout -b your-name/topic`.
+  `git checkout -b topic`.
 * Make your changes.
 * Run the lint script described below.
 * Commit locally and push that to your repo.

--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -12,8 +12,8 @@ policies and contribution forms [3].
 <head>
 <title>Shadow DOM Test: A_05_05_03</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#event-dispatch">
-<meta name="assert" content="Event Dispatch: If the relatedTarget and target are the same for a given node, its the event listeners must not be invoked.">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-path-trimming">
+<meta name="assert" content="Event Path Trimming: event listeners for trusted events must not be invoked on a node for which the target and relatedTarget are the same.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -37,19 +37,29 @@ A_05_05_03_T01.step(unit(function (ctx) {
     var s = host.createShadowRoot();
 
     var div1 = d.createElement('div');
-    div1.setAttribute('style', 'height:100%; width:100%');
+    div1.setAttribute('style', 'height:50%; width:100%');
     div1.setAttribute('id', 'div1');
     s.appendChild(div1);
 
-    s.addEventListener('mouseover', A_05_05_03_T01.step_func(function(event) {
+    var div2 = d.createElement('div');
+    div2.setAttribute('style', 'height:50%; width:100%');
+    div2.setAttribute('id', 'div2');
+    s.appendChild(div2);
+
+    // Add an event listner above its shadow root. If both target and
+    // relatedTarget are in the same shadow tree under the root,
+    // retargeted target and relatedTarget will be the same node
+    // and the event must not invoke the handler.
+    host.addEventListener('mouseover', A_05_05_03_T01.step_func(function(event) {
     	assert_true(false, 'Event listeners shouldn\'t be invoked if target and relatedTarget ' +
     			'are the same');
     }), false);
 
-
+    // Note: this is not a "trusted event", thus user agents may not
+    // suppress invoking event handlers.
     var evt = document.createEvent("MouseEvents");
     evt.initMouseEvent("mouseover", true, false, window,
-      0, 10, 10, 10, 10, false, false, false, false, 0, div1);
+      0, 10, 10, 10, 10, false, false, false, false, 0, div2);
 
     div1.dispatchEvent(evt);
 

--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -58,7 +58,7 @@ A_05_05_03_T01.step(unit(function (ctx) {
         }
         if (event.target !== event.relatedTarget)
             return;
-        assert_true(true, 'Cannot determine whether the event is trusted, ' +
+        assert_true(false, 'Cannot determine whether the event is trusted, ' +
             'but event handler is invoked anyway with ' +
             'target === relatedTarget.');
     }), false);

--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -29,41 +29,43 @@ A_05_05_03_T01.step(unit(function (ctx) {
     var d = newRenderedHTMLDocument(ctx);
 
     var host = d.createElement('div');
-    host.setAttribute('style', 'height:50%; width:100%');
     host.setAttribute('id', 'host');
     d.body.appendChild(host);
 
     //Shadow root to play with
     var s = host.createShadowRoot();
 
-    var div1 = d.createElement('div');
-    div1.setAttribute('style', 'height:50%; width:100%');
-    div1.setAttribute('id', 'div1');
-    s.appendChild(div1);
+    var input1 = d.createElement('input');
+    input1.setAttribute('id', 'input1');
+    s.appendChild(input1);
 
-    var div2 = d.createElement('div');
-    div2.setAttribute('style', 'height:50%; width:100%');
-    div2.setAttribute('id', 'div2');
-    s.appendChild(div2);
+    var input2 = d.createElement('input');
+    input2.setAttribute('id', 'input2');
+    s.appendChild(input2);
+
+    // Focus before installing the event handler.
+    input2.focus();
 
     // Add an event listner above its shadow root. If both target and
     // relatedTarget are in the same shadow tree under the root,
     // retargeted target and relatedTarget will be the same node
     // and the event must not invoke the handler.
-    host.addEventListener('mouseover', A_05_05_03_T01.step_func(function(event) {
-        if (('isTrusted' in event) && event.isTrusted) {
+    host.addEventListener('focusin', A_05_05_03_T01.step_func(function(event) {
+        if (('isTrusted' in event) && event.isTrusted &&
+            (event.target == event.relatedTarget)) {
             assert_true(false, 'Trusted event must not invoke its listeners' +
                 'if target and relatedTarget are the same');
         }
+        if (event.target !== event.relatedTarget)
+            return;
+        assert_true(true, 'Cannot determine whether the event is trusted, ' +
+            'but event handler is invoked anyway with ' +
+            'target === relatedTarget.');
     }), false);
 
-    // Note: this is not a "trusted event", thus user agents may not
-    // suppress invoking event handlers.
-    var evt = document.createEvent("MouseEvents");
-    evt.initMouseEvent("mouseover", true, false, window,
-      0, 10, 10, 10, 10, false, false, false, false, 0, div2);
-
-    div1.dispatchEvent(evt);
+    // Causes a "focusin" event, from #input2 to #input1.
+    // It should be viewed outside the shadow as "target == relatedTarget".
+    input1.focus();
 
     A_05_05_03_T01.done();
 }));

--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -51,8 +51,10 @@ A_05_05_03_T01.step(unit(function (ctx) {
     // retargeted target and relatedTarget will be the same node
     // and the event must not invoke the handler.
     host.addEventListener('mouseover', A_05_05_03_T01.step_func(function(event) {
-    	assert_true(false, 'Event listeners shouldn\'t be invoked if target and relatedTarget ' +
-    			'are the same');
+        if (('isTrusted' in event) && event.isTrusted) {
+            assert_true(false, 'Trusted event must not invoke its listeners' +
+                'if target and relatedTarget are the same');
+        }
     }), false);
 
     // Note: this is not a "trusted event", thus user agents may not

--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -13,7 +13,7 @@ policies and contribution forms [3].
 <title>Shadow DOM Test: A_05_05_03</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
 <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-path-trimming">
-<meta name="assert" content="Event Path Trimming: event listeners for trusted events must not be invoked on a node for which the target and relatedTarget are the same.">
+<meta name="assert" content="Event Path Trimming: In cases where both relatedTarget and target of a trusted event are part of the same shadow tree, the conforming UAs must stop events at the shadow root to avoid the appearance of spurious mouseover and mouseout events firing from the same node.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -34,6 +34,7 @@ A_05_05_03_T01.step(unit(function (ctx) {
 
     //Shadow root to play with
     var s = host.createShadowRoot();
+    s.id = 'shadow';
 
     var input1 = d.createElement('input');
     input1.setAttribute('id', 'input1');
@@ -43,31 +44,38 @@ A_05_05_03_T01.step(unit(function (ctx) {
     input2.setAttribute('id', 'input2');
     s.appendChild(input2);
 
-    // Focus before installing the event handler.
-    input2.focus();
-
-    // Add an event listner above its shadow root. If both target and
-    // relatedTarget are in the same shadow tree under the root,
-    // retargeted target and relatedTarget will be the same node
-    // and the event must not invoke the handler.
-    host.addEventListener('focusin', A_05_05_03_T01.step_func(function(event) {
-        if (('isTrusted' in event) && event.isTrusted &&
-            (event.target == event.relatedTarget)) {
-            assert_true(false, 'Trusted event must not invoke its listeners' +
-                'if target and relatedTarget are the same');
+    // Add an event listener in its shadow root.
+    s.addEventListener('focusin', A_05_05_03_T01.step_func(function(event) {
+        if (event.deepPath[0].id == 'input1') {
+          assert_equals(event.deepPath.length, 7);
+          assert_equals(event.deepPath[1].id, 'shadow');
+          assert_equals(event.deepPath[2].id, 'host');
+          assert_equals(event.deepPath[3].tagName, 'BODY');
+          assert_equals(event.deepPath[4].tagName, 'HTML');
+          assert_equals(event.deepPath[5], d);
+          assert_equals(event.deepPath[6], ctx.iframes[0].contentWindow);
+        } else if (event.deepPath[0].id == 'input2') {
+          assert_equals(event.deepPath.length, 2);
+          assert_equals(event.deepPath[1].id, 'shadow');
+          A_05_05_03_T01.done();
+        } else {
+          assert_true(false, 'Unexpected event happend.' + event);
         }
-        if (event.target !== event.relatedTarget)
-            return;
-        assert_true(false, 'Cannot determine whether the event is trusted, ' +
-            'but event handler is invoked anyway with ' +
-            'target === relatedTarget.');
     }), false);
 
-    // Causes a "focusin" event, from #input2 to #input1.
-    // It should be viewed outside the shadow as "target == relatedTarget".
+    // Expected event path:
+    // <input>, #shadow-root, <div>, <body>, <html>, #document, window
     input1.focus();
 
-    A_05_05_03_T01.done();
+    // Causes a "focusin" event, from #input1 to #input2
+    // In this case, original relatedTarget is #input1, and original target
+    // is #input2.
+    // It should be viewed outside the shadow as "target == relatedTarget"
+    // after event retargeting, therefore, event.deepPath above the shadow
+    // host will be trimmed.
+    // Expected event path:
+    // <input>, #shadow-root
+    input2.focus();
 }));
 </script>
 </body>


### PR DESCRIPTION
Event retargeting happens at the shadow tree boundary and event
handler should be installed above the shadow root.

In the old test the handler is installed on the shadow root, which
retargeting is not yet happening while bubbling the event.

Also change the initial target and relatedTarget to be different to
make sure if they are retargeted to the same node.
