### PR TITLE
Wait for animation ready before waiting a frame

### DIFF
--- a/web-animations/animation/playbackRate.html
+++ b/web-animations/animation/playbackRate.html
@@ -72,8 +72,10 @@ promise_test(function(t) {
   var previousAnimationCurrentTime;
   return animation.ready.then(function() {
     previousAnimationCurrentTime = animation.currentTime;
-    previousTimelineCurrentTime = animation.timeline.currentTime;
     animation.playbackRate = 1;
+    return animation.ready;
+  }).then(function() {
+    previousTimelineCurrentTime = animation.timeline.currentTime;
     return waitForAnimationFrames(1);
   }).then(function() {
     assert_equals(animation.playbackRate, 1,


### PR DESCRIPTION
Setting animation.playbackRate puts the animation into pending state.
This test fails in Chrome because the animation isn't ready until one frame has passed and had not progressed its currentTime during that time.
This change ensures that we wait for the animation to be ready before testing the rate at which its currentTime progresses.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
