### PR TITLE
Create textdecoder-fatal-single-byte.html

### DIFF
--- a/encoding/textdecoder-fatal-single-byte.html
+++ b/encoding/textdecoder-fatal-single-byte.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<title>Encoding API: Fatal flag for single byte encodings</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+var singleByteEncodings = [
+     {encoding: 'IBM866', bad: []},
+     {encoding: 'ISO-8859-2', bad: []},
+     {encoding: 'ISO-8859-3', bad: [0xA5, 0xAE, 0xBE, 0xC3, 0xD0, 0xE3, 0xF0]},
+     {encoding: 'ISO-8859-4', bad: []},
+     {encoding: 'ISO-8859-5', bad: []},
+     {encoding: 'ISO-8859-6', bad: [0xA1, 0xA2, 0xA3, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAE, 0xAF, 0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBC, 0xBD, 0xBE, 0xC0, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF]},
+     {encoding: 'ISO-8859-7', bad: [0xAE, 0xD2, 0xFF]},
+     {encoding: 'ISO-8859-8', bad: [0xA1, 0xBF, 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xFB, 0xFC, 0xFF]},
+     {encoding: 'ISO-8859-8-I', bad: [0xA1, 0xBF, 0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF, 0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xFB, 0xFC, 0xFF]},
+     {encoding: 'ISO-8859-10', bad: []},
+     {encoding: 'ISO-8859-13', bad: []},
+     {encoding: 'ISO-8859-14', bad: []},
+     {encoding: 'ISO-8859-15', bad: []},
+     {encoding: 'ISO-8859-16', bad: []},
+     {encoding: 'KOI8-R', bad: []},
+     {encoding: 'KOI8-U', bad: []},
+     {encoding: 'macintosh', bad: []},
+     {encoding: 'windows-874', bad: [0xDB, 0xDC, 0xDD, 0xDE, 0xFC, 0xFD, 0xFE, 0xFF] },
+     {encoding: 'windows-1250', bad: []},
+     {encoding: 'windows-1251', bad: []},
+     {encoding: 'windows-1252', bad: []},
+     {encoding: 'windows-1253', bad: [0xAA, 0xD2, 0xFF]},
+     {encoding: 'windows-1254', bad: []},
+     {encoding: 'windows-1255', bad: [0xCA, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF, 0xFB, 0xFC, 0xFF]},
+     {encoding: 'windows-1256', bad: []},
+     {encoding: 'windows-1257', bad: [0xA1, 0xA5]},
+     {encoding: 'windows-1258', bad: []},
+     {encoding: 'x-mac-cyrillic', bad: []},
+];
+
+singleByteEncodings.forEach(function(t) {
+    Array.apply(null, Array(256)).forEach(function(a,i) {
+        if (t.bad.length && t.bad.indexOf(i) != -1) {
+            test(function() {
+                assert_throws(new TypeError(), function() {
+                    new TextDecoder(t.encoding, {fatal: true}).decode(new Uint8Array([i]));
+                });
+            }, 'Throw due to fatal flag: ' + t.encoding + ' doesn\'t have a pointer ' + i);
+        }
+        else {
+            test(function() {
+                assert_equals(typeof new TextDecoder(t.encoding, {fatal: true}).decode(new Uint8Array([i])), "string");
+            }, 'Not throw: ' + t.encoding + ' has a pointer ' + i);
+        }
+    });
+
+});
+
+</script>

--- a/encoding/textdecoder-fatal-single-byte.html
+++ b/encoding/textdecoder-fatal-single-byte.html
@@ -22,7 +22,7 @@ var singleByteEncodings = [
      {encoding: 'KOI8-R', bad: []},
      {encoding: 'KOI8-U', bad: []},
      {encoding: 'macintosh', bad: []},
-     {encoding: 'windows-874', bad: [0xDB, 0xDC, 0xDD, 0xDE, 0xFC, 0xFD, 0xFE, 0xFF] },
+     {encoding: 'windows-874', bad: [0xDB, 0xDC, 0xDD, 0xDE, 0xFC, 0xFD, 0xFE, 0xFF]},
      {encoding: 'windows-1250', bad: []},
      {encoding: 'windows-1251', bad: []},
      {encoding: 'windows-1252', bad: []},
@@ -36,8 +36,8 @@ var singleByteEncodings = [
 ];
 
 singleByteEncodings.forEach(function(t) {
-    Array.apply(null, Array(256)).forEach(function(a,i) {
-        if (t.bad.length && t.bad.indexOf(i) != -1) {
+    for (var i = 0; i < 256; ++i) {
+        if (t.bad.indexOf(i) != -1) {
             test(function() {
                 assert_throws(new TypeError(), function() {
                     new TextDecoder(t.encoding, {fatal: true}).decode(new Uint8Array([i]));
@@ -49,8 +49,7 @@ singleByteEncodings.forEach(function(t) {
                 assert_equals(typeof new TextDecoder(t.encoding, {fatal: true}).decode(new Uint8Array([i])), "string");
             }, 'Not throw: ' + t.encoding + ' has a pointer ' + i);
         }
-    });
-
+    }
 });
 
 </script>


### PR DESCRIPTION
I see that Chrome doesn't throw for undefined pointer when fatal flag is set so some test would be useful (https://github.com/w3c/web-platform-tests/issues/2892). 
