### PR TITLE
Add web-platform tests for KeyframeEffect.setFrames

### DIFF
--- a/web-animations/keyframe-effect/setFrames.html
+++ b/web-animations/keyframe-effect/setFrames.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>KeyframeEffect setFrames() tests</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-keyframeeffect-setframes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../testcommon.js"></script>
+<script src="../resources/keyframe-utils.js"></script>
+<body>
+<div id="log"></div>
+<div id="target"></div>
+<script>
+'use strict';
+
+var target = document.getElementById('target');
+
+test(function(t) {
+  gEmptyKeyframeListTests.forEach(function(frame) {
+    var effect = new KeyframeEffect(target, {});
+    effect.setFrames(frame);
+    assert_frame_lists_equal(effect.getFrames(), []);
+  });
+}, 'Keyframes can be replaced with an empty keyframe');
+
+gPropertyIndexedKeyframesTests.forEach(function(subtest) {
+  test(function(t) {
+    var effect = new KeyframeEffect(target, {});
+    effect.setFrames(subtest.input);
+    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+  }, 'Keyframes can be replaced with ' + subtest.desc);
+});
+
+gKeyframeSequenceTests.forEach(function(subtest) {
+  test(function(t) {
+    var effect = new KeyframeEffect(target, {});
+    effect.setFrames(subtest.input);
+    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+  }, 'Keyframes can be replaced with ' + subtest.desc);
+});
+
+gInvalidKeyframesTests.forEach(function(subtest) {
+  test(function(t) {
+    var effect = new KeyframeEffect(target, {});
+    assert_throws(subtest.expected, function() {
+      effect.setFrames(subtest.input);
+    });
+  }, "Invalid KeyframeEffect option by " + subtest.desc);
+});
+</script>
+</body>

--- a/web-animations/resources/keyframe-utils.js
+++ b/web-animations/resources/keyframe-utils.js
@@ -399,6 +399,35 @@ var gKeyframeSequenceTests = [
                border: "3px dashed rgb(7, 8, 9)" }] },
 ];
 
+var gInvalidKeyframesTests = [
+  { desc:     "keyframes with an out-of-bounded positive offset",
+    input:    [ { opacity: 0 },
+                { opacity: 0.5, offset: 2 },
+                { opacity: 1 } ],
+    expected: { name: "TypeError" } },
+  { desc:     "keyframes with an out-of-bounded negative offset",
+    input:    [ { opacity: 0 },
+                { opacity: 0.5, offset: -1 },
+                { opacity: 1 } ],
+    expected: { name: "TypeError" } },
+  { desc:     "keyframes not loosely sorted by offset",
+    input:    [ { opacity: 0, offset: 1 },
+                { opacity: 1, offset: 0 } ],
+    expected: { name: "TypeError" } },
+  { desc:     "property-indexed keyframes with an invalid easing value",
+    input:    { opacity: [ 0, 0.5, 1 ],
+                easing: "inherit" },
+    expected: { name: "TypeError" } },
+  { desc:     "a keyframe sequence with an invalid easing value",
+    input:    [ { opacity: 0, easing: "jumpy" },
+                { opacity: 1 } ],
+    expected: { name: "TypeError" } },
+  { desc:     "keyframes with an invalid composite value",
+    input:    [ { opacity: 0, composite: "alternate" },
+                { opacity: 1 } ],
+    expected: { name: "TypeError" } }
+];
+
 // ------------------------------
 //  KeyframeEffectOptions
 // ------------------------------


### PR DESCRIPTION
Some tests are expected to fail until Bug 1216843 and 1216844 are resolved, so that
we specify that on the meta file `setFrames.html.ini`.

MozReview-Commit-ID: 6z2P1KkGJhb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1244591
