### PR TITLE
The load events we fire on iframe/frame/object (in the document case) should not be cancelable.

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-load-event.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-load-event.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test some sanity behavior around iframe load/error events</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+async_test(function(t) {
+  var obj = document.createElement("iframe");
+  obj.onload = t.step_func_done(function(e){
+    assert_true(obj.contentWindow instanceof Window, "The iframe element should represent a nested browsing context.")
+    assert_equals(Object.getPrototypeOf(e).constructor, Event, "The load event should use the Event interface.");
+    assert_true(e.isTrusted, "The load event should be a trusted event.");
+    assert_false(e.cancelable, "The load event should not be a cancelable event.");
+    assert_false(e.bubbles, "The load event should not be a bubble event.");
+    assert_equals(e.target, obj, "The load event target should be the corresponding object element.");
+  });
+
+  obj.onerror = t.step_func_done(function(e){
+    assert_unreached("The error event should not be fired.");
+  });
+
+  var url = URL.createObjectURL(new Blob([""], { type: "text/html" }));
+
+  obj.src = url;
+  document.body.appendChild(obj);
+}, "load event of blob URL");
+
+async_test(function(t) {
+  var obj = document.createElement("iframe");
+  obj.onload = t.step_func_done(function(e){
+    assert_true(obj.contentWindow instanceof Window, "The object element should represent a nested browsing context.")
+    assert_equals(Object.getPrototypeOf(e).constructor, Event, "The load event should use the Event interface.");
+    assert_true(e.isTrusted, "The load event should be a trusted event.");
+    assert_false(e.cancelable, "The load event should not be a cancelable event.");
+    assert_false(e.bubbles, "The load event should not be a bubble event.");
+    assert_equals(e.target, obj, "The load event target should be the corresponding object element.");
+  });
+
+  obj.onerror = t.step_func_done(function(e){
+    assert_unreached("The error event should not be fired.");
+  });
+
+  document.body.appendChild(obj);
+}, "load event of initial about:blank");
+
+</script>
+</body>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1268953
