### PR TITLE
Test initial LF in pre/textarea/listing with innerHTML

### DIFF
--- a/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
+++ b/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
@@ -22,25 +22,8 @@ x</listing>
 </div>
 </div>
 
-<script id="expected" type="text/html">
-<div id="inner">
-<pre id="pre1">x</pre>
-<pre id="pre2">
-
-x</pre>
-<textarea id="textarea1">x</textarea>
-<textarea id="textarea2">
-
-x</textarea>
-<listing id="listing1">x</listing>
-<listing id="listing2">
-
-x</listing>
-</div>
-</script>
-
 <script>
-var expected_outer = expected.textContent;
+var expected_outer = '\n<div id="inner">\n<pre id="pre1">x</pre>\n<pre id="pre2">\n\nx</pre>\n<textarea id="textarea1">x</textarea>\n<textarea id="textarea2">\n\nx</textarea>\n<listing id="listing1">x</listing>\n<listing id="listing2">\n\nx</listing>\n</div>\n';
 var expected_inner = expected_outer.replace('\n<div id="inner">', '').replace('</div>\n', '');
 var expected_1 = 'x';
 var expected_2 = '\nx';

--- a/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
+++ b/html/syntax/serializing-html-fragments/initial-linefeed-pre.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<title>innerHTML getter for pre/textarea/listing with initial LF</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id="outer">
+<div id="inner">
+<pre id="pre1">
+x</pre>
+<pre id="pre2">
+
+x</pre>
+<textarea id="textarea1">
+x</textarea>
+<textarea id="textarea2">
+
+x</textarea>
+<listing id="listing1">
+x</listing>
+<listing id="listing2">
+
+x</listing>
+</div>
+</div>
+
+<script id="expected" type="text/html">
+<div id="inner">
+<pre id="pre1">x</pre>
+<pre id="pre2">
+
+x</pre>
+<textarea id="textarea1">x</textarea>
+<textarea id="textarea2">
+
+x</textarea>
+<listing id="listing1">x</listing>
+<listing id="listing2">
+
+x</listing>
+</div>
+</script>
+
+<script>
+var expected_outer = expected.textContent;
+var expected_inner = expected_outer.replace('\n<div id="inner">', '').replace('</div>\n', '');
+var expected_1 = 'x';
+var expected_2 = '\nx';
+
+test(function() {
+  assert_equals(outer.innerHTML, expected_outer);
+}, 'outer div');
+
+test(function() {
+  assert_equals(inner.innerHTML, expected_inner);
+}, 'inner div');
+
+['pre', 'textarea', 'listing'].forEach(function(tag) {
+  test(function() {
+    assert_equals(document.getElementById(tag + '1').innerHTML, expected_1);
+  }, tag + '1');
+
+  test(function() {
+    assert_equals(document.getElementById(tag + '2').innerHTML, expected_2);
+  }, tag + '2');
+});
+</script>


### PR DESCRIPTION
The HTML spec requires this for proper round-tripping, but only
Presto has implemented it so far.

Ref. https://github.com/whatwg/html/issues/944
