### PR TITLE
HTML: Add simple test of focus event targets

### DIFF
--- a/html/editing/focus/focus-management/focus-event-targets-simple.html
+++ b/html/editing/focus/focus-management/focus-event-targets-simple.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Focus events fire at correct targets in correct order in simple case</title>
+  <link rel="author" title="Chris Rebert" href="http://chrisrebert.com">
+  <link rel="help" href="https://html.spec.whatwg.org/#focus-update-steps">
+  <link rel="help" href="https://html.spec.whatwg.org/#focus-chain">
+  <meta name="flags" content="dom">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <input type="text" id="a">
+  <script>
+// Record all the focus event targets in an array.
+// Modulo special cases in the "focus update steps" algorithm,
+// this should be the same as the new focus chain, except in reverse order.
+var newFocusChainReversedNotQuite = [];
+var pushTarget = function (e) {
+  newFocusChainReversedNotQuite.push(e.target);
+};
+// Window is the root node for event dispatch per https://html.spec.whatwg.org/multipage/webappapis.html#events-and-the-window-object
+window.addEventListener('focus', pushTarget, true);// Use event capturing since focus event doesn't bubble
+var input = document.getElementById('a');
+input.focus();
+window.removeEventListener('focus', pushTarget, true);
+test(function() {
+  assert_array_equals(newFocusChainReversedNotQuite, [input], "Exactly 1 focus event should fire and its target should be the input");
+}, "Focus events fire at correct targets in correct order in simple case");
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Refs https://github.com/twbs/bootstrap/issues/18365
Refs https://bugzilla.mozilla.org/show_bug.cgi?id=1228802
Firefox is firing extra `focus`es at `document` and `window`.
~~Edge seems to fire an extra `focus` at `window`.~~
