### PR TITLE
track kind=invalid> should behave like metadata, not subtitles;

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/kind.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/kind.html
@@ -13,7 +13,7 @@ test(function(){
 test(function(){
     var track = document.createElement('track');
     track.setAttribute('kind', 'invalid');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
     assert_equals(track.getAttribute('kind'), 'invalid');
 }, document.title + ' invalid value in content attribute');
 
@@ -27,14 +27,14 @@ test(function(){
 test(function(){
     var track = document.createElement('track');
     track.setAttribute('kind', 'CAPT\u0130ONS');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
     assert_equals(track.getAttribute('kind'), 'CAPT\u0130ONS');
 }, document.title + ' content attribute with uppercase turkish I (with dot)');
 
 test(function(){
     var track = document.createElement('track');
     track.setAttribute('kind', 'capt\u0131ons');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
     assert_equals(track.getAttribute('kind'), 'capt\u0131ons');
 }, document.title + ' content attribute with lowercase turkish i (dotless)');
 
@@ -76,7 +76,7 @@ test(function(){
 test(function(){
     var track = document.createElement('track');
     track.setAttribute('kind', 'captions\u0000');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
     assert_equals(track.getAttribute('kind'), 'captions\u0000');
 }, document.title + ' content attribute "captions\\u0000"');
 
@@ -126,21 +126,21 @@ test(function(){
     var track = document.createElement('track');
     track.kind = 'CAPT\u0130ONS';
     assert_equals(track.getAttribute('kind'), 'CAPT\u0130ONS');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
 }, document.title + ' setting IDL attribute with uppercase turkish I (with dot)');
 
 test(function(){
     var track = document.createElement('track');
     track.kind = 'capt\u0131ons';
     assert_equals(track.getAttribute('kind'), 'capt\u0131ons');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
 }, document.title + ' setting IDL attribute with lowercase turkish I (dotless)');
 
 test(function(){
     var track = document.createElement('track');
     track.kind = 'captions\u0000';
     assert_equals(track.getAttribute('kind'), 'captions\u0000');
-    assert_equals(track.kind, 'subtitles');
+    assert_equals(track.kind, 'metadata');
 }, document.title + ' setting IDL attribute with \\u0000');
 
 </script>

--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/kind.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/kind.html
@@ -26,6 +26,6 @@ test(function(){
 test(function(){
     var track = document.createElement('track');
     track.kind = 'captions\u0000';
-    assert_equals(track.track.kind, 'subtitles');
+    assert_equals(track.track.kind, 'metadata');
 }, document.title+', \\u0000');
 </script>


### PR DESCRIPTION
This follows a spec change https://github.com/whatwg/html/issues/293,
which AFAIK no other browser has implemented, so it has some regression
potential.

The web-platform tests changed are out-of-date and match the old spec,
so I'm changing them here to match the new spec.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1269712
