### PR TITLE
Remove unreferenced code from battery-unplugging-manual.html

### DIFF
--- a/battery-status/battery-unplugging-manual.html
+++ b/battery-status/battery-unplugging-manual.html
@@ -28,9 +28,6 @@
     The battery must not be full or reach full capacity during the time the test is run.
   </li>
 </ol>
-<p>
-  The highest prime number discovered so far is:  <output id="prime"></output>
-</p>
 
 <div id="note">
   Unplug the charger and wait for all the tests to complete.
@@ -69,7 +66,6 @@
       assert_greater_than(battery.level, 0);
       assert_less_than_equal(battery.level, 1.0);
       onlevelchange_test.done();
-      w.terminate();
     });
   };
 


### PR DESCRIPTION
Related code has been removed at
https://github.com/w3c/web-platform-tests/commit/2257982236fd868acc624bca950c68b4d15842be
