### PR TITLE
Explicitly state 'blink' should create HTMLUnknownElement, like the spec

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -3222,6 +3222,7 @@ window.onload = function() {
       'document.createElement("acronym")',
     ],
     HTMLUnknownElement: [
+      'document.createElement("blink")',
       'document.createElement("quasit")',
       'document.createElement("bgsound")',
       'document.createElement("isindex")',


### PR DESCRIPTION
https://html.spec.whatwg.org/#other-elements,-attributes-and-apis:blink
