### PR TITLE
Merge URLUtilsReadOnly into WorkerLocation (inline URLUtilsReadOnly)

### DIFF
--- a/workers/interfaces.idl
+++ b/workers/interfaces.idl
@@ -1,22 +1,4 @@
 // -----------------------------------------------------------------------------
-// URL
-// -----------------------------------------------------------------------------
-[NoInterfaceObject/*,
- Exposed=(Window,Worker)*/]
-interface URLUtilsReadOnly {
-  stringifier readonly attribute USVString href;
-  readonly attribute USVString origin;
-
-  readonly attribute USVString protocol;
-  readonly attribute USVString host;
-  readonly attribute USVString hostname;
-  readonly attribute USVString port;
-  readonly attribute USVString pathname;
-  readonly attribute USVString search;
-  readonly attribute USVString hash;
-};
-
-// -----------------------------------------------------------------------------
 // DOM
 // -----------------------------------------------------------------------------
 //[Exposed=Window,Worker]
@@ -111,5 +93,14 @@ interface NavigatorOnLine {
 };
 
 //[Exposed=Worker]
-interface WorkerLocation { };
-WorkerLocation implements URLUtilsReadOnly;
+interface WorkerLocation {
+  stringifier readonly attribute USVString href;
+  readonly attribute USVString origin;
+  readonly attribute USVString protocol;
+  readonly attribute USVString host;
+  readonly attribute USVString hostname;
+  readonly attribute USVString port;
+  readonly attribute USVString pathname;
+  readonly attribute USVString search;
+  readonly attribute USVString hash;
+};


### PR DESCRIPTION
URLUtilsReadOnly has been removed from the URL spec.

References:
https://github.com/whatwg/html/commit/32a7a2092eeff52aca78a0224816a9b327
https://github.com/whatwg/url/commit/c2877946857bc904ecb8a5805abc423c82d9da98
