### PR TITLE
Clicking on a <div> which itself has no click event handler still fires a click event

### DIFF
--- a/uievents/order-of-events/mouse-events/click-on-div-manual.html
+++ b/uievents/order-of-events/mouse-events/click-on-div-manual.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Clicking on a div element that has no click event handler fires a click event</title>
+    <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+    <link rel="help" href="https://w3c.github.io/uievents/#event-type-click">
+    <link rel="help" href="https://dom.spec.whatwg.org/#concept-event-dispatch">
+    <meta name="flags" content="interact">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+#square {
+  width: 100px;
+  height: 100px;
+  background-color: blue;
+  color: white;
+  /* Center the "Click me" text */
+  line-height: 100px;
+  text-align: center;
+}
+    </style>
+  </head>
+  <body>
+    <p>Click on the blue square below. If a "PASS" result appears, the test passes; otherwise, it fails.</p>
+    <div id="square">Click me</div>
+    <script>
+setup({explicit_timeout: true});
+async_test(function(t) {
+  document.addEventListener('click', function (event) {
+    var square = document.getElementById('square');
+    t.step(function () {
+      assert_equals(event.target, square, 'target of click event must be the test square');
+      assert_equals(event.eventPhase, Event.BUBBLING_PHASE, 'click event must propagate to the document object during the Bubbling Phase');
+      square.textContent = 'PASS';
+      square.style.backgroundColor = 'green';
+      t.done();
+    });
+  }, false);
+}, "Clicking on a div element and having a click event listener on only document");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This test is in reference to the requirement in https://w3c.github.io/uievents/#event-type-click that:

> The `click` event type MUST be dispatched on the _topmost event target_ indicated by the pointer, when the user presses down and releases the primary pointer button, or otherwise activates the pointer in a manner that simulates such an action.
> [...]
> In graphical user interfaces [the [topmost event target](https://w3c.github.io/uievents/#glossary-topmost-event-target)] is the element under the user's pointing device. [...]

And in particular to the fact that this requirement doesn't include any preconditions regarding the presence of click event handlers on the element itself.

---

Refs https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
Refs https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
