### PR TITLE
Fix two HTML template element tests for "in frameset" mode.

### DIFF
--- a/html/syntax/parsing/template/additions-to-the-in-frameset-insertion-mode/end-tag-frameset.html
+++ b/html/syntax/parsing/template/additions-to-the-in-frameset-insertion-mode/end-tag-frameset.html
@@ -20,7 +20,7 @@ testInIFrame('/html/semantics/scripting-1/the-template-element/resources/framese
     var frameset = doc.querySelector('frameset');
     assert_equals(frameset.children.length, 0, 'Wrong number of frameset children elements');
 
-}, '<template> tag should be ignored if there\'s TEMPLATE element in the stack of open elements');
+}, '<template> tag should be ignored in "in frameset" insertion mode');
 
 </script>
 </body>

--- a/html/syntax/parsing/template/additions-to-the-in-frameset-insertion-mode/end-tag-frameset.html
+++ b/html/syntax/parsing/template/additions-to-the-in-frameset-insertion-mode/end-tag-frameset.html
@@ -3,8 +3,8 @@
 <head>
 <title>HTML Templates: additions to 'in frameset' insertion mode</title>
 <meta name="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<meta name="assert" content="If parser is in 'in frameset' insertion mode and meets frameset end tag then if the stack of open elements has a template element in html scope then this is a parse error; ignore the token">
-<link rel="help" href="http://www.w3.org/TR/2013/WD-html-templates-20130214/#in-head-addition">
+<meta name="assert" content="If parser is in 'in frameset' insertion mode then a start tag or an end tag whose name is 'template' is a parsing error">
+<link rel="help" href="https://www.w3.org/TR/2015/WD-html51-20151008/syntax.html#parsing-main-inframeset">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/html/resources/common.js"></script>
@@ -18,15 +18,9 @@ testInIFrame('/html/semantics/scripting-1/the-template-element/resources/framese
     var doc = context.iframes[0].contentDocument;
 
     var frameset = doc.querySelector('frameset');
-    assert_equals(frameset.children.length, 1, 'Wrong number of frameset children elements');
+    assert_equals(frameset.children.length, 0, 'Wrong number of frameset children elements');
 
-    var template = frameset.querySelector('template');
-    assert_equals(template.tagName, 'TEMPLATE', 'FRAMESET should contain template element');
-    assert_equals(template.content.childNodes.length, 0,
-            'Template content should be empty');
-
-}, '</frameset> tag should be ignored if there\'s TEMPLATE element in '
-    + 'the stack of open elements');
+}, '<template> tag should be ignored if there\'s TEMPLATE element in the stack of open elements');
 
 </script>
 </body>

--- a/html/syntax/parsing/template/creating-an-element-for-the-token/template-owner-document.html
+++ b/html/syntax/parsing/template/creating-an-element-for-the-token/template-owner-document.html
@@ -68,26 +68,6 @@ test(function () {
 
 test(function () {
     var doc = newHTMLDocument();
-
-    doc.open();
-    doc.write('<frameset><template id="tmpl1"><div id="div">DIV</div></template></frameset>');
-    doc.close();
-
-    var template = doc.querySelector('#tmpl1');
-
-    var div = template.content.querySelector('#div');
-
-    assert_equals(div.ownerDocument, template.content.ownerDocument,
-            'Wrong ownerDocument of the element in template');
-
-}, 'Test ownerDocument property of the element in a template. '
-    + 'Current DOCUMENT has no browsing context. Test template element '
-    + 'in the root of the frameset');
-
-
-
-test(function () {
-    var doc = newHTMLDocument();
     doc.body.innerHTML = '<template id="tmpl1">'
         + '<template id="tmpl2"><div id="div">DIV</div></template></template>';
 


### PR DESCRIPTION
In the latest HTML specification, "in frameset" mode treats any tag with name 'template' as a parsing error:
https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inframeset

Updated end-tag-frameset.html's assertion so that it expects no template element be generated under frameset, and removed a test case in template-owner-document.html which were testing the owner document of a template element under a frameset element as the parsing beahvior is already tested by the other test.

The new behavior matches that of Firefox, and I'm intending to change WebKit's behavior in webkit.org/b/143519.
