### PR TITLE
Stop trying to setSelectionRange on <input type="email">

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -278,7 +278,9 @@ var validator = {
     var old_value = ctl.value;
     ctl.value = "a";
     ctl.value = old_value;
-    ctl.setSelectionRange(ctl.value.length, ctl.value.length);
+    if (ctl.type !== 'email') {
+      ctl.setSelectionRange(ctl.value.length, ctl.value.length);
+    }
     document.execCommand("Delete");
     document.disgnMode = "off";
   },


### PR DESCRIPTION
Per the "Bookkeeping details" subsection of https://html.spec.whatwg.org/multipage/forms.html#e-mail-state-(type=email) ,`setSelectionRange()` does not apply to `<input>` elements in the E-mail state.

And per https://html.spec.whatwg.org/multipage/forms.html#textFieldSelection

> For input elements, calling these methods while they don't apply […]
> must throw an InvalidStateError exception.
