### PR TITLE
Add a warning when running ./serve when tools.serve cannot be imported

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -1,4 +1,11 @@
-from tools.serve import serve
+import sys
+
+try:
+  from tools.serve import serve
+except ImportError:
+    print("tools.serve not found.  Did you forget to run "
+          '"git submodule update --init --recursive"?')
+    sys.exit(2)
 
 def main():
     serve.main()

--- a/serve.py
+++ b/serve.py
@@ -1,10 +1,11 @@
 import sys
+import logging
 
 try:
-  from tools.serve import serve
+    from tools.serve import serve
 except ImportError:
-    print("tools.serve not found.  Did you forget to run "
-          '"git submodule update --init --recursive"?')
+    logging.error("tools.serve not found.  Did you forget to run "
+                  '"git submodule update --init --recursive"?')
     sys.exit(2)
 
 def main():


### PR DESCRIPTION
This is similar to the warning in https://github.com/w3c/web-platform-tests/blob/master/lint.

@jgraham Does this look okay?

A similar change could also be made in https://github.com/w3c/web-platform-tests/blob/master/manifest, which I could make in a separate patch.

Also, am I following the right process in creating this pull request?
