### PR TITLE
Point XHR target to the correct folder.txt

### DIFF
--- a/XMLHttpRequest/open-url-base.htm
+++ b/XMLHttpRequest/open-url-base.htm
@@ -13,7 +13,7 @@
     <script>
       test(function() {
         var client = new XMLHttpRequest()
-        client.open("GET", "folder.txt", false)
+        client.open("GET", "resources/folder.txt", false)
         client.send(null)
         assert_equals(client.responseText, "bottom\n")
       })


### PR DESCRIPTION
There are two folder.txt files, one is located under XMLHttpRequest (which contains the text "top"), the other is located at XMLHttpRequest/resources (which contains the text "bottom"). This PR points to the correct folder.txt in order to obtain the expected test output.
