### PR TITLE
Fix cloning test for documents

### DIFF
--- a/dom/nodes/Node-cloneNode.html
+++ b/dom/nodes/Node-cloneNode.html
@@ -235,7 +235,7 @@ test(function() {
 
 test(function() {
     var html = document.implementation.createHTMLDocument("title");
-    var copy = html.cloneNode();
+    var copy = html.cloneNode(true);
     check_copy(html, copy, Document);
     assert_equals(html.title, copy.title);
 }, "implementation.createHTMLDocument");


### PR DESCRIPTION
`<title>` elements are not copied over when cloning documents unless the cloning is deep.
