### PR TITLE
encoding legacy directories

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -25,6 +25,7 @@ INDENT TABS: web-animations/*
 INDENT TABS: webaudio/*
 INDENT TABS: webvtt/*
 INDENT TABS: XMLHttpRequest/*
+INDENT TABS: encoding/legacy*/*
 
 TRAILING WHITESPACE: app-uri/*
 TRAILING WHITESPACE: battery-status/*
@@ -43,6 +44,7 @@ TRAILING WHITESPACE: webaudio/*
 TRAILING WHITESPACE: WebIDL/*
 TRAILING WHITESPACE: webvtt/*
 TRAILING WHITESPACE: XMLHttpRequest/*
+TRAILING WHITESPACE: encoding/legacy*/*
 
 ## File types that should never be checked ##
 


### PR DESCRIPTION
The overwhelming majority of the cases are tabs for the somewhat more complex than usual javascript that drives the tests. I wanted to retain those so that i can read the code easily. I've run all the tests sufficiently often already to believe that these tabs aren't affecting the results.
