### PR TITLE
Align document.title for SVG documents with HTML spec;

### DIFF
--- a/html/dom/documents/dom-tree-accessors/document.title-09.html
+++ b/html/dom/documents/dom-tree-accessors/document.title-09.html
@@ -5,9 +5,16 @@
 <div id="log"></div>
 <script>
 var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+var HTML_NAMESPACE = "http://www.w3.org/1999/xhtml";
 
 function newSVGDocument() {
   return document.implementation.createDocument(SVG_NAMESPACE, "svg", null);
+}
+
+function assertIsSVGTitle(element, expectedText) {
+  assert_equals(element.namespaceURI, SVG_NAMESPACE);
+  assert_equals(element.localName, "title");
+  assert_equals(element.textContent, expectedText);
 }
 
 test(function() {
@@ -16,10 +23,7 @@ test(function() {
   var child = doc.createElementNS(SVG_NAMESPACE, "x-child");
   doc.documentElement.appendChild(child);
   doc.title = "foo";
-  var lastChild = doc.documentElement.lastChild;
-  assert_equals(lastChild.namespaceURI, SVG_NAMESPACE);
-  assert_equals(lastChild.localName, "title");
-  assert_equals(lastChild.textContent, "foo");
+  assertIsSVGTitle(doc.documentElement.firstChild, "foo");
   assert_equals(doc.title, "foo");
 }, "No title element in SVG document");
 
@@ -48,13 +52,46 @@ test(function() {
   child.appendChild(title);
   doc.documentElement.appendChild(child);
   assert_equals(doc.title, "");
+
+  // Now test that on setting, we create a new element and don't change the
+  // existing one
+  doc.title = "bar";
+  assert_equals(title.textContent, "foo");
+  assertIsSVGTitle(doc.documentElement.firstChild, "bar");
+  assert_equals(doc.title, "bar");
 }, "Title element not child of SVG root");
 
 test(function() {
   var doc = newSVGDocument();
-  var title = doc.createElement("title");
+  var title = doc.createElementNS(HTML_NAMESPACE, "title");
   title.textContent = "foo";
   doc.documentElement.appendChild(title);
   assert_equals(doc.title, "");
 }, "Title element not in SVG namespace");
+
+test(function() {
+  // "SVG" != "svg"
+  var doc = document.implementation.createDocument(SVG_NAMESPACE, "SVG", null);
+
+  // Per spec, this does nothing
+  doc.title = "foo";
+  assert_equals(doc.documentElement.childNodes.length, 0);
+  assert_equals(doc.title, "");
+
+  // An SVG title is ignored by .title
+  doc.documentElement.appendChild(doc.createElementNS(SVG_NAMESPACE, "title"));
+  doc.documentElement.lastChild.textContent = "foo";
+  assert_equals(doc.title, "");
+
+  // But an HTML title is respected
+  doc.documentElement.appendChild(doc.createElementNS(HTML_NAMESPACE, "title"));
+  doc.documentElement.lastChild.textContent = "bar";
+  assert_equals(doc.title, "bar");
+
+  // Even if it's not a child of the root
+  var div = doc.createElementNS(HTML_NAMESPACE, "div");
+  div.appendChild(doc.documentElement.lastChild);
+  doc.documentElement.appendChild(div);
+  assert_equals(doc.title, "bar");
+}, 'Root element not named "svg"');
 </script>


### PR DESCRIPTION
This allows setting, and for getting, pays attention to only children of
the root element (instead of all descendants as in HTML).

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1213818
