### PR TITLE
Remove data: src from iframe in Web Animations tests

### DIFF
--- a/web-animations/animatable/animate.html
+++ b/web-animations/animatable/animate.html
@@ -102,7 +102,6 @@ test(function(t) {
 
 async_test(function(t) {
   var iframe = document.createElement('iframe');
-  iframe.src = 'data:text/html;charset=utf-8,';
   iframe.width = 10;
   iframe.height = 10;
 

--- a/web-animations/animation-timeline/document-timeline.html
+++ b/web-animations/animation-timeline/document-timeline.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
-<iframe src="data:text/html;charset=utf-8," width="10" height="10" id="iframe"></iframe>
+<iframe width="10" height="10" id="iframe"></iframe>
 <script>
 'use strict';
 


### PR DESCRIPTION
Chrome considers iframes with data: sources as cross-origin from the embedding page (https://crbug.com/607795) and fails Web Animations tests as a result. Having a src set is not required for the test to work so removing it makes the test compatible with Chrome.
