### PR TITLE
Ignore shorthand properties when all their subproperties are not-animatable;

### DIFF
--- a/web-animations/animation-model/animation-types/not-animatable.html
+++ b/web-animations/animation-model/animation-types/not-animatable.html
@@ -98,7 +98,7 @@ test(function(t) {
       transitionTimingFunction: 'ease-out'
     }
   ];
-  var defaultKeyframeProperties = [ 'computedOffset', 'easing', 'offset' ];
+  var defaultKeyframeProperties = [ 'easing', 'offset', 'computedOffset' ];
 
   var div = createDiv(t);
   var anim = div.animate(frames, 1000);


### PR DESCRIPTION
This patch also includes a tweak to not-animatable.html to match the order in
which properties are enumerated on the object. This test was always in error but
we never noticed since the test failed before reaching the test in question.

Making the test dependent on the order in which object properties is enumerated
is not good but we will remove this test in the next patch. In this patch we
just make sure it passes.

MozReview-Commit-ID: AKXdHj4nUMv

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1264822
