### PR TITLE
CSP: Correct a cookie name.

### DIFF
--- a/content-security-policy/blink-contrib/combine-header-and-meta-policies.sub.html
+++ b/content-security-policy/blink-contrib/combine-header-and-meta-policies.sub.html
@@ -4,7 +4,7 @@
 <head>
     <!-- Programmatically converted from a WebKit Reftest, please forgive resulting idiosyncracies.-->
     <meta http-equiv="Content-Security-Policy" content="img-src 'none'">
-    <title>combine-multiple-policies</title>
+    <title>combine-header-and-meta-policies</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src='../support/logTest.sub.js?logs=["TEST COMPLETE"]'></script>

--- a/content-security-policy/blink-contrib/combine-header-and-meta-policies.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib/combine-header-and-meta-policies.sub.html.sub.headers
@@ -2,5 +2,5 @@ Expires: Mon, 26 Jul 1997 05:00:00 GMT
 Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
-Set-Cookie: combine-multiple-policies={{$id:uuid()}}; Path=/content-security-policy/blink-contrib
+Set-Cookie: combine-header-and-meta-policies={{$id:uuid()}}; Path=/content-security-policy/blink-contrib
 Content-Security-Policy: script-src 'self' 'unsafe-inline'; connect-src 'self'; style-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
'combine-header-and-meta-policies' was named differently than the cookie
set in the header file. This patch corrects the latter.
