### PR TITLE
Replace createShadowRoot with attachShadow

### DIFF
--- a/shadow-dom/resources/shadow-dom-utils.js
+++ b/shadow-dom/resources/shadow-dom-utils.js
@@ -115,7 +115,7 @@ function createTestMediaPlayer(d) {
         '</div>' +
     '</div>';
 
-    var playerShadowRoot = d.querySelector('#player-shadow-host').createShadowRoot();
+    var playerShadowRoot = d.querySelector('#player-shadow-host').attachShadow({mode: 'open'});
     playerShadowRoot.innerHTML = '' +
         '<div id="controls">' +
             '<button class="play-button">PLAY</button>' +
@@ -131,10 +131,10 @@ function createTestMediaPlayer(d) {
             '</div>' +
         '</div>';
 
-    var timeLineShadowRoot = playerShadowRoot.querySelector('#timeline-shadow-host').createShadowRoot();
+    var timeLineShadowRoot = playerShadowRoot.querySelector('#timeline-shadow-host').attachShadow({mode: 'open'});
     timeLineShadowRoot.innerHTML =  '<div class="slider-thumb" id="timeline-slider-thumb"></div>';
 
-    var volumeShadowRoot = playerShadowRoot.querySelector('#volume-shadow-host').createShadowRoot();
+    var volumeShadowRoot = playerShadowRoot.querySelector('#volume-shadow-host').attachShadow({mode: 'open'});
     volumeShadowRoot.innerHTML = '<div class="slider-thumb" id="volume-slider-thumb"></div>';
 
     return {

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-001.html
@@ -13,7 +13,7 @@ policies and contribution forms [3].
 <title>Shadow DOM Test: A_10_02_02_01</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-aware-methods">
-<meta name="assert" content="Extensions to Element Interface: createShadowRoot method creates new instance of Shadow root object">
+<meta name="assert" content="Extensions to Element Interface: attachShadow method creates new instance of Shadow root object">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../../../../html/resources/common.js"></script>
@@ -28,9 +28,9 @@ test(function () {
     var host = d.createElement('div');
     d.body.appendChild(host);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
-    assert_true(s instanceof ShadowRoot, 'createShadowRoot() method should create new instance ' +
+    assert_true(s instanceof ShadowRoot, 'attachShadow() method should create new instance ' +
             'of ShadowRoot object');
 
 }, 'A_10_02_02_01_T01');

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-element-interface/methods/test-002.html
@@ -13,7 +13,7 @@ policies and contribution forms [3].
 <title>Shadow DOM Test: A_10_02_02_02</title>
 <link rel="author" title="Sergey G. Grekhov" href="mailto:sgrekhov@unipro.ru">
 <link rel="help" href="http://www.w3.org/TR/2013/WD-shadow-dom-20130514/#shadow-aware-methods">
-<meta name="assert" content="Extensions to Element Interface: createShadowRoot method">
+<meta name="assert" content="Extensions to Element Interface: attachShadow method">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../../../../html/resources/common.js"></script>
@@ -33,10 +33,10 @@ test(unit(function (ctx) {
     span.innerHTML = 'Some text';
     host.appendChild(span);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     // span should become invisible as shadow root content
-    assert_equals(span.offsetTop, 0, 'createShadowRoot() method should establish ' +
+    assert_equals(span.offsetTop, 0, 'attachShadow() method should establish ' +
             'the context object as the shadow host of the ShadowRoot object');
 
 }), 'A_10_02_02_02_T01');

--- a/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/extensions-to-event-interface/event-path-001.html
@@ -28,7 +28,7 @@ t.step(unit(function(ctx) {
     var doc = newRenderedHTMLDocument(ctx);
     var host = doc.createElement('div');
 
-    var shadowRoot = host.createShadowRoot();
+    var shadowRoot = host.attachShadow({mode: 'open'});
     var child = doc.createElement('div');
 
     doc.body.appendChild(host);

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/activeElement-confirm-return-null.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/activeElement-confirm-return-null.html
@@ -29,7 +29,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(s.activeElement, null, 'activeElement attribute of the ShadowRoot must return null if there\'s no focused element');
 
@@ -42,7 +42,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp = d.createElement('input');
     d.body.appendChild(inp);
@@ -60,7 +60,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp = d.createElement('input');
     d.body.appendChild(inp);

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-007.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-007.html
@@ -29,7 +29,7 @@ test(unit(function (ctx) {
     var host = d.createElement('div');
     host.setAttribute('id', 'shRoot');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp = d.createElement('input');
     inp.setAttribute('type', 'text');

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-009.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-009.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-010.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-010.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';
@@ -48,7 +48,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.setAttribute('id', 'spanId');

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-011.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_true(s.styleSheets != null, 'ShadowRoot styleSheets attribute shouldn\'t be null');
     assert_equals(s.styleSheets.length, 0, 'attribute must return the shadow root style sheets only');
@@ -42,7 +42,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var style = d.createElement('style');
     s.appendChild(style);

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-012.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-012.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(s.nodeType, 11, 'The nodeType attribute of a ShadowRoot ' +
             'instance must return DOCUMENT_FRAGMENT_NODE');

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-013.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-attributes/test-013.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(s.nodeName, '#document-fragment', 'The nodeName attribute of a ShadowRoot instance ' +
             'must return "#document-fragment".');

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-001.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-001.html
@@ -28,7 +28,7 @@ test(function () {
     var el = d.createElement('div');
     d.body.appendChild(el);
 
-    var s = el.createShadowRoot();
+    var s = el.attachShadow({mode: 'open'});
 
     var child = d.createElement('span');
     child.setAttribute('id', 'span_id');
@@ -50,7 +50,7 @@ test(function () {
     var el = d.createElement('div');
     d.body.appendChild(el);
 
-    var s = el.createShadowRoot();
+    var s = el.attachShadow({mode: 'open'});
 
     assert_true(s.getElementById('span_id') == null, ' ShadowRoot getElementById() ' +
             'method should return null if matching element not found');

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-004.html
@@ -27,7 +27,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-006.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-006.html
@@ -44,7 +44,7 @@ test(function () {
 
     var el = d.createElement('div');
 
-    var s = el.createShadowRoot();
+    var s = el.attachShadow({mode: 'open'});
     d.body.appendChild(el);
 
     if (typeof(s) == 'undefined' || typeof (s.elementFromPoint(1, 1)) != 'object') {

--- a/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-007.html
+++ b/shadow-dom/untriaged/elements-and-dom-objects/shadowroot-object/shadowroot-methods/test-007.html
@@ -28,7 +28,7 @@ test(function () {
     var el = d.createElement('div');
     d.body.appendChild(el);
 
-    var s = el.createShadowRoot();
+    var s = el.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';
@@ -47,7 +47,7 @@ test(function () {
     var el = d.createElement('div');
     d.body.appendChild(el);
 
-    var s = el.createShadowRoot();
+    var s = el.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';

--- a/shadow-dom/untriaged/events/event-dispatch/test-003.html
+++ b/shadow-dom/untriaged/events/event-dispatch/test-003.html
@@ -33,7 +33,7 @@ A_05_05_03_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
     s.id = 'shadow';
 
     var input1 = d.createElement('input');

--- a/shadow-dom/untriaged/events/event-retargeting/test-001.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-001.html
@@ -35,7 +35,7 @@ A_05_01_01_T1.step(function () {
         var div = d.createElement('div');
         d.body.appendChild(div);
 
-        var s = div.createShadowRoot();
+        var s = div.attachShadow({mode: 'open'});
 
         var div2 = d.createElement('div');
         s.appendChild(div2);
@@ -77,7 +77,7 @@ A_05_01_01_T2.step(function () {
         var div = d.createElement('div');
         d.body.appendChild(div);
 
-        var s = div.createShadowRoot();
+        var s = div.attachShadow({mode: 'open'});
 
         var div2 = d.createElement('div');
         s.appendChild(div2);

--- a/shadow-dom/untriaged/events/event-retargeting/test-003.html
+++ b/shadow-dom/untriaged/events/event-retargeting/test-003.html
@@ -37,11 +37,11 @@ A_05_01_03_T01.step(unit(function (ctx) {
     '</div>';
 
     var ul = d.querySelector('#shadow-root');
-    var s = ul.createShadowRoot();
+    var s = ul.attachShadow({mode: 'open'});
 
     //make shadow subtree
     var div = document.createElement('div');
-    div.innerHTML = '<content select=".shadow"><span id="flbk">Fallback item</span></content>';
+    div.innerHTML = '<slot name="shadow"><span id="flbk">Fallback item</span></slot>';
     s.appendChild(div);
 
     d.body.addEventListener('click', A_05_01_03_T01.step_func(function (event) {

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-001.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-001.html
@@ -34,7 +34,7 @@ A_05_04_01_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-002.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-002.html
@@ -34,7 +34,7 @@ A_05_04_02_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-003.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-003.html
@@ -34,7 +34,7 @@ A_05_04_03_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-004.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-004.html
@@ -34,7 +34,7 @@ A_05_04_04_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-005.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-005.html
@@ -34,7 +34,7 @@ A_05_04_05_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-006.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-006.html
@@ -34,7 +34,7 @@ A_05_04_06_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-007.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-007.html
@@ -34,7 +34,7 @@ A_05_04_07_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-008.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-008.html
@@ -34,7 +34,7 @@ A_05_04_08_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-009.html
+++ b/shadow-dom/untriaged/events/events-created-by-users-do-not-stop/test-009.html
@@ -34,7 +34,7 @@ A_05_04_09_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');

--- a/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html
+++ b/shadow-dom/untriaged/events/retargeting-focus-events/test-001.html
@@ -38,7 +38,7 @@ A_05_03_01_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');
@@ -78,7 +78,7 @@ A_05_03_01_T02.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');
@@ -121,7 +121,7 @@ A_05_03_01_T03.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');
@@ -161,7 +161,7 @@ A_05_03_01_T04.step(unit(function (ctx) {
      d.body.appendChild(host);
 
      //Shadow root to play with
-     var s = host.createShadowRoot();
+     var s = host.attachShadow({mode: 'open'});
 
      var inp1 = d.createElement('input');
      inp1.setAttribute('id', 'inp1');
@@ -202,34 +202,34 @@ A_05_03_01_T05.step(unit(function (ctx) {
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');
     inp1.setAttribute('type', 'checkbox');
-    inp1.setAttribute('class', 'clazz1');
+    inp1.setAttribute('slot', 'slot1');
     host.appendChild(inp1);
 
     var inp2 = d.createElement('input');
     inp2.setAttribute('id', 'inp2');
     inp2.setAttribute('type', 'checkbox');
-    inp2.setAttribute('class', 'clazz2');
+    inp2.setAttribute('slot', 'slot2');
     host.appendChild(inp2);
 
     var inp3 = d.createElement('input');
     inp3.setAttribute('id', 'inp3');
     inp3.setAttribute('type', 'checkbox');
-    inp3.setAttribute('class', 'clazz1');
+    inp3.setAttribute('slot', 'slot1');
     host.appendChild(inp3);
 
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var shadowDiv = document.createElement('div');
-    shadowDiv.innerHTML = '<content select=".clazz1"></content>';
+    shadowDiv.innerHTML = '<slot name="slot1"></slot>';
     s.appendChild(shadowDiv);
 
     //element outside the shadow tree
     var inp4 = d.createElement('input');
     inp4.setAttribute('id', 'inp4');
     inp4.setAttribute('type', 'checkbox');
-    inp4.setAttribute('class', 'clazz1');
+    inp4.setAttribute('slot', 'slot1');
     d.body.appendChild(inp4);
 
     inp1.focus();
@@ -268,34 +268,34 @@ A_05_03_01_T06.step(unit(function (ctx) {
     var inp1 = d.createElement('input');
     inp1.setAttribute('id', 'inp1');
     inp1.setAttribute('type', 'checkbox');
-    inp1.setAttribute('class', 'clazz1');
+    inp1.setAttribute('slot', 'slot1');
     host.appendChild(inp1);
 
     var inp2 = d.createElement('input');
     inp2.setAttribute('id', 'inp2');
     inp2.setAttribute('type', 'checkbox');
-    inp2.setAttribute('class', 'clazz2');
+    inp2.setAttribute('slot', 'slot2');
     host.appendChild(inp2);
 
     var inp3 = d.createElement('input');
     inp3.setAttribute('id', 'inp3');
     inp3.setAttribute('type', 'checkbox');
-    inp3.setAttribute('class', 'clazz1');
+    inp3.setAttribute('slot', 'slot1');
     host.appendChild(inp3);
 
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var shadowDiv = document.createElement('div');
-    shadowDiv.innerHTML = '<content select=".clazz1"></content>';
+    shadowDiv.innerHTML = '<slot name="slot1"></slot>';
     s.appendChild(shadowDiv);
 
     //element outside the shadow tree
     var inp4 = d.createElement('input');
     inp4.setAttribute('id', 'inp4');
     inp4.setAttribute('type', 'checkbox');
-    inp4.setAttribute('class', 'clazz1');
+    inp4.setAttribute('slot', 'slot1');
     d.body.appendChild(inp4);
 
     inp4.focus();

--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-001.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-001.html
@@ -34,7 +34,7 @@ A_05_02_01_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div1 = d.createElement('div');
     div1.setAttribute('style', 'height:40px; width:100%');

--- a/shadow-dom/untriaged/events/retargeting-relatedtarget/test-002.html
+++ b/shadow-dom/untriaged/events/retargeting-relatedtarget/test-002.html
@@ -34,7 +34,7 @@ A_05_02_02_T01.step(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div1 = d.createElement('div');
     div1.setAttribute('style', 'height:100%; width:100%');

--- a/shadow-dom/untriaged/events/test-001.html
+++ b/shadow-dom/untriaged/events/test-001.html
@@ -36,7 +36,7 @@ A_05_00_01_T1.step(function () {
         var div = d.createElement('div');
         d.body.appendChild(div);
 
-        var s = div.createShadowRoot();
+        var s = div.attachShadow({mode: 'open'});
 
         var div2 = d.createElement('div');
         s.appendChild(div2);

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-001.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-001.html
@@ -31,7 +31,7 @@ test(function () {
 
     var div = d.createElement('div');
     d.body.appendChild(div);
-    var s = div.createShadowRoot();
+    var s = div.attachShadow({mode: 'open'});
 
 
     HTML5_FORM_ASSOCIATED_ELEMENTS.forEach(function (tagName) {
@@ -56,7 +56,7 @@ test(function () {
 
     var div = d.createElement('div');
     form.appendChild(div);
-    s = div.createShadowRoot();
+    s = div.attachShadow({mode: 'open'});
 
     HTML5_FORM_ASSOCIATED_ELEMENTS.forEach(function (tagName) {
 

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-002.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/html-forms/test-002.html
@@ -31,7 +31,7 @@ test(function () {
 
     var div = d.createElement('div');
     d.body.appendChild(div);
-    var s = div.createShadowRoot();
+    var s = div.attachShadow({mode: 'open'});
 
 
     HTML5_FORM_ASSOCIATED_ELEMENTS.forEach(function (tagName) {
@@ -58,7 +58,7 @@ test(function () {
 
     var div = d.createElement('div');
     form.appendChild(div);
-    var s = div.createShadowRoot();
+    var s = div.attachShadow({mode: 'open'});
 
     HTML5_FORM_ASSOCIATED_ELEMENTS.forEach(function (tagName) {
 
@@ -88,10 +88,11 @@ test(function () {
 
         var el = d.createElement(tagName);
         el.setAttribute('id', tagName + '_id');
+        el.setAttribute('slot', tagName + '_slot');
         div.appendChild(el);
 
-        var s = div.createShadowRoot();
-        s.innerHTML = '<content select="' + tagName + '"></content>';
+        var s = div.attachShadow({mode: 'open'});
+        s.innerHTML = '<slot name="' + tagName + '_slot"></slot>';
 
         assert_true(s.querySelector('#' + tagName + '_id') == null, 'Distributed form-associated element ' + tagName +
         ' in shadow tree must not be accessible shadow tree accessors');

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
@@ -58,7 +58,7 @@ A_08_01_01_T01.step(function () {
     //create Shadow root
     var root = d.createElement('div');
     d.body.appendChild(root);
-    var s = root.createShadowRoot();
+    var s = root.attachShadow({mode: 'open'});
 
     // create base element, set iframe as a target
     var base = d.createElement('base');

--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-002.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-002.html
@@ -32,7 +32,7 @@ test(unit(function (ctx) {
     //create Shadow root
     var root = d.createElement('div');
     d.body.appendChild(root);
-    var s = root.createShadowRoot();
+    var s = root.attachShadow({mode: 'open'});
 
     s.appendChild(link);
 

--- a/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html
+++ b/shadow-dom/untriaged/shadow-trees/nested-shadow-trees/nested_tree_reftest.html
@@ -21,9 +21,9 @@
     <div id='host'>
     </div>
     <script>
-      var shadowRoot = document.getElementById('host').createShadowRoot();
+      var shadowRoot = document.getElementById('host').attachShadow({mode: 'open'});
       shadowRoot.innerHTML = '<div id="sub" style="width: 100%;height:100%;"></div>';
-      var nestedRoot = shadowRoot.getElementById('sub').createShadowRoot();
+      var nestedRoot = shadowRoot.getElementById('sub').attachShadow({mode: 'open'});
       nestedRoot.innerHTML = '<div style="width:100%; height:100%;background-color: green;"></div>';
     </script>
   </body>

--- a/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html
+++ b/shadow-dom/untriaged/shadow-trees/reprojection/reprojection-001.html
@@ -29,11 +29,11 @@ policies and contribution forms [3].
   <div class="pass">Orange.</div>
 </div>
 <script>
-  var shadowRoot = host.createShadowRoot(host);
-  shadowRoot.innerHTML = '<div id="host2">Hello a Shadow Root.<content></content><div>Banana.</div></div>';
+  var shadowRoot = host.attachShadow({mode: 'open'});
+  shadowRoot.innerHTML = '<div id="host2">Hello a Shadow Root.<slot></slot><div>Banana.</div></div>';
   var host2 = shadowRoot.getElementById("host2");
-  var shadowRoot2 = host2.createShadowRoot(host2);
-  shadowRoot2.innerHTML = '<div>Hello a Shadow Root2.</div><div><content></content></div>';
+  var shadowRoot2 = host2.attachShadow({mode: 'open'});
+  shadowRoot2.innerHTML = '<div>Hello a Shadow Root2.</div><div><slot></slot></div>';
 </script>
 </body>
 </html>

--- a/shadow-dom/untriaged/shadow-trees/shadow-root-001.html
+++ b/shadow-dom/untriaged/shadow-trees/shadow-root-001.html
@@ -26,7 +26,7 @@ p { color: black; }
 <p>You should see green text saying "PASS" below.</p>
 <div id="host">FAIL</div>
 <script>
-var shadowRoot = window.host.createShadowRoot();
+var shadowRoot = window.host.attachShadow({mode: 'open'});
 shadowRoot.innerHTML =
     '<style>#pass { color: green; }</style>\n' +
     '<div id="pass">PASS</div>';

--- a/shadow-dom/untriaged/shadow-trees/shadow-root-002.html
+++ b/shadow-dom/untriaged/shadow-trees/shadow-root-002.html
@@ -34,7 +34,7 @@ in this order.
 <div class="pass">C</div>
 </div>
 <script>
-var shadowRoot = window.host.createShadowRoot();
+var shadowRoot = window.host.attachShadow({mode: 'open'});
 
 shadowRoot.innerHTML =
     '<style>\n' +
@@ -42,7 +42,7 @@ shadowRoot.innerHTML =
     '* { color: red; }\n' +
     '</style>' +
     '<div class="shadow-pass">A</div>\n' +
-    '<content>FAIL</content>' +
+    '<slot>FAIL</slot>' +
     '<div class="shadow-pass">D</div>';
 </script>
 </body>

--- a/shadow-dom/untriaged/shadow-trees/text-decoration-001.html
+++ b/shadow-dom/untriaged/shadow-trees/text-decoration-001.html
@@ -13,7 +13,7 @@
         </span>
         <script>
             var parent = document.getElementById('parent');
-            var shadow = parent.createShadowRoot();
+            var shadow = parent.attachShadow({mode: 'open'});
             var child = document.createElement('span');
             child.textContent = "if NOT underlined, it is success.";
             shadow.appendChild(child);

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/dom-tree-accessors-001.html
@@ -199,7 +199,7 @@ test(function () {
     body.appendChild(pHost);
     doc.documentElement.appendChild(body);
 
-    var shadowRoot = body.createShadowRoot();
+    var shadowRoot = body.attachShadow({mode: 'open'});
     var pShadow = doc.createElementNS(namespace, 'p');
     pShadow.className = "shadow";
     shadowRoot.appendChild(pShadow);
@@ -213,7 +213,7 @@ test(function () {
 test(function () {
     var doc = document.implementation.createHTMLDocument('');
     populateTestContentToHostDocument(doc);
-    var shadowRoot = doc.documentElement.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     populateTestContentToShadowRoot(shadowRoot);
 
     shadowRoot.querySelectorAll('p')[0].id = 'test-id';

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/ownerdocument-001.html
@@ -27,11 +27,11 @@ policies and contribution forms [3].
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
     doc.body.innerHTML = '<div>A<div>B</div>C<div><span>D</span></div>E</div>';
-    var nodeIterator = doc.createNodeIterator(doc.documentElement,
+    var nodeIterator = doc.createNodeIterator(doc.body,
                                               NodeFilter.SHOW_ELEMENT, null);
     var node;
     while (node = nodeIterator.nextNode()) {
-        var shadowRoot = node.createShadowRoot();
+        var shadowRoot = node.attachShadow({mode: 'open'});
         assert_equals(shadowRoot.ownerDocument, doc);
     }
 }, 'ownerDocument property of a shadow root should be the document of the ' +
@@ -50,7 +50,7 @@ test(function () {
 
     for (var depth = 1; depth <= MAX_DEPTH; ++depth) {
         var host = doc.getElementById('depth-' + depth);
-        var shadowRoot = host.createShadowRoot();
+        var shadowRoot = host.attachShadow({mode: 'open'});
         assert_equals(shadowRoot.ownerDocument, doc,
                       'ownerDocument mismatch for #depth-' + depth);
     }
@@ -60,7 +60,7 @@ test(function () {
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var div = doc.createElement('div');
     shadowRoot.appendChild(div);
     assert_equals(div.ownerDocument, doc);
@@ -70,7 +70,7 @@ test(function () {
 test(function () {
     var doc1 = document.implementation.createHTMLDocument('Test 1');
     var doc2 = document.implementation.createHTMLDocument('Test 2');
-    var shadowRoot = doc1.body.createShadowRoot();
+    var shadowRoot = doc1.body.attachShadow({mode: 'open'});
     var div = doc2.createElement('div');
     shadowRoot.appendChild(div);
     assert_equals(div.ownerDocument, doc1);
@@ -81,7 +81,7 @@ test(function () {
 test(function () {
     var doc1 = document.implementation.createHTMLDocument('Test 1');
     var doc2 = document.implementation.createHTMLDocument('Test 2');
-    var shadowRoot = doc1.body.createShadowRoot();
+    var shadowRoot = doc1.body.attachShadow({mode: 'open'});
     doc2.body.innerHTML =
         '<div id="root">A<div>B</div>C<div><span>D</span></div>E</div>';
     shadowRoot.appendChild(doc2.getElementById('root'));
@@ -97,7 +97,7 @@ test(function () {
 test(function () {
     var doc1 = document.implementation.createHTMLDocument('Test 1');
     var doc2 = document.implementation.createHTMLDocument('Test 2');
-    var shadowRoot = doc1.body.createShadowRoot();
+    var shadowRoot = doc1.body.attachShadow({mode: 'open'});
     doc2.body.innerHTML = '<div id="parent"><div id="child"></div></div>';
     shadowRoot.appendChild(doc2.getElementById('child'));
     assert_equals(doc2.getElementById('parent').ownerDocument, doc2);

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-001.html
@@ -35,7 +35,7 @@ function createTestDocument() {
     pHost.className = 'test-class';
     pHost.id = 'test-id';
     doc.body.appendChild(pHost);
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var pShadow = doc.createElement('p');
     pShadow.className = 'test-class';
     pShadow.id = 'test-id';

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/selectors-api-002.html
@@ -36,7 +36,7 @@ function createTestDocument() {
     pHost.className = 'test-class';
     pHost.id = 'test-id';
     doc.body.appendChild(pHost);
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var pShadow = doc.createElement('p');
     pShadow.className = 'test-class';
     pShadow.id = 'test-id';

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/shadow-root-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/shadow-root-001.html
@@ -25,22 +25,22 @@ policies and contribution forms [3].
 <script>
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     assert_equals(shadowRoot.parentNode, null);
 }, 'The parentNode attribute of a shadow root must always return null.');
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     assert_equals(shadowRoot.parentElement, null);
 }, 'The parentElement attribute of a shadow root must always return null.');
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var outerShadowRoot = doc.body.createShadowRoot();
+    var outerShadowRoot = doc.body.attachShadow({mode: 'open'});
     var div = doc.createElement('div');
     outerShadowRoot.appendChild(div);
-    var innerShadowRoot = div.createShadowRoot();
+    var innerShadowRoot = div.attachShadow({mode: 'open'});
     assert_equals(innerShadowRoot.parentNode, null);
 },
     'The parentNode attribute of a shadow root must always return null, ' +
@@ -49,10 +49,10 @@ test(function () {
 
 test(function () {
     var doc = document.implementation.createHTMLDocument('Test');
-    var outerShadowRoot = doc.body.createShadowRoot();
+    var outerShadowRoot = doc.body.attachShadow({mode: 'open'});
     var div = doc.createElement('div');
     outerShadowRoot.appendChild(div);
-    var innerShadowRoot = div.createShadowRoot();
+    var innerShadowRoot = div.attachShadow({mode: 'open'});
     assert_equals(innerShadowRoot.parentElement, null);
 },
     'The parentElement attribute of a shadow root must always return null, ' +

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-005.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-005.html
@@ -26,7 +26,7 @@ test(function () {
     var d = newHTMLDocument();
     var div = d.createElement('div');
     d.body.appendChild(div);
-    var s = div.createShadowRoot();
+    var s = div.attachShadow({mode: 'open'});
 
     // node in shadow with id
     var input = d.createElement('input');
@@ -52,7 +52,7 @@ test(function () {
         var d = newHTMLDocument();
         var div = d.createElement('div');
         d.body.appendChild(div);
-        var s = div.createShadowRoot();
+        var s = div.attachShadow({mode: 'open'});
 
         var form = d.createElement('form');
         form.setAttribute('id', 'form_id');

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-007.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-007.html
@@ -26,7 +26,7 @@ test(function () {
     var d = newHTMLDocument();
     var div = d.createElement('div');
     d.body.appendChild(div);
-    var s = div.createShadowRoot();
+    var s = div.attachShadow({mode: 'open'});
 
     var input = d.createElement('input');
     input.setAttribute('type', 'text');
@@ -61,7 +61,7 @@ test(function () {
         div = d.createElement('div');
         d.body.appendChild(div);
 
-        var s = div.createShadowRoot();
+        var s = div.attachShadow({mode: 'open'});
         s.appendChild(form);
         s.appendChild(el);
 

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-011.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/test-011.html
@@ -35,7 +35,7 @@ test(unit(function (ctx) {
     //create Shadow root
     var root = d.createElement('div');
     d.body.appendChild(root);
-    var s = root.createShadowRoot();
+    var s = root.attachShadow({mode: 'open'});
 
     s.appendChild(link);
 

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-001.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-001.html
@@ -28,7 +28,7 @@ test(function () {
     try {
         host.style.display = 'none';
         document.body.appendChild(host);
-        var shadowRoot = host.createShadowRoot();
+        var shadowRoot = host.attachShadow({mode: 'open'});
         var iframe = document.createElement('iframe');
         iframe.style.display = 'none';
         iframe.name = 'test-name';

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-002.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-002.html
@@ -25,7 +25,7 @@ policies and contribution forms [3].
 <script>
 function testNameAttribute(elementName) {
     var doc = document.implementation.createHTMLDocument('Title');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var element = doc.createElement(elementName);
     element.name = 'test-name';
     shadowRoot.appendChild(element);

--- a/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-003.html
+++ b/shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-003.html
@@ -26,7 +26,7 @@ policies and contribution forms [3].
 <script>
 function testIDAttribute(elementName) {
     var doc = document.implementation.createHTMLDocument('Title');
-    var shadowRoot = doc.body.createShadowRoot();
+    var shadowRoot = doc.body.attachShadow({mode: 'open'});
     var element = doc.createElement(elementName);
     element.id = 'test-id';
     shadowRoot.appendChild(element);

--- a/shadow-dom/untriaged/styles/not-apply-in-shadow-root-001.html
+++ b/shadow-dom/untriaged/styles/not-apply-in-shadow-root-001.html
@@ -29,7 +29,7 @@ div {
 <div id="shadow-host"></div>
 <script>
 var shadowHost = document.getElementById('shadow-host');
-var shadowRoot = shadowHost.createShadowRoot();
+var shadowRoot = shadowHost.attachShadow({mode: 'open'});
 var style = document.createElement('style');
 style.innerHTML = 'div { background: red }';
 

--- a/shadow-dom/untriaged/styles/test-001.html
+++ b/shadow-dom/untriaged/styles/test-001.html
@@ -37,7 +37,7 @@ test(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div1 = d.createElement('div');
     div1.innerHTML ='<span id="shd" class="invis">This is the shadow tree</span>';
@@ -67,7 +67,7 @@ test(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div1 = d.createElement('div');
     div1.innerHTML ='<span id="shd" class="invis">This is the shadow tree</span>';

--- a/shadow-dom/untriaged/styles/test-003.html
+++ b/shadow-dom/untriaged/styles/test-003.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(s.styleSheets.length, 0, 'There should be no style sheets');
 }), 'A_06_00_03_T01');
@@ -41,7 +41,7 @@ test(unit(function (ctx) {
     d.body.appendChild(host);
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(s.styleSheets.length, 0, 'There should be no style sheets');
 }), 'A_06_00_03_T02');
@@ -54,7 +54,7 @@ test(unit(function (ctx) {
     var host = d.createElement('div');
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var style = d.createElement('style');
     style.textContent = 'div {width: 50%;}';

--- a/shadow-dom/untriaged/styles/test-005.html
+++ b/shadow-dom/untriaged/styles/test-005.html
@@ -36,7 +36,7 @@ test(unit(function (ctx) {
     var host = d.querySelector('#sr');
 
     //Shadow root to play with
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var style = d.createElement('style');
     style.innerHTML ='.invis {display:none}';

--- a/shadow-dom/untriaged/styles/test-008.html
+++ b/shadow-dom/untriaged/styles/test-008.html
@@ -32,7 +32,7 @@ test(unit(function (ctx) {
 
     var host = d.querySelector('#shHost');
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div = d.createElement('div');
     div.innerHTML ='<span id="spn2">This is a shadow root child</span>';

--- a/shadow-dom/untriaged/user-interaction/active-element/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/active-element/test-001.html
@@ -27,7 +27,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp = d.createElement('input');
     inp.setAttribute('type', 'text');

--- a/shadow-dom/untriaged/user-interaction/active-element/test-002.html
+++ b/shadow-dom/untriaged/user-interaction/active-element/test-002.html
@@ -28,7 +28,7 @@ test(unit(function (ctx) {
     var host = d.createElement('div');
     host.setAttribute('id', 'shRoot');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp = d.createElement('input');
     inp.setAttribute('type', 'text');

--- a/shadow-dom/untriaged/user-interaction/editing/inheritance-of-content-editable-001.html
+++ b/shadow-dom/untriaged/user-interaction/editing/inheritance-of-content-editable-001.html
@@ -29,7 +29,7 @@ test(unit(function (ctx) {
     host.contentEditable = "true";
     d.body.appendChild(host);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(host.contentEditable, "true");
     assert_equals(s.contentEditable, undefined);
@@ -42,7 +42,7 @@ test(unit(function (ctx) {
     host.contentEditable = "false";
     d.body.appendChild(host);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(host.contentEditable, 'false');
     assert_equals(s.contentEditable, undefined);
@@ -55,7 +55,7 @@ test(unit(function (ctx) {
     d.body.appendChild(host);
     d.body.contentEditable = "true";
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     assert_equals(host.contentEditable, 'inherit');
     assert_equals(s.contentEditable, undefined);

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-001.html
@@ -40,7 +40,7 @@ A_07_02_01_T01.step(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('type', 'text');

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-002.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-002.html
@@ -47,7 +47,7 @@ A_07_02_02_T01.step(unit(function (ctx) {
     var chb2 = d.createElement('input');
     chb2.setAttribute('type', 'checkbox');
     chb2.setAttribute('id', 'chb2');
-    chb2.setAttribute('class', 'shadow');
+    chb2.setAttribute('slot', 'shadow');
     chb2.addEventListener('focus', A_07_02_02_T01.step_func(function(event) {
         assert_equals(counter++, 0, 'Point 1: wrong focus navigation order');
         expectations[1] = true;
@@ -58,7 +58,7 @@ A_07_02_02_T01.step(unit(function (ctx) {
     var chb3 = d.createElement('input');
     chb3.setAttribute('type', 'checkbox');
     chb3.setAttribute('id', 'chb3');
-    chb3.setAttribute('class', 'shadow');
+    chb3.setAttribute('slot', 'shadow');
     chb3.addEventListener('focus', A_07_02_02_T01.step_func(function(event) {
         assert_equals(counter++, 1, 'Point 2: wrong focus navigation order');
         expectations[2] = true;
@@ -66,10 +66,10 @@ A_07_02_02_T01.step(unit(function (ctx) {
     expectations[2] = false;
     host.appendChild(chb3);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div = d.createElement('div');
-    div.innerHTML = '<content select=".shadow"></content>';
+    div.innerHTML = '<slot name="shadow"></slot>';
     s.appendChild(div);
 
     var inp1 = d.createElement('input');
@@ -154,7 +154,7 @@ A_07_02_02_T02.step(unit(function (ctx) {
     var chb2 = d.createElement('input');
     chb2.setAttribute('type', 'checkbox');
     chb2.setAttribute('id', 'chb2');
-    chb2.setAttribute('class', 'shadow');
+    chb2.setAttribute('slot', 'shadow');
     chb2.addEventListener('focus', A_07_02_02_T02.step_func(function(event) {
         assert_equals(counter++, 2, 'Point 3: wrong focus navigation order');
         expectations[1] = true;
@@ -165,7 +165,7 @@ A_07_02_02_T02.step(unit(function (ctx) {
     var chb3 = d.createElement('input');
     chb3.setAttribute('type', 'checkbox');
     chb3.setAttribute('id', 'chb3');
-    chb3.setAttribute('class', 'shadow');
+    chb3.setAttribute('slot', 'shadow');
     chb3.addEventListener('focus', A_07_02_02_T02.step_func(function(event) {
         assert_equals(counter++, 3, 'Point 4: wrong focus navigation order');
         expectations[2] = true;
@@ -173,10 +173,10 @@ A_07_02_02_T02.step(unit(function (ctx) {
     expectations[2] = false;
     host.appendChild(chb3);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div = d.createElement('div');
-    div.innerHTML = '<content select=".shadow"></content>';
+    div.innerHTML = '<slot name="shadow"></slot>';
     s.appendChild(div);
 
     var inp1 = d.createElement('input');

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-003.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-003.html
@@ -47,7 +47,7 @@ A_07_02_03_T01.step(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('type', 'text');
@@ -149,7 +149,7 @@ A_07_02_03_T02.step(unit(function (ctx) {
     var chb2 = d.createElement('input');
     chb2.setAttribute('type', 'checkbox');
     chb2.setAttribute('id', 'chb2');
-    chb2.setAttribute('class', 'shadow');
+    chb2.setAttribute('slot', 'shadow');
     chb2.setAttribute('tabindex', '3');
     chb2.addEventListener('focus', A_07_02_03_T02.step_func(function(event) {
         assert_equals(counter++, 2, 'Point 2: wrong focus navigation order');
@@ -161,7 +161,7 @@ A_07_02_03_T02.step(unit(function (ctx) {
     var chb3 = d.createElement('input');
     chb3.setAttribute('type', 'checkbox');
     chb3.setAttribute('id', 'chb3');
-    chb3.setAttribute('class', 'shadow');
+    chb3.setAttribute('slot', 'shadow');
     chb3.setAttribute('tabindex', '2');
     chb3.addEventListener('focus', A_07_02_03_T02.step_func(function(event) {
         assert_equals(counter++, 1, 'Point 3: wrong focus navigation order');
@@ -170,10 +170,10 @@ A_07_02_03_T02.step(unit(function (ctx) {
     invoked[3] = false;
     host.appendChild(chb3);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div = d.createElement('div');
-    div.innerHTML = '<content select=".shadow"></content>';
+    div.innerHTML = '<slot name="shadow"></slot>';
     s.appendChild(div);
 
     var inp1 = d.createElement('input');

--- a/shadow-dom/untriaged/user-interaction/focus-navigation/test-004.html
+++ b/shadow-dom/untriaged/user-interaction/focus-navigation/test-004.html
@@ -49,7 +49,7 @@ A_07_02_04_T01.step(unit(function (ctx) {
     //make shadow host focusable
     host.setAttribute('tabindex', '3');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('type', 'text');
@@ -154,7 +154,7 @@ A_07_02_04_T02.step(unit(function (ctx) {
     var chb2 = d.createElement('input');
     chb2.setAttribute('type', 'checkbox');
     chb2.setAttribute('id', 'chb2');
-    chb2.setAttribute('class', 'shadow');
+    chb2.setAttribute('slot', 'shadow');
     chb2.setAttribute('tabindex', '3');
     chb2.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
         assert_equals(counter++, 4, 'Point 2: wrong focus navigation order');
@@ -166,7 +166,7 @@ A_07_02_04_T02.step(unit(function (ctx) {
     var chb3 = d.createElement('input');
     chb3.setAttribute('type', 'checkbox');
     chb3.setAttribute('id', 'chb3');
-    chb3.setAttribute('class', 'shadow');
+    chb3.setAttribute('slot', 'shadow');
     chb3.setAttribute('tabindex', '2');
     chb3.addEventListener('focus', A_07_02_04_T02.step_func(function(event) {
         assert_equals(counter++, 1, 'Point 3: wrong focus navigation order');
@@ -175,10 +175,10 @@ A_07_02_04_T02.step(unit(function (ctx) {
     invoked[3] = false;
     host.appendChild(chb3);
 
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var div = d.createElement('div');
-    div.innerHTML = '<content select=".shadow"></content>';
+    div.innerHTML = '<slot name="shadow"></slot>';
     s.appendChild(div);
 
     var inp1 = d.createElement('input');
@@ -265,7 +265,7 @@ A_07_02_04_T03.step(unit(function (ctx) {
     var host = d.createElement('div');
     host.setAttribute('tabindex', '1');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('type', 'text');
@@ -357,7 +357,7 @@ A_07_02_04_T04.step(unit(function (ctx) {
     var host = d.createElement('div');
     host.setAttribute('tabindex', '3');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var inp1 = d.createElement('input');
     inp1.setAttribute('type', 'text');

--- a/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html
+++ b/shadow-dom/untriaged/user-interaction/ranges-and-selections/test-001.html
@@ -27,7 +27,7 @@ test(unit(function (ctx) {
 
     var host = d.createElement('div');
     d.body.appendChild(host);
-    var s = host.createShadowRoot();
+    var s = host.attachShadow({mode: 'open'});
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';
@@ -57,10 +57,11 @@ test(unit(function (ctx) {
 
     var span = d.createElement('span');
     span.innerHTML = 'Some text';
+    span.setAttribute('slot', 'span');
     host.appendChild(span);
 
-    var s = host.createShadowRoot();
-    s.innerHTML = '<content select="span"></content>';
+    var s = host.attachShadow({mode: 'open'});
+    s.innerHTML = '<slot name="span"></slot>';
 
     var range = d.createRange();
     range.setStart(span.firstChild, 0);


### PR DESCRIPTION
This is almost mechanical change from createShadowRoot() to attachShadow({mode: 'open'}).

For some tests that uses `<content>` element, I also replaced it with `<slot>`.
