### PR TITLE
Change document-color-01.html to not remove the top-level body.

### DIFF
--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
@@ -9,13 +9,12 @@
 <iframe id="iframe"></iframe>
 <script>
 test(function() {
-  var doc = document.getElementById("iframe").contentDocument;
-  var body = doc.documentElement.removeChild(doc.body);
-  assert_equals(doc.fgColor, "");
-  assert_equals(doc.bgColor, "");
-  assert_equals(doc.linkColor, "");
-  assert_equals(doc.vlinkColor, "");
-  assert_equals(doc.alinkColor, "");
-  doc.body = body;
+  var body = document.documentElement.removeChild(document.body);
+  assert_equals(document.fgColor, "");
+  assert_equals(document.bgColor, "");
+  assert_equals(document.linkColor, "");
+  assert_equals(document.vlinkColor, "");
+  assert_equals(document.alinkColor, "");
+  document.body = body;
 })
 </script>

--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
@@ -6,15 +6,48 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
-<iframe id="iframe"></iframe>
 <script>
 test(function() {
+  document.fgColor = "green";
+  document.bgColor = "green";
+  document.linkColor = "green";
+  document.vlinkColor = "green";
+  document.alinkColor = "green";
+
   var body = document.documentElement.removeChild(document.body);
+
+  // When there is no body element, the color attributes return an
+  // empty string upon getting.
   assert_equals(document.fgColor, "");
   assert_equals(document.bgColor, "");
   assert_equals(document.linkColor, "");
   assert_equals(document.vlinkColor, "");
   assert_equals(document.alinkColor, "");
+
+  // Re-add body and reset color attributes.
   document.body = body;
-})
+  document.fgColor = "";
+  document.bgColor = "";
+  document.linkColor = "";
+  document.vlinkColor = "";
+  document.alinkColor = "";
+}, "getting document color attributes with no body");
+
+test(function() {
+  var body = document.documentElement.removeChild(document.body);
+
+  // When there is no body element, setting the color attributes has no effect.
+  document.fgColor = "red";
+  document.bgColor = "red";
+  document.linkColor = "red";
+  document.vlinkColor = "red";
+  document.alinkColor = "red";
+  assert_equals(document.fgColor, "");
+  assert_equals(document.bgColor, "");
+  assert_equals(document.linkColor, "");
+  assert_equals(document.vlinkColor, "");
+  assert_equals(document.alinkColor, "");
+
+  document.body = body;
+}, "setting document color attributes with no body");
 </script>

--- a/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
+++ b/html/obsolete/requirements-for-implementations/other-elements-attributes-and-apis/document-color-01.html
@@ -6,13 +6,16 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
+<iframe id="iframe"></iframe>
 <script>
 test(function() {
-  document.documentElement.removeChild(document.body);
-  assert_equals(document.fgColor, "");
-  assert_equals(document.bgColor, "");
-  assert_equals(document.linkColor, "");
-  assert_equals(document.vlinkColor, "");
-  assert_equals(document.alinkColor, "");
+  var doc = document.getElementById("iframe").contentDocument;
+  var body = doc.documentElement.removeChild(doc.body);
+  assert_equals(doc.fgColor, "");
+  assert_equals(doc.bgColor, "");
+  assert_equals(doc.linkColor, "");
+  assert_equals(doc.vlinkColor, "");
+  assert_equals(doc.alinkColor, "");
+  doc.body = body;
 })
 </script>


### PR DESCRIPTION
When this test page is loaded, it doesn't show any results currently because the top-level body is removed. In order to test behavior of a document when a body is removed, this pull request would change the test to remove the body of an document in an iframe inside the top-level body.

This will make it easier to fix #2391 (missing coverage for document color attributes).
