### PR TITLE
List more events that should not work document.createEvent()

### DIFF
--- a/dom/nodes/Document-createEvent.html
+++ b/dom/nodes/Document-createEvent.html
@@ -33,11 +33,23 @@ function testAlias(arg, iface) {
                   "isTrusted should be initialized to false");
   }, "createEvent('" + arg + "') should be initialized correctly.");
 }
-aliases.forEach(function(alias) {
-  testAlias(alias[0], alias[1]);
-  testAlias(alias[0].toLowerCase(), alias[1]);
-  testAlias(alias[0].toUpperCase(), alias[1]);
-});
+for (var alias in aliases) {
+  var iface = aliases[alias];
+  testAlias(alias, iface);
+  testAlias(alias.toLowerCase(), iface);
+  testAlias(alias.toUpperCase(), iface);
+
+  if (!alias.endsWith("s")) {
+    var plural = alias + "s";
+    if (!(plural in aliases)) {
+      test(function () {
+        assert_throws("NOT_SUPPORTED_ERR", function () {
+          var evt = document.createEvent(plural);
+        });
+      }, 'Should throw NOT_SUPPORTED_ERR for pluralized legacy event interface "' + plural + '"');
+    }
+  }
+}
 
 test(function() {
   assert_throws("NOT_SUPPORTED_ERR", function() {
@@ -61,12 +73,73 @@ This list is not exhaustive.
 */
 var someNonCreateableEvents = [
   "AnimationEvent",
+  "AnimationPlayerEvent",
+  "ApplicationCacheErrorEvent",
+  "AudioProcessingEvent",
+  "AutocompleteErrorEvent",
+  "BeforeInstallPromptEvent",
+  "BeforeUnloadEvent",
+  "BlobEvent",
+  "ClipboardEvent",
+  "CloseEvent",
+  "CompositionEvent",
+  "DeviceLightEvent",
+  "DeviceMotionEvent",
+  "DeviceOrientationEvent",
   "DragEvent",
   "ErrorEvent",
+  "ExtendableEvent",
+  "ExtendableMessageEvent",
+  "FetchEvent",
   "FocusEvent",
+  "FontFaceSetLoadEvent",
+  "GamepadEvent",
+  "GeofencingEvent",
+  "HashChangeEvent",
+  "IDBVersionChangeEvent",
+  "InstallEvent",
   "KeyEvent",
+  "MIDIConnectionEvent",
+  "MIDIMessageEvent",
+  "MediaEncryptedEvent",
+  "MediaKeyEvent",
+  "MediaKeyMessageEvent",
+  "MediaQueryListEvent",
+  "MediaStreamEvent",
+  "MediaStreamTrackEvent",
+  "MutationEvent",
+  "NotificationEvent",
+  "OfflineAudioCompletionEvent",
+  "OrientationEvent",
+  "PageTransitionEvent",
   "PointerEvent",
+  "PopStateEvent",
+  "PresentationConnectionAvailableEvent",
+  "PresentationConnectionCloseEvent",
+  "ProgressEvent",
+  "PromiseRejectionEvent",
+  "PushEvent",
+  "RTCDTMFToneChangeEvent",
+  "RTCDataChannelEvent",
+  "RTCIceCandidateEvent",
+  "RelatedEvent",
+  "ResourceProgressEvent",
+  "SVGEvent",
+  "SVGZoomEvent",
+  "SecurityPolicyViolationEvent",
+  "ServicePortConnectEvent",
+  "ServiceWorkerMessageEvent",
+  "SpeechRecognitionError",
+  "SpeechRecognitionEvent",
+  "SpeechSynthesisEvent",
+  "StorageEvent",
+  "SyncEvent",
+  "TextEvent",
+  "TrackEvent",
   "TransitionEvent",
+  "WebGLContextEvent",
+  "WebKitAnimationEvent",
+  "WebKitTransitionEvent",
   "WheelEvent"
 ];
 someNonCreateableEvents.forEach(function (eventInterface) {

--- a/dom/nodes/Document-createEvent.js
+++ b/dom/nodes/Document-createEvent.js
@@ -1,13 +1,13 @@
-var aliases = [
-  ["CustomEvent", "CustomEvent"],
-  ["Event", "Event"],
-  ["Events", "Event"],
-  ["HTMLEvents", "Event"],
-  ["KeyboardEvent", "KeyboardEvent"],
-  ["MessageEvent", "MessageEvent"],
-  ["MouseEvent", "MouseEvent"],
-  ["MouseEvents", "MouseEvent"],
-  ["TouchEvent", "TouchEvent"],
-  ["UIEvent", "UIEvent"],
-  ["UIEvents", "UIEvent"]
-];
+var aliases = {
+  "CustomEvent": "CustomEvent",
+  "Event": "Event",
+  "Events": "Event",
+  "HTMLEvents": "Event",
+  "KeyboardEvent": "KeyboardEvent",
+  "MessageEvent": "MessageEvent",
+  "MouseEvent": "MouseEvent",
+  "MouseEvents": "MouseEvent",
+  "TouchEvent": "TouchEvent",
+  "UIEvent": "UIEvent",
+  "UIEvents": "UIEvent"
+};


### PR DESCRIPTION
These are all of the events that currently work in Chromium, from
@doomdavve's work to stop the spread:
https://bugs.chromium.org/p/chromium/issues/detail?id=569690

This reveals that Gecko (Firefox Nightly) supports some of these as
well, namely BeforeUnloadEvent, CompositionEvent, DeviceMotionEvent,
DeviceOrientationEvent, DragEvent, DragEvents, HashChangeEvent,
MutationEvent, MutationEvents, PopStateEvent, SVGEvent, SVGEvents,
SVGZoomEvent, SVGZoomEvents, StorageEvent, TextEvent, and TextEvents.

KeyboardEvents (pluralized) is supported by Chromium, but adding it to
this list would also test KeyboardEventss. Instead ensure that no
pluralized forms of legacy events are supported except those listed.
