### PR TITLE
Fix throw incorrect exception

### DIFF
--- a/IndexedDB/idbindex_openCursor2.htm
+++ b/IndexedDB/idbindex_openCursor2.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("InvalidStateError", function(){
+        assert_throws("TransactionInactiveError", function(){
             index.openCursor();
         });
         t.done();

--- a/IndexedDB/idbindex_openKeyCursor3.htm
+++ b/IndexedDB/idbindex_openKeyCursor3.htm
@@ -20,7 +20,7 @@
 
         e.target.transaction.abort();
 
-        assert_throws("InvalidStateError", function(){
+        assert_throws("TransactionInactiveError", function(){
             index.openKeyCursor();
         });
         t.done();


### PR DESCRIPTION
When transaction is not active or finished., throw a  TransactionInactiveError exception.
