### PR TITLE
Make suppressing event handling on a document also block script execution for that document.

### DIFF
--- a/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts-subframe.html
+++ b/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts-subframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script>
+  var x = 0;
+</script>
+<!-- This script's URI is:
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', 'data:text/plain,aaa', false);
+  xhr.send();
+  x=1;
+  -->
+<script defer src="data:application/javascript,var%20x%20=%200;%20var%20xhr%20=%20new%20XMLHttpRequest();%20xhr.open('GET',%20'data:text/plain,aaa',%20false);%20xhr.send();%20x=1"></script>
+
+<!-- This script's URI is:
+  parent.postMessage(x, '*');
+-->
+<script defer src="data:application/javascript,parent.postMessage(x, '*');"></script>
+

--- a/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts.html
+++ b/XMLHttpRequest/xmlhttprequest-sync-block-defer-scripts.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Check that a sync XHR in a defer script blocks later defer scripts from running</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<!--
+  We run the test in a subframe, because something in the testharness stuff
+  interferes with defer scripts -->
+<script>
+  var t = async_test();
+  onmessage = t.step_func_done(function(e) {
+    assert_equals(e.data, 1);
+  });
+</script>
+<iframe src="xmlhttprequest-sync-block-defer-scripts-subframe.html"></iframe>

--- a/XMLHttpRequest/xmlhttprequest-sync-block-scripts.html
+++ b/XMLHttpRequest/xmlhttprequest-sync-block-scripts.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Check that while a sync XHR is in flight async script loads don't complete and run script</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<body>
+<script>
+var scriptRan = false;
+var onloadFired = false;
+test(function() {
+  var s = document.createElement("script");
+  s.src = "data:application/javascript,scriptRan = true;";
+  s.onload = function() { onloadFired = true; }
+  document.body.appendChild(s);
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", "data:,", false);
+  xhr.send();
+  assert_false(scriptRan, "Script should not have run");
+  assert_false(onloadFired, "load event for <script> should not have fired");
+});
+</script>
+</body>


### PR DESCRIPTION
Note that we do this here instead of when we suspend timeouts, because it makes
it simpler to handle situations in which a window's document changes while
things are suspended/blocked.

The nsDocumentViewer.cpp is not strictly needed, but avoids some extraneous
calls to SuppressEventHandling with a 0 suppression count.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1267989
