### PR TITLE
Completed MediaSource.removeSourceBuffer tests

### DIFF
--- a/media-source/mediasource-removesourcebuffer.html
+++ b/media-source/mediasource-removesourcebuffer.html
@@ -12,13 +12,13 @@
           mediasource_test(function(test, mediaElement, mediaSource)
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
-              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+              assert_class_string(sourceBuffer, "SourceBuffer", "New SourceBuffer returned");
 
               mediaSource.removeSourceBuffer(sourceBuffer);
 
               var sourceBuffer2 = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
-              assert_true(sourceBuffer2 != null, "New SourceBuffer returned");
-              assert_true(sourceBuffer != sourceBuffer2, "SourceBuffers are different instances.");
+              assert_class_string(sourceBuffer2, "SourceBuffer", "New SourceBuffer returned");
+              assert_not_equals(sourceBuffer, sourceBuffer2, "SourceBuffers are different instances.");
               assert_equals(mediaSource.sourceBuffers.length, 1, "sourceBuffers.length == 1");
 
               test.done();
@@ -35,7 +35,7 @@
           mediasource_test(function(test, mediaElement, mediaSource)
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
-              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+              assert_class_string(sourceBuffer, "SourceBuffer", "New SourceBuffer returned");
 
               mediaSource.removeSourceBuffer(sourceBuffer);
 
@@ -49,14 +49,14 @@
           mediasource_test(function(test, mediaElement, mediaSource)
           {
               var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
-              assert_true(sourceBuffer != null, "New SourceBuffer returned");
+              assert_class_string(sourceBuffer, "SourceBuffer", "New SourceBuffer returned");
 
               mediaSource.endOfStream();
-              assert_true(mediaSource.readyState == "ended", "MediaSource in ended state");
+              assert_equals(mediaSource.readyState, "ended", "MediaSource in ended state");
               mediaSource.removeSourceBuffer(sourceBuffer);
 
-              assert_true(mediaSource.sourceBuffers.length == 0, "MediaSource.sourceBuffers is empty");
-              assert_true(mediaSource.activeSourceBuffers.length == 0, "MediaSource.activesourceBuffers is empty");
+              assert_equals(mediaSource.sourceBuffers.length, 0, "MediaSource.sourceBuffers is empty");
+              assert_equals(mediaSource.activeSourceBuffers.length, 0, "MediaSource.activesourceBuffers is empty");
 
               test.done();
           }, "Test calling removeSourceBuffer() in ended state.");
@@ -71,8 +71,8 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_true(mediaSource.sourceBuffers.length == 1, "MediaSource.sourceBuffers is not empty");
-                  assert_true(mediaSource.activeSourceBuffers.length == 1, "MediaSource.activesourceBuffers is not empty");
+                  assert_equals(mediaSource.sourceBuffers.length, 1, "MediaSource.sourceBuffers is not empty");
+                  assert_equals(mediaSource.activeSourceBuffers.length, 1, "MediaSource.activesourceBuffers is not empty");
                   assert_equals(mediaElement.readyState, mediaElement.HAVE_METADATA);
                   assert_equals(mediaSource.duration, segmentInfo.duration);
                   test.expectEvent(mediaSource.activeSourceBuffers, "removesourcebuffer", "SourceBuffer removed from activeSourceBuffers.");
@@ -82,11 +82,29 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_true(mediaSource.sourceBuffers.length == 0, "MediaSource.sourceBuffers is empty");
-                  assert_true(mediaSource.activeSourceBuffers.length == 0, "MediaSource.activesourceBuffers is empty");
+                  assert_equals(mediaSource.sourceBuffers.length, 0, "MediaSource.sourceBuffers is empty");
+                  assert_equals(mediaSource.activeSourceBuffers.length, 0, "MediaSource.activesourceBuffers is empty");
                   test.done();
               });
           }, "Test removesourcebuffer event on activeSourceBuffers.");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaElement.addEventListener('error', test.unreached_func("Unexpected event 'error'"));
+              var mimetype = MediaSourceUtil.AUDIO_VIDEO_TYPE;
+              var sourceBuffer = mediaSource.addSourceBuffer(mimetype);
+              sourceBuffer.appendBuffer(new Uint8Array(0));
+              assert_true(sourceBuffer.updating, "Updating flag set when a buffer is appended.");
+              test.expectEvent(sourceBuffer, 'abort');
+              test.expectEvent(sourceBuffer, 'updateend');
+
+              mediaSource.removeSourceBuffer(sourceBuffer);
+              assert_false(sourceBuffer.updating, "Updating flag reset after abort.");
+              test.waitForExpectedEvents(function()
+              {
+                  test.done();
+              });
+          }, "Test abort event when removeSourceBuffer() called while SourceBuffer is updating");
         </script>
     </body>
 </html>


### PR DESCRIPTION
New test to ensure that the "abort" event gets fired when the SourceBuffer is updating.

Other tests updated to use more specific "assert_xx" calls instead of generic "assert_true" calls, as requested in the Test Review Checklist:
http://testthewebforward.org/docs/review-checklist.html#script-tests-only

(Note tests still do not cover TextTrack-related steps)
