### PR TITLE
Remove document.charset from historical.html because it was eventually added to the spec.

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -47,7 +47,6 @@ var documentNuked = [
   "domConfig",
   "normalizeDocument",
   "renameNode",
-  "charset",
   "defaultCharset",
   "height",
   "width"


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=647621
