### PR TITLE
Update responsexml-basic.htm

### DIFF
--- a/XMLHttpRequest/responsexml-basic.htm
+++ b/XMLHttpRequest/responsexml-basic.htm
@@ -17,7 +17,7 @@
         assert_equals(client.responseXML, null)
         client.send(null)
         assert_equals(client.responseXML.documentElement.localName, "html", 'localName is html')
-        assert_equals(client.responseXML.documentElement.childNodes.length, 5, 'childNodes is 5')
+        assert_equals(client.responseXML.documentElement.childNodes.length, 2, 'childNodes is 2')
         assert_equals(client.responseXML.getElementById("n1").localName, client.responseXML.documentElement.childNodes[1].localName)
         assert_equals(client.responseXML.getElementById("n2"), null, 'getElementById("n2")')
         assert_equals(client.responseXML.getElementsByTagName("p")[1].namespaceURI, "namespacesarejuststrings", 'namespaceURI')


### PR DESCRIPTION
`resources/well-formed.xml` contains the following:

``` html
<html xmlns="http://www.w3.org/1999/xhtml">
  <p id="n&#49;">1</p>
  <p xmlns="namespacesarejuststrings" id="n2">2</p>
</html>
```

Which looks like it does contain 2 childNodes instead of 5.
