### PR TITLE
Make createAttribute in an HTML document lowercase the passed-in attribute name.

### DIFF
--- a/dom/nodes/Document-createAttribute.html
+++ b/dom/nodes/Document-createAttribute.html
@@ -19,7 +19,7 @@ var tests = ["title", "TITLE", null, undefined];
 tests.forEach(function(name) {
   test(function() {
     var attribute = document.createAttribute(name);
-    attr_is(attribute, "", String(name), null, null, String(name));
+    attr_is(attribute, "", String(name).toLowerCase(), null, null, String(name).toLowerCase());
     assert_equals(attribute.ownerElement, null);
   }, "createAttribute(" + format_value(name) + ")");
 });


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1205364
