### PR TITLE
Give HTMLBodyElement event handler tests descriptions

### DIFF
--- a/html/webappapis/scripting/events/event-handler-attributes-body-window.html
+++ b/html/webappapis/scripting/events/event-handler-attributes-body-window.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<title>HTMLBodyElement.onblur</title>
+<title>HTMLBodyElement event handlers</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -18,7 +18,7 @@ handlers.forEach(function(handler) {
   test(function() {
     document.body['on' + handler] = f;
     assert_equals(window['on' + handler], f);
-  });
+  }, handler);
 });
 
 </script>


### PR DESCRIPTION
The tests were given no descriptions, and ended up with very
useful failure reports such as "onblur 1", "onblur 2" etc.
Just use the handler name as the description, and fix the test
title.
