### PR TITLE
Changed SRI crossorigin tests to use www domain rather than ports.

### DIFF
--- a/subresource-integrity/crossorigin-creds-script.js.sub.headers
+++ b/subresource-integrity/crossorigin-creds-script.js.sub.headers
@@ -1,2 +1,2 @@
-Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}{{GET[acao_port]}}
+Access-Control-Allow-Origin: {{location[scheme]}}://{{domains[]}}{{GET[acao_port]}}
 Access-Control-Allow-Credentials: true

--- a/subresource-integrity/crossorigin-creds-style.css.sub.headers
+++ b/subresource-integrity/crossorigin-creds-style.css.sub.headers
@@ -1,2 +1,2 @@
-Access-Control-Allow-Origin: {{location[scheme]}}://{{location[hostname]}}{{GET[acao_port]}}
+Access-Control-Allow-Origin: {{location[scheme]}}://{{domains[]}}{{GET[acao_port]}}
 Access-Control-Allow-Credentials: true

--- a/subresource-integrity/subresource-integrity.sub.html
+++ b/subresource-integrity/subresource-integrity.sub.html
@@ -21,8 +21,6 @@
     // ports in those cases.
     var main_domain = "{{domains[]}}";
     var www_domain = "{{domains[www]}}";
-    console.log(main_domain);
-    console.log(www_domain);
     var default_port = "{{ports[http][0]}}";
     if (location.protocol === "https:") {
       default_port = "{{ports[https][0]}}";

--- a/subresource-integrity/subresource-integrity.sub.html
+++ b/subresource-integrity/subresource-integrity.sub.html
@@ -19,23 +19,33 @@
     // Thus, we only want the Access-Control-Allow-Origin header to have
     // the port if it's not port 80 or 443, since the user agent will elide the
     // ports in those cases.
+    var main_domain = "{{domains[]}}";
+    var www_domain = "{{domains[www]}}";
+    console.log(main_domain);
+    console.log(www_domain);
     var default_port = "{{ports[http][0]}}";
-    var response_port = "";
+    if (location.protocol === "https:") {
+      default_port = "{{ports[https][0]}}";
+    }
+
+    var port_string = "";
     if (default_port !== "80" && default_port !== "443")
-      response_port = ":" + default_port;
+      port_string = ":" + default_port;
+
+    www_host_and_port = www_domain + port_string;
 
     // <script> tests
     var xorigin_anon_script = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-anon-script.js';
 
     var xorigin_creds_script = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-creds-script.js?acao_port='
-      + response_port;
+      + port_string;
 
     var xorigin_ineligible_script = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-ineligible-script.js';
 
     var SRIScriptTest = function(pass, name, src, integrityValue, crossoriginValue) {
@@ -71,16 +81,16 @@
     // Note that all of these style URLs have query parameters started, so any
     // additional parameters should be appended starting with '&'.
     var xorigin_anon_style = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-anon-style.css?';
 
     var xorigin_creds_style = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-creds-style.css?acao_port='
-      + response_port;
+      + port_string;
 
     var xorigin_ineligible_style = location.protocol
-      + '//' + location.hostname + ':' + {{ports[http][1]}}
+      + '//' + www_host_and_port
       + '/subresource-integrity/crossorigin-ineligible-style.css?';
 
     // <link> tests


### PR DESCRIPTION
The use of ports for crossdomain tests was causing problems if you wanted to run the tests on HTTPS. This reworks the tests to use the www subdomain for crossorigin tests instead.

cc @hillbrad @devd @fmarier @mozfreddyb
