### PR TITLE
Add tests for scroll restoration mode

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/blank1.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/blank1.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+body {
+    height: 2000px;
+    width: 2000px;
+}
+</style>
+<body> Blank 1 </body>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/blank2.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/blank2.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style>
+body {
+    height: 2000px;
+    width: 2000px;
+}
+</style>
+<body> Blank 2 </body>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/page-with-fragment.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/resources/page-with-fragment.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<style>
+body {
+    height: 2000px;
+    width: 2000px;
+}
+#fragment {
+    position: absolute;
+    top: 800px;
+    background-color: #faa;
+    display: block;
+    height: 100px;
+    width: 100px;
+}
+
+</style>
+<body>
+Page with fragment
+  <a id="fragment" name="fragment" class='box'></a>
+</body>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-basic.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-basic.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>Verify existence and basic read/write function of history.scrollRestoration</title>
+
+<style>
+  body {
+    height: 2000px;
+    width: 2000px;
+  }
+</style>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
+
+  test(function() {
+    assert_equals(history.scrollRestoration, 'auto');
+  }, 'Default value is "auto"');
+
+  test(function() {
+    history.scrollRestoration = 'manual';
+    assert_equals(history.scrollRestoration, 'manual', 'should be able to set "manual"');
+    history.scrollRestoration = 'auto';
+    assert_equals(history.scrollRestoration, 'auto', 'should be able to set "auto"');
+  }, 'It is writable');
+
+  test(function() {
+    history.scrollRestoration = 'auto';
+    for (var v of [3.1415, {}, 'bogus']) {
+      history.scrollRestoration = v;
+      assert_equals(history.scrollRestoration, 'auto', `setting to invalid value (${v}) should be ignored`);
+    }
+  }, 'Invalid values are ignored');
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-fragment-scrolling-cross-origin.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-fragment-scrolling-cross-origin.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta name=timeout content=long>
+<title>Precedence of scroll restoration mode over fragment scrolling in cross-origin history traversal</title>
+<style>
+  iframe {
+    height: 300px;
+    width: 300px;
+  }
+</style>
+
+<body>
+  <iframe></iframe>
+</body>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
+
+  // The test does the following navigation steps for iframe
+  // 1. load page-with-fragment.html#fragment
+  // 2. load blank1
+  // 3. go back to page-with-fragment.html
+  async_test(function(t) {
+    var iframe = document.querySelector('iframe');
+    var baseURL = location.href.substring(0, location.href.lastIndexOf('/'));
+
+    var steps = [
+      function() {
+        iframe.src = 'resources/page-with-fragment.html#fragment';
+      }, function() {
+        assert_equals(iframe.contentWindow.location.href, baseURL + '/resources/page-with-fragment.html#fragment', 'should be on page-with-fragment page');
+        // wait one animation frame to ensure layout is run and fragment scrolling is complete
+        iframe.contentWindow.requestAnimationFrame(function() {
+          assert_equals(iframe.contentWindow.scrollY, 800, 'should scroll to fragment');
+
+          iframe.contentWindow.history.scrollRestoration = 'manual';
+          assert_equals(iframe.contentWindow.history.scrollRestoration, 'manual');
+          setTimeout(next, 0);
+        });
+      }, function() {
+        // navigate to a new page from a different origin
+        iframe.src = iframe.src.replace("http://", "http://www.").replace("page-with-fragment.html#fragment", "blank1.html");
+      }, function() {
+        // going back causes the iframe to traverse back
+        history.back();
+      }, function() {
+        // coming back from history, scrollRestoration should be set to manual and respected
+        assert_equals(iframe.contentWindow.location.href, baseURL + '/resources/page-with-fragment.html#fragment', 'should be back on page-with-fragment page');
+        iframe.contentWindow.requestAnimationFrame(function() {
+          assert_equals(iframe.contentWindow.history.scrollRestoration, 'manual', 'navigating back should retain scrollRestoration value');
+          assert_equals(iframe.contentWindow.scrollX, 0, 'should not scroll to fragment');
+          assert_equals(iframe.contentWindow.scrollY, 0, 'should not scroll to fragment');
+          t.done();
+        });
+      }
+    ];
+
+    var stepCount = 0;
+    var next = t.step_func(function() {
+      steps[stepCount++]();
+    });
+
+    iframe.onload = next;
+    next();
+  }, 'Manual scroll restoration should take precedent over scrolling to fragment in cross origin navigation');
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-fragment-scrolling-samedoc.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-fragment-scrolling-samedoc.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<style>
+  body {
+    height: 2000px;
+    width: 2000px;
+  }
+
+  #fragment {
+    position: absolute;
+    top: 800px;
+    background-color: #faa;
+    display: block;
+    height: 100px;
+    width: 100px;
+  }
+</style>
+
+<body>
+  <a id="fragment" name="fragment" class='box'></a>
+</body>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
+
+  async_test(function(t) {
+    history.scrollRestoration = 'manual';
+    assert_equals(history.scrollRestoration, 'manual');
+
+    location.hash = '#fragment';
+    assert_equals(window.scrollY, 800, 'new navigations should scroll to fragment');
+
+    // create a new entry and reset the scroll before verification
+    history.pushState(null, null, '#done');
+    window.scrollTo(0, 0);
+    assert_equals(window.scrollY, 0, 'should reset scroll before verification');
+
+    setTimeout(function() {
+      // setup verification
+      window.addEventListener('hashchange', t.step_func(function() {
+        assert_equals(location.hash, '#fragment');
+        assert_equals(history.scrollRestoration, 'manual');
+        // navigating back should give precedent to history restoration which is 'manual'
+        assert_equals(window.scrollX, 0, 'should not scroll to fragment');
+        assert_equals(window.scrollY, 0, 'should not scroll to fragment');
+        t.done();
+      }));
+      // kick off verification
+      window.history.back();
+    }, 0);
+
+  }, 'Manual scroll restoration should take precedent over scrolling to fragment in cross doc navigation');
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-navigation-cross-origin.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-navigation-cross-origin.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta name=timeout content=long>
+<title>Correct behaviour of scroll restoration mode is cross origin history traversal</title>
+
+<style>
+  iframe {
+    height: 300px;
+    width: 300px;
+  }
+</style>
+
+<body>
+  <iframe></iframe>
+</body>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
+
+  // The test does the following navigation steps for iframe
+  // 1. load blank1
+  // 2. load blank2
+  // 3. go back to blank1
+  async_test(function(t) {
+    var iframe = document.querySelector('iframe');
+    var baseURL = location.href.substring(0, location.href.lastIndexOf('/'));
+
+    var steps = [
+      function() {
+        iframe.src = 'resources/blank1.html';
+      },
+      function() {
+        assert_equals(iframe.contentWindow.location.href, baseURL + '/resources/blank1.html', 'should be on first blank page');
+        iframe.contentWindow.history.scrollRestoration = 'manual';
+        assert_equals(iframe.contentWindow.history.scrollRestoration, 'manual');
+        iframe.contentWindow.scrollTo(500, 500);
+        assert_equals(iframe.contentWindow.scrollX, 500, 'scripted scrolling should take effect');
+        assert_equals(iframe.contentWindow.scrollY, 500, 'scripted scrolling should take effect');
+        setTimeout(next, 0);
+      },
+      function() {
+        // navigate to new page
+        iframe.src = 'resources/blank2.html';
+      },
+      function() {
+        assert_equals(iframe.contentWindow.location.href, baseURL + '/resources/blank2.html', 'should be on second blank page');
+        assert_equals(iframe.contentWindow.history.scrollRestoration, 'auto', 'new page loads should set scrollRestoration to "auto"');
+        setTimeout(next, 0);
+      }, function() {
+        iframe.contentWindow.history.back();
+      }, function() {
+        // coming back scrollRestoration should be restored to 'manual' and respected
+        assert_equals(iframe.contentWindow.location.href, baseURL + '/resources/blank1.html', 'should be back on first blank page');
+        assert_equals(iframe.contentWindow.history.scrollRestoration, 'manual', 'navigating back should retain scrollRestoration value');
+        assert_equals(iframe.contentWindow.scrollX, 0, 'horizontal scroll offset should not be restored');
+        assert_equals(iframe.contentWindow.scrollY, 0, 'vertical scroll offset should not be restored');
+        t.done();
+      }
+    ];
+
+    var stepCount = 0;
+    var next = t.step_func(function() {
+      steps[stepCount++]();
+    });
+
+    iframe.onload = next;
+    next();
+  }, 'Navigating to new page should reset to "auto" and navigating back should restore and respect scroll restoration mode');
+
+</script>

--- a/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-navigation-samedoc.html
+++ b/html/browsers/browsing-the-web/history-traversal/persisted-user-state-restoration/scroll-restoration-navigation-samedoc.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<title>Correct behaviour of scroll restoration mode in same document history traversals</title>
+
+<style>
+  body {
+    height: 10000px;
+    width: 10000px;
+  }
+</style>
+
+<body></body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
+
+  async_test(function(t) {
+    history.scrollRestoration = 'auto';
+    window.scrollTo(0, 0);
+
+    // create history entries and then verify the impact of scrollRestoration
+    // when they are popped
+    var entries = {
+      /* For scroll restoration mode 'auto', the spec does not require scroll
+         position to be restored at any particular value. */
+      '#1': {type: 'push',    expectedScroll: null,  scrollRestoration: 'auto'},
+      '#2': {type: 'replace', expectedScroll: null, scrollRestoration: 'auto'},
+      /* For scroll restoration mode 'manual', the spec requires scroll position
+         not to be restored. So we expect [555,555] which is the latest position
+         before navigation. */
+      '#3': {type: 'push',    expectedScroll: [555, 555], scrollRestoration: 'manual'},
+      '#4': {type: 'replace', expectedScroll: [555, 555], scrollRestoration: 'manual'}
+    };
+
+    // setup entries
+    for (var key in entries) {
+      var entry = entries[key],
+        beforeValue = history.scrollRestoration,
+        newValue = entry.scrollRestoration;
+
+      var args = [{key: key}, '', key];
+      if (entry.type == 'push') {
+        history.pushState.apply(history, args);
+      } else {
+        history.pushState(null, '', key);
+        history.replaceState.apply(history, args);
+      }
+      assert_equals(history.scrollRestoration, beforeValue, `history.scrollRestoration value is retained after pushing new state`);
+      history.scrollRestoration = newValue;
+      assert_equals(history.scrollRestoration, newValue, `Setting scrollRestoration to ${newValue} works as expected`);
+      window.scrollBy(50, 100);
+    }
+
+    // setup verification
+    window.addEventListener('hashchange', t.step_func(function() {
+      var key = location.hash,
+        entry = entries[key];
+
+      if (key === '') {
+        t.done();
+        return;
+      }
+      assert_equals(history.state.key, key, `state should have key: ${key}`);
+      assert_equals(history.scrollRestoration, entry.scrollRestoration, 'scrollRestoration is updated correctly');
+      if (entry.expectedScroll) {
+        assert_equals(window.scrollX, entry.expectedScroll[0], `scrollX is correct for ${key}`);
+        assert_equals(window.scrollY, entry.expectedScroll[1], `scrollY is correct for ${key}`);
+      }
+
+      window.history.back();
+    }));
+
+    // reset the scroll and kick off the verification
+    setTimeout(function() {
+      history.pushState(null, null, '#done');
+      window.scrollTo(555, 555);
+      window.history.back();
+    }, 0);
+
+  }, 'history.{push,replace}State retain scroll restoration mode and navigation in the same document respects it');
+</script>

--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2309,8 +2309,11 @@ interface BarProp {
            attribute boolean visible;
 };
 
+enum ScrollRestoration { "auto", "manual" };
 interface History {
+
   readonly attribute long length;
+  attribute ScrollRestoration scrollRestoration;
   readonly attribute any state;
   void go(optional long delta);
   void back();


### PR DESCRIPTION
Fixes #2434. Tests are based on Blink tests for [scroll restoration mode](https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/LayoutTests/fast/history/scroll-restoration/).

They cover basic API, behaviour of the feature on navigation, and its relation with fragment scrolling.
