### PR TITLE
media-source/mediasource-buffered.html: check for correct webm duration

### DIFF
--- a/media-source/mediasource-buffered.html
+++ b/media-source/mediasource-buffered.html
@@ -15,12 +15,12 @@
             var manifestFilenameB = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
 
             var expectationsA = {
-              webm: "{ [0.000, 2.022) }",
+              webm: "{ [0.000, 2.023) }",
               mp4: "{ [0.000, 2.043) }",
             };
 
             var expectationsB = {
-              webm: "{ [0.000, 2.000) }",
+              webm: "{ [0.000, 2.001) }",
               mp4: "{ [0.000, 2.000) }",
             };
 
@@ -99,7 +99,7 @@
                     test.waitForExpectedEvents(function()
                     {
                         var expectationsAV = {
-                            webm: ["{ [0.000, 2.003) }", "{ [0.000, 2.022) }"],
+                            webm: ["{ [0.000, 2.003) }", "{ [0.000, 2.023) }"],
                             mp4: ["{ [0.000, 2.000) }", "{ [0.000, 2.043) }"],
                         };
 


### PR DESCRIPTION
media-source/mediasource-buffered.html currently checks for the wrong duration.

i.e. blink's msetests check for the correct vaules:
 https://github.com/acolwell/msetests/blob/master/blink/mediasource-buffered.html

firefox also detects the correct vaules but has the tests disabled right now:
 https://bugzilla.mozilla.org/show_bug.cgi?id=1192164

manifestA has a duration of 2.023 (currently 2.022)
manifestB has a duration of 2.001 (currently 2.000)
