### PR TITLE
Wait for at least one close event to fire before ending close-multiple test, to prevent instability,

### DIFF
--- a/websockets/interfaces/WebSocket/close/close-multiple.html
+++ b/websockets/interfaces/WebSocket/close/close-multiple.html
@@ -14,9 +14,13 @@ async_test(function(t) {
   ws.close();
   ws.close();
   ws.close();
-  setTimeout(t.step_func(function() {
+  var f = t.step_func(function() {
+    if (i < 1) {
+      setTimeout(f, 500);
+    }
     assert_equals(i, 1);
     t.done()
-  }), 50);
+  });
+  setTimeout(f, 500);
 });
 </script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1213121
