### PR TITLE
W3C referrerpolicy content attribute doesn't work in FF. r=josh,

### DIFF
--- a/referrer-policy/generic/common.js
+++ b/referrer-policy/generic/common.js
@@ -22,7 +22,7 @@ function parseUrlQueryString(queryString) {
 function appendIframeToBody(url, attributes) {
   var iframe = document.createElement("iframe");
   iframe.src = url;
-  // Extend element with attributes. (E.g. "referrer_policy" or "rel")
+  // Extend element with attributes. (E.g. "referrerPolicy" or "rel")
   if (attributes) {
     for (var attr in attributes) {
       iframe[attr] = attributes[attr];
@@ -40,7 +40,7 @@ function loadImage(src, callback, attributes) {
     callback(image);
   }
   image.src = src;
-  // Extend element with attributes. (E.g. "referrer_policy" or "rel")
+  // Extend element with attributes. (E.g. "referrerPolicy" or "rel")
   if (attributes) {
     for (var attr in attributes) {
       image[attr] = attributes[attr];

--- a/referrer-policy/generic/referrer-policy-test-case.js
+++ b/referrer-policy/generic/referrer-policy-test-case.js
@@ -76,7 +76,7 @@ function ReferrerPolicyTestCase(scenario, testDescription, sanityChecker) {
       // Depending on the delivery method, extend the subresource element with
       // these attributes.
       var elementAttributesForDeliveryMethod = {
-        "attr-referrer":  {referrerpolicy: t._scenario.referrer_policy},
+        "attr-referrer":  {referrerPolicy: t._scenario.referrer_policy},
         "rel-noreferrer": {rel: "noreferrer"}
       };
 


### PR DESCRIPTION
MozReview-Commit-ID: KKq7ZRJziBu

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1261003
