### PR TITLE
Improve dirtying algorithm for form validation tests

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -304,9 +304,10 @@ var validator = {
       ) ||
       ctl.tagName === "TEXTAREA"
     ) {
-      ctl.setSelectionRange(ctl.value.length, ctl.value.length);
+      ctl.value += "1";
+      ctl.setSelectionRange(ctl.value.length - 1, ctl.value.length);
+      document.execCommand("Delete");
     }
-    document.execCommand("Delete");
     document.designMode = "off";
   },
 


### PR DESCRIPTION
The `set_dirty()` function in `html/semantics/forms/constraints/support/validator.js` makes an empty selection using `setSelectionRange()` and then performs `document.execCommand("Delete")`, apparently assuming that this is a no-op.

At least in Chrome, that's not the case! Chrome deletes the last character in the input!

As `document.execCommand()` is notoriously not well-standardized, unrelated tests should avoid relying on its behavior in edge cases (such as empty selections).
So the new strategy is to add an extra character to the input's value, select this character, and then delete this character.
