### PR TITLE
Improve stability of the presto-testo Document::contentType tests.

### DIFF
--- a/dom/nodes/Document-contentType/contentType/contenttype_bmp.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_bmp.html
@@ -2,14 +2,14 @@
 <title>BMP document.contentType === 'image/bmp'</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<iframe style="display:none"></iframe>
 <div id=log></div>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "image/bmp");
   }), false);
   iframe.src = "../resources/t.bmp";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_css.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_css.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/css");
   }), false);
   iframe.src = "../resources/style.css";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_datauri_01.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_datauri_01.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/plain");
   }), false);
   iframe.src = "data:;,<!DOCTYPE html>";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_datauri_02.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_datauri_02.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/html");
   }), false);
   iframe.src = "data:text/html;charset=utf-8,<!DOCTYPE html>";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_gif.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_gif.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "image/gif");
   }), false);
   iframe.src = "../resources/t.gif";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_html.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_html.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/html");
   }), false);
   iframe.src = "../resources/blob.htm";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_javascripturi.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_javascripturi.html
@@ -3,14 +3,14 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/html");
     assert_equals(iframe.contentDocument.documentElement.textContent, "text/html");
   }), false);
   iframe.src = "javascript:document.contentType";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_jpg.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_jpg.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "image/jpeg");
   }), false);
   iframe.src = "../resources/t.jpg";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_mimeheader_01.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_mimeheader_01.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/xml");
   }), false);
   iframe.src = "../support/contenttype_setter.py?type=text&subtype=xml";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_mimeheader_02.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_mimeheader_02.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/html");
   }), false);
   iframe.src = "../support/contenttype_setter.py?type=text&subtype=html&mimeHead=text%2Fxml";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_png.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_png.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "image/png");
   }), false);
   iframe.src = "../resources/t.png";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_txt.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_txt.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "text/plain");
   }), false);
   iframe.src = "../resources/blob.txt";
+  document.body.appendChild(iframe);
 });
 </script>

--- a/dom/nodes/Document-contentType/contentType/contenttype_xml.html
+++ b/dom/nodes/Document-contentType/contentType/contenttype_xml.html
@@ -3,13 +3,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
-<iframe style="display:none"></iframe>
 <script>
 async_test(function() {
-  var iframe = document.getElementsByTagName('iframe')[0];
+  var iframe = document.createElement('iframe');
   iframe.addEventListener('load', this.step_func_done(function() {
     assert_equals(iframe.contentDocument.contentType, "application/xml");
   }), false);
   iframe.src = "../resources/blob.xml";
+  document.body.appendChild(iframe);
 });
 </script>


### PR DESCRIPTION
This ensures that the load event from the initial about:blank document does
not interfere with the test.
