### PR TITLE
Add new tests for fetch request on blob resource.

### DIFF
--- a/fetch/api/basic/scheme-blob.js
+++ b/fetch/api/basic/scheme-blob.js
@@ -34,12 +34,12 @@ checkKoUrl("blob:http://{{domains[www]}}:{{ports[http][0]}}/", "GET",
           "Fetching [GET] blob:http://{{domains[www]}}:{{ports[http][0]}}/ is KO");
 
 var invalidRequestMethods = [
-  ["POST"],
-  ["OPTIONS"],
-  ["HEAD"],
-  ["PUT"],
-  ["DELETE"],
-  ["INVALID"],
+  "POST",
+  "OPTIONS",
+  "HEAD",
+  "PUT",
+  "DELETE",
+  "INVALID",
 ];
 invalidRequestMethods.forEach(function(method) {
   checkKoUrl(URL.createObjectURL(blob2), method, "Fetching [" + method + "] URL.createObjectURL(blob) is KO");

--- a/fetch/api/basic/scheme-blob.js
+++ b/fetch/api/basic/scheme-blob.js
@@ -32,7 +32,17 @@ function checkKoUrl(url, method, desc) {
 var blob2 = new Blob(["Blob's data"], { "type" : "text/plain" });
 checkKoUrl("blob:http://{{domains[www]}}:{{ports[http][0]}}/", "GET",
           "Fetching [GET] blob:http://{{domains[www]}}:{{ports[http][0]}}/ is KO");
-checkKoUrl(URL.createObjectURL(blob2), "POST",
-           "Fetching [POST] URL.createObjectURL(blob) is KO");
+
+var invalidRequestMethods = [
+  ["POST"],
+  ["OPTIONS"],
+  ["HEAD"],
+  ["PUT"],
+  ["DELETE"],
+  ["INVALID"],
+];
+invalidRequestMethods.forEach(function(method) {
+  checkKoUrl(URL.createObjectURL(blob2), method, "Fetching [" + method + "] URL.createObjectURL(blob) is KO");
+});
 
 done();


### PR DESCRIPTION
Add new tests for HTTP methods described in RFC7231 except forbidden methods (CONNECT, TRACE, TRACK).  An invalid HTTP method is also tested.
A network error should be returned for all HTTP methods except GET (c.f. https://fetch.spec.whatwg.org/#basic-fetch).
