### PR TITLE
Fix the test that assumes event is not dispatched

### DIFF
--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-003.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-003.html
@@ -12,8 +12,8 @@ policies and contribution forms [3].
 <head>
 <title>Shadow DOM Test: A_05_02_03</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
-<link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-201305214#retargeting-related-target">
-<meta name="assert" content="Retargeting relatedTarget:Event listeners must not be invoked on a node for which the target and relatedTarget are the same.">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-relatedtarget-retargeting">
+<meta name="assert" content="The value of the Event object's relatedTarget attribute must be the result of the retargeting algorithm with the event's currentTarget and relatedTarget as input. The result is called a relative related target.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../../../html/resources/common.js"></script>
@@ -34,27 +34,19 @@ A_05_02_03_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div1 = d.createElement('div');
     div1.setAttribute('style', 'height:100%; width:100%');
     div1.setAttribute('id', 'div1');
     s.appendChild(div1);
 
-    var div2 = d.createElement('div');
-    div2.setAttribute('style', 'height:100%; width:100%');
-    div2.setAttribute('id', 'div2');
-    s.appendChild(div2);
-
-    s.addEventListener('mouseover', A_05_02_03_T01.step_func(function(event) {
-        assert_true(false, 'Event listeners shouldn\'t be invoked if target and relatedTarget are the same');
+    host.addEventListener('mouseover', A_05_02_03_T01.step_func(function(event) {
+        assert_unreached('Event listeners shouldn\'t be invoked if relative target and relative related target are the same');
     }), false);
 
-
-    var evt = document.createEvent("MouseEvents");
-    evt.initMouseEvent("mouseover", true, false, window,
-      0, 10, 10, 10, 10, false, false, false, false, 0, div1);
-
+    var evt = new MouseEvent("mouseover",
+                             { relatedTarget: div1, relatedTargetScoped: true });
     div1.dispatchEvent(evt);
 
     A_05_02_03_T01.done();


### PR DESCRIPTION
The test assumed that an event will not be dispatched when
target and relatedTarget are the same, but with the current
spec this happens only for trusted event or explicitly initilized
with relatedTarget true.
