### PR TITLE
Implement Encoding Standard-compliant big5 encoder. r=emk.

### DIFF
--- a/encoding/big5-encoder.html
+++ b/encoding/big5-encoder.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=big5> <!-- test breaks if the server overrides this -->
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+ function encode(input, output, desc) {
+   test(function() {
+     var a = document.createElement("a"); // <a> uses document encoding for URL's query
+     // Append and prepend X to test for off-by-one errors
+     a.href = "https://example.com/?X" + input + "X";
+     assert_equals(a.search.substr(1), "X" + output + "X"); // remove leading "?"
+   }, "big5 encoder: " + desc);
+ }
+
+ encode("ab", "ab", "very basic")
+ // edge cases
+ encode("\u9EA6", "%26%2340614%3B", "Highest-pointer BMP character excluded from encoder");
+ encode("\uD858\uDE6B", "%26%23156267%3B", "Highest-pointer character excluded from encoder");
+ encode("\u3000", "%A1@", "Lowest-pointer character included in encoder");
+ encode("\u20AC", "%A3%E1", "Euro; the highest-pointer character before a range of 30 unmapped pointers");
+ encode("\u4E00", "%A4@", "The lowest-pointer character after the range of 30 unmapped pointers");
+ encode("\uD85D\uDE07", "%C8%A4", "The highest-pointer character before a range of 41 unmapped pointers");
+ encode("\uFFE2", "%C8%CD", "The lowest-pointer character after the range of 41 unmapped pointers");
+ encode("\u79D4", "%FE%FE", "The last character in the index");
+ // not in index
+ encode("\u2603", "%26%239731%3B", "The canonical BMP test character that is not in the index");
+ encode("\uD83D\uDCA9", "%26%23128169%3B", "The canonical astral test character that is not in the index");
+ // duplicate low bits
+ encode("\uD840\uDFB5", "%FDj", "A Plane 2 character whose low 16 bits match a BMP character that has a lower pointer");
+ // prefer last
+ encode("\u2550", "%F9%F9", "A duplicate-mapped code point that prefers the highest pointer in the encoder");
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=912470
