### PR TITLE
Allow objectStores and indexes to be renamed.

### DIFF
--- a/IndexedDB/interfaces.idl
+++ b/IndexedDB/interfaces.idl
@@ -88,7 +88,7 @@ interface IDBDatabase : EventTarget {
 };
 
 interface IDBObjectStore {
-    readonly    attribute DOMString      name;
+    attribute DOMString name;
     readonly    attribute any            keyPath;
     readonly    attribute DOMStringList  indexNames;
     readonly    attribute IDBTransaction transaction;
@@ -106,7 +106,7 @@ interface IDBObjectStore {
 };
 
 interface IDBIndex {
-    readonly    attribute DOMString      name;
+    attribute DOMString name;
     readonly    attribute IDBObjectStore objectStore;
     readonly    attribute any            keyPath;
     readonly    attribute boolean        multiEntry;


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1118028
