### PR TITLE
Updated constraint syntax

### DIFF
--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html
@@ -20,7 +20,7 @@ constraint (width &gt;=0) in getUserMedia works</p>
 <script>
 var t = async_test("Tests that setting an impossible constraint in getUserMedia fails", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {mandatory: {width: {min:Infinity}}}}, t.step_func(function (stream) {
+  navigator.getUserMedia({video: {width: {min:Infinity}}}, t.step_func(function (stream) {
     assert_unreached("a Video stream of infinite width cannot be created");
     t.done();
   }), t.step_func(function(error) {

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html
@@ -9,7 +9,7 @@
 <body>
 <p class="instructions">When prompted, accept to share your video stream.</p>
 <h1 class="instructions">Description</h1>
-<p class="instructions">This test checks that setting an optional constraint in
+<p class="instructions">This test checks that setting an advanced constraint in
 getUserMedia is handled as optional</p>
 
 <div id='log'></div>
@@ -19,7 +19,7 @@ getUserMedia is handled as optional</p>
 <script>
 var t = async_test("Tests that setting an optional constraint in getUserMedia is handled as optional", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {optional: [{width: {min:1024}}, {width: {max: 800}}]}},
+  navigator.getUserMedia({video: {advanced: [{width: {min:1024, max: 800}}]}},
       t.step_func(function (stream) {
         assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
         t.done();

--- a/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html
+++ b/mediacapture-streams/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html
@@ -19,7 +19,7 @@ constraint (width &gt;=0) in getUserMedia works</p>
 <script>
 var t = async_test("Tests that setting a trivial mandatory constraint in getUserMedia works", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {mandatory: {width: {min:0}}}}, t.step_func(function (stream) {
+  navigator.getUserMedia({video: {width: {min:0}}}, t.step_func(function (stream) {
     assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
     t.done();
   }), t.step_func(function(error) {


### PR DESCRIPTION
These tests were using old non-standard syntax, in one case mixing
it with new syntax. Now it should be all standard syntax.
