### PR TITLE
Add a bunch of tests for Web Storage to ensure all DOMStrings work

### DIFF
--- a/webstorage/storage_setitem.html
+++ b/webstorage/storage_setitem.html
@@ -7,6 +7,14 @@
 <script>
 ["localStorage", "sessionStorage"].forEach(function(name) {
     var test_error = { name: "test" };
+    var interesting_strs = ["\uD7FF", "\uD800", "\uDBFF", "\uDC00",
+                            "\uDFFF", "\uE000", "\uFFFD", "\uFFFE", "\uFFFF",
+                            "\uD83C\uDF4D", "\uD83Ca", "a\uDF4D",
+                            "\uDBFF\uDFFF"];
+
+    for (var i = 0; i <= 0xFF; i++) {
+        interesting_strs.push(String.fromCharCode(i));
+    }
 
     test(function() {
         var storage = window[name];
@@ -156,5 +164,60 @@
         assert_equals(storage.getItem("null"), "test2");
         assert_equals(storage["null"], "test2");
     }, name + "[null]");
+
+    test(function() {
+        var storage = window[name];
+        storage.clear();
+
+        storage["foo\0bar"] = "user1";
+        assert_true("foo\0bar" in storage);
+        assert_false("foo\0" in storage);
+        assert_false("foo\0baz" in storage);
+        assert_false("foo" in storage);
+        assert_equals(storage.length, 1, "storage.length")
+        assert_equals(storage.getItem("foo\0bar"), "user1");
+        assert_equals(storage.getItem("foo\0"), null);
+        assert_equals(storage.getItem("foo\0baz"), null);
+        assert_equals(storage.getItem("foo"), null);
+        assert_equals(storage["foo\0bar"], "user1");
+        assert_equals(storage["foo\0"], undefined);
+        assert_equals(storage["foo\0baz"], undefined);
+        assert_equals(storage["foo"], undefined);
+    }, name + " key containing null");
+
+    test(function() {
+        var storage = window[name];
+        storage.clear();
+
+        storage["name"] = "foo\0bar";
+        assert_true("name" in storage);
+        assert_equals(storage.length, 1, "storage.length")
+        assert_equals(storage.getItem("name"), "foo\0bar");
+        assert_equals(storage["name"], "foo\0bar");
+    }, name + " value containing null");
+
+    for (i = 0; i < interesting_strs.length; i++) {
+        var str = interesting_strs[i];
+        test(function() {
+            var storage = window[name];
+            storage.clear();
+
+            storage[str] = "user1";
+            assert_true(str in storage);
+            assert_equals(storage.length, 1, "storage.length")
+            assert_equals(storage.getItem(str), "user1");
+            assert_equals(storage[str], "user1");
+        }, name + "[" + format_value(str) + "]");
+
+        test(function() {
+            var storage = window[name];
+            storage.clear();
+
+            storage["name"] = str;
+            assert_equals(storage.length, 1, "storage.length")
+            assert_equals(storage.getItem("name"), str);
+            assert_equals(storage["name"], str);
+        }, name + "[] = " + format_value(str));
+    }
 });
 </script>


### PR DESCRIPTION
IE at least used to use an XML-backed store which required both keys and values to match the Char production in XML 1.0. These tests should suffice for both XML 1.0 and XML 1.1.
