### PR TITLE
More createDocument tests

### DIFF
--- a/dom/nodes/DOMImplementation-createDocument.html
+++ b/dom/nodes/DOMImplementation-createDocument.html
@@ -11,6 +11,10 @@
 <script src="Document-createElementNS.js"></script>
 <div id="log"></div>
 <script>
+var htmlNamespace = "http://www.w3.org/1999/xhtml"
+var svgNamespace = "http://www.w3.org/2000/svg"
+var mathMLNamespace = "http://www.w3.org/1998/Math/MathML"
+
 test(function() {
   var tests = createElementNS_tests.map(function(t) {
     return [t[0], t[1], null, t[2]]
@@ -57,6 +61,21 @@ test(function() {
     [null, "foo", document.implementation.createDocumentType("foo", "", ""), null],
     ["foo", null, document.implementation.createDocumentType("foo", "", ""), null],
     ["foo", "bar", document.implementation.createDocumentType("foo", "", ""), null],
+    [htmlNamespace, "", null, null],
+    [svgNamespace, "", null, null],
+    [mathMLNamespace, "", null, null],
+    [null, "html", null, null],
+    [null, "svg", null, null],
+    [null, "math", null, null],
+    [null, "", document.implementation.createDocumentType("html",
+        "-//W3C//DTD XHTML 1.0 Transitional//EN",
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd")],
+    [null, "", document.implementation.createDocumentType("svg",
+        "-//W3C//DTD SVG 1.1//EN",
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd")],
+    [null, "", document.implementation.createDocumentType("math",
+        "-//W3C//DTD MathML 2.0//EN",
+        "http://www.w3.org/Math/DTD/mathml2/mathml2.dtd")],
   ])
 
   tests.forEach(function(t, i) {
@@ -70,6 +89,7 @@ test(function() {
         assert_equals(doc.nodeType, doc.DOCUMENT_NODE)
         assert_equals(doc.nodeName, "#document")
         assert_equals(doc.nodeValue, null)
+        assert_equals(Object.getPrototypeOf(doc), XMLDocument.prototype)
         var omitRootElement = qualifiedName === null || String(qualifiedName) === ""
         if (omitRootElement) {
           assert_equals(doc.documentElement, null)

--- a/dom/nodes/DOMImplementation-createDocument.html
+++ b/dom/nodes/DOMImplementation-createDocument.html
@@ -123,7 +123,9 @@ test(function() {
         var doc = document.implementation.createDocument(namespace, qualifiedName, doctype)
         assert_equals(doc.compatMode, "CSS1Compat")
         assert_equals(doc.characterSet, "UTF-8")
-        assert_equals(doc.contentType, "application/xml")
+        assert_equals(doc.contentType, namespace == htmlNamespace ? "text/html"
+                                 : namespace == svgNamespace ?  "image/svg+xml"
+                                 : "application/xml")
         assert_equals(doc.URL, "about:blank")
         assert_equals(doc.documentURI, "about:blank")
         assert_equals(doc.createElement("DIV").localName, "DIV");


### PR DESCRIPTION
This catches a Gecko bug where it looks at the document type in some
cases to determine the type of document produced
(https://bugzilla.mozilla.org/show_bug.cgi?id=520969).
