### PR TITLE
CSP: Test that hashes in default-src are allowed

### DIFF
--- a/content-security-policy/blink-contrib-2/scripthash-default-src.sub.html
+++ b/content-security-policy/blink-contrib-2/scripthash-default-src.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <title>script-hash allowed from default-src</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    
+    <script>done();</script>
+    </head>
+
+    <body>
+    <div id="log"></div>
+    <script async defer src="../support/checkReport.sub.js?reportExists=false"></script>
+    </body>
+</html>

--- a/content-security-policy/blink-contrib-2/scripthash-default-src.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/scripthash-default-src.sub.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: scripthash-default-src={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
+Content-Security-Policy: default-src 'self' 'sha256-sc3CeiHrlck5tH2tTC4MnBYFnI9D5zp8f9odqnmGQjE='; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/blink-contrib-2/stylehash-default-src.sub.html
+++ b/content-security-policy/blink-contrib-2/stylehash-default-src.sub.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+    <title>stylehash allowed from default-src</title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    </head>
+
+    <body>
+    <p id="p">Test</p>
+    <style>p#p { color: green; }</style>
+    <script>
+    var color = window.getComputedStyle(document.querySelector('#p')).color;
+    assert_equals(color, "rgb(0, 128, 0)");
+    done();
+    </script>
+
+    <div id="log"></div>
+    <script async defer src="../support/checkReport.sub.js?reportExists=false"></script>
+    </body>
+</html>

--- a/content-security-policy/blink-contrib-2/stylehash-default-src.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/stylehash-default-src.sub.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: stylehash-default-src={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
+Content-Security-Policy: default-src 'self' 'sha256-SXMrww9+PS7ymkxYbv91id+HfXeO7p1uCY0xhNb4MIw='; script-src 'self' 'unsafe-inline'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
This adds a test to verify that hashes in default-src are carried through to script hash and style hash checks.
