### PR TITLE
Validate capture target authenticity

### DIFF
--- a/pointerevents/pointerevent_capture_suppressing_mouse-manual.html
+++ b/pointerevents/pointerevent_capture_suppressing_mouse-manual.html
@@ -34,6 +34,7 @@
         <script type='text/javascript'>
             var isPointerCapture = false;
             var isRelatedTargetValueTested = false;
+            var isTargetAuthenticityTested = false;
             var count = 0;
 
             var detected_pointertypes = {};
@@ -91,6 +92,13 @@
                                 assert_true(event.relatedTarget==null, "relatedTarget is null when the capture is set")
                             }, "relatedTarget is null when the capture is set. relatedTarget is " + event.relatedTarget);
                             isRelatedTargetValueTested = true;
+                        }
+                        var hitTest = document.elementFromPoint(event.clientX, event.clientY);
+                        if(event.target !== hitTest && !isTargetAuthenticityTested) {
+                            test(function () {
+                                assert_unreached("pointerover for this target shouldn't trigger events on capture target");
+                            }, "pointerover should only trigger over the black rectangle");
+                            isTargetAuthenticityTested = true;
                         }
                     }
                     else {


### PR DESCRIPTION
This PR adds a test guaranteeing that during a pointerevents capture the capturing element receives `pointerover` events only when the pointer is actually above the element.

In jquery/PEP#177 it was discovered that `pointerover`,`pointerout`,`pointerenter` and `pointerleave` events of non-capturing elements were not suppressed, but redirected to the capturing element.

The PR implicitly expands on step 6 of the test, making sure that to neither the black nor the purple rectangle anything happens in this step.

>  Put your mouse over the purple rectangle and then move it out. Nothing should happen
