### PR TITLE
Add tests for ShadowRoot interface, its attributes, and Element.prototype.attachShadow

### DIFF
--- a/shadow-dom/Element-interface-attachShadow.html
+++ b/shadow-dom/Element-interface-attachShadow.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Shadow DOM: Attaching a ShadowRoot</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Element.prototype.attachShadow should create an instance of ShadowRoot">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#widl-Element-attachShadow-ShadowRoot-ShadowRootInit-shadowRootInitDict">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function () {
+    assert_true('attachShadow' in Element.prototype, 'Element.prototype.attachShadow must exist');
+    assert_equals(typeof(document.createElement('div').attachShadow), 'function', 'An instance of div must have attachShadow which is a function');
+}, 'Check the existence of Element.attachShadow');
+
+test(function () {
+    assert_false('attachShadow' in Node.prototype, 'Node.prototype.attachShadow must not exist');
+    assert_false('attachShadow' in CharacterData.prototype, 'CharacterData.prototype.attachShadow must not exist');
+    assert_false('attachShadow' in Comment.prototype, 'Comment.prototype.attachShadow must not exist');
+    assert_equals(typeof(document.createComment('').attachShadow), 'undefined', 'An instance of comment must not have attachShadow');
+    assert_false('attachShadow' in Document.prototype, 'Document.prototype.attachShadow must not exist');
+    assert_equals(typeof(document.attachShadow), 'undefined', 'An instance of document must not have attachShadow which is a function');
+    assert_false('attachShadow' in DocumentFragment.prototype, 'DocumentFragment.prototype.attachShadow must not exist');
+    assert_equals(typeof((new DOMParser()).parseFromString('', 'text/html').attachShadow), 'undefined', 'An instance of document must not have attachShadow which is a function');
+    assert_false('attachShadow' in Text.prototype, 'Text.prototype.attachShadow must not exist');
+    assert_equals(typeof(document.createTextNode('').attachShadow), 'undefined', 'An instance of text node must not have attachShadow');
+}, 'Nodes other than Element should not have attachShadow');
+
+test(function () {
+    assert_throws({'name': 'TypeError'}, function () {
+        document.createElement('div').attachShadow({})
+    }, 'attachShadow must throw a TypeError when mode is omitted');
+
+    assert_throws({'name': 'TypeError'}, function () {
+        document.createElement('div').attachShadow({mode: true})
+    }, 'attachShadow must throw a TypeError when mode is a boolean');
+
+    assert_throws({'name': 'TypeError'}, function () {
+        document.createElement('div').attachShadow({mode: 1})
+    }, 'attachShadow must throw a TypeError when mode is 1');
+}, 'Element.attachShadow must throw a TypeError if mode is not "open" or "closed"');
+
+test(function () {
+    assert_true(document.createElement('div').attachShadow({mode: "open"}) instanceof ShadowRoot,
+        'attachShadow({mode: "open"}) should create an instance of ShadowRoot');
+    assert_true(document.createElement('div').attachShadow({mode: "closed"}) instanceof ShadowRoot,
+        'attachShadow({mode: "closed"}) should create an instance of ShadowRoot');
+}, 'Element.attachShadow must create an instance of ShadowRoot');
+
+test(function () {
+    assert_throws({'name': 'InvalidStateError'}, function () {
+        var div = document.createElement('div');
+        div.attachShadow({mode: "open"});
+        div.attachShadow({mode: "open"});
+    }, 'Calling attachShadow({mode: "open"}) twice on the same element must throw');
+
+    assert_throws({'name': 'InvalidStateError'}, function () {
+        var div = document.createElement('div');
+        div.attachShadow({mode: "closed"});
+        div.attachShadow({mode: "closed"});
+    }, 'Calling attachShadow({mode: "closed"}) twice on the same element must throw');
+
+    assert_throws({'name': 'InvalidStateError'}, function () {
+        var div = document.createElement('div');
+        div.attachShadow({mode: "open"});
+        div.attachShadow({mode: "closed"});
+    }, 'Calling attachShadow({mode: "closed"}) after attachShadow({mode: "open"}) on the same element must throw');
+
+    assert_throws({'name': 'InvalidStateError'}, function () {
+        var div = document.createElement('div');
+        div.attachShadow({mode: "closed"});
+        div.attachShadow({mode: "open"});
+    }, 'Calling attachShadow({mode: "open"}) after attachShadow({mode: "closed"}) on the same element must throw');
+}, 'Element.attachShadow must throw a InvalidStateError if the context object already hosts a shadow tree');
+
+test(function () {
+    for (var elementName of ['button', 'details', 'input', 'marquee', 'meter', 'progress', 'select', 'textarea', 'keygen']) {
+        assert_throws({'name': 'NotSupportedError'}, function () {
+            document.createElement(elementName).attachShadow({mode: "open"});
+        }, 'Calling attachShadow({mode: "open"}) on ' + elementName + ' element must throw');
+
+        assert_throws({'name': 'NotSupportedError'}, function () {
+            document.createElement(elementName).attachShadow({mode: "closed"});
+        }, 'Calling attachShadow({mode: "closed"}) on ' + elementName + ' element must throw');
+    }
+}, 'Element.attachShadow must throw a NotSupportedError for button, details, input, marquee, meter, progress, select, textarea, and keygen elements');
+
+</script>
+</body>
+</html>

--- a/shadow-dom/Element-interface-shadowRoot-attribute.html
+++ b/shadow-dom/Element-interface-shadowRoot-attribute.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Shadow DOM: Element interface shadowRoot attribute</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="shadowRoot attribute on Element interface must return the associated open shadow tree if there is one">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function () {
+    assert_true('shadowRoot' in Element.prototype, 'shadowRoot must be defined on Element prototype');
+    assert_true('shadowRoot' in document.createElement('div'), 'shadowRoot must be defined on an instance of div element');
+    assert_false('shadowRoot' in Node.prototype, 'shadowRoot must not be defined on Node prototype');
+    assert_false('shadowRoot' in Text.prototype, 'shadowRoot must not be defined on Text prototype');
+    assert_false('shadowRoot' in document.createTextNode(''), 'shadowRoot must not be defined on an instance of Text node');
+    assert_false('shadowRoot' in Comment.prototype, 'shadowRoot must not be defined on Comment prototype');
+    assert_false('shadowRoot' in document.createComment(''), 'shadowRoot must not be defined on an instance of Comment node');
+    assert_false('shadowRoot' in Document.prototype, 'shadowRoot must not be defined on Document prototype');
+    assert_false('shadowRoot' in document, 'shadowRoot must not be defined on an instance of Document');
+    assert_false('shadowRoot' in DocumentFragment.prototype, 'shadowRoot must not be defined on DocumentFragment prototype');
+    assert_false('shadowRoot' in (new DOMParser).parseFromString('', 'text/html'), 'shadowRoot must not be defined on an instance of DocumentFragment node');
+}, 'shadowRoot must be defined on Element prototype');
+
+test(function () {
+    var host = document.createElement('div');
+    assert_equals(host.shadowRoot, null, 'shadowRoot must return null when the host does not have a shadow tree attached to it');
+
+    var openShadowRoot = host.attachShadow({mode: 'open'});
+    assert_equals(host.shadowRoot, openShadowRoot, 'shadowRoot must return the open shadow root attachShadow attached');
+}, 'shadowRoot attribute must return the open shadow root associated with the element');
+
+test(function () {
+    var host = document.createElement('div');
+    host.attachShadow({mode: 'closed'});
+    assert_equals(host.shadowRoot, null);
+}, 'shadowRoot attribute must return null if the shadow root attached to the element is closed');
+
+</script>
+</body>
+</html>

--- a/shadow-dom/ShadowRoot-interface.html
+++ b/shadow-dom/ShadowRoot-interface.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Shadow DOM: ShadowRoot interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="ShadowRoot interface and its attributes must be defined">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='https://svn.webkit.org/repository/webkit/trunk/LayoutTests/resources/testharness.css'>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function () {
+    assert_true('ShadowRoot' in window, '"ShadowRoot" exists on window');
+}, 'Check the existence of ShadowRoot interface');
+
+test(function () {
+    assert_equals(ShadowRoot.prototype.__proto__, DocumentFragment.prototype, 'ShadowRoot must inherit from DocumentFragment');
+}, 'ShadowRoot must inherit from DocumentFragment');
+
+test(function () {
+    assert_throws({'name': 'TypeError'}, function () { new ShadowRoot(); }, 'new ShadowRoot() must throw a TypeError');
+}, 'ShadowRoot must not be a constructor');
+
+function testActiveElement(mode) {
+    test(function () {
+        var host = document.createElement('div');
+        document.body.appendChild(host);
+        var shadowRoot = host.attachShadow({'mode': mode});
+        shadowRoot.appendChild(document.createElement('input'));
+        assert_equals(shadowRoot.activeElement, null, 'ShadowRoot.host must return null if an ' + mode + ' shadow tree does not have a focused element');
+        shadowRoot.firstChild.focus();
+        assert_equals(shadowRoot.activeElement, shadowRoot.firstChild, 'ShadowRoot.host must return the focused element of an ' + mode + ' shadow tree');
+        host.remove();
+        assert_equals(shadowRoot.activeElement, null, 'ShadowRoot.host must return null if an ' + mode + ' shadow tree lost focus');
+    }, 'ShadowRoot.activeElement must return the focused element of the context object when shadow root is ' + mode + '.');
+}
+
+testActiveElement('open');
+testActiveElement('closed');
+
+test(function () {
+    var host1 = document.createElement('div');
+    assert_equals(host1.attachShadow({'mode': 'open'}).host, host1, 'ShadowRoot.host must return the shadow host of an open shadow tree')
+
+    var host2 = document.createElement('div');
+    assert_equals(host2.attachShadow({'mode': 'closed'}).host, host2, 'ShadowRoot.host must return the shadow host of a closed shadow tree');
+}, 'ShadowRoot.host must return the shadow host of the context object.');
+
+function testInnerHTML(mode) {
+    test(function () {
+        var host = document.createElement('div');
+        var shadowRoot = host.attachShadow({'mode': mode});
+        assert_equals(shadowRoot.innerHTML, '', 'ShadowRoot.innerHTML must be an empty string when the shadow root does not have any children');
+
+        shadowRoot.appendChild(document.createTextNode('hello'));
+        assert_equals(shadowRoot.innerHTML, 'hello', 'ShadowRoot.innerHTML must serialize a text node child');
+
+        shadowRoot.appendChild(document.createElement('span'));
+        assert_equals(shadowRoot.innerHTML, 'hello<span></span>', 'ShadowRoot.innerHTML must serialize a HTML element child');
+    }, 'ShadowRoot.innerHTML must return the result of the HTML fragment serialization algorithm when shadow root is ' + mode + '.');
+}
+
+testInnerHTML('open');
+testInnerHTML('closed');
+
+function testSetInnerHTML(mode) {
+    test(function () {
+        var host = document.createElement('div');
+        var shadowRoot = host.attachShadow({'mode': mode});
+        shadowRoot.innerHTML = 'hello';
+        assert_equals(shadowRoot.childNodes.length, 1, 'ShadowRoot.innerHTML = "hello" must insert a single child (text node)');
+        assert_true(shadowRoot.firstChild instanceof Text, 'The first child of the shadow root after ShadowRoot.innerHTML = "hello" must be a Text node');
+        assert_equals(shadowRoot.firstChild.data, 'hello', 'The first Text node should contain the string "hello" after ShadowRoot.innerHTML = "hello"');
+
+        shadowRoot.innerHTML = '<b>hello</b>';
+        assert_equals(shadowRoot.childNodes.length, 1, 'ShadowRoot.innerHTML = "<b>hello</b>" must insert a single child (b)');
+        assert_true(shadowRoot.firstChild instanceof HTMLElement, 'The first child of the shadow root after ShadowRoot.innerHTML = "<b>hello</b>" must be a HTML element');
+        assert_equals(shadowRoot.firstChild.localName, 'b', 'The local name of the shadow root\'s first child after ShadowRoot.innerHTML = "<b>hello</b>" must be "b"');
+        assert_equals(shadowRoot.innerHTML, '<b>hello</b>', 'ShadowRoot.innerHTML must be "<b>hello</b>" after ShadowRoot.innerHTML = "<b>hello</b>"');
+
+        shadowRoot.innerHTML = '';
+        assert_equals(shadowRoot.childNodes.length, 0, 'ShadowRoot.innerHTML = "" must remove all its children');
+    }, 'ShadowRoot.innerHTML must replace all with the result of invoking the fragment parsing algorithm when shadow root is ' + mode + '.');
+}
+
+testSetInnerHTML('open');
+testSetInnerHTML('closed');
+
+function testStyleSheets(mode) {
+    test(function () {
+        var host = document.createElement('div');
+        var shadowRoot = host.attachShadow({'mode': mode});
+
+        assert_equals(shadowRoot.styleSheets.length, 0, 'shadowRoot.styleSheets must be empty when the shadow root does not contain any stylesheets');
+        shadowRoot.innerHTML = '<span></span><style> a.rule {} </style><style> b.rule {} </style>';
+        assert_equals(shadowRoot.styleSheets.length, 2, 'shadowRoot.styleSheets must contain two items when the shadow root has two style elements');
+        var styles = shadowRoot.querySelectorAll('style');
+        assert_equals(shadowRoot.styleSheets[0], styles[0].sheet, 'shadowRoot.styleSheets[0] must be the first style element in the shadow root');
+        assert_equals(shadowRoot.styleSheets[1], styles[1].sheet, 'shadowRoot.styleSheets[1] must be the second style element in the shadow root');
+    }, 'ShadowRoot.styleSheets must return a StyleSheetList sequence containing the shadow root style sheets when shadow root is ' + mode + '.');
+}
+
+testStyleSheets('open');
+testStyleSheets('closed');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
These tests were imported from http://trac.webkit.org/changeset/189841.
