### PR TITLE
Remove untested IDL fragments from battery-interface-idlharness.html

### DIFF
--- a/battery-status/battery-interface-idlharness.html
+++ b/battery-status/battery-interface-idlharness.html
@@ -9,15 +9,8 @@
 interface Navigator { };
 
 interface EventTarget {
-  void addEventListener(DOMString type, EventListener? callback, optional boolean capture);
-  void removeEventListener(DOMString type, EventListener? callback, optional boolean capture);
-  boolean dispatchEvent(Event event);
 };
 
-[Callback]
-interface EventListener {
-  void handleEvent(Event event);
-};
 [TreatNonObjectAsNull]
 callback EventHandlerNonNull = any (Event event);
 typedef EventHandlerNonNull? EventHandler;


### PR DESCRIPTION
This will bypass 2 failures not specific to Battery Status API.
