### PR TITLE
template-as-a-descendant.html erroneously asserts that frameset.innerHTML accepts a template element

### DIFF
--- a/html/semantics/scripting-1/the-template-element/template-element/template-as-a-descendant.html
+++ b/html/semantics/scripting-1/the-template-element/template-element/template-as-a-descendant.html
@@ -22,11 +22,25 @@ function templateIsAChild(element) {
         'Template element should be a descendant of the ' + element.tagName + ' element');
 }
 
+function templateIsDisallowedAsAChild(element) {
+    element.innerHTML = '<template>some text</template>';
+
+    assert_equals(element.querySelector('template'), null,
+        'Template element should not be allowed as a descendant of the ' + element.tagName + ' element');
+}
+
 function templateIsAnIndirectChild(element) {
     element.innerHTML = '<div><template>some text</template></div>';
 
     assert_not_equals(element.querySelector('template'), null,
         'Template element should be a descendant of the ' + element.tagName + ' element');
+}
+
+function templateIsDisallowedAsAnIndirectChild(element) {
+    element.innerHTML = '<div><template>some text</template></div>';
+
+    assert_equals(element.querySelector('template'), null,
+        'Template element should not be allowed as indirect descendant of the ' + element.tagName + ' element');
 }
 
 function templateIsAnAppendedChild(doc, element) {
@@ -58,13 +72,16 @@ var parameters = [['Template element as a descendant of the BODY element. ' +
                   ['Template element as a descendant of the HEAD element. ' +
                    'Template element is created by innerHTML',
                    doc.head],
-                   ['Template element as a descendant of the FRAMESET element. ' +
-                    'Template element is created by innerHTML',
-                    frameset]
                    ];
 generate_tests(templateIsAChild, parameters,
-        'Template element as a descendant of the HEAD, BODY and FRAMESET elements');
+        'Template element as a descendant of the HEAD and BODY elements');
 
+parameters = [['Template element as a descendant of the FRAMESET element. ' +
+               'Template element is created by innerHTML',
+               frameset],
+               ];
+generate_tests(templateIsDisallowedAsAChild, parameters,
+    'Template element should be disallowed as a descendant of the FRAMESET elements');
 
 
 parameters = [['Template element as an indirect descendant of the BODY element. ' +
@@ -73,12 +90,16 @@ parameters = [['Template element as an indirect descendant of the BODY element. 
               ['Template element as an indirect descendant of the HEAD element. ' +
                'Template element is created by innerHTML',
                doc.head],
-               ['Template element as an indirect descendant of the FRAMESET element. ' +
-                'Template element is created by innerHTML',
-                frameset]
                ];
 generate_tests(templateIsAnIndirectChild, parameters,
         'Template element as an indirect descendant of the HEAD, BODY and FRAMESET elements');
+
+parameters = [['Template element as a descendant of the FRAMESET element. ' +
+               'Template element is created by innerHTML',
+               frameset],
+               ];
+generate_tests(templateIsDisallowedAsAnIndirectChild, parameters,
+    'Template element should be disallowed as an indirect descendant of the FRAMESET elements');
 
 
 


### PR DESCRIPTION
Fix the test by replacing the test case to assert that the start tag and the end tag tokens of template element are ignored.

The "in frameset" insertion mode doesn't accept either a start tag or an end tag whose tag name is "template" [1].
Since HTML fragment parsing algorithm [2] starts the HTML parser with a start tag token whose tag name is "frameset",
innerHTML on a frameset element parses the content of innerHTML using the "in frameset" insertion mode.
As a result, start tag whose tag name is "template" is a parsing error and should be ignored.

New behavior matches Firefox (47.0a1) and I intend to change WebKit's behavior in webkit.org/b/143519.

[1] https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inframeset
[2] https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
