### PR TITLE
Make websockets connection serialization test less timing sensitive.

### DIFF
--- a/websockets/constructor/014.html
+++ b/websockets/constructor/014.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>WebSockets: serialize establish a connection</title>
+<meta name=timeout content=long>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=../constants.js?pipe=sub></script>
@@ -12,24 +13,25 @@ async_test(function(t) {
   var prevDate;
   var date;
   for (var i = 0; i < 4; ++i) {
-    ws[i] = new WebSocket(SCHEME_DOMAIN_PORT+'/handshake_sleep_1');
+    ws[i] = new WebSocket(SCHEME_DOMAIN_PORT+'/handshake_sleep_2');
     ws[i].id = i;
     ws[i].onopen = t.step_func(function(e) {
       events++;
       date = new Date();
-      if (prevDate)
-        assert_greater_than(date-prevDate, 998);
+      if (prevDate) {
+        assert_greater_than(date - prevDate, 1000);
+      }
       prevDate = date;
       this.onopen = t.step_func(function() {assert_unreached()});
-    })
-    ws[i].onclose = t.step_func(function(e) {
+    }.bind(ws[i]))
+    ws[i].onclose = t.step_func(function() {
       events++;
       if (events == 8) {
         t.done();
       }
       this.onclose = t.step_func(function() {assert_unreached()});
-    });
+    }.bind(ws[i]));
     ws[i].onerror = ws[i].onmessage = t.step_func(function() {assert_unreached()});
   }
-}, null, {timeout:10000});
+});
 </script>

--- a/websockets/handlers/handshake_sleep_2_wsh.py
+++ b/websockets/handlers/handshake_sleep_2_wsh.py
@@ -4,7 +4,7 @@ from mod_pywebsocket import msgutil
 import time
 
 def web_socket_do_extra_handshake(request):
-    time.sleep(1)
+    time.sleep(2)
 
 def web_socket_transfer_data(request):
     pass


### PR DESCRIPTION
This is very intermittent on gecko infrastructure
