### PR TITLE
Test that :in-range / :out-of-range only match when the input has a range limitation

### DIFF
--- a/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
+++ b/html/semantics/selectors/pseudo-classes/inrange-outofrange.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>Selector: pseudo-classes (:in-range, :out-of-range)</title>
-<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id=link1>
-<link rel=help href="https://html.spec.whatwg.org/multipage/#pseudo-classes" id=link2>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org" id="link1">
+<link rel="author" title="Chris Rebert" href="http://chrisrebert.com" id="link2">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-in-range" id="link3">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#selector-out-of-range" id="link4">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="utils.js"></script>
@@ -33,6 +35,17 @@
 <input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2008-03-01T23:59:59" id="datetimelocalunder">
 <input type="datetime-local" min="2008-03-12T23:59:59" max="2015-02-13T23:59:59" value="2016-01-01T23:59:59" id="datetimelocalover">
 
+<!-- None of the following have range limitations since they have neither min nor max attributes -->
+<input type="number" value="0" id="numbernolimit">
+<input type="date" value="2010-10-10" id="datenolimit">
+<input type="time" value="02:00:00" id="timenolimit">
+<input type="week" value="2016-W07" id="weeknolimit">
+<input type="month" value="2000-06" id="monthnolimit">
+<input type="datetime-local" value="2012-11-28T23:59:59" id="datetimelocalnolimit">
+
+<!-- range inputs have default minimum of 0 and default maximum of 100 -->
+<input type="range" value="50" id="range0">
+
 <!-- range input's value gets immediately clamped to the nearest boundary point -->
 <input type="range" min="2" max="7" value="5" id="range1">
 <input type="range" min="2" max="7" value="1" id="range2">
@@ -57,15 +70,15 @@
 <input min="1" value="0" type="reset">
 
 <script>
-  testSelector(":in-range", ["number1", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow");
+  testSelector(":in-range", ["number1", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' matches all elements that are candidates for constraint validation, have range limitations, and that are neither suffering from an underflow nor suffering from an overflow");
 
   testSelector(":out-of-range", ["number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' matches all elements that are candidates for constraint validation, have range limitations, and that are either suffering from an underflow or suffering from an overflow");
 
   document.getElementById("number1").value = -10;
-  testSelector(":in-range", ["datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' update number1's value < min");
+  testSelector(":in-range", ["datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' update number1's value < min");
   testSelector(":out-of-range", ["number1", "number3", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number1's value < min");
 
   document.getElementById("number3").min = 0;
-  testSelector(":in-range", ["number3", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range1", "range2", "range3"], "':in-range' update number3's min < value");
+  testSelector(":in-range", ["number3", "datein", "timein", "weekin", "monthin", "datetimelocalin", "range0", "range1", "range2", "range3"], "':in-range' update number3's min < value");
   testSelector(":out-of-range", ["number1", "number4", "dateunder", "dateover", "timeunder", "timeover", "weekunder", "weekover", "monthunder", "monthover", "datetimelocalunder", "datetimelocalover"], "':out-of-range' update number3's min < value");
 </script>


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/scripting.html#selector-in-range

> The `:in-range` pseudo-class must match all elements that are [...], **have range limitations**, and [...]

(Ditto for `:out-of-range`.)

Per https://html.spec.whatwg.org/multipage/forms.html#have-range-limitations

> An element **has range limitations** if it has a defined **minimum** or a defined **maximum**.

Per https://html.spec.whatwg.org/multipage/forms.html#concept-input-min

> If the element has a `min` attribute, and [...], then that number is the element's **minimum**; otherwise, if the `type` attribute's current state defines a **default minimum**, then that is the **minimum**; otherwise, the element has _no_ **minimum**.

(Likewise for `max` and **maximum**.)

And finally:
Per https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range):concept-input-min-default
and https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range):concept-input-max-default

> 4.10.5.1.13 Range state (`type=range`)
> [...]
> The **default minimum** is 0. [...] The **default maximum** is 100.
