### PR TITLE
Added AudioTrackList and VideoTrackList to known interfaces

### DIFF
--- a/media-source/interfaces.html
+++ b/media-source/interfaces.html
@@ -15,8 +15,11 @@ interface EventTarget {
 interface URL {};
 interface HTMLVideoElement {};
 interface AudioTrack {};
+interface AudioTrackList {};
 interface VideoTrack {};
+interface VideoTrackList {};
 interface TextTrack {};
+interface TextTrackList {};
 interface TimeRanges {};
 typedef double DOMHighResTimeStamp;
 </script>


### PR DESCRIPTION
The checks on the "audioTracks", "videoTracks", and "textTracks" attributes could not succeed beause the test harness did not know anything about the AudioTrackList, VideoTrackList and TextTrackList interfaces.
