### PR TITLE
Fix "setting withCredentials when in DONE state (synchronous)" test

### DIFF
--- a/XMLHttpRequest/XMLHttpRequest-withCredentials.js
+++ b/XMLHttpRequest/XMLHttpRequest-withCredentials.js
@@ -43,6 +43,7 @@ function test_withCredentials(worker) {
   test(function() {
     var client = new XMLHttpRequest()
     client.open("GET", "resources/delay.py?ms=1000", false)
+    client.send();
     assert_throws("InvalidStateError", function() { client.withCredentials = true })
   }, "setting withCredentials when in DONE state (synchronous)")
 }


### PR DESCRIPTION
It's redundant and does not check what the spec says, see #2228

Closes #2228
