### PR TITLE
Test for Service Worker / Cache API with credentials in Requests

### DIFF
--- a/service-workers/cache-storage/resources/credentials-iframe.html
+++ b/service-workers/cache-storage/resources/credentials-iframe.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Controlled frame for Cache API test with credentials</title>
+<script>
+
+function xhr(url, username, password) {
+  return new Promise(function(resolve, reject) {
+    var xhr = new XMLHttpRequest(), async = true;
+    xhr.open('GET', url, async, username, password);
+    xhr.send();
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState !== XMLHttpRequest.DONE)
+        return;
+      if (xhr.status === 200) {
+        resolve(xhr.responseText);
+      } else {
+        reject(new Error(xhr.statusText));
+      }
+    };
+  });
+}
+
+window.onmessage = function(e) {
+  Promise.all(e.data.map(function(item) {
+    return xhr(item.name, item.username, item.password);
+  }))
+    .then(function() {
+      navigator.serviceWorker.controller.postMessage('keys');
+      navigator.serviceWorker.onmessage = function(e) {
+        window.parent.postMessage(e.data, '*');
+      };
+    });
+};
+
+</script>
+<body>
+Hello? Yes, this is iframe.
+</body>

--- a/service-workers/cache-storage/resources/credentials-worker.js
+++ b/service-workers/cache-storage/resources/credentials-worker.js
@@ -1,0 +1,59 @@
+var cache_name = 'credentials';
+
+function assert_equals(actual, expected, message) {
+  if (!Object.is(actual, expected))
+    throw Error(message + ': expected: ' + expected + ', actual: ' + actual);
+}
+
+self.onfetch = function(e) {
+  if (!/\.txt$/.test(e.request.url)) return;
+  var content = e.request.url;
+  var cache;
+  e.respondWith(
+    self.caches.open(cache_name)
+      .then(function(result) {
+        cache = result;
+        return cache.put(e.request, new Response(content));
+      })
+
+      .then(function() { return cache.match(e.request); })
+      .then(function(result) { return result.text(); })
+      .then(function(text) {
+        assert_equals(text, content, 'Cache.match() body should match');
+      })
+
+      .then(function() { return cache.matchAll(e.request); })
+      .then(function(results) {
+        assert_equals(results.length, 1, 'Should have one response');
+        return results[0].text();
+      })
+      .then(function(text) {
+        assert_equals(text, content, 'Cache.matchAll() body should match');
+      })
+
+      .then(function() { return self.caches.match(e.request); })
+      .then(function(result) { return result.text(); })
+      .then(function(text) {
+        assert_equals(text, content, 'CacheStorage.match() body should match');
+      })
+
+     .then(function() {
+        return new Response('dummy');
+      })
+  );
+};
+
+self.onmessage = function(e) {
+  if (e.data === 'keys') {
+    self.caches.open(cache_name)
+      .then(function(cache) { return cache.keys(); })
+      .then(function(requests) {
+        var urls = requests.map(function(request) { return request.url; });
+        self.clients.matchAll().then(function(clients) {
+          clients.forEach(function(client) {
+            client.postMessage(urls);
+          });
+        });
+      });
+  }
+};

--- a/service-workers/cache-storage/serviceworker/credentials.html
+++ b/service-workers/cache-storage/serviceworker/credentials.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Cache Storage: Verify credentials are respected by Cache operations</title>
+<link rel="help" href="https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-storage">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../service-workers/resources/test-helpers.js"></script>
+<style>iframe { display: none; }</style>
+<script>
+
+var worker = "../resources/credentials-worker.js";
+var scope = "../resources/credentials-iframe.html";
+promise_test(function(t) {
+  return self.caches.delete('credentials')
+    .then(function() {
+      return service_worker_unregister_and_register(t, worker, scope)
+    })
+    .then(function(reg) {
+      return wait_for_state(t, reg.installing, 'activated');
+    })
+    .then(function() {
+      return with_iframe(scope);
+    })
+    .then(function(frame) {
+      frame.contentWindow.postMessage([
+        {name: 'file.txt', username: 'aa', password: 'bb'},
+        {name: 'file.txt', username: 'cc', password: 'dd'},
+        {name: 'file.txt'}
+      ], '*');
+      return new Promise(function(resolve, reject) {
+        window.onmessage = t.step_func(function(e) {
+          resolve(e.data);
+        });
+      });
+    })
+    .then(function(data) {
+      assert_equals(data.length, 3, 'three entries should be present');
+      assert_equals(data.filter(function(url) { return /@/.test(url); }).length, 2,
+        'two entries should contain credentials');
+      assert_true(data.some(function(url) { return /aa:bb@/.test(url); }),
+        'entry with credentials aa:bb should be present');
+      assert_true(data.some(function(url) { return /cc:dd@/.test(url); }),
+        'entry with credentials cc:dd should be present');
+    });
+}, "Cache API matching includes credentials");
+</script>


### PR DESCRIPTION
Fetch does not allow credentials to be used with fetch() or the synthetic Request constructor, but the Service Worker Cache APIs should respect such requests. Add a test (from Blink) that uses XHR to hand a Service Worker actual Request objects with credentials, and exercise the Cache APIs.
