### PR TITLE
explicitly whitelisting git submodules that are not currently scanned

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -109,3 +109,7 @@ PARSE-FAILED:content-security-policy/svg/including.sub.svg
 #Helper files that aren't valid XML
 PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/empty.xml
 PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/minimal_html.xml
+
+# Git submodules are not currently scanned
+*:tools/*
+*:resources/*


### PR DESCRIPTION
Adding these submodules to the whitelist for now, as per this conversation https://github.com/servo/servo/issues/8285
