### PR TITLE
Fix location_assign.html.

### DIFF
--- a/html/browsers/history/the-location-interface/location_assign.html
+++ b/html/browsers/history/the-location-interface/location_assign.html
@@ -18,7 +18,7 @@
 
     test(function () {
       var href = location.href;
-      location.assign("http://:");
+      assert_throws('SYNTAX_ERR', function() { location.assign("http://:"); });
       assert_equals(location.href, href);
     }, "URL that fails to parse");
     </script>


### PR DESCRIPTION
location.assign() with a bad URL should throw a SyntaxError. So, the last
assert_equals() wasn't executed.

https://html.spec.whatwg.org/multipage/browsers.html#dom-location-assign
