### PR TITLE
Add some web platform tests that ensure that error events are fired on the window an event listener comes from, even if it's attached to an event target in a different window, and no matter how it got there.

### DIFF
--- a/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-1.html
+++ b/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-1.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>
+  When a listener from window A is added to an event target in window B via the
+  addEventListener function from window B, errors in that listener should be
+  reported to window A.
+</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+test(function() {
+  var f = new frames[0].Function("thereIsNoSuchCallable()");
+  frames[1].document.addEventListener("myevent", f);
+  var frame0ErrorFired = false;
+  var frame1ErrorFired = false;
+  var ourErrorFired = false;
+  frames[0].addEventListener("error", function() {
+    frame0ErrorFired = true;
+  });
+  frames[1].addEventListener("error", function() {
+    frame1ErrorFired = true;
+  });
+  addEventListener("error", function() {
+    ourErrorFired = true;
+  });
+  frames[1].document.dispatchEvent(new Event("myevent"));
+  assert_true(frame0ErrorFired);
+  assert_false(frame1ErrorFired);
+  assert_false(ourErrorFired);
+}, "The error event from an event listener should fire on that listener's global");
+</script>

--- a/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-2.html
+++ b/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-2.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>
+  When a listener from window A is added to an event target in window B via the
+  addEventListener function from window A, errors in that listener should be
+  reported to window A.
+</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+test(function() {
+  var f = new frames[0].Function("thereIsNoSuchCallable()");
+  frames[0].document.addEventListener.call(frames[1].document, "myevent", f);
+  var frame0ErrorFired = false;
+  var frame1ErrorFired = false;
+  var ourErrorFired = false;
+  frames[0].addEventListener("error", function() {
+    frame0ErrorFired = true;
+  });
+  frames[1].addEventListener("error", function() {
+    frame1ErrorFired = true;
+  });
+  addEventListener("error", function() {
+    ourErrorFired = true;
+  });
+  frames[1].document.dispatchEvent(new Event("myevent"));
+  assert_true(frame0ErrorFired);
+  assert_false(frame1ErrorFired);
+  assert_false(ourErrorFired);
+}, "The error event from an event listener should fire on that listener's global");
+</script>

--- a/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-3.html
+++ b/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-3.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>
+  When a listener from window A is added to an event target in window A via the
+  addEventListener function from window A, errors in that listener should be
+  reported to window A.
+</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+test(function() {
+  var f = new frames[1].Function("thereIsNoSuchCallable()");
+  frames[1].document.addEventListener("myevent", f);
+  var frame0ErrorFired = false;
+  var frame1ErrorFired = false;
+  var ourErrorFired = false;
+  frames[0].addEventListener("error", function() {
+    frame0ErrorFired = true;
+  });
+  frames[1].addEventListener("error", function() {
+    frame1ErrorFired = true;
+  });
+  addEventListener("error", function() {
+    ourErrorFired = true;
+  });
+  frames[1].document.dispatchEvent(new Event("myevent"));
+  assert_false(frame0ErrorFired);
+  assert_true(frame1ErrorFired);
+  assert_false(ourErrorFired);
+}, "The error event from an event listener should fire on that listener's global");
+</script>

--- a/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-4.html
+++ b/html/webappapis/scripting/processing-model-2/window-onerror-with-cross-frame-event-listeners-4.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>
+  When a listener from window A is added to an event target in window A via the
+  addEventListener function from window B, errors in that listener should be
+  reported to window A.
+</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+test(function() {
+  var f = new frames[1].Function("thereIsNoSuchCallable()");
+  frames[0].document.addEventListener.call(frames[1].document, "myevent", f);
+  var frame0ErrorFired = false;
+  var frame1ErrorFired = false;
+  var ourErrorFired = false;
+  frames[0].addEventListener("error", function() {
+    frame0ErrorFired = true;
+  });
+  frames[1].addEventListener("error", function() {
+    frame1ErrorFired = true;
+  });
+  addEventListener("error", function() {
+    ourErrorFired = true;
+  });
+  frames[1].document.dispatchEvent(new Event("myevent"));
+  assert_false(frame0ErrorFired);
+  assert_true(frame1ErrorFired);
+  assert_false(ourErrorFired);
+}, "The error event from an event listener should fire on that listener's global");
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1259784
