### PR TITLE
Fix resource URLs for testharness in 3 shadow-dom tests

### DIFF
--- a/shadow-dom/Element-interface-attachShadow.html
+++ b/shadow-dom/Element-interface-attachShadow.html
@@ -5,9 +5,9 @@
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="Element.prototype.attachShadow should create an instance of ShadowRoot">
 <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#widl-Element-attachShadow-ShadowRoot-ShadowRootInit-shadowRootInitDict">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
-<link rel='stylesheet' href='../../resources/testharness.css'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='/resources/testharness.css'>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/Element-interface-shadowRoot-attribute.html
+++ b/shadow-dom/Element-interface-shadowRoot-attribute.html
@@ -5,9 +5,9 @@
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="shadowRoot attribute on Element interface must return the associated open shadow tree if there is one">
 <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
-<link rel='stylesheet' href='../../resources/testharness.css'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='/resources/testharness.css'>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/ShadowRoot-interface.html
+++ b/shadow-dom/ShadowRoot-interface.html
@@ -5,9 +5,9 @@
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="ShadowRoot interface and its attributes must be defined">
 <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#the-shadowroot-interface">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
-<link rel='stylesheet' href='https://svn.webkit.org/repository/webkit/trunk/LayoutTests/resources/testharness.css'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='/resources/testharness.css'>
 </head>
 <body>
 <div id="log"></div>


### PR DESCRIPTION
This patch fixes issue #2215.
