### PR TITLE
Check on SourceBufferList getter added

### DIFF
--- a/media-source/mediasource-sourcebufferlist.html
+++ b/media-source/mediasource-sourcebufferlist.html
@@ -13,9 +13,22 @@
           {
               assert_equals(mediaSource.sourceBuffers.length, expected.length, "sourceBuffers length");
               assert_equals(mediaSource.activeSourceBuffers.length, 0, "activeSourceBuffers length");
-              for (var i = 0; i < expected.length; ++i)
+              for (var i = 0; i < expected.length; ++i) {
                 assert_equals(mediaSource.sourceBuffers[i], expected[i], "Verifying mediaSource.sourceBuffers[" + i + "]");
+              }
+              assert_equals(mediaSource.sourceBuffers[expected.length], undefined,
+                "If index is greater than or equal to the length attribute then return undefined.");
           }
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var sourceBufferA = mediaSource.addSourceBuffer(MediaSourceUtil.VIDEO_ONLY_TYPE);
+              verifySourceBufferLists(mediaSource, [sourceBufferA]);
+
+              var sourceBufferB = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+              verifySourceBufferLists(mediaSource, [sourceBufferA, sourceBufferB]);
+              test.done();
+          }, "Test SourceBufferList getter method");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {


### PR DESCRIPTION
Added a test case specifically dedicated to testing that the getter returns the right SourceBuffer instances, as well as undefined when index is out of range.
