### PR TITLE
change/input events on radio/checkbox should be trusted

### DIFF
--- a/html/semantics/forms/the-input-element/checkbox.html
+++ b/html/semantics/forms/the-input-element/checkbox.html
@@ -34,6 +34,7 @@
     c1_click_fired = true;
     assert_false(c1_input_fired, "click event should fire before input event");
     assert_false(c1_change_fired, "click event should fire before change event");
+    assert_false(e.isTrusted, "click()-initiated click event should not be trusted");
   });
   checkbox1.oninput = t1.step_func(function(e) {
     c1_input_fired = true;

--- a/html/semantics/forms/the-input-element/radio.html
+++ b/html/semantics/forms/the-input-element/radio.html
@@ -83,6 +83,7 @@
     click_fired = true;
     assert_false(input_fired, "click event should fire before input event");
     assert_false(change_fired, "click event should fire before change event");
+    assert_false(e.isTrusted, "click()-initiated click event shouldn't be trusted");
   });
 
   radio5.oninput = t1.step_func(function(e) {
@@ -90,7 +91,7 @@
     assert_true(click_fired, "input event should fire after click event");
     assert_false(change_fired, "input event should fire before change event");
     assert_true(e.bubbles, "input event should bubble")
-    assert_false(e.isTrusted, "click()-initiated input event shouldn't be trusted");
+    assert_true(e.isTrusted, "input event should be trusted");
     assert_false(e.cancelable, "input event should not be cancelable");
   });
 
@@ -99,7 +100,7 @@
     assert_true(click_fired, "change event should fire after click event");
     assert_true(input_fired, "change event should fire after input event");
     assert_true(e.bubbles, "change event should bubble")
-    assert_false(e.isTrusted, "click()-initiated change event shouldn't be trusted");
+    assert_true(e.isTrusted, "change event should be trusted");
     assert_false(e.cancelable, "change event should not be cancelable");
   });
 


### PR DESCRIPTION
This reverts
5d1a5c182cf0cddb4690613f913c8abd427946cf
3775815f6b9404c9b4f671263645efc7632963fe

Also test that isTrusted is false for the click event.

Ref.
https://github.com/whatwg/html/issues/1126
https://github.com/w3c/web-platform-tests/issues/1418#issuecomment-214615790

cc @smaug---- @cvrebert 
