### PR TITLE
Implement non-zero dimension attribute parsing

### DIFF
--- a/html/rendering/non-replaced-elements/tables/table-cell-width-ref.html
+++ b/html/rendering/non-replaced-elements/tables/table-cell-width-ref.html
@@ -1,0 +1,37 @@
+<style>
+body {
+  margin: 0;
+}
+
+.row {
+  clear: both;
+}
+
+.row div {
+  float: left;
+}
+
+.red {
+  background-color: red;
+}
+</style>
+
+<div class="row">
+  <div class="red" style="width: 200px">a</div>
+  <div style="width: 200px">a</div>
+</div>
+
+<div class="row">
+  <div class="red" style="width: 200px">a</div>
+  <div style="width: 200px">a</div>
+</div>
+
+<div class="row">
+  <div class="red" style="width: 100px">a</div>
+  <div style="width: 300px">a</div>
+</div>
+
+<div class="row">
+  <div class="red" style="width: 100px">a</div>
+  <div style="width: 300px">a</div>
+</div>

--- a/html/rendering/non-replaced-elements/tables/table-cell-width.html
+++ b/html/rendering/non-replaced-elements/tables/table-cell-width.html
@@ -1,0 +1,54 @@
+<link rel="match" href="table-cell-width-ref.html">
+<style>
+body {
+  margin: 0;
+}
+
+table {
+  width: 400px;
+  border-collapse: collapse;
+}
+
+th {
+  font-weight: normal;
+  text-align: left;
+}
+
+td, th {
+  padding: 0;
+}
+
+td:first-child, th:first-child {
+  background-color: red;
+}
+</style>
+
+<!-- width=0 should be treated as 'auto' -->
+<table>
+  <tr>
+    <th width=0>a</th>
+    <th>a</th>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td width=0>a</td>
+    <td>a</td>
+  </tr>
+</table>
+
+<!-- test valid width attribute value-->
+<table>
+  <tr>
+    <th width=100>a</th>
+    <th>a</th>
+  </tr>
+</table>
+
+<table>
+  <tr>
+    <td width=100>a</td>
+    <td>a</td>
+  </tr>
+</table>

--- a/html/rendering/non-replaced-elements/tables/table-width-ref.html
+++ b/html/rendering/non-replaced-elements/tables/table-width-ref.html
@@ -1,0 +1,13 @@
+<style>
+p {
+  padding: 0;
+  margin: 0;
+}
+</style>
+
+<p>a b</p>
+
+<hr>
+
+<p>a</p>
+<p>b</p>

--- a/html/rendering/non-replaced-elements/tables/table-width.html
+++ b/html/rendering/non-replaced-elements/tables/table-width.html
@@ -1,0 +1,30 @@
+<link rel="match" href="table-width-ref.html">
+
+<style>
+table {
+  border-collapse: collapse;
+}
+
+td {
+  padding: 0;
+}
+</style>
+
+<!-- width=0 should be treated as 'auto' -->
+<table width=0>
+  <tr>
+    <td>
+      a b
+    </td>
+  </tr>
+</table>
+
+<hr>
+
+<table width=1>
+  <tr>
+    <td>
+      a b
+    </td>
+  </tr>
+</table>


### PR DESCRIPTION
Fixes #8445

The only attributes I found that we have implemented that uses non-zero
dimenion attributes:
- `width` for `<td>` and `<th>` (table cells)
- `width` for `<table>`

I updated these implementations to use the new non-zero dimension
attribute parsing and added associated regression tests.
