### PR TITLE
Change the expected width/height value of PE

### DIFF
--- a/pointerevents/pointerevent_constructor.html
+++ b/pointerevents/pointerevent_constructor.html
@@ -57,8 +57,8 @@
                 generate_tests(assert_equals, [
                     ["default pointerId", event.pointerId, 0],
                     ["default pointerType", event.pointerType, ""],
-                    ["default width", event.width, 0],
-                    ["default height", event.height, 0],
+                    ["default width", event.width, 1],
+                    ["default height", event.height, 1],
                     ["default tiltX", event.tiltX, 0],
                     ["default tiltY", event.tiltY, 0],
                     ["default pressure", event.pressure, 0],


### PR DESCRIPTION
@RByers @dtapuska @mustaqahmed @patrickhlauke 

Changing the expected value of width/height
properties of pointer events to 1.

closes #3100 
