### PR TITLE
Fixing flaky test in general readable stream tests

### DIFF
--- a/streams/readable-streams/general.js
+++ b/streams/readable-streams/general.js
@@ -281,8 +281,12 @@ promise_test(() => {
 promise_test(() => {
 
   let pullCount = 0;
+  const startPromise = Promise.resolve();
 
   const rs = new ReadableStream({
+    start() {
+      return startPromise;
+    },
     pull(c) {
       // Don't enqueue immediately after start. We want the stream to be empty when we call .read() on it.
       if (pullCount > 0) {
@@ -292,9 +296,9 @@ promise_test(() => {
     }
   });
 
-  return delay(1).then(() => {
+  return startPromise.then(() => {
     assert_equals(pullCount, 1, 'pull should be called once start finishes');
-
+  }).then(() => {
     const reader = rs.getReader();
     const read = reader.read();
     assert_equals(pullCount, 2, 'pull should be called when read is called');


### PR DESCRIPTION
WebKit slow bots have difficulties with small delay values, typically below 50 ms.

The modified test with a delay increased from 1 to 10 ms is still flaky.
https://bugs.webkit.org/show_bug.cgi?id=155760

It might be good for other tests to either increase delay values or make them more predictable.
