### PR TITLE
Tests that easing property in KeyframeEffectOptions is passed to KeyframeEffectReadOnly.

### DIFF
--- a/web-animations/keyframe-effect/constructor.html
+++ b/web-animations/keyframe-effect/constructor.html
@@ -108,7 +108,7 @@ test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, {
       left: ["10px", "20px"]
     }, { easing: easing });
-    assert_equals(effect.getFrames()[0].easing, expected,
+    assert_equals(effect.timing.easing, expected,
                   "resulting easing for '" + easing + "'");
   });
 }, "easing values are parsed correctly when passed to the " +


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1216842
