### PR TITLE
Update battery-unplugging-manual.html

### DIFF
--- a/battery-status/battery-unplugging-manual.html
+++ b/battery-status/battery-unplugging-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Battery Test: battery not full, charger unplugging</title>
+<title>Battery Test: charger unplugging</title>
 <meta name="flags" content="interact">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -16,16 +16,15 @@
 
 <h2>Description</h2>
 <p>
-  This test validates that all of the BatteryManager attributes exist and are set to correct values, with corresponding events fired, when the charger is unplugged.
+  This test validates that all of the BatteryManager attributes exist and
+  are set to correct values, with corresponding events fired,
+  when the charger is unplugged.
 </p>
 
 <h2>Preconditions</h2>
 <ol>
   <li>
     The device is plugged in to the charger before this test is run.
-  </li>
-  <li>
-    The battery must not be full or reach full capacity during the time the test is run.
   </li>
 </ol>
 
@@ -41,10 +40,21 @@
 
   setup({ explicit_timeout: true });
 
-  var onchargingchange_test = async_test('When the device is unplugged in and its charging state is updated, must set the charging attribute\'s value to false and fire a chargingchange event.');
-  var onchargingtimechange_test = async_test('When the device is unplugged in and its charging time is updated, must set the chargingTime attribute\'s value to Infinity and fire a chargingtimechange event.');
-  var ondischargingtimechange_test = async_test('When the device is unplugged in and its discharging time is updated, must set the dischargingTime attribute\'s value and fire a dischargingtimechange event.');
-  var onlevelchange_test = async_test('When the device is plugged in and the battery level is updated, must set the level attribute\'s value and fire a levelchange event.');
+  var onchargingchange_test = async_test(
+      'When the device is unplugged in and its charging state is updated, ' +
+      'must set the charging attribute\'s value to false and ' +
+      'fire a chargingchange event.');
+  var onchargingtimechange_test = async_test(
+      'When the device is unplugged in and its charging time is updated, ' +
+      'must set the chargingTime attribute\'s value to Infinity and ' +
+      'fire a chargingtimechange event.');
+  var ondischargingtimechange_test = async_test(
+      'When the device is unplugged in and its discharging time is updated, ' +
+      'must set the dischargingTime attribute\'s value and '
+      'fire a dischargingtimechange event.');
+  var onlevelchange_test = async_test(
+      'When the device is unplugged in and the battery level is updated, ' +
+      must set the level attribute\'s value and fire a levelchange event.');
 
   var batterySuccess = function (battery) {
     battery.onchargingchange = onchargingchange_test.step_func(function () {
@@ -53,12 +63,14 @@
     });
 
     battery.onchargingtimechange = onchargingtimechange_test.step_func(function () {
-      assert_equals(battery.chargingTime, Infinity, 'The value of the chargingTime attribute must be set to Infinity.');
+      assert_equals(battery.chargingTime, Infinity,
+          'The value of the chargingTime attribute must be set to Infinity.');
       onchargingtimechange_test.done();
     });
 
     battery.ondischargingtimechange = ondischargingtimechange_test.step_func(function () {
-      assert_less_than(battery.dischargingTime, Infinity, 'The value of the dischargingTime attribute must be set to the remaining discharging time.');
+      assert_less_than(battery.dischargingTime, Infinity,
+          'The value of the dischargingTime attribute must be set to the remaining discharging time.');
       ondischargingtimechange_test.done();
     });
 


### PR DESCRIPTION
- The spec doesn't say that battery cannot be full to get all the
  events fired; thus no need this constraint. Moveover Chrome 49
  and Firefox Nightly get all tests pass if run the test file when
  battery is full.
- Fix a typo and use the + operator to make long literal strings.
