### PR TITLE
Document attributes should not leak shadow nodes

### DIFF
--- a/shadow-dom/leaktests/html-collection.html
+++ b/shadow-dom/leaktests/html-collection.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name='author' title='Google' href='http://www.google.com'>
+<meta name='assert' content='document attributes that returns HTMLCollection should not expose nodes in shadow tree.'>
+<link rel='help' href='https://w3c.github.io/webcomponents/spec/shadow/'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</head>
+<body>
+<template id='collection-template'>
+  <img>
+  <embed></embed>
+  <plugin></plugin>
+  <applet></applet>
+  <object type='application/x-java-applet'></object>
+  <a href='http://example.com'></a>
+  <a name='test'></a>
+  <form name='test'></form>
+  <script></script>
+</template>
+<div id='doc'></div>
+<div id='host'></div>
+</body>
+<script>
+'use strict';
+
+function fillTemplate(root, prefix) {
+    var tmpl = document.getElementById('collection-template');
+    root.appendChild(document.importNode(tmpl.content, true));
+    for (var i = 0; i < root.childNodes.length; ++i) {
+	var el = root.childNodes[i];
+	if (el.nodeType != 1)
+	    continue;
+	el.id = prefix + el.tagName.toLowerCase();
+    }
+}
+
+// Construct subtree with 'doc-*' ids.
+var doc = document.getElementById('doc');
+fillTemplate(doc, 'doc-');
+
+// Construct shadow subtree with 'shadow-*' ids.
+var host = document.getElementById('host');
+var shadow = host.attachShadow({mode: 'open'});
+fillTemplate(shadow, 'shadow-');
+
+function testCollection(collection) {
+    var elements = document[collection];
+    assert_greater_than(elements.length, 0, 'document.' + collection + ' should have at least 1 element.');
+    for (var i = 0; i < elements.length; ++i) {
+        if (elements[i].id) {
+            assert_equals(elements[i].id.indexOf('shadow-'), -1, 'document.' + collection + ' should not contain elements in shadow tree.');
+        }
+    }
+}
+
+var testParams = [
+    ['document.scripts should not contain shadow nodes', 'scripts'],
+    ['document.all should not contain shadow nodes', 'all'],
+    ['document.forms should not contain shadow nodes', 'forms'],
+    ['document.images should not contain shadow nodes', 'images'],
+    ['document.links should not contain shadow nodes', 'links'],
+    ['document.anchors should not contain shadow nodes', 'anchors'],
+    ['document.embeds should not contain shadow nodes', 'embeds'],
+    ['document.plugins should not contain shadow nodes', 'plugins'],
+    ['document.applets should not contain shadow nodes', 'applets']];
+
+generate_tests(testCollection, testParams);
+
+</script>
+</html>


### PR DESCRIPTION
Document attributes that returns HTMLCollection (document.all,
document.forms, etc.) should not leak any elements in shadow tree.

In this test, these attributes are tested:
- document.scripts
- document.all
- document.forms
- document.images
- document.links
- document.anchors
- document.embeds
- document.plugins
- document.applets
