### PR TITLE
Test that :read-only matches <input>s to which [readonly] doesn't apply

### DIFF
--- a/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
+++ b/html/semantics/selectors/pseudo-classes/readwrite-readonly.html
@@ -47,6 +47,8 @@
 <script>
   testSelector("#set0 :read-write", [], "The :read-write pseudo-class must not match input elements to which the readonly attribute does not apply");
 
+  testSelector("#set0 :read-only", ["checkbox1", "hidden1", "range1", "color1", "radio1", "file1", "submit1", "image1", "button1", "reset1"], "The :read-only pseudo-class must match input elements to which the readonly attribute does not apply");
+
   testSelector("#set1 :read-write", ["input1"], "The :read-write pseudo-class must match input elements to which the readonly attribute applies, and that are mutable");
 
   testSelector("#set1 :read-only", ["input2"], "The :read-only pseudo-class must not match input elements to which the readonly attribute applies, and that are mutable");


### PR DESCRIPTION
This tests the other side of #2839.
As a reminder, per https://html.spec.whatwg.org/multipage/scripting.html#selector-read-only

> The `:read-write` pseudo-class must match any element falling into one of the following categories [...]
> The `:read-only` pseudo-class must match all other HTML elements.

Refs https://bugs.chromium.org/p/chromium/issues/detail?id=604154
Refs https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7229941/
