### PR TITLE
Check for TypeError being thrown when a non-ByteString value is supplied

### DIFF
--- a/XMLHttpRequest/setrequestheader-bogus-value.htm
+++ b/XMLHttpRequest/setrequestheader-bogus-value.htm
@@ -12,16 +12,20 @@
     <script>
       function try_value(value) {
         test(function() {
-          var client = new XMLHttpRequest()
-          client.open("GET", "...")
-          assert_throws("SyntaxError", function() { client.setRequestHeader("x-test", value) }, ' given value ' + value+', ')
-        })
+          var client = new XMLHttpRequest();
+          client.open("GET", "...");
+          assert_throws("SyntaxError", function() { client.setRequestHeader("x-test", value) }, ' given value ' + value+', ');
+        });
       }
-      try_value("t\rt")
-      try_value("t\nt")
+      try_value("t\rt");
+      try_value("t\nt");
       try_value("t\bt");
       try_value("\x7f");
-      try_value("ﾃｽﾄ")
+      test(function() {
+        var client = new XMLHttpRequest();
+        client.open("GET", "...");
+        assert_throws(new TypeError(), function() { client.setRequestHeader("x-test", "ﾃｽﾄ") }, ' given value ﾃｽﾄ,');
+      });
 
       test(function() {
         var client = new XMLHttpRequest()


### PR DESCRIPTION
According to http://heycam.github.io/webidl/#es-ByteString, when a value of any ByteString element is greater than 255, a TypeError is thrown. The Japanese characters ("TESUTO") have ByteString elements greater than 255, and so a TypeError is thrown. The code flow does not ever reach the point where a DOMException is thrown when these Japanese characters are supplied.
