### PR TITLE
Fix ordering of reportValidity() event firing assertions

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -229,8 +229,8 @@ var validator = {
         assert_true(ctl.reportValidity(), "The reportValidity method should be true.");
         assert_false(eventFired, "The invalid event should not be fired.");
       } else {
-        assert_true(eventFired, "The invalid event should be fired.");
         assert_false(ctl.reportValidity(), "The reportValidity method should be false.");
+        assert_true(eventFired, "The invalid event should be fired.");
       }
     }, data.name);
 


### PR DESCRIPTION
The test in question is supposed to check that `reportValidity()` fires an event, but the assertion was happening before `reportValidity()` had even been called.
The two assertions within `test_reportValidity()` in `html/semantics/forms/constraints/support/validator.js` were in the wrong order and should have been swapped.
Presumably this is a copy-paste-o from when the test was originally written.

Relevant spec: https://html.spec.whatwg.org/multipage/forms.html#dom-cva-reportvalidity
