### PR TITLE
Fix FormData test setting Blob / getting File

### DIFF
--- a/XMLHttpRequest/formdata-set.htm
+++ b/XMLHttpRequest/formdata-set.htm
@@ -80,8 +80,12 @@
         assert_equals(fd.get('key'), "value1");
     }, 'testFormDataSetToFormNull2');
     test(function() {
-        assert_object_equals(create_formdata(['key', new Blob(), 'blank.txt']).get('key'),
-                             new File(new Blob(), 'blank.txt'));
+        var fd = new FormData();
+        fd.set('key', new Blob([]), 'blank.txt');
+        var file = fd.get('key');
+
+        assert_true(file instanceof File);
+        assert_equals(file.name, 'blank.txt');
     }, 'testFormDataSetEmptyBlob');
 
     function create_formdata() {


### PR DESCRIPTION
Correct two issues with a FormData set() test case:
- Incorrect use of File constructor - first argument must be a sequence.
- assert_object_equals doesn't actually compare host objects usefully.

The intent of the test case is to check that the value returned after setting a Blob plus name is indeed a File object with that name, so just do that directly.

Passes in Firefox 44 and upcoming Chrome 50.

Resolves https://github.com/w3c/web-platform-tests/issues/2616
