### PR TITLE
Check for the existence of Attr.nodeName

### DIFF
--- a/dom/nodes/attributes.js
+++ b/dom/nodes/attributes.js
@@ -6,6 +6,7 @@ function attr_is(attr, v, ln, ns, p, n) {
   assert_equals(attr.namespaceURI, ns)
   assert_equals(attr.prefix, p)
   assert_equals(attr.name, n)
+  assert_equals(attr.nodeName, n);
   assert_equals(attr.specified, true)
 }
 


### PR DESCRIPTION
Similar to `Attr.nodeValue`, it's a passthrough to `Attr.name`. For completeness until it's formally removed.

https://developer.mozilla.org/en-US/docs/Web/API/Attr
