### PR TITLE
Don't use (new Document()).body in Event-dispatch-bubbles-false.html.

### DIFF
--- a/dom/events/Event-dispatch-bubbles-false.html
+++ b/dom/events/Event-dispatch-bubbles-false.html
@@ -23,7 +23,7 @@ function targetsForDocumentChain(document) {
     return [
         document,
         document.documentElement,
-        document.body,
+        document.getElementsByTagName("body")[0],
         document.getElementById("table"),
         document.getElementById("table-body"),
         document.getElementById("parent")


### PR DESCRIPTION
This is undefined in Gecko, and isn't relevant to the test at hand.
