### PR TITLE
Add nonexistent-origin.web-platform.test to hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ To get the tests running, you need to set up the test domains in your
 following entries are required:
 
 ```
-127.0.0.1	web-platform.test
-127.0.0.1	www.web-platform.test
-127.0.0.1	www1.web-platform.test
-127.0.0.1	www2.web-platform.test
-127.0.0.1	xn--n8j6ds53lwwkrqhv28a.web-platform.test
-127.0.0.1	xn--lve-6lad.web-platform.test
+127.0.0.1   web-platform.test
+127.0.0.1   www.web-platform.test
+127.0.0.1   www1.web-platform.test
+127.0.0.1   www2.web-platform.test
+127.0.0.1   xn--n8j6ds53lwwkrqhv28a.web-platform.test
+127.0.0.1   xn--lve-6lad.web-platform.test
+0.0.0.0     nonexistent-origin.web-platform.test
 ```
 
 Because web-platform-tests uses git submodules, you must ensure that


### PR DESCRIPTION
XMLHttpRequest/send-network-error-async-events.sub.htm does not pass without it on Windows

Also converted to spaces instead of tabs since between GitHub's Markdown viewer, my text editor, and Git's built-in diff viewer, nobody agreed on how wide the tab width was supposed to be, so I couldn't figure out how to align using tabs.
