### PR TITLE
Test stripping of tab/CR/LF in URLs

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -4208,5 +4208,21 @@
     "pathname": "/jqueryui@1.2.3",
     "search": "",
     "hash": ""
+  },
+  "# tab/LF/CR",
+  {
+    "input": "h\tt\nt\rp://h\to\ns\rt:9\t0\n0\r0/p\ta\nt\rh?q\tu\ne\rry#f\tr\na\rg",
+    "base": "about:blank",
+    "href": "http://host:9000/path?query#frag",
+    "origin": "http://host:9000",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "host:9000",
+    "hostname": "host",
+    "port": "9000",
+    "pathname": "/path",
+    "search": "?query",
+    "hash": "#frag"
   }
 ]


### PR DESCRIPTION
This tests the following spec change:
https://github.com/whatwg/url/commit/7b40216f809c7fe3c9a1680b5c1b06a771c9ebd8

(The new test passes in Chromium and Gecko.)
