### PR TITLE
fixup! Wait for at least one close event to fire before ending close-multiple test, to prevent instability, rs=Ms2ger

### DIFF
--- a/websockets/interfaces/WebSocket/close/close-multiple.html
+++ b/websockets/interfaces/WebSocket/close/close-multiple.html
@@ -17,6 +17,7 @@ async_test(function(t) {
   var f = t.step_func(function() {
     if (i < 1) {
       setTimeout(f, 500);
+      return;
     }
     assert_equals(i, 1);
     t.done()


### PR DESCRIPTION
Missing a return.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1213121
