### PR TITLE
P1 Fetch "only-if-cached" cache mode tests.

### DIFF
--- a/fetch/api/request/request-cache.html
+++ b/fetch/api/request/request-cache.html
@@ -8,10 +8,58 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="resources/get-host-info.sub.js"></script>
   </head>
   <body>
     <script>
     var now = new Date();
+    /**
+     * Each test is run twice: once using etag/If-None-Match and once with
+     * date/If-Modified-Since.  Each test run gets its own URL and randomized
+     * content and operates independently.
+     *
+     * The test steps are run with request_cache.length fetch requests issued
+     * and their immediate results sanity-checked.  The cache.py server script
+     * stashes an entry containing any If-None-Match, If-Modified-Since, Pragma,
+     * and Cache-Control observed headers for each request it receives.  When
+     * the test fetches have run, this state is retrieved from cache.py and the
+     * expected_* lists are checked, including their length.
+     *
+     * This means that if a request_* fetch is expected to hit the cache and not
+     * touch the network, then there will be no entry for it in the expect_*
+     * lists.  AKA (request_cache.length - expected_validation_headers.length)
+     * should equal the number of cache hits that didn't touch the network.
+     *
+     * Test dictionary keys:
+     * - state: required string that determines whether the Expires response for
+     *   the fetched document should be set in the future ("fresh") or past
+     *   ("stale").
+     * - vary: optional string to be passed to the server for it to quote back
+     *   in a Vary header on the response to us.
+     * - cache_control: optional string to be passed to the server for it to
+     *   quote back in a Cache-Control header on the response to us.
+     * - redirect: optional string "same-origin" or "cross-origin".  If
+     *   provided, the server will issue an absolute redirect to the script on
+     *   the same or a different origin, as appropriate.  The redirected
+     *   location is the script with the redirect parameter removed, so the
+     *   content/state/etc. will be as if you hadn't specified a redirect.
+     * - request_cache: required array of cache modes to use (via `cache`).
+     * - request_headers: optional array of explicit fetch `headers` arguments.
+     *   If provided, the server will log an empty dictionary for each request
+     *   instead of the request headers it would normally log.
+     * - response: optional array of specialized response handling.  Right now,
+     *   "error" array entries indicate a network error response is expected
+     *   which will reject with a TypeError.
+     * - expected_validation_headers: required boolean array indicating whether
+     *   the server should have seen an If-None-Match/If-Modified-Since header
+     *   in the request.
+     * - expected_no_cache_headers: required boolean array indicating whether
+     *   the server should have seen Pragma/Cache-control:no-cache headers in
+     *   the request.
+     * - expected_max_age_headers: optional boolean array indicating whether
+     *   the server should have seen a Cache-Control:max-age=0 header in the
+     *   request.
+     */
     var tests = [
       {
         name: 'RequestCache "default" mode checks the cache for previously cached content and goes to the network for stale responses',
@@ -100,6 +148,62 @@
         request_cache: ["force-cache", "default"],
         expected_validation_headers: [false],
         expected_no_cache_headers: [false],
+      },
+      {
+        name: 'RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for stale responses',
+        state: "stale",
+        request_cache: ["default", "only-if-cached"],
+        expected_validation_headers: [false],
+        expected_no_cache_headers: [false]
+      },
+      {
+        name: 'RequestCache "only-if-cached" mode checks the cache for previously cached content and avoids revalidation for fresh responses',
+        state: "fresh",
+        request_cache: ["default", "only-if-cached"],
+        expected_validation_headers: [false],
+        expected_no_cache_headers: [false]
+      },
+      {
+        name: 'RequestCache "only-if-cached" mode checks the cache for previously cached content and does not go to the network if a cached response is not found',
+        state: "fresh",
+        request_cache: ["only-if-cached"],
+        response: ["error"],
+        expected_validation_headers: [],
+        expected_no_cache_headers: []
+      },
+      {
+        name: 'RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content',
+        state: "fresh",
+        request_cache: ["default", "only-if-cached"],
+        redirect: "same-origin",
+        expected_validation_headers: [false, false],
+        expected_no_cache_headers: [false, false],
+      },
+      {
+        name: 'RequestCache "only-if-cached" (with "same-origin") uses cached same-origin redirects to same-origin content',
+        state: "stale",
+        request_cache: ["default", "only-if-cached"],
+        redirect: "same-origin",
+        expected_validation_headers: [false, false],
+        expected_no_cache_headers: [false, false],
+      },
+      {
+        name: 'RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects',
+        state: "fresh",
+        request_cache: ["default", "only-if-cached"],
+        redirect: "cross-origin",
+        response: [null, "error"],
+        expected_validation_headers: [false, false],
+        expected_no_cache_headers: [false, false],
+      },
+      {
+        name: 'RequestCache "only-if-cached" (with "same-origin") does not follow redirects across origins and rejects',
+        state: "stale",
+        request_cache: ["default", "only-if-cached"],
+        redirect: "cross-origin",
+        response: [null, "error"],
+        expected_validation_headers: [false, false],
+        expected_no_cache_headers: [false, false],
       },
       {
         name: 'RequestCache "no-store" mode does not check the cache for previously cached content and goes to the network regardless',
@@ -348,6 +452,9 @@
         expected_no_cache_headers: [false, true],
       },
     ];
+    function base_path() {
+      return location.pathname.replace(/\/[^\/]*$/, '/');
+    }
     function make_url(uuid, id, value, content, info) {
       var dates = {
         fresh: new Date(now.getFullYear() + 1, now.getMonth(), now.getDay()).toGMTString(),
@@ -361,16 +468,36 @@
       if ("cache_control" in info) {
         cache_control = "&cache_control=" + info.cache_control;
       }
+      var redirect = "";
+
       var ignore_request_headers = "";
       if ("request_headers" in info) {
         // Ignore the request headers that we send since they may be synthesized by the test.
         ignore_request_headers = "&ignore";
       }
-      return "resources/cache.py?token=" + uuid +
-             "&content=" + content +
-             "&" + id + "=" + value +
-             "&expires=" + dates[info.state] +
-             vary + cache_control + ignore_request_headers;
+      var url_sans_redirect = "resources/cache.py?token=" + uuid +
+        "&content=" + content +
+        "&" + id + "=" + value +
+        "&expires=" + dates[info.state] +
+        vary + cache_control + ignore_request_headers;
+      // If there's a redirect, the target is the script without any redirect at
+      // either the same domain or a different domain.
+      if ("redirect" in info) {
+        var host_info = get_host_info();
+        var origin;
+        switch (info.redirect) {
+          case "same-origin":
+            origin = host_info['HTTP_ORIGIN'];
+            break;
+          case "cross-origin":
+            origin = host_info['HTTP_REMOTE_ORIGIN'];
+            break;
+        }
+        var redirected_url = origin + base_path() + url_sans_redirect;
+        return url_sans_redirect + "&redirect=" + encodeURIComponent(redirected_url);
+      } else {
+        return url_sans_redirect;
+      }
     }
     function expected_status(type, identifier, init) {
       if (type == "date" &&
@@ -395,21 +522,10 @@
         .then(function(response) {
           return response.text();
         }).then(function(text) {
-          return JSON.parse(text);
-        });
-    }
-    function populate_cache(url, content, info, type, identifier) {
-      var init = {cache: info.request_cache[0]};
-      if ("request_headers" in info) {
-        init.headers = info.request_headers[0];
-      }
-      return fetch(url, init)
-        .then(function(response) {
-          assert_array_equals([response.status, response.statusText],
-                              expected_status(type, identifier, init));
-          return response.text();
-        }).then(function(text) {
-          assert_equals(text, expected_response_text(type, identifier, init, content));
+          // null will be returned if the server never received any requests
+          // for the given uuid.  Normalize that to an empty list consistent
+          // with our representation.
+          return JSON.parse(text) || [];
         });
     }
     function make_test(type, info) {
@@ -418,22 +534,34 @@
         var identifier = (type == "tag" ? Math.random() : now.toGMTString());
         var content = Math.random().toString();
         var url = make_url(uuid, type, identifier, content, info);
-        var fetch_functions = [function() {
-          return populate_cache(url, content, info, type, identifier);
-        }];
-        for (var i = 1; i < info.request_cache.length; ++i) {
+        var fetch_functions = [];
+        for (var i = 0; i < info.request_cache.length; ++i) {
           fetch_functions.push(function(idx) {
             var init = {cache: info.request_cache[idx]};
             if ("request_headers" in info) {
               init.headers = info.request_headers[idx];
             }
+            if (init.cache === "only-if-cached") {
+              // only-if-cached requires we use same-origin mode.
+              init.mode = "same-origin";
+            }
             return fetch(url, init)
               .then(function(response) {
+                if ("response" in info && info.response[idx] === "error") {
+                  assert_true(false, "fetch should have been an error");
+                  return;
+                }
                 assert_array_equals([response.status, response.statusText],
                                     expected_status(type, identifier, init));
                 return response.text();
               }).then(function(text) {
                 assert_equals(text, expected_response_text(type, identifier, init, content));
+              }, function(reason) {
+                if ("response" in info && info.response[idx] === "error") {
+                  assert_throws(new TypeError(), function() { throw reason; });
+                } else {
+                  throw reason;
+                }
               });
           });
         }

--- a/fetch/api/request/request-error.html
+++ b/fetch/api/request/request-error.html
@@ -63,6 +63,12 @@
       },"RequestInit's mode is no-cors and integrity is not empty");
 
       test(function() {
+        assert_throws(new TypeError() ,
+                      function() { new Request("", {"mode" : "cors", "cache" : "only-if-cached"}); },
+                      "Expect TypeError exception");
+      },"RequestInit's cache mode is only-if-cached and mode is not same-origin");
+
+      test(function() {
         var initialHeaders = new Headers([["Content-Type", "potato"]]);
         var initialRequest = new Request("", {"headers" : initialHeaders});
         var request = new Request(initialRequest);

--- a/fetch/api/request/resources/cache.py
+++ b/fetch/api/request/resources/cache.py
@@ -10,6 +10,7 @@ def main(request, response):
     expires = request.GET.first("expires", None)
     vary = request.GET.first("vary", None)
     cc = request.GET.first("cache_control", None)
+    redirect = request.GET.first("redirect", None)
     inm = request.headers.get("If-None-Match", None)
     ims = request.headers.get("If-Modified-Since", None)
     pragma = request.headers.get("Pragma", None)
@@ -43,8 +44,16 @@ def main(request, response):
     if cc:
         response.headers.set("Cache-Control", cc)
 
-    if ((inm is not None and inm == tag) or
-        (ims is not None and ims == date)):
+    # The only-if-cached redirect tests wants CORS to be okay, the other tests
+    # are all same-origin anyways and don't care.
+    response.headers.set("Access-Control-Allow-Origin", "*");
+
+    if redirect:
+        response.headers.set("Location", redirect);
+        response.status = (302, "Redirect")
+        return ""
+    elif ((inm is not None and inm == tag) or
+          (ims is not None and ims == date)):
         response.status = (304, "Not Modified")
         return ""
     else:

--- a/fetch/api/request/resources/get-host-info.sub.js
+++ b/fetch/api/request/resources/get-host-info.sub.js
@@ -1,0 +1,32 @@
+// This file is duplicated verbatim from:
+// service-workers/service-worker/resources/get-host-info.sub.js
+// with the rationale that:
+// - it's better to not reinvent this
+// - at the same time, referencing tests deep inside a sibling test group is
+//   not a great idea and copying the file is the lesser evil.
+function get_host_info() {
+  var ORIGINAL_HOST = '127.0.0.1';
+  var REMOTE_HOST = 'localhost';
+  var UNAUTHENTICATED_HOST = 'example.test';
+  var HTTP_PORT = 8000;
+  var HTTPS_PORT = 8443;
+  try {
+    // In W3C test, we can get the hostname and port number in config.json
+    // using wptserve's built-in pipe.
+    // http://wptserve.readthedocs.org/en/latest/pipes.html#built-in-pipes
+    HTTP_PORT = eval('{{ports[http][0]}}');
+    HTTPS_PORT = eval('{{ports[https][0]}}');
+    ORIGINAL_HOST = eval('\'{{host}}\'');
+    REMOTE_HOST = 'www1.' + ORIGINAL_HOST;
+  } catch (e) {
+  }
+  return {
+    HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT,
+    HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + ':' + HTTP_PORT,
+    HTTPS_REMOTE_ORIGIN: 'https://' + REMOTE_HOST + ':' + HTTPS_PORT,
+    HTTPS_REMOTE_ORIGIN_WITH_CREDS: 'https://foo:bar@' + REMOTE_HOST + ':' + HTTPS_PORT,
+    UNAUTHENTICATED_ORIGIN: 'http://' + UNAUTHENTICATED_HOST + ':' + HTTP_PORT
+  };
+}

--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -431,7 +431,7 @@ async_test(function(t) {
     var scope = 'resources/simple.html?cache';
     var frame;
     var cacheTypes = [
-      undefined, 'default', 'no-store', 'reload', 'no-cache', 'force-cache'
+      undefined, 'default', 'no-store', 'reload', 'no-cache', 'force-cache', 'only-if-cached'
     ];
     service_worker_unregister_and_register(t, worker, scope)
       .then(function(reg) {
@@ -443,8 +443,13 @@ async_test(function(t) {
           assert_equals(frame.contentWindow.document.body.textContent, 'default');
           var tests = cacheTypes.map(function(type) {
             return new Promise(function(resolve, reject) {
-                return frame.contentWindow.fetch(scope + '=' + type,
-                                                 {cache: type})
+                var init = {cache: type};
+                if (type === 'only-if-cached') {
+                  // For privacy reasons, for the time being, only-if-cached
+                  // requires the mode to be same-origin.
+                  init.mode = 'same-origin';
+                }
+                return frame.contentWindow.fetch(scope + '=' + type, init)
                   .then(function(response) { return response.text(); })
                   .then(function(response_text) {
                       var expected = (type === undefined) ? 'default' : type;


### PR DESCRIPTION
request-error.html:
- Add test verifying we enforce only-if-cached requires same-origin mode.

request-cache.html (only-if-cached does not hit network):
- Add comment block explaining the test dictionary arguments.
- Eliminate duplicated code in populate_cache which seems to have existed only
  for historical reasons and is now moot.
- Add `response` optional test dictionary array for cases where a network error
  is expected as the result of the fetch.  Normalize server results to handle
  this case since test cases may no longer talk to the server at all.
- Add only-if-cached tests that verify the network is not touched in any of
  the fresh cached, stale cached, and not cached cases.

request-cache.html (cross-origin redirects in the cache are not traversed):
- Tests added to request/request-cache.html instead of under redirect/ because
  redirect/ and redirect.py explicitly disable caching.  Also, the issue is
  about cache behavior, not the redirect-following logic.
- Enhance cache.py to accept a "redirect" parameter that generates a 302
  redirect using a Location header when received.
- Make the "error" handling generate a test failure if we don't fail when
  expected.
- Add "redirect" argument to request-cache.html test info dicts to tell
  cache.py to generate a redirect.
- Add test cases for "only-if-cached" to first prime with redirect, expecting
  success on same-origin redirects and failure on cross-origin redirects.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1272436
