### PR TITLE
Add subclassing support to Promise::Reject.  r=baku,efaust

### DIFF
--- a/js/builtins/Promise-subclassing.html
+++ b/js/builtins/Promise-subclassing.html
@@ -206,4 +206,15 @@ promise_test(function testPromiseResolve() {
   });
 }, "Promise.resolve behavior");
 
+promise_test(function testPromiseReject() {
+  clearLog();
+  var p = LoggingPromise.reject(5);
+  var log = takeLog();
+  assert_array_equals(log, ["Reject 1", "Constructor 1"]);
+
+  return p.catch(function(arg) {
+    assert_equals(arg, 5);
+  });
+}, "Promise.reject behavior");
+
 </script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1170760
