### PR TITLE
Misc improvements to progress event tests

### DIFF
--- a/XMLHttpRequest/event-loadstart-upload.htm
+++ b/XMLHttpRequest/event-loadstart-upload.htm
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang=en>
 <meta charset=utf-8>
-<title>XMLHttpRequest: The send() method: Fire a progress event named progress (synchronous flag is unset)</title>
+<title>XMLHttpRequest: The send() method: Fire a progress event named loadstart on upload object (synchronous flag is unset)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://xhr.spec.whatwg.org/#handler-xhr-onprogress" data-tested-assertations="../.." />
@@ -12,16 +12,18 @@
   var test = async_test();
   test.step(function() {
     var client = new XMLHttpRequest();
-    client.onprogress = test.step_func(function(e) {
+    client.upload.onloadstart = test.step_func(function(e) {
       assert_true(e instanceof ProgressEvent);
-      assert_equals(e.type, "progress");
+      assert_equals(e.total, 7, 'upload.onloadstart: event.total');
+      assert_equals(e.loaded, 0, 'upload.onloadstart: event.loaded');
+      assert_equals(e.type, "loadstart");
       test.done();
     });
     client.onreadystatechange = test.step_func(function() {
       if (client.readyState === 4)
-        assert_unreached("onprogress not called.");
+        assert_unreached("onloadstart not called.");
     });
-    client.open("GET", "resources/trickle.py");
-    client.send(null);
+    client.open("POST", "resources/trickle.py?ms=5&count=8");
+    client.send('foo=bar');
   });
 </script>

--- a/XMLHttpRequest/event-upload-progress.htm
+++ b/XMLHttpRequest/event-upload-progress.htm
@@ -5,8 +5,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
     <link rel="help" href="https://xhr.spec.whatwg.org/#handler-xhr-onprogress" data-tested-assertations="../.." />
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::*//a[contains(@href,'#make-upload-progress-notifications')] following::ol[1]/li[8]" />
-    <link rel="help" href="https://xhr.spec.whatwg.org/#make-upload-progress-notifications" data-tested-assertations=".. ../following::ul/li[1]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#dom-xmlhttprequest-upload" data-tested-assertations=".." />
 
 <div id="log"></div>
@@ -14,7 +12,11 @@
   var test = async_test();
   test.step(function() {
     var client = new XMLHttpRequest();
-    client.upload.onprogress = test.step_func(function() {
+    client.upload.onprogress = test.step_func(function(e) {
+      assert_true(e instanceof ProgressEvent);
+      // This short payload will most likely be sent before the first progress evt
+      assert_equals(e.loaded, 22);
+      assert_equals(e.total, 22);
       test.done();
     });
     client.onreadystatechange = test.step_func(function() {


### PR DESCRIPTION
We lacked a proper upload.onloadstart test, this one exposes a Chrome bug (it fails to set event.total correctly). Some minor changes too.
