### PR TITLE
Make <xmp> and <listing> use HTMLPreElement as their primary interface, per <https://github.com/whatwg/html/issues/1015>.

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -3215,7 +3215,11 @@ window.onload = function() {
     HTMLHeadingElement: ['document.createElement("h1")'],
     HTMLParagraphElement: ['document.createElement("p")'],
     HTMLHRElement: ['document.createElement("hr")'],
-    HTMLPreElement: ['document.createElement("pre")'],
+    HTMLPreElement: [
+      'document.createElement("pre")',
+      'document.createElement("listing")',
+      'document.createElement("xmp")',
+    ],
     HTMLQuoteElement: [
       'document.createElement("blockquote")',
       'document.createElement("q")',


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1266851
