### PR TITLE
Assert correct ordering of click, input, and change events when clicking checkboxes or radios

### DIFF
--- a/html/semantics/forms/the-input-element/checkbox.html
+++ b/html/semantics/forms/the-input-element/checkbox.html
@@ -2,7 +2,8 @@
 <meta charset=utf-8>
 <title>input type checkbox</title>
 <link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
-<link rel=help href="https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox)">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#run-synthetic-click-activation-steps">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
@@ -19,16 +20,25 @@
       checkbox4 = document.getElementById('checkbox4'),
       checkbox5 = document.getElementById('checkbox5'),
       checkbox6 = document.getElementById('checkbox6'),
-      c1_input_fired = false, c1_change_fired = false,
-      t1 = async_test("click on mutable checkbox fires the input and change events"),
+      c1_click_fired = false,
+      c1_input_fired = false,
+      c1_change_fired = false,
+      t1 = async_test("click on mutable checkbox fires a click event, then an input event, then a change event"),
       t2 = async_test("click on non-mutable checkbox doesn't fire the input or change event"),
       t3 = async_test("pre-activation steps on unchecked checkbox"),
       t4 = async_test("pre-activation steps on checked checkbox"),
       t5 = async_test("canceled activation steps on unchecked checkbox"),
       t6 = async_test("canceled activation steps on unchecked checkbox (indeterminate=true in onclick)");
 
-  checkbox1.oninput= t1.step_func(function(e) {
+  checkbox1.onclick = t1.step_func(function () {
+    c1_click_fired = true;
+    assert_false(c1_input_fired, "click event should fire before input event");
+    assert_false(c1_change_fired, "click event should fire before change event");
+  });
+  checkbox1.oninput = t1.step_func(function(e) {
     c1_input_fired = true;
+    assert_true(c1_click_fired, "input event should fire after click event");
+    assert_false(c1_change_fired, "input event should fire before change event");
     assert_true(e.bubbles, "event should bubble");
     assert_true(e.isTrusted, "event should be trusted");
     assert_false(e.cancelable, "event should not be cancelable");
@@ -38,6 +48,8 @@
 
   checkbox1.onchange = t1.step_func(function(e) {
     c1_change_fired = true;
+    assert_true(c1_click_fired, "change event should fire after click event");
+    assert_true(c1_input_fired, "change event should fire after input event");
     assert_true(e.bubbles, "event should bubble")
     assert_true(e.isTrusted, "event should be trusted");
     assert_false(e.cancelable, "event should not be cancelable");

--- a/html/semantics/forms/the-input-element/radio.html
+++ b/html/semantics/forms/the-input-element/radio.html
@@ -37,8 +37,7 @@
       radio9 = document.getElementById('radio9'),
       radio10 = document.getElementById('radio10'),
       radio11 = document.getElementById('radio11'),
-      t1 = async_test("click on mutable radio fires the input event"),
-      t2 = async_test("click on mutable radio fires the change event"),
+      t1 = async_test("click on mutable radio fires click event, then input event, then change event"),
       t3 = async_test("click on non-mutable radio doesn't fire the input event"),
       t4 = async_test("click on non-mutable radio doesn't fire the change event"),
       t5 = async_test("canceled activation steps on unchecked radio"),
@@ -80,18 +79,28 @@
     assert_false(radio11.checked);
   }, "changing the name of a radio input element and setting its checkedness to true makes all the other elements' checkedness in the same radio button group be set to false");
 
-  radio5.oninput= t1.step_func(function(e) {
-    input_fired = true;
-    assert_true(e.bubbles, "event should bubble")
-    assert_true(e.isTrusted, "event should be trusted");
-    assert_false(e.cancelable, "event should not be cancelable");
+  radio5.onclick = t1.step_func(function(e) {
+    click_fired = true;
+    assert_false(input_fired, "click event should fire before input event");
+    assert_false(change_fired, "click event should fire before change event");
   });
 
-  radio5.onchange = t2.step_func(function(e) {
+  radio5.oninput = t1.step_func(function(e) {
+    input_fired = true;
+    assert_true(click_fired, "input event should fire after click event");
+    assert_false(change_fired, "input event should fire before change event");
+    assert_true(e.bubbles, "input event should bubble")
+    assert_true(e.isTrusted, "input event should be trusted");
+    assert_false(e.cancelable, "input event should not be cancelable");
+  });
+
+  radio5.onchange = t1.step_func(function(e) {
     change_fired = true;
-    assert_true(e.bubbles, "event should bubble")
-    assert_true(e.isTrusted, "event should be trusted");
-    assert_false(e.cancelable, "event should not be cancelable");
+    assert_true(click_fired, "change event should fire after click event");
+    assert_true(input_fired, "change event should fire after input event");
+    assert_true(e.bubbles, "change event should bubble")
+    assert_true(e.isTrusted, "change event should be trusted");
+    assert_false(e.cancelable, "change event should not be cancelable");
   });
 
   radio6.oninput= t3.step_func_done(function(e) {
@@ -107,11 +116,6 @@
     assert_true(input_fired);
     t1.done();
   });
-
-  t2.step(function() {
-    assert_true(change_fired);
-    t2.done();
-  })
 
   t3.step(function(){
     radio6.click();


### PR DESCRIPTION
Background: https://www.w3.org/Bugs/Public/show_bug.cgi?id=28985
