### PR TITLE
ShadowRoot.getElementsByTagName() is deprecated.

### DIFF
--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-002.html
@@ -30,53 +30,33 @@ function assert_singleton_node_list(nodeList, expectedNode) {
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var image = doc.createElement('img');
     shadowRoot.appendChild(image);
 
-    assert_singleton_node_list(shadowRoot.getElementsByTagName('img'), image);
+    assert_singleton_node_list(shadowRoot.querySelectorAll('img'), image);
 },
     'Elements in a shadow tree should be accessible via shadow root\'s ' +
-    'getElementsByTagName() DOM tree accessor.'
-);
-
-test(function () {
-    var namespace = 'http://www.w3.org/1999/xhtml';
-    var doc = document.implementation.createDocument(namespace, 'html');
-    doc.documentElement.appendChild(doc.createElementNS(namespace, 'head'));
-    var body = doc.createElementNS(namespace, 'body');
-    var imageHost = doc.createElementNS(namespace, 'img');
-    body.appendChild(imageHost);
-    doc.documentElement.appendChild(body);
-
-    var shadowRoot = body.createShadowRoot();
-    var imageShadow = doc.createElementNS(namespace, 'img');
-    shadowRoot.appendChild(imageShadow);
-
-    assert_singleton_node_list(
-        shadowRoot.getElementsByTagNameNS(namespace, 'img'), imageShadow);
-},
-    'Elements in a shadow tree should be accessible via shadow root\'s ' +
-    'getElementsByTagNameNS() DOM tree accessor.'
+    'querySelectorAll() DOM tree accessor.'
 );
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var div = doc.createElement('div');
     div.className = 'div-class';
     shadowRoot.appendChild(div);
 
     assert_singleton_node_list(
-        shadowRoot.getElementsByClassName('div-class'), div);
+        shadowRoot.querySelectorAll('.div-class'), div);
 },
-    'Elements in a shadow tree should be accessible via shadow root\'s ' +
-    'getElementsByClassName() DOM tree accessor.'
+    'Elements with a specific class in a shadow tree should be accessible via' +
+    'shadow root\'s querySelectorAll() DOM tree accessor.'
 );
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var div = doc.createElement('div');
     div.id = 'div-id';
     shadowRoot.appendChild(div);

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-009.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-009.html
@@ -53,10 +53,10 @@ A_04_01_09.setup = function () {
     ctx.d = newHTMLDocument();
     A_04_01_09.setupBlock(ctx, 'd', ctx.d.body);
 
-    ctx.s1 = ctx.d_p1.createShadowRoot();
+    ctx.s1 = ctx.d_p1.attachShadow({mode: 'open'});
     A_04_01_09.setupBlock(ctx, 's1', ctx.s1);
 
-    ctx.s2 = ctx.s1_p1.createShadowRoot();
+    ctx.s2 = ctx.s1_p1.attachShadow({mode: 'open'});
     A_04_01_09.setupBlock(ctx, 's2', ctx.s2);
 
     assert_true(ctx.d_div1 != null, 'setup:d_div1');
@@ -69,77 +69,37 @@ A_04_01_09.setup = function () {
     return ctx;
 };
 
-//check getElementsByTagName
+//check querySelectorAll
 test(function () {
     var ctx = A_04_01_09.setup();
 
     assert_nodelist_contents_equal_noorder(
-        ctx.s1.getElementsByTagName('div'), [ctx.s1_div1, ctx.s1_div2],
+        ctx.s1.querySelectorAll('div'), [ctx.s1_div1, ctx.s1_div2],
         'nodes, other than shadow root descendants, should not be accessible with ' +
             'ShadowRoot.getElementsByTagName (s1)');
 
     assert_nodelist_contents_equal_noorder(
-        ctx.s2.getElementsByTagName('div'), [ctx.s2_div1, ctx.s2_div2],
+        ctx.s2.querySelectorAll('div'), [ctx.s2_div1, ctx.s2_div2],
         'nodes, other than shadow root descendants, should not be accessible with ' +
             'ShadowRoot.getElementsByTagName (s2)');
 
 }, 'A_04_01_09_T01');
 
-// getElementsByTagNameNS
+//check querySelectorAll for class
 test(function () {
     var ctx = A_04_01_09.setup();
 
     assert_nodelist_contents_equal_noorder(
-        ctx.s1.getElementsByTagNameNS('*', 'div'), [ctx.s1_div1, ctx.s1_div2],
-        'nodes, other than shadow root descendants, should not be accessible with ' +
-            'ShadowRoot.getElementsByTagNameNS (s1)');
-
-    assert_nodelist_contents_equal_noorder(
-        ctx.s2.getElementsByTagNameNS('*', 'div'), [ctx.s2_div1, ctx.s2_div2],
-        'nodes, other than shadow root descendants, should not be accessible with ' +
-            'ShadowRoot.getElementsByTagNameNS (s2)');
-
-}, 'A_04_01_09_T02');
-
-//check getElementsByClassName
-test(function () {
-    var ctx = A_04_01_09.setup();
-
-    assert_nodelist_contents_equal_noorder(
-        ctx.s1.getElementsByClassName('cls'), [ctx.s1_div1, ctx.s1_p1, ctx.s1_div2],
+        ctx.s1.querySelectorAll('.cls'), [ctx.s1_div1, ctx.s1_p1, ctx.s1_div2],
         'nodes, other than shadow root descendants, should not be accessible with ' +
             'ShadowRoot.getElementsByClassName (s1)');
 
     assert_nodelist_contents_equal_noorder(
-        ctx.s2.getElementsByClassName('cls'), [ctx.s2_div1, ctx.s2_p1, ctx.s2_div2],
+        ctx.s2.querySelectorAll('.cls'), [ctx.s2_div1, ctx.s2_p1, ctx.s2_div2],
         'nodes, other than shadow root descendants, should not be accessible with ' +
             'ShadowRoot.getElementsByClassName (s2)');
 
 }, 'A_04_01_09_T03');
-
-// check getElementById
-test(function () {
-    var ctx = A_04_01_09.setup();
-
-    assert_equals(ctx.s1.getElementById('d_id1'), null, 'Expected no access to d_div1 from s1.getElementById()');
-    assert_equals(ctx.s1.getElementById('d_id2'), null, 'Expected no access to d_div2 from s1.getElementById()');
-    assert_equals(ctx.s2.getElementById('d_id1'), null, 'Expected no access to d_div1 from s2.getElementById()');
-    assert_equals(ctx.s2.getElementById('d_id2'), null, 'Expected no access to d_div1 from s2.getElementById()');
-
-
-    assert_equals(ctx.s1.getElementById('s1_id1'), ctx.s1_div1, 'Expected access to s1_div1 form s1.getElementById()');
-    assert_equals(ctx.s1.getElementById('s1_id2'), ctx.s1_div2, 'Expected access to s1_div2 form s1.getElementById()');
-    assert_equals(ctx.s2.getElementById('s2_id1'), ctx.s2_div1, 'Expected access to s2_div1 form s2.getElementById()');
-    assert_equals(ctx.s2.getElementById('s2_id2'), ctx.s2_div2, 'Expected access to s2_div2 form s2.getElementById()');
-
-
-    assert_equals(ctx.s1.getElementById('s2_id1'), null, 'Expected no access to s2_div1 form s1.getElementById()');
-    assert_equals(ctx.s1.getElementById('s2_id2'), null, 'Expected no access to s2_div2 form s1.getElementById()');
-    assert_equals(ctx.s2.getElementById('s1_id1'), null, 'Expected no access to s1_div1 form s2.getElementById()');
-    assert_equals(ctx.s2.getElementById('s1_id2'), null, 'Expected no access to s1_div2 form s2.getElementById()');
-
-}, 'A_04_01_09_T04');
-
 
 // check querySelector for id
 test(function () {


### PR DESCRIPTION
Replaced getElementsByTagName() with querySelectorAll() (as well for getElementsByClassName())
