### PR TITLE
Add test for AddEventListenerOptions passive member

### DIFF
--- a/dom/events/AddEventListenerOptions-passive.html
+++ b/dom/events/AddEventListenerOptions-passive.html
@@ -106,6 +106,8 @@ test(function() {
   testOptionEquivalence({}, {passive:false}, true);
   testOptionEquivalence({passive:true}, {passive:false}, true);
   testOptionEquivalence(undefined, {passive:true}, true);
+  testOptionEquivalence({capture: true, passive: false}, {capture: true, passive: true}, true);
+
 }, "Equivalence of option values");
 
 </script>

--- a/dom/events/AddEventListenerOptions-passive.html
+++ b/dom/events/AddEventListenerOptions-passive.html
@@ -1,0 +1,111 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<title>EventListenerOptions.passive</title>
+<link rel="author" title="Rick Byers" href="mailto:rbyers@chromium.org">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-addeventlisteneroptions-passive">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+
+<script>
+
+test(function() {
+  var supportsPassive = false;
+  var query_options = {
+    get passive() {
+      supportsPassive = true;
+      return false;
+    },
+    get dummy() {
+      assert_unreached("dummy value getter invoked");
+      return false;
+    }
+  };
+
+  document.addEventListener('test_event', null, query_options);
+  assert_true(supportsPassive, "addEventListener doesn't support the passive option");
+
+  supportsPassive = false;
+  document.removeEventListener('test_event', null, query_options);
+  assert_false(supportsPassive, "removeEventListener supports the passive option when it should not");
+}, "Supports passive option on addEventListener only");
+
+function testPassiveValue(optionsValue, expectedDefaultPrevented) {
+  var defaultPrevented = undefined;
+  var handler = function handler(e) {
+    assert_false(e.defaultPrevented, "Event prematurely marked defaultPrevented");
+    e.preventDefault();
+    defaultPrevented = e.defaultPrevented;
+  }
+  document.addEventListener('test', handler, optionsValue);
+  var uncanceled = document.body.dispatchEvent(new Event('test', {bubbles: true, cancelable: true}));
+
+  assert_equals(defaultPrevented, expectedDefaultPrevented, "Incorrect defaultPrevented for options: " + JSON.stringify(optionsValue));
+  assert_equals(uncanceled, !expectedDefaultPrevented, "Incorrect return value from dispatchEvent");
+
+  document.removeEventListener('test', handler, optionsValue);
+}
+
+test(function() {
+  testPassiveValue(undefined, true);
+  testPassiveValue({}, true);
+  testPassiveValue({passive: false}, true);
+  testPassiveValue({passive: true}, false);
+  testPassiveValue({passive: 0}, true);
+  testPassiveValue({passive: 1}, false);
+}, "preventDefault should be ignored if-and-only-if the passive option is true");
+
+function testPassiveWithOtherHandlers(optionsValue, expectedDefaultPrevented) {
+  var handlerInvoked1 = false;
+  var dummyHandler1 = function() {
+    handlerInvoked1 = true;
+  };
+  var handlerInvoked2 = false;
+  var dummyHandler2 = function() {
+    handlerInvoked2 = true;
+  };
+
+  document.addEventListener('test', dummyHandler1, {passive:true});
+  document.addEventListener('test', dummyHandler2);
+
+  testPassiveValue(optionsValue, expectedDefaultPrevented);
+
+  assert_true(handlerInvoked1, "Extra passive handler not invoked");
+  assert_true(handlerInvoked2, "Extra non-passive handler not invoked");
+
+  document.removeEventListener('test', dummyHandler1);
+  document.removeEventListener('test', dummyHandler2);
+}
+
+test(function() {
+  testPassiveWithOtherHandlers({}, true);
+  testPassiveWithOtherHandlers({passive: false}, true);
+  testPassiveWithOtherHandlers({passive: true}, false);
+}, "passive behavior of one listener should be unaffeted by the presence of other listeners");
+
+function testOptionEquivalence(optionValue1, optionValue2, expectedEquality) {
+  var invocationCount = 0;
+  var handler = function handler(e) {
+    invocationCount++;
+  }
+  document.addEventListener('test', handler, optionValue1);
+  document.addEventListener('test', handler, optionValue2);
+  document.body.dispatchEvent(new Event('test', {bubbles: true}));
+  assert_equals(invocationCount, expectedEquality ? 1 : 2, "equivalence of options " +
+    JSON.stringify(optionValue1) + " and " + JSON.stringify(optionValue2));
+  document.removeEventListener('test', handler, optionValue1);
+  document.removeEventListener('test', handler, optionValue2);
+}
+
+test(function() {
+  // Sanity check options that should be treated as distinct handlers
+  testOptionEquivalence({capture:true}, {capture:false, passive:false}, false);
+  testOptionEquivalence({capture:true}, {passive:true}, false);
+
+  // Option values that should be treated as equivalent
+  testOptionEquivalence({}, {passive:false}, true);
+  testOptionEquivalence({passive:true}, {passive:false}, true);
+  testOptionEquivalence(undefined, {passive:true}, true);
+}, "Equivalence of option values");
+
+</script>

--- a/dom/events/EventListenerOptions-capture.html
+++ b/dom/events/EventListenerOptions-capture.html
@@ -16,9 +16,9 @@ function testCaptureValue(captureValue, expectedValue) {
     handlerPhase = e.eventPhase;
   }
   document.addEventListener('test', handler, captureValue);
-  document.body.dispatchEvent(new Event('test', {'bubbles': true}));
+  document.body.dispatchEvent(new Event('test', {bubbles: true}));
   document.removeEventListener('test', handler, captureValue);
-  document.body.dispatchEvent(new Event('test', {'bubbles': true}));
+  document.body.dispatchEvent(new Event('test', {bubbles: true}));
   assert_equals(handlerPhase, expectedValue, "Incorrect event phase for value: " + JSON.stringify(captureValue));
 }
 
@@ -72,7 +72,7 @@ function testOptionEquality(addOptionValue, removeOptionValue, expectedEquality)
   }
   document.addEventListener('test', handler, addOptionValue);
   document.removeEventListener('test', handler, removeOptionValue);
-  document.body.dispatchEvent(new Event('test', {'bubbles': true}));
+  document.body.dispatchEvent(new Event('test', {bubbles: true}));
   assert_equals(!handlerInvoked, expectedEquality, "equivalence of options " +
     JSON.stringify(addOptionValue) + " and " + JSON.stringify(removeOptionValue));
   if (handlerInvoked)


### PR DESCRIPTION
Also includes a minor style cleanup to the related capture option test.

Includes logic from blink tests for this feature (updated for WPT style): [passive_dispatch.html](https://chromium.googlesource.com/chromium/src/+/b4cc79f5db2ea11ff1c865ce43bca1b035c6ef97/third_party/WebKit/LayoutTests/fast/events/eventlisteneroptions/passive_dispatch.html), [passive_inequality.html](https://chromium.googlesource.com/chromium/src/+/b4cc79f5db2ea11ff1c865ce43bca1b035c6ef97/third_party/WebKit/LayoutTests/fast/events/eventlisteneroptions/passive_inequality.html) and [passive_query.html](https://chromium.googlesource.com/chromium/src/+/b4cc79f5db2ea11ff1c865ce43bca1b035c6ef97/third_party/WebKit/LayoutTests/fast/events/eventlisteneroptions/passive_query.html).
