### PR TITLE
Fix incorrect assumption that preventDefault() *immediately* runs canceled activation steps

### DIFF
--- a/html/semantics/forms/the-input-element/checkbox.html
+++ b/html/semantics/forms/the-input-element/checkbox.html
@@ -83,9 +83,22 @@
 
   checkbox5.onclick = t5.step_func(function(e) {
     e.preventDefault();
-    assert_false(checkbox5.checked);
+    /*
+    The prevention of the click doesn't have an effect until after all the
+    click event handlers have been run.
+    */
+    assert_true(checkbox5.checked);
     assert_false(checkbox5.indeterminate);
-    t5.done();
+    window.setTimeout(t5.step_func(function(e) {
+      /*
+      The click event has finished being dispatched, so the checkedness and
+      determinateness have been toggled back by now because the event
+      was preventDefault-ed.
+      */
+      assert_false(checkbox5.checked);
+      assert_false(checkbox5.indeterminate);
+      t5.done();
+    }), 0);
   });
 
   t5.step(function(){
@@ -97,9 +110,22 @@
   checkbox6.onclick = t6.step_func(function(e) {
     checkbox6.indeterminate = true;
     e.preventDefault();
-    assert_false(checkbox6.checked);
-    assert_false(checkbox6.indeterminate);
-    t6.done();
+    /*
+    The prevention of the click doesn't have an effect until after all the
+    click event handlers have been run.
+    */
+    assert_true(checkbox6.checked);
+    assert_true(checkbox6.indeterminate);
+    window.setTimeout(t6.step_func(function(e) {
+      /*
+      The click event has finished being dispatched, so the checkedness and
+      determinateness have been toggled back by now because the event
+      was preventDefault-ed.
+      */
+      assert_false(checkbox6.checked);
+      assert_false(checkbox6.indeterminate);
+      t6.done();
+    }), 0);
   });
 
   t6.step(function(){


### PR DESCRIPTION
As I read things, per the specs, the flow when a checkbox is clicked and then an event handler `preventDefault()`s the `click` event is:

> https://html.spec.whatwg.org/multipage/interaction.html#run-synthetic-click-activation-steps
> 
> [...]
> 
> (3) Run _pre-click activation steps_ on the element.

(Which in the case of a checkbox is to toggle its checkedness)

> (4) Fire a `click` event at the element. [...]

This ultimately invokes our event handler, which calls `preventDefault()`, which simply [sets the event's internal canceled flag](https://dom.spec.whatwg.org/#dom-event-preventdefault) **and has no other immediate effect**.

> (5) [...] If the [`click`] event is canceled, the user agent must _run canceled activation steps_ on the element instead [of _post-click activation steps_].

(The _canceled activation steps_ for a checkbox being to [reset the checkedness and indeterminateness to the values they had before the user clicked the checkbox](https://html.spec.whatwg.org/multipage/forms.html#checkbox-state-%28type=checkbox%29:canceled-activation-steps).)

So it is only at this point, after all the event handlers have already been processed, that the checkbox becomes unchecked again (assuming it had been unchecked prior to being clicked on).

---

The current test code seems to have been written under the assumption that calling `preventDefault()` immediately runs _canceled activation steps_ before it returns to its caller, which I claim is an incorrect assumption per my above reasoning. My proposed fix is to delay the asserting of the effects of the checkbox getting reset until after the _canceled activation steps_ have run, by wrapping the assertions in `setTimeout(..., 0)`. If there's some better or more proper way to accomplish this delaying, I'm all ears.

Note that this change makes these 2 tests pass in Chrome, whereas they were failing previously.
