### PR TITLE
Make fullscreen enabled flag not be affected after document is loaded.

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe-allowfullscreen.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe-allowfullscreen.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Check how allowfullscreen affects fullscreen enabled flag</title>
+<link rel="author" title="Xidorn Quan" href="https://www.upsuper.org">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#initialise-the-document-object">
+<link rel="help" href="https://fullscreen.spec.whatwg.org/#fullscreen-enabled-flag">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+<script>
+  async_test(function(t) {
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/blank.htm";
+    var eventWatcher = new EventWatcher(t, iframe, "load");
+    document.body.appendChild(iframe);
+    t.add_cleanup(function() {
+      document.body.removeChild(iframe);
+    });
+
+    assert_true(document.fullscreenEnabled, "Top level document has fullscreen enabled flag set");
+    eventWatcher.wait_for("load").then(t.step_func(function() {
+      assert_false(iframe.contentDocument.fullscreenEnabled, "Document inside iframe without allowfullscreen attribute should not have fullscreen enabled flag set");
+      iframe.setAttribute("allowfullscreen", true);
+      assert_false(iframe.contentDocument.fullscreenEnabled, "Setting allowfullscreen attribute after document load should not affect fullscreen enabled flag");
+      iframe.contentWindow.location.reload();
+      return eventWatcher.wait_for("load");
+    })).then(t.step_func(function() {
+      assert_true(iframe.contentDocument.fullscreenEnabled, "Fullscreen enabled flag should be set when a new document is loaded with allowfullscreen attribute present");
+      iframe.removeAttribute("allowfullscreen");
+      assert_true(iframe.contentDocument.fullscreenEnabled, "Removing allowfullscreen attribute should not affect fullscreen enabled flag");
+      iframe.contentWindow.location.reload();
+      return eventWatcher.wait_for("load");
+    })).then(t.step_func_done(function() {
+      assert_false(iframe.contentDocument.fullscreenEnabled, "Fullscreen enabled flag should be reset when a new document is loaded with allowfullscreen attribute absent");
+    }));
+  }, "iframe-allowfullscreen");
+
+  async_test(function(t) {
+    var iframe = document.createElement("iframe");
+    iframe.src = "support/blank.htm";
+    var eventWatcher = new EventWatcher(t, iframe, "load");
+    document.body.appendChild(iframe);
+    t.add_cleanup(function() {
+      document.body.removeChild(iframe);
+    });
+
+    var newWin;
+    assert_true(document.fullscreenEnabled, "Top level document has fullscreen enabled flag set");
+    eventWatcher.wait_for("load").then(t.step_func(function() {
+      assert_false(iframe.contentDocument.fullscreenEnabled, "Document inside iframe without allowfullscreen attribute should not have fullscreen enabled flag set");
+      newWin = iframe.contentWindow.open("support/blank.htm");
+      t.add_cleanup(function() {
+        newWin.close();
+      });
+      var newWinEventWatcher = new EventWatcher(t, newWin, "load");
+      return newWinEventWatcher.wait_for("load");
+    })).then(t.step_func_done(function() {
+      assert_true(newWin.document.fullscreenEnabled, "Document in the new window is a top level document, thus should has fullscreen enabled flag set");
+    }));
+  }, "iframe-allowfullscreen-dialog");
+</script>


### PR DESCRIPTION
MozReview-Commit-ID: L2dMAUr63qv

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1270648
