### PR TITLE
Fix observedAttributes test to ensure attributeChangedCallback exists

### DIFF
--- a/custom-elements/custom-elements-registry/define.html
+++ b/custom-elements/custom-elements-registry/define.html
@@ -164,6 +164,7 @@
   test(() => {
     class C {
       static get observedAttributes() { throw_rethrown_error(); }
+      attributeChangedCallback() {}
     }
     assert_rethrown(() => {
       customElements.define('test-define-observedattributes-rethrow', C);


### PR DESCRIPTION
As per the discussion in whatwg/html#1373[1] observedAttributes is not read
when attributeChangedCallback does not exist.

[1] https://github.com/whatwg/html/issues/1373
