### PR TITLE
HTML radio tests: Assert that events initiated via HTMLElement.click() shouldn't be trusted

### DIFF
--- a/html/semantics/forms/the-input-element/radio.html
+++ b/html/semantics/forms/the-input-element/radio.html
@@ -90,7 +90,7 @@
     assert_true(click_fired, "input event should fire after click event");
     assert_false(change_fired, "input event should fire before change event");
     assert_true(e.bubbles, "input event should bubble")
-    assert_true(e.isTrusted, "input event should be trusted");
+    assert_false(e.isTrusted, "click()-initiated input event shouldn't be trusted");
     assert_false(e.cancelable, "input event should not be cancelable");
   });
 
@@ -99,7 +99,7 @@
     assert_true(click_fired, "change event should fire after click event");
     assert_true(input_fired, "change event should fire after input event");
     assert_true(e.bubbles, "change event should bubble")
-    assert_true(e.isTrusted, "change event should be trusted");
+    assert_false(e.isTrusted, "click()-initiated change event shouldn't be trusted");
     assert_false(e.cancelable, "change event should not be cancelable");
   });
 


### PR DESCRIPTION
Fixes #1418.
