### PR TITLE
P1 implement response.redirected - Fetch API & Cache API & ServiceWorker changed. r=bkelly, r=baku.

### DIFF
--- a/service-workers/service-worker/fetch-request-redirect.https.html
+++ b/service-workers/service-worker/fetch-request-redirect.https.html
@@ -146,12 +146,13 @@ promise_test(function(t) {
             assert_resolves(
                 iframe_test(REDIRECT_TO_HTML_URL),
                 'Normal redirected iframe loading should succeed.'),
-            assert_resolves(
+            assert_rejects(
                 iframe_test(SCOPE + '?url=' +
                             encodeURIComponent(REDIRECT_TO_HTML_URL) +
-                            '&redirect-mode=follow'),
+                            '&redirect-mode=follow',
+                            true /* timeout_enabled */),
                 'Redirected iframe loading with Request.redirect=follow should'+
-                ' succeed.'),
+                ' fail.'),
             assert_rejects(
                 iframe_test(SCOPE + '?url=' +
                             encodeURIComponent(REDIRECT_TO_HTML_URL) +


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1243792
