### PR TITLE
Getting outerHTML on a node from an XML document should not use the self-closing form of empty container tags from the HTML namespace.

### DIFF
--- a/html/syntax/serializing-xml-fragments/outerHTML.html
+++ b/html/syntax/serializing-xml-fragments/outerHTML.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>HTML Test: element.outerHTML to verify XML fragment serialization algorithm</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="https://w3c.github.io/DOM-Parsing/#dfn-concept-serialize-xml">
+    <link rel="help" href="https://w3c.github.io/DOM-Parsing/#widl-Element-outerHTML">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="../html-element-list.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      test(function() {
+        var doc = document.implementation.createDocument(null, "");
+        assert_equals(doc.contentType, "application/xml");
+        var html_ns = "http://www.w3.org/1999/xhtml";
+        elements_with_end_tag.forEach(function(ele) {
+          test(function() {
+            var e = doc.createElementNS(html_ns, ele);
+            assert_equals(e.outerHTML,
+                          `<${ele} xmlns="${html_ns}"></${ele}>`,
+                          ele + " node created." );
+          }, "Node for " + ele);
+        });
+        elements_without_end_tag.forEach(function(ele) {
+          test(function() {
+            var e = doc.createElementNS(html_ns, ele);
+            assert_equals(e.outerHTML,
+                          `<${ele} xmlns="${html_ns}" />`,
+                          ele + " node created." );
+          }, "Node for " + ele);
+        });
+      }, document.title);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1032979
