### PR TITLE
Add a <div> to the multi-arg document.writeln test

### DIFF
--- a/html/dom/dynamic-markup-insertion/document-writeln/document.writeln-03.html
+++ b/html/dom/dynamic-markup-insertion/document-writeln/document.writeln-03.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#documents-in-the-dom">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
 <script>
 test(function() {
   var iframe = document.createElement("iframe");


### PR DESCRIPTION
This ensures that document.body is not null, which the test assumes.

With this change, the test passed in at least Firefox and Chrome.
