### PR TITLE
Test only elements for which attachShadow is allowed.

### DIFF
--- a/shadow-dom/resources/shadow-dom-utils.js
+++ b/shadow-dom/resources/shadow-dom-utils.js
@@ -13,7 +13,7 @@ policies and contribution forms [3].
 "use strict";
 
 // custom element is also allowed.
-var ATTACHSHADOW_WHITELISTED_ELEMENTS = [
+var ATTACHSHADOW_SAFELISTED_ELEMENTS = [
     'article',
     'aside',
     'blockquote',

--- a/shadow-dom/resources/shadow-dom-utils.js
+++ b/shadow-dom/resources/shadow-dom-utils.js
@@ -12,6 +12,27 @@ policies and contribution forms [3].
 
 "use strict";
 
+// custom element is also allowed.
+var ATTACHSHADOW_WHITELISTED_ELEMENTS = [
+    'article',
+    'aside',
+    'blockquote',
+    'body',
+    'div',
+    'footer',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'header',
+    'nav',
+    'p',
+    'section',
+    'span'
+];
+
 var HTML5_ELEMENT_NAMES = [
     'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio',
     'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button',

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
@@ -29,8 +29,8 @@ function testElement(elementName) {
     var doc = document.implementation.createHTMLDocument('Test');
     var element = doc.createElement(elementName);
     doc.body.appendChild(element);
-    var shadowRoot = element.createShadowRoot();
-    HTML5_ELEMENT_NAMES.forEach(function (name) {
+    var shadowRoot = element.attachShadow({mode: 'open'});
+    ATTACHSHADOW_WHITELISTED_ELEMENTS.forEach(function (name) {
         shadowRoot.appendChild(doc.createElement(name));
     });
 
@@ -41,7 +41,7 @@ function testElement(elementName) {
     }
 }
 
-var testParameters = HTML5_ELEMENT_NAMES.map(function (name) {
+var testParameters = ATTACHSHADOW_WHITELISTED_ELEMENTS.map(function (name) {
     return [
         'ownerDocument property of any elements in a shadow tree should ' +
         'match the document of the shadow host, when the host is a "' +

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-002.html
@@ -30,7 +30,7 @@ function testElement(elementName) {
     var element = doc.createElement(elementName);
     doc.body.appendChild(element);
     var shadowRoot = element.attachShadow({mode: 'open'});
-    ATTACHSHADOW_WHITELISTED_ELEMENTS.forEach(function (name) {
+    ATTACHSHADOW_SAFELISTED_ELEMENTS.forEach(function (name) {
         shadowRoot.appendChild(doc.createElement(name));
     });
 
@@ -41,7 +41,7 @@ function testElement(elementName) {
     }
 }
 
-var testParameters = ATTACHSHADOW_WHITELISTED_ELEMENTS.map(function (name) {
+var testParameters = ATTACHSHADOW_SAFELISTED_ELEMENTS.map(function (name) {
     return [
         'ownerDocument property of any elements in a shadow tree should ' +
         'match the document of the shadow host, when the host is a "' +


### PR DESCRIPTION
The old test tried to createShadowRoot() on all known HTML5 elements, whereas new one only tries to attach shadow on whitelisted elements.

We can add test for custom elements later.
