### PR TITLE
SRI: Fix issue with ports 80 and 443 in 'use-credentials' tests.

### DIFF
--- a/subresource-integrity/crossorigin-creds-script.js.sub.headers
+++ b/subresource-integrity/crossorigin-creds-script.js.sub.headers
@@ -1,2 +1,2 @@
-Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}:{{ports[http][0]}}
+Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}{{GET[acao_port]}}
 Access-Control-Allow-Credentials: true

--- a/subresource-integrity/crossorigin-creds-style.css.sub.headers
+++ b/subresource-integrity/crossorigin-creds-style.css.sub.headers
@@ -1,2 +1,2 @@
-Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}:{{ports[http][0]}}
+Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}{{GET[acao_port]}}
 Access-Control-Allow-Credentials: true

--- a/subresource-integrity/subresource-integrity.sub.html
+++ b/subresource-integrity/subresource-integrity.sub.html
@@ -78,7 +78,6 @@
       + '//' + location.hostname + ':' + {{ports[http][1]}}
       + '/subresource-integrity/crossorigin-creds-style.css?acao_port='
       + response_port;
-    console.log("xorigin_creds_style = " + xorigin_creds_style);
 
     var xorigin_ineligible_style = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}

--- a/subresource-integrity/subresource-integrity.sub.html
+++ b/subresource-integrity/subresource-integrity.sub.html
@@ -8,6 +8,22 @@
 
 <div id="container"></div>
 <script>
+    // This horrible hack is needed for the 'use-credentials' tests because, on
+    // response, if port 80 or 443 is the current port, it will not appear to
+    // the browser as part of the origin string. Since the origin *string* is
+    // used for CORS access control, instead of the origin itself, if there
+    // isn't an exact string match, the check will fail. For example,
+    // "http://example.com" would not match "http://example.com:80", because
+    // they are not exact string matches, even though the origins are the same.
+    //
+    // Thus, we only want the Access-Control-Allow-Origin header to have
+    // the port if it's not port 80 or 443, since the user agent will elide the
+    // ports in those cases.
+    var default_port = "{{ports[http][0]}}";
+    var response_port = "";
+    if (default_port !== "80" && default_port !== "443")
+      response_port = ":" + default_port;
+
     // <script> tests
     var xorigin_anon_script = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
@@ -15,7 +31,8 @@
 
     var xorigin_creds_script = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
-      + '/subresource-integrity/crossorigin-creds-script.js';
+      + '/subresource-integrity/crossorigin-creds-script.js?acao_port='
+      + response_port;
 
     var xorigin_ineligible_script = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
@@ -51,17 +68,21 @@
         document.body.appendChild(e);
     };
 
+    // Note that all of these style URLs have query parameters started, so any
+    // additional parameters should be appended starting with '&'.
     var xorigin_anon_style = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
-      + '/subresource-integrity/crossorigin-anon-style.css';
+      + '/subresource-integrity/crossorigin-anon-style.css?';
 
     var xorigin_creds_style = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
-      + '/subresource-integrity/crossorigin-creds-style.css';
+      + '/subresource-integrity/crossorigin-creds-style.css?acao_port='
+      + response_port;
+    console.log("xorigin_creds_style = " + xorigin_creds_style);
 
     var xorigin_ineligible_style = location.protocol
       + '//' + location.hostname + ':' + {{ports[http][1]}}
-      + '/subresource-integrity/crossorigin-ineligible-style.css';
+      + '/subresource-integrity/crossorigin-ineligible-style.css?';
 
     // <link> tests
     // Style tests must be done synchronously because they rely on the presence
@@ -376,7 +397,7 @@
         true,
         "<crossorigin='anonymous'> with correct hash, ACAO: *",
         {
-            href: xorigin_anon_style + '?1',
+            href: xorigin_anon_style + '&1',
             integrity: "sha256-CzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk7gyCWUV4=",
             crossorigin: "anonymous"
         }
@@ -387,7 +408,7 @@
         false,
         "<crossorigin='anonymous'> with incorrect hash, ACAO: *",
         {
-            href: xorigin_anon_style + '?2',
+            href: xorigin_anon_style + '&2',
             integrity: "sha256-deadbeefCzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk=",
             crossorigin: "anonymous"
         }
@@ -398,7 +419,7 @@
         true,
         "<crossorigin='use-credentials'> with correct hash, CORS-eligible",
         {
-            href: xorigin_creds_style + '?1',
+            href: xorigin_creds_style + '&1',
             integrity: "sha256-CzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk7gyCWUV4=",
             crossorigin: "use-credentials"
         }
@@ -409,7 +430,7 @@
         false,
         "<crossorigin='use-credentials'> with incorrect hash CORS-eligible",
         {
-            href: xorigin_creds_style + '?2',
+            href: xorigin_creds_style + '&2',
             integrity: "sha256-deadbeefCzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk=",
             crossorigin: "use-credentials"
         }
@@ -420,7 +441,7 @@
         false,
         "<crossorigin='anonymous'> with CORS-ineligible resource",
         {
-            href: xorigin_ineligible_style + '?1',
+            href: xorigin_ineligible_style + '&1',
             integrity: "sha256-CzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk7gyCWUV4=",
             crossorigin: "anonymous"
         }
@@ -431,7 +452,7 @@
         false,
         "Cross-origin, not CORS request, with correct hash",
         {
-            href: xorigin_anon_style + '?3',
+            href: xorigin_anon_style + '&3',
             integrity: "sha256-CzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk7gyCWUV4="
         }
     );
@@ -441,7 +462,7 @@
         false,
         "Cross-origin, not CORS request, with hash mismatch",
         {
-            href: xorigin_anon_style + '?4',
+            href: xorigin_anon_style + '&4',
             integrity: "sha256-deadbeefCzHgdJ7wOccM8L89n4bhcJMz3F+SPLT7YZk="
         }
     );
@@ -451,7 +472,7 @@
         true,
         "Cross-origin, empty integrity",
         {
-            href: xorigin_anon_style + '?5',
+            href: xorigin_anon_style + '&5',
             integrity: ""
         }
     );


### PR DESCRIPTION
This was an issue that @fmarier pointed out to where our 'use-credentials' tests are failing if wpt-serve is run on port 80 or 443. Bbecause CORS checks for an exact string match with Access-Control-Allow-Origin, not an _origin_ match, our test was failing because it was appending the literal :80 or :443. For example, the response would be `Access-Control-Allow-Origin: http://web-platform.test:80`, which would fail because user agents would compare this to the requesting origin string of `http://web-platform.test`. 

This pull request addresses this by passing in the expected literal port, an empty string in the case of ports 80 and 443. It's an ugly hack... but it works.

cc @mikewest @hillbrad 
