### PR TITLE
Escape a control character to work around a JSON parser bug

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -1938,7 +1938,7 @@
     "hash": ""
   },
   {
-    "input": "http://example.com/foo\t%91",
+    "input": "http://example.com/foo\t\u0091%91",
     "base": "about:blank",
     "href": "http://example.com/foo%C2%91%91",
     "origin": "http://example.com",


### PR DESCRIPTION
It’s not visible in the github diff view, but `\u0091` replaces a literal U+0091 character.

https://github.com/rust-lang-nursery/rustc-serialize/pull/142
