### PR TITLE
IndexedDB: Import blink's tests for getAll/getAllKeys

### DIFF
--- a/IndexedDB/idbindex_getAll.html
+++ b/IndexedDB/idbindex_getAll.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<title>IndexedDB: Test IDBIndex.getAll.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+var ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+function doSetup(dbName, dbVersion, onsuccess) {
+  var delete_request = indexedDB.deleteDatabase(dbName);
+  delete_request.onerror = function() {
+    assert_unreached('deleteDatabase should not fail');
+  };
+  delete_request.onsuccess = function(e) {
+    var req = indexedDB.open(dbName, dbVersion);
+    req.onsuccess = onsuccess;
+    req.onerror = function() {
+      assert_unreached('open should not fail');
+    };
+    req.onupgradeneeded = function(evt) {
+      var connection = evt.target.result;
+
+      var store = connection.createObjectStore('generated',
+            {autoIncrement: true, keyPath: 'id'});
+      var index = store.createIndex('test_idx', 'upper');
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter, upper: letter.toUpperCase()});
+      });
+
+      store = connection.createObjectStore('out-of-line', null);
+      index = store.createIndex('test_idx', 'upper');
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter, upper: letter.toUpperCase()}, letter);
+      });
+
+      store = connection.createObjectStore('out-of-line-not-unique', null);
+      index = store.createIndex('test_idx', 'half');
+      alphabet.forEach(function(letter) {
+        if (letter <= 'm')
+          store.put({ch: letter, half: 'first'}, letter);
+        else
+          store.put({ch: letter, half: 'second'}, letter);
+      });
+
+      store = connection.createObjectStore('out-of-line-multi', null);
+      index = store.createIndex('test_idx', 'attribs', {multiEntry: true});
+      alphabet.forEach(function(letter) {
+        attrs = [];
+        if (['a', 'e', 'i', 'o', 'u'].indexOf(letter) != -1)
+          attrs.push('vowel');
+        else
+          attrs.push('consonant');
+        if (letter == 'a')
+          attrs.push('first');
+        if (letter == 'z')
+          attrs.push('last');
+        store.put({ch: letter, attribs: attrs}, letter);
+      });
+
+      store = connection.createObjectStore('empty', null);
+      index = store.createIndex('test_idx', 'upper');
+    };
+  };
+}
+
+function createGetAllRequest(t, storeName, connection, range, maxCount) {
+    var transaction = connection.transaction(storeName, 'readonly');
+    var store = transaction.objectStore(storeName);
+    var index = store.index('test_idx');
+    // TODO(cmumford): Simplify once crbug.com/335871 is fixed.
+    var req = maxCount !== undefined ? index.getAll(range, maxCount) :
+              range !== undefined ? index.getAll(range) : index.getAll();
+    req.onerror = t.unreached_func('getAll request should succeed');
+    return req;
+}
+
+doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
+    var connection = evt.target.result;
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection, 'C');
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), ['c']);
+          assert_array_equals(data.map(e => e.upper), ['C']);
+          t.done();
+      });
+    }, 'Single item get');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'empty', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAll() on empty object store should return an empty array');
+          t.done();
+      });
+    }, 'Empty object store');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), alphabet);
+          assert_array_equals(data.map(e => e.upper), ALPHABET);
+          t.done();
+      });
+    }, 'Get all keys');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection, undefined,
+                                    10);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), 'abcdefghij'.split(''));
+          assert_array_equals(data.map(e => e.upper), 'ABCDEFGHIJ'.split(''));
+          t.done();
+      });
+    }, 'maxCount=10');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('G', 'M'));
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_array_equals(data.map(e => e.ch), 'ghijklm'.split(''));
+          assert_array_equals(data.map(e => e.upper), 'GHIJKLM'.split(''));
+          t.done();
+      });
+    }, 'Get bound range');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('G', 'M'), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), 'ghi'.split(''));
+          assert_array_equals(data.map(e => e.upper), 'GHI'.split(''));
+          t.done();
+      });
+    }, 'Get bound range with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+          IDBKeyRange.bound('G', 'K', false, true));
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), 'ghij'.split(''));
+          assert_array_equals(data.map(e => e.upper), 'GHIJ'.split(''));
+          t.done();
+      });
+    }, 'Get upper excluded');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+          IDBKeyRange.bound('G', 'K', true, false));
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), 'hijk'.split(''));
+          assert_array_equals(data.map(e => e.upper), 'HIJK'.split(''));
+          t.done();
+      });
+    }, 'Get lower excluded');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'generated',
+          connection, IDBKeyRange.bound(4, 15), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_true(Array.isArray(data));
+          assert_equals(data.length, 0);
+          t.done();
+      });
+    }, 'Get bound range (generated) with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line',
+          connection, "Doesn't exist");
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAll() using a nonexistent key should return an empty array');
+          t.done();
+      req.onerror = t.unreached_func('getAll request should succeed');
+      });
+    }, 'Non existent key');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+          undefined, 0);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), alphabet);
+          assert_array_equals(data.map(e => e.upper), ALPHABET);
+          t.done();
+      });
+    }, 'maxCount=0');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line-not-unique', connection,
+                                    'first');
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), 'abcdefghijklm'.split(''));
+          assert_true(data.every(e => e.half === 'first'));
+          t.done();
+      });
+    }, 'Retrieve multiEntry key');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line-multi', connection,
+                                    'vowel');
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_class_string(data, 'Array', 'result should be an array');
+          assert_array_equals(data.map(e => e.ch), ['a', 'e', 'i', 'o', 'u']);
+          assert_array_equals(data[0].attribs, ['vowel', 'first']);
+          assert_true(data.every(e => e.attribs[0] === 'vowel'));
+          t.done();
+      });
+    }, 'Retrieve one key multiple values');
+});
+
+</script>

--- a/IndexedDB/idbindex_getAll.html
+++ b/IndexedDB/idbindex_getAll.html
@@ -68,9 +68,7 @@ function createGetAllRequest(t, storeName, connection, range, maxCount) {
     var transaction = connection.transaction(storeName, 'readonly');
     var store = transaction.objectStore(storeName);
     var index = store.index('test_idx');
-    // TODO(cmumford): Simplify once crbug.com/335871 is fixed.
-    var req = maxCount !== undefined ? index.getAll(range, maxCount) :
-              range !== undefined ? index.getAll(range) : index.getAll();
+    var req = index.getAll(range, maxCount);
     req.onerror = t.unreached_func('getAll request should succeed');
     return req;
 }
@@ -82,8 +80,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), ['c']);
-          assert_array_equals(data.map(e => e.upper), ['C']);
+          assert_array_equals(data.map(function(e) { return e.ch; }), ['c']);
+          assert_array_equals(data.map(function(e) { return e.upper; }), ['C']);
           t.done();
       });
     }, 'Single item get');
@@ -102,8 +100,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), alphabet);
-          assert_array_equals(data.map(e => e.upper), ALPHABET);
+          assert_array_equals(data.map(function(e) { return e.ch; }), alphabet);
+          assert_array_equals(data.map(function(e) { return e.upper; }), ALPHABET);
           t.done();
       });
     }, 'Get all keys');
@@ -114,8 +112,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), 'abcdefghij'.split(''));
-          assert_array_equals(data.map(e => e.upper), 'ABCDEFGHIJ'.split(''));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'abcdefghij'.split(''));
+          assert_array_equals(data.map(function(e) { return e.upper; }), 'ABCDEFGHIJ'.split(''));
           t.done();
       });
     }, 'maxCount=10');
@@ -125,8 +123,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
                                     IDBKeyRange.bound('G', 'M'));
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
-          assert_array_equals(data.map(e => e.ch), 'ghijklm'.split(''));
-          assert_array_equals(data.map(e => e.upper), 'GHIJKLM'.split(''));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'ghijklm'.split(''));
+          assert_array_equals(data.map(function(e) { return e.upper; }), 'GHIJKLM'.split(''));
           t.done();
       });
     }, 'Get bound range');
@@ -137,8 +135,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), 'ghi'.split(''));
-          assert_array_equals(data.map(e => e.upper), 'GHI'.split(''));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'ghi'.split(''));
+          assert_array_equals(data.map(function(e) { return e.upper; }), 'GHI'.split(''));
           t.done();
       });
     }, 'Get bound range with maxCount');
@@ -149,8 +147,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), 'ghij'.split(''));
-          assert_array_equals(data.map(e => e.upper), 'GHIJ'.split(''));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'ghij'.split(''));
+          assert_array_equals(data.map(function(e) { return e.upper; }), 'GHIJ'.split(''));
           t.done();
       });
     }, 'Get upper excluded');
@@ -161,8 +159,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), 'hijk'.split(''));
-          assert_array_equals(data.map(e => e.upper), 'HIJK'.split(''));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'hijk'.split(''));
+          assert_array_equals(data.map(function(e) { return e.upper; }), 'HIJK'.split(''));
           t.done();
       });
     }, 'Get lower excluded');
@@ -195,8 +193,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), alphabet);
-          assert_array_equals(data.map(e => e.upper), ALPHABET);
+          assert_array_equals(data.map(function(e) { return e.ch; }), alphabet);
+          assert_array_equals(data.map(function(e) { return e.upper; }), ALPHABET);
           t.done();
       });
     }, 'maxCount=0');
@@ -207,8 +205,8 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), 'abcdefghijklm'.split(''));
-          assert_true(data.every(e => e.half === 'first'));
+          assert_array_equals(data.map(function(e) { return e.ch; }), 'abcdefghijklm'.split(''));
+          assert_true(data.every(function(e) { return e.half === 'first'; }));
           t.done();
       });
     }, 'Retrieve multiEntry key');
@@ -219,9 +217,9 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_class_string(data, 'Array', 'result should be an array');
-          assert_array_equals(data.map(e => e.ch), ['a', 'e', 'i', 'o', 'u']);
+          assert_array_equals(data.map(function(e) { return e.ch; }), ['a', 'e', 'i', 'o', 'u']);
           assert_array_equals(data[0].attribs, ['vowel', 'first']);
-          assert_true(data.every(e => e.attribs[0] === 'vowel'));
+          assert_true(data.every(function(e) { return e.attribs[0] === 'vowel'; }));
           t.done();
       });
     }, 'Retrieve one key multiple values');

--- a/IndexedDB/idbindex_getAll.html
+++ b/IndexedDB/idbindex_getAll.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 var ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
@@ -223,6 +224,9 @@ doSetup(location.pathname + '-IDBIndex.getAll', 1, function(evt) {
           t.done();
       });
     }, 'Retrieve one key multiple values');
+
+    // Explicit done needed in case async_test body fails synchronously.
+    done();
 });
 
 </script>

--- a/IndexedDB/idbindex_getAllKeys.html
+++ b/IndexedDB/idbindex_getAllKeys.html
@@ -58,10 +58,7 @@ function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
     var transaction = connection.transaction(storeName, 'readonly');
     var store = transaction.objectStore(storeName);
     var index = store.index('test_idx');
-    // TODO(cmumford): Simplify once crbug.com/335871 is fixed.
-    var req = maxCount !== undefined ? index.getAllKeys(range, maxCount) :
-              range !== undefined ? index.getAllKeys(range) :
-              index.getAllKeys();
+    var req = index.getAllKeys(range, maxCount);
     req.onerror = t.unreached_func('getAllKeys request should succeed');
     return req;
 }
@@ -111,7 +108,7 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
                                     10);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-                             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+                             'abcdefghij'.split(''),
                              'getAllKeys() should return a..j');
           t.done();
       });
@@ -122,8 +119,8 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
                                     IDBKeyRange.bound('G', 'M'));
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-                             ['g', 'h', 'i', 'j', 'k', 'l', 'm'],
-                             'getAllKeys() should return g..m');
+                              'ghijklm'.split(''),
+                              'getAllKeys() should return g..m');
           t.done();
       });
     }, 'Get bound range');

--- a/IndexedDB/idbindex_getAllKeys.html
+++ b/IndexedDB/idbindex_getAllKeys.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<title>IndexedDB: Test IDBIndex.getAllKeys.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+function doSetup(dbName, dbVersion, onsuccess) {
+  var delete_request = indexedDB.deleteDatabase(dbName);
+  delete_request.onerror = function() {
+    assert_unreached('deleteDatabase should not fail');
+  };
+  delete_request.onsuccess = function(e) {
+    var req = indexedDB.open(dbName, dbVersion);
+    req.onsuccess = onsuccess;
+    req.onerror = function() {
+      assert_unreached('open should not fail');
+    };
+    req.onupgradeneeded = function(evt) {
+      var connection = evt.target.result;
+
+      var store = connection.createObjectStore('generated',
+            {autoIncrement: true, keyPath: 'id'});
+      var index = store.createIndex('test_idx', 'upper');
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter, upper: letter.toUpperCase()});
+      });
+
+      store = connection.createObjectStore('out-of-line', null);
+      index = store.createIndex('test_idx', 'upper');
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter, upper: letter.toUpperCase()}, letter);
+      });
+
+      store = connection.createObjectStore('out-of-line-multi', null);
+      index = store.createIndex('test_idx', 'attribs', {multiEntry: true});
+      alphabet.forEach(function(letter) {
+        attrs = [];
+        if (['a', 'e', 'i', 'o', 'u'].indexOf(letter) != -1)
+          attrs.push('vowel');
+        else
+          attrs.push('consonant');
+        if (letter == 'a')
+          attrs.push('first');
+        if (letter == 'z')
+          attrs.push('last');
+        store.put({ch: letter, attribs: attrs}, letter.toUpperCase());
+      });
+
+      store = connection.createObjectStore('empty', null);
+      index = store.createIndex('test_idx', 'upper');
+    };
+  };
+}
+
+function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
+    var transaction = connection.transaction(storeName, 'readonly');
+    var store = transaction.objectStore(storeName);
+    var index = store.index('test_idx');
+    // TODO(cmumford): Simplify once crbug.com/335871 is fixed.
+    var req = maxCount !== undefined ? index.getAllKeys(range, maxCount) :
+              range !== undefined ? index.getAllKeys(range) :
+              index.getAllKeys();
+    req.onerror = t.unreached_func('getAllKeys request should succeed');
+    return req;
+}
+
+doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
+    var connection = evt.target.result;
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection, 'C');
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_array_equals(evt.target.result, ['c']);
+          t.done();
+      });
+    }, 'Single item get');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'empty', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAllKeys() on empty object store should return empty array');
+          t.done();
+      });
+    }, 'Empty object store');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, alphabet,
+              'getAllKeys() should return a..z');
+          t.done();
+      });
+    }, 'Get all keys');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'generated', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+               19, 20, 21, 22, 23, 24, 25, 26],
+              'getAllKeys() should return 1..26');
+          t.done();
+      });
+    }, 'Get all generated keys');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
+                                    10);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+                             ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'],
+                             'getAllKeys() should return a..j');
+          t.done();
+      });
+    }, 'maxCount=10');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('G', 'M'));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+                             ['g', 'h', 'i', 'j', 'k', 'l', 'm'],
+                             'getAllKeys() should return g..m');
+          t.done();
+      });
+    }, 'Get bound range');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('G', 'M'), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+                             ['g', 'h', 'i'],
+                             'getAllKeys() should return g..i');
+          t.done();
+      });
+    }, 'Get bound range with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+          IDBKeyRange.bound('G', 'K', false, true));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+                             ['g', 'h', 'i', 'j'],
+                             'getAllKeys() should return g..j');
+          t.done();
+      });
+    }, 'Get upper excluded');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+          IDBKeyRange.bound('G', 'K', true, false));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+                             ['h', 'i', 'j', 'k'],
+                             'getAllKeys() should return h..k');
+          t.done();
+      });
+    }, 'Get lower excluded');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'generated',
+          connection, IDBKeyRange.bound(4, 15), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+                              'getAllKeys() should return []');
+          t.done();
+      });
+    }, 'Get bound range (generated) with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line',
+          connection, "Doesn't exist");
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAllKeys() using a nonexistent key should return empty array');
+          t.done();
+      req.onerror = t.unreached_func('getAllKeys request should succeed');
+      });
+    }, 'Non existent key');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+          undefined, 0);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, alphabet,
+              'getAllKeys() should return a..z');
+          t.done();
+      });
+    }, 'maxCount=0');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line-multi', connection,
+                                        'vowel');
+      req.onsuccess = t.step_func(function(evt) {
+        assert_array_equals(evt.target.result, ['A','E','I','O','U'])
+        t.done();
+      });
+      req.onerror = t.unreached_func('getAllKeys request should succeed');
+    }, 'Retrieve multiEntry keys');
+});
+
+</script>

--- a/IndexedDB/idbindex_getAllKeys.html
+++ b/IndexedDB/idbindex_getAllKeys.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
@@ -198,6 +199,9 @@ doSetup(location.pathname + '-IDBIndex.getAllKeys', 1, function(evt) {
       });
       req.onerror = t.unreached_func('getAllKeys request should succeed');
     }, 'Retrieve multiEntry keys');
+
+    // Explicit done needed in case async_test body fails synchronously.
+    done();
 });
 
 </script>

--- a/IndexedDB/idbobjectstore_getAll.html
+++ b/IndexedDB/idbobjectstore_getAll.html
@@ -39,9 +39,7 @@ function doSetup(dbName, dbVersion, onsuccess) {
 function createGetAllRequest(t, storeName, connection, range, maxCount) {
     var transaction = connection.transaction(storeName, 'readonly');
     var store = transaction.objectStore(storeName);
-    // TODO(cmumford): Simplify once crbug.com/335871 is closed.
-    var req = maxCount !== undefined ? store.getAll(range, maxCount) :
-              range !== undefined ? store.getAll(range) : store.getAll();
+    var req = store.getAll(range, maxCount);
     req.onerror = t.unreached_func('getAll request should succeed');
     return req;
 }
@@ -81,7 +79,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       var req = createGetAllRequest(t, 'out-of-line', connection);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-              alphabet.map(c => 'value-' + c));
+              alphabet.map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Get all values');
@@ -91,8 +89,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
                                     10);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-              ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
-                  .map(c => 'value-' + c));
+              'abcdefghij'.split('').map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Test maxCount');
@@ -102,8 +99,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
                                     IDBKeyRange.bound('g', 'm'));
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-              ['g', 'h', 'i', 'j', 'k', 'l', 'm']
-                  .map(c => 'value-' + c));
+              'ghijklm'.split('').map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Get bound range');
@@ -113,7 +109,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
                                     IDBKeyRange.bound('g', 'm'), 3);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, ['g', 'h', 'i']
-              .map(c => 'value-' + c));
+              .map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Get bound range with maxCount');
@@ -123,7 +119,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
                                     IDBKeyRange.bound('g', 'k', false, true));
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, ['g', 'h', 'i', 'j']
-              .map(c => 'value-' + c));
+              .map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Get upper excluded');
@@ -133,7 +129,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
                                     IDBKeyRange.bound('g', 'k', true, false));
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result, ['h', 'i', 'j', 'k']
-              .map(c => 'value-' + c));
+              .map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'Get lower excluded');
@@ -144,8 +140,8 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       req.onsuccess = t.step_func(function(evt) {
           var data = evt.target.result;
           assert_true(Array.isArray(data));
-          assert_array_equals(data.map(e => e.ch), ['d', 'e', 'f']);
-          assert_array_equals(data.map(e => e.id), [4, 5, 6]);
+          assert_array_equals(data.map(function(e) { return e.ch; }), ['d', 'e', 'f']);
+          assert_array_equals(data.map(function(e) { return e.id; }), [4, 5, 6]);
           t.done();
       });
     }, 'Get bound range (generated) with maxCount');
@@ -165,7 +161,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
       var req = createGetAllRequest(t, 'out-of-line', connection, undefined, 0);
       req.onsuccess = t.step_func(function(evt) {
           assert_array_equals(evt.target.result,
-              alphabet.map(c => 'value-' + c));
+              alphabet.map(function(c) { return 'value-' + c; }));
           t.done();
       });
     }, 'zero maxCount');

--- a/IndexedDB/idbobjectstore_getAll.html
+++ b/IndexedDB/idbobjectstore_getAll.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<title>IndexedDB: Test IDBObjectStore.getAll.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+function doSetup(dbName, dbVersion, onsuccess) {
+  var delete_request = indexedDB.deleteDatabase(dbName);
+  delete_request.onerror = function() {
+    assert_unreached('deleteDatabase should not fail');
+  };
+  delete_request.onsuccess = function(e) {
+    var req = indexedDB.open(dbName, dbVersion);
+    req.onsuccess = onsuccess;
+    req.onerror = function() {
+      assert_unreached('open should not fail');
+    };
+    req.onupgradeneeded = function(evt) {
+      var connection = evt.target.result;
+
+      var store = connection.createObjectStore('generated',
+            {autoIncrement: true, keyPath: 'id'});
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter});
+      });
+
+      store = connection.createObjectStore('out-of-line', null);
+      alphabet.forEach(function(letter) {
+        store.put('value-' + letter, letter);
+      });
+
+      store = connection.createObjectStore('empty', null);
+    };
+  };
+}
+
+function createGetAllRequest(t, storeName, connection, range, maxCount) {
+    var transaction = connection.transaction(storeName, 'readonly');
+    var store = transaction.objectStore(storeName);
+    // TODO(cmumford): Simplify once crbug.com/335871 is closed.
+    var req = maxCount !== undefined ? store.getAll(range, maxCount) :
+              range !== undefined ? store.getAll(range) : store.getAll();
+    req.onerror = t.unreached_func('getAll request should succeed');
+    return req;
+}
+
+doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
+    var connection = evt.target.result;
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection, 'c');
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['value-c']);
+          t.done();
+      });
+    }, 'Single item get');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'generated', connection, 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_true(Array.isArray(data));
+          assert_equals(data.length, 1);
+          assert_equals(data[0].id, 3);
+          assert_equals(data[0].ch, 'c');
+          t.done();
+      });
+    }, 'Single item get (generated key)');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'empty', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAll() on empty object store should return an empty array');
+          t.done();
+      });
+    }, 'getAll on empty object store');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              alphabet.map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Get all values');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection, undefined,
+                                    10);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+                  .map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Test maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'm'));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              ['g', 'h', 'i', 'j', 'k', 'l', 'm']
+                  .map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Get bound range');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'm'), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['g', 'h', 'i']
+              .map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Get bound range with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'k', false, true));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['g', 'h', 'i', 'j']
+              .map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Get upper excluded');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'k', true, false));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['h', 'i', 'j', 'k']
+              .map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'Get lower excluded');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'generated', connection,
+                                    IDBKeyRange.bound(4, 15), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_true(Array.isArray(data));
+          assert_array_equals(data.map(e => e.ch), ['d', 'e', 'f']);
+          assert_array_equals(data.map(e => e.id), [4, 5, 6]);
+          t.done();
+      });
+    }, 'Get bound range (generated) with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection,
+                                    "Doesn't exist");
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAll() using a nonexistent key should return an empty array');
+          t.done();
+      });
+      req.onerror = t.unreached_func('getAll request should succeed');
+    }, 'Non existent key');
+
+    async_test(function(t) {
+      var req = createGetAllRequest(t, 'out-of-line', connection, undefined, 0);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              alphabet.map(c => 'value-' + c));
+          t.done();
+      });
+    }, 'zero maxCount');
+});
+
+</script>

--- a/IndexedDB/idbobjectstore_getAll.html
+++ b/IndexedDB/idbobjectstore_getAll.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
@@ -165,6 +166,9 @@ doSetup(location.pathname + '-IDBObjectStore.getAll', 1, function(evt) {
           t.done();
       });
     }, 'zero maxCount');
+
+    // Explicit done needed in case async_test body fails synchronously.
+    done();
 });
 
 </script>

--- a/IndexedDB/idbobjectstore_getAllKeys.html
+++ b/IndexedDB/idbobjectstore_getAllKeys.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<title>IndexedDB: Test IDBObjectStore.getAllKeys.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+function doSetup(dbName, dbVersion, onsuccess) {
+  var delete_request = indexedDB.deleteDatabase(dbName);
+  delete_request.onerror = function() {
+    assert_unreached('deleteDatabase should not fail');
+  };
+  delete_request.onsuccess = function(e) {
+    var req = indexedDB.open(dbName, dbVersion);
+    req.onsuccess = onsuccess;
+    req.onerror = function() {
+      assert_unreached('open should not fail');
+    };
+    req.onupgradeneeded = function(evt) {
+      var connection = evt.target.result;
+
+      var store = connection.createObjectStore('generated',
+            {autoIncrement: true, keyPath: 'id'});
+      alphabet.forEach(function(letter) {
+        store.put({ch: letter});
+      });
+
+      store = connection.createObjectStore('out-of-line', null);
+      alphabet.forEach(function(letter) {
+        store.put('value-' + letter, letter);
+      });
+
+      store = connection.createObjectStore('empty', null);
+    };
+  };
+}
+
+function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
+    var transaction = connection.transaction(storeName, 'readonly');
+    var store = transaction.objectStore(storeName);
+    // TODO(cmumford): Simplify once crbug.com/335871 is closed.
+    var req = maxCount !== undefined ? store.getAllKeys(range, maxCount) :
+              range !== undefined ? store.getAllKeys(range) :
+              store.getAllKeys();
+    req.onerror = t.unreached_func('getAllKeys request should succeed');
+    return req;
+}
+
+doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
+    var connection = evt.target.result;
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection, 'c');
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['c']);
+          t.done();
+      });
+    }, 'Single item get');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'generated', connection, 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_true(Array.isArray(data));
+          assert_array_equals(data, [3]);
+          t.done();
+      });
+    }, 'Single item get (generated key)');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'empty', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAllKeys() on empty object store should return an empty ' +
+                  'array');
+          t.done();
+      });
+    }, 'getAllKeys on empty object store');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, alphabet);
+          t.done();
+      });
+    }, 'Get all values');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
+                                    10);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+          t.done();
+      });
+    }, 'Test maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'm'));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result,
+              ['g', 'h', 'i', 'j', 'k', 'l', 'm']);
+          t.done();
+      });
+    }, 'Get bound range');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'm'), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['g', 'h', 'i']);
+          t.done();
+      });
+    }, 'Get bound range with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'k', false, true));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['g', 'h', 'i', 'j']);
+          t.done();
+      });
+    }, 'Get upper excluded');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    IDBKeyRange.bound('g', 'k', true, false));
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, ['h', 'i', 'j', 'k']);
+          t.done();
+      });
+    }, 'Get lower excluded');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'generated', connection,
+                                    IDBKeyRange.bound(4, 15), 3);
+      req.onsuccess = t.step_func(function(evt) {
+          var data = evt.target.result;
+          assert_true(Array.isArray(data));
+          assert_array_equals(data, [4, 5, 6]);
+          t.done();
+      });
+    }, 'Get bound range (generated) with maxCount');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection,
+                                    "Doesn't exist");
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, [],
+              'getAllKeys() using a nonexistent key should return an ' +
+                  'empty array');
+          t.done();
+      });
+      req.onerror = t.unreached_func('getAllKeys request should succeed');
+    }, 'Non existent key');
+
+    async_test(function(t) {
+      var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
+          0);
+      req.onsuccess = t.step_func(function(evt) {
+          assert_array_equals(evt.target.result, alphabet);
+          t.done();
+      });
+    }, 'zero maxCount');
+});
+
+</script>

--- a/IndexedDB/idbobjectstore_getAllKeys.html
+++ b/IndexedDB/idbobjectstore_getAllKeys.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+setup({explicit_done: true});
 
 var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
@@ -158,6 +159,9 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
           t.done();
       });
     }, 'zero maxCount');
+
+    // Explicit done needed in case async_test body fails synchronously.
+    done();
 });
 
 </script>

--- a/IndexedDB/idbobjectstore_getAllKeys.html
+++ b/IndexedDB/idbobjectstore_getAllKeys.html
@@ -39,10 +39,7 @@ function doSetup(dbName, dbVersion, onsuccess) {
 function createGetAllKeysRequest(t, storeName, connection, range, maxCount) {
     var transaction = connection.transaction(storeName, 'readonly');
     var store = transaction.objectStore(storeName);
-    // TODO(cmumford): Simplify once crbug.com/335871 is closed.
-    var req = maxCount !== undefined ? store.getAllKeys(range, maxCount) :
-              range !== undefined ? store.getAllKeys(range) :
-              store.getAllKeys();
+    var req = store.getAllKeys(range, maxCount);
     req.onerror = t.unreached_func('getAllKeys request should succeed');
     return req;
 }
@@ -89,8 +86,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection, undefined,
                                     10);
       req.onsuccess = t.step_func(function(evt) {
-          assert_array_equals(evt.target.result,
-              ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+          assert_array_equals(evt.target.result, 'abcdefghij'.split(''));
           t.done();
       });
     }, 'Test maxCount');
@@ -99,8 +95,7 @@ doSetup(location.pathname + '-IDBObjectStore.getAllKeys', 1, function(evt) {
       var req = createGetAllKeysRequest(t, 'out-of-line', connection,
                                     IDBKeyRange.bound('g', 'm'));
       req.onsuccess = t.step_func(function(evt) {
-          assert_array_equals(evt.target.result,
-              ['g', 'h', 'i', 'j', 'k', 'l', 'm']);
+          assert_array_equals(evt.target.result, 'ghijklm'.split(''));
           t.done();
       });
     }, 'Get bound range');


### PR DESCRIPTION
Adds tests for new methods:

IDBObjectStore.getAll()
IDBObjectStore.getAllKeys()
IDBIndex.getAll()
IDBIndex.getAllKeys()

Present in Chrome Canary (likely to ship in M48), and experimental in FF41.
Specified in Editor's Draft: https://w3c.github.io/IndexedDB/
