### PR TITLE
Window's named properties object should not claim to have duplicates of a given property name if it has multiple iframes with that name.

### DIFF
--- a/html/browsers/the-window-object/window-named-properties.html
+++ b/html/browsers/the-window-object/window-named-properties.html
@@ -10,6 +10,8 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <iframe name="bar"></iframe>
+<iframe name="baz"></iframe>
+<iframe name="baz"></iframe>
 <iframe name="constructor"></iframe>
 <script>
 function assert_data_propdesc(pd, Writable, Enumerable, Configurable) {
@@ -31,7 +33,7 @@ test(function() {
   assert_true("bar" in gsp, "bar in gsp");
   assert_true(gsp.hasOwnProperty("bar"), "gsp.hasOwnProperty(\"bar\")");
   assert_data_propdesc(Object.getOwnPropertyDescriptor(gsp, "bar"),
-                       false, true, true);
+                       true, false, true);
 }, "Static name on the prototype");
 test(function() {
   assert_equals(window.constructor, Window);
@@ -45,10 +47,15 @@ test(function() {
 
   var gsp = Object.getPrototypeOf(proto);
   assert_true("constructor" in gsp, "constructor in gsp");
-  assert_true(gsp.hasOwnProperty("constructor"), "gsp.hasOwnProperty(\"constructor\")");
-  assert_data_propdesc(Object.getOwnPropertyDescriptor(gsp, "constructor"),
-                       false, true, true);
+  assert_false(gsp.hasOwnProperty("constructor"), "gsp.hasOwnProperty(\"constructor\")");
+  assert_equals(Object.getOwnPropertyDescriptor(gsp, "constructor"), undefined);
 }, "constructor");
+test(function() {
+  var gsp = Object.getPrototypeOf(Object.getPrototypeOf(window));
+  var names = Object.getOwnPropertyNames(gsp);
+  assert_equals(names.filter((name) => name == "baz").length, 1);
+
+}, "duplicate property names")
 var t = async_test("Dynamic name")
 var t2 = async_test("Ghost name")
 t.step(function() {


### PR DESCRIPTION
The web platform test was pretty buggy in a few ways:

1)  It claimed that "bar" should be non-writable and enumerable.  This
explicitly contradicts the spec:
http://heycam.github.io/webidl/#named-properties-object-getownproperty step 3
substep 8 sets [[Writable]] to true, and
https://html.spec.whatwg.org/multipage/browsers.html#named-access-on-the-window-object
explicitly says these properties are unenumerable.

2)  It claimed that "constructor" should be exposed on the named properties
object.  But the named property visibility algorithm obviously returns false
for that property name, so it should not be exposed.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1245554
