### PR TITLE
Move out a test for autofocus input from focus.html to focus-autofocus.html.

### DIFF
--- a/html/semantics/selectors/pseudo-classes/focus-autofocus.html
+++ b/html/semantics/selectors/pseudo-classes/focus-autofocus.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Selector: pseudo-classes (:focus for autofocus)</title>
+<link rel="author" title="Kent Tamura" href="mailto:tkent@chromium.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes">
+<link rel=help href="https://html.spec.whatwg.org/multipage/forms.html#autofocusing-a-form-control:-the-autofocus-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+// This test can't be merged to focus.html because element.focus() may affect
+// autofocus behavior.
+var autofocusTest = async_test(":focus selector should work with an autofocused element.");
+var input = document.createElement("input");
+input.autofocus = true;
+input.addEventListener("focus", function() {
+  autofocusTest.step(function() {
+    assert_array_equals(document.querySelectorAll(":focus"), [input])
+    autofocusTest.done();
+  });
+}, false);
+document.body.appendChild(input);
+</script>
+</body>

--- a/html/semantics/selectors/pseudo-classes/focus.html
+++ b/html/semantics/selectors/pseudo-classes/focus.html
@@ -11,7 +11,6 @@
   <button id=button1 type=submit>button1</button>
   <input id=input1>
   <input id=input2 disabled>
-  <input id=input3 autofocus>
   <textarea id=textarea1>textarea1</textarea>
   <input type=checkbox id=checkbox1 checked>
   <input type=radio id=radio1 checked>
@@ -20,8 +19,6 @@
   <iframe src="focus-iframe.html" id=iframe onload="load()"></iframe>
 
   <script>
-    testSelector(":focus", ["input3"], "input3 has the attribute autofocus");
-
     document.getElementById("input1").focus(); // set the focus on input1
     testSelector(":focus", ["input1"], "input1 has the focus");
 


### PR DESCRIPTION
Focusing steps triggered by autofocus attribute is done asynchronously.
Autofocus test in focus.html didn't work.
https://html.spec.whatwg.org/multipage/forms.html#autofocusing-a-form-control:-the-autofocus-attribute

> 1. Queue a task that runs the focusing steps for the element.

Also, element.focus() cancels autofocus processing in Firefox.  We need a
separated test file to test autofocus.
