### PR TITLE
Add tests for activeDuration;

### DIFF
--- a/web-animations/keyframe-effect/getComputedTiming.html
+++ b/web-animations/keyframe-effect/getComputedTiming.html
@@ -129,6 +129,75 @@ gGetComputedTimingTests.forEach(function(stest) {
      "constructed by " + stest.desc);
 });
 
+var gActiveDurationTests = [
+  { desc:     "an empty KeyframeEffectOptions object",
+    input:    { },
+    expected: 0 },
+  { desc:     "a non-zero duration and default iteration count",
+    input:    { duration: 1000 },
+    expected: 1000 },
+  { desc:     "a non-zero duration and integral iteration count",
+    input:    { duration: 1000, iterations: 7 },
+    expected: 7000 },
+  { desc:     "a non-zero duration and fractional iteration count",
+    input:    { duration: 1000, iterations: 2.5 },
+    expected: 2500 },
+  { desc:     "an non-zero duration and infinite iteration count",
+    input:    { duration: 1000, iterations: Infinity },
+    expected: Infinity },
+  { desc:     "an non-zero duration and zero iteration count",
+    input:    { duration: 1000, iterations: 0 },
+    expected: 0 },
+  { desc:     "a zero duration and default iteration count",
+    input:    { duration: 0 },
+    expected: 0 },
+  { desc:     "a zero duration and fractional iteration count",
+    input:    { duration: 0, iterations: 2.5 },
+    expected: 0 },
+  { desc:     "a zero duration and infinite iteration count",
+    input:    { duration: 0, iterations: Infinity },
+    expected: 0 },
+  { desc:     "a zero duration and zero iteration count",
+    input:    { duration: 0, iterations: 0 },
+    expected: 0 },
+  { desc:     "an infinite duration and default iteration count",
+    input:    { duration: Infinity },
+    expected: Infinity },
+  { desc:     "an infinite duration and zero iteration count",
+    input:    { duration: Infinity, iterations: 0 },
+    expected: 0 },
+  { desc:     "an infinite duration and fractional iteration count",
+    input:    { duration: Infinity, iterations: 2.5 },
+    expected: Infinity },
+  { desc:     "an infinite duration and infinite iteration count",
+    input:    { duration: Infinity, iterations: Infinity },
+    expected: Infinity },
+  { desc:     "an infinite duration and zero iteration count",
+    input:    { duration: Infinity, iterations: 0 },
+    expected: 0 },
+  { desc:     "an invalid duration and default iteration count",
+    input:    { duration: "cabbage" },
+    expected: 0 },
+  { desc:     "a non-zero duration and invalid iteration count",
+    input:    { duration: 1000, iterations: "cabbage" },
+    expected: 1000 },
+  { desc:     "an invalid duration and invalid iteration count",
+    input:    { duration: "cabbage", iterations: "cabbage" },
+    expected: 0 }
+];
+
+gActiveDurationTests.forEach(function(stest) {
+  test(function(t) {
+    var effect = new KeyframeEffectReadOnly(target,
+                                            { left: ["10px", "20px"] },
+                                            stest.input);
+
+    assert_equals(effect.getComputedTiming().activeDuration,
+                  stest.expected);
+
+  }, "getComputedTiming().activeDuration for " + stest.desc);
+});
+
 done();
 </script>
 </body>


### PR DESCRIPTION
Before we go fixing endTime, we should add tests that activeDuration (which
endTime builds on) is being calculated correctly. (Spoiler: it wasn't, hence
parts 2 and 3 in this patch series.)

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1249212
