### PR TITLE
crossOrigin attribute should be nullable

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -5,7 +5,7 @@ var embeddedElements = {
     alt: "string",
     src: "url",
     srcset: "string",
-    crossOrigin: {type: "enum", keywords: ["", "anonymous", "use-credentials"]},
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
     useMap: "string",
     isMap: "boolean",
     width: {type: "unsigned long", customGetter: true},
@@ -84,7 +84,7 @@ var embeddedElements = {
   video: {
     // HTMLMediaElement
     src: "url",
-    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}},
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
     // As with "keytype", we have no missing value default defined here.
     preload: {type: "enum", keywords: ["none", "metadata", "auto"], nonCanon: {"": "auto"}, defaultVal: null},
     autoplay: "boolean",
@@ -100,7 +100,7 @@ var embeddedElements = {
   audio: {
     // HTMLMediaElement
     src: "url",
-    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}},
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
     // As with "keytype", we have no missing value default defined here.
     preload: {type: "enum", keywords: ["none", "metadata", "auto"], nonCanon: {"": "auto"}, defaultVal: null},
     autoplay: "boolean",

--- a/html/dom/elements-misc.js
+++ b/html/dom/elements-misc.js
@@ -13,7 +13,7 @@ var miscElements = {
     charset: "string",
     // TODO: async attribute (complicated).
     defer: "boolean",
-    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}},
+    crossOrigin: {type: "enum", keywords: ["anonymous", "use-credentials"], nonCanon:{"": "anonymous"}, isNullable: true, defaultVal: null, invalidVal: "anonymous"},
   },
   noscript: {},
 

--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1048,7 +1048,7 @@ interface HTMLBaseElement : HTMLElement {
 
 interface HTMLLinkElement : HTMLElement {
            attribute DOMString href;
-           attribute DOMString crossOrigin;
+           attribute DOMString? crossOrigin;
            attribute DOMString rel;
   [PutForwards=value] readonly attribute DOMTokenList relList;
            attribute DOMString media;
@@ -1173,7 +1173,7 @@ interface HTMLImageElement : HTMLElement {
            attribute DOMString src;
            attribute DOMString srcset;
            attribute DOMString sizes;
-           attribute DOMString crossOrigin;
+           attribute DOMString? crossOrigin;
            attribute DOMString useMap;
            attribute boolean isMap;
            attribute unsigned long width;
@@ -1286,7 +1286,7 @@ interface HTMLMediaElement : HTMLElement {
   // network state
            attribute DOMString src;
   readonly attribute DOMString currentSrc;
-           attribute DOMString crossOrigin;
+           attribute DOMString? crossOrigin;
   const unsigned short NETWORK_EMPTY = 0;
   const unsigned short NETWORK_IDLE = 1;
   const unsigned short NETWORK_LOADING = 2;
@@ -1949,7 +1949,7 @@ interface HTMLScriptElement : HTMLElement {
            attribute DOMString charset;
            attribute boolean async;
            attribute boolean defer;
-           attribute DOMString crossOrigin;
+           attribute DOMString? crossOrigin;
            attribute DOMString text;
 
   // also has obsolete members

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -271,6 +271,7 @@ ReflectionTests.typeMap = {
      *   "keywords": array of keywords as given by the spec (required)
      *   "nonCanon": dictionary mapping non-canonical values to their
      *     canonical equivalents (defaults to {})
+     *   "isNullable": Indicates if attribute is nullable (defaults to false)
      *
      * Tests are mostly hardcoded into reflects(), since they depend on the
      * keywords.  All expected values are computed in reflects() using a helper
@@ -592,9 +593,14 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
 
     var typeInfo = this.typeMap[data.type];
 
+    if (typeof data.isNullable == "undefined") {
+        data.isNullable = false;
+    }
+
     // Test that typeof idlObj[idlName] is correct.  If not, further tests are
     // probably pointless, so bail out.
-    if (!ReflectionHarness.test(typeof idlObj[idlName], typeInfo.jsType, "typeof IDL attribute")) {
+    var isDefaultValueNull = data.isNullable && data.defaultVal === null;
+    if (!ReflectionHarness.test(typeof idlObj[idlName], isDefaultValueNull ? "object" : typeInfo.jsType, "typeof IDL attribute")) {
         return;
     }
 
@@ -603,7 +609,7 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
     if (defaultVal === undefined) {
         defaultVal = typeInfo.defaultVal;
     }
-    if (defaultVal !== null) {
+    if (defaultVal !== null || data.isNullable) {
         ReflectionHarness.test(idlObj[idlName], defaultVal, "IDL get with DOM attribute unset");
     }
 
@@ -650,7 +656,14 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
 
         // Per spec, the expected DOM values are the same as the value we set
         // it to.
-        idlDomExpected = idlTests.slice(0);
+        if (!data.isNullable) {
+            idlDomExpected = idlTests.slice(0);
+        } else {
+            idlDomExpected = [];
+            for (var i = 0; i < idlTests.length; i++) {
+                idlDomExpected.push((idlTests[i] === null || idlTests[i] === undefined) ? null : idlTests[i]);
+            }
+        }
 
         // Now we have the fun of calculating what the expected IDL values are.
         domExpected = [];
@@ -659,7 +672,11 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
             domExpected.push(this.enumExpected(data.keywords, data.nonCanon, data.invalidVal, domTests[i]));
         }
         for (var i = 0; i < idlTests.length; i++) {
-            idlIdlExpected.push(this.enumExpected(data.keywords, data.nonCanon, data.invalidVal, idlTests[i]));
+            if (data.isNullable && (idlTests[i] === null || idlTests[i] === undefined)) {
+                idlIdlExpected.push(null);
+            } else {
+                idlIdlExpected.push(this.enumExpected(data.keywords, data.nonCanon, data.invalidVal, idlTests[i]));
+            }
         }
         break;
 
@@ -687,7 +704,7 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
 
     if (!data.customGetter) {
         for (var i = 0; i < domTests.length; i++) {
-            if (domExpected[i] === null) {
+            if (domExpected[i] === null && !data.isNullable) {
                 // If you follow all the complicated logic here, you'll find that
                 // this will only happen if there's no expected value at all (like
                 // for tabIndex, where the default is too complicated).  So skip
@@ -723,10 +740,14 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
                 if (data.type == "boolean") {
                     // Special case yay
                     ReflectionHarness.test(domObj.hasAttribute(domName), Boolean(idlTests[i]), "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by hasAttribute()");
-                } else if (idlDomExpected[i] !== null) {
-                    ReflectionHarness.test(domObj.getAttribute(domName), idlDomExpected[i] + "", "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by getAttribute()");
+                } else if (idlDomExpected[i] !== null || data.isNullable) {
+                    var expected = idlDomExpected[i] + "";
+                    if (data.isNullable && idlDomExpected[i] === null) {
+                        expected = null;
+                    }
+                    ReflectionHarness.test(domObj.getAttribute(domName), expected, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by getAttribute()");
                 }
-                if (idlIdlExpected[i] !== null) {
+                if (idlIdlExpected[i] !== null || data.isNullable) {
                     ReflectionHarness.test(idlObj[idlName], idlIdlExpected[i], "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by IDL get");
                 }
                 if (ReflectionHarness.catchUnexpectedExceptions) {


### PR DESCRIPTION
crossOrigin attribute should be nullable on the following interfaces:
HTMLLinkElement, HTMLImageElement, HTMLMediaElement and HTMLScriptElement

The reflection tests were updated so that:
- If the content attribute is in its missing value default then the IDL
  attribute must return null.
- on setting, if the new value is null, the content attribute must be
  removed.
