### PR TITLE
Test that clicking on <body> or <html> fires click events

### DIFF
--- a/uievents/order-of-events/mouse-events/click-on-body-manual.html
+++ b/uievents/order-of-events/mouse-events/click-on-body-manual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Clicking on the body element itself fires a click event</title>
+    <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+    <link rel="help" href="https://w3c.github.io/uievents/#event-type-click">
+    <meta name="flags" content="interact">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+html {
+  background-color: white;
+  margin: 0;
+}
+body {
+  background-color: blue;
+  margin: 0;
+}
+#guineapig {
+  background-color: white;
+  margin-bottom: 100px;/* Expose an area of the body element itself */
+}
+#other {
+  background-color: white;
+}
+    </style>
+  </head>
+  <body>
+    <p id="guineapig">Click on the blue area below. If a "PASS" result appears, the test passes; otherwise, it fails.</p>
+    <p id="other">&nbsp;</p><!-- Needed to prevent the margin from collapsing -->
+    <script>
+setup({explicit_timeout: true});
+async_test(function(t) {
+  document.body.addEventListener('click', function (event) {
+    t.step(function () {
+      assert_equals(event.target, document.body, 'target of click event must be the body element');
+      assert_equals(event.eventPhase, Event.AT_TARGET, 'click event must propagate to the body element at the Target Phase');
+      var passed = event.target === document.body && event.eventPhase === Event.AT_TARGET;
+      document.body.style.backgroundColor = 'white';
+      var guineapig = document.getElementById('guineapig');
+      guineapig.style.marginBottom = '16px';
+      if (passed) {
+        guineapig.textContent = 'PASS';
+        guineapig.style.backgroundColor = 'green';
+      }
+      t.done();
+    });
+  }, false);
+}, "Clicking on the body element itself should fire a click event targeted at the body element");
+    </script>
+  </body>
+</html>

--- a/uievents/order-of-events/mouse-events/click-on-html-manual.html
+++ b/uievents/order-of-events/mouse-events/click-on-html-manual.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Clicking on the html element itself fires a click event</title>
+    <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+    <link rel="help" href="https://w3c.github.io/uievents/#event-type-click">
+    <meta name="flags" content="interact">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+html {
+  background-color: blue;
+  margin: 0;
+}
+body {
+  background-color: red;
+  height: 0;
+  margin: 0;
+}
+#guineapig {
+  background-color: white;
+  padding-top: 50px;/* Text is easier to see when it's not at the exact top of the viewport */
+  margin-top: 0;/* Ensure there's no exposed html element above this */
+  margin-bottom: 100px;/* Expose an area of the html element itself */
+}
+#other {
+  background-color: white;
+  height: 100vh;/* Push the rest of the html element outside of the viewport */
+}
+    </style>
+  </head>
+  <body>
+    <p id="guineapig">Click on the blue area below. If a "PASS" result appears, the test passes; otherwise, it fails.</p>
+    <p id="other">&nbsp;</p><!-- Needed to prevent the margin from collapsing -->
+    <script>
+setup({explicit_timeout: true});
+async_test(function(t) {
+  document.documentElement.addEventListener('click', function (event) {
+    t.step(function () {
+      assert_equals(event.target, document.documentElement, 'target of click event must be the html element');
+      assert_equals(event.eventPhase, Event.AT_TARGET, 'click event must propagate to the html element at the Target Phase');
+      var passed = event.target === document.documentElement && event.eventPhase === Event.AT_TARGET;
+      document.documentElement.style.backgroundColor = 'white';
+      document.getElementById('other').style.height = 'auto';
+      var guineapig = document.getElementById('guineapig');
+      guineapig.style.marginBottom = '16px';
+      if (passed) {
+        guineapig.textContent = 'PASS';
+        guineapig.style.backgroundColor = 'green';
+      }
+      t.done();
+    });
+  }, false);
+}, "Clicking on the html element itself should fire a click event targeted at the html element");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
These tests are in reference to the requirement in https://w3c.github.io/uievents/#event-type-click that:

> The `click` event type MUST be dispatched on the _topmost event target_ indicated by the pointer, when the user presses down and releases the primary pointer button, or otherwise activates the pointer in a manner that simulates such an action.

---

See also https://bugs.webkit.org/show_bug.cgi?id=151933
