### PR TITLE
Follow-up to fix mistaken precision value in changeset c2f257b08990;

### DIFF
--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -15,7 +15,7 @@ var MS_PER_SEC = 1000;
 // The recommended minimum precision to use for time values[1].
 //
 // [1] https://w3c.github.io/web-animations/#precision-of-time-values
-var TIME_PRECISION = 0.000001;
+var TIME_PRECISION = 0.0005; // ms
 
 // Allow implementations to substitute an alternative method for comparing
 // times based on their precision requirements.


### PR DESCRIPTION
The precision value was for seconds despite the fact that we are comparing
milliseconds. This was causing intermittent failures such as:

  https://treeherder.mozilla.org/logviewer.html#?job_id=26711451&repo=mozilla-inbound

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1267893
