### PR TITLE
Adding more request/response consume tests, including empty body and blob body

### DIFF
--- a/fetch/api/basic/stream-response.js
+++ b/fetch/api/basic/stream-response.js
@@ -11,8 +11,6 @@ function streamBody(reader, test, count) {
     } else {
       test.step(function() {
         assert_true(count >= 2, "Retrieve body progressively");
-        test.done();
-        return;
       });
     }
   });
@@ -20,16 +18,14 @@ function streamBody(reader, test, count) {
 
 //simulate streaming:
 //count is large enough to let the UA deliver the body before it is completely retrieved
-async_test(function(test) {
-  fetch(RESOURCES_DIR + "trickle.py?ms=30&count=100").then(function(resp) {
+promise_test(function(test) {
+  return fetch(RESOURCES_DIR + "trickle.py?ms=30&count=100").then(function(resp) {
     var count = 0;
     if (resp.body)
       return streamBody(resp.body.getReader(), test, count);
     else
       test.step(function() {
         assert_unreached( "Body does not exist in response");
-        test.done();
-        return;
       });
   });
 }, "Stream response's body");

--- a/fetch/api/headers/headers-basic.html
+++ b/fetch/api/headers/headers-basic.html
@@ -25,7 +25,7 @@
       var parameters = [null, 1];
       parameters.forEach(function(parameter) {
         test(function() {
-          assert_throws(new TypeError(), () => new Headers(parameter));
+          assert_throws(new TypeError(), function() { new Headers(parameter) });
         }, "Create headers with " + parameter + " should throw");
       });
 

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Request consume empty bodies</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#request">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#body-mixin">
+    <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+    function checkBodyText(request) {
+      return request.text().then( function(bodyAsText) {
+        assert_equals(bodyAsText, "", "Resolved value should be empty");
+        assert_false(request.bodyUsed);
+      });
+    }
+
+    function checkBodyBlob(request) {
+      return request.blob().then(function(bodyAsBlob) {
+        var promise = new Promise(function (resolve, reject) {
+          var reader = new FileReader();
+          reader.onload = function(evt) {
+            resolve(reader.result)
+          };
+          reader.onerror = function() {
+            reject("Blob's reader failed");
+          };
+          reader.readAsText(bodyAsBlob);
+        });
+        return promise.then(function(body) {
+          assert_equals(body, "", "Resolved value should be empty");
+          assert_false(request.bodyUsed);
+        });
+      });
+    }
+
+    function checkBodyArrayBuffer(request) {
+      return request.arrayBuffer().then( function(bodyAsArrayBuffer) {
+        assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
+        assert_false(request.bodyUsed);
+      });
+    }
+
+    function checkBodyJSON(request) {
+      return request.json().then(
+        (bodyAsJSON) => {
+          assert_unreached("JSON parsing should fail");
+        },
+        () => {
+          assert_false(request.bodyUsed);
+        });
+    }
+
+    function checkBodyFormData(request) {
+      return request.formData().then(function(bodyAsFormData) {
+        assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
+        assert_false(request.bodyUsed);
+     });
+    }
+
+    function checkRequestBody(bodyType, checkFunction) {
+      promise_test(function(test) {
+        var request = new Request("", {"method": "POST"});
+        assert_false(request.bodyUsed);
+        return checkFunction(request);
+      }, "Consume request's body as " + bodyType);
+    }
+
+    var formData = new FormData();
+    checkRequestBody("text", checkBodyText);
+    checkRequestBody("blob", checkBodyBlob);
+    checkRequestBody("arrayBuffer", checkBodyArrayBuffer);
+    checkRequestBody("json", checkBodyJSON);
+    checkRequestBody("formData", checkBodyFormData);
+
+    </script>
+  </body>
+</html>

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -12,7 +12,7 @@
   <body>
     <script>
     function checkBodyText(request) {
-      return request.text().then( function(bodyAsText) {
+      return request.text().then(function(bodyAsText) {
         assert_equals(bodyAsText, "", "Resolved value should be empty");
         assert_false(request.bodyUsed);
       });
@@ -20,7 +20,7 @@
 
     function checkBodyBlob(request) {
       return request.blob().then(function(bodyAsBlob) {
-        var promise = new Promise(function (resolve, reject) {
+        var promise = new Promise(function(resolve, reject) {
           var reader = new FileReader();
           reader.onload = function(evt) {
             resolve(reader.result)
@@ -38,7 +38,7 @@
     }
 
     function checkBodyArrayBuffer(request) {
-      return request.arrayBuffer().then( function(bodyAsArrayBuffer) {
+      return request.arrayBuffer().then(function(bodyAsArrayBuffer) {
         assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
         assert_false(request.bodyUsed);
       });
@@ -78,7 +78,7 @@
 
     function checkRequestWithEmptyBody(bodyType, body, asText) {
       promise_test(function(test) {
-        var request = new Request("", {"method": "POST", "body" : body});
+        var request = new Request("", {"method": "POST", "body": body});
         assert_false(request.bodyUsed, "bodyUsed is false at init");
         if (asText) {
           return request.text().then(function(bodyAsString) {

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -61,7 +61,7 @@
      });
     }
 
-    function checkRequestBody(bodyType, checkFunction) {
+    function checkRequestWithNoBody(bodyType, checkFunction) {
       promise_test(function(test) {
         var request = new Request("", {"method": "POST"});
         assert_false(request.bodyUsed);
@@ -70,12 +70,34 @@
     }
 
     var formData = new FormData();
-    checkRequestBody("text", checkBodyText);
-    checkRequestBody("blob", checkBodyBlob);
-    checkRequestBody("arrayBuffer", checkBodyArrayBuffer);
-    checkRequestBody("json", checkBodyJSON);
-    checkRequestBody("formData", checkBodyFormData);
+    checkRequestWithNoBody("text", checkBodyText);
+    checkRequestWithNoBody("blob", checkBodyBlob);
+    checkRequestWithNoBody("arrayBuffer", checkBodyArrayBuffer);
+    checkRequestWithNoBody("json", checkBodyJSON);
+    checkRequestWithNoBody("formData", checkBodyFormData);
 
+    function checkResponseWithEmptyBody(bodyType, body, asText) {
+      promise_test(function(test) {
+        var response = new Response("", {"method": "POST", "body" : body});
+        assert_false(response.bodyUsed, "bodyUsed is false at init");
+        if (asText) {
+          return response.text().then(function(bodyAsString) {
+            assert_equals(bodyAsString.length, 0, "Resolved value should be empty");
+            assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+          });
+        }
+        return response.arrayBuffer().then(function(bodyAsArrayBuffer) {
+          assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
+          assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+        });
+      }, "Consume empty " + bodyType + " response body as " + (asText ? "text" : "arrayBuffer"));
+    }
+
+    // FIXME: Add BufferSource, FormData and URLSearchParams.
+    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), false);
+    checkResponseWithEmptyBody("text", "", false);
+    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), true);
+    checkResponseWithEmptyBody("text", "", true);
     </script>
   </body>
 </html>

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -46,10 +46,10 @@
 
     function checkBodyJSON(request) {
       return request.json().then(
-        (bodyAsJSON) => {
+        function(bodyAsJSON) {
           assert_unreached("JSON parsing should fail");
         },
-        () => {
+        function() {
           assert_false(request.bodyUsed);
         });
     }

--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -76,28 +76,28 @@
     checkRequestWithNoBody("json", checkBodyJSON);
     checkRequestWithNoBody("formData", checkBodyFormData);
 
-    function checkResponseWithEmptyBody(bodyType, body, asText) {
+    function checkRequestWithEmptyBody(bodyType, body, asText) {
       promise_test(function(test) {
-        var response = new Response("", {"method": "POST", "body" : body});
-        assert_false(response.bodyUsed, "bodyUsed is false at init");
+        var request = new Request("", {"method": "POST", "body" : body});
+        assert_false(request.bodyUsed, "bodyUsed is false at init");
         if (asText) {
-          return response.text().then(function(bodyAsString) {
+          return request.text().then(function(bodyAsString) {
             assert_equals(bodyAsString.length, 0, "Resolved value should be empty");
-            assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+            assert_true(request.bodyUsed, "bodyUsed is true after being consumed");
           });
         }
-        return response.arrayBuffer().then(function(bodyAsArrayBuffer) {
+        return request.arrayBuffer().then(function(bodyAsArrayBuffer) {
           assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
-          assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+          assert_true(request.bodyUsed, "bodyUsed is true after being consumed");
         });
-      }, "Consume empty " + bodyType + " response body as " + (asText ? "text" : "arrayBuffer"));
+      }, "Consume empty " + bodyType + " request body as " + (asText ? "text" : "arrayBuffer"));
     }
 
     // FIXME: Add BufferSource, FormData and URLSearchParams.
-    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), false);
-    checkResponseWithEmptyBody("text", "", false);
-    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), true);
-    checkResponseWithEmptyBody("text", "", true);
+    checkRequestWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), false);
+    checkRequestWithEmptyBody("text", "", false);
+    checkRequestWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), true);
+    checkRequestWithEmptyBody("text", "", true);
     </script>
   </body>
 </html>

--- a/fetch/api/request/request-consume.html
+++ b/fetch/api/request/request-consume.html
@@ -40,7 +40,7 @@
 
     function checkBodyArrayBuffer(request, expectedBody) {
       return request.arrayBuffer().then(function(bodyAsArrayBuffer) {
-        assert_array_equals(bodyAsArrayBuffer, stringToArrayBuffer(expectedBody), "Retrieve and verify request's body");
+        validateBufferFromString(bodyAsArrayBuffer, expectedBody, "Retrieve and verify request's body");
         assert_true(request.bodyUsed, "body as arrayBuffer: bodyUsed turned true");
       });
     }

--- a/fetch/api/request/request-consume.html
+++ b/fetch/api/request/request-consume.html
@@ -8,6 +8,7 @@
     <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="../resources/utils.js"></script>
   </head>
   <body>
     <script>
@@ -37,19 +38,9 @@
       });
     }
 
-    <!-- Taken from https://developers.google.com -->
-    function str2ab(str) {
-      var buf = new ArrayBuffer(str.length*2); // 2 bytes for each char
-      var bufView = new Uint16Array(buf);
-      for (var i=0, strLen=str.length; i < strLen; i++) {
-        bufView[i] = str.charCodeAt(i);
-      }
-      return buf;
-    }
-
     function checkBodyArrayBuffer(request, expectedBody) {
-      return request.arrayBuffer().then( function(bodyAsArrayBuffer) {
-        assert_array_equals(bodyAsArrayBuffer, str2ab(expectedBody), "Retrieve and verify request's body");
+      return request.arrayBuffer().then(function(bodyAsArrayBuffer) {
+        assert_array_equals(bodyAsArrayBuffer, stringToArrayBuffer(expectedBody), "Retrieve and verify request's body");
         assert_true(request.bodyUsed, "body as arrayBuffer: bodyUsed turned true");
       });
     }
@@ -79,11 +70,27 @@
 
     var formData = new FormData();
     formData.append("name", "value")
-    checkRequestBody("This is request's body", "text", checkBodyText);
-    checkRequestBody("This is request's body", "blob", checkBodyBlob);
-    checkRequestBody("This is request's body", "arrayBuffer", checkBodyArrayBuffer);
-    checkRequestBody(JSON.stringify("This is request's body"), "json", checkBodyJSON);
+    var textData = JSON.stringify("This is response's body");
+    var blob = new Blob([textData], { "type" : "text/plain" });
+
+    checkRequestBody(textData, "text", checkBodyText);
+    checkRequestBody(textData, "blob", checkBodyBlob);
+    checkRequestBody(textData, "arrayBuffer", checkBodyArrayBuffer);
+    checkRequestBody(textData, "json", checkBodyJSON);
     checkRequestBody(formData, "formData", checkBodyFormData);
+
+    function checkBlobResponseBody(blobBody, blobData, bodyType, checkFunction) {
+      promise_test(function(test) {
+        var response = new Response(blobBody);
+        assert_false(response.bodyUsed, "bodyUsed is false at init");
+        return checkFunction(response, blobData);
+      }, "Consume blob response's body as " + bodyType);
+    }
+
+    checkBlobResponseBody(blob, textData, "blob", checkBodyBlob);
+    checkBlobResponseBody(blob, textData, "text", checkBodyText);
+    checkBlobResponseBody(blob, textData, "json", checkBodyJSON);
+    checkBlobResponseBody(blob, textData, "arrayBuffer", checkBodyArrayBuffer);
 
     var goodJSONValues = ["null", "1", "true", "\"string\""];
     goodJSONValues.forEach(function(value) {

--- a/fetch/api/resources/utils.js
+++ b/fetch/api/resources/utils.js
@@ -63,8 +63,9 @@ function readTextStream(reader, asyncTest, expectedValue, retrievedArrayBuffer) 
         newBuffer =  new ArrayBuffer(data.value.length + retrievedArrayBuffer.length);
         newBuffer.set(retrievedArrayBuffer, 0);
         newBuffer.set(data.value, retrievedArrayBuffer.length);
-      } else
+      } else {
         newBuffer = data.value;
+      }
       readTextStream(reader, asyncTest, expectedValue, newBuffer);
       return;
     }

--- a/fetch/api/response/response-clone.html
+++ b/fetch/api/response/response-clone.html
@@ -45,12 +45,12 @@
           "Expect response.headers has name:value header");
       }, "Check Response's clone has the expected attribute values");
 
-      async_test(function(test) {
-        readTextStream(response.body.getReader(), test, body);
+      promise_test(function(test) {
+        return validateStreamFromString(response.body.getReader(), body);
       }, "Check orginal response's body after cloning");
 
-      async_test(function(test) {
-        readTextStream(clonedResponse.body.getReader(), test, body);
+      promise_test(function(test) {
+        return validateStreamFromString(clonedResponse.body.getReader(), body);
       }, "Check cloned response's body");
 
       promise_test(function(test) {

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Response consume empty bodies</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#response">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#body-mixin">
+    <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+    function checkBodyText(response) {
+      return response.text().then( function(bodyAsText) {
+        assert_equals(bodyAsText, "", "Resolved value should be empty");
+        assert_false(response.bodyUsed);
+      });
+    }
+
+    function checkBodyBlob(response) {
+      return response.blob().then(function(bodyAsBlob) {
+        var promise = new Promise(function (resolve, reject) {
+          var reader = new FileReader();
+          reader.onload = function(evt) {
+            resolve(reader.result)
+          };
+          reader.onerror = function() {
+            reject("Blob's reader failed");
+          };
+          reader.readAsText(bodyAsBlob);
+        });
+        return promise.then(function(body) {
+          assert_equals(body, "", "Resolved value should be empty");
+          assert_false(response.bodyUsed);
+        });
+      });
+    }
+
+    function checkBodyArrayBuffer(response) {
+      return response.arrayBuffer().then( function(bodyAsArrayBuffer) {
+        assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
+        assert_false(response.bodyUsed);
+      });
+    }
+
+    function checkBodyJSON(response) {
+      return response.json().then(
+        (bodyAsJSON) => {
+          assert_unreached("JSON parsing should fail");
+        },
+        () => {
+          assert_false(response.bodyUsed);
+        });
+    }
+
+    function checkBodyFormData(response) {
+      return response.formData().then(function(bodyAsFormData) {
+        assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
+        assert_false(response.bodyUsed);
+     });
+    }
+
+    function checkResponseBody(bodyType, checkFunction) {
+      promise_test(function(test) {
+        var response = new Response();
+        assert_false(response.bodyUsed);
+        return checkFunction(response);
+      }, "Consume response's body as " + bodyType);
+    }
+
+    var formData = new FormData();
+    checkResponseBody("text", checkBodyText);
+    checkResponseBody("blob", checkBodyBlob);
+    checkResponseBody("arrayBuffer", checkBodyArrayBuffer);
+    checkResponseBody("json", checkBodyJSON);
+    checkResponseBody("formData", checkBodyFormData);
+
+    </script>
+  </body>
+</html>

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -61,7 +61,7 @@
      });
     }
 
-    function checkResponseBody(bodyType, checkFunction) {
+    function checkResponseWithNoBody(bodyType, checkFunction) {
       promise_test(function(test) {
         var response = new Response();
         assert_false(response.bodyUsed);
@@ -70,12 +70,34 @@
     }
 
     var formData = new FormData();
-    checkResponseBody("text", checkBodyText);
-    checkResponseBody("blob", checkBodyBlob);
-    checkResponseBody("arrayBuffer", checkBodyArrayBuffer);
-    checkResponseBody("json", checkBodyJSON);
-    checkResponseBody("formData", checkBodyFormData);
+    checkResponseWithNoBody("text", checkBodyText);
+    checkResponseWithNoBody("blob", checkBodyBlob);
+    checkResponseWithNoBody("arrayBuffer", checkBodyArrayBuffer);
+    checkResponseWithNoBody("json", checkBodyJSON);
+    checkResponseWithNoBody("formData", checkBodyFormData);
 
+    function checkResponseWithEmptyBody(bodyType, body, asText) {
+      promise_test(function(test) {
+        var response = new Response("", {"method": "POST", "body" : body});
+        assert_false(response.bodyUsed, "bodyUsed is false at init");
+        if (asText) {
+          return response.text().then(function(bodyAsString) {
+            assert_equals(bodyAsString.length, 0, "Resolved value should be empty");
+            assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+          });
+        }
+        return response.arrayBuffer().then(function(bodyAsArrayBuffer) {
+          assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
+          assert_true(response.bodyUsed, "bodyUsed is true after being consumed");
+        });
+      }, "Consume empty " + bodyType + " response body as " + (asText ? "text" : "arrayBuffer"));
+    }
+
+    // FIXME: Add BufferSource, FormData and URLSearchParams.
+    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), false);
+    checkResponseWithEmptyBody("text", "", false);
+    checkResponseWithEmptyBody("blob", new Blob([], { "type" : "text/plain" }), true);
+    checkResponseWithEmptyBody("text", "", true);
     </script>
   </body>
 </html>

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -46,10 +46,10 @@
 
     function checkBodyJSON(response) {
       return response.json().then(
-        (bodyAsJSON) => {
+        function(bodyAsJSON) {
           assert_unreached("JSON parsing should fail");
         },
-        () => {
+        function() {
           assert_false(response.bodyUsed);
         });
     }

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -78,7 +78,7 @@
 
     function checkResponseWithEmptyBody(bodyType, body, asText) {
       promise_test(function(test) {
-        var response = new Response("", {"method": "POST", "body" : body});
+        var response = new Response(body);
         assert_false(response.bodyUsed, "bodyUsed is false at init");
         if (asText) {
           return response.text().then(function(bodyAsString) {

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -12,7 +12,7 @@
   <body>
     <script>
     function checkBodyText(response) {
-      return response.text().then( function(bodyAsText) {
+      return response.text().then(function(bodyAsText) {
         assert_equals(bodyAsText, "", "Resolved value should be empty");
         assert_false(response.bodyUsed);
       });
@@ -20,7 +20,7 @@
 
     function checkBodyBlob(response) {
       return response.blob().then(function(bodyAsBlob) {
-        var promise = new Promise(function (resolve, reject) {
+        var promise = new Promise(function(resolve, reject) {
           var reader = new FileReader();
           reader.onload = function(evt) {
             resolve(reader.result)
@@ -38,7 +38,7 @@
     }
 
     function checkBodyArrayBuffer(response) {
-      return response.arrayBuffer().then( function(bodyAsArrayBuffer) {
+      return response.arrayBuffer().then(function(bodyAsArrayBuffer) {
         assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
         assert_false(response.bodyUsed);
       });

--- a/fetch/api/response/response-consume.html
+++ b/fetch/api/response/response-consume.html
@@ -8,6 +8,7 @@
     <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="../resources/utils.js"></script>
   </head>
   <body>
     <script>
@@ -39,16 +40,14 @@
 
     function checkBodyArrayBuffer(response, expectedBody) {
       return response.arrayBuffer().then( function(bodyAsArrayBuffer) {
-        var decoder = new TextDecoder("utf-8");
-        var strBody = decoder.decode(bodyAsArrayBuffer);
-        assert_equals(strBody, expectedBody, "Retrieve and verify response's body");
+        assert_array_equals(bodyAsArrayBuffer, stringToArrayBuffer(expectedBody), "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as arrayBuffer: bodyUsed turned true");
       });
     }
 
-    function checkBodyJson(response, expectedBody) {
-      return response.json().then(function(bodyAsJson) {
-        var strBody = JSON.stringify(bodyAsJson)
+    function checkBodyJSON(response, expectedBody) {
+      return response.json().then(function(bodyAsJSON) {
+        var strBody = JSON.stringify(bodyAsJSON)
         assert_equals(strBody, expectedBody, "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as json: bodyUsed turned true");
       });
@@ -70,12 +69,29 @@
     }
 
     var formData = new FormData();
-    formData.append("name", "value")
-    checkResponseBody("This is response's body", "text", checkBodyText);
-    checkResponseBody("This is response's body", "blob", checkBodyBlob);
-    checkResponseBody("This is response's body", "arrayBuffer", checkBodyArrayBuffer);
-    checkResponseBody(JSON.stringify("This is response's body"), "json", checkBodyJson);
+    formData.append("name", "value");
+    var textData = JSON.stringify("This is response's body");
+    var blob = new Blob([textData], { "type" : "text/plain" });
+
+    checkResponseBody(textData, "text", checkBodyText);
+    checkResponseBody(textData, "blob", checkBodyBlob);
+    checkResponseBody(textData, "arrayBuffer", checkBodyArrayBuffer);
+    checkResponseBody(textData, "json", checkBodyJSON);
     checkResponseBody(formData, "formData", checkBodyFormData);
+
+    function checkBlobResponseBody(blobBody, blobData, bodyType, checkFunction) {
+      promise_test(function(test) {
+        var response = new Response(blobBody);
+        assert_false(response.bodyUsed, "bodyUsed is false at init");
+        return checkFunction(response, blobData);
+      }, "Consume blob response's body as " + bodyType);
+    }
+
+    checkBlobResponseBody(blob, textData, "blob", checkBodyBlob);
+    checkBlobResponseBody(blob, textData, "text", checkBodyText);
+    checkBlobResponseBody(blob, textData, "json", checkBodyJSON);
+    checkBlobResponseBody(blob, textData, "arrayBuffer", checkBodyArrayBuffer);
+
     </script>
   </body>
 </html>

--- a/fetch/api/response/response-consume.html
+++ b/fetch/api/response/response-consume.html
@@ -40,7 +40,7 @@
 
     function checkBodyArrayBuffer(response, expectedBody) {
       return response.arrayBuffer().then( function(bodyAsArrayBuffer) {
-        assert_array_equals(bodyAsArrayBuffer, stringToArrayBuffer(expectedBody), "Retrieve and verify response's body");
+        validateBufferFromString(bodyAsArrayBuffer, expectedBody, "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as arrayBuffer: bodyUsed turned true");
       });
     }

--- a/fetch/api/response/response-init-002.html
+++ b/fetch/api/response/response-init-002.html
@@ -52,10 +52,10 @@
       checkResponseInit(urlSearchParams, "application/x-www-form-urlencoded;charset=UTF-8", "name=value");
       checkResponseInit(usvString, "text/plain;charset=UTF-8", "This is a USVString");
 
-      async_test(function(test) {
+      promise_test(function(test) {
         var body = "This is response body";
         var response = new Response(body);
-        readTextStream(response.body.getReader(), test, body);
+        return validateStreamFromString(response.body.getReader(), body);
       }, "Read Response's body as readableStream");
     </script>
   </body>


### PR DESCRIPTION
In addition to the new consume tests, this patch converts an ansyc test into a promise test. It also removes the use of TextDecoder API as it is not supported in all engines.
