### PR TITLE
[10743] Add content type to XmlDocument constructor based on namespace

### DIFF
--- a/dom/nodes/DOMImplementation-createDocument.html
+++ b/dom/nodes/DOMImplementation-createDocument.html
@@ -123,7 +123,7 @@ test(function() {
         var doc = document.implementation.createDocument(namespace, qualifiedName, doctype)
         assert_equals(doc.compatMode, "CSS1Compat")
         assert_equals(doc.characterSet, "UTF-8")
-        assert_equals(doc.contentType, namespace == htmlNamespace ? "text/html"
+        assert_equals(doc.contentType, namespace == htmlNamespace ? "application/xhtml+xml"
                                  : namespace == svgNamespace ?  "image/svg+xml"
                                  : "application/xml")
         assert_equals(doc.URL, "about:blank")

--- a/dom/nodes/Document-contentType/contentType/createDocument.html
+++ b/dom/nodes/Document-contentType/contentType/createDocument.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<title>document.implementation.createDocument: document.contentType === 'application/xml'</title>
+<title>document.implementation.createDocument: document.contentType === 'application/xhtml+xml'</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id=log></div>
 <script>
 test(function() {
   var doc = document.implementation.createDocument("http://www.w3.org/1999/xhtml", "html", null);
-  assert_equals(doc.contentType, "application/xml");
+  assert_equals(doc.contentType, "application/xhtml+xml");
 });
 </script>


### PR DESCRIPTION
[10743] Fix namespace in createDocument test

[10743] Remove test ini file, match returns static strings instead of DOMString.

[10743] Fix arguments to XMLDocument::new

Update failing test

[10743] Add content type to XmlDocument constructor based on namespace

[10743] Fix namespace in createDocument test

[10743] Remove test ini file, match returns static strings instead of DOMString.

[10743] Fix arguments to XMLDocument::new

Update failing test
