### PR TITLE
Use presentation hints correctly for the dimensions of `<img>`.

### DIFF
--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-dim-ref.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-dim-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>img width/height - reference</title>
+<style>
+p { width: 50px; height: 50px; }
+</style>
+<p><img src=/images/green.png>
+<p><img src=/images/green.png style="width: 10px">
+<p><img src=/images/green.png style="height: 10px">
+<p><img src=/images/green.png style="width: 10%">
+<p><img src=/images/green.png style="height: 10%">

--- a/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-dim.html
+++ b/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/img-dim.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>img width/height</title>
+<link rel=match href=img-dim-ref.html>
+<style>
+p { width: 50px; height: 50px; }
+</style>
+<p><img src=/images/green.png>
+<p><img src=/images/green.png width=10>
+<p><img src=/images/green.png height=10>
+<p><img src=/images/green.png width=10%>
+<p><img src=/images/green.png height=10%>


### PR DESCRIPTION
Mostly straightforward; includes some extra fixes to make `<canvas>`
work the same way as `<img>` for reflow.
