### PR TITLE
Add support for the MS932 label of Shift_JIS. r=emk,

### DIFF
--- a/dom/nodes/Document-characterSet-normalization.html
+++ b/dom/nodes/Document-characterSet-normalization.html
@@ -282,6 +282,7 @@ var encodingMap = {
   ],
   "shift_jis": [
     "csshiftjis",
+    "ms932",
     "ms_kanji",
     "shift-jis",
     "shift_jis",

--- a/encoding/resources/encodings.js
+++ b/encoding/resources/encodings.js
@@ -419,6 +419,7 @@ var encodings_table =
       {
         "labels": [
           "csshiftjis",
+          "ms932",
           "ms_kanji",
           "shift-jis",
           "shift_jis",


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1120813
