### PR TITLE
Replaced InvalidAccessError by TypeError in MSE tests

### DIFF
--- a/media-source/mediasource-addsourcebuffer.html
+++ b/media-source/mediasource-addsourcebuffer.html
@@ -20,7 +20,7 @@
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                           function() { mediaSource.addSourceBuffer(""); },
                           "addSourceBuffer() threw an exception when passed an empty string.");
               test.done();

--- a/media-source/mediasource-append-buffer.html
+++ b/media-source/mediasource-append-buffer.html
@@ -517,7 +517,7 @@
               test.expectEvent(sourceBuffer, "update", "Append success.");
               test.expectEvent(sourceBuffer, "updateend", "Append ended.");
 
-              assert_throws( { name: "TypeError"} ,
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendBuffer(null); },
                   "appendBuffer(null) throws an exception.");
               test.done();
@@ -527,7 +527,7 @@
           {
               mediaSource.removeSourceBuffer(sourceBuffer);
 
-              assert_throws( { name: "InvalidStateError"} ,
+              assert_throws("InvalidStateError",
                   function() { sourceBuffer.appendBuffer(mediaData); },
                   "appendBuffer() throws an exception when called after removeSourceBuffer().");
               test.done();

--- a/media-source/mediasource-appendwindow.html
+++ b/media-source/mediasource-appendwindow.html
@@ -44,39 +44,39 @@
                   function() { sourceBuffer.appendWindowStart = Number.NaN; },
                   "set appendWindowStart throws an exception for Number.NaN.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowStart = 600.0; },
                   "set appendWindowStart throws an exception when greater than appendWindowEnd.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowStart = sourceBuffer.appendWindowEnd; },
                   "set appendWindowStart throws an exception when equal to appendWindowEnd.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowEnd = sourceBuffer.appendWindowStart; },
                   "set appendWindowEnd throws an exception when equal to appendWindowStart.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowEnd = sourceBuffer.appendWindowStart - 1; },
                   "set appendWindowEnd throws an exception if less than appendWindowStart.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowStart = -100.0; },
                   "set appendWindowStart throws an exception when less than 0.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowEnd = -100.0; },
                   "set appendWindowEnd throws an exception when less than 0.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowEnd = Number.NaN; },
                   "set appendWindowEnd throws an exception if NaN.");
 
-              assert_throws("InvalidAccessError",
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowEnd = undefined; },
                   "set appendWindowEnd throws an exception if undefined.");
 
-              assert_throws({name: "TypeError"},
+              assert_throws(new TypeError(),
                   function() { sourceBuffer.appendWindowStart = undefined; },
                   "set appendWindowStart throws an exception if undefined.");
 

--- a/media-source/mediasource-duration-boundaryconditions.html
+++ b/media-source/mediasource-duration-boundaryconditions.html
@@ -49,14 +49,14 @@
           DurationBoundaryConditionTest(Number.MAX_VALUE, null, "Set duration to Number.MAX_VALUE");
           DurationBoundaryConditionTest(Number.MIN_VALUE, null, "Set duration to Number.MIN_VALUE");
           DurationBoundaryConditionTest(Number.MAX_VALUE - 1, null, "Set duration to Number.MAX_VALUE - 1");
-          DurationBoundaryConditionTest(Number.MIN_VALUE - 1, "InvalidAccessError", "Set duration to Number.MIN_VALUE - 1");
+          DurationBoundaryConditionTest(Number.MIN_VALUE - 1, new TypeError(), "Set duration to Number.MIN_VALUE - 1");
           DurationBoundaryConditionTest(Number.POSITIVE_INFINITY, null, "Set duration to Number.POSITIVE_INFINITY");
-          DurationBoundaryConditionTest(Number.NEGATIVE_INFINITY, "InvalidAccessError", "Set duration to Number.NEGATIVE_INFINITY");
-          DurationBoundaryConditionTest(-1 * Number.MAX_VALUE, "InvalidAccessError", "Set duration to lowest value.");
-          DurationBoundaryConditionTest(-101.9, "InvalidAccessError", "Set duration to a negative double.");
+          DurationBoundaryConditionTest(Number.NEGATIVE_INFINITY, new TypeError(), "Set duration to Number.NEGATIVE_INFINITY");
+          DurationBoundaryConditionTest(-1 * Number.MAX_VALUE, new TypeError(), "Set duration to lowest value.");
+          DurationBoundaryConditionTest(-101.9, new TypeError(), "Set duration to a negative double.");
           DurationBoundaryConditionTest(101.9, null, "Set duration to a positive double.");
           DurationBoundaryConditionTest(0, null, "Set duration to zero");
-          DurationBoundaryConditionTest(NaN, "InvalidAccessError", "Set duration to NaN");
+          DurationBoundaryConditionTest(NaN, new TypeError(), "Set duration to NaN");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-remove.html
+++ b/media-source/mediasource-remove.html
@@ -13,7 +13,7 @@
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
 
-              assert_throws("InvalidAccessError", function()
+              assert_throws(new TypeError(), function()
               {
                   sourceBuffer.remove(-1, 2);
               }, "remove");
@@ -42,7 +42,7 @@
 
               mediaSource.duration = 10;
 
-              assert_throws("InvalidAccessError", function()
+              assert_throws(new TypeError(), function()
               {
                   sourceBuffer.remove(11, 12);
               }, "remove");
@@ -56,7 +56,7 @@
 
               mediaSource.duration = 10;
 
-              assert_throws("InvalidAccessError", function()
+              assert_throws(new TypeError(), function()
               {
                   sourceBuffer.remove(2, 1);
               }, "remove");
@@ -68,7 +68,7 @@
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
 
-              assert_throws("InvalidAccessError", function()
+              assert_throws(new TypeError(), function()
               {
                   sourceBuffer.remove(0, Number.NEGATIVE_INFINITY);
               }, "remove");
@@ -80,7 +80,7 @@
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
 
-              assert_throws("InvalidAccessError", function()
+              assert_throws(new TypeError(), function()
               {
                   sourceBuffer.remove(0, Number.NaN);
               }, "remove");

--- a/media-source/mediasource-timestamp-offset.html
+++ b/media-source/mediasource-timestamp-offset.html
@@ -17,7 +17,7 @@
                   var sourceBuffer = mediaSource.addSourceBuffer(segmentInfo.type);
 
                   if (expected == "TypeError")  {
-                      assert_throws({name: "TypeError"},
+                      assert_throws(new TypeError(),
                           function() { sourceBuffer.timestampOffset = value; },
                           "setting timestampOffset to " + description + " throws an exception.");
                   } else {


### PR DESCRIPTION
The MSE spec now uses TypeError exceptions throughout but some tests were still expecting InvalidAccessError exceptions.

Also improved consistency: all calls to "assert_throws" that expect a TypeError now use the form "assert_throws(new TypeError(), ...)".
