### PR TITLE
Remove invalid-as-of-ES6 test of ProgressEvent.length

### DIFF
--- a/progress-events/interface.html
+++ b/progress-events/interface.html
@@ -7,10 +7,6 @@
 test(function() {
   assert_equals(typeof ProgressEvent, "function")
   assert_equals(ProgressEvent.length, 1)
-  assert_throws(new TypeError(), function() {
-    "use strict";
-    delete ProgressEvent.length;
-  })
 })
 test(function() {
   var desc = Object.getOwnPropertyDescriptor(ProgressEvent, "prototype")


### PR DESCRIPTION
As of ES6, the length property on functions is configurable, and can be deleted.
