### PR TITLE
validator.js:set_conditions(): Set HTMLInputElement.checked IDL attr regardless of truth value

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -279,7 +279,7 @@ var validator = {
       ctl.removeAttribute(item);
     });
     for (var attr in obj) {
-      if (obj[attr] || obj[attr] === "")
+      if (attr === "checked" || obj[attr] || obj[attr] === "")
         ctl[attr] = obj[attr];
     }
   },


### PR DESCRIPTION
If you have

``` html
 <input type="checked" id="myInput">
```

and then do

``` js
myInput.checked = true;
```

the following will still be true:

``` js
ASSERT(myInput.getAttribute('checked') === null);
```

and therefore

``` js
myInput.removeAttribute('checked');
```

will be a no-op, so the `<input>`'s checkedness WON'T get reset as mentioned in https://html.spec.whatwg.org/multipage/forms.html#attr-input-checked

So if the next test requires the `<input>`'s checkedness to be false (which is the case in `html/semantics/forms/constraints/form-validation-validity-valueMissing.html`), we need to explicitly set the `HTMLInputElement.checked` IDL property to `false`.

(Continuation of #2187.)
CC: @zcorpan
