### PR TITLE
Use deepPath for event path trimming.

### DIFF
--- a/shadow-dom/events/event-dispatch/test-003.html
+++ b/shadow-dom/events/event-dispatch/test-003.html
@@ -12,8 +12,8 @@ policies and contribution forms [3].
 <head>
 <title>Shadow DOM Test: A_05_05_03</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#event-dispatch">
-<meta name="assert" content="Event Dispatch: If the relatedTarget and target are the same for a given node, its the event listeners must not be invoked.">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-path-trimming">
+<meta name="assert" content="Event Path Trimming: In cases where both relatedTarget and target of a trusted event are part of the same shadow tree, the conforming UAs must stop events at the shadow root to avoid the appearance of spurious mouseover and mouseout events firing from the same node.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -29,31 +29,52 @@ A_05_05_03_T01.step(unit(function (ctx) {
     var d = newRenderedHTMLDocument(ctx);
 
     var host = d.createElement('div');
-    host.setAttribute('style', 'height:50%; width:100%');
     host.setAttribute('id', 'host');
     d.body.appendChild(host);
 
     //Shadow root to play with
     var s = host.createShadowRoot();
+    s.id = 'shadow';
 
-    var div1 = d.createElement('div');
-    div1.setAttribute('style', 'height:100%; width:100%');
-    div1.setAttribute('id', 'div1');
-    s.appendChild(div1);
+    var input1 = d.createElement('input');
+    input1.setAttribute('id', 'input1');
+    s.appendChild(input1);
 
-    s.addEventListener('mouseover', A_05_05_03_T01.step_func(function(event) {
-    	assert_true(false, 'Event listeners shouldn\'t be invoked if target and relatedTarget ' +
-    			'are the same');
+    var input2 = d.createElement('input');
+    input2.setAttribute('id', 'input2');
+    s.appendChild(input2);
+
+    input1.addEventListener('focusin', A_05_05_03_T01.step_func(function(event) {
+        assert_equals(event.deepPath.length, 7);
+        assert_equals(event.deepPath[0].id, 'input1');
+        assert_equals(event.deepPath[1].id, 'shadow');
+        assert_equals(event.deepPath[2].id, 'host');
+        assert_equals(event.deepPath[3].tagName, 'BODY');
+        assert_equals(event.deepPath[4].tagName, 'HTML');
+        assert_equals(event.deepPath[5], d);
+        assert_equals(event.deepPath[6], ctx.iframes[0].contentWindow);
     }), false);
 
+    input2.addEventListener('focusin', A_05_05_03_T01.step_func(function(event) {
+        assert_equals(event.deepPath.length, 2);
+        assert_equals(event.deepPath[0].id, 'input2');
+        assert_equals(event.deepPath[1].id, 'shadow');
+        A_05_05_03_T01.done();
+    }), false);
 
-    var evt = document.createEvent("MouseEvents");
-    evt.initMouseEvent("mouseover", true, false, window,
-      0, 10, 10, 10, 10, false, false, false, false, 0, div1);
+    // Expected event path for #input1:
+    // <input>, #shadow-root, <div>, <body>, <html>, #document, window
+    input1.focus();
 
-    div1.dispatchEvent(evt);
-
-    A_05_05_03_T01.done();
+    // Causes a "focusin" event, from #input1 to #input2
+    // In this case, original relatedTarget is #input1, and original target
+    // is #input2.
+    // It should be viewed outside the shadow as "target == relatedTarget"
+    // after event retargeting, therefore, event.deepPath above the shadow
+    // host will be trimmed.
+    // Expected event path for #input2:
+    // <input>, #shadow-root
+    input2.focus();
 }));
 </script>
 </body>


### PR DESCRIPTION
What this test (test-003.html) does is now specced as
Event Path Trimming", and when retargeted "target" and
relatedTarget" become same, not only trusted events are
not dispatched, Event.deepPath is also trimmed for these
nodes.

Now the test uses .deepPath rather than relying on
generating "trusted" events and checking if event handler
is not invoked.
