### PR TITLE
HTMLHyperlinkElementUtils.origin should be readonly

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -859,7 +859,7 @@ typedef (Int8Array or Uint8Array or Uint8ClampedArray or
 [NoInterfaceObject, Exposed=Window]
 interface HTMLHyperlinkElementUtils {
   stringifier attribute USVString href;
-           attribute USVString origin;
+  readonly attribute USVString origin;
            attribute USVString protocol;
            attribute USVString username;
            attribute USVString password;


### PR DESCRIPTION
HTMLHyperlinkElementUtils.origin should be readonly as per:
- https://html.spec.whatwg.org/#htmlhyperlinkelementutils
