### PR TITLE
innerText for non-display:none elements with display:none ancestors should use textContent.

### DIFF
--- a/innerText/getter-tests.js
+++ b/innerText/getter-tests.js
@@ -72,6 +72,7 @@ testText("<div style='display:none'>abc", "abc", "display:none container");
 testText("<div style='display:none'>abc  def", "abc  def", "No whitespace compression in display:none container");
 testText("<div style='display:none'> abc def ", " abc def ", "No removal of leading/trailing whitespace in display:none container");
 testText("<div>123<span style='display:none'>abc", "123", "display:none child not rendered");
+testText("<div style='display:none'><span id='target'>abc", "abc", "display:none container with non-display-none target child");
 
 /**** display:contents ****/
 


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1226293
