### PR TITLE
new tests for a redirect/fetch context bug

### DIFF
--- a/content-security-policy/media-src/media-src-redir-bug.sub.html
+++ b/content-security-policy/media-src/media-src-redir-bug.sub.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <title>Video element src attribute must match src list - positive test</title>
+    <script src='/resources/testharness.js'></script>
+    <script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+    <h1>Video element in media-src list - redirect test</h1>
+    <div id='log'></div>
+    
+  <p>This test tests a buggy interaction in Chrome 46.  Two hosts (self and www2) are both allowed
+    as media-src, but only one (self) is allowed for connect-src.  If a video src starts on
+    an allowed host (self), and is redirected to another allowed media-src host, it should succeed. But a bug
+    causes the redirect to be done in a fetch context to which connect-src is being applied instead, so
+    the load is blocked. (This test passes in Firefox 45, modulo an event listener not firing.)</p>
+
+  <script>
+    var src_test = async_test("In-policy async video src");
+    var src_redir_test = async_test("in-policy async video src w/redir")
+    var source_test = async_test("In-policy async video source element");
+    var source_redir_test = async_test("In-policy async video source element w/redir");
+
+    function media_loaded(t) {
+      t.done();
+    }
+
+    function media_error_handler(t) {
+      t.step( function () {
+          assert_unreached("Media error handler shouldn't be triggered for allowed domain.");
+      });
+      t.done();
+    }
+  </script>
+
+    <video id="videoObject" width="320" height="240" controls
+           onloadeddata="media_loaded(source_test)">
+        <source id="videoSourceObject"
+                type="video/mp4"
+                onerror="media_error_handler(source_test)"
+                src="http://www2.{{host}}:{{ports[http][0]}}/media/white.mp4">
+    </video>
+    
+    <video id="videoObject2" width="320" height="240" controls
+           onerror="media_error_handler(src_test)"
+           onloadeddata="media_loaded(src_test)"
+           src="http://www2.{{host}}:{{ports[http][0]}}/media/white.mp4">
+
+    <video id="videoObject3" width="320" height="240" controls
+           onloadeddata="media_loaded(source_redir_test)">
+        <source id="videoSourceObject"
+                type="video/mp4"
+                onerror="media_error_handler(source_test)"
+                src="/common/redirect.py?location=http://www2.{{host}}:{{ports[http][0]}}/media/white.mp4">
+    </video>
+        
+    <video id="videoObject2" width="320" height="240" controls
+           onerror="media_error_handler(src_test)"
+           onloadeddata="media_loaded(src_test)"
+           src="/common/redirect.py?location=http://www2.{{host}}:{{ports[http][0]}}/media/white.mp4">
+        
+  <script async defer src="../support/checkReport.sub.js?reportExists=false">
+  </script>
+
+</body>
+</html>

--- a/content-security-policy/media-src/media-src-redir-bug.sub.html.sub.headers
+++ b/content-security-policy/media-src/media-src-redir-bug.sub.html.sub.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Set-Cookie: media-src-redir-bug={{$id:uuid()}}; Path=/content-security-policy/media-src/
+Content-Security-Policy: script-src * 'unsafe-inline'; media-src http://www2.{{host}}:{{ports[http][0]}}/ 'self'; connect-src 'self'; report-uri  ../support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION
Chrome seems to switch fetch contexts when a media-src responds with a redirect, and block on connect-src directives instead.
