### PR TITLE
Add "disabled" to list of attributes to reset between form validation tests

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -262,8 +262,19 @@ var validator = {
   },
 
   set_conditions: function (ctl, obj) {
-    ["required", "pattern", "step", "max", "min", "maxlength",
-     "value", "multiple", "checked", "selected"].forEach(function(item) {
+    [
+      "checked",
+      "max",
+      "maxlength",
+      "min",
+      "minlength",
+      "multiple",
+      "pattern",
+      "required",
+      "selected",
+      "step",
+      "value"
+    ].forEach(function(item) {
       ctl.removeAttribute(item);
     });
     for (var attr in obj) {

--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -264,6 +264,7 @@ var validator = {
   set_conditions: function (ctl, obj) {
     [
       "checked",
+      "disabled",
       "max",
       "maxlength",
       "min",


### PR DESCRIPTION
The `disabled` attribute was sticking around between tests, causing spurious failures in `html/semantics/forms/constraints/form-validation-willValidate.html`
