### PR TITLE
Test that :read-write doesn't match input types to which [readonly] doesn't apply

### DIFF
--- a/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
+++ b/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
@@ -7,6 +7,20 @@
 <script src="utils.js"></script>
 <div id="log"></div>
 
+<div id=set0>
+<!-- The readonly attribute does not apply to the following input types -->
+<input id=checkbox1 type=checkbox>
+<input id=hidden1 type=hidden value=abc>
+<input id=range1 type=range>
+<input id=color1 type=color>
+<input id=radio1 type=radio>
+<input id=file1 type=file>
+<input id=submit1 type=submit>
+<input id=image1 type=image>
+<input id=button1 type=button value="Button">
+<input id=reset1 type=reset>
+</div>
+
 <div id=set1>
 <input id=input1>
 <input id=input2 readonly>
@@ -31,6 +45,8 @@
 </div>
 
 <script>
+  testSelector("#set0 :read-write", [], "The :read-write pseudo-class must not match input elements to which the readonly attribute does not apply");
+
   testSelector("#set1 :read-write", ["input1"], "The :read-write pseudo-class must match input elements to which the readonly attribute applies, and that are mutable");
 
   testSelector("#set1 :read-only", ["input2"], "The :read-only pseudo-class must not match input elements to which the readonly attribute applies, and that are mutable");


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/scripting.html#selector-read-write

> The `:read-write` pseudo-class must match any element falling into one of the following categories, which for the purposes of Selectors are thus considered user-alterable:
> - `<input>` elements [to which the `readonly` attribute applies](https://html.spec.whatwg.org/multipage/forms.html#the-input-element:attr-input-readonly-3), and that are mutable (i.e. that do not have the `readonly` attribute specified and that are not disabled)
> - [...]
