### PR TITLE
When throwing an exception from XHR open() due to not being in an active document, make sure it's an InvalidStateError.

### DIFF
--- a/XMLHttpRequest/open-url-multi-window-6.htm
+++ b/XMLHttpRequest/open-url-multi-window-6.htm
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>XMLHttpRequest: open() in document that is not fully active (but may be active) should throw</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method">
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var test = async_test(),
+          client,
+          count = 0,
+          win = window.open("resources/init.htm");
+      test.add_cleanup(function() { win.close(); });
+      function init() {
+        test.step(function() {
+          if(0 == count) {
+            var doc = win.document;
+            var ifr = document.createElement("iframe");
+            ifr.onload = function() {
+              // Again, do things async so we're not doing loads from inside
+              // load events.
+              setTimeout(function() {
+                client = new ifr.contentWindow.XMLHttpRequest();
+                count++;
+                // Important to do a normal navigation, not a reload.
+                win.location.href = "resources/init.htm";
+              }, 100);
+            }
+            doc.body.appendChild(ifr);
+          } else if(1 == count) {
+            assert_throws("InvalidStateError", function() { client.open("GET", "...") })
+            test.done()
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/XMLHttpRequest/resources/init.htm
+++ b/XMLHttpRequest/resources/init.htm
@@ -4,6 +4,17 @@
     <title>support init file</title>
   </head>
   <body>
-    <script> parent.init() </script>
+    <script>
+      onload = function() {
+        // Run async, because navigations from inside onload can be a bit weird.
+        setTimeout(function() {
+          if (parent != window) {
+            parent.init()
+          } else {
+            opener.init();
+          }
+        }, 0);
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1265970
