### PR TITLE
Update URL-related interfaces and their tests up to spec

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -141,7 +141,7 @@ var embeddedElements = {
     hreflang: "string",
     type: "string",
 
-          //URLUtils
+    // HTMLHyperlinkElementUtils
     href: "url",
 
     // Obsolete

--- a/html/dom/elements-text.js
+++ b/html/dom/elements-text.js
@@ -10,7 +10,7 @@ var textElements = {
     hreflang: "string",
     type: "string",
 
-    // URLUtils
+    // HTMLHyperlinkElementUtils
     href: "url",
 
     // Obsolete

--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -11,16 +11,6 @@
 <h1>HTML IDL tests</h1>
 <div id=log></div>
 
-<!-- URLUtils* stubs -->
-<script type=text/plain class=untested>
-interface URLUtils {
-  stringifier;
-};
-interface URLUtilsReadOnly {
-  stringifier;
-};
-</script>
-<!-- DOM IDLs -->
 <script type=text/plain class=untested>
 [Constructor(DOMString type, optional EventInit eventInitDict)/*,
  Exposed=(Window,Worker)*/]
@@ -868,6 +858,21 @@ typedef (Int8Array or Uint8Array or Uint8ClampedArray or
          Float32Array or Float64Array or
          DataView) ArrayBufferView;
 
+[NoInterfaceObject, Exposed=Window]
+interface HTMLHyperlinkElementUtils {
+  stringifier attribute USVString href;
+           attribute USVString origin;
+           attribute USVString protocol;
+           attribute USVString username;
+           attribute USVString password;
+           attribute USVString host;
+           attribute USVString hostname;
+           attribute USVString port;
+           attribute USVString pathname;
+           attribute USVString search;
+           attribute USVString hash;
+};
+
 interface HTMLAllCollection : HTMLCollection {
   // inherits length and 'getter'
   Element? item(unsigned long index);
@@ -1125,19 +1130,17 @@ interface HTMLDivElement : HTMLElement {
 };
 
 interface HTMLAnchorElement : HTMLElement {
-           attribute DOMString target;
-           attribute DOMString download;
-  [PutForwards=value] attribute DOMSettableTokenList ping;
-           attribute DOMString rel;
+  attribute DOMString target;
+  attribute DOMString download;
+  [PutForwards=value] readonly attribute DOMSettableTokenList ping;
+  attribute DOMString rel;
   readonly attribute DOMTokenList relList;
-           attribute DOMString hreflang;
-           attribute DOMString type;
+  attribute DOMString hreflang;
+  attribute DOMString type;
 
-           attribute DOMString text;
-
-  // also has obsolete members
+  attribute DOMString text;
 };
-HTMLAnchorElement implements URLUtils;
+HTMLAnchorElement implements HTMLHyperlinkElementUtils;
 
 interface HTMLDataElement : HTMLElement {
            attribute DOMString value;
@@ -1494,20 +1497,17 @@ interface HTMLMapElement : HTMLElement {
 };
 
 interface HTMLAreaElement : HTMLElement {
-           attribute DOMString alt;
-           attribute DOMString coords;
-           attribute DOMString shape;
-           attribute DOMString target;
-           attribute DOMString download;
-  [PutForwards=value] attribute DOMSettableTokenList ping;
-           attribute DOMString rel;
+  attribute DOMString alt;
+  attribute DOMString coords;
+  attribute DOMString shape;
+  attribute DOMString target;
+  attribute DOMString download;
+  [PutForwards=value] readonly attribute DOMSettableTokenList ping;
+  attribute DOMString rel;
   readonly attribute DOMTokenList relList;
-           attribute DOMString hreflang;
-           attribute DOMString type;
-
-  // also has obsolete members
+  // hreflang and type are not reflected
 };
-HTMLAreaElement implements URLUtils;
+HTMLAreaElement implements HTMLHyperlinkElementUtils;
 
 interface HTMLTableElement : HTMLElement {
            attribute HTMLTableCaptionElement? caption;
@@ -2320,11 +2320,22 @@ interface History {
 };
 
 [Unforgeable] interface Location {
-  void assign(DOMString url);
-  void replace(DOMString url);
+  stringifier attribute USVString href;
+           attribute USVString origin;
+           attribute USVString protocol;
+           attribute USVString host;
+           attribute USVString hostname;
+           attribute USVString port;
+           attribute USVString pathname;
+           attribute USVString search;
+           attribute USVString hash;
+
+  void assign(USVString url);
+  void replace(USVString url);
   void reload();
+
+  [SameObject] readonly attribute USVString[] ancestorOrigins;
 };
-Location implements URLUtils;
 
 [Constructor(DOMString type, optional PopStateEventInit eventInitDict), Exposed=Window,Worker]
 interface PopStateEvent : Event {
@@ -2816,8 +2827,17 @@ WorkerNavigator implements NavigatorLanguage;
 WorkerNavigator implements NavigatorOnLine;
 
 [Exposed=Worker]
-interface WorkerLocation { };
-WorkerLocation implements URLUtilsReadOnly;
+interface WorkerLocation {
+  stringifier readonly attribute USVString href;
+  readonly attribute USVString origin;
+  readonly attribute USVString protocol;
+  readonly attribute USVString host;
+  readonly attribute USVString hostname;
+  readonly attribute USVString port;
+  readonly attribute USVString pathname;
+  readonly attribute USVString search;
+  readonly attribute USVString hash;
+};
 
 interface Storage {
   readonly attribute unsigned long length;

--- a/url/interfaces.html
+++ b/url/interfaces.html
@@ -9,54 +9,38 @@
 <div id=log></div>
 
 <script type=text/plain>
-[Constructor(DOMString url, optional DOMString base = "about:blank"),
- Exposed=Window,Worker]
+[Constructor(USVString url, optional USVString base),
+ Exposed=(Window,Worker)]
 interface URL {
-  static DOMString domainToASCII(ScalarValueString domain);
-  static DOMString domainToUnicode(ScalarValueString domain);
-};
-URL implements URLUtils;
+  static USVString domainToASCII(USVString domain);
+  static USVString domainToUnicode(USVString domain);
 
-[NoInterfaceObject]
-interface URLUtils {
-  stringifier attribute ScalarValueString href;
-  readonly attribute DOMString origin;
-
-           attribute ScalarValueString protocol;
-           attribute ScalarValueString username;
-           attribute ScalarValueString password;
-           attribute ScalarValueString host;
-           attribute ScalarValueString hostname;
-           attribute ScalarValueString port;
-           attribute ScalarValueString pathname;
-           attribute ScalarValueString search;
-           readonly attribute URLSearchParams searchParams;
-           attribute ScalarValueString hash;
+  stringifier attribute USVString href;
+  readonly attribute USVString origin;
+           attribute USVString protocol;
+           attribute USVString username;
+           attribute USVString password;
+           attribute USVString host;
+           attribute USVString hostname;
+           attribute USVString port;
+           attribute USVString pathname;
+           attribute USVString search;
+  readonly attribute URLSearchParams searchParams;
+           attribute USVString hash;
 };
 
-[NoInterfaceObject]
-interface URLUtilsReadOnly {
-  stringifier readonly attribute DOMString href;
-  readonly attribute DOMString origin;
-
-  readonly attribute DOMString protocol;
-  readonly attribute DOMString host;
-  readonly attribute DOMString hostname;
-  readonly attribute DOMString port;
-  readonly attribute DOMString pathname;
-  readonly attribute DOMString search;
-  readonly attribute DOMString hash;
-};
+[Constructor(optional (USVString or URLSearchParams) init = ""),
+ Exposed=(Window,Worker)]
 interface URLSearchParams {
-  void append(ScalarValueString name, ScalarValueString value);
-  void delete(ScalarValueString name);
-  DOMString? get(ScalarValueString name);
-  sequence<DOMString> getAll(ScalarValueString name);
-  boolean has(ScalarValueString name);
-  void set(ScalarValueString name, ScalarValueString value);
+  void append(USVString name, USVString value);
+  void delete(USVString name);
+  USVString? get(USVString name);
+  sequence<USVString> getAll(USVString name);
+  boolean has(USVString name);
+  void set(USVString name, USVString value);
+  iterable<USVString, USVString>;
   stringifier;
 };
-typedef DOMString ScalarValueString;
 </script>
 <script>
 "use strict";


### PR DESCRIPTION
The URL spec recently changed and the variour "mixins" interfaces are gone,
this commit updates our code and WPT accordingly.

The new expected failures related to HTMLAnchorElement and HTMLAreaElement's
attributes are due to their moving to the HTMLHyperLinkElementUtils interface,
which is not anymore in a separate <script class=untested> element.
