### PR TITLE
Add subclassing support to Promise::Race.  r=baku,efaust

### DIFF
--- a/js/builtins/Promise-subclassing.html
+++ b/js/builtins/Promise-subclassing.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+
+var theLog = [];
+var speciesGets = 0;
+var speciesCalls = 0;
+var constructorCalls = 0;
+var resolveCalls = 0;
+var rejectCalls = 0;
+var thenCalls = 0;
+var catchCalls = 0;
+var allCalls = 0;
+var raceCalls = 0;
+var nextCalls = 0;
+
+function takeLog() {
+  var oldLog = theLog;
+  theLog = [];
+  speciesGets = speciesCalls = constructorCalls = resolveCalls =
+    rejectCalls = thenCalls = catchCalls = allCalls = raceCalls =
+    nextCalls = 0;
+  return oldLog;
+}
+
+function clearLog() {
+  takeLog();
+}
+
+function log(str) {
+  theLog.push(str);
+}
+
+class LoggingPromise extends Promise {
+  constructor(func) {
+    super(func);
+    ++constructorCalls;
+    log(`Constructor ${constructorCalls}`);
+  }
+
+  static get [Symbol.species]() {
+    ++speciesGets;
+    log(`Species get ${speciesGets}`);
+    return LoggingSpecies;
+  }
+
+  static resolve(val) {
+    ++resolveCalls;
+    log(`Resolve ${resolveCalls}`);
+    return super.resolve(val);
+  }
+
+  static reject(val) {
+    ++rejectCalls;
+    log(`Reject ${rejectCalls}`);
+    return super.reject(val);
+  }
+
+  then(resolve, reject) {
+    ++thenCalls;
+    log(`Then ${thenCalls}`);
+    return super.then(resolve, reject);
+  }
+
+  catch(handler) {
+    ++catchCalls;
+    log(`Catch ${catchCalls}`);
+    return super.catch(handler);
+  }
+
+  static all(val) {
+    ++allCalls;
+    log(`All ${allCalls}`);
+    return super.all(val);
+  }
+
+  static race(val) {
+    ++raceCalls;
+    log(`Race ${raceCalls}`);
+    return super.race(val);
+  }
+}
+
+class LoggingIterable {
+  constructor(array) {
+    this.iter = array[Symbol.iterator]();
+  }
+
+  get [Symbol.iterator]() { return () => this }
+
+  next() {
+    ++nextCalls;
+    log(`Next ${nextCalls}`);
+    return this.iter.next();
+  }
+}
+
+class LoggingSpecies extends LoggingPromise {
+  constructor(func) {
+    ++speciesCalls;
+    log(`Species call ${speciesCalls}`);
+    super(func)
+  }
+}
+
+class SpeciesLessPromise extends LoggingPromise {
+  static get [Symbol.species]() {
+    return undefined;
+  }
+}
+
+promise_test(function testBasicConstructor() {
+  var p = new LoggingPromise((resolve) => resolve(5));
+  var log = takeLog();
+  assert_array_equals(log, ["Constructor 1"]);
+  assert_true(p instanceof LoggingPromise);
+  return p.then(function(arg) {
+    assert_equals(arg, 5);
+  });
+}, "Basic constructor behavior");
+
+promise_test(function testPromiseRace() {
+  clearLog();
+  var p = LoggingPromise.race(new LoggingIterable([1, 2]));
+  var log = takeLog();
+  assert_array_equals(log, ["Race 1", "Constructor 1",
+                            "Next 1", "Resolve 1",
+                            "Next 2", "Resolve 2",
+                            "Next 3"]);
+  assert_true(p instanceof LoggingPromise);
+  return p.then(function(arg) {
+    assert_true(arg == 1 || arg == 2);
+  });
+}, "Promise.race behavior");
+
+promise_test(function testPromiseRaceNoSpecies() {
+  clearLog();
+  var p = SpeciesLessPromise.race(new LoggingIterable([1, 2]));
+  var log = takeLog();
+  assert_array_equals(log, ["Race 1", "Constructor 1",
+                            "Next 1", "Resolve 1",
+                            "Next 2", "Resolve 2",
+                            "Next 3"]);
+  assert_true(p instanceof SpeciesLessPromise);
+  return p.then(function(arg) {
+    assert_true(arg == 1 || arg == 2);
+  });
+}, "Promise.race without species behavior");
+
+</script>


### PR DESCRIPTION
Note that the web platform tests don't actually have quite the behavior they're
expected to per the spec yet.  They will get adjusted later on as we add
subclassing support to Promise.resolve and Promise.prototype.then.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1170760
