### PR TITLE
Update expected values in data-uri.htm

### DIFF
--- a/XMLHttpRequest/data-uri.htm
+++ b/XMLHttpRequest/data-uri.htm
@@ -23,7 +23,7 @@
         if (method.toUpperCase() !== 'GET') {
           assert_equals(client.status, 0);
           assert_equals(client.responseText, '');
-          assert_equals(client.statusText, 'OK');
+          assert_equals(client.statusText, '');
           test.done();
           return;
         }


### PR DESCRIPTION
Per the spec, empty byte sequence should be expected for status == 0.

In the Content-Type comparison, the expected value is changed to
lowercase and the reply is modified to remove any spaces between
parameters, and a case-insensitive compare is done.  The only part that
is possibly case sensitive in the media-type is the parameter value, but
in this case (UTF-8 vs utf-8), it does not seem to matter.
