### PR TITLE
Start allowing sync XHR with credentials in window scopes again, since no one except for us bothered to implement the spec.

### DIFF
--- a/cors/credentials-flag.htm
+++ b/cors/credentials-flag.htm
@@ -17,6 +17,13 @@ var url = CROSSDOMAIN + 'resources/cors-cookie.py?ident='
  * widthCredentials
  */
 // XXX Do some https tests here as well
+
+test(function () {
+    var client = new XMLHttpRequest()
+    client.open('GET', CROSSDOMAIN, false)
+    client.withCredentials = true;
+}, 'Setting withCredentials on a sync XHR object should not throw')
+
 async_test(function () {
     var id = new Date().getTime() + '_1',
         client = new XMLHttpRequest()


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1260515
