### PR TITLE
Selector [foo='bar' I] (uppercase I) is valid

### DIFF
--- a/selectors/attribute-selectors/attribute-case/syntax.html
+++ b/selectors/attribute-selectors/attribute-case/syntax.html
@@ -12,6 +12,7 @@ setup({explicit_done:true});
 var valid = [
   "[foo='BAR'] /* sanity check (valid) */",
   "[foo='bar' i]",
+  "[foo='bar' I]",
   "[foo=bar i]",
   '[foo="bar" i]',
   "[foo='bar'i]",
@@ -37,7 +38,6 @@ var valid = [
 var invalid = [
   "[foo[ /* sanity check (invalid) */",
   "[foo='bar' i i]",
-  "[foo='bar' I]",
   "[foo i ='bar']",
   "[foo= i 'bar']",
   "[i foo='bar']",


### PR DESCRIPTION
Change expectation of [foo='bar' I] test case from invalid to valid.

Fixes https://lists.w3.org/Archives/Public/www-style/2016Jan/0169.html

r=@fsoder
