### PR TITLE
Make hash change test faster to run and increase timeout,

### DIFF
--- a/html/browsers/browsing-the-web/scroll-to-fragid/007.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/007.html
@@ -1,12 +1,13 @@
 <!doctype html>
 <!-- this tests the spec as it hopefully will be once bug https://www.w3.org/Bugs/Public/show_bug.cgi?id=17155 is fixed -->
 <title>Fragment Navigation: hashchange event multiple changes old/newURL</title>
+<meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
 <div id="log"></div>
 <script>
-var t = async_test(undefined, {timeout:30000});
+var t = async_test();
 t.step(function() {
   var original_url = location.href;
   assert_equals(location.hash, "", "Page must be loaded with no hash");
@@ -19,12 +20,12 @@ t.step(function() {
 
   addEventListener("hashchange",
                    t.step_func(function(e) {
-                     if (count < 1000) {
+                     if (count < 100) {
                        location.hash = "test" + count++;
                        hashes.push(location.hash);
-                     } else if (count === 1000) {
+                     } else if (count === 100) {
                        expected = [];
-                       for (var i=0; i<1000; i++) {
+                       for (var i=0; i<100; i++) {
                           expected.push("#test" + i);
                        }
                        assert_array_equals(hashes, expected);


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1226462
