### PR TITLE
Echo status code and reason in websocket /echo handler

### DIFF
--- a/websockets/handlers/echo_wsh.py
+++ b/websockets/handlers/echo_wsh.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 from mod_pywebsocket import msgutil
+from mod_pywebsocket import common
 
 _GOODBYE_MESSAGE = u'Goodbye'
 
@@ -23,3 +24,13 @@ def web_socket_transfer_data(request):
         else:
             request.ws_stream.send_message(line, binary=True)
 
+def web_socket_passive_closing_handshake(request):
+    # Echo close status code and reason
+    code, reason = request.ws_close_code, request.ws_close_reason
+
+    # No status received is a reserved pseudo code representing an empty code,
+    # so echo back an empty code in this case.
+    if code == common.STATUS_NO_STATUS_RECEIVED:
+        code = None
+
+    return code, reason


### PR DESCRIPTION
This echoes the WebSocket close code (except `NO_STATUS`) and reason sent by the client close frame in the server's close frame.

A few tests rely on the final close code and reason being the same as that sent by the client. [Section 7.1.5 of RFC6455](https://tools.ietf.org/html/rfc6455#section-7.1.5) states that "_The WebSocket Connection Close Code_ is defined as the status code contained in the first Close control frame received by the application implementing this protocol", suggesting that the server needs to echo the code for those tests to pass. There is very similar language for the close reason in [section 7.1.6](https://tools.ietf.org/html/rfc6455#section-7.1.6).

Firefox appears to implement the behavior I would expect from the wording in the spec, and fails the following tests, which I believe this change will fix:

http://w3c-test.org/websockets/Close-reason-unpaired-surrogates.htm
http://w3c-test.org/websockets/Secure-Close-1000-verify-code.htm
http://w3c-test.org/websockets/Secure-Close-1005-verify-code.htm
http://w3c-test.org/websockets/Secure-Close-3000-verify-code.htm
http://w3c-test.org/websockets/Secure-Close-Reason-Unpaired-surrogates.htm
