### PR TITLE
BarProp.visible attribute should be readonly as per the latest HTML s…

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2304,7 +2304,7 @@ Window implements GlobalEventHandlers;
 Window implements WindowEventHandlers;
 
 interface BarProp {
-           attribute boolean visible;
+  readonly attribute boolean visible;
 };
 
 enum ScrollRestoration { "auto", "manual" };


### PR DESCRIPTION
…pecification

BarProp.visible attribute should be readonly as per the latest HTML specification:
https://html.spec.whatwg.org/multipage/browsers.html#barprop
