### PR TITLE
Make webstorage event tests resilient to existing data

### DIFF
--- a/webstorage/eventTestHarness.js
+++ b/webstorage/eventTestHarness.js
@@ -33,6 +33,20 @@ function countStorageEvents(callback, expectedNumEvents, times)
     setTimeout(onTimeout, 20);
 }
 
+function clearStorage(storageName, callback)
+{
+    if (window[storageName].length === 0) {
+        storageEventList = [];
+        setTimeout(callback, 0);
+    } else {
+        window[storageName].clear();
+        runAfterNStorageEvents(function() {
+            storageEventList = [];
+            callback();
+        }, 1);
+    }
+}
+
 function testStorages(testCallback)
 {
     testCallback("sessionStorage");

--- a/webstorage/event_basic.js
+++ b/webstorage/event_basic.js
@@ -4,15 +4,11 @@ testStorages(function(storageString) {
         var storage = window[storageString];
         t.add_cleanup(function() { storage.clear() });
 
-        storageEventList = new Array();
-        storage.clear();
+        clearStorage(storageString, t.step_func(step1));
         assert_equals(storage.length, 0, "storage.length");
-
-        runAfterNStorageEvents(t.step_func(step1), 0);
 
         function step1(msg)
         {
-            storageEventList = new Array();
             storage.setItem('FOO', 'BAR');
 
             runAfterNStorageEvents(t.step_func(step2), 1);

--- a/webstorage/event_body_attribute.js
+++ b/webstorage/event_body_attribute.js
@@ -4,11 +4,14 @@ testStorages(function(storageString) {
         var storage = window[storageString];
         t.add_cleanup(function() { storage.clear() });
 
-        storage.clear();
+        clearStorage(storageString, t.step_func(step0));
         assert_equals(storage.length, 0, "storage.length");
 
-        iframe.onload = t.step_func(step1);
-        iframe.src = "resources/event_body_handler.html";
+        function step0(msg)
+        {
+            iframe.onload = t.step_func(step1);
+            iframe.src = "resources/event_body_handler.html";
+        }
 
         function step1(msg)
         {

--- a/webstorage/event_case_sensitive.js
+++ b/webstorage/event_case_sensitive.js
@@ -4,11 +4,14 @@ testStorages(function(storageString) {
         var storage = window[storageString];
         t.add_cleanup(function() { storage.clear() });
 
-        storage.clear();
+        clearStorage(storageString, t.step_func(step0));
         assert_equals(storage.length, 0, "storage.length");
-        storage.foo = "test";
 
-        runAfterNStorageEvents(t.step_func(step1), 1);
+        function step0(msg)
+        {
+            storage.foo = "test";
+            runAfterNStorageEvents(t.step_func(step1), 1);
+        }
 
         function step1(msg)
         {

--- a/webstorage/event_constructor_eventinit.html
+++ b/webstorage/event_constructor_eventinit.html
@@ -9,21 +9,18 @@
     <h1>event_Constructor</h1>
     <div id="log"></div>
     <script>
-        test(function() {
-            var t = async_test("StorageEvent constructor and nulls");
+        async_test(function(t) {
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.type, 'storage', 'type');
-                    assert_equals(event.key, null, 'key');
-                    assert_equals(event.oldValue, null, 'oldValue');
-                    assert_equals(event.newValue, null, 'newValue');
-                    assert_equals(event.url, 'null', 'url');
-                    assert_equals(event.storageArea, null, 'storageArea');
-                });
+                assert_equals(event.type, 'storage', 'type');
+                assert_equals(event.key, null, 'key');
+                assert_equals(event.oldValue, null, 'oldValue');
+                assert_equals(event.newValue, null, 'newValue');
+                assert_equals(event.url, 'null', 'url');
+                assert_equals(event.storageArea, null, 'storageArea');
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
             var event = new StorageEvent('storage', {
                 key: null,
                 oldValue: null,
@@ -31,7 +28,7 @@
                 url: null
             });
             window.dispatchEvent(event);
-        }, "Construct StorageEvent with StorageEventInit.");
+        }, "StorageEvent constructor and nulls - Construct StorageEvent with StorageEventInit.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_key.html
+++ b/webstorage/event_local_key.html
@@ -4,40 +4,35 @@
   <title>WebStorage Test: localStorage event - key</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_local_key</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("key property test of local event");
-
-        test(function() {
+        async_test(function(t) {
             localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = ['name', null]
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.key, expected.shift());
-                });
+                assert_equals(event.key, expected.shift());
                 if (!expected.length) {
                     t.done();
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/local_set_item_clear_iframe.html');
             document.body.appendChild(el);
-        }, "Local event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "key property test of local event - Local event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_newvalue.html
+++ b/webstorage/event_local_newvalue.html
@@ -4,40 +4,35 @@
   <title>WebStorage Test: localStorage event - newValue</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_local_newValue</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("newValue property test of local event");
-
-        test(function() {
+        async_test(function(t) {
             localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = ['user1', 'user2', null]
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.newValue, expected.shift());
-                });
+                assert_equals(event.newValue, expected.shift());
                 if (!expected.length) {
                     t.done();
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/local_change_item_iframe.html');
             document.body.appendChild(el);
-        }, "Local event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "newValue property test of local event - Local event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_oldvalue.html
+++ b/webstorage/event_local_oldvalue.html
@@ -4,40 +4,35 @@
   <title>WebStorage Test: localStorage event - oldValue</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_local_oldValue</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("oldValue property test of local event");
-
-        test(function() {
+        async_test(function(t) {
             localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = [null, 'user1', null]
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.oldValue, expected.shift());
-                });
+                assert_equals(event.oldValue, expected.shift());
                 if (!expected.length) {
                     t.done();
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/local_change_item_iframe.html');
             document.body.appendChild(el);
-        }, "Local event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "oldValue property test of local event - Local event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_removeitem.html
+++ b/webstorage/event_local_removeitem.html
@@ -9,10 +9,11 @@
 
 <script>
 
-var t = async_test("key property test of local event");
-
-t.step(function() {
+async_test(function(t) {
     localStorage.clear();
+    t.add_cleanup(function() { localStorage.clear() });
+
+    self.step = function(f) { t.step(f); };
 
     var event_index = 0;
     window.addEventListener('storage', t.step_func(function(event) {
@@ -39,6 +40,6 @@ t.step(function() {
     el.setAttribute('id', 'ifrm');
     el.setAttribute('src', 'resources/local_set_item_remove_iframe.html');
     document.body.appendChild(el);
-});
+}, "key property test of local event");
 
 </script>

--- a/webstorage/event_local_storagearea.html
+++ b/webstorage/event_local_storagearea.html
@@ -4,41 +4,36 @@
   <title>WebStorage Test: localStorage event - storageArea</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_local_storageArea</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("storageArea property test of local event");
-
-        test(function() {
+        async_test(function(t) {
             localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.storageArea.length, 1);
-                    var key = event.storageArea.key(0);
-                    var value = event.storageArea.getItem(key);
-                    assert_equals(key, "name");
-                    assert_equals(value, "user1");
-                });
+                assert_equals(event.storageArea.length, 1);
+                var key = event.storageArea.key(0);
+                var value = event.storageArea.getItem(key);
+                assert_equals(key, "name");
+                assert_equals(value, "user1");
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/local_set_item_iframe.html');
             document.body.appendChild(el);
-        }, "Local event is fired due to an invocation of the setItem() method.");
+        }, "storageArea property test of local event - Local event is fired due to an invocation of the setItem() method.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_storageeventinit.html
+++ b/webstorage/event_local_storageeventinit.html
@@ -9,20 +9,18 @@
     <h1>event_local_StorageEventInit</h1>
     <div id="log"></div>
     <script>
-        test(function() {
-            var t = async_test("storageeventinit test");
+        async_test(function(t) {
+
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.key, 'key');
-                    assert_equals(event.oldValue, 'oldValue');
-                    assert_equals(event.newValue, 'newValue');
-                    assert_equals(event.url, window.location.href);
-                    assert_equals(event.storageArea, window.localStorage);
-                });
+                assert_equals(event.key, 'key');
+                assert_equals(event.oldValue, 'oldValue');
+                assert_equals(event.newValue, 'newValue');
+                assert_equals(event.url, window.location.href);
+                assert_equals(event.storageArea, window.localStorage);
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var event = new StorageEvent('storage', {
                 key: 'key',
@@ -33,7 +31,7 @@
             });
 
             window.dispatchEvent(event);
-        }, "Storage event is fired due to set values for StorageEventInit.");
+        }, "storageeventinit test - Storage event is fired due to set values for StorageEventInit.");
     </script>
  </body>
 </html>

--- a/webstorage/event_local_url.html
+++ b/webstorage/event_local_url.html
@@ -4,45 +4,40 @@
   <title>WebStorage Test: localStorage event - url</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_local_url</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("url property test of local event");
-
-        test(function() {
+        async_test(function(t) {
             localStorage.clear();
+            t.add_cleanup(function() { localStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             function onStorageEvent(event) {
-                t.step(function() {
-                    var url = window.location.href;
+                var url = window.location.href;
 
-                    var pos = url.lastIndexOf("/");
-                    if (pos != -1) {
-                        url = url.substr(0, pos + 1);
-                        url = url + "resources/local_set_item_iframe.html";
-                    }
+                var pos = url.lastIndexOf("/");
+                if (pos != -1) {
+                    url = url.substr(0, pos + 1);
+                    url = url + "resources/local_set_item_iframe.html";
+                }
 
-                   assert_equals(event.url, url);
-                });
+                assert_equals(event.url, url);
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/local_set_item_iframe.html');
             document.body.appendChild(el);
-        }, "Local event is fired due to an invocation of the setItem() method.");
+        }, "url property test of local event - Local event is fired due to an invocation of the setItem() method.");
     </script>
  </body>
 </html>

--- a/webstorage/event_session_key.html
+++ b/webstorage/event_session_key.html
@@ -4,40 +4,35 @@
   <title>WebStorage Test: sessionStorage event - key</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_session_key</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("key property test of session event");
-
-        test(function() {
+        async_test(function(t) {
             sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = ['name', null]
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.key, expected.shift());
-                });
+                assert_equals(event.key, expected.shift());
                 if (!expected.length) {
                     t.done();
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/session_set_item_clear_iframe.html');
             document.body.appendChild(el);
-        }, "Session event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "key property test of session event - Session event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_session_newvalue.html
+++ b/webstorage/event_session_newvalue.html
@@ -4,23 +4,20 @@
   <title>WebStorage Test: sessionStorage event - newValue</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_session_newValue</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("newvalue property test of session event");
-
-        test(function() {
+        async_test(function(t) {
             sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = ['user1', 'user2', null]
             function onStorageEvent(event) {
                 t.step(function() {
@@ -31,13 +28,13 @@
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/session_change_item_iframe.html');
             document.body.appendChild(el);
-        }, "Session event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "newvalue property test of session event - Session event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_session_oldvalue.html
+++ b/webstorage/event_session_oldvalue.html
@@ -4,40 +4,35 @@
   <title>WebStorage Test: sessionStorage event - oldValue</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_session_oldValue</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("oldvalue property test of session event");
-
-        test(function() {
+        async_test(function(t) {
             sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             var expected = [null, 'user1', null]
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.oldValue, expected.shift());
-                });
+                assert_equals(event.oldValue, expected.shift());
                 if (!expected.length) {
                     t.done();
                 }
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/session_change_item_iframe.html');
             document.body.appendChild(el);
-        }, "Session event is fired due to an invocation of the setItem(), clear() methods.");
+        }, "oldvalue property test of session event - Session event is fired due to an invocation of the setItem(), clear() methods.");
     </script>
  </body>
 </html>

--- a/webstorage/event_session_removeitem.html
+++ b/webstorage/event_session_removeitem.html
@@ -9,10 +9,11 @@
 
 <script>
 
-var t = async_test("key property test of session event");
-
-t.step(function() {
+async_test(function(t) {
     sessionStorage.clear();
+    t.add_cleanup(function() { sessionStorage.clear() });
+
+    self.step = function(f) { t.step(f); };
 
     var event_index = 0;
     window.addEventListener('storage', t.step_func(function(event) {
@@ -39,5 +40,5 @@ t.step(function() {
     el.setAttribute('id', 'ifrm');
     el.setAttribute('src', 'resources/session_set_item_remove_iframe.html');
     document.body.appendChild(el);
-});
+}, "key property test of session event");
 </script>

--- a/webstorage/event_session_storagearea.html
+++ b/webstorage/event_session_storagearea.html
@@ -4,40 +4,36 @@
   <title>WebStorage Test: sessionStorage event - storageArea</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_session_storageArea</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("storageArea property test of session event");
+        async_test(function(t) {
+            sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear() });
 
-        test(function() {
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.storageArea.length, 1);
-                    var key = event.storageArea.key(0);
-                    var value = event.storageArea.getItem(key);
-                    assert_equals(key, "name");
-                    assert_equals(value, "user1");
-                });
+                assert_equals(event.storageArea.length, 1);
+                var key = event.storageArea.key(0);
+                var value = event.storageArea.getItem(key);
+                assert_equals(key, "name");
+                assert_equals(value, "user1");
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/session_set_item_iframe.html');
             document.body.appendChild(el);
-        }, "Session event is fired due to an invocation of the setItem() method.");
+        }, "storageArea property test of session event - session event is fired due to an invocation of the setItem() method.");
     </script>
 
  </body>

--- a/webstorage/event_session_storageeventinit.html
+++ b/webstorage/event_session_storageeventinit.html
@@ -9,20 +9,17 @@
     <h1>event_session_StorageEventInit</h1>
     <div id="log"></div>
     <script>
-        test(function() {
-            var t = async_test("storageeventinit test");
+        async_test(function(t) {
             function onStorageEvent(event) {
-                t.step(function() {
-                    assert_equals(event.key, 'key');
-                    assert_equals(event.oldValue, 'oldValue');
-                    assert_equals(event.newValue, 'newValue');
-                    assert_equals(event.url, window.location.href);
-                    assert_equals(event.storageArea, window.sessionStorage);
-                });
+                assert_equals(event.key, 'key');
+                assert_equals(event.oldValue, 'oldValue');
+                assert_equals(event.newValue, 'newValue');
+                assert_equals(event.url, window.location.href);
+                assert_equals(event.storageArea, window.sessionStorage);
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var event = new StorageEvent('storage', {
                 key: 'key',
@@ -33,7 +30,7 @@
             });
 
             window.dispatchEvent(event);
-        }, "Storage event is fired due to set values for StorageEventInit.");
+        }, "storageeventinit test - Storage event is fired due to set values for StorageEventInit.");
     </script>
  </body>
 </html>

--- a/webstorage/event_session_url.html
+++ b/webstorage/event_session_url.html
@@ -4,45 +4,40 @@
   <title>WebStorage Test: sessionStorage event - url</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
-  <script>
-      function fail(msg) {
-          t.step(function() {
-              assert_unreached(msg);
-          });
-          t.done();
-      }
-  </script>
  </head>
  <body>
     <h1>event_session_url</h1>
     <div id="log"></div>
     <script>
-        var t = async_test("url property test of session event");
-
-        test(function() {
+        async_test(function(t) {
             sessionStorage.clear();
+            t.add_cleanup(function() { sessionStorage.clear() });
+
+            self.fail = t.step_func(function(msg) {
+                assert_unreached(msg);
+                t.done();
+            });
+
             function onStorageEvent(event) {
-                t.step(function() {
-                    var url = window.location.href;
+                var url = window.location.href;
 
-                    var pos = url.lastIndexOf("/");
-                    if (pos != -1) {
-                        url = url.substr(0, pos + 1);
-                        url = url + "resources/session_set_item_iframe.html";
-                    }
+                var pos = url.lastIndexOf("/");
+                if (pos != -1) {
+                    url = url.substr(0, pos + 1);
+                    url = url + "resources/session_set_item_iframe.html";
+                }
 
-                   assert_equals(event.url, url);
-                });
+                assert_equals(event.url, url);
                 t.done();
             }
 
-            window.addEventListener('storage', onStorageEvent, false);
+            window.addEventListener('storage', t.step_func(onStorageEvent), false);
 
             var el = document.createElement("iframe");
             el.setAttribute('id', 'ifrm');
             el.setAttribute('src', 'resources/session_set_item_iframe.html');
             document.body.appendChild(el);
-        }, "Session event is fired due to an invocation of the setItem() method.");
+        }, "url property test of session event - Session event is fired due to an invocation of the setItem() method.");
     </script>
  </body>
 </html>

--- a/webstorage/event_setattribute.js
+++ b/webstorage/event_setattribute.js
@@ -4,16 +4,17 @@ testStorages(function(storageString) {
         var storage = window[storageString];
         t.add_cleanup(function() { storage.clear() });
 
-        storageEventList = new Array();
-        storage.clear();
+        clearStorage(storageString, t.step_func(step0));
         assert_equals(storage.length, 0, "storage.length");
 
-        iframe.onload = t.step_func(step1);
-        iframe.src = "resources/event_setattribute_handler.html";
+        function step0(msg)
+        {
+            iframe.onload = t.step_func(step1);
+            iframe.src = "resources/event_setattribute_handler.html";
+        }
 
         function step1(msg)
         {
-            storageEventList = new Array();
             storage.setItem('FOO', 'BAR');
 
             runAfterNStorageEvents(t.step_func(step2), 1);

--- a/webstorage/resources/local_set_item_remove_iframe.html
+++ b/webstorage/resources/local_set_item_remove_iframe.html
@@ -2,7 +2,7 @@
 <html>
  <body>
     <script>
-        parent.t.step(function() {
+        parent.step(function() {
             localStorage.setItem("name", "user1");
             localStorage.removeItem('name');
         });

--- a/webstorage/resources/session_set_item_remove_iframe.html
+++ b/webstorage/resources/session_set_item_remove_iframe.html
@@ -2,7 +2,7 @@
 <html>
  <body>
      <script>
-        parent.t.step(function() {
+        parent.step(function() {
             sessionStorage.setItem("name", "user1");
             sessionStorage.removeItem('name');
         });


### PR DESCRIPTION
Per issue #2173 the webstorage eventTestHarness.js can be confused if there are pre-existing records in storage. A storage.clear() call at the start of the test will generate an unexpected event. Fix this by introducing a clearStorage() helper that waits on the event if storage is non-empty before proceeding.

Also, rework tests that have a confusing mix of test() and async_test().
