### PR TITLE
Location.origin should be readonly

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2322,7 +2322,7 @@ interface History {
 
 [Unforgeable] interface Location {
   stringifier attribute USVString href;
-           attribute USVString origin;
+  readonly attribute USVString origin;
            attribute USVString protocol;
            attribute USVString host;
            attribute USVString hostname;


### PR DESCRIPTION
Location.origin should be readonly as per the latest HTML specification:
https://html.spec.whatwg.org/multipage/browsers.html#location
