### PR TITLE
Remove tests with embedded credentials from cache-match and cache-put

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -64,18 +64,6 @@ var simple_entries = [
     name: 'cat_in_the_hat',
     request: new Request('http://example.com/cat/in/the/hat'),
     response: new Response('')
-  },
-
-  {
-    name: 'secret_cat',
-    request: new Request('http://tom:jerry@example.com/cat'),
-    response: new Response('')
-  },
-
-  {
-    name: 'top_secret_cat',
-    request: new Request('http://tom:j3rry@example.com/cat'),
-    response: new Response('')
   }
 ];
 
@@ -278,24 +266,6 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
             'just a string fragment.');
         });
   }, 'Cache.match with string fragment "http" as query');
-
-prepopulated_cache_test(simple_entries, function(cache, entries) {
-    return cache.matchAll(entries.secret_cat.request.url)
-      .then(function(result) {
-          assert_response_array_equivalent(
-            result, [entries.secret_cat.response],
-            'Cache.matchAll should not ignore embedded credentials');
-        });
-  }, 'Cache.matchAll with URL containing credentials');
-
-prepopulated_cache_test(simple_entries, function(cache, entries) {
-    return cache.match(entries.secret_cat.request.url)
-      .then(function(result) {
-          assert_response_equals(
-            result, entries.secret_cat.response,
-            'Cache.match should not ignore embedded credentials');
-        });
-  }, 'Cache.match with URL containing credentials');
 
 prepopulated_cache_test(vary_entries, function(cache, entries) {
     return cache.matchAll('http://example.com/c')

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -180,42 +180,6 @@ cache_test(function(cache) {
   }, 'Cache.put called twice with request URLs that differ only by a fragment');
 
 cache_test(function(cache) {
-    var entries = {
-      dark: {
-        url: 'http://darkhelmet:12345@example.com/spaceballs',
-        body: 'Moranis'
-      },
-
-      skroob: {
-        url: 'http://skroob:12345@example.com/spaceballs',
-        body: 'Brooks'
-      },
-
-      control: {
-        url: 'http://example.com/spaceballs',
-        body: 'v(o.o)v'
-      }
-    };
-
-    return Promise.all(Object.keys(entries).map(function(key) {
-        return cache.put(new Request(entries[key].url),
-                         new Response(entries[key].body));
-      }))
-      .then(function() {
-          return Promise.all(Object.keys(entries).map(function(key) {
-              return cache.match(entries[key].url)
-                .then(function(result) {
-                    return result.text();
-                  })
-                .then(function(body) {
-                    assert_equals(body, entries[key].body,
-                                  'Cache put should store response body.');
-                  });
-            }));
-        });
-  }, 'Cache.put with request URLs containing embedded credentials');
-
-cache_test(function(cache) {
     var url = 'http://example.com/foo';
     return cache.put(url, new Response('some body'))
       .then(function() { return cache.match(url); })


### PR DESCRIPTION
Creating a `Request` with an url with embedded credentials should throw
a `TypeError` (see: https://fetch.spec.whatwg.org/#dom-request 13.3), thus the removed tests fail if the `Request` spec is followed.

Closes #2098
