### PR TITLE
Fix websockets/Secure-Close-server-initiated.htm

### DIFF
--- a/websockets/Secure-Close-server-initiated-close.htm
+++ b/websockets/Secure-Close-server-initiated-close.htm
@@ -17,7 +17,7 @@
         var isOpenCalled = false;
 
         wsocket.addEventListener('open', testOpen.step_func(function (evt) {
-            wsocket.send(".close");
+            wsocket.send("Goodbye");
             isOpenCalled = true;
             testOpen.done();
         }), true);


### PR DESCRIPTION
Looks like it was just using the wrong message to signal closure.
