### PR TITLE
Initial implementation of ownPropertyKeys proxy handler

### DIFF
--- a/dom/collections/HTMLCollection-supported-property-names.html
+++ b/dom/collections/HTMLCollection-supported-property-names.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<meta charset=utf-8>
+<link rel=help href=https://dom.spec.whatwg.org/#interface-htmlcollection>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id=log></div>
+
+<!-- with no attribute -->
+<span></span>
+
+<!-- with `id` attribute -->
+<span id=''></span>
+<span id='some-id'></span>
+<span id='some-id'></span><!-- to ensure no duplicates -->
+
+<!-- with `name` attribute -->
+<span name=''></span>
+<span name='some-name'></span>
+<span name='some-name'></span><!-- to ensure no duplicates -->
+
+<!-- with `name` and `id` attribute -->
+<span id='another-id' name='another-name'></span>
+
+<script>
+test(function () {
+  var elements = document.getElementsByTagName("span");
+  assert_array_equals(
+    Object.getOwnPropertyNames(elements),
+    ['0', '1', '2', '3', '4', '5', '6', '7', 'some-id', 'some-name', 'another-id', 'another-name']
+  );
+}, 'Object.getOwnPropertyNames on HTMLCollection');
+
+test(function () {
+  var elem = document.createElementNS('some-random-namespace', 'foo');
+  this.add_cleanup(function () {elem.remove();});
+  elem.setAttribute("name", "some-name");
+  document.body.appendChild(elem);
+
+  var elements = document.getElementsByTagName("foo");
+  assert_array_equals(Object.getOwnPropertyNames(elements), ['0']);
+}, 'Object.getOwnPropertyNames on HTMLCollection with non-HTML namespace');
+
+test(function () {
+  var elem = document.createElement('foo');
+  this.add_cleanup(function () {elem.remove();});
+  document.body.appendChild(elem);
+
+  var elements = document.getElementsByTagName("foo");
+  elements.someProperty = "some value";
+
+  assert_array_equals(Object.getOwnPropertyNames(elements), ['0', 'someProperty']);
+}, 'Object.getOwnPropertyNames on HTMLCollection with expando object');
+</script>

--- a/js/builtins/Object.prototype.getOwnPropertyNames.html
+++ b/js/builtins/Object.prototype.getOwnPropertyNames.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<title>Object.prototype.getOwnPropertyNames</title>
+<link rel=help href=http://es5.github.io/#x15.2.3.4>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<div id=log></div>
+<script>
+test(function () {
+  var obj = {0: 'a', 1: 'b', 2: 'c'};
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['0', '1', '2']
+  );
+}, "object");
+
+test(function () {
+  var arr = ['a', 'b', 'c'];
+  assert_array_equals(
+    Object.getOwnPropertyNames(arr).sort(),
+    ['0', '1', '2', 'length']
+  );
+}, "array-like");
+
+test(function () {
+  var obj = Object.create({}, {
+    getFoo: {
+      value: function() { return this.foo; },
+      enumerable: false
+    }
+  });
+  obj.foo = 1;
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['foo', 'getFoo']
+  );
+}, "non-enumerable property");
+
+test(function() {
+  function ParentClass() {}
+  ParentClass.prototype.inheritedMethod = function() {};
+
+  function ChildClass() {
+    this.prop = 5;
+    this.method = function() {};
+  }
+  ChildClass.prototype = new ParentClass;
+  ChildClass.prototype.prototypeMethod = function() {};
+
+  var obj = new ChildClass;
+  assert_array_equals(
+    Object.getOwnPropertyNames(obj).sort(),
+    ['method', 'prop']
+  );
+}, 'items on the prototype chain are not listed');
+</script>


### PR DESCRIPTION
Generates `SupportedPropertyNames` on DOM structs that should implement
it. Most of them are unimplemented now (which can be implemented in
later PRs), with the exception of `HTMLCollection`. Also added a couple
relevant WPT tests.

Closes #6390

Closes #2215
