### PR TITLE
Align Fetch Request tests with WebKit ones

### DIFF
--- a/fetch/api/request/request-clone.sub.html
+++ b/fetch/api/request/request-clone.sub.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <script>
-      var headers = new Headers( {"name":"value"} );
+      var headers = new Headers({"name" : "value"});
       var emptyHeaders = new Headers();
 
       var initValuesDict = {"method" : "POST",
@@ -43,6 +43,21 @@
         var requestToCheck = RequestInitialized.clone();
         checkRequest(requestToCheck, expectedInitialized);
       }, "Check cloning a request");
+
+      test(function() {
+        var initialRequest = new Request("", {"headers" : new Headers({"a": "1", "b" : "2"})});
+        var request = initialRequest.clone();
+        assert_equals(request.headers.get("a"), "1", "cloned request should have header 'a'");
+        assert_equals(request.headers.get("b"), "2", "cloned request should have header 'b'");
+
+        initialRequest.headers.delete("a");
+        assert_equals(request.headers.get("a"), "1", "cloned request should still have header 'a'");
+
+        request.headers.delete("a");
+        assert_equals(initialRequest.headers.get("b"), "2", "initial request should have header 'b'");
+
+      }, "Check cloning a request copies the headers");
+
     </script>
   </body>
 </html>

--- a/fetch/api/request/request-consume.html
+++ b/fetch/api/request/request-consume.html
@@ -98,7 +98,7 @@
     var badJSONValues = ["undefined", "{", "a", "["];
     badJSONValues.forEach(function(value) {
       promise_test(function(test) {
-        var request = new Request("", {"method": "POST", "body": "{"});
+        var request = new Request("", {"method": "POST", "body": value});
         return promise_rejects(test, new SyntaxError(), request.json());
       }, "Trying to consume bad JSON text as JSON: '" + value + "'");
     });

--- a/fetch/api/request/request-consume.html
+++ b/fetch/api/request/request-consume.html
@@ -84,6 +84,24 @@
     checkRequestBody("This is request's body", "arrayBuffer", checkBodyArrayBuffer);
     checkRequestBody(JSON.stringify("This is request's body"), "json", checkBodyJSON);
     checkRequestBody(formData, "formData", checkBodyFormData);
+
+    var goodJSONValues = ["null", "1", "true", "\"string\""];
+    goodJSONValues.forEach(function(value) {
+      promise_test(function(test) {
+        var request = new Request("", {"method": "POST", "body": value});
+        return request.json().then(function(v) {
+          assert_equals(v, JSON.parse(value));
+        });
+      }, "Consume JSON from text: '" + JSON.stringify(value) + "'");
+    });
+
+    var badJSONValues = ["undefined", "{", "a", "["];
+    badJSONValues.forEach(function(value) {
+      promise_test(function(test) {
+        var request = new Request("", {"method": "POST", "body": "{"});
+        return promise_rejects(test, new SyntaxError(), request.json());
+      }, "Trying to consume bad JSON text as JSON: '" + value + "'");
+    });
     </script>
   </body>
 </html>

--- a/fetch/api/request/request-init-002.html
+++ b/fetch/api/request/request-init-002.html
@@ -29,6 +29,9 @@
           assert_throws(new TypeError(),
                         function() { new Request("", {"method": "GET", "body": body}); }
           );
+          assert_throws(new TypeError(),
+                        function() { new Request("", {"method": "HEAD", "body": body}); }
+          );
           var reqHeaders = request.headers;
           var mime = reqHeaders.get("Content-Type");
           assert_true(mime && mime.search(bodyType) > -1, "Content-Type header should be \"" + bodyType + "\", not \"" + mime + "\"");
@@ -36,7 +39,7 @@
             //not equals: cannot guess formData exact value
             assert_true( bodyAsText.search(expectedTextBody) > -1, "Retrieve and verify request body");
           });
-        }, "Initialize Response's body with " + bodyType);
+        }, "Initialize Request's body with " + bodyType);
       }
 
       var blob = new Blob(["This is a blob"], {type: "application/octet-binary"});
@@ -55,7 +58,7 @@
       } else {
         promise_test(function(test) {
           return Promise.reject("URLSearchParams not supported");
-        }, "Initialize Response's body with application/x-www-form-urlencoded;charset=UTF-8");
+        }, "Initialize Request's body with application/x-www-form-urlencoded;charset=UTF-8");
       }
     </script>
   </body>

--- a/fetch/api/request/request-structure.html
+++ b/fetch/api/request/request-structure.html
@@ -51,7 +51,7 @@
             break;
 
           case "headers":
-            request.headers = new Headers ( {"name":"value"} );
+            request.headers = new Headers ({"name":"value"});
             assert_false(request.headers.has("name"), "Headers attribute is read only");
             return;
             break;
@@ -117,16 +117,18 @@
            "Attribute " + attributeToCheck + " is read only. Default value is " + defaultValue);
       }
 
-      for (var idx in methods)
+      for (var idx in methods) {
         test(function() {
           assert_true(methods[idx] in request, "request has " + methods[idx] + " method");
         }, "Request has " + methods[idx] + " method");
+      }
 
-      for (var idx in attributes)
+      for (var idx in attributes) {
         test(function() {
           assert_true(attributes[idx] in request, "request has " + attributes[idx] + " attribute");
           IsreadOnly(request, attributes[idx]);
         }, "Check " + attributes[idx] + " attribute");
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
Adding new tests coming from WebKit:
- Checking how headers are cloned when cloning a request
- Various (good and failing) JSON parsing when calling Request.json()
- Checking that a HEAD request cannot take a body
  Making some minor clean-up to some tests.
