### PR TITLE
The named getter on document should not return images with an empty name.

### DIFF
--- a/html/dom/documents/dom-tree-accessors/nameditem-06.html
+++ b/html/dom/documents/dom-tree-accessors/nameditem-06.html
@@ -15,7 +15,7 @@
 <img id=test3>
 
 <img id=test4>
-<img id=test4>
+<img id=test4 name="">
 
 <img name=test5>
 <img id=test5>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1223523
