### PR TITLE
Fix #2280: Update HTMLScriptElement event and htmlFor tests

### DIFF
--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/script-IDL-event-htmlfor.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/script-IDL-event-htmlfor.html
@@ -16,8 +16,8 @@ test(function() {
   var script = document.createElement("script");
   script.setAttribute("event", "blah");
   script.setAttribute("for", "blah");
-  assert_equals(script.event, "");
-  assert_equals(script.htmlFor, "");
+  assert_equals(script.event, "blah");
+  assert_equals(script.htmlFor, "blah");
   assert_equals(script.getAttribute("event"), "blah");
   assert_equals(script.getAttribute("for"), "blah");
 })
@@ -27,10 +27,10 @@ test(function() {
   script.setAttribute("for", "blah");
   script.event = "foo";
   script.htmlFor = "foo";
-  assert_equals(script.event, "");
-  assert_equals(script.htmlFor, "");
-  assert_equals(script.getAttribute("event"), "blah");
-  assert_equals(script.getAttribute("for"), "blah");
+  assert_equals(script.event, "foo");
+  assert_equals(script.htmlFor, "foo");
+  assert_equals(script.getAttribute("event"), "foo");
+  assert_equals(script.getAttribute("for"), "foo");
 })
 test(function() {
   var script = document.createElement("script");
@@ -38,10 +38,10 @@ test(function() {
   script.setAttribute("for", "blah");
   script.event = null;
   script.htmlFor = null;
-  assert_equals(script.event, "");
-  assert_equals(script.htmlFor, "");
-  assert_equals(script.getAttribute("event"), "blah");
-  assert_equals(script.getAttribute("for"), "blah");
+  assert_equals(script.event, "null");
+  assert_equals(script.htmlFor, "null");
+  assert_equals(script.getAttribute("event"), "null");
+  assert_equals(script.getAttribute("for"), "null");
 })
 test(function() {
   var script = document.createElement("script");
@@ -49,9 +49,9 @@ test(function() {
   script.setAttribute("for", "blah");
   script.event = undefined;
   script.htmlFor = undefined;
-  assert_equals(script.event, "");
-  assert_equals(script.htmlFor, "");
-  assert_equals(script.getAttribute("event"), "blah");
-  assert_equals(script.getAttribute("for"), "blah");
+  assert_equals(script.event, "undefined");
+  assert_equals(script.htmlFor, "undefined");
+  assert_equals(script.getAttribute("event"), "undefined");
+  assert_equals(script.getAttribute("for"), "undefined");
 })
 </script>


### PR DESCRIPTION
Update the tests for the event and htmlFor IDL attributes of the
HTMLScriptElement to expect the correct behavior:

The .event and .htmlFor IDL attributes of the script element should reflect
the element's "event" and "for" content attributes (respectively),
and not return the empty string on getting and do nothing on setting
as previously stated.

See whatwg/html#253 for the related correction to the spec.
