### PR TITLE
Fix mixed-content web platform tests to not screw up their bytes on Windows.

### DIFF
--- a/mixed-content/generic/expect.py
+++ b/mixed-content/generic/expect.py
@@ -70,20 +70,20 @@ def main(request, response):
             if content_type == "image/png":
                 response_data = open(os.path.join(request.doc_root,
                                                   "images",
-                                                  "smiley.png")).read()
+                                                  "smiley.png"), "rb").read()
             elif content_type == "audio/mpeg":
                 response_data = open(os.path.join(request.doc_root,
                                                   "media",
-                                                  "sound_5.oga")).read()
+                                                  "sound_5.oga"), "rb").read()
             elif content_type == "video/mp4":
                 response_data = open(os.path.join(request.doc_root,
                                                   "media",
-                                                  "movie_5.mp4")).read()
+                                                  "movie_5.mp4"), "rb").read()
             elif content_type == "application/javascript":
                 response_data = open(os.path.join(request.doc_root,
                                                   "mixed-content",
                                                   "generic",
-                                                  "worker.js")).read()
+                                                  "worker.js"), "rb").read()
             else:
                 response_data = "/* purged */"
         elif action == "take":


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1268915
