### PR TITLE
Fix the test for parsing a template element inside a XML docuemnt.

### DIFF
--- a/html/semantics/scripting-1/the-template-element/additions-to-parsing-xhtml-documents/node-document.html
+++ b/html/semantics/scripting-1/the-template-element/additions-to-parsing-xhtml-documents/node-document.html
@@ -32,8 +32,11 @@ test(function() {
 
     assert_equals(template.ownerDocument, doc.body.ownerDocument,
             'Wrong template node owner document');
-    assert_not_equals(template.content.ownerDocument, doc,
-            'Wrong template content owner document');
+    var ownerDoc = template.content.ownerDocument;
+    assert_not_equals(ownerDoc, doc, 'Wrong template content owner document');
+    assert_not_equals(ownerDoc, document, 'Wrong template content owner document');
+    assert_equals(ownerDoc.defaultView, null,
+            'Template content owner document should not have a browsing context');
 
 }, 'Parsing XHTML: Node\'s node document must be set to that of the element '
     + 'to which it will be appended. Test empty template');

--- a/html/semantics/scripting-1/the-template-element/additions-to-parsing-xhtml-documents/node-document.html
+++ b/html/semantics/scripting-1/the-template-element/additions-to-parsing-xhtml-documents/node-document.html
@@ -32,7 +32,7 @@ test(function() {
 
     assert_equals(template.ownerDocument, doc.body.ownerDocument,
             'Wrong template node owner document');
-    assert_equals(template.content.ownerDocument, doc,
+    assert_not_equals(template.content.ownerDocument, doc,
             'Wrong template content owner document');
 
 }, 'Parsing XHTML: Node\'s node document must be set to that of the element '


### PR DESCRIPTION
The test previously asserted that template.content.ownerDocuemnt is that of the parsed document.

This patch negates the assertion per
https://html.spec.whatwg.org/#template-contents
https://html.spec.whatwg.org/#appropriate-template-contents-owner-document
which always uses the appropriate template contents owner document for template's content fragment.

The new behavior matches that of Firefox (47.0a1 or 44.0.2) and I'm changing WebKit's behavior in webkit.org/b/148850.
