### PR TITLE
Added constructor tests for Touch and TouchEvent

### DIFF
--- a/touch-events/create-touch-touchlist.html
+++ b/touch-events/create-touch-touchlist.html
@@ -1,185 +1,50 @@
 <!DOCTYPE HTML>
 <html>
-<!--
-    Test cases for Touch Events v1 Recommendation
-    http://www.w3.org/TR/touch-events/
-
-    These tests are based on Mozilla-Nokia-Google's single-touch tests.
-
-    The primary purpose of the tests in this document is checking that the createTouch and
-    createTouchList interfaces of the Touch Events APIs are correctly implemented.
-    Other interactions are covered in other test files.
-
-    This document references Test Assertions (abbrev TA below) written by Cathy Chan
-    http://www.w3.org/2010/webevents/wiki/TestAssertions
--->
-
 <head>
-<title>Touch Events createTouch and createTouchList Interface Tests</title>
-<meta name="viewport" content="width=device-width">
+<title>document.createTouch and document.createTouchList Tests</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="touch-support.js"></script>
+<body>
+<div id="target0"></div>
 <script>
-        setup({explicit_done: true});
+test(function() {
+    var testTarget = document.getElementById('target0');
+    var touch1 = document.createTouch(window, testTarget, 42, 15, 20, 35, 40);
+    assert_equals(touch1.target, testTarget, "touch.target is target0");
+    assert_equals(touch1.identifier, 42, "touch.identifier is requested value");
+    assert_equals(touch1.pageX, 15, "touch.pageX is requested value");
+    assert_equals(touch1.pageY, 20, "touch.pageY is requested value");
+    assert_equals(touch1.screenX, 35, "touch.screenX is requested value");
+    assert_equals(touch1.screenY, 40, "touch.screenY is requested value");
+}, "document.createTouch exists and creates a Touch object with requested properties");
 
-        // Check a Touch object's atttributes for existence and correct type
-        // TA: 1.1.2, 1.1.3
-        function check_Touch_object (t) {
-                test(function() {
-                        assert_equals(Object.prototype.toString.call(t), "[object Touch]", "touch is of type Touch");
-                }, "touch point is a Touch object");
-                [
-                        ["long", "identifier"],
-                        ["EventTarget", "target"],
-                        ["long", "screenX"],
-                        ["long", "screenY"],
-                        ["long", "clientX"],
-                        ["long", "clientY"],
-                        ["long", "pageX"],
-                        ["long", "pageY"],
-                ].forEach(function(attr) {
-                        var type = attr[0];
-                        var name = attr[1];
+test(function() {
+    var touchList = document.createTouchList();
+    assert_equals(touchList.length, 0, "touchList.length is 0");
+    check_TouchList_object(touchList);
+}, "document.createTouchList exists and correctly creates a TouchList from zero Touch objects");
 
-                        // existence check
-                        test(function() {
-                                assert_true(name in t, name + " attribute in Touch object");
-                        }, "Touch." + name + " attribute exists");
+test(function() {
+    var testTarget = document.getElementById('target0');
+    var touch1 = document.createTouch(window, testTarget, 42, 15, 20, 35, 40);
+    var touchList = document.createTouchList(touch1);
+    assert_equals(touchList.length, 1, "touchList.length is 1");
+    assert_equals(touchList.item(0), touch1, "touchList.item(0) is touch1");
+    check_TouchList_object(touchList);
+}, "document.createTouchList exists and correctly creates a TouchList from a single Touch");
 
-                        // type check
-                        switch(type) {
-                        case "long":
-                                test(function() {
-                                        assert_equals(typeof t[name], "number", name + " attribute of type long");
-                                }, "Touch." + name + " attribute is of type number (long)");
-                                break;
-                        case "EventTarget":
-                                // An event target is some type of Element
-                                test(function() {
-                                        assert_true(t[name] instanceof Element, "EventTarget must be an Element.");
-                                }, "Touch." + name + " attribute is of type Element");
-                                break;
-                        default:
-                                break;
-                        }
-                });
-        }
-
-        // Check a TouchList object's attributes and methods for existence and proper type
-        // Also make sure all of the members of the list are Touch objects
-        // TA: 1.2.1, 1.2.2, 1.2.5, 1.2.6
-        function check_TouchList_object (tl) {
-                test(function() {
-                        assert_equals(Object.prototype.toString.call(tl), "[object TouchList]", "touch list is of type TouchList");
-                }, "touch list is a TouchList object");
-                [
-                        ["unsigned long", "length"],
-                        ["function", "item"],
-                ].forEach(function(attr) {
-                        var type = attr[0];
-                        var name = attr[1];
-
-                        // existence check
-                        test(function() {
-                                assert_true(name in tl, name + " attribute in TouchList");
-                        }, "TouchList." + name + " attribute exists");
-
-                        // type check
-                        switch(type) {
-                        case "unsigned long":
-                                test(function() {
-                                        assert_equals(typeof tl[name], "number", name + " attribute of type long");
-                                }, "TouchList." + name + " attribute is of type number (unsigned long)");
-                                break;
-                        case "function":
-                                test(function() {
-                                        assert_equals(typeof tl[name], "function", name + " attribute of type function");
-                                }, "TouchList." + name + " attribute is of type function");
-                                break;
-                        default:
-                                break;
-                        }
-                });
-                // Each member of tl should be a proper Touch object
-                for (var i=0; i < tl.length; i++) {
-                        check_Touch_object(tl.item(i));
-                }
-                // TouchList.item(x) should return null if x is >= TouchList.length
-                test(function() {
-                        var t = tl.item(tl.length);
-                        assert_equals(t, null, "TouchList.item(TouchList.length) must return null");
-                }, "TouchList.item returns null if the index is >= the length of the list");
-        }
-
-    function check_touch_clientXY(touch) {
-                assert_equals(touch.clientX, touch.pageX - window.pageXOffset, "touch.clientX is touch.pageX - window.pageXOffset.");
-                assert_equals(touch.clientY, touch.pageY - window.pageYOffset, "touch.clientY is touch.pageY - window.pageYOffset.");
-    }
-
-        function run() {
-                var target0 = document.getElementById("target0");
-                var touch1, touch2;
-
-                test(function() {
-                        touch1 = document.createTouch(window, target0, 42, 15, 20, 35, 40);
-                        assert_equals(touch1.target, target0, "touch.target is target0");
-                        assert_equals(touch1.identifier, 42, "touch.identifier is requested value");
-                        assert_equals(touch1.pageX, 15, "touch.pageX is requested value");
-                        assert_equals(touch1.pageY, 20, "touch.pageY is requested value");
-                        check_touch_clientXY(touch1);
-                        assert_equals(touch1.screenX, 35, "touch.screenX is requested value");
-                        assert_equals(touch1.screenY, 40, "touch.screenY is requested value");
-                }, "document.createTouch exists and creates a Touch object with requested properties");
-
-                touch2 = document.createTouch(window, target0, 44, 25, 30, 45, 50);
-
-                var touchList;
-
-                test(function() {
-                        touchList = document.createTouchList();
-                        assert_equals(touchList.length, 0, "touchList.length is 0");
-                }, "document.createTouchList exists and correctly creates a TouchList from zero Touch objects");
-
-                if (touchList)
-                        check_TouchList_object(touchList);
-
-                test(function() {
-                        touchList = document.createTouchList(touch1);
-                        assert_equals(touchList.length, 1, "touchList.length is 1");
-                        assert_equals(touchList.item(0), touch1, "touchList.item(0) is input touch1");
-                }, "document.createTouchList exists and correctly creates a TouchList from a single Touch");
-
-                if (touchList)
-                        check_TouchList_object(touchList);
-
-                test(function() {
-                        touchList = document.createTouchList(touch1, touch2);
-                        assert_equals(touchList.length, 2, "touchList.length is 2");
-                        assert_equals(touchList.item(0), touch1, "touchList.item(0) is input touch1");
-                        assert_equals(touchList.item(1), touch2, "touchList.item(1) is input touch2");
-                }, "document.createTouchList exists and correctly creates a TouchList from two Touch objects");
-
-                if (touchList)
-                        check_TouchList_object(touchList);
-
-                target0.innerHTML = "Test complete."
-                done();
-        }
+test(function() {
+    var testTarget = document.getElementById('target0');
+    var touch1 = document.createTouch(window, testTarget, 42, 15, 20, 35, 40);
+    var touch2 = document.createTouch(window, target0, 44, 25, 30, 45, 50);
+    var touchList = document.createTouchList(touch1, touch2);
+    assert_equals(touchList.length, 2, "touchList.length is 2");
+    assert_equals(touchList.item(0), touch1, "touchList.item(0) is touch1");
+    assert_equals(touchList.item(1), touch2, "touchList.item(1) is touch2");
+    check_TouchList_object(touchList);
+}, "document.createTouchList exists and correctly creates a TouchList from two Touch objects");
 </script>
-<style>
-        div {
-                margin: 0em;
-                padding: 2em;
-        }
-    #target0 {
-                background: yellow;
-                border: 1px solid orange;
-    }
-</style>
 </head>
-<body onload="run()">
-        <h1>Touch Events: createTouch and createTouchList tests</h1>
-        <div id="target0">Please wait for test to complete...</div>
-        <div id="log"></div>
 </body>
 </html>

--- a/touch-events/touch-support.js
+++ b/touch-events/touch-support.js
@@ -1,0 +1,106 @@
+// Check a Touch object's attributes for existence and correct type
+// TA: 1.1.2, 1.1.3
+function check_Touch_object(t) {
+    assert_equals(Object.prototype.toString.call(t), "[object Touch]", "touch is of type Touch");
+    [
+        ["long", "identifier"],
+        ["EventTarget", "target"],
+        ["long", "screenX"],
+        ["long", "screenY"],
+        ["long", "clientX"],
+        ["long", "clientY"],
+        ["long", "pageX"],
+        ["long", "pageY"],
+        ["long", "radiusX"],
+        ["long", "radiusY"],
+        ["long", "rotationAngle"],
+        ["long", "force"],
+    ].forEach(function(attr) {
+        var type = attr[0];
+        var name = attr[1];
+
+        // existence check
+        assert_true(name in t, name + " attribute in Touch object");
+
+        // type check
+        switch (type) {
+            case "long":
+                assert_equals(typeof t[name], "number", name + " attribute of type long");
+                break;
+            case "EventTarget":
+                // An event target is some type of Element
+                assert_true(t[name] instanceof Element, "EventTarget must be an Element.");
+                break;
+            default:
+                break;
+        }
+    });
+}
+
+// Check a TouchList object's attributes and methods for existence and proper type
+// Also make sure all of the members of the list are Touch objects
+// TA: 1.2.1, 1.2.2, 1.2.5, 1.2.6
+function check_TouchList_object(tl) {
+    assert_equals(Object.prototype.toString.call(tl), "[object TouchList]", "touch list is of type TouchList");
+    [
+        ["unsigned long", "length"],
+        ["function", "item"],
+    ].forEach(function(attr) {
+        var type = attr[0];
+        var name = attr[1];
+
+        // existence check
+        assert_true(name in tl, name + " attribute in TouchList");
+
+        // type check
+        switch (type) {
+            case "unsigned long":
+                assert_equals(typeof tl[name], "number", name + " attribute of type long");
+                break;
+            case "function":
+                assert_equals(typeof tl[name], "function", name + " attribute of type function");
+                break;
+            default:
+                break;
+        }
+    });
+    // Each member of tl should be a proper Touch object
+    for (var i = 0; i < tl.length; i++) {
+        check_Touch_object(tl.item(i));
+    }
+    // TouchList.item(x) should return null if x is >= TouchList.length
+    var t = tl.item(tl.length);
+    assert_equals(t, null, "TouchList.item returns null if the index is >= the length of the list");
+}
+
+// Check a TouchEvent event's attributes for existence and proper type
+// Also check that each of the event's TouchList objects are valid
+// TA: 1.{3,4,5}.1.1, 1.{3,4,5}.1.2
+function check_TouchEvent(ev) {
+    assert_true(ev instanceof TouchEvent, ev.type + " event is a TouchEvent event");
+    [
+        ["TouchList", "touches"],
+        ["TouchList", "targetTouches"],
+        ["TouchList", "changedTouches"],
+        ["boolean", "altKey"],
+        ["boolean", "metaKey"],
+        ["boolean", "ctrlKey"],
+        ["boolean", "shiftKey"],
+    ].forEach(function(attr) {
+        var type = attr[0];
+        var name = attr[1];
+        // existence check
+        assert_true(name in ev, name + " attribute in " + ev.type + " event");
+        // type check
+        switch (type) {
+            case "boolean":
+                assert_equals(typeof ev[name], "boolean", name + " attribute of type boolean");
+                break;
+            case "TouchList":
+                assert_equals(Object.prototype.toString.call(ev[name]), "[object TouchList]", name + " attribute of type TouchList");
+                break;
+            default:
+                break;
+        }
+    });
+}

--- a/touch-events/touch-touchevent-constructor.html
+++ b/touch-events/touch-touchevent-constructor.html
@@ -1,0 +1,116 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Touch and TouchEvent Constructor Tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="touch-support.js"></script>
+</head>
+<body>
+<div id="target0"></div>
+<script>
+test(function() {
+    assert_throws(new TypeError(), function() {new Touch();}, "Touch constructor requires initialize dictionary");
+    assert_throws(new TypeError(), function() {new Touch({});}, "Touch constructor requires identifier and target");
+}, "Create a Touch object with insufficient properties");
+
+test(function() {
+    var testIdentifier = 74;
+    var testTarget = document.getElementById('target0');
+    var approxEpsilon = 0.00001;
+
+    var touch1 = new Touch({
+        identifier: testIdentifier,
+        target: testTarget,
+    });
+    check_Touch_object(touch1);
+    assert_equals(touch1.target, testTarget, "touch.target is requested value");
+    assert_equals(touch1.identifier, testIdentifier, "touch.identifier is requested value");
+    assert_approx_equals(touch1.pageX, 0, approxEpsilon, "touch.pageX is default value");
+    assert_approx_equals(touch1.pageY, 0, approxEpsilon, "touch.pageY is default value");
+    assert_approx_equals(touch1.screenX, 0, approxEpsilon, "touch.screenX is default value");
+    assert_approx_equals(touch1.screenY, 0, approxEpsilon, "touch.screenY is default value");
+    assert_approx_equals(touch1.clientX, 0, approxEpsilon, "touch.clientX is default value.");
+    assert_approx_equals(touch1.clientY, 0, approxEpsilon, "touch.clientY is default value.");
+}, "Touch constructor exists and creates a Touch object with minimum properties");
+
+test(function() {
+    var testIdentifier = 42;
+    var testTarget = document.getElementById('target0');
+    var testPageX = 15;
+    var testPageY = 20.2;
+    var testScreenX = 35.34;
+    var testScreenY = 40.56;
+    var testClientX = 10.175;
+    var testClientY = 5;
+    var approxEpsilon = 0.00001;
+
+    var touch1 = new Touch({
+        identifier: testIdentifier,
+        target: testTarget,
+        pageX: testPageX,
+        pageY: testPageY,
+        screenX: testScreenX,
+        screenY: testScreenY,
+        clientX: testClientX,
+        clientY: testClientY,
+    });
+    check_Touch_object(touch1);
+    assert_equals(touch1.identifier, testIdentifier, "touch.identifier is requested value");
+    assert_equals(touch1.target, testTarget, "touch.target is requested value");
+    assert_approx_equals(touch1.pageX, testPageX, approxEpsilon, "touch.pageX is requested value");
+    assert_approx_equals(touch1.pageY, testPageY, approxEpsilon, "touch.pageY is requested value");
+    assert_approx_equals(touch1.screenX, testScreenX, approxEpsilon, "touch.screenX is requested value");
+    assert_approx_equals(touch1.screenY, testScreenY, approxEpsilon, "touch.screenY is requested value");
+    assert_approx_equals(touch1.clientX, testClientX, approxEpsilon, "touch.clientX is requested value.");
+    assert_approx_equals(touch1.clientY, testClientY, approxEpsilon, "touch.clientY is requested value.");
+}, "Touch constructor exists and creates a Touch object with requested properties");
+
+
+test(function() {
+    var testTarget = document.getElementById('target0');
+
+    var touch1 = new Touch({
+        identifier: 45,
+        target: testTarget,
+        pageX: 45,
+        pageY: 50,
+        screenX: 65,
+        screenY: 60,
+        clientX: 70,
+        clientY: 75,
+    });
+    var touch2 = new Touch({
+        identifier: 52,
+        target: testTarget,
+        pageX: 15,
+        pageY: 20,
+        screenX: 15,
+        screenY: 20,
+        clientX: 15,
+        clientY: 20,
+    });
+
+    var touchEvent1 = new TouchEvent("ontouchstart", {
+        touches: [touch1, touch2],
+        targetTouches: [touch1],
+        altKey: true,
+        metaKey: false,
+    });
+
+    check_TouchEvent(touchEvent1);
+    assert_equals(touchEvent1.type, "ontouchstart", "touchEvent.type is requested value");
+    assert_equals(touchEvent1.touches.length, 2, "touchEvent.touches.length is requested value");
+    assert_equals(touchEvent1.touches[0], touch1, "touchEvent.touches[0] is requested value");
+    assert_equals(touchEvent1.touches[1], touch2, "touchEvent.touches[1] is requested value");
+    assert_equals(touchEvent1.targetTouches.length, 1, "touchEvent.targetTouches.length is requested value");
+    assert_equals(touchEvent1.targetTouches[0], touch1, "touchEvent.targetTouches[0] is requested value");
+    assert_equals(touchEvent1.changedTouches.length, 0, "touchEvent.changedTouches.length is requested value");
+    assert_equals(touchEvent1.altKey, true, "touchEvent.altKey is requested value");
+    assert_equals(touchEvent1.metaKey, false, "touchEvent.metaKey is requested value");
+    assert_equals(touchEvent1.ctrlKey, false, "touchEvent.ctrlKey is requested value");
+    assert_equals(touchEvent1.shiftKey, false, "touchEvent.shiftKey is requested value.");
+}, "TouchEvent constructor exists and creates a TouchEvent object with requested properties");
+</script>
+</body>
+</html>


### PR DESCRIPTION
@RByers Added constructor tests for Touch and TouchEvent based on [Touch Events v2 - Touch Interface](https://w3c.github.io/touch-events/#touch-interface) and [Touch Events v2 - TouchEvent Interface](https://w3c.github.io/touch-events/#touchevent-interface)

Browser support:
Chrome Canary: Yes
Firefox, Safari, Edge: Not yet

Issue tracking: https://github.com/w3c/touch-events/issues/27

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/2299)

<!-- Reviewable:end -->
