### PR TITLE
Rename KeyframeEffectReadOnly.getFrames() and KeyframeEffect.setFrames() to getKeyframes()/setKeyframes(); r=hiro,

### DIFF
--- a/web-animations/animatable/animate.html
+++ b/web-animations/animatable/animate.html
@@ -30,7 +30,7 @@ gPropertyIndexedKeyframesTests.forEach(function(subtest) {
   test(function(t) {
     var div = createDiv(t);
     var anim = div.animate(subtest.input, 2000);
-    assert_frame_lists_equal(anim.effect.getFrames(), subtest.output);
+    assert_frame_lists_equal(anim.effect.getKeyframes(), subtest.output);
   }, 'Element.animate() accepts ' + subtest.desc);
 });
 
@@ -38,7 +38,7 @@ gKeyframeSequenceTests.forEach(function(subtest) {
   test(function(t) {
     var div = createDiv(t);
     var anim = div.animate(subtest.input, 2000);
-    assert_frame_lists_equal(anim.effect.getFrames(), subtest.output);
+    assert_frame_lists_equal(anim.effect.getKeyframes(), subtest.output);
   }, 'Element.animate() accepts ' + subtest.desc);
 });
 

--- a/web-animations/animation-model/animation-types/not-animatable.html
+++ b/web-animations/animation-model/animation-types/not-animatable.html
@@ -14,7 +14,7 @@ test(function(t) {
   var div = createDiv(t);
   var anim = div.animate({ display: [ 'inline', 'inline-block' ] }, 1000);
 
-  assert_equals(anim.effect.getFrames().length, 0,
+  assert_equals(anim.effect.getKeyframes().length, 0,
                 'Animation specified using property-indexed notation but'
                 + ' consisting of only non-animatable properties should not'
                 + ' contain any keyframes');
@@ -25,13 +25,13 @@ test(function(t) {
   var anim = div.animate([ { display: 'inline' }, { display: 'inline-block' } ],
                          1000);
 
-  assert_equals(anim.effect.getFrames().length, 2,
+  assert_equals(anim.effect.getKeyframes().length, 2,
                 'Animation specified using a keyframe sequence where each'
                 + ' keyframe contains only non-animatable properties should'
                 + ' return an equal number of (empty) keyframes');
-  assert_false(anim.effect.getFrames()[0].hasOwnProperty('display'),
+  assert_false(anim.effect.getKeyframes()[0].hasOwnProperty('display'),
                'Initial keyframe should not have the \'display\' property');
-  assert_false(anim.effect.getFrames()[1].hasOwnProperty('display'),
+  assert_false(anim.effect.getKeyframes()[1].hasOwnProperty('display'),
                'Final keyframe should not have the \'display\' property');
 }, '\'display\' property cannot be animated using a keyframe sequence');
 
@@ -58,7 +58,7 @@ test(function(t) {
   var div = createDiv(t);
   var anim = div.animate(properties, 1000);
 
-  assert_equals(anim.effect.getFrames().length, 0,
+  assert_equals(anim.effect.getKeyframes().length, 0,
                 'Animation specified using property-indexed notation but'
                 + ' consisting of only non-animatable properties should not'
                 + ' contain any keyframes');
@@ -103,15 +103,15 @@ test(function(t) {
   var div = createDiv(t);
   var anim = div.animate(frames, 1000);
 
-  assert_equals(anim.effect.getFrames().length, 2,
+  assert_equals(anim.effect.getKeyframes().length, 2,
                 'Animation specified using a keyframe sequence where each'
                 + ' keyframe contains only non-animatable properties should'
                 + ' return an equal number of (empty) keyframes');
-  assert_array_equals(Object.keys(anim.effect.getFrames()[0]),
+  assert_array_equals(Object.keys(anim.effect.getKeyframes()[0]),
                       defaultKeyframeProperties,
                       'Initial keyframe should not contain any properties other'
                       + ' than the default keyframe properties');
-  assert_array_equals(Object.keys(anim.effect.getFrames()[1]),
+  assert_array_equals(Object.keys(anim.effect.getKeyframes()[1]),
                       defaultKeyframeProperties,
                       'Final keyframe should not contain any properties other'
                       + ' than the default keyframe properties');

--- a/web-animations/keyframe-effect/constructor.html
+++ b/web-animations/keyframe-effect/constructor.html
@@ -21,7 +21,8 @@ var target = document.getElementById("target");
 
 test(function(t) {
   gEmptyKeyframeListTests.forEach(function(frames) {
-    assert_equals(new KeyframeEffectReadOnly(target, frames).getFrames().length,
+    assert_equals(new KeyframeEffectReadOnly(target, frames)
+                        .getKeyframes().length,
                   0, "number of frames for " + JSON.stringify(frames));
   });
 }, "a KeyframeEffectReadOnly can be constructed with no frames");
@@ -34,7 +35,7 @@ test(function(t) {
       left: ["10px", "20px"],
       easing: easing
     });
-    assert_equals(effect.getFrames()[0].easing, expected,
+    assert_equals(effect.getKeyframes()[0].easing, expected,
                   "resulting easing for '" + easing + "'");
   });
 }, "easing values are parsed correctly when passed to the " +
@@ -48,7 +49,7 @@ test(function(t) {
       { offset: 0, left: "10px", easing: easing },
       { offset: 1, left: "20px" }
     ]);
-    assert_equals(effect.getFrames()[0].easing, expected,
+    assert_equals(effect.getKeyframes()[0].easing, expected,
                   "resulting easing for '" + easing + "'");
   });
 }, "easing values are parsed correctly when passed to the " +
@@ -68,37 +69,37 @@ test(function(t) {
    "KeyframeEffectReadOnly constructor in KeyframeTimingOptions");
 
 test(function(t) {
-  var getFrame = function(composite) {
+  var getKeyframe = function(composite) {
     return { left: [ "10px", "20px" ], composite: composite };
   };
   gGoodKeyframeCompositeValueTests.forEach(function(composite) {
-    var effect = new KeyframeEffectReadOnly(target, getFrame(composite));
-    assert_equals(effect.getFrames()[0].composite, composite,
+    var effect = new KeyframeEffectReadOnly(target, getKeyframe(composite));
+    assert_equals(effect.getKeyframes()[0].composite, composite,
                   "resulting composite for '" + composite + "'");
   });
   gBadCompositeValueTests.forEach(function(composite) {
     assert_throws(new TypeError, function() {
-      new KeyframeEffectReadOnly(target, getFrame(composite));
+      new KeyframeEffectReadOnly(target, getKeyframe(composite));
     });
   });
 }, "composite values are parsed correctly when passed to the " +
    "KeyframeEffectReadOnly constructor in property-indexed keyframes");
 
 test(function(t) {
-  var getFrames = function(composite) {
+  var getKeyframes = function(composite) {
     return [
       { offset: 0, left: "10px", composite: composite },
       { offset: 1, left: "20px" }
     ];
   };
   gGoodKeyframeCompositeValueTests.forEach(function(composite) {
-    var effect = new KeyframeEffectReadOnly(target, getFrames(composite));
-    assert_equals(effect.getFrames()[0].composite, composite,
+    var effect = new KeyframeEffectReadOnly(target, getKeyframes(composite));
+    assert_equals(effect.getKeyframes()[0].composite, composite,
                   "resulting composite for '" + composite + "'");
   });
   gBadCompositeValueTests.forEach(function(composite) {
     assert_throws(new TypeError, function() {
-      new KeyframeEffectReadOnly(target, getFrames(composite));
+      new KeyframeEffectReadOnly(target, getKeyframes(composite));
     });
   });
 }, "composite values are parsed correctly when passed to the " +
@@ -109,7 +110,7 @@ test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, {
       left: ["10px", "20px"]
     }, { composite: composite });
-    assert_equals(effect.getFrames()[0].composite, composite,
+    assert_equals(effect.getKeyframes()[0].composite, composite,
                   "resulting composite for '" + composite + "'");
   });
   gBadCompositeValueTests.forEach(function(composite) {
@@ -125,13 +126,15 @@ test(function(t) {
 gPropertyIndexedKeyframesTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, subtest.input);
-    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+    assert_frame_lists_equal(effect.getKeyframes(), subtest.output);
   }, "a KeyframeEffectReadOnly can be constructed with " + subtest.desc);
 
   test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, subtest.input);
-    var secondEffect = new KeyframeEffectReadOnly(target, effect.getFrames());
-    assert_frame_lists_equal(secondEffect.getFrames(), effect.getFrames());
+    var secondEffect =
+      new KeyframeEffectReadOnly(target, effect.getKeyframes());
+    assert_frame_lists_equal(secondEffect.getKeyframes(),
+                             effect.getKeyframes());
   }, "a KeyframeEffectReadOnly constructed with " + subtest.desc +
      " roundtrips");
 });
@@ -159,13 +162,15 @@ test(function(t) {
 gKeyframeSequenceTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, subtest.input);
-    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+    assert_frame_lists_equal(effect.getKeyframes(), subtest.output);
   }, "a KeyframeEffectReadOnly can be constructed with " + subtest.desc);
 
   test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, subtest.input);
-    var secondEffect = new KeyframeEffectReadOnly(target, effect.getFrames());
-    assert_frame_lists_equal(secondEffect.getFrames(), effect.getFrames());
+    var secondEffect =
+      new KeyframeEffectReadOnly(target, effect.getKeyframes());
+    assert_frame_lists_equal(secondEffect.getKeyframes(),
+                             effect.getKeyframes());
   }, "a KeyframeEffectReadOnly constructed with " + subtest.desc +
      " roundtrips");
 });

--- a/web-animations/keyframe-effect/setKeyframes.html
+++ b/web-animations/keyframe-effect/setKeyframes.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffect setFrames() tests</title>
-<link rel="help" href="https://w3c.github.io/web-animations/#dom-keyframeeffect-setframes">
+<title>KeyframeEffect setKeyframes() tests</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-keyframeeffect-setkeyframes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../testcommon.js"></script>
@@ -17,24 +17,24 @@ var target = document.getElementById('target');
 test(function(t) {
   gEmptyKeyframeListTests.forEach(function(frame) {
     var effect = new KeyframeEffect(target, {});
-    effect.setFrames(frame);
-    assert_frame_lists_equal(effect.getFrames(), []);
+    effect.setKeyframes(frame);
+    assert_frame_lists_equal(effect.getKeyframes(), []);
   });
 }, 'Keyframes can be replaced with an empty keyframe');
 
 gPropertyIndexedKeyframesTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffect(target, {});
-    effect.setFrames(subtest.input);
-    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+    effect.setKeyframes(subtest.input);
+    assert_frame_lists_equal(effect.getKeyframes(), subtest.output);
   }, 'Keyframes can be replaced with ' + subtest.desc);
 });
 
 gKeyframeSequenceTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffect(target, {});
-    effect.setFrames(subtest.input);
-    assert_frame_lists_equal(effect.getFrames(), subtest.output);
+    effect.setKeyframes(subtest.input);
+    assert_frame_lists_equal(effect.getKeyframes(), subtest.output);
   }, 'Keyframes can be replaced with ' + subtest.desc);
 });
 
@@ -42,7 +42,7 @@ gInvalidKeyframesTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffect(target, {});
     assert_throws(subtest.expected, function() {
-      effect.setFrames(subtest.input);
+      effect.setKeyframes(subtest.input);
     });
   }, 'KeyframeEffect constructor throws with ' + subtest.desc);
 });


### PR DESCRIPTION
MozReview-Commit-ID: GwLLY39l1KE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1271904
