### PR TITLE
Additional boundary checks on VideoPlaybackQuality attributes

### DIFF
--- a/media-source/mediasource-getvideoplaybackquality.html
+++ b/media-source/mediasource-getvideoplaybackquality.html
@@ -17,44 +17,46 @@
               {
                   var videoElement = e.target;
                   var newQuality = videoElement.getVideoPlaybackQuality();
+                  var now = window.performance.now();
 
-                  assert_not_equals(previousQuality, newQuality, "Verify new object");
-                  assert_greater_than(newQuality.creationTime, previousQuality.creationTime, "creationTime");
+                  assert_not_equals(previousQuality, newQuality,
+                    "New quality object is different from the previous one");
+                  assert_greater_than(newQuality.creationTime, previousQuality.creationTime,
+                    "creationTime increases monotonically");
+                  assert_approx_equals(newQuality.creationTime, now, 100,
+                    "creationTime roughly equals current time");
 
                   assert_greater_than_equal(newQuality.totalVideoFrames, 0, "totalVideoFrames >= 0");
-                  assert_greater_than_equal(newQuality.totalVideoFrames, previousQuality.totalVideoFrames, "totalVideoFrames");
+                  assert_greater_than_equal(newQuality.totalVideoFrames, previousQuality.totalVideoFrames,
+                    "totalVideoFrames increases monotonically");
+                  assert_less_than(newQuality.totalVideoFrames, 50,
+                    "totalVideoFrames should remain low as duration is 1s and framerate less than 30fps");
 
                   assert_greater_than_equal(newQuality.droppedVideoFrames, 0, "droppedVideoFrames >= 0");
-                  assert_greater_than_equal(newQuality.droppedVideoFrames, previousQuality.droppedVideoFrames, "droppedVideoFrames");
+                  assert_greater_than_equal(newQuality.droppedVideoFrames, previousQuality.droppedVideoFrames,
+                    "droppedVideoFrames increases monotonically");
+                  assert_less_than_equal(newQuality.droppedVideoFrames, newQuality.totalVideoFrames,
+                    "droppedVideoFrames is only a portion of totalVideoFrames");
 
                   assert_greater_than_equal(newQuality.corruptedVideoFrames, 0, "corruptedVideoFrames >= 0");
-                  assert_greater_than_equal(newQuality.corruptedVideoFrames, previousQuality.corruptedVideoFrames, "corruptedVideoFrames");
+                  assert_greater_than_equal(newQuality.corruptedVideoFrames, previousQuality.corruptedVideoFrames,
+                    "corruptedVideoFrames increases monotonically");
+                  assert_less_than_equal(newQuality.corruptedVideoFrames, newQuality.totalVideoFrames,
+                    "corruptedVideoFrames is only a portion of totalVideoFrames");
+
                   previousQuality = newQuality;
                   timeUpdateCount++;
               }));
 
               mediaElement.addEventListener('error', test.unreached_func("Unexpected event 'error'"));
 
-              test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-              test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-              test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
               sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
 
               test.waitForExpectedEvents(function()
               {
-                  assert_false(sourceBuffer.updating, "updating");
                   assert_greater_than(mediaSource.duration, 1, "duration");
-
                   mediaSource.duration = 1;
-
-                  assert_true(sourceBuffer.updating, "updating");
-                  test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-              });
-
-              test.waitForExpectedEvents(function()
-              {
                   mediaSource.endOfStream();
                   mediaElement.play();
                   test.expectEvent(mediaElement, 'ended', 'mediaElement');
@@ -66,6 +68,49 @@
                   test.done();
               });
           }, "Test HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API");
+
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              var previousQuality = mediaElement.getVideoPlaybackQuality();
+              var timeUpdateCount = 0;
+              var startTime = 0;
+              mediaElement.addEventListener("timeupdate", test.step_func(function (e)
+              {
+                  var videoElement = e.target;
+                  var newQuality = videoElement.getVideoPlaybackQuality();
+                  var now = window.performance.now();
+
+                  assert_greater_than_equal(newQuality.totalFrameDelay, 0, "totalFrameDelay >= 0");
+                  assert_greater_than_equal(newQuality.totalFrameDelay, previousQuality.totalFrameDelay,
+                    "totalFrameDelay increases monotonically");
+                  assert_less_than(newQuality.totalFrameDelay, (now - startTime) / 1000,
+                    "totalFrameDelay does not exceed the time elapsed since playback started");
+
+                  previousQuality = newQuality;
+                  timeUpdateCount++;
+              }));
+
+              mediaElement.addEventListener('error', test.unreached_func("Unexpected event 'error'"));
+
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  assert_greater_than(mediaSource.duration, 1, "duration");
+                  mediaSource.duration = 1;
+                  mediaSource.endOfStream();
+                  startTime = window.performance.now();
+                  mediaElement.play();
+                  test.expectEvent(mediaElement, 'ended', 'mediaElement');
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_greater_than(timeUpdateCount, 2, "timeUpdateCount");
+                  test.done();
+              });
+          }, "Test the totalFrameDelay attribute of HTMLVideoElement.getVideoPlaybackQuality() with MediaSource API");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-getvideoplaybackquality.html
+++ b/media-source/mediasource-getvideoplaybackquality.html
@@ -29,8 +29,8 @@
                   assert_greater_than_equal(newQuality.totalVideoFrames, 0, "totalVideoFrames >= 0");
                   assert_greater_than_equal(newQuality.totalVideoFrames, previousQuality.totalVideoFrames,
                     "totalVideoFrames increases monotonically");
-                  assert_less_than(newQuality.totalVideoFrames, 50,
-                    "totalVideoFrames should remain low as duration is 1s and framerate less than 30fps");
+                  assert_less_than(newQuality.totalVideoFrames, 300,
+                    "totalVideoFrames should remain low as duration is less than 10s and framerate less than 30fps");
 
                   assert_greater_than_equal(newQuality.droppedVideoFrames, 0, "droppedVideoFrames >= 0");
                   assert_greater_than_equal(newQuality.droppedVideoFrames, previousQuality.droppedVideoFrames,
@@ -55,8 +55,7 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_greater_than(mediaSource.duration, 1, "duration");
-                  mediaSource.duration = 1;
+                  assert_less_than(mediaSource.duration, 10, "duration");
                   mediaSource.endOfStream();
                   mediaElement.play();
                   test.expectEvent(mediaElement, 'ended', 'mediaElement');
@@ -97,8 +96,7 @@
               test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
               test.waitForExpectedEvents(function()
               {
-                  assert_greater_than(mediaSource.duration, 1, "duration");
-                  mediaSource.duration = 1;
+                  assert_less_than(mediaSource.duration, 10, "duration");
                   mediaSource.endOfStream();
                   startTime = window.performance.now();
                   mediaElement.play();


### PR DESCRIPTION
Also added checks on the totalFrameDelay attribute, in a separate test because the feature is marked as at-risk in the current CR.

Note the test incorrectly assumed that setting the duration would start a SourceBuffer update, which is no longer true.
