### PR TITLE
Fix about:blank iframe base URL test

### DIFF
--- a/html/infrastructure/urls/terminology-0/document-base-url.html
+++ b/html/infrastructure/urls/terminology-0/document-base-url.html
@@ -59,10 +59,10 @@
       var iframe = document.createElement("iframe");
       iframe.onload = this.step_func_done(function () {
         var doc = iframe.contentDocument;
-        var base = doc.body.appendChild(document.createElement("base"));
+        var base = doc.body.appendChild(doc.createElement("base"));
         base.href = "sub/";
         assert_resolve_url(doc, location.href.replace("/document-base-url.html", "/sub"));
-        assert_equals(doc.baseURI, document.baseURI);
+        assert_equals(doc.baseURI, document.baseURI.replace("/document-base-url.html", "/sub/"));
       });
       iframe.setAttribute("src", "about:blank");
       document.body.appendChild(iframe);


### PR DESCRIPTION
- No longer accidentally tests cross-document <base> element adoption.
- Now correctly tests that doc's base URL, which was updated two lines earlier.
