### PR TITLE
Stop using designMode and execCommand for dirtying in HTML form constraint tests

### DIFF
--- a/html/semantics/forms/constraints/support/validator.js
+++ b/html/semantics/forms/constraints/support/validator.js
@@ -285,30 +285,10 @@ var validator = {
   },
 
   set_dirty: function(ctl) {
-    document.designMode = "on";
     ctl.focus();
     var old_value = ctl.value;
     ctl.value = "a";
     ctl.value = old_value;
-    if (
-      // See https://html.spec.whatwg.org/multipage/#input-type-attr-summary
-      // and https://html.spec.whatwg.org/multipage/#textFieldSelection
-      (
-        ctl.tagName === "INPUT" && (
-          ctl.type === "text" ||
-          ctl.type === "search" ||
-          ctl.type === "tel" ||
-          ctl.type === "url" ||
-          ctl.type === "password"
-        )
-      ) ||
-      ctl.tagName === "TEXTAREA"
-    ) {
-      ctl.value += "1";
-      ctl.setSelectionRange(ctl.value.length - 1, ctl.value.length);
-      document.execCommand("Delete");
-    }
-    document.designMode = "off";
   },
 
   pre_check: function(ctl, item) {


### PR DESCRIPTION
Reverts part of 4b3ce31884b64ff56a9c9d259d8a1faac02ad8f4
Reasserts #928
Closes #923
See also: https://critic.hoppipolla.co.uk/showcomment?chain=12393

`document.designMode` and `document.execCommand()` are not currently well-standardized, and are not especially germane to these tests. They aren't spec'd to affect either the "dirty value flag" or the "last edited by the user" flag any differently than simply modifying the `.value` property would, which the test code already does.
Therefore, this commit removes them from `validator.js:set_dirty()`
