### PR TITLE
HTMLAllCollection should not inherit HTMLCollection

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -871,11 +871,11 @@ interface HTMLHyperlinkElementUtils {
            attribute USVString hash;
 };
 
-interface HTMLAllCollection : HTMLCollection {
-  // inherits length and 'getter'
-  Element? item(unsigned long index);
+interface HTMLAllCollection {
+  readonly attribute unsigned long length;
+  getter Element? item(unsigned long index);
   (HTMLCollection or Element)? item(DOMString name);
-  legacycaller getter (HTMLCollection or Element)? namedItem(DOMString name); // shadows inherited namedItem()
+  legacycaller getter (HTMLCollection or Element)? namedItem(DOMString name);
 };
 
 interface HTMLFormControlsCollection : HTMLCollection {


### PR DESCRIPTION
HTMLAllCollection should not inherit HTMLCollection as per the latest HTML
specification:
- https://html.spec.whatwg.org/#the-htmlallcollection-interface
