### PR TITLE
Add a test for incumbent global handling when invoking promise callbacks.

### DIFF
--- a/js/builtins/Promise-incumbent-global-subframe.sub.html
+++ b/js/builtins/Promise-incumbent-global-subframe.sub.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<iframe src="{{location[scheme]}}://{{domains[www2]}}:{{ports[http][0]}}{{location[path]}}/../Promise-incumbent-global-subsubframe.sub.html"></iframe>
+<script>
+  document.domain = "{{host}}";
+  onmessage = function(e) {
+    if (e.data == "start") {
+      frames[0].Promise.resolve().then(frames[0].postMessage.bind(frames[0], "start", "*"));
+    } else {
+      parent.postMessage(e.data, "*");
+    }
+  }
+</script>

--- a/js/builtins/Promise-incumbent-global-subsubframe.sub.html
+++ b/js/builtins/Promise-incumbent-global-subsubframe.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script>
+  document.domain = "{{host}}";
+  onmessage = function (e) {
+    parent.postMessage(
+      {
+        actual: e.origin,
+        expected: "{{location[scheme]}}://{{domains[www1]}}:{{ports[http][0]}}",
+        reason: "Incumbent should have been the caller of then()"
+      },
+      "*");
+  }
+</script>

--- a/js/builtins/Promise-incumbent-global.sub.html
+++ b/js/builtins/Promise-incumbent-global.sub.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe src="{{location[scheme]}}://{{domains[www1]}}:{{ports[http][0]}}{{location[path]}}/../Promise-incumbent-global-subframe.sub.html"></iframe>
+<script>
+
+var t = async_test("Check the incumbent global Promise callbacks are called with");
+
+onload = t.step_func(function() {
+  onmessage = t.step_func_done(function(e) {
+    var d = e.data;
+    assert_equals(d.actual, d.expected, d.reason);
+  });
+
+  frames[0].postMessage("start", "*");
+});
+
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1258391
