### PR TITLE
Battery: add a test loading an iframe page that is NOT about:blank

### DIFF
--- a/battery-status/battery-promise-iframe.html
+++ b/battery-status/battery-promise-iframe.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Battery Test: each Navigator object has a battery promise for BatteryManager</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  iframe {
+    display: none;
+  }
+</style>
+<div id="log"></div>
+<iframe id="blank" src="about:blank"></iframe>
+<iframe id="frame" src="support-iframe-initial.html"></iframe>
+<script>
+promise_test(function(t) {
+  var iframe = document.querySelector('#blank');
+  var originalPromise = navigator.getBattery();
+
+  return originalPromise.then(function(originalManager) {
+    var promise = iframe.contentWindow.navigator.getBattery();
+
+    assert_true(originalManager instanceof BatteryManager);
+    assert_not_equals(iframe.contentWindow.navigator,
+        navigator,
+        'navigator objects shall be different');
+    assert_not_equals(promise,
+        originalPromise,
+        'battery promises in different navigators shall be different');
+    assert_equals(iframe.contentWindow.navigator.getBattery(),
+        promise,
+        'battery promises in same navigator shall be same');
+
+    return promise;
+  }).then(function(manager) {
+    assert_equals(manager.__proto__,
+        iframe.contentWindow.BatteryManager.prototype);
+    assert_true(manager instanceof iframe.contentWindow.BatteryManager);
+  });
+
+}, 'iframe has a different Navigator object thus getting another battery promise');
+
+async_test(function (t) {
+  var iframe = document.querySelector('#blank');
+  var originalNavigator = iframe.contentWindow.navigator;
+  var originalPromise = iframe.contentWindow.navigator.getBattery();
+
+  iframe.onload = t.step_func(function() {
+    assert_equals(iframe.contentWindow.navigator,
+        originalNavigator,
+        'navigator objects shall be same');
+    assert_equals(iframe.contentWindow.navigator.getBattery(),
+        originalPromise,
+        'battery status promises shall be same');
+    t.done();
+  });
+
+  iframe.src = 'support-iframe.html';
+}, 'setting src of an iframe with initial about:blank makes same Navigator object and battery promise');
+
+async_test(function (t) {
+  window.onmessage = t.step_func(function(e) {
+    var iframe = document.querySelector('#frame');
+    var originalNavigator = iframe.contentWindow.navigator;
+    var originalPromise = iframe.contentWindow.navigator.getBattery();
+
+    assert_equals(e.data, 'loaded');
+
+    iframe.onload = t.step_func(function() {
+      assert_not_equals(iframe.contentWindow.navigator,
+          originalNavigator,
+          'navigator objects shall be changed');
+      assert_not_equals(iframe.contentWindow.navigator.getBattery(),
+          originalPromise,
+          'battery status promises shall be different');
+      t.done();
+    });
+
+    iframe.src = 'support-iframe.html';
+  });
+}, 'setting src of an iframe with initial frame makes its Navigator object vary thus getting another battery promise');
+</script>

--- a/battery-status/battery-promise-iframe.html
+++ b/battery-status/battery-promise-iframe.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Battery Test: each Navigator object has a battery promise for BatteryManager</title>
+<title>Battery Test: iframe has a different Navigator object</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/battery-status/battery-promise-window.html
+++ b/battery-status/battery-promise-window.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Battery Test: each Navigator object has a battery promise for BatteryManager</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #note {
+    background-color: #fef1b5;
+    border: solid 1px #cdab2d;
+    padding: 5px;
+    margin: 15px;
+    display: block;
+  }
+</style>
+<div id="note">
+  Allow pop-up windows before running the tests.
+</div>
+<div id="log"></div>
+<script>
+async_test(function (t) {
+  var win = window.open('support-window-open.html');
+  window.onmessage = t.step_func(function(e) {
+    assert_array_equals(e.data, [false, false, true]);
+    win.close();
+    t.done();
+  });
+}, 'window.open() makes a different Navigator object thus getting another battery promise');
+</script>

--- a/battery-status/battery-promise-window.html
+++ b/battery-status/battery-promise-window.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Battery Test: each Navigator object has a battery promise for BatteryManager</title>
+<title>Battery Test: window.open() makes a different Navigator object</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/battery-status/battery-promise.html
+++ b/battery-status/battery-promise.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Battery Test: each Navigator object has a battery promise for BatteryManager</title>
+<title>Battery Test: navigator.getBattery() always return same battery promise</title>
 <link rel="author" title="YuichiNukiyama" href="https://github.com/YuichiNukiyama">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/battery-status/battery-promise.html
+++ b/battery-status/battery-promise.html
@@ -4,23 +4,7 @@
 <link rel="author" title="YuichiNukiyama" href="https://github.com/YuichiNukiyama">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<style>
-  #note {
-    background-color: #fef1b5;
-    border: solid 1px #cdab2d;
-    padding: 5px;
-    margin: 15px;
-    display: block;
-  }
-  iframe {
-    display: none;
-  }
-</style>
-<div id="note">
-  Allow pop-up windows before running the tests.
-</div>
 <div id="log"></div>
-<iframe src="about:blank"></iframe>
 <script>
 promise_test(function () {
   return navigator.getBattery().then(function (result) {
@@ -32,57 +16,4 @@ promise_test(function () {
 test(function () {
   assert_equals(navigator.getBattery(), navigator.getBattery());
 }, 'navigator.getBattery() shall always return the same promise');
-
-promise_test(function(t) {
-  var iframe = document.querySelector('iframe');
-  var originalPromise = navigator.getBattery();
-
-  return originalPromise.then(function(originalManager) {
-    var promise = iframe.contentWindow.navigator.getBattery();
-
-    assert_true(originalManager instanceof BatteryManager);
-    assert_not_equals(iframe.contentWindow.navigator,
-        navigator,
-        'navigator objects shall be different');
-    assert_not_equals(promise,
-        originalPromise,
-        'battery promises in different navigators shall be different');
-    assert_equals(iframe.contentWindow.navigator.getBattery(),
-        promise,
-        'battery promises in same navigator shall be same');
-
-    return promise;
-  }).then(function(manager) {
-    assert_equals(manager.__proto__,
-        iframe.contentWindow.BatteryManager.prototype);
-    assert_true(manager instanceof iframe.contentWindow.BatteryManager);
-  });
-
-}, 'iframe has a different Navigator object thus getting another battery promise');
-
-async_test(function (t) {
-  var iframe = document.querySelector('iframe');
-  var originalNavigator = iframe.contentWindow.navigator;
-  var originalPromise = iframe.contentWindow.navigator.getBattery();
-
-  iframe.onload = t.step_func(function() {
-    assert_equals(iframe.contentWindow.navigator,
-        originalNavigator,
-        'navigator objects shall be same');
-    assert_equals(iframe.contentWindow.navigator.getBattery(),
-        originalPromise,
-        'battery status promises shall be same');
-    t.done();
-  });
-  iframe.src = 'support-iframe.html';
-}, 'setting iframe\'s src makes same Navigator object and battery promise');
-
-async_test(function (t) {
-  var win = window.open('support-window-open.html');
-  window.onmessage = t.step_func(function(e) {
-    assert_array_equals(e.data, [false, false, true]);
-    win.close();
-    t.done();
-  });
-}, 'window.open() makes a different Navigator object thus getting another battery promise');
 </script>

--- a/battery-status/support-iframe-initial.html
+++ b/battery-status/support-iframe-initial.html
@@ -1,0 +1,5 @@
+<!DOCTYPE HTML>
+<meta charset="utf-8">
+<script>
+window.parent.postMessage('loaded', '*');
+</script>


### PR DESCRIPTION
Also split the tests checking a battery promise per navigator because
onmessage is used in both iframe and new window scenarios.

Resolve #3107.
