### PR TITLE
Update websocket test: C0 controls are trimmed from URLs

### DIFF
--- a/websockets/constructor/018.html
+++ b/websockets/constructor/018.html
@@ -6,9 +6,9 @@
 <div id=log></div>
 <script>
 async_test(function(t) {
-  var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo-query?x\u0000');
+  var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo-query?x\u0000y\u0000');
   ws.onmessage = t.step_func(function(e) {
-    assert_equals(e.data, 'x%00');
+    assert_equals(e.data, 'x%00y');
     ws.close();
     t.done();
   })


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/comms.html#dom-websocket says to parse the first argument with https://url.spec.whatwg.org/#concept-url-parser, which in turns says:

> Remove any leading and trailing C0 controls and space from input.

Which links to:

> The C0 controls and space are C0 controls and code point U+0020. 
> The C0 controls are code points in the range U+0000 to U+001F, inclusive.

So a trailing U+0000 is removed from a string when parsing it as an URL.
