### PR TITLE
Basic tests for ignoring 'secure' cookies

### DIFF
--- a/cookies/resources/echo-json.py
+++ b/cookies/resources/echo-json.py
@@ -1,0 +1,15 @@
+import json
+
+def main(request, response):
+    headers = [("Content-Type", "application/json"),
+               ("Access-Control-Allow-Credentials", "true")]
+
+    if "origin" in request.headers:
+        headers.append(("Access-Control-Allow-Origin", request.headers["origin"]))
+
+    values = []
+    for key in request.cookies:
+        for value in request.cookies.get_list(key):
+            values.append("\"%s\": \"%s\"" % (key, value))
+    body = "{ %s }" % ",".join(values)
+    return headers, body

--- a/cookies/resources/testharness-helpers.js
+++ b/cookies/resources/testharness-helpers.js
@@ -1,0 +1,49 @@
+// Given an array of potentially asynchronous tests, this function will execute
+// each in serial, ensuring that one and only one test is executing at a time.
+//
+// The test array should look like this:
+//
+//
+//     var tests = [
+//       [
+//         "Test description goes here.",
+//         function () {
+//           // Test code goes here. `this` is bound to the test object.
+//         }
+//       ],
+//       ...
+//     ];
+//
+// The |setup| and |teardown| arguments are functions which are executed before
+// and after each test, respectively.
+function executeTestsSerially(testList, setup, teardown) {
+  var tests = testList.map(function (t) {
+    return {
+      test: async_test(t[0]),
+      code: t[1]
+    };
+  });
+
+  var executeNextTest = function () {
+    var current = tests.shift();
+    if (current === undefined) {
+      return;
+    }
+
+    // Setup the test fixtures.
+    if (setup) {
+      setup();
+    }
+
+    // Bind a callback to tear down the test fixtures.
+    if (teardown) {
+      current.test.add_cleanup(teardown);
+    }
+
+    // Execute the test.
+    current.test.step(current.code);
+  };
+
+  add_result_callback(function () { setTimeout(executeNextTest, 0) });
+  executeNextTest();
+}

--- a/cookies/secure/set-from-dom.https.sub.html
+++ b/cookies/secure/set-from-dom.https.sub.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `document.cookie` on a secure page</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  var tests = [
+    [
+      "'secure' cookie visible in `document.cookie`",
+      function () {
+        document.cookie = "secure_from_secure_dom=1; secure; path=/";
+        assert_not_equals(document.cookie.match(/secure_from_secure_dom=1/), null);
+        this.done();
+      }
+    ],
+    [
+      "'secure' cookie visible in HTTP request",
+      function () {
+        document.cookie = "secure_from_secure_dom=1; secure; path=/";
+        assert_not_equals(document.cookie.match(/secure_from_secure_dom=1/), null);
+        fetch("https://{{host}}:{{ports[https][0]}}/cookies/resources/echo-json.py",
+              { "credentials": "include" })
+          .then(this.step_func(function (r) {
+            return r.json();
+          }))
+          .then(this.step_func_done(function (j) {
+            assert_equals(j["secure_from_secure_dom"], "secure_from_secure_dom=1");
+          }));
+      }
+    ]
+  ];
+
+  function clearKnownCookie() {
+    document.cookie = "secure_from_secure_dom=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  executeTestsSerially(tests, clearKnownCookie, clearKnownCookie);
+</script>
+</body>
+</html>

--- a/cookies/secure/set-from-dom.sub.html
+++ b/cookies/secure/set-from-dom.sub.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `document.cookie` on a non-secure page</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  var tests = [
+    [
+      "'secure' cookie not set in `document.cookie`",
+      function () {
+        var originalCookie = document.cookie;
+        document.cookie = "secure_from_nonsecure_dom=1; secure; path=/";
+        assert_equals(document.cookie, originalCookie);
+        this.done();
+      }
+    ],
+    [
+      "'secure' cookie not sent in HTTP request",
+      function () {
+        document.cookie = "secure_from_nonsecure_dom=1; secure; path=/";
+        fetch("https://{{host}}:{{ports[https][0]}}/cookies/resources/echo-json.py", { "credentials": "include" })
+          .then(this.step_func(function (r) {
+              return r.json();
+          }))
+          .then(this.step_func_done(function (j) {
+              assert_equals(j["secure_from_nonsecure_dom"], undefined);
+          }));
+      }
+    ]
+  ];
+
+  function clearKnownCookie() {
+    document.cookie = "secure_from_nonsecure_dom=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  executeTestsSerially(tests, clearKnownCookie, clearKnownCookie);
+</script>
+</body>
+</html>
+

--- a/cookies/secure/set-from-http.https.sub.html
+++ b/cookies/secure/set-from-http.https.sub.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `Set-Cookie` HTTP header on a secure page</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  function clearKnownCookie() {
+    document.cookie = "secure_from_secure_http=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  test(function () {
+    assert_not_equals(document.cookie.match(/secure_from_secure_http=1/), null);
+  }, "'secure' cookie present in `document.cookie`");
+
+  promise_test(function (t) {
+    t.add_cleanup(clearKnownCookie);
+    return fetch("https://{{host}}:{{ports[https][0]}}/cookies/resources/echo-json.py",
+                 { "credentials": "include" })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (j) {
+        assert_equals(j["secure_from_secure_http"], "secure_from_secure_http=1");
+      });
+  }, "'secure' cookie sent in HTTP request");
+</script>
+</body>
+</html>
+

--- a/cookies/secure/set-from-http.https.sub.html.headers
+++ b/cookies/secure/set-from-http.https.sub.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: secure_from_secure_http=1; Secure; Path=/

--- a/cookies/secure/set-from-http.sub.html
+++ b/cookies/secure/set-from-http.sub.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `Set-Cookie` HTTP header on a non-secure page</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  function clearKnownCookie() {
+    document.cookie = "secure_from_nonsecure_http=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  test(function () {
+    assert_equals(document.cookie.match(/secure_from_nonsecure_http=1/), null);
+  }, "'secure' cookie not present in `document.cookie`");
+
+  promise_test(function (t) {
+    t.add_cleanup(clearKnownCookie);
+    return fetch("https://{{host}}:{{ports[https][0]}}/cookies/resources/echo-json.py",
+                 { "credentials": "include" })
+      .then(function (r) {
+        return r.json();
+      })
+      .then(function (j) {
+        assert_equals(j["secure_from_nonsecure_http"], undefined);
+      });
+  }, "'secure' cookie not sent in HTTP request");
+</script>
+</body>
+</html>
+

--- a/cookies/secure/set-from-http.sub.html.headers
+++ b/cookies/secure/set-from-http.sub.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: secure_from_nonsecure_http=1; Secure; Path=/

--- a/cookies/secure/set-from-ws.https.sub.html
+++ b/cookies/secure/set-from-ws.https.sub.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `Set-Cookie` HTTP header on a non-secure WebSocket</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  function clearKnownCookie() {
+    document.cookie = "ws_test_secure_from_nonsecure=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  async_test(function (t) {
+    t.add_cleanup(clearKnownCookie);
+    assert_equals(document.cookie.match(/ws_test_secure_from_nonsecure=/), null);
+
+    clearKnownCookie();
+    var ws = new WebSocket("ws://{{host}}:{{ports[ws][0]}}/set-cookie-secure?secure_from_nonsecure");
+    ws.onclose = t.step_func_done(function () {
+      assert_unreached("'close' should not fire before 'open'.");
+    });
+    ws.onopen = t.step_func(function (e) {
+      ws.onclose = null;
+      ws.close();
+      assert_false(/ws_test_secure_from_nonsecure=test/.test(document.cookie));
+
+      var ws2 = new WebSocket("wss://{{host}}:{{ports[wss][0]}}/echo-cookie");
+      ws2.onclose = t.step_func_done(function () {
+        assert_unreached("'close' should not fire before 'open'.");
+      });
+      ws2.onmessage = t.step_func_done(function (e) {
+        ws2.onclose = null;
+        ws2.close();
+        assert_false(/ws_test_secure_from_nonsecure=test/.test(e.data));
+      });
+    });
+  }, "'secure' cookie not sent in WSS request when set from WS");
+</script>
+</body>
+</html>

--- a/cookies/secure/set-from-wss.https.sub.html
+++ b/cookies/secure/set-from-wss.https.sub.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset=utf-8>
+  <title>Set 'secure' cookie from `Set-Cookie` HTTP header on a secure WebSocket</title>
+  <meta name=help href="https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/cookies/resources/testharness-helpers.js"></script>
+</head>
+<body>
+<div id=log></div>
+<script>
+  function clearKnownCookie() {
+    document.cookie = "ws_test_secure_from_secure=0; Secure; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/";
+  }
+
+  async_test(function (t) {
+    t.add_cleanup(clearKnownCookie);
+    assert_equals(document.cookie.match(/ws_test_secure_from_secure=/), null);
+
+    clearKnownCookie();
+    var ws = new WebSocket("wss://{{host}}:{{ports[wss][0]}}/set-cookie-secure?secure_from_secure");
+    ws.onclose = t.step_func_done(function () {
+      assert_unreached("'close' should not fire before 'open'.");
+    });
+    ws.onopen = t.step_func(function (e) {
+      ws.onclose = null;
+      ws.close();
+      assert_regexp_match(document.cookie, /ws_test_secure_from_secure=test/);
+      var ws2 = new WebSocket("wss://{{host}}:{{ports[wss][0]}}/echo-cookie");
+      ws2.onclose = t.step_func_done(function () {
+        assert_unreached("'close' should not fire before 'open'.");
+      });
+      ws2.onmessage = t.step_func_done(function (e) {
+        ws2.onclose = null;
+        ws2.close();
+        assert_regexp_match(e.data, /ws_test_secure_from_secure=test/);
+      });
+    });
+  }, "'secure' cookie not sent in HTTP request");
+</script>
+</body>
+</html>

--- a/websockets/handlers/set-cookie-secure_wsh.py
+++ b/websockets/handlers/set-cookie-secure_wsh.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+import urlparse
+
+from mod_pywebsocket import common, msgutil, util
+from mod_pywebsocket.handshake import hybi
+
+
+def web_socket_do_extra_handshake(request):
+    url_parts = urlparse.urlsplit(request.uri)
+    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASet-Cookie: ws_test_'+(url_parts.query or '')+'=test; Secure; Path=/\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
+    return
+
+def web_socket_transfer_data(request):
+    while True:
+        return


### PR DESCRIPTION
https://tools.ietf.org/html/draft-west-leave-secure-cookies-alone
defines some new behavior for cookies whose 'secure' flag is set. These
will be ignored completely when set from a non-secure page.

Currently, this behavior is only implemented behind a flag in Chrome,
but Firefox and Chrome stable are expected to shift to this behavior in
the relatively near future.
