### PR TITLE
Fix dom::GetArrayIndexFromId to actually follow the spec for large indices (i.e. ones that don't fit in in int32_t).

### DIFF
--- a/dom/collections/HTMLCollection-supported-property-indices.html
+++ b/dom/collections/HTMLCollection-supported-property-indices.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<!-- We want to use a tag name that will not interact with our test harness,
+     so just make one up.  "foo" is a good one -->
+
+<!-- Ids that look like negative indices.  These should come first, so we can
+     assert that lookups for nonnegative indices find these by index -->
+<foo id="-2"></foo>
+<foo id="-1"></foo>
+
+<!-- Ids that look like nonnegative indices -->
+<foo id="0"></foo>
+<foo id="1"></foo>
+
+<!-- Ids that look like nonnegative indices near 2^31 = 2147483648 -->
+<foo id="2147483645"></foo> <!-- 2^31 - 3 -->
+<foo id="2147483646"></foo> <!-- 2^31 - 2 -->
+<foo id="2147483647"></foo> <!-- 2^31 - 1 -->
+<foo id="2147483648"></foo> <!-- 2^31 -->
+<foo id="2147483649"></foo> <!-- 2^31 + 1 -->
+
+<!-- Ids that look like nonnegative indices near 2^32 = 4294967296 -->
+<foo id="4294967293"></foo> <!-- 2^32 - 3 -->
+<foo id="4294967294"></foo> <!-- 2^32 - 2 -->
+<foo id="4294967295"></foo> <!-- 2^32 - 1 -->
+<foo id="4294967296"></foo> <!-- 2^32 -->
+<foo id="4294967297"></foo> <!-- 2^32 + 1 -->
+
+<script>
+test(function() {
+  var collection = document.getElementsByTagName("foo");
+  assert_equals(collection.item(-2), null);
+  assert_equals(collection.item(-1), null);
+  assert_equals(collection.namedItem(-2), document.getElementById("-2"));
+  assert_equals(collection.namedItem(-1), document.getElementById("-1"));
+  assert_equals(collection[-2], document.getElementById("-2"));
+  assert_equals(collection[-1], document.getElementById("-1"));
+}, "Handling of property names that look like negative integers");
+
+test(function() {
+  var collection = document.getElementsByTagName("foo");
+  assert_equals(collection.item(0), document.getElementById("-2"));
+  assert_equals(collection.item(1), document.getElementById("-1"));
+  assert_equals(collection.namedItem(0), document.getElementById("0"));
+  assert_equals(collection.namedItem(1), document.getElementById("1"));
+  assert_equals(collection[0], document.getElementById("-2"));
+  assert_equals(collection[1], document.getElementById("-1"));
+}, "Handling of property names that look like small nonnegative integers");
+
+test(function() {
+  var collection = document.getElementsByTagName("foo");
+  assert_equals(collection.item(2147483645), null);
+  assert_equals(collection.item(2147483646), null);
+  assert_equals(collection.item(2147483647), null);
+  assert_equals(collection.item(2147483648), null);
+  assert_equals(collection.item(2147483649), null);
+  assert_equals(collection.namedItem(2147483645),
+                document.getElementById("2147483645"));
+  assert_equals(collection.namedItem(2147483646),
+                document.getElementById("2147483646"));
+  assert_equals(collection.namedItem(2147483647),
+                document.getElementById("2147483647"));
+  assert_equals(collection.namedItem(2147483648),
+                document.getElementById("2147483648"));
+  assert_equals(collection.namedItem(2147483649),
+                document.getElementById("2147483649"));
+  assert_equals(collection[2147483645], undefined);
+  assert_equals(collection[2147483646], undefined);
+  assert_equals(collection[2147483647], undefined);
+  assert_equals(collection[2147483648], undefined);
+  assert_equals(collection[2147483649], undefined);
+}, "Handling of property names that look like integers around 2^31");
+
+test(function() {
+  var collection = document.getElementsByTagName("foo");
+  assert_equals(collection.item(4294967293), null);
+  assert_equals(collection.item(4294967294), null);
+  assert_equals(collection.item(4294967295), null);
+  assert_equals(collection.item(4294967296), document.getElementById("-2"));
+  assert_equals(collection.item(4294967297), document.getElementById("-1"));
+  assert_equals(collection.namedItem(4294967293),
+                document.getElementById("4294967293"));
+  assert_equals(collection.namedItem(4294967294),
+                document.getElementById("4294967294"));
+  assert_equals(collection.namedItem(4294967295),
+                document.getElementById("4294967295"));
+  assert_equals(collection.namedItem(4294967296),
+                document.getElementById("4294967296"));
+  assert_equals(collection.namedItem(4294967297),
+                document.getElementById("4294967297"));
+  assert_equals(collection[4294967293], undefined);
+  assert_equals(collection[4294967294], undefined);
+  assert_equals(collection[4294967295], document.getElementById("4294967295"));
+  assert_equals(collection[4294967296], document.getElementById("4294967296"));
+  assert_equals(collection[4294967297], document.getElementById("4294967297"));
+}, "Handling of property names that look like integers around 2^32");
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1254293
