### PR TITLE
Add a test for pointer event clientX and clientY

### DIFF
--- a/pointerevents/pointerevent_properties_mouse-manual.html
+++ b/pointerevents/pointerevent_properties_mouse-manual.html
@@ -34,10 +34,10 @@
 
                         if (event.type != 'pointerout' && event.type != 'pointerleave' ) {
                             test(function () {
-                                assert_between_inclusive(event.clientX, rectSquare1.left, rectSquare1.right - 1, "ClientX should be in the boundaries of the black box");
+                                assert_true(event.clientX >= rectSquare1.left && event.clientX < rectSquare1.right, "ClientX should be in the boundaries of the black box");
                             }, event.type + ".clientX attribute is correct.");
                             test(function () {
-                                assert_between_inclusive(event.clientY, rectSquare1.top, rectSquare1.bottom - 1, "ClientY should be in the boundaries of the black box");
+                              assert_true(event.clientY >= rectSquare1.top && event.clientY < rectSquare1.bottom, "ClientY should be in the boundaries of the black box");
                             }, event.type + ".clientY attribute is correct.");
                         } else {
                             test(function () {

--- a/pointerevents/pointerevent_properties_mouse-manual.html
+++ b/pointerevents/pointerevent_properties_mouse-manual.html
@@ -32,18 +32,17 @@
                             assert_equals(event.pointerType, 'mouse', 'pointerType should be mouse');
                         }, event.type + ".pointerType attribute is correct.");
 
-                        if (event.type != 'pointerout' && event.type != 'pointerleave' ) { 
+                        if (event.type != 'pointerout' && event.type != 'pointerleave' ) {
                             test(function () {
-                                assert_between_inclusive(event.clientX, 100, 100 + rectSquare1.width - 1, "ClientX should be in the boundaries of the black box");
-                            }, event.type + ".ClientX attribute is correct.");
-    
+                                assert_between_inclusive(event.clientX, rectSquare1.left, rectSquare1.right - 1, "ClientX should be in the boundaries of the black box");
+                            }, event.type + ".clientX attribute is correct.");
                             test(function () {
-                                assert_between_inclusive(event.clientY, 150, 150 + rectSquare1.height - 1, "ClientY should be in the boundaries of the black box");
-                            }, event.type + ".ClientY attribute is correct.");
+                                assert_between_inclusive(event.clientY, rectSquare1.top, rectSquare1.bottom - 1, "ClientY should be in the boundaries of the black box");
+                            }, event.type + ".clientY attribute is correct.");
                         } else {
                             test(function () {
-                                assert_true(event.clientX < 100 || event.clientX > 100 + rectSquare1.width - 1 || event.clientY < 150 || event.clientY > 150 + rectSquare1.Height - 1, "ClientX/Y should be out of the boundaries of the black box");
-                            }, event.type + " ClientX and ClientY attribute is correct.");
+                                assert_true(event.clientX < rectSquare1.left || event.clientX > rectSquare1.right - 1 || event.clientY < rectSquare1.top || event.clientY > rectSquare1.bottom - 1, "ClientX/Y should be out of the boundaries of the black box");
+                            }, event.type + "'s ClientX and ClientY attributes are correct.");
                         }
 
                         test(function () {

--- a/pointerevents/pointerevent_properties_mouse-manual.html
+++ b/pointerevents/pointerevent_properties_mouse-manual.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Pointer Events properties tests</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <!-- Additional helper script for common checks across event types -->
+        <script type="text/javascript" src="pointerevent_support.js"></script>
+        <script>
+            var detected_pointertypes = {};
+            var detected_eventTypes = {};
+            var test_pointerEvent = async_test("pointerdown event received");
+            // showPointerTypes is defined in pointerevent_support.js
+            // Requirements: the callback function will reference the test_pointerEvent object and
+            // will fail unless the async_test is created with the var name "test_pointerEvent".
+            add_completion_callback(showPointerTypes);
+
+            function run() {
+                var square1 = document.getElementById("square1");
+                var rectSquare1 = square1.getBoundingClientRect();
+                var pointerover_event;
+
+                var eventList = ['pointerenter', 'pointerover', 'pointermove', 'pointerdown', 'pointerup', 'pointerout', 'pointerleave'];
+                eventList.forEach(function(eventName) {
+                    on_event(square1, eventName, function (event) {
+                        if (detected_eventTypes[event.type])
+                            return;
+                        detected_pointertypes[event.pointerType] = true;
+                        test(function () {
+                            assert_equals(event.pointerType, 'mouse', 'pointerType should be mouse');
+                        }, event.type + ".pointerType attribute is correct.");
+
+                        if (event.type != 'pointerout' && event.type != 'pointerleave' ) { 
+                            test(function () {
+                                assert_between_inclusive(event.clientX, 100, 100 + rectSquare1.width - 1, "ClientX should be in the boundaries of the black box");
+                            }, event.type + ".ClientX attribute is correct.");
+    
+                            test(function () {
+                                assert_between_inclusive(event.clientY, 150, 150 + rectSquare1.height - 1, "ClientY should be in the boundaries of the black box");
+                            }, event.type + ".ClientY attribute is correct.");
+                        } else {
+                            test(function () {
+                                assert_true(event.clientX < 100 || event.clientX > 100 + rectSquare1.width - 1 || event.clientY < 150 || event.clientY > 150 + rectSquare1.Height - 1, "ClientX/Y should be out of the boundaries of the black box");
+                            }, event.type + " ClientX and ClientY attribute is correct.");
+                        }
+
+                        test(function () {
+                            assert_equals(event.isPrimary, true, "isPrimary should be true");
+                        }, event.type + ".isPrimary attribute is correct.");
+
+                        check_PointerEvent(event);
+                        detected_eventTypes[event.type] = true;
+                        if (Object.keys(detected_eventTypes).length == eventList.length)
+                            test_pointerEvent.done();
+                    });
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Pointer Events pointerdown tests</h1>
+        <h4>
+            Test Description: This test checks the properties of mouse pointer events. Move your mouse over the black square and click on it. Then move it off the black square.
+        </h4>
+        Test passes if the proper behavior of the events is observed.
+        <div id="square1" class="square"></div>
+        <div class="spacer"></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+            <p>Refresh the page to run the tests again with a different pointer type.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>
+

--- a/pointerevents/pointerevent_styles.css
+++ b/pointerevents/pointerevent_styles.css
@@ -1,3 +1,20 @@
+.spacer {
+height: 100px;
+}
+
+#square1 {
+background: black;
+top: 150px;
+left: 100px;
+}
+
+.square {
+height: 20px;
+width: 20px;
+position: absolute;
+padding: 0px;
+}
+
 #target0 {
 background: black;
 color: white;


### PR DESCRIPTION
closes #3111

Although these properties are from mouse events and do not directly exists in pointer event spec but there should be some tests handling pointer events and verifying these properties. Particularly since there was a bug in Blink about this I thought it is worth to add a test for it.
