### PR TITLE
Use regex to match against Content-Type header value

### DIFF
--- a/XMLHttpRequest/data-uri.htm
+++ b/XMLHttpRequest/data-uri.htm
@@ -9,7 +9,7 @@
 
 <script>
   function do_test(method, uri, charset, testNamePostfix) {
-    if (typeof charset === 'undefined' || charset === null) charset = 'text/plain';
+    if (typeof charset === 'undefined' || charset === null) charset = /text\/plain/i;
     var test = async_test("XHR method " + method + " with charset " + charset+(testNamePostfix||''));
     test.step(function() {
       var client = new XMLHttpRequest();
@@ -30,7 +30,7 @@
 
         assert_equals(client.responseText, "Hello, World!");
         assert_equals(client.status, 200);
-        assert_equals(client.getResponseHeader('Content-Type'), charset);
+        assert_regexp_match(client.getResponseHeader('Content-Type'), charset);
         var allHeaders = client.getAllResponseHeaders();
         assert_regexp_match(allHeaders, /content\-type\:/i, 'getAllResponseHeaders() includes Content-Type');
         assert_false(/content\-length\:/i.test(allHeaders), 'getAllResponseHeaders() must not include Content-Length');
@@ -42,9 +42,9 @@
   }
   do_test('GET', "data:text/plain,Hello, World!");
   do_test('GET', "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==", undefined, " (base64)");
-  do_test('GET', "data:text/html,Hello, World!", 'text/html');
-  do_test('GET', "data:text/html;charset=UTF-8,Hello, World!", 'text/html;charset=UTF-8');
-  do_test('GET', "data:image/png,Hello, World!", 'image/png');
+  do_test('GET', "data:text/html,Hello, World!", /text\/html/i);
+  do_test('GET', "data:text/html;charset=UTF-8,Hello, World!", /text\/html; *charset=UTF-8/i);
+  do_test('GET', "data:image/png,Hello, World!", /image\/png/i);
   do_test('POST', "data:text/plain,Hello, World!");
   do_test('PUT', "data:text/plain,Hello, World!");
   do_test('DELETE', "data:text/plain,Hello, World!");


### PR DESCRIPTION
This is to better match against UAs that generate whitespaces between the MIME type and the charset key-value pair (e.g. `text/plain; charset=UTF-8`).
