### PR TITLE
Fix <base> href getter to follow the spec; it should be using the fallback base URI to resolve against, not the document URI.

### DIFF
--- a/html/semantics/document-metadata/the-base-element/base_about_blank.html
+++ b/html/semantics/document-metadata/the-base-element/base_about_blank.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>base element in about:blank document should resolve against its fallback base URI</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe></iframe>
+<script>
+var t = async_test();
+addEventListener("load", t.step_func_done(function() {
+  var doc = frames[0].document;
+  var b = doc.createElement("base");
+  b.setAttribute("href", "test");
+  var newBaseValue = location.href.replace(/\/[^/]*$/, "/") + "test";
+  assert_equals(b.href, newBaseValue);
+  assert_equals(doc.baseURI, location.href);
+  doc.head.appendChild(b);
+  assert_equals(doc.baseURI, newBaseValue);
+}));
+</script>

--- a/html/semantics/document-metadata/the-base-element/base_href_invalid.html
+++ b/html/semantics/document-metadata/the-base-element/base_href_invalid.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>base element with unparseable href should have .href getter return attr value</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+test(function() {
+  var b = document.createElement("base");
+  b.setAttribute("href", "//test:test");
+  assert_equals(b.href, "//test:test");
+});
+</script>

--- a/html/semantics/document-metadata/the-base-element/base_srcdoc.html
+++ b/html/semantics/document-metadata/the-base-element/base_srcdoc.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>base element in srcdoc document should resolve against its fallback base URI</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<iframe srcdoc=""></iframe>
+<script>
+var t = async_test();
+addEventListener("load", t.step_func_done(function() {
+  var doc = frames[0].document;
+  var b = doc.createElement("base");
+  b.setAttribute("href", "test");
+  var newBaseValue = location.href.replace(/\/[^/]*$/, "/") + "test";
+  assert_equals(b.href, newBaseValue);
+  assert_equals(doc.baseURI, location.href);
+  doc.head.appendChild(b);
+  assert_equals(doc.baseURI, newBaseValue);
+}));
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1266077
