### PR TITLE
Increase thoroughness of :in-range & :out-of-range tests

### DIFF
--- a/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
+++ b/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
@@ -11,17 +11,61 @@
 <input type=number value=0 min=0 max=10 id=number2 disabled>
 <input type=number value=0 min=1 max=10 id=number3>
 <input type=number value=11 min=0 max=10 id=number4>
+<input type=number value=0 min=0 max=10 id=number5 readonly>
+
+<input type="date" min="2005-10-10" max="2020-10-10" value="2010-10-10" id="datein">
+<input type="date" min="2010-10-10" max="2020-10-10" value="2005-10-10" id="dateunder">
+<input type="date" min="2010-10-10" max="2020-10-10" value="2030-10-10" id="dateover">
+
+<input type="time" min="01:00:00" max="05:00:00" value="02:00:00" id="timein">
+<input type="time" min="02:00:00" max="05:00:00" value="01:00:00" id="timeunder">
+<input type="time" min="02:00:00" max="05:00:00" value="07:00:00" id="timeover">
+
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W07" id="weekin">
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W02" id="weekunder">
+<input type="week" min="2016-W05" max="2016-W10" value="2016-W26" id="weekover">
+
+<input type="month" min="2000-04" max="2000-09" value="2000-06" id="monthin">
+<input type="month" min="2000-04" max="2000-09" value="2000-02" id="monthunder">
+<input type="month" min="2000-04" max="2000-09" value="2000-11" id="monthover">
+
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2012-11-28T23:59:59" id="datetimelocalin">
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2008-03-01T23:59:59" id="datetimelocalunder">
+<input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2016-01-01T23:59:59" id="datetimelocalover">
+
+<!-- range input's value gets immediately clamped to the nearest boundary point -->
+<input type="range" min="2" max="7" value="5" id="range1">
+<input type="range" min="2" max="7" value="1" id="range2">
+<input type="range" min="2" max="7" value="9" id="range3">
+
+<!-- None of the following input types can have range limitations -->
+<input min="1" value="0" type="text">
+<input min="1" value="0" type="search">
+<input min="1" value="0" type="url">
+<input min="1" value="0" type="tel">
+<input min="1" value="0" type="email">
+<input min="1" value="0" type="password">
+<input min="1" value="#000000" type="color">
+<input min="1" value="0" type="checkbox">
+<input min="1" value="0" type="radio">
+<input min="1" value="0" type="file">
+<input min="1" value="0" type="submit">
+<input min="1" value="0" type="image">
+<!-- The following types are also barred from constraint validation -->
+<input min="1" value="0" type="hidden">
+<input min="1" value="0" type="button">
+<input min="1" value="0" type="reset">
 
 <script>
-  testSelector(":in-range", ["number1"], "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow");
+  testSelector(":in-range", ["number1", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow");
 
-  testSelector(":out-of-range", ["number3", "number4"], "':out-of-range' matches all elements that are candidates for constraint validation, have range limitations, and that are either suffering from an underflow or suffering from an overflow");
+  testSelector(":out-of-range", ["number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' matches all elements that are candidates for constraint validation, have range limitations, and that are either suffering from an underflow or suffering from an overflow");
 
   document.getElementById("number1").value = -10;
-  testSelector(":in-range", [], "':in-range' update number1's value < min");
-  testSelector(":out-of-range", ["number1", "number3", "number4"], "':out-of-range' update number1's value < min");
+  testSelector(":in-range", ["datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' update number1's value < min");
+  testSelector(":out-of-range", ["number1", "number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number1's value < min");
 
   document.getElementById("number3").min = 0;
-  testSelector(":in-range", ["number3"], "':in-range' update number3's min < value");
-  testSelector(":out-of-range", ["number1", "number4"], "':out-of-range' update number3's min < value");
+  testSelector(":in-range", ["number3", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' update number3's min < value");
+  testSelector(":out-of-range", ["number1", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number3's min < value");
 </script>


### PR DESCRIPTION
- Add `readonly` attribute test
- Test temporal `<input>`s with range limitations
- Test that `<input type="range">` never matches `:out-of-range`
- Test that `<input>` types which cannot have range limitations and/or are barred from constraint validation never match
