### PR TITLE
Remove duplicate functions in shadow-dom/testcommon.js

### DIFF
--- a/shadow-dom/resources/shadow-dom-utils.js
+++ b/shadow-dom/resources/shadow-dom-utils.js
@@ -38,57 +38,6 @@ var HTML5_ELEMENT_NAMES = [
     'wbr'
 ];
 
-// http://www.whatwg.org/specs/web-apps/current-work/multipage/forms.html#form-associated-element
-var HTML5_FORM_ASSOCIATED_ELEMENTS = ['button', 'fieldset', 'input', 'keygen', 'label',
-                                      'object', 'output', 'select', 'textarea'];
-
-function newDocument() {
-    return document.implementation.createDocument(
-        'http://www.w3.org/1999/xhtml', 'html');
-}
-
-function newHTMLDocument() {
-    return document.implementation.createHTMLDocument('Test Document');
-}
-
-function newIFrame(ctx, src) {
-    if (typeof(ctx) == 'undefined' || typeof (ctx.iframes) != 'object') {
-        assert_unreached('Illegal context object in newIFrame');
-    }
-
-    var iframe = document.createElement('iframe');
-    if (!ctx.debug) {
-        iframe.style.display = 'none';
-    }
-    if (typeof(src) != 'undefined') {
-        iframe.src = src;
-    }
-    document.body.appendChild(iframe);
-    ctx.iframes.push(iframe);
-
-    assert_true(typeof(iframe.contentWindow) != 'undefined'
-        && typeof(iframe.contentWindow.document) != 'undefined'
-        && iframe.contentWindow.document != document, 'Failed to create new rendered document'
-    );
-    return iframe;
-}
-function newRenderedHTMLDocument(ctx) {
-    var frame = newIFrame(ctx);
-    return frame.contentWindow.document;
-}
-
-function newContext() {
-    return {iframes:[]};
-}
-
-function cleanContext(ctx) {
-    if (!ctx.debug) {
-        ctx.iframes.forEach(function (e) {
-            e.parentNode.removeChild(e);
-        });
-    }
-}
-
 function unit(f) {
     return function () {
         var ctx = newContext();
@@ -135,7 +84,6 @@ function assert_nodelist_contents_equal_noorder(actual, expected, message) {
         }
     }
 }
-
 
 //Example taken from http://www.w3.org/TR/shadow-dom/#event-retargeting-example
 function createTestMediaPlayer(d) {

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-005.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-005.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Element Interface: shadowRoot of type ShadowRoot">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-006.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/attributes/test-006.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Element Interface: shadowRoot of type ShadowRoot">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/elements-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/elements-001.html
@@ -18,7 +18,8 @@ policies and contribution forms [3].
 <meta name="assert" content="All HTML elements must be able to host shadow trees.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/non-element-nodes-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/non-element-nodes-001.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Nodes, that are not elements, are not allowed to become shadow hosts.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Element Interface: createShadowRoot method creates new instance of Shadow root object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Element Interface: createShadowRoot method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-003.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Element Interface: createShadowRoot method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Extensions to Event Interface: event.deepPath() cross the shadow boundary">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/activeElement-confirm-return-null.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/activeElement-confirm-return-null.html
@@ -17,7 +17,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: confirm activeElement return null">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-007.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-007.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: readonly attribute Element? activeElement; actual value">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-009.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-009.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: innerHTML of type DOMString; Test getter">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-010.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-010.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: innerHTML of type DOMString; Test setter">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: styleSheets of type StyleSheetList, readonly">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-012.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-012.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: The nodeType attribute of a ShadowRoot instance must return DOCUMENT_FRAGMENT_NODE">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-013.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-013.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: The nodeName attribute of a ShadowRoot instance must return "#document-fragment".">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-014.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-014.html
@@ -17,7 +17,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The ShadowRoot element: olderShadowRoot attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: HTMLElement getElementById(DOMString elementId) method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: Selection? getSelection() method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-006.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-006.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: Element? elementFromPoint(float x, float y) method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-007.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-007.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: Element? elementFromPoint(float x, float y) method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-010.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="ShadowRoot Object: Invoking the cloneNode() method on a ShadowRoot instance must always throw a DATA_CLONE_ERR exception.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../../testcommon.js"></script>
+<script src="../../../../../html/resources/common.js"></script>
+<script src="../../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The content HTML element: fallback content">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-002.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The content HTML element: select attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-003.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The content HTML element: invalid select attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-005.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-005.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The content HTML element: reset-style-inheritance attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-006.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-content-html-element/test-006.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The content HTML element: getDistributedNodes method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The shadow HTML element: fallback content">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-002.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The shadow HTML element: shadow insertion point">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-004.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/the-shadow-html-element/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The shadow HTML element: no reset-style-inheritance attribute">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-dispatch/test-001.html
+++ b/shadow-dom/untriaged/events/event-dispatch/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Dispatch: At the time of event dispatch:The Event target and currentTarget attributes must return the relative target for the node on which event listeners are invoked">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-dispatch/test-002.html
+++ b/shadow-dom/untriaged/events/event-dispatch/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Dispatch: The MouseEvent relatedTarget attribute must return the adjusted related target">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-dispatch/test-003.html
+++ b/shadow-dom/untriaged/events/event-dispatch/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Path Trimming: In cases where both relatedTarget and target of a trusted event are part of the same shadow tree, the conforming UAs must stop events at the shadow root to avoid the appearance of spurious mouseover and mouseout events firing from the same node.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-retargeting/test-001.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Retargeting:test that event.target is retargeted when event crosses shadow boundary and vice versa">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-retargeting/test-002.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-002.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Retargeting:Event retargeting for document nodes distributed among insertion points">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-retargeting/test-003.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Retargeting:Event retargeting for fallback content">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/event-retargeting/test-004.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Event Retargeting:Retargeting algorithm">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-001.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-002.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-003.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-004.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-005.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-005.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-006.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-006.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-007.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-007.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-008.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-008.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-009.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-009.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="The following events must not be stopped at the nearest shadow boundary if created by users: abort, error, select, change, load, reset, resize, scroll, selectstart">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html
+++ b/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting focus events:The focus, DOMFocusIn, blur, and DOMFocusOut events must be treated in the same way as events with a relatedTarget, where the corresponding node that is losing focus as a result of target gaining focus or the node that is gaining focus, and thus causing the blurring of target acts as the related target">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-focus-events/test-002.html
+++ b/shadow-dom/untriaged/events/retargeting-focus-events/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting focus events:The blur event must be treated in the same way as events with a relatedTarget, where the node that is gaining focus causing the blurring of target acts as the related target">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-focus-events/test-003.html
+++ b/shadow-dom/untriaged/events/retargeting-focus-events/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting focus events:The focus event must be treated in the same way as events with a relatedTarget, where the corresponding node that is losing focus as a result of target gaining focus or the node that is gaining focus">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-001.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting relatedTarget:Event retargeting is a process of computing relative targets for each ancestor of the node at which the event is dispatched. A relative target is a DOM node that most accurately represents the target of a dispatched event at a given ancestor while maintaining the upper boundary encapsulation.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-002.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting relatedTarget:For a given node, the relatedTarget must be changed to its ancestor (or self) that is in the same shadow tree as the node">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-003.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Retargeting relatedTarget:Event listeners must not be invoked on a node for which the target and relatedTarget are the same.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/events/test-001.html
+++ b/shadow-dom/untriaged/events/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Events:The mutation event types must never be dispatched in a shadow DOM subtree.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-001.html
+++ b/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements and Their Shadow Trees: If the element can have fallback content, UA should allow the shadow tree to contain at least one insertion point.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-002.html
+++ b/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements and Their Shadow Trees: Elements that have no fallback content should allow the shadow tree to contain no insertion points or an insertion point that matches nothing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-003.html
+++ b/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements and Their Shadow Trees: Check that fieldset can contain at least two insertion points with matching criteria 'legend:first-of-type' and 'universal selector'">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-004.html
+++ b/shadow-dom/untriaged/html-elements-and-their-shadow-trees/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements and Their Shadow Trees: Check that details can contain at least two insertion points with matching criteria 'summary:first-of-type' and 'universal selector'">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-001.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements in shadow trees: Form elements and form-associated elements in shadow tree are not accessible using document DOM object's tree accessors">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-002.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-002.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements in shadow trees: Form elements and form-associated elements in shadow tree must be accessible using shadow tree accessors">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-003.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-003.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements in shadow trees: form should submit elements in shadow tree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements in shadow trees: base element must behave as inert, or not part of the document tree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-002.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="HTML Elements in shadow trees: link element must behave as inert not as part of the document tree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/composition/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/composition/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Composition:Composition algorithm">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/content-pseudo-element/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/content-pseudo-element/test-001.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Children, Distributed To Insertion Points">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/content-pseudo-element/test-002.html
+++ b/shadow-dom/untriaged/shadow-trees/content-pseudo-element/test-002.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="::content pseudo-element, Relative Selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-001.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-001.html
@@ -15,7 +15,7 @@ policies and contribution forms [3].
 <link rel="author" title="Yuta Kitamura" href="mailto:yutak@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-trees">
 <meta name="assert" content="Lower-boundary Encapsulation: Each insertion point participates in distribution by providing a matching criteria for the child nodes. The matching criteria determines whether a given node could be distributed to a given insertion point.">
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <p>

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-002.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-002.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <link rel="author" title="Yuta Kitamura" href="mailto:yutak@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-trees">
 <meta name="assert" content="Lower-boundary Encapsulation: Each insertion point participates in distribution by providing a matching criteria for the child nodes. The matching criteria determines whether a given node could be distributed to a given insertion point.">
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 <style>
 ol {
     list-style-type: decimal;

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-003.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/distribution-003.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Lower-boundary encapsulation: The distribution does not affect the state of the document tree or shadow trees">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-003.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-003.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Lower-boundary encapsulation: The distribution is a result of executing a stable algorithm">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-004.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-004.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Lower-boundary encapsulation: The distribution reoccurs whenever any variable affecting it is changed">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-005.html
+++ b/shadow-dom/untriaged/shadow-trees/lower-boundary-encapsulation/test-005.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Lower-boundary encapsulation: An insertion point may be active or inactive. An active insertion point participates in the distribution process, whereas the inactive insertion does not">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest-ref.html
+++ b/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest-ref.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" >
     <title>Shadow DOM Test Ref file - Tests nested shadow tree.</title>
     <link rel="author" title="shingo.miyazawa" href="mailto:kumatronik@gmail.com" >
-    <script src="../../testcommon.js"></script>
+    <script src="../../../../html/resources/common.js"></script>
     <meta name="assert" content="nested shadow tree style is valid." >
     <style>
       #host {

--- a/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html
+++ b/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html
@@ -6,7 +6,7 @@
     <link rel="match" href="nested_tree_reftest-ref.html" >
     <link rel="author" title="shingo.miyazawa" href="mailto:kumatronik@gmail.com" >
     <link rel="help" href="https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/shadow/index.html#nested-shadow-trees" >
-    <script src="../../testcommon.js"></script>
+    <script src="../../../../html/resources/common.js"></script>
     <meta name="assert" content="nested shadow tree style is valid." >
     <style>
       #host {

--- a/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Nested Shadow Subtrees:Any element in a shadow tree can be a shadow host, thus producing nested shadow trees">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/rendering-shadow-trees/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/rendering-shadow-trees/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Rendering Shadow DOM Subtrees:rendering algorithm">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html
+++ b/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <link rel="author" title="Hayato Ito" href="mailto:hayato@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#reprojection">
 <meta name="assert" content="a node is distributed into more than one insertion point.">
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 <style>
 .pass { color: green; }
 </style>

--- a/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-002.html
+++ b/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-002.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <link rel="author" title="Hayato Ito" href="mailto:hayato@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#reprojection">
 <meta name="assert" content="A node is distributed into more than one insertion point with a select attribute.">
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 <style>
 .pass { color: green; }
 .fail { color: red; }

--- a/shadow-dom/untriaged/shadow-trees/reprojection/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/reprojection/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Reprojection: The nodes distributed into that insertion point must appear as if they were child nodes of the shadow host in the context of distribution within the shadow DOM subtree, hosted by said shadow host">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-001.html
+++ b/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Insertion Points: A valid selector fragment may contain a type selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-002.html
+++ b/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-002.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Insertion Points: A valid selector fragment may contain an universal selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-003.html
+++ b/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-003.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Insertion Points: A valid selector fragment may contain a class selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-004.html
+++ b/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-004.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Insertion Points: A valid selector fragment may contain an ID selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-005.html
+++ b/shadow-dom/untriaged/shadow-trees/satisfying-matching-criteria/test-005.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Matching Insertion Points: A valid selector fragment may contain an attribute selector">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/shadow-root-001.html
+++ b/shadow-dom/untriaged/shadow-trees/shadow-root-001.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <link rel="author" title="Yuta Kitamura" href="mailto:yutak@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-trees">
 <meta name="assert" content="When a shadow root is attached, the shadow tree is rendered.">
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
 <style>
 p { color: black; }
 * { color: red; }

--- a/shadow-dom/untriaged/shadow-trees/shadow-root-002.html
+++ b/shadow-dom/untriaged/shadow-trees/shadow-root-002.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <link rel="author" title="Yuta Kitamura" href="mailto:yutak@google.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-trees">
 <meta name="assert" content="On distribution, content element is replaced with the shadow host's children.">
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
 <style>
 p { color: black; }
 .pass { color: green; }

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-001.html
@@ -19,7 +19,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The shadow nodes and named shadow elements are not accessible using shadow host's document DOM tree accessors.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-002.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The nodes are accessible using shadow root's DOM tree accessor methods.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-001.html
@@ -19,7 +19,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The ownerDocument property of all nodes in shadow tree refers to the document of the shadow host.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
@@ -19,7 +19,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The ownerDocument property of all nodes in shadow tree refers to the document of the shadow host.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-001.html
@@ -17,7 +17,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: Nodes in a shadow tree must not be accessible through selector APIs of owner document.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-002.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: Nodes in a shadow tree must be accessible through selector APIs of the shadow root.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/shadow-root-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/shadow-root-001.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The parentNode and parentElement attributes of the shadow root object must always return null.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-005.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-005.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation:The nodes with a unique id and named elements are not addressable from any attributes of elements in shadow host's document">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-007.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-007.html
@@ -16,7 +16,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation:The nodes with a unique id and named elements are addressable from any attributes of elements in the same shadow DOM subtree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-009.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-009.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: no nodes other than shadow root descendants are accessible with shadow root DOM tree accessor methods">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-011.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-011.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation:The style sheets, represented by the shadow nodes are not accessible using shadow host document's CSSOM extensions">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-001.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The nodes and named elements are not accessible from Window object named properties.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>
@@ -54,7 +54,7 @@ frameTest.step(function () {
         '<html>',
         '<head>',
         '<title>Frames Test</title>',
-        '<script src="../../testcommon.js"><' + '/script>',
+        '<script src="../../../../html/resources/common.js"><' + '/script>',
         '</head>',
         '<frameset id="host" cols="50%,*">',
         '<frame src="about:blank" name="host-frame1">',

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-002.html
@@ -18,7 +18,7 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The nodes and named elements are not accessible from Window object named properties.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-003.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-003.html
@@ -18,7 +18,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Upper-boundary encapsulation: The nodes and named elements are not accessible from Window object named properties.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/css-variables/test-001.html
+++ b/shadow-dom/untriaged/styles/css-variables/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="CSS variables: The shadow host styles being inherited by the children of the shadow root must also apply to CSS Variables.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/deep-combinator/deep-combinator-001.html
+++ b/shadow-dom/untriaged/styles/deep-combinator/deep-combinator-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="/deep/ should select through all Shadow trees">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/not-apply-in-shadow-root-001.html
+++ b/shadow-dom/untriaged/styles/not-apply-in-shadow-root-001.html
@@ -15,7 +15,7 @@ policies and contribution forms [3].
 <link rel="author" title="Kazuhito Hokamura" href="mailto:k.hokamura@gmail.com">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#styles">
 <meta name="assert" content="Styles: CSS rules declared in an enclosing tree must not apply in a shadow tree if apply-author-styles flag is not set.">
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
 <style>
 div {
   width: 100px;

--- a/shadow-dom/untriaged/styles/shadow-pseudoelement/shadow-pseudoelement-001.html
+++ b/shadow-dom/untriaged/styles/shadow-pseudoelement/shadow-pseudoelement-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="::shadow should match a shadow root">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-001.html
+++ b/shadow-dom/untriaged/styles/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles: CSS rules declared in an enclosing tree must not apply in a shadow tree if apply-author-styles flag is set to false for this tree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-003.html
+++ b/shadow-dom/untriaged/styles/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles: Each shadow root has an associated list of zero or more style sheets, named shadow root style sheets">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-005.html
+++ b/shadow-dom/untriaged/styles/test-005.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles:CSS rules declared in a shadow root style sheets must not apply in the document tree,">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-007.html
+++ b/shadow-dom/untriaged/styles/test-007.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles:The @host @-rule matches a shadow host in the nesting tree.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-008.html
+++ b/shadow-dom/untriaged/styles/test-008.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles:the styles of the shadow host are inherited by the children of the shadow root">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-009.html
+++ b/shadow-dom/untriaged/styles/test-009.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles:the styles of the insertion point nodes are inherited by those child nodes of the shadow host that are assigned to this insertion point">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/styles/test-010.html
+++ b/shadow-dom/untriaged/styles/test-010.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="Styles:the styles of the shadow insertion point node are inherited by the child nodes of the shadow root of the shadow tree, distributed to this shadow insertion point">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../testcommon.js"></script>
+<script src="../../../html/resources/common.js"></script>
+<script src="../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/active-element/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/active-element/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: each shadow root must also have an activeElement property to store the value of the focused element in the shadow tree.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/active-element/test-002.html
+++ b/shadow-dom/untriaged/user-interaction/active-element/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: Document's activeElement property must be adjusted">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/editing/inheritance-of-content-editable-001.html
+++ b/shadow-dom/untriaged/user-interaction/editing/inheritance-of-content-editable-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: Shadow trees must not be propagated contentEditable attribute from shadow host">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: The navigation order within a shadow tree must be computed as a list of focusable elements in tree order as-rendered">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-002.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: The navigation order within a shadow tree must be computed as a list of focusable elements in tree order as-rendered  with the exception of any elements, distributed its insertion points, and is called shadow DOM navigation order.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-003.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-003.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: For sequential focus navigation, the shadow DOM navigation order sequence must be inserted into the document navigation order in place of the shadow host as if the shadow host were assigned the value of auto for determining its position and shadow host is not focusable">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-004.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-004.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: For sequential focus navigation, the shadow DOM navigation order sequence must be inserted into the document navigation order immediately after the shadow host, if the shadow host is focusable;">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: Selection, returned by the window.getSelection() method must never return a selection within a shadow tree">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-002.html
+++ b/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-002.html
@@ -16,7 +16,8 @@ policies and contribution forms [3].
 <meta name="assert" content="User Interaction: The getSelection() method of the shadow root object must return the current selection in this shadow tree.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="../../testcommon.js"></script>
+<script src="../../../../html/resources/common.js"></script>
+<script src="../../../resources/shadow-dom-utils.js"></script>
 </head>
 <body>
 <div id="log"></div>


### PR DESCRIPTION
The original functions were in html/resources/common.js and shadow-dom
had wrapped version of them, but now we don't need the wrapper and
we use html/resources/common.js directly.

Renamed and moved "testcommon.js" to "resources/shadow-dom-utils.js".
I plan to further cleanup of the file and its usage.
