### PR TITLE
Fix the "get the parent" loop when dispatching event (fixes #6733)

### DIFF
--- a/dom/events/Event-dispatch-bubbles-false.html
+++ b/dom/events/Event-dispatch-bubbles-false.html
@@ -30,32 +30,29 @@ function targetsForDocumentChain(document) {
     ];
 }
 
-function testChain(document, targetParents, phases, label) {
-    test(function() {
-        var event_type = "click";
-        var target = document.getElementById("target");
-        var targets = targetParents.concat(target);
-        var expected_targets = targets.concat(target);
+function testChain(document, targetParents, phases, event_type) {
+    var target = document.getElementById("target");
+    var targets = targetParents.concat(target);
+    var expected_targets = targets.concat(target);
 
-        var actual_targets = [], actual_phases = [];
-        var test_event = function(evt) {
-            actual_targets.push(evt.currentTarget);
-            actual_phases.push(evt.eventPhase);
-        }
+    var actual_targets = [], actual_phases = [];
+    var test_event = function(evt) {
+        actual_targets.push(evt.currentTarget);
+        actual_phases.push(evt.eventPhase);
+    }
 
-        for (var i = 0; i < targets.length; i++) {
-            targets[i].addEventListener(event_type, test_event, true);
-            targets[i].addEventListener(event_type, test_event, false);
-        }
+    for (var i = 0; i < targets.length; i++) {
+        targets[i].addEventListener(event_type, test_event, true);
+        targets[i].addEventListener(event_type, test_event, false);
+    }
 
-        var evt = document.createEvent("Event");
-        evt.initEvent(event_type, false, true);
+    var evt = document.createEvent("Event");
+    evt.initEvent(event_type, false, true);
 
-        target.dispatchEvent(evt);
+    target.dispatchEvent(evt);
 
-        assert_array_equals(actual_targets, expected_targets, "targets");
-        assert_array_equals(actual_phases, phases, "phases");
-    }, label + ": Event.dispatchEvent with Event.bubbles set to false.");
+    assert_array_equals(actual_targets, expected_targets, "targets");
+    assert_array_equals(actual_phases, phases, "phases");
 }
 
 var phasesForDocumentChain = [
@@ -69,13 +66,33 @@ var phasesForDocumentChain = [
     Event.AT_TARGET,
 ];
 
-chainWithWindow = [window].concat(targetsForDocumentChain(document));
-testChain(
-    document, chainWithWindow, [Event.CAPTURING_PHASE].concat(phasesForDocumentChain),
-    "In document with a browsing context");
+test(function () {
+    var chainWithWindow = [window].concat(targetsForDocumentChain(document));
+    testChain(
+        document, chainWithWindow, [Event.CAPTURING_PHASE].concat(phasesForDocumentChain), "click");
+}, "In window.document with click event");
 
-var documentClone = document.cloneNode(true);
-testChain(
-    documentClone, targetsForDocumentChain(documentClone), phasesForDocumentChain,
-    "In document without a browsing context");
+test(function () {
+    testChain(document, targetsForDocumentChain(document), phasesForDocumentChain, "load");
+}, "In window.document with load event")
+
+test(function () {
+    var documentClone = document.cloneNode(true);
+    testChain(
+        documentClone, targetsForDocumentChain(documentClone), phasesForDocumentChain, "click");
+}, "In window.document.cloneNode(true)");
+
+test(function () {
+    var newDocument = new Document();
+    newDocument.appendChild(document.documentElement.cloneNode(true));
+    testChain(
+        newDocument, targetsForDocumentChain(newDocument), phasesForDocumentChain, "click");
+}, "In new Document()");
+
+test(function () {
+    var HTMLDocument = document.implementation.createHTMLDocument();
+    HTMLDocument.body.appendChild(document.getElementById("table").cloneNode(true));
+    testChain(
+        HTMLDocument, targetsForDocumentChain(HTMLDocument), phasesForDocumentChain, "click");
+}, "In DOMImplementation.createHTMLDocument()");
 </script>


### PR DESCRIPTION
The DOM specification says:

A document's get the parent algorithm, given an event, returns null
if event's type attribute value is "load" or document does not have
a browsing context, and the document's associated Window object
otherwise.
