### PR TITLE
Test that document.createEvent("KeyEvents") is no longer supported

### DIFF
--- a/dom/nodes/Document-createEvent.html
+++ b/dom/nodes/Document-createEvent.html
@@ -64,6 +64,7 @@ var someNonCreateableEvents = [
   "DragEvent",
   "ErrorEvent",
   "FocusEvent",
+  "KeyEvent",
   "PointerEvent",
   "TransitionEvent",
   "WheelEvent"

--- a/dom/nodes/Document-createEvent.js
+++ b/dom/nodes/Document-createEvent.js
@@ -4,7 +4,6 @@ var aliases = [
   ["Events", "Event"],
   ["HTMLEvents", "Event"],
   ["KeyboardEvent", "KeyboardEvent"],
-  ["KeyEvents", "KeyboardEvent"],
   ["MessageEvent", "MessageEvent"],
   ["MouseEvent", "MouseEvent"],
   ["MouseEvents", "MouseEvent"],


### PR DESCRIPTION
It has been dropped from DOM:
https://github.com/whatwg/dom/issues/148
