### PR TITLE
Make tests for [before]unload events in window.close not depend on timers,

### DIFF
--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_beforeunload-1.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_beforeunload-1.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <script>
+onload = function() {opener.postMessage("loaded", "*")};
 onbeforeunload = function() {
   opener.callback();
 }

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_beforeunload.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_beforeunload.html
@@ -6,8 +6,11 @@
 <script>
 var t = async_test();
 var w = window.open("close_beforeunload-1.html");
-setTimeout(function() {
+onmessage = t.step_func(function(event) {
+  if (event.data != "loaded") {
+    return;
+  }
   w.close();
-}, 1000);
+});
 callback = function() {t.done()}
 </script>

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_unload-1.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_unload-1.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <script>
+onload = function() {opener.postMessage("loaded", "*")};
 onunload = function() {
   opener.callback();
 }

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_unload.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/close_unload.html
@@ -6,8 +6,11 @@
 <script>
 var t = async_test();
 var w = window.open("close_unload-1.html");
-setTimeout(function() {
+onmessage = t.step_func(function(event) {
+  if (event.data != "loaded") {
+    return;
+  }
   w.close();
-}, 1000);
+});
 callback = function() {t.done()}
 </script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1215800
