### PR TITLE
Fix fallback loading of <embed> inside an <object> with no type attribute to actually work reliably.

### DIFF
--- a/html/semantics/embedded-content/the-embed-element/embed-in-object-fallback-subdocument.html
+++ b/html/semantics/embedded-content/the-embed-element/embed-in-object-fallback-subdocument.html
@@ -1,0 +1,4 @@
+<script>
+  var varName = location.search.substr(1);
+  parent[varName] = true;
+</script>

--- a/html/semantics/embedded-content/the-embed-element/embed-in-object-fallback.html
+++ b/html/semantics/embedded-content/the-embed-element/embed-in-object-fallback.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Ensure that embed elements inside object elements load when the objects
+  fall back but not otherwise</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  var child1Loaded = false;
+  var child2Loaded = false;
+  var child3Loaded = false;
+  var parent3Loaded = false;
+</script>
+<object>
+  <embed src="embed-in-object-fallback-subdocument.html?child1Loaded">
+</object>
+<object>
+  <embed id="two" src="embed-in-object-fallback-subdocument.html?child2Loaded">
+  <!-- Something that forces the embed to be in the tree before the <object>
+       is done parsing -->
+  <script>
+    test(function() {
+      assert_equals(document.getElementById("two").localName,
+                    "embed");
+    }, "We have the right embed element");
+  </script>
+</object>
+<object data="embed-in-object-fallback-subdocument.html?parent3Loaded">
+  <embed src="embed-in-object-fallback-subdocument.html?child3Loaded">
+</object>
+<script>
+  var t = async_test("Check that the right things loaded");
+  onload = t.step_func_done(function() {
+    assert_true(child1Loaded, "child 1 should load");
+    assert_true(child2Loaded, "child 2 should load");
+    assert_false(child3Loaded, "child 3 should not load");
+    assert_true(parent3Loaded, "parent 3 should load");
+  });
+</script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1272651
