### PR TITLE
Checks MediaSource.activeSourceBuffers and changes to track state

### DIFF
--- a/media-source/mediasource-activesourcebuffers.html
+++ b/media-source/mediasource-activesourcebuffers.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Checks MediaSource.activeSourceBuffers and changes to selected/enabled track state</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          // Audio / Video files supported by the user agent under test
+          var subType = MediaSourceUtil.getSubType(MediaSourceUtil.AUDIO_ONLY_TYPE);
+          var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
+          var manifestFilenameVideo = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
+          var manifestFilenameAV = subType + "/test-av-384k-44100Hz-1ch-320x240-30fps-10kfr-manifest.json";
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+              MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
+              {
+                  var sourceBuffer = mediaSource.addSourceBuffer(typeAudio);
+                  assert_equals(mediaSource.activeSourceBuffers.length, 0,
+                    "activeSourceBuffers is empty to start with");
+                  
+                  test.expectEvent(mediaElement, "loadedmetadata");
+                  test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
+                  sourceBuffer.appendBuffer(dataAudio);
+
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                        "activeSourceBuffers updated when media element is loaded");
+                      assert_equals(mediaSource.activeSourceBuffers[0], sourceBuffer,
+                        "activeSourceBuffers contains sourceBuffer when media element is loaded");
+                      test.done();
+                  });
+              });
+          }, "SourceBuffer added to activeSourceBuffers list when its only audio track gets loaded (and thus becomes enabled).");
+
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+              MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
+              {
+                  var sourceBuffer = mediaSource.addSourceBuffer(typeVideo);
+                  assert_equals(mediaSource.activeSourceBuffers.length, 0,
+                    "activeSourceBuffers is empty to start with");
+
+                  test.expectEvent(mediaElement, "loadedmetadata");
+                  test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
+                  sourceBuffer.appendBuffer(dataVideo);
+                  
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                        "activeSourceBuffers updated when media element is loaded");
+                      assert_equals(mediaSource.activeSourceBuffers[0], sourceBuffer,
+                        "activeSourceBuffers contains sourceBuffer when media element is loaded");
+                      test.done();
+                  });
+              });
+          }, "SourceBuffer added to activeSourceBuffers list when its only video track gets loaded (and thus becomes selected).");
+
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+              MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
+              {
+                  MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
+                  {
+                      var sourceBufferAudio = mediaSource.addSourceBuffer(typeAudio);
+                      var sourceBufferVideo = mediaSource.addSourceBuffer(typeVideo);
+                      assert_equals(mediaSource.activeSourceBuffers.length, 0,
+                        "activeSourceBuffers is empty to start with");
+                      assert_equals(mediaSource.sourceBuffers.length, 2,
+                        "sourceBuffers list contains both SourceBuffers");
+                      assert_equals(mediaSource.sourceBuffers[0], sourceBufferAudio,
+                        "first SourceBuffer is the audio one");
+                      assert_equals(mediaSource.sourceBuffers[1], sourceBufferVideo,
+                        "second SourceBuffer is the video one");
+
+                      test.expectEvent(mediaElement, "loadedmetadata");
+                      test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
+                      sourceBufferAudio.appendBuffer(dataAudio);
+                      sourceBufferVideo.appendBuffer(dataVideo);
+                      
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_equals(mediaSource.activeSourceBuffers.length, 2,
+                            "activeSourceBuffers list updated when tracks are loaded");
+                          assert_equals(mediaSource.activeSourceBuffers[0], sourceBufferAudio,
+                            "first active SourceBuffer is the audio one");
+                          assert_equals(mediaSource.activeSourceBuffers[1], sourceBufferVideo,
+                            "second active SourceBuffer is the video one");
+                          test.done();
+                      });
+                  });
+              });
+          }, "Active SourceBuffers must appear in the same order as they appear in the sourceBuffers attribute.");
+
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+              MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
+              {
+                  MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
+                  {
+                      var sourceBufferAudio = mediaSource.addSourceBuffer(typeAudio);
+                      var sourceBufferVideo = mediaSource.addSourceBuffer(typeVideo);
+
+                      test.expectEvent(sourceBufferAudio.audioTracks, "addtrack");
+                      test.expectEvent(sourceBufferVideo.videoTracks, "addtrack");
+                      sourceBufferAudio.appendBuffer(dataAudio);
+                      sourceBufferVideo.appendBuffer(dataVideo);
+                      
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_equals(mediaSource.activeSourceBuffers.length, 2,
+                            "activeSourceBuffers list updated when tracks are loaded");
+                          assert_equals(sourceBufferAudio.audioTracks.length, 1,
+                            "audio track list contains loaded audio track");
+                          assert_equals(sourceBufferVideo.videoTracks.length, 1,
+                            "video track list contains loaded video track");
+
+                          test.expectEvent(mediaSource.activeSourceBuffers, "removesourcebuffer");
+                          sourceBufferAudio.audioTracks[0].enabled = false;
+
+                          test.waitForExpectedEvents(function()
+                          {
+                              assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                                "audio source buffer no longer in the activeSourceBuffers list");
+                              assert_equals(mediaSource.activeSourceBuffers[0], sourceBufferVideo,
+                                "activeSourceBuffers list only contains the video SourceBuffer");
+
+                              test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
+                              test.expectEvent(mediaSource.activeSourceBuffers, "removesourcebuffer");
+                              sourceBufferAudio.audioTracks[0].enabled = true;
+                              sourceBufferVideo.videoTracks[0].selected = false;
+
+                              test.waitForExpectedEvents(function()
+                              {
+                                  assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                                    "video source buffer no longer in the activeSourceBuffers list");
+                                  assert_equals(mediaSource.activeSourceBuffers[0], sourceBufferAudio,
+                                    "activeSourceBuffers list only contains the audio SourceBuffer");
+                                  test.done();
+                              });
+                          });
+                      });
+                  });
+              });
+          }, "Active SourceBuffers list reflects changes to selected audio/video tracks associated with separate SourceBuffers.");
+
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+              MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAV, function (typeAV, dataAV)
+              {
+                  var sourceBuffer = mediaSource.addSourceBuffer(typeAV);
+
+                  test.expectEvent(sourceBuffer.audioTracks, "addtrack");
+                  test.expectEvent(sourceBuffer.videoTracks, "addtrack");
+                  sourceBuffer.appendBuffer(dataAV);
+                  
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                        "activeSourceBuffers list updated when tracks are loaded");
+                      assert_equals(sourceBuffer.audioTracks.length, 1,
+                        "audio track list contains loaded audio track");
+                      assert_equals(sourceBuffer.videoTracks.length, 1,
+                        "video track list contains loaded video track");
+
+                      mediaSource.activeSourceBuffers.addEventListener("removesourcebuffer", test.unreached_func(
+                        "Unexpected removal from activeSourceBuffers list"));
+                      mediaSource.activeSourceBuffers.addEventListener("addsourcebuffer", test.unreached_func(
+                        "Unexpected insertion in activeSourceBuffers list"));
+
+                      // Changes should only trigger events at the
+                      // AudioTrack/VideoTrack instance
+                      test.expectEvent(sourceBuffer.audioTracks, "change");
+                      sourceBuffer.audioTracks[0].enabled = false;
+
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                            "activeSourceBuffers list unchanged");
+
+                          test.expectEvent(sourceBuffer.videoTracks, "change");
+                          sourceBuffer.audioTracks[0].enabled = true;
+                          sourceBuffer.videoTracks[0].selected = false;
+
+                          test.waitForExpectedEvents(function()
+                          {
+                              assert_equals(mediaSource.activeSourceBuffers.length, 1,
+                                "activeSourceBuffers list unchanged");
+                              test.done();
+                          });
+                      });
+                  });
+              });
+          }, "Active SourceBuffers list ignores changes to selected audio/video tracks " +
+            "that do not affect the activation of the SourceBuffer.");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-activesourcebuffers.html
+++ b/media-source/mediasource-activesourcebuffers.html
@@ -23,7 +23,7 @@
                   var sourceBuffer = mediaSource.addSourceBuffer(typeAudio);
                   assert_equals(mediaSource.activeSourceBuffers.length, 0,
                     "activeSourceBuffers is empty to start with");
-                  
+
                   test.expectEvent(mediaElement, "loadedmetadata");
                   test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
                   sourceBuffer.appendBuffer(dataAudio);
@@ -52,7 +52,7 @@
                   test.expectEvent(mediaElement, "loadedmetadata");
                   test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
                   sourceBuffer.appendBuffer(dataVideo);
-                  
+
                   test.waitForExpectedEvents(function()
                   {
                       assert_equals(mediaSource.activeSourceBuffers.length, 1,
@@ -87,7 +87,7 @@
                       test.expectEvent(mediaSource.activeSourceBuffers, "addsourcebuffer");
                       sourceBufferAudio.appendBuffer(dataAudio);
                       sourceBufferVideo.appendBuffer(dataVideo);
-                      
+
                       test.waitForExpectedEvents(function()
                       {
                           assert_equals(mediaSource.activeSourceBuffers.length, 2,
@@ -117,7 +117,7 @@
                       test.expectEvent(sourceBufferVideo.videoTracks, "addtrack");
                       sourceBufferAudio.appendBuffer(dataAudio);
                       sourceBufferVideo.appendBuffer(dataVideo);
-                      
+
                       test.waitForExpectedEvents(function()
                       {
                           assert_equals(mediaSource.activeSourceBuffers.length, 2,
@@ -167,7 +167,7 @@
                   test.expectEvent(sourceBuffer.audioTracks, "addtrack");
                   test.expectEvent(sourceBuffer.videoTracks, "addtrack");
                   sourceBuffer.appendBuffer(dataAV);
-                  
+
                   test.waitForExpectedEvents(function()
                   {
                       assert_equals(mediaSource.activeSourceBuffers.length, 1,


### PR DESCRIPTION
The tests only cover the configurations required by the specification, namely:
- one SourceBuffer with one audio and/or one video track
- one SourceBuffer with an audio track and one SourceBuffer with a video track

The tests do not try to create more SourceBuffer objects in particular and do not create text tracks.

The tests should cover all steps in section 2.4.5 "Changes to selected/enabled track state":
https://w3c.github.io/media-source/#active-source-buffer-changes

Note that Edge apparently does not yet support resetting the delaying-the-load-event-flag of the media element, and does not want to reach HAVE_CURRENT_DATA for video-only tracks, unless "endOfStream()" is called. This makes the test harness time out in some cases (because the "load" event is not fired on "window"), even though the underlying test cases actually pass. If needed, I may add calls to "mediaSource.endOfStream()".
