### PR TITLE
Update scripthash normalization test to *fail* on normalization

### DIFF
--- a/content-security-policy/blink-contrib-2/scripthash-unicode-normalization.sub.html
+++ b/content-security-policy/blink-contrib-2/scripthash-unicode-normalization.sub.html
@@ -6,37 +6,68 @@
     <title>scripthash-unicode-normalization</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/content-security-policy/support/alertAssert.sub.js?alerts=%5B%22PASS%22%2C%22PASS%22%5D">
-
 
     </script>
     <!-- enforcing policy:
-script-src 'self' 'unsafe-inline' 'sha256-xy4iRAvdlFCq+M5+4yu4B7dy0Kc2FfljmZO4Jkj3Yhw='; connect-src 'self';
+script-src 'self' 'nonce-nonceynonce' 'sha256-dWTP4Di8KBjaiXvQ5mRquI9OoBSo921ahYxLfYSiuT8='; connect-src 'self';
 -->
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <!-- The following two scripts contain two separate code points (U+00C5
-        and U+212B, respectively) which, depending on your text editor, might be
-        rendered the same. However, their difference is important as they should
-        be NFC normalized to the same code point, thus they should hash to the
-        same value.-->
-    <script>
-        'Å';
-        alert_assert('PASS');
-
-    </script>
-    <script>
-        'Å';
-        alert_assert('PASS');
-
-    </script>
 </head>
 
 <body>
+    <!-- The following two scripts contain two separate code points (U+00C5
+        and U+212B, respectively) which, depending on your text editor, might be
+        rendered the same.However, their difference is important because, under
+        NFC normalization, they would become the same code point, which would be
+        against the spec. This test, therefore, validates that the scripts have
+        *different* hash values. -->
+    <script nonce="nonceynonce">
+      var matchingContent = 'Å';
+      var nonMatchingContent = 'Å';
+
+      // This script should have a hash value of
+      // sha256-9UFeeZbvnMa0tLNu76v96T4Hh+UtDWHm2lPQJoTWb9c=
+      var scriptContent1 = "window.finish('" + matchingContent + "');";
+
+      // This script should have a hash value of
+      // sha256-iNjjXUXds31FFvkAmbC74Sxnvreug3PzGtu16udQyqM=
+      var scriptContent2 = "window.finish('" + nonMatchingContent + "');";
+
+      var script1 = document.createElement('script');
+      script1.innerHTML = scriptContent1;
+      var script2 = document.createElement('script');
+      script2.innerHTML = scriptContent2;
+
+      script1.test = async_test("Inline script with hash in CSP");
+      script2.test = async_test("Inline script without hash in CSP");
+
+      var failure = function() {
+        assert_unreached();
+      }
+
+      window.finish = function(content) {
+        if (content == matchingContent) {
+          script1.test.step(function() {
+            script1.test.done();
+          });
+        } else {
+          assert_unreached();
+        }
+      }
+
+      script1.onerror = failure;
+      script2.onerror = script2.test.step_func(function() {
+        script2.test.done();
+      });
+      document.body.appendChild(script1);
+      document.body.appendChild(script2);
+    </script>
+
     <p>
         This tests Unicode normalization. While appearing the same, the strings in the scripts are different Unicode points, but through normalization, should be the same when the hash is taken.
     </p>
     <div id="log"></div>
-    <script async defer src="../support/checkReport.sub.js?reportExists=false"></script>
+    <script async defer src="../support/checkReport.sub.js?reportExists=true"></script>
 </body>
 
 </html>

--- a/content-security-policy/blink-contrib-2/scripthash-unicode-normalization.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/scripthash-unicode-normalization.sub.html.sub.headers
@@ -3,4 +3,4 @@ Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
 Set-Cookie: scripthash-unicode-normalization={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
-Content-Security-Policy: script-src 'self' 'sha256-xy4iRAvdlFCq+M5+4yu4B7dy0Kc2FfljmZO4Jkj3Yhw='; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}
+Content-Security-Policy: script-src 'self' 'nonce-nonceynonce' 'sha256-9UFeeZbvnMa0tLNu76v96T4Hh+UtDWHm2lPQJoTWb9c='; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
Previously, several user agents normalized NFC-equivalent code points to the same value before calculating digests. This, however, is actually not in the CSP spec, and thus this test was incorrect. As discussed on public-webappsec (https://lists.w3.org/Archives/Public/public-webappsec/2015Oct/0105.html), this update to the test verifies that for NFC-equivalent code points, normalization does _not_ occur.

cc @mikewest @hillbrad @annevk @fmarier @inexorabletash 
