### PR TITLE
Don't break test unnecessarily in IE

### DIFF
--- a/html/dom/documents/dom-tree-accessors/document.title-09.html
+++ b/html/dom/documents/dom-tree-accessors/document.title-09.html
@@ -7,7 +7,7 @@
 var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 
 function newSVGDocument() {
-  return document.implementation.createDocument(SVG_NAMESPACE, "svg");
+  return document.implementation.createDocument(SVG_NAMESPACE, "svg", null);
 }
 
 test(function() {


### PR DESCRIPTION
IE11 doesn't treat the third argument of createDocument() as optional.
