### PR TITLE
Changing input type to file clears value IDL attr

### DIFF
--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -25,7 +25,7 @@
     { type: "color", sanitizedValue: "#000000" },
     { type: "checkbox" },
     { type: "radio" },
-    { type: "file", sanitizedValue: "" },
+    { type: "file" },
     { type: "submit" },
     { type: "image" },
     { type: "reset" },
@@ -41,6 +41,10 @@
             assert_throws("INVALID_STATE_ERR", function() {
               input.value = "  foo\rbar  ";
             });
+            assert_equals(input.value, "");
+          } else if (types[j].type === "file") {
+            input.value = "  foo\rbar  ";
+            input.type = types[j].type;  // change state
             assert_equals(input.value, "");
           } else {
             input.value = "  foo\rbar  ";

--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -25,7 +25,7 @@
     { type: "color", sanitizedValue: "#000000" },
     { type: "checkbox" },
     { type: "radio" },
-    { type: "file" },
+    { type: "file", sanitizedValue: "" },
     { type: "submit" },
     { type: "image" },
     { type: "reset" },


### PR DESCRIPTION
I think this is correct.

According to step 3 of
https://html.spec.whatwg.org/multipage/forms.html#input-type-change 
a type change causing a value mode transition from non-filename to filename should update the
input internal value state to the empty string.

According to
https://html.spec.whatwg.org/multipage/forms.html#dom-input-value a
subsequent read of the value IDL attribute in filename value mode should return the empty
string (assuming no selected files).

Refs: https://github.com/servo/servo/pull/9514/
