### PR TITLE
Update keyframe-effect/constructor.html to no longer refer to PropertyIndexedKeyframes or Keyframe;

### DIFF
--- a/web-animations/keyframe-effect/constructor.html
+++ b/web-animations/keyframe-effect/constructor.html
@@ -79,7 +79,7 @@ test(function(t) {
                   "resulting easing for '" + easing + "'");
   });
 }, "easing values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in PropertyIndexedKeyframes");
+   "KeyframeEffectReadOnly constructor in a property-indexed keyframe");
 
 test(function(t) {
   gEasingValueTests.forEach(function(subtest) {
@@ -93,7 +93,7 @@ test(function(t) {
                   "resulting easing for '" + easing + "'");
   });
 }, "easing values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in Keyframe");
+   "KeyframeEffectReadOnly constructor in regular keyframes");
 
 test(function(t) {
   gEasingValueTests.forEach(function(subtest) {
@@ -135,7 +135,7 @@ test(function(t) {
                   });
   });
 }, "composite values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in PropertyIndexedKeyframes");
+   "KeyframeEffectReadOnly constructor in property-indexed keyframes");
 
 test(function(t) {
   var getFrames = function(composite) {
@@ -155,7 +155,7 @@ test(function(t) {
                   });
   });
 }, "composite values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in Keyframe");
+   "KeyframeEffectReadOnly constructor in regular keyframes");
 
 test(function(t) {
   gGoodOptionsCompositeValueTests.forEach(function(composite) {
@@ -176,12 +176,12 @@ test(function(t) {
    "KeyframeEffectReadOnly constructor in KeyframeTimingOptions");
 
 var gPropertyIndexedKeyframesTests = [
-  { desc:   "a one property two value PropertyIndexedKeyframes specification",
+  { desc:   "a one property two value property-indexed keyframes specification",
     input:  { left: ["10px", "20px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear", left: "10px" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "20px" }]
   },
-  { desc:   "a one shorthand property two value PropertyIndexedKeyframes"
+  { desc:   "a one shorthand property two value property-indexed keyframes"
             + " specification",
     input:  { margin: ["10px", "10px 20px 30px 40px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -191,7 +191,7 @@ var gPropertyIndexedKeyframesTests = [
                marginTop: "10px", marginRight: "20px",
                marginBottom: "30px", marginLeft: "40px" }] },
   { desc:   "a two property (one shorthand and one of its longhand components)"
-            + " two value PropertyIndexedKeyframes specification",
+            + " two value property-indexed keyframes specification",
     input:  { marginTop: ["50px", "60px"],
               margin: ["10px", "10px 20px 30px 40px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -200,14 +200,14 @@ var gPropertyIndexedKeyframesTests = [
              { offset: 1, computedOffset: 1, easing: "linear",
                marginTop: "60px", marginRight: "20px",
                marginBottom: "30px", marginLeft: "40px" }] },
-  { desc:   "a two property two value PropertyIndexedKeyframes specification",
+  { desc:   "a two property two value property-indexed keyframes specification",
     input:  { left: ["10px", "20px"],
               top: ["30px", "40px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
                left: "10px", top: "30px" },
              { offset: 1, computedOffset: 1, easing: "linear",
                left: "20px", top: "40px" }] },
-  { desc:   "a two property PropertyIndexedKeyframes specification with"
+  { desc:   "a two property property-indexed keyframes specification with"
             + " different numbers of values",
     input:  { left: ["10px", "20px", "30px"],
               top: ["40px", "50px"] },
@@ -217,7 +217,7 @@ var gPropertyIndexedKeyframesTests = [
                left: "20px" },
              { offset: 1.0, computedOffset: 1.0, easing: "linear",
                left: "30px", top: "50px" }] },
-  { desc:   "a PropertyIndexedKeyframes specification with an invalid value",
+  { desc:   "a property-indexed keyframes specification with an invalid value",
     input:  { left: ["10px", "20px", "30px", "40px", "50px"],
               top:  ["15px", "25px", "invalid", "45px", "55px"] },
     output: [{ offset: 0.00, computedOffset: 0.00, easing: "linear",
@@ -230,47 +230,47 @@ var gPropertyIndexedKeyframesTests = [
                left: "40px", top: "45px" },
              { offset: 1.00, computedOffset: 1.00, easing: "linear",
                left: "50px", top: "55px" }] },
-  { desc:   "a one property two value PropertyIndexedKeyframes specification"
+  { desc:   "a one property two value property-indexed keyframes specification"
             + " that needs to stringify its values",
     input:  { opacity: [0, 1] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear", opacity: "0" },
              { offset: 1, computedOffset: 1, easing: "linear", opacity: "1" }]
   },
-  { desc:   "a one property one value PropertyIndexedKeyframes specification",
+  { desc:   "a one property one value property-indexed keyframes specification",
     input:  { left: ["10px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "10px" }]
   },
-  { desc:   "a one property one non-array value PropertyIndexedKeyframes"
+  { desc:   "a one property one non-array value property-indexed keyframes"
             + " specification",
     input:  { left: "10px" },
     output: [{ offset: 0, computedOffset: 0, easing: "linear" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "10px" }] },
-  { desc:   "a one property two value PropertyIndexedKeyframes specification"
+  { desc:   "a one property two value property-indexed keyframes specification"
             + " where the first value is invalid",
     input:  { left: ["invalid", "10px"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "10px" }] },
-  { desc:   "a one property two value PropertyIndexedKeyframes specification"
+  { desc:   "a one property two value property-indexed keyframes specification"
             + " where the second value is invalid",
     input:  { left: ["10px", "invalid"] },
     output: [{ offset: 0, computedOffset: 0, easing: "linear", left: "10px" },
              { offset: 1, computedOffset: 1, easing: "linear" }] },
-  { desc:   "a two property PropertyIndexedKeyframes specification where one"
-            + " property is missing from the first Keyframe",
+  { desc:   "a two property property-indexed keyframes specification where one"
+            + " property is missing from the first keyframe",
     input:  [{ offset: 0, left: "10px" },
              { offset: 1, left: "20px", top: "30px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear", left: "10px" },
              { offset: 1, computedOffset: 1, easing: "linear",
                left: "20px", top: "30px" }] },
-  { desc:   "a two property PropertyIndexedKeyframes specification where one"
-            + " property is missing from the last Keyframe",
+  { desc:   "a two property property-indexed keyframes specification where one"
+            + " property is missing from the last keyframe",
     input:  [{ offset: 0, left: "10px", top: "20px" },
              { offset: 1, left: "30px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
                left: "10px" , top: "20px" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "30px" }] },
-  { desc:   "a PropertyIndexedKeyframes specification with repeated values"
+  { desc:   "a property-indexed keyframes specification with repeated values"
             + " at offset 0 with different easings",
     input:  [{ offset: 0.0, left: "100px", easing: "ease" },
              { offset: 0.0, left: "200px", easing: "ease" },
@@ -320,24 +320,24 @@ test(function(t) {
   });
   new KeyframeEffectReadOnly(target, [kf1, kf2]);
   assert_array_equals(actualOrder, expectedOrder, "property access order");
-}, "the KeyframeEffectReadOnly constructor reads Keyframe properties in the " +
+}, "the KeyframeEffectReadOnly constructor reads keyframe properties in the " +
    "expected order");
 
 var gKeyframeSequenceTests = [
-  { desc:   "a one property two Keyframe sequence",
+  { desc:   "a one property two keyframe sequence",
     input:  [{ offset: 0, left: "10px" },
              { offset: 1, left: "20px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear", left: "10px" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "20px" }]
   },
-  { desc:   "a two property two Keyframe sequence",
+  { desc:   "a two property two keyframe sequence",
     input:  [{ offset: 0, left: "10px", top: "30px" },
              { offset: 1, left: "20px", top: "40px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
                left: "10px", top: "30px" },
              { offset: 1, computedOffset: 1, easing: "linear",
                left: "20px", top: "40px" }] },
-  { desc:   "a one shorthand property two Keyframe sequence",
+  { desc:   "a one shorthand property two keyframe sequence",
     input:  [{ offset: 0, margin: "10px" },
              { offset: 1, margin: "20px 30px 40px 50px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -347,7 +347,7 @@ var gKeyframeSequenceTests = [
                marginTop: "20px", marginRight: "30px",
                marginBottom: "40px", marginLeft: "50px" }] },
   { desc:   "a two property (a shorthand and one of its component longhands)"
-            + " two Keyframe sequence",
+            + " two keyframe sequence",
     input:  [{ offset: 0, margin: "10px", marginTop: "20px" },
              { offset: 1, marginTop: "70px", margin: "30px 40px 50px 60px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -356,7 +356,7 @@ var gKeyframeSequenceTests = [
              { offset: 1, computedOffset: 1, easing: "linear",
                marginTop: "70px", marginRight: "40px",
                marginBottom: "50px", marginLeft: "60px" }] },
-  { desc:   "a Keyframe sequence with duplicate values for a given interior"
+  { desc:   "a keyframe sequence with duplicate values for a given interior"
             + " offset",
     input:  [{ offset: 0.0, left: "10px" },
              { offset: 0.5, left: "20px" },
@@ -371,7 +371,7 @@ var gKeyframeSequenceTests = [
                left: "40px" },
              { offset: 1.0, computedOffset: 1.0, easing: "linear",
                left: "50px" }] },
-  { desc:   "a Keyframe sequence with duplicate values for offsets 0 and 1",
+  { desc:   "a keyframe sequence with duplicate values for offsets 0 and 1",
     input:  [{ offset: 0, left: "10px" },
              { offset: 0, left: "20px" },
              { offset: 0, left: "30px" },
@@ -383,7 +383,7 @@ var gKeyframeSequenceTests = [
              { offset: 1, computedOffset: 1, easing: "linear", left: "40px" },
              { offset: 1, computedOffset: 1, easing: "linear", left: "60px" }]
   },
-  { desc:   "a two property four Keyframe sequence",
+  { desc:   "a two property four keyframe sequence",
     input:  [{ offset: 0, left: "10px" },
              { offset: 0, top: "20px" },
              { offset: 1, top: "30px" },
@@ -392,7 +392,7 @@ var gKeyframeSequenceTests = [
                left: "10px", top: "20px" },
              { offset: 1, computedOffset: 1, easing: "linear",
                left: "40px", top: "30px" }] },
-  { desc:   "a one property Keyframe sequence with some omitted offsets",
+  { desc:   "a one property keyframe sequence with some omitted offsets",
     input:  [{ offset: 0.00, left: "10px" },
              { offset: 0.25, left: "20px" },
              { left: "30px" },
@@ -408,7 +408,7 @@ var gKeyframeSequenceTests = [
                left: "40px" },
              { offset: 1.00, computedOffset: 1.00, easing: "linear",
                left: "50px" }] },
-  { desc:   "a two property Keyframe sequence with some omitted offsets",
+  { desc:   "a two property keyframe sequence with some omitted offsets",
     input:  [{ offset: 0.00, left: "10px", top: "20px" },
              { offset: 0.25, left: "30px" },
              { left: "40px" },
@@ -424,7 +424,7 @@ var gKeyframeSequenceTests = [
                left: "50px", top: "60px" },
              { offset: 1.00, computedOffset: 1.00, easing: "linear",
                left: "70px", top: "80px" }] },
-  { desc:   "a one property Keyframe sequence with all omitted offsets",
+  { desc:   "a one property keyframe sequence with all omitted offsets",
     input:  [{ left: "10px" },
              { left: "20px" },
              { left: "30px" },
@@ -440,7 +440,7 @@ var gKeyframeSequenceTests = [
                left: "40px" },
              { offset: 1.00, computedOffset: 1.00, easing: "linear",
                left: "50px" }] },
-  { desc:   "a Keyframe sequence with different easing values, but the same"
+  { desc:   "a keyframe sequence with different easing values, but the same"
             + " easing value for a given offset",
     input:  [{ offset: 0.0, easing: "ease",     left: "10px"},
              { offset: 0.0, easing: "ease",     top: "20px"},
@@ -454,7 +454,7 @@ var gKeyframeSequenceTests = [
                left: "30px", top: "40px" },
              { offset: 1.0, computedOffset: 1.0, easing: "linear",
                left: "50px", top: "60px" }] },
-  { desc:   "a Keyframe sequence with different composite values, but the"
+  { desc:   "a keyframe sequence with different composite values, but the"
             + " same composite value for a given offset",
     input:  [{ offset: 0.0, composite: "replace", left: "10px" },
              { offset: 0.0, composite: "replace", top: "20px" },
@@ -468,14 +468,14 @@ var gKeyframeSequenceTests = [
                composite: "add",     left: "30px", top: "40px" },
              { offset: 1.0, computedOffset: 1.0, easing: "linear",
                composite: "replace", left: "50px", top: "60px" }] },
-  { desc:   "a one property two Keyframe sequence that needs to stringify"
+  { desc:   "a one property two keyframe sequence that needs to stringify"
             + " its values",
     input:  [{ offset: 0, opacity: 0 },
              { offset: 1, opacity: 1 }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear", opacity: "0" },
              { offset: 1, computedOffset: 1, easing: "linear", opacity: "1" }]
   },
-  { desc:   "a Keyframe sequence where shorthand precedes longhand",
+  { desc:   "a keyframe sequence where shorthand precedes longhand",
     input:  [{ offset: 0, margin: "10px", marginRight: "20px" },
              { offset: 1, margin: "30px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -484,7 +484,7 @@ var gKeyframeSequenceTests = [
              { offset: 1, computedOffset: 1, easing: "linear",
                marginBottom: "30px", marginLeft: "30px",
                marginRight: "30px", marginTop: "30px" }] },
-  { desc:   "a Keyframe sequence where longhand precedes shorthand",
+  { desc:   "a keyframe sequence where longhand precedes shorthand",
     input:  [{ offset: 0, marginRight: "20px", margin: "10px" },
              { offset: 1, margin: "30px" }],
     output: [{ offset: 0, computedOffset: 0, easing: "linear",
@@ -493,7 +493,7 @@ var gKeyframeSequenceTests = [
              { offset: 1, computedOffset: 1, easing: "linear",
                marginBottom: "30px", marginLeft: "30px",
                marginRight: "30px", marginTop: "30px" }] },
-  { desc:   "a Keyframe sequence where lesser shorthand precedes greater"
+  { desc:   "a keyframe sequence where lesser shorthand precedes greater"
             + " shorthand",
     input:  [{ offset: 0,
                borderLeft: "1px solid rgb(1, 2, 3)",
@@ -509,7 +509,7 @@ var gKeyframeSequenceTests = [
                borderLeftColor:   "rgb(7, 8, 9)", borderLeftWidth:   "3px",
                borderRightColor:  "rgb(7, 8, 9)", borderRightWidth:  "3px",
                borderTopColor:    "rgb(7, 8, 9)", borderTopWidth:    "3px" }] },
-  { desc:   "a Keyframe sequence where greater shorthand precedes lesser"
+  { desc:   "a keyframe sequence where greater shorthand precedes lesser"
             + " shorthand",
     input:  [{ offset: 0, border: "2px dotted rgb(4, 5, 6)",
                borderLeft: "1px solid rgb(1, 2, 3)" },
@@ -560,7 +560,7 @@ gInvalidEasingInKeyframeSequenceTests.forEach(function(subtest) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target, subtest.input);
     });
-  }, "Invalid easing [" + subtest.desc + "] in KeyframeSequence " +
+  }, "Invalid easing [" + subtest.desc + "] in keyframe sequence " +
      "should be thrown");
 });
 


### PR DESCRIPTION
These types have been removed from the normative part of the Web Animations
spec.

MozReview-Commit-ID: LJkWvuDCT55

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1260655
