### PR TITLE
Part3: reftests for -webkit-text-fill-color.

### DIFF
--- a/compat/webkit-text-fill-color-property-001-ref.html
+++ b/compat/webkit-text-fill-color-property-001-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>webkit-text-fill-color: untouched</title>
+<link rel="author" title="Jeremy Chen" href="jeremychen@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<div style="color: green">These texts should be green</div>

--- a/compat/webkit-text-fill-color-property-001a.html
+++ b/compat/webkit-text-fill-color-property-001a.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>webkit-text-fill-color: green</title>
+<link rel="author" title="Jeremy Chen" href="jeremychen@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="help" href="https://compat.spec.whatwg.org/#the-webkit-text-fill-color">
+<meta name="assert" content="The color of texts should be green">
+<link rel="match" href="webkit-text-fill-color-property-001-ref.html">
+<div style="-webkit-text-fill-color: green;">These texts should be green</div>

--- a/compat/webkit-text-fill-color-property-001b.html
+++ b/compat/webkit-text-fill-color-property-001b.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>webkit-text-fill-color: green</title>
+<link rel="author" title="Jeremy Chen" href="jeremychen@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="help" href="https://compat.spec.whatwg.org/#the-webkit-text-fill-color">
+<meta name="assert" content="The color of texts should be green">
+<link rel="match" href="webkit-text-fill-color-property-001-ref.html">
+<div style="color: red; -webkit-text-fill-color: green;">These texts should be green</div>

--- a/compat/webkit-text-fill-color-property-001c.html
+++ b/compat/webkit-text-fill-color-property-001c.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>webkit-text-fill-color: green</title>
+<link rel="author" title="Jeremy Chen" href="jeremychen@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="help" href="https://compat.spec.whatwg.org/#the-webkit-text-fill-color">
+<meta name="assert" content="The color of texts should be green">
+<link rel="match" href="webkit-text-fill-color-property-001-ref.html">
+<div style="color: red; -webkit-text-fill-color: green;">These texts <span style="color: red">should be green</span></div>


### PR DESCRIPTION
Add this test into web-platform-tests.

Since -webkit-text-fill-color is on compat spec, we might want this
feature to be tested on different browsers.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1247777
