### PR TITLE
Add tests for dispatching an event in a shadow tree and extensions to Event interface.

### DIFF
--- a/shadow-dom/Extensions-to-Event-Interface.html
+++ b/shadow-dom/Extensions-to-Event-Interface.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Shadow DOM: Extensions to Event Interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Event interface must have composedPath() as a method">
+<link rel="help" href="http://w3c.github.io/webcomponents/spec/shadow/#extensions-to-event-interface">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="resources/event-path-test-helpers.js"></script>
+<link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test(function () {
+    assert_true('composedPath' in Event.prototype);
+    assert_true('composedPath' in new Event('my-event'));
+}, 'composedPath() must exist on Event');
+
+test(function () {
+    var event = new Event('my-event');
+    assert_array_equals(event.composedPath(), []);
+}, 'composedPath() must return an empty array when the event has not been dispatched');
+
+test(function () {
+    var event = new Event('my-event');
+    document.body.dispatchEvent(event);
+    assert_array_equals(event.composedPath(), []);
+}, 'composedPath() must return an empty array when the event is no longer dispatched');
+
+test(function () {
+    assert_true('composed' in Event.prototype);
+    assert_true('composed' in new Event('my-event'));
+}, 'composed must exist on Event');
+
+test(function () {
+    var event = new Event('my-event');
+    assert_false(event.composed);
+}, 'composed on EventInit must default to false');
+
+test(function () {
+    var event = new Event('my-event', {composed: true});
+    assert_true(event.composed);
+
+    event = new Event('my-event', {composed: false});
+    assert_false(event.composed);
+}, 'composed on EventInit must set the composed flag');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  *: indicates start  digit: event path order
+A (4) --------------------------- A-SR (3)
++ B ------------ B-SR             + A1 (2) --- A1-SR (1)
+  + C            + B1 --- B1-SR   + A2-S       + A1a (*; 0)
+  + D --- D-SR     + B1a    + B1b --- B1b-SR
+          + D1              + B1c-S   + B1b1
+                                      + B1b2
+*/
+
+function testComposedEvent(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        var log = dispatchEventWithLog(nodes, nodes.A1a, new Event('my-event', {composed: true, bubbles: true}));
+
+        var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR', 'A'];
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], expectedPath);
+        assert_array_equals(log.pathAtTargets[1], expectedPath);
+        assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : ['A1', 'A-SR', 'A'],
+            'composedPath must only contain unclosed nodes of the current target.');
+    }, 'The event must propagate out of ' + mode + ' mode shadow boundaries when the composed flag is set');
+}
+
+testComposedEvent('open');
+testComposedEvent('closed');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  *: indicates start  digit: event path order
+A ------------------------------- A-SR
++ B ------------ B-SR             + A1 --- A1-SR (1)
+  + C            + B1 --- B1-SR   + A2-S   + A1a (*; 0)
+  + D --- D-SR     + B1a  + B1b --- B1b-SR
+          + D1            + B1c-S   + B1b1
+                                    + B1b2
+*/
+
+function testNonComposedEvent(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        var log = dispatchEventWithLog(nodes, nodes.A1a, new Event('my-event', {composed: false, bubbles: true}));
+
+        var expectedPath = ['A1a', 'A1-SR'];
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], expectedPath);
+        assert_array_equals(log.pathAtTargets[1], expectedPath);
+    }, 'The event must not propagate out of ' + mode + ' mode shadow boundaries when the composed flag is unset');
+}
+
+testNonComposedEvent('open');
+testNonComposedEvent('closed');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+A ------------------------------- A-SR
++ B ------------ B-SR             + A1 ----------- A1-SR (1)
+  + C            + B1 --- B1-SR   + A2-S [*; 0-1]  + A1a (*; 0)
+  + D --- D-SR     + B1a  + B1b --- B1b-SR
+          + D1            + B1c-S   + B1b1
+                                    + B1b2
+*/
+
+function testNonComposedEventWithRelatedTarget(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        var log = dispatchEventWithLog(nodes, nodes.A1a, new MouseEvent('foo', {composed: false, bubbles: true, relatedTarget: nodes['A2-S']}));
+
+        var expectedPath = ['A1a', 'A1-SR'];
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], expectedPath);
+        assert_array_equals(log.pathAtTargets[1], expectedPath);
+        assert_array_equals(log.relatedTargets, ['A2-S', 'A2-S']);
+    }, 'The event must not propagate out of ' + mode + ' mode shadow boundaries when the composed flag is unset on an event with relatedTarget');
+}
+
+testNonComposedEventWithRelatedTarget('open');
+testNonComposedEventWithRelatedTarget('closed');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+A ------------------------------------------------ A-SR
++ B ------------ B-SR (4)                          + A1 --- A1-SR
+  + C            + B1 (3) [0,3-4] --- B1-SR (2)    + A2-S   + A1a
+  + D --- D-SR     + B1a (*; 0)       + B1b [1-2] --- B1b-SR
+          + D1                        + B1c-S (1)     + B1b1
+                                                      + B1b2 [*]
+*/
+
+function testScopedEventWithUnscopedRelatedTargetThroughSlot(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        var log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {scoped: true, relatedTargetScoped: false, bubbles: true, relatedTarget: nodes['B1b2']}));
+
+        var expectedPath = ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR'];
+        var pathExposedToB1a = ['B1a', 'B1', 'B-SR'];
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.pathAtTargets[1], expectedPath);
+        assert_array_equals(log.pathAtTargets[2], expectedPath);
+        assert_array_equals(log.pathAtTargets[3], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.pathAtTargets[4], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.relatedTargets, ['B1', 'B1b', 'B1b', 'B1', 'B1']);
+    }, 'The event must not propagate out of ' + mode + ' mode shadow tree of the target but must propagate out of inner shadow trees when the scoped flag is set');
+}
+
+testScopedEventWithUnscopedRelatedTargetThroughSlot('open');
+testScopedEventWithUnscopedRelatedTargetThroughSlot('closed');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+A ------------------------------- A-SR (3)
++ B ------------ B-SR             + A1 (2) ------- A1-SR (1)
+  + C            + B1 --- B1-SR   + A2-S [*; 0-3]  + A1a (*; 0)
+  + D --- D-SR     + B1a  + B1b --- B1b-SR
+          + D1            + B1c-S   + B1b1
+                                    + B1b2
+*/
+
+function testComposedEventWithRelatedTarget(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        log = dispatchEventWithLog(nodes, nodes.A1a, new MouseEvent('foo', {composed: true, bubbles: true, relatedTarget: nodes['A2-S']}));
+
+        var expectedPath = ['A1a', 'A1-SR', 'A1', 'A-SR'];
+        var pathExposedToA1 = ['A1', 'A-SR'];
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], expectedPath);
+        assert_array_equals(log.pathAtTargets[1], expectedPath);
+        assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToA1);
+        assert_array_equals(log.pathAtTargets[3], mode == 'open' ? expectedPath : pathExposedToA1);
+        assert_array_equals(log.relatedTargets, ['A2-S', 'A2-S', 'A2-S', 'A2-S']);
+    }, 'The event must propagate out of ' + mode + ' mode shadow tree in which the relative target and the relative related target are the same');
+}
+
+testComposedEventWithRelatedTarget('open');
+testComposedEventWithRelatedTarget('closed');
+
+/*
+-SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+A (8) [0-5,8] ---------------------------------------- A-SR (7)
++ B (5)  ------- B-SR (4)                              + A1 [6,7] --- A1-SR
+  + C            + B1 (3) ------- B1-SR (2)            + A2-S (6)     + A1a [*]
+  + D --- D-SR     + B1a (*; 0)   + B1b ------- B1b-SR
+          + D1                    + B1c-S (1)   + B1b1
+                                                + B1b2
+*/
+
+function testComposedEventThroughSlot(mode) {
+    test(function () {
+        var nodes = createTestTree(mode);
+        log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {composed: true, bubbles: true, relatedTarget: nodes.A1a}));
+
+        var expectedPath =          ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR', 'B', 'A2-S', 'A-SR', 'A'];
+        var expectedRelatedTarget = ['A',   'A',     'A',     'A',   'A',   'A', 'A1',   'A1',   'A'];
+        var pathExposedToB1a =      ['B1a',                   'B1', 'B-SR', 'B',                 'A'];
+        var pathExposedToB1cS =     ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR', 'B',                 'A'];
+        var pathExposedToB =        [                                       'B',                 'A'];
+        var pathExposedToA1 =       [                                       'B', 'A2-S', 'A-SR', 'A'];
+
+        assert_array_equals(log.eventPath, expectedPath);
+        assert_array_equals(log.eventPath.length, log.pathAtTargets.length);
+        assert_array_equals(log.pathAtTargets[0], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.pathAtTargets[1], mode == 'open' ? expectedPath : pathExposedToB1cS);
+        assert_array_equals(log.pathAtTargets[2], mode == 'open' ? expectedPath : pathExposedToB1cS);
+        assert_array_equals(log.pathAtTargets[3], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.pathAtTargets[4], mode == 'open' ? expectedPath : pathExposedToB1a);
+        assert_array_equals(log.pathAtTargets[5], mode == 'open' ? expectedPath : pathExposedToB);
+        assert_array_equals(log.pathAtTargets[6], mode == 'open' ? expectedPath : pathExposedToA1);
+        assert_array_equals(log.pathAtTargets[7], mode == 'open' ? expectedPath : pathExposedToA1);
+        assert_array_equals(log.pathAtTargets[8], mode == 'open' ? expectedPath : pathExposedToB);
+        assert_array_equals(log.relatedTargets, expectedRelatedTarget);
+    }, 'composedPath() must contain and only contain the unclosed nodes of target in ' + mode + ' mode shadow trees');
+}
+
+testComposedEventThroughSlot('open');
+testComposedEventThroughSlot('closed');
+
+</script>
+</body>
+</html>

--- a/shadow-dom/Extensions-to-Event-Interface.html
+++ b/shadow-dom/Extensions-to-Event-Interface.html
@@ -5,10 +5,9 @@
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="Event interface must have composedPath() as a method">
 <link rel="help" href="http://w3c.github.io/webcomponents/spec/shadow/#extensions-to-event-interface">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script src="resources/event-path-test-helpers.js"></script>
-<link rel='stylesheet' href='../../resources/testharness.css'>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/event-inside-shadow-tree.html
+++ b/shadow-dom/event-inside-shadow-tree.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Shadow DOM: Firing an event inside a shadow tree</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="The event path calculation algorithm must be used to determine event path">
+<link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-paths">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function dispatchEventWithLog(target, event) {
+    var log = [];
+
+    for (var node = target; node; node = node.parentNode || node.host) {
+        node.addEventListener(event.type, (function (event) {
+            log.push([this, event.target]);
+        }).bind(node));
+    }
+
+    target.dispatchEvent(event);
+
+    return log;
+}
+
+function createShadowRootWithGrandChild(mode) {
+    var host = document.createElement('div');
+    var root = host.attachShadow({mode: mode});
+
+    var parent = document.createElement('span');
+    root.appendChild(parent);
+
+    var target = document.createElement('b');
+    parent.appendChild(target);
+    return {target: target, parent: parent, root: root, host: host};
+}
+
+function testEventInDetachedShadowTree(mode) {
+    test(function () {
+        var shadow = createShadowRootWithGrandChild(mode);
+
+        log = dispatchEventWithLog(shadow.target, new Event('foo', {composed: true, bubbles: true}));
+
+        assert_array_equals(log.length, 4, 'EventPath must contain [target, parent, shadow root, shadow host]');
+        assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+        assert_array_equals(log[1], [shadow.parent, shadow.target], 'EventPath[1] must be the parent of the target');
+        assert_array_equals(log[2], [shadow.root, shadow.target], 'EventPath[2] must be the shadow root');
+        assert_array_equals(log[3], [shadow.host, shadow.host], 'EventPath[3] must be the shadow host');
+
+    }, 'Firing an event inside a grand child of a detached ' + mode + ' mode shadow tree');
+}
+
+testEventInDetachedShadowTree('open');
+testEventInDetachedShadowTree('closed');
+
+function testEventInShadowTreeInsideDocument(mode) {
+    test(function () {
+        var shadow = createShadowRootWithGrandChild(mode);
+        document.body.appendChild(shadow.host);
+
+        log = dispatchEventWithLog(shadow.target, new Event('foo', {composed: true, bubbles: true}));
+
+        assert_array_equals(log.length, 7, 'EventPath must contain [target, parent, shadow root, shadow host, body, html, document]');
+        assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+        assert_array_equals(log[1], [shadow.parent, shadow.target], 'EventPath[1] must be the parent of the target');
+        assert_array_equals(log[2], [shadow.root, shadow.target], 'EventPath[2] must be the shadow root');
+        assert_array_equals(log[3], [shadow.host, shadow.host], 'EventPath[3] must be the shadow host');
+        assert_array_equals(log[4], [document.body, shadow.host], 'EventPath[4] must be the body element (parent of shadow host)');
+        assert_array_equals(log[5], [document.documentElement, shadow.host], 'EventPath[5] must be the html element');
+        assert_array_equals(log[6], [document, shadow.host], 'EventPath[6] must be the document node');
+
+    }, 'Firing an event inside a grand child of an in-document ' + mode + ' mode shadow tree');
+}
+
+testEventInShadowTreeInsideDocument('open');
+testEventInShadowTreeInsideDocument('closed');
+
+function createNestedShadowRoot(innerMode, outerMode) {
+    var outerHost = document.createElement('div');
+    var outerRoot = outerHost.attachShadow({mode: outerMode});
+
+    var outerChild = document.createElement('p');
+    outerRoot.appendChild(outerChild);
+
+    var innerHost = document.createElement('span');
+    outerChild.appendChild(innerHost);
+
+    var innerRoot = innerHost.attachShadow({mode: innerMode});
+    var innerChild = document.createElement('span');
+    innerRoot.appendChild(innerChild);
+
+    return {target: innerChild, innerRoot: innerRoot, innerHost: innerHost, outerChild: outerChild, outerRoot: outerRoot, outerHost: outerHost};
+}
+
+function testEventInDetachedNestedShadowTree(innerMode, outerMode) {
+    test(function () {
+        var shadow = createNestedShadowRoot(innerMode, outerMode);
+
+        log = dispatchEventWithLog(shadow.target, new Event('bar', {composed: true, bubbles: true}));
+
+        assert_array_equals(log.length, 6, 'EventPath must contain [target, inner root, inner host, parent, outer root, outer host]');
+        assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+        assert_array_equals(log[1], [shadow.innerRoot, shadow.target], 'EventPath[1] must be the inner shadow root');
+        assert_array_equals(log[2], [shadow.innerHost, shadow.innerHost], 'EventPath[2] must be the inner shadow host');
+        assert_array_equals(log[3], [shadow.outerChild, shadow.innerHost], 'EventPath[3] must be the parent of the inner shadow host');
+        assert_array_equals(log[4], [shadow.outerRoot, shadow.innerHost], 'EventPath[4] must be the outer shadow root');
+        assert_array_equals(log[5], [shadow.outerHost, shadow.outerHost], 'EventPath[5] must be the outer shadow host');
+
+    }, 'Firing an event inside a detached ' + innerMode + ' mode shadow tree inside ' + outerMode + ' mode shadow tree');
+}
+
+testEventInDetachedNestedShadowTree('open',  'open');
+testEventInDetachedNestedShadowTree('open',  'closed');
+testEventInDetachedNestedShadowTree('closed', 'open');
+testEventInDetachedNestedShadowTree('closed', 'closed');
+
+function testEventInNestedShadowTreeInsideDocument(innerMode, outerMode) {
+    test(function () {
+        var shadow = createNestedShadowRoot(innerMode, outerMode);
+        document.body.appendChild(shadow.outerHost);
+
+        log = dispatchEventWithLog(shadow.target, new Event('bar', {composed: true, bubbles: true}));
+
+        assert_array_equals(log.length, 6, 'EventPath must contain [target, inner root, inner host, parent, outer root, outer host]');
+        assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+        assert_array_equals(log[1], [shadow.innerRoot, shadow.target], 'EventPath[1] must be the inner shadow root');
+        assert_array_equals(log[2], [shadow.innerHost, shadow.innerHost], 'EventPath[2] must be the inner shadow host');
+        assert_array_equals(log[3], [shadow.outerChild, shadow.innerHost], 'EventPath[3] must be the parent of the inner shadow host');
+        assert_array_equals(log[4], [shadow.outerRoot, shadow.innerHost], 'EventPath[4] must be the outer shadow root');
+        assert_array_equals(log[5], [shadow.outerHost, shadow.outerHost], 'EventPath[5] must be the outer shadow host');
+        assert_array_equals(log[6], [document.body, shadow.outerHost], 'EventPath[6] must be the body element');
+        assert_array_equals(log[7], [document.documentElement, shadow.outerHost], 'EventPath[7] must be the html element');
+        assert_array_equals(log[8], [document, shadow.outerHost], 'EventPath[8] must be the document node');
+
+    }, 'Firing an event inside an in-document ' + innerMode + ' mode shadow tree inside ' + outerMode + ' mode shadow tree');
+}
+
+testEventInNestedShadowTreeInsideDocument('open',  'open');
+testEventInNestedShadowTreeInsideDocument('open',  'closed');
+testEventInNestedShadowTreeInsideDocument('closed', 'open');
+testEventInNestedShadowTreeInsideDocument('closed', 'closed');
+
+</script>
+</body>
+</html>

--- a/shadow-dom/event-inside-shadow-tree.html
+++ b/shadow-dom/event-inside-shadow-tree.html
@@ -5,9 +5,8 @@
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="The event path calculation algorithm must be used to determine event path">
 <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-paths">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
-<link rel='stylesheet' href='../../resources/testharness.css'>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="log"></div>

--- a/shadow-dom/event-inside-slotted-node.html
+++ b/shadow-dom/event-inside-slotted-node.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Shadow DOM: Firing an event inside a node assigned to a slot</title>
+    <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+    <meta name="assert" content="The event path calculation algorithm must be used to determine event path">
+    <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-paths">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+    <div id="log"></div>
+    <script>
+
+        function dispatchEventWithLog(shadow, event) {
+            var log = [];
+
+            var attachedNodes = [];
+            for (var nodeKey in shadow) {
+                var startingNode = shadow[nodeKey];
+                for (var node = startingNode; node; node = node.parentNode) {
+                    if (attachedNodes.indexOf(node) >= 0)
+                        continue;
+                    attachedNodes.push(node);
+                    node.addEventListener(event.type, (function (event) {
+                        log.push([this, event.target]);
+                    }).bind(node));
+                }
+            }
+
+            shadow.target.dispatchEvent(event);
+
+            return log;
+        }
+
+        function element(name, children, className) {
+            var element = document.createElement(name);
+            if (className)
+                element.className = className;
+            if (children) {
+                for (var child of children)
+                    element.appendChild(child);
+            }
+            return element;
+        }
+
+        function attachShadow(host, mode, children) {
+            var shadowRoot = host.attachShadow({mode: mode});
+            if (children) {
+                for (var child of children)
+                    shadowRoot.appendChild(child);
+            }
+            return shadowRoot;
+        }
+
+        function createShadowHostWithAssignedGrandChild(mode) {
+            var host = element('div', [
+                element('b', [
+                    element('i')
+                ])
+            ]);
+
+            var root = attachShadow(host, mode, [
+                element('span', [
+                    element('slot')
+                ])
+            ]);
+
+            return {target: host.querySelector('i'), targetParent: host.querySelector('b'), host: host,
+                    slot: root.querySelector('slot'), slotParent: root.querySelector('span'), root: root};
+        }
+
+        function testEventInDetachedShadowHostDescendant(mode) {
+            test(function () {
+                var shadow = createShadowHostWithAssignedGrandChild(mode);
+
+                log = dispatchEventWithLog(shadow, new Event('foo', {bubbles: true, composed: true}));
+
+                assert_equals(log.length, 6, 'EventPath must contain [target, target parent, slot, slot parent, shadow root, shadow host]');
+                assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+                assert_array_equals(log[1], [shadow.targetParent, shadow.target], 'EventPath[1] must be the parent of the target');
+                assert_array_equals(log[2], [shadow.slot, shadow.target], 'EventPath[2] must be the slot');
+                assert_array_equals(log[3], [shadow.slotParent, shadow.target], 'EventPath[3] must be the parent of the slot');
+                assert_array_equals(log[4], [shadow.root, shadow.target], 'EventPath[4] must be the shadow root');
+                assert_array_equals(log[5], [shadow.host, shadow.target], 'EventPath[5] must be the shadow host');
+
+            }, 'Firing an event inside a grand child of a detached ' + mode + ' mode shadow host');
+        }
+
+        testEventInDetachedShadowHostDescendant('open');
+        testEventInDetachedShadowHostDescendant('closed');
+
+        function testEventInShadowHostDescendantInsideDocument(mode) {
+            test(function () {
+                var shadow = createShadowHostWithAssignedGrandChild(mode);
+                document.body.appendChild(shadow.host);
+
+                log = dispatchEventWithLog(shadow, new Event('foo', {bubbles: true, composed: true}));
+
+                assert_equals(log.length, 9, 'EventPath must contain [target, target parent, slot, slot parent, shadow root, shadow host, body, html, document]');
+                assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+                assert_array_equals(log[1], [shadow.targetParent, shadow.target], 'EventPath[1] must be the parent of the target');
+                assert_array_equals(log[2], [shadow.slot, shadow.target], 'EventPath[2] must be the slot');
+                assert_array_equals(log[3], [shadow.slotParent, shadow.target], 'EventPath[3] must be the parent of the slot');
+                assert_array_equals(log[4], [shadow.root, shadow.target], 'EventPath[4] must be the shadow root');
+                assert_array_equals(log[5], [shadow.host, shadow.target], 'EventPath[5] must be the shadow host');
+                assert_array_equals(log[6], [document.body, shadow.target], 'EventPath[6] must be the body element');
+                assert_array_equals(log[7], [document.documentElement, shadow.target], 'EventPath[7] must be the html element');
+                assert_array_equals(log[8], [document, shadow.target], 'EventPath[8] must be the html element');
+
+            }, 'Firing an event inside a grand child of an in-document ' + mode + ' mode shadow host');
+        }
+
+        testEventInShadowHostDescendantInsideDocument('open');
+        testEventInShadowHostDescendantInsideDocument('closed');
+
+        function createNestedShadowTreesWithSlots(innerMode, outerUpperMode, outerLowerMode) {
+            var upperHost = element('upper-host', [
+                element('p', [
+                    element('lower-host', [
+                        element('a')
+                    ])
+                ])
+            ]);
+
+            var upperShadow = attachShadow(upperHost, outerUpperMode, [
+                element('b', [
+                    element('slot', [], 'upper-slot')
+                ])
+            ]);
+
+            var lowerHost = upperHost.querySelector('lower-host');
+            var lowerShadow = attachShadow(lowerHost, outerLowerMode, [
+                element('em', [
+                    element('inner-host', [
+                        element('span', [
+                            element('slot', [], 'lower-slot')
+                        ])
+                    ])
+                ])
+            ]);
+
+            innerShadow = attachShadow(lowerShadow.querySelector('inner-host'), innerMode, [
+                element('i', [
+                    element('slot', [], 'inner-slot')
+                ])
+            ]);
+
+            return {
+                host: upperHost,
+                target: upperHost.querySelector('a'),
+                upperShadow: upperShadow,
+                upperSlot: upperShadow.querySelector('slot'),
+                lowerShadow: lowerShadow,
+                lowerSlot: lowerShadow.querySelector('slot'),
+                innerShadow: innerShadow,
+                innerSlot: innerShadow.querySelector('slot'),
+            };
+        }
+
+        /*
+        upper-host (14) -- (upperShadow; 13)
+         + p (10)          + b (12)
+          |                  + slot (upperSlot; 11)
+          + lower-host (9) -- (lowerShadow; 8)
+            + a (target; 0)   + em (7)
+                                + inner-host (6) -------- (innerShadow; 5)
+                                  + span (2)              + i (4)
+                                    + slot (lowerSlot; 1) + slot (innerSlot; 3)
+        */
+
+        function testEventUnderTwoShadowRoots(outerUpperMode, outerLowerMode, innerMode) {
+            test(function () {
+                var shadow = createNestedShadowTreesWithSlots(innerMode, outerUpperMode, outerLowerMode);
+
+                log = dispatchEventWithLog(shadow, new Event('foo', {bubbles: true, composed: true}));
+
+                assert_equals(log.length, 15, 'EventPath must contain 15 targets');
+
+                assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+                assert_array_equals(log[1], [shadow.lowerSlot, shadow.target], 'EventPath[1] must be the slot inside the lower shadow tree');
+                assert_array_equals(log[2], [shadow.lowerSlot.parentNode, shadow.target], 'EventPath[2] must be the parent of the slot inside the lower shadow tree');
+                assert_array_equals(log[3], [shadow.innerSlot, shadow.target], 'EventPath[3] must be the slot inside the shadow tree inside the lower shadow tree');
+                assert_array_equals(log[4], [shadow.innerSlot.parentNode, shadow.target], 'EventPath[4] must be the child of the inner shadow root');
+                assert_array_equals(log[5], [shadow.innerShadow, shadow.target], 'EventPath[5] must be the inner shadow root');
+                assert_array_equals(log[6], [shadow.innerShadow.host, shadow.target], 'EventPath[6] must be the host of the inner shadow tree');
+                assert_array_equals(log[7], [shadow.lowerShadow.firstChild, shadow.target], 'EventPath[7] must be the parent of the inner shadow host');
+                assert_array_equals(log[8], [shadow.lowerShadow, shadow.target], 'EventPath[8] must be the lower shadow root');
+                assert_array_equals(log[9], [shadow.lowerShadow.host, shadow.target], 'EventPath[9] must be the lower shadow host');
+                assert_array_equals(log[10], [shadow.host.firstChild, shadow.target], 'EventPath[10] must be the parent of the grand parent of the target');
+                assert_array_equals(log[11], [shadow.upperSlot, shadow.target], 'EventPath[11] must be the slot inside the upper shadow tree');
+                assert_array_equals(log[12], [shadow.upperSlot.parentNode, shadow.target], 'EventPath[12] must be the parent of the slot inside the upper shadow tree');
+                assert_array_equals(log[13], [shadow.upperShadow, shadow.target], 'EventPath[13] must be the upper shadow root');
+                assert_array_equals(log[14], [shadow.host, shadow.target], 'EventPath[14] must be the host');
+
+            }, 'Firing an event on a node with two ancestors with a detached ' + outerUpperMode + ' and ' + outerLowerMode
+                + ' shadow trees with an inner ' + innerMode + ' shadow tree');
+        }
+
+        testEventUnderTwoShadowRoots('open', 'open', 'open');
+        testEventUnderTwoShadowRoots('open', 'open', 'closed');
+        testEventUnderTwoShadowRoots('open', 'closed', 'open');
+        testEventUnderTwoShadowRoots('open', 'closed', 'closed');
+        testEventUnderTwoShadowRoots('closed', 'open', 'open');
+        testEventUnderTwoShadowRoots('closed', 'open', 'closed');
+        testEventUnderTwoShadowRoots('closed', 'closed', 'open');
+        testEventUnderTwoShadowRoots('closed', 'closed', 'closed');
+
+        /*
+        upper-host (11) -- (upperShadow; 10)
+         + p (7)           + b (9)
+          |                  + slot (upperSlot; 8)
+          + lower-host (6) -- (lowerShadow; 5)
+            + a               + em (4)
+                                + inner-host (3) -- (innerShadow; 2)
+                                  + span            + i (1)
+                                    + slot            + slot (innerSlot, target; 0)
+        */
+
+        function testEventInsideNestedShadowsUnderAnotherShadow(outerUpperMode, outerLowerMode, innerMode) {
+            test(function () {
+                var shadow = createNestedShadowTreesWithSlots(innerMode, outerUpperMode, outerLowerMode);
+                shadow.deepestNodeInLightDOM = shadow.target; // Needed for dispatchEventWithLog to attach event listeners. 
+                shadow.target = shadow.innerSlot;
+
+                log = dispatchEventWithLog(shadow, new Event('foo', {bubbles: true, composed: true}));
+
+                assert_equals(log.length, 12, 'EventPath must contain 12 targets');
+
+                assert_array_equals(log[0], [shadow.target, shadow.target], 'EventPath[0] must be the target');
+                assert_array_equals(log[1], [shadow.target.parentNode, shadow.target], 'EventPath[1] must be the parent of the target');
+                assert_array_equals(log[2], [shadow.innerShadow, shadow.target], 'EventPath[2] must be the inner shadow root');
+                assert_array_equals(log[3], [shadow.innerShadow.host, shadow.innerShadow.host], 'EventPath[3] must be the inner shadow host');
+                assert_array_equals(log[4], [shadow.lowerShadow.firstChild, shadow.innerShadow.host], 'EventPath[4] must be the parent of the inner shadow host');
+                assert_array_equals(log[5], [shadow.lowerShadow, shadow.innerShadow.host], 'EventPath[5] must be the lower (but outer) shadow root');
+                assert_array_equals(log[6], [shadow.lowerShadow.host, shadow.lowerShadow.host], 'EventPath[6] must be the lower (but outer) shadow root');
+                assert_array_equals(log[7], [shadow.host.firstChild, shadow.lowerShadow.host], 'EventPath[7] must be the slot inside the upper shadow tree');
+                assert_array_equals(log[8], [shadow.upperSlot, shadow.lowerShadow.host], 'EventPath[8] must be the slot inside the upper shadow tree');
+                assert_array_equals(log[9], [shadow.upperSlot.parentNode, shadow.lowerShadow.host], 'EventPath[9] must be the parent of the slot inside the upper shadow tree');
+                assert_array_equals(log[10], [shadow.upperShadow, shadow.lowerShadow.host], 'EventPath[10] must be the upper shadow root');
+                assert_array_equals(log[11], [shadow.upperShadow.host, shadow.lowerShadow.host], 'EventPath[11] must be the host');
+
+            }, 'Firing an event on a node with two ancestors with a detached ' + outerUpperMode + ' and ' + outerLowerMode
+                + ' shadow trees with an inner ' + innerMode + ' shadow tree');
+        }
+
+        testEventInsideNestedShadowsUnderAnotherShadow('open', 'open', 'open');
+        testEventInsideNestedShadowsUnderAnotherShadow('open', 'open', 'closed');
+        testEventInsideNestedShadowsUnderAnotherShadow('open', 'closed', 'open');
+        testEventInsideNestedShadowsUnderAnotherShadow('open', 'closed', 'closed');
+        testEventInsideNestedShadowsUnderAnotherShadow('closed', 'open', 'open');
+        testEventInsideNestedShadowsUnderAnotherShadow('closed', 'open', 'closed');
+        testEventInsideNestedShadowsUnderAnotherShadow('closed', 'closed', 'open');
+        testEventInsideNestedShadowsUnderAnotherShadow('closed', 'closed', 'closed');
+
+    </script>
+    </body>
+</html>

--- a/shadow-dom/event-inside-slotted-node.html
+++ b/shadow-dom/event-inside-slotted-node.html
@@ -5,9 +5,8 @@
     <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
     <meta name="assert" content="The event path calculation algorithm must be used to determine event path">
     <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#event-paths">
-    <script src="../../resources/testharness.js"></script>
-    <script src="../../resources/testharnessreport.js"></script>
-    <link rel='stylesheet' href='../../resources/testharness.css'>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
     <div id="log"></div>

--- a/shadow-dom/event-with-related-target.html
+++ b/shadow-dom/event-with-related-target.html
@@ -5,10 +5,9 @@
     <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
     <meta name="assert" content="The retargeting algorithm is used to determine relative targets">
     <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#retargeting-relatedtarget">
-    <script src="../../resources/testharness.js"></script>
-    <script src="../../resources/testharnessreport.js"></script>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
     <script src="resources/event-path-test-helpers.js"></script>
-    <link rel='stylesheet' href='../../resources/testharness.css'>
 </head>
 <body>
     <div id="log"></div>

--- a/shadow-dom/event-with-related-target.html
+++ b/shadow-dom/event-with-related-target.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Shadow DOM: Firing an event with relatedTarget inside a shadow tree</title>
+    <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+    <meta name="assert" content="The retargeting algorithm is used to determine relative targets">
+    <link rel="help" href="https://w3c.github.io/webcomponents/spec/shadow/#retargeting-relatedtarget">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="resources/event-path-test-helpers.js"></script>
+    <link rel='stylesheet' href='../../resources/testharness.css'>
+</head>
+<body>
+    <div id="log"></div>
+    <script>
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A ----------------------------------------------- A-SR
+        + B ----------- B-SR (4)                          + A1 --- A1-SR
+          + C           + B1 (3) [*; 0-4] --- B1-SR (2)   + A2-S   + A1a
+          + D --- D-SR    + B1a (*; 0)        + B1b [1,2] --- B1b-SR
+                  + D1                        + B1c-S (1)     + B1b1
+                                                              + B1b2
+        */
+        function testEventAtB1aWithB1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['B1',  'B1',    'B1',    'B1', 'B1'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at B1 with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1aWithB1a('open');
+        testEventAtB1aWithB1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A ------------------------------------------------- A-SR
+        + B ----------- B-SR (4)                            + A1 --- A1-SR
+          + C           + B1 (3) [0,3-4] --- B1-SR (2)      + A2-S   + A1a
+          + D --- D-SR    + B1a (*; 0)       + B1b [1,2] --- B1b-SR
+                  + D1                       + B1c-S (1)     + B1b1 [*]
+                                                             + B1b2
+        */
+        function testEventAtB1aWithB1b1(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1b1}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['B1',  'B1b',   'B1b',   'B1', 'B1'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at B1b1 with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1aWithB1b1('open');
+        testEventAtB1aWithB1b1('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A -------------------------------------------------- A-SR
+        + B ------------- B-SR (5)                           + A1 --- A1-SR
+          + C             + B1 (4) ------- B1-SR (3)         + A2-S   + A1a
+          + D --- D-SR    + B1a [*; 0-5]   + B1b (2) --- B1b-SR (1)
+                  + D1                     + B1c-S       + B1b1 (*; 0)
+                                                         + B1b2
+        */
+        function testEventAtB1b1WithB1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.B1b1, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1a}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1b1', 'B1b-SR', 'B1b', 'B1-SR', 'B1', 'B-SR'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['B1a',  'B1a',    'B1a', 'B1a',   'B1a', 'B1a'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1b1 with relatedNode at B1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1b1WithB1a('open');
+        testEventAtB1b1WithB1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A (8) -------------------------------------------------- A-SR (7)
+        + B (5) -------------- B-SR (4)                          + A1 -------- A1-SR
+          + C                  + B1 (3) [*; 0-4] --- B1-SR (2)   + A2-S (6)    + A1a
+          + D [0-8] --- D-SR     + B1a (*; 0)        + B1b ------ B1b-SR
+                        + D1 [*]                     + B1c-S (1)  + B1b1
+                                                                  + B1b2
+        */
+        function testEventAtB1aWithD1(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.D1}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR', 'B', 'A2-S', 'A-SR', 'A'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['D', 'D', 'D', 'D', 'D', 'D', 'D', 'D', 'D'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at D1 with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1aWithD1('open');
+        testEventAtB1aWithD1('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A (6) ----------------------------------- A-SR (5)
+        + B (3) [0] ----------- B-SR              + A1 ------ A1-SR
+          + C                   + B1 ----- B1-SR  + A2-S (4)  + A1a
+          + D (2) --- D-SR (1)  + B1a [*]  + B1b --- B1b-SR
+                        + D1 (*; 0)         + B1c-S   + B1b1
+                                                      + B1b2
+        */
+        function testEventAtD1WithB1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.D1, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1a}));
+
+                assert_array_equals(log.eventPath,
+                    ['D1', 'D-SR', 'D', 'B', 'A2-S', 'A-SR', 'A'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['B', 'B', 'B', 'B', 'B', 'B', 'B'], 'The related targets must be correct.');
+
+            }, 'Firing an event at D1 with relatedNode at B1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtD1WithB1a('open');
+        testEventAtD1WithB1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A (8) [0-5,8] ---------------------------------------- A-SR (7)
+        + B (5)  ------- B-SR (4)                              + A1 [6,7] --- A1-SR
+          + C            + B1 (3) ----- B1-SR (2)              + A2-S (6)     + A1a [*]
+          + D --- D-SR   + B1a (*; 0)   + B1b ------- B1b-SR
+                  + D1                  + B1c-S (1)   + B1b1
+                                                      + B1b2
+        */
+        function testEventAtB1aWithA1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.A1a}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR', 'B', 'A2-S', 'A-SR', 'A'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['A',   'A',     'A',     'A',   'A',   'A', 'A1',   'A1',   'A'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1aWithA1a('open');
+        testEventAtB1aWithA1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A (4) ----------------------------------------- A-SR (3)
+        + B [0-4]  ----- B-SR                           + A1 (2) --- A1-SR (1)
+          + C            + B1 ------- B1-SR             + A2-S       + A1a (*; 0)
+          + D --- D-SR     + B1a [*]  + B1b --- B1b-SR
+                  + D1                + B1c-S   + B1b1
+                                                + B1b2
+        */
+        function testEventAtA1aWithB1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                log = dispatchEventWithLog(nodes, nodes.A1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1a}));
+
+                assert_array_equals(log.eventPath,
+                    ['A1a', 'A1-SR', 'A1', 'A-SR', 'A'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['B', 'B', 'B', 'B', 'B'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtA1aWithB1a('open');
+        testEventAtA1aWithB1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A (8) ----------------------------------- A-SR (7)
+        + B (5)  ----- B-SR (4)                   + A2-S (6)
+          + C          + B1 (3) ----- B1-SR (2)
+          + D --- D-SR   + B1a (*; 0) + B1b ------- B1b-SR
+                  + D1                + B1c-S (1)   + B1b1
+                                                    + B1b2
+        A1 [0-6] --- A1-SR
+                   + A1a [*]
+        */
+        function testEventAtB1aWithDetachedA1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                nodes['A-SR'].removeChild(nodes.A1);
+                log = dispatchEventWithLog(nodes, nodes.B1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.A1a}));
+
+                assert_array_equals(log.eventPath,
+                    ['B1a', 'B1c-S', 'B1-SR', 'B1', 'B-SR', 'B', 'A2-S', 'A-SR', 'A'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets,
+                    ['A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1'], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtB1aWithDetachedA1a('open');
+        testEventAtB1aWithDetachedA1a('closed');
+
+        /*
+        -SR: ShadowRoot  -S: Slot  target: (~)  relatedTarget: [~]  *: indicates start  digit: event path order
+        A ----------------------------------- A-SR
+        + B [0-3]  ----- B-SR                 + A2-S
+          + C            + B1 -------- B1-SR
+          + D --- D-SR     + B1a [*]   + B1b --- B1b-SR
+                  + D1                 + B1c-S   + B1b1
+                                                 + B1b2
+        A1 (2) --- A1-SR (1)
+                   + A1a (*; 0)
+        */
+        function testEventAtA1aWithDetachedB1a(mode) {
+            test(function () {
+                var nodes = createTestTree(mode);
+
+                nodes['A-SR'].removeChild(nodes.A1);
+                log = dispatchEventWithLog(nodes, nodes.A1a, new MouseEvent('foo', {bubbles: true, composed: true, relatedTarget: nodes.B1a}));
+
+                assert_array_equals(log.eventPath,      ['A1a', 'A1-SR', 'A1'], 'The event path must be correct.');
+                assert_array_equals(log.relatedTargets, ['B',   'B',     'B' ], 'The related targets must be correct.');
+
+            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+        }
+
+        testEventAtA1aWithDetachedB1a('open');
+        testEventAtA1aWithDetachedB1a('closed');
+
+    </script>
+    </body>
+</html>

--- a/shadow-dom/resources/event-path-test-helpers.js
+++ b/shadow-dom/resources/event-path-test-helpers.js
@@ -1,0 +1,93 @@
+
+function dispatchEventWithLog(shadow, target, event) {
+    var eventPath = [];
+    var relatedTargets = [];
+    var pathAtTargets = [];
+
+    var attachedNodes = [];
+    for (var nodeKey in shadow) {
+        var startingNode = shadow[nodeKey];
+        for (var node = startingNode; node; node = node.parentNode) {
+            if (attachedNodes.indexOf(node) >= 0)
+                continue;
+            attachedNodes.push(node);
+            node.addEventListener(event.type, (function (event) {
+                eventPath.push(this.label);
+                relatedTargets.push(event.relatedTarget ? event.relatedTarget.label : null);
+
+                if (!event.composedPath) // Don't fail all tests just for the lack of composedPath.
+                    return;
+
+                pathAtTargets.push(event.composedPath().map(function (node) { return node.label; }));
+            }).bind(node));
+        }
+    }
+
+    target.dispatchEvent(event);
+
+    return {eventPath: eventPath, relatedTargets: relatedTargets, pathAtTargets: pathAtTargets};
+}
+
+/*
+-SR: ShadowRoot  -S: Slot
+A ------------------------------- A-SR
++ B ------------ B-SR             + A1 --- A1-SR
+  + C            + B1 --- B1-SR   + A2-S   + A1a
+  + D --- D-SR     + B1a  + B1b --- B1b-SR
+          + D1            + B1c-S   + B1b1
+                                    + B1b2
+*/
+function createTestTree(mode) {
+    var namedNodes = {};
+
+    function element(name) {
+        var element = document.createElement(name.indexOf('-S') > 0 ? 'slot' : 'div');
+        element.label = name;
+        namedNodes[name] = element;
+        for (var i = 1; i < arguments.length; i++) {
+            var item = arguments[i];
+            if (typeof(item) == 'function')
+                item(element);
+            else
+                element.appendChild(item);
+        }
+        return element;
+    }
+
+    function shadow(name) {
+        var children = [];
+        for (var i = 1; i < arguments.length; i++)
+            children.push(arguments[i]);
+        return function (element) {
+            var shadowRoot = element.attachShadow({mode: mode});
+            shadowRoot.label = name;
+            namedNodes[name] = shadowRoot;
+            for (var child of children)
+                shadowRoot.appendChild(child);
+        }
+    }
+
+    var host = element('A',
+        shadow('A-SR',
+            element('A1',
+                shadow('A1-SR',
+                    element('A1a'))),
+            element('A2-S')
+        ),
+        element('B',
+            shadow('B-SR',
+                element('B1',
+                    shadow('B1-SR',
+                        element('B1b',
+                            shadow('B1b-SR',
+                                element('B1b1'),
+                                element('B1b2'))),
+                        element('B1c-S')),
+                    element('B1a'))),
+            element('C'),
+            element('D',
+                shadow('D-SR',
+                    element('D1')))));
+
+    return namedNodes;
+}


### PR DESCRIPTION
Merge tests written for WebKit's implementation of shadow DOM API
which tests dispatching events inside a shadow tree as well as
extensions to the Event interface: "scoped", "relatedTargetScoped" and "deepPath()".
