### PR TITLE
Implement attribute 'fgColor' on 'document'

### DIFF
--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-02.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-02.html
@@ -15,6 +15,12 @@ test(function() {
   assert_equals(document.alinkColor, document.body.aLink);
 })
 test(function() {
+  document.fgColor = null;
+  assert_equals(document.fgColor, "");
+  assert_equals(document.body.text, "");
+  assert_equals(document.body.getAttribute("text"), "");
+})
+test(function() {
   document.fgColor = "blue";
   assert_equals(document.fgColor, "blue");
   assert_equals(document.body.text, "blue");

--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-03.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-03.html
@@ -15,6 +15,12 @@ test(function() {
   assert_equals(document.alinkColor, document.body.aLink);
 })
 test(function() {
+  document.body.text = null;
+  assert_equals(document.fgColor, "");
+  assert_equals(document.body.text, "");
+  assert_equals(document.body.getAttribute("text"), "");
+})
+test(function() {
   document.body.text = "blue";
   assert_equals(document.fgColor, "blue");
   assert_equals(document.body.text, "blue");


### PR DESCRIPTION
The 'text' attribute was implemented on '<body>' in #7841
