### PR TITLE
Check that SourceBuffer.mode is correctly initialized

### DIFF
--- a/media-source/mediasource-addsourcebuffer-mode.html
+++ b/media-source/mediasource-addsourcebuffer-mode.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Checks MediaSource.addSourceBuffer() sets SourceBuffer.mode appropriately</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              // Note all mime types in mediasource-util.js
+              // set the "generate timestamps flag" to false
+              var mime = MediaSourceUtil.VIDEO_ONLY_TYPE;
+              var sourceBuffer = mediaSource.addSourceBuffer(mime);
+              assert_equals(sourceBuffer.mode, "segments");
+              test.done();
+          }, "addSourceBuffer() sets SourceBuffer.mode to 'segments' when the generate timestamps flag is false");
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var mime = 'audio/aac';
+              if (!MediaSource.isTypeSupported(mime)) {
+                  mime = 'audio/mpeg';
+                  if (!MediaSource.isTypeSupported(mime)) {
+                      assert_unreached("Browser does not support the audio/aac and audio/mpeg MIME types used in this test");
+                  }
+              }
+              sourceBuffer = mediaSource.addSourceBuffer(mime);
+              assert_equals(sourceBuffer.mode, "sequence");
+              test.done();
+          }, "addSourceBuffer() sets SourceBuffer.mode to 'sequence' when the generate timestamps flag is true");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-addsourcebuffer-mode.html
+++ b/media-source/mediasource-addsourcebuffer-mode.html
@@ -1,37 +1,31 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Checks MediaSource.addSourceBuffer() sets SourceBuffer.mode appropriately</title>
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-        <script src="mediasource-util.js"></script>
-    </head>
-    <body>
-        <div id="log"></div>
-        <script>
-          mediasource_test(function(test, mediaElement, mediaSource)
-          {
-              // Note all mime types in mediasource-util.js
-              // set the "generate timestamps flag" to false
-              var mime = MediaSourceUtil.VIDEO_ONLY_TYPE;
-              var sourceBuffer = mediaSource.addSourceBuffer(mime);
-              assert_equals(sourceBuffer.mode, "segments");
-              test.done();
-          }, "addSourceBuffer() sets SourceBuffer.mode to 'segments' when the generate timestamps flag is false");
+<meta charset="utf-8">
+<title>Checks MediaSource.addSourceBuffer() sets SourceBuffer.mode appropriately</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    mediasource_test(function(test, mediaElement, mediaSource)
+    {
+        // Note all mime types in mediasource-util.js
+        // set the "generate timestamps flag" to false
+        var mime = MediaSourceUtil.VIDEO_ONLY_TYPE;
+        var sourceBuffer = mediaSource.addSourceBuffer(mime);
+        assert_equals(sourceBuffer.mode, "segments");
+        test.done();
+    }, "addSourceBuffer() sets SourceBuffer.mode to 'segments' when the generate timestamps flag is false");
 
-          mediasource_test(function(test, mediaElement, mediaSource)
-          {
-              var mime = 'audio/aac';
-              if (!MediaSource.isTypeSupported(mime)) {
-                  mime = 'audio/mpeg';
-                  if (!MediaSource.isTypeSupported(mime)) {
-                      assert_unreached("Browser does not support the audio/aac and audio/mpeg MIME types used in this test");
-                  }
-              }
-              sourceBuffer = mediaSource.addSourceBuffer(mime);
-              assert_equals(sourceBuffer.mode, "sequence");
-              test.done();
-          }, "addSourceBuffer() sets SourceBuffer.mode to 'sequence' when the generate timestamps flag is true");
-        </script>
-    </body>
-</html>
+    mediasource_test(function(test, mediaElement, mediaSource)
+    {
+        var mime = 'audio/aac';
+        if (!MediaSource.isTypeSupported(mime)) {
+            mime = 'audio/mpeg';
+            if (!MediaSource.isTypeSupported(mime)) {
+                assert_unreached("Browser does not support the audio/aac and audio/mpeg MIME types used in this test");
+            }
+        }
+        sourceBuffer = mediaSource.addSourceBuffer(mime);
+        assert_equals(sourceBuffer.mode, "sequence");
+        test.done();
+    }, "addSourceBuffer() sets SourceBuffer.mode to 'sequence' when the generate timestamps flag is true");
+</script>

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -359,6 +359,9 @@
         return media_test(function(test)
         {
             var mediaTag = document.createElement("video");
+            if (!document.body) {
+                document.body = document.createElement("body");
+            }
             document.body.appendChild(mediaTag);
 
             test.removeMediaElement_ = true;


### PR DESCRIPTION
SourceBuffer.mode should be set to "segments" unless the generate timestamps flag is true. Note that setting the generate timestamps flag to true requires using the audio/aac or audio/mpeg MIME type in practice. The test will fail on browsers that don't support either MIME type.
