### PR TITLE
caches.match with wrong name should resolve to undefined.

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-storage-match.js
+++ b/service-workers/cache-storage/script-tests/cache-storage-match.js
@@ -111,11 +111,9 @@ promise_test(function(test) {
           return self.caches.match(transaction.request, {cacheName: 'foo'});
         })
       .then(function(response) {
-          assert_unreached('The match with bad cache name should reject.');
-        })
-      .catch(function(err) {
-          assert_equals(err.name, 'NotFoundError',
-                        'The match should reject with NotFoundError.');
+          assert_equals(response, undefined,
+                        'The match with bad cache name should resolve to ' +
+                        'undefined.');
           return self.caches.has('foo');
         })
       .then(function(has_foo) {


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1271069
