### PR TITLE
Fix some test at Processing model 2

### DIFF
--- a/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html
+++ b/html/webappapis/scripting/processing-model-2/body-onerror-compile-error-data-url.html
@@ -19,7 +19,7 @@
         assert_equals(typeof lineno, 'number', 'third arg');
     });
     t_col.step(function() {
-        assert_equals(typeof column, 'number', 'fourth arg');
+        assert_equals(typeof colno, 'number', 'fourth arg');
     });
     ">
   <div id=log></div>

--- a/html/webappapis/scripting/processing-model-2/body-onerror-compile-error.html
+++ b/html/webappapis/scripting/processing-model-2/body-onerror-compile-error.html
@@ -19,7 +19,7 @@
         assert_equals(typeof lineno, 'number', 'third arg');
     });
     t_col.step(function() {
-        assert_equals(typeof column, 'number', 'fourth arg');
+        assert_equals(typeof colno, 'number', 'fourth arg');
     });
     ">
   <div id=log></div>

--- a/html/webappapis/scripting/processing-model-2/body-onerror-runtime-error.html
+++ b/html/webappapis/scripting/processing-model-2/body-onerror-runtime-error.html
@@ -19,7 +19,7 @@
         assert_equals(typeof lineno, 'number', 'third arg');
     });
     t_col.step(function(){
-        assert_equals(typeof column, 'number', 'fourth arg');
+        assert_equals(typeof colno, 'number', 'fourth arg');
     });
     ">
   <div id=log></div>

--- a/html/webappapis/scripting/processing-model-2/compile-error-data-url.html
+++ b/html/webappapis/scripting/processing-model-2/compile-error-data-url.html
@@ -17,11 +17,11 @@
         ran = true;
         col_value = d;
         assert_equals(typeof a, 'string', 'first arg');
-        assert_equals(b, 'data:text/javascript,for(;) {}', 'second arg');
+        assert_equals(b, 'data:text/javascript,for(;){}', 'second arg');
         assert_equals(typeof c, 'number', 'third arg');
     });
   </script>
-  <script src="data:text/javascript,for(;) {}"></script>
+  <script src="data:text/javascript,for(;){}"></script>
   <script>
     t.step(function(){
         assert_true(ran, 'ran');

--- a/html/webappapis/scripting/processing-model-2/runtime-error-data-url.html
+++ b/html/webappapis/scripting/processing-model-2/runtime-error-data-url.html
@@ -28,7 +28,7 @@
         t.done();
     });
     t_col.step(function(){
-        assert_equals(typeof col_value, number, 'fourth arg');
+        assert_equals(typeof col_value, 'number', 'fourth arg');
         t_col.done();
     });
   </script>


### PR DESCRIPTION
I found some missing things at [/html/webappapis/scripting/processing-model-2/](https://github.com/w3c/web-platform-tests/tree/master/html/webappapis/scripting/processing-model-2)

Don't know if this matters or not. But what I saw:
1. cross-origin fails on Firefox and Chrome.
2. this is in Firefox: `window.onerror = function(event, source, lineno, colno, error) { ... };` but in Chrome `window.onerror = function(event[EventError])`

Hope this will be helpful.
