### PR TITLE
HTMLAllCollection should be rooted at the document, not the root element, so it can find the root element.

### DIFF
--- a/html/infrastructure/common-dom-interfaces/collections/htmlallcollection.html
+++ b/html/infrastructure/common-dom-interfaces/collections/htmlallcollection.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html>
+<html id="root">
 <head>
 <title>HTMLAllCollection Tests</title>
 <link rel="author" title="Dan Druta" href="mailto:dan.druta@att.com"/>
@@ -11,8 +11,10 @@
 </head>
 <body id="tags">
 <img src="../../../../images/green.png" name="picture">
+<a name="foo"></a>
+<a name="foo"></a>
 <script>
-test(function(){ assert_equals(document.all.length,12)}, "Test for HTMLAllCollection size");
+test(function(){ assert_equals(document.all.length,14)}, "Test for HTMLAllCollection size");
 
 test(function(){ assert_equals(document.all.item(0).tagName,"HTML")}, "Test lookup by index using ()");
 
@@ -29,6 +31,16 @@ test(function(){ assert_equals(document.all["picture"].nodeName,"IMG")}, "Test l
 test(function(){ assert_equals(document.all.picture.nodeName,"IMG")}, "Test lookup IMG in collection using .");
 
 test(function(){ assert_equals(document.all.tags.id,"tags")}, "Test lookup tags in collection using .");
+
+test(function() {
+  assert_equals(document.all["root"], document.documentElement);
+}, "Should find root element too");
+
+test(function() {
+  assert_equals(document.all["foo"].length, 2);
+}, "Should find both anchors and produce a list");
+
+test
 </script>
 <div id="log"></div>
 </body>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1253591
