### PR TITLE
Media source duration change algorithm (step 2 in particular)

### DIFF
--- a/media-source/mediasource-config-changes.js
+++ b/media-source/mediasource-config-changes.js
@@ -68,17 +68,6 @@ function mediaSourceConfigChangeTest(directory, idA, idB, description)
 
                     // Truncate the presentation to a duration of 2 seconds.
                     mediaSource.duration = 2;
-
-                    assert_true(sourceBuffer.updating, "updating");
-                    test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-                    test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-                    test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-                });
-
-                test.waitForExpectedEvents(function()
-                {
-                    assert_false(sourceBuffer.updating, "updating");
-
                     mediaSource.endOfStream();
 
                     assert_false(sourceBuffer.updating, "updating");

--- a/media-source/mediasource-config-changes.js
+++ b/media-source/mediasource-config-changes.js
@@ -64,10 +64,8 @@ function mediaSourceConfigChangeTest(directory, idA, idB, description)
                 test.waitForExpectedEvents(function()
                 {
                     assert_false(sourceBuffer.updating, "updating");
-                    assert_greater_than(mediaSource.duration, 2, "duration");
+                    assert_less_than(mediaSource.duration, 5, "duration");
 
-                    // Truncate the presentation to a duration of 2 seconds.
-                    mediaSource.duration = 2;
                     mediaSource.endOfStream();
 
                     assert_false(sourceBuffer.updating, "updating");

--- a/media-source/mediasource-duration-buffered.html
+++ b/media-source/mediasource-duration-buffered.html
@@ -1,106 +1,100 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Duration truncation with buffered coded frames</title>
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-        <script src="mediasource-util.js"></script>
-    </head>
-    <body>
-        <div id="log"></div>
-        <script>
-            var subType = MediaSourceUtil.getSubType(MediaSourceUtil.AUDIO_ONLY_TYPE);
-            var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
-            var manifestFilenameVideo = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
+<meta charset="utf-8">
+<title>Duration truncation with buffered coded frames</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    var subType = MediaSourceUtil.getSubType(MediaSourceUtil.AUDIO_ONLY_TYPE);
+    var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
+    var manifestFilenameVideo = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
 
-            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
+        sourceBuffer.appendBuffer(initSegment);
+        test.waitForExpectedEvents(function()
+        {
+            sourceBuffer.duration = segmentInfo.duration;
+            var midSegment = segmentInfo.media[2];
+            var newDuration = midSegment.timecode + 1;
+            var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
+            test.expectEvent(sourceBuffer, "updateend");
+            sourceBuffer.appendBuffer(midData);
+            test.waitForExpectedEvents(function()
             {
-                var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
-                test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
-                sourceBuffer.appendBuffer(initSegment);
+                assert_equals(sourceBuffer.buffered.length, 1);
+                assert_greater_than(newDuration, sourceBuffer.buffered.start(0));
+                mediaSource.duration = newDuration;
+                assert_equals(mediaSource.duration, newDuration);
+                test.done();
+            });
+        });
+    }, "MediaSource.duration: Truncating the duration succeeds when new duration is greater than the highest starting time of buffered coded frames");
+
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
+        sourceBuffer.appendBuffer(initSegment);
+        test.waitForExpectedEvents(function()
+        {
+            sourceBuffer.duration = segmentInfo.duration;
+            var midSegment = segmentInfo.media[segmentInfo.media.length-1];
+            var newDuration = midSegment.timecode / 2.0;
+            var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
+            test.expectEvent(sourceBuffer, "updateend");
+            sourceBuffer.appendBuffer(midData);
+            test.waitForExpectedEvents(function()
+            {
+                assert_equals(sourceBuffer.buffered.length, 1);
+                assert_greater_than(sourceBuffer.buffered.start(0), newDuration);
+                assert_throws("InvalidStateError", function ()
+                {
+                    mediaSource.duration = newDuration;
+                });
+                test.done();
+            });
+        });
+    }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time of buffered coded frames");
+
+
+    mediasource_test(function(test, mediaElement, mediaSource)
+    {
+        mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+        MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
+        {
+            MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
+            {
+                var sourceBufferAudio = mediaSource.addSourceBuffer(typeAudio);
+                var sourceBufferVideo = mediaSource.addSourceBuffer(typeVideo);
+                var newDuration = 1.2;
+
+                sourceBufferAudio.appendWindowEnd = 2.0;
+                sourceBufferAudio.appendWindowStart = newDuration / 2.0;
+                sourceBufferAudio.appendBuffer(dataAudio);
+
+                sourceBufferVideo.appendWindowEnd = 2.0;
+                sourceBufferVideo.appendWindowStart = newDuration * 1.3;
+                sourceBufferVideo.appendBuffer(dataVideo);
+
+                test.expectEvent(sourceBufferAudio, "updateend");
+                test.expectEvent(sourceBufferVideo, "updateend");
                 test.waitForExpectedEvents(function()
                 {
-                    sourceBuffer.duration = segmentInfo.duration;
-                    var midSegment = segmentInfo.media[2];
-                    var newDuration = midSegment.timecode + 1;
-                    var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
-                    test.expectEvent(sourceBuffer, "updateend");
-                    sourceBuffer.appendBuffer(midData);
-                    test.waitForExpectedEvents(function()
+                    assert_equals(sourceBufferAudio.buffered.length, 1);
+                    assert_equals(sourceBufferVideo.buffered.length, 1);
+                    assert_less_than(sourceBufferAudio.buffered.start(0), newDuration);
+                    assert_greater_than(sourceBufferVideo.buffered.start(0), newDuration);
+                    assert_throws("InvalidStateError", function ()
                     {
-                        assert_equals(sourceBuffer.buffered.length, 1);
-                        assert_greater_than(newDuration, sourceBuffer.buffered.start(0));
                         mediaSource.duration = newDuration;
-                        assert_equals(mediaSource.duration, newDuration);
-                        test.done();
                     });
+                    test.done();
                 });
-            }, "MediaSource.duration: Truncating the duration succeeds when new duration is greater than the highest starting time of buffered coded frames");
-
-
-            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-            {
-                var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
-                test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
-                sourceBuffer.appendBuffer(initSegment);
-                test.waitForExpectedEvents(function()
-                {
-                    sourceBuffer.duration = segmentInfo.duration;
-                    var midSegment = segmentInfo.media[segmentInfo.media.length-1];
-                    var newDuration = midSegment.timecode / 2.0;
-                    var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
-                    test.expectEvent(sourceBuffer, "updateend");
-                    sourceBuffer.appendBuffer(midData);
-                    test.waitForExpectedEvents(function()
-                    {
-                        assert_equals(sourceBuffer.buffered.length, 1);
-                        assert_greater_than(sourceBuffer.buffered.start(0), newDuration);
-                        assert_throws("InvalidStateError", function ()
-                        {
-                            mediaSource.duration = newDuration;
-                        });
-                        test.done();
-                    });
-                });
-            }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time of buffered coded frames");
-
-
-            mediasource_test(function(test, mediaElement, mediaSource)
-            {
-                mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
-                MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
-                {
-                    MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
-                    {
-                        var sourceBufferAudio = mediaSource.addSourceBuffer(typeAudio);
-                        var sourceBufferVideo = mediaSource.addSourceBuffer(typeVideo);
-                        var newDuration = 1.2;
-
-                        sourceBufferAudio.appendWindowEnd = 2.0;
-                        sourceBufferAudio.appendWindowStart = newDuration / 2.0;
-                        sourceBufferAudio.appendBuffer(dataAudio);
-
-                        sourceBufferVideo.appendWindowEnd = 2.0;
-                        sourceBufferVideo.appendWindowStart = newDuration * 1.3;
-                        sourceBufferVideo.appendBuffer(dataVideo);
-
-                        test.expectEvent(sourceBufferAudio, "updateend");
-                        test.expectEvent(sourceBufferVideo, "updateend");
-                        test.waitForExpectedEvents(function()
-                        {
-                            assert_equals(sourceBufferAudio.buffered.length, 1);
-                            assert_equals(sourceBufferVideo.buffered.length, 1);
-                            assert_less_than(sourceBufferAudio.buffered.start(0), newDuration);
-                            assert_greater_than(sourceBufferVideo.buffered.start(0), newDuration);
-                            assert_throws("InvalidStateError", function ()
-                            {
-                                mediaSource.duration = newDuration;
-                            });
-                            test.done();
-                        });
-                    });
-                });
-            }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time for at least some buffered coded frames");
-        </script>
-    </body>
-</html>
+            });
+        });
+    }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time for at least some buffered coded frames");
+</script>

--- a/media-source/mediasource-duration-buffered.html
+++ b/media-source/mediasource-duration-buffered.html
@@ -29,13 +29,13 @@
                     test.waitForExpectedEvents(function()
                     {
                         assert_equals(sourceBuffer.buffered.length, 1);
-                        assert_less_than(sourceBuffer.buffered.start(0), newDuration);
+                        assert_greater_than(newDuration, sourceBuffer.buffered.start(0));
                         mediaSource.duration = newDuration;
                         assert_equals(mediaSource.duration, newDuration);
                         test.done();
                     });
                 });
-            }, "Duration truncation succeeds when coded frames do not first need to be removed");
+            }, "MediaSource.duration: Truncating the duration succeeds when new duration is greater than the highest starting time of buffered coded frames");
 
 
             mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
@@ -62,7 +62,7 @@
                         test.done();
                     });
                 });
-            }, "Duration truncation throws an InvalidStateError exception when coded frames first need to be removed");
+            }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time of buffered coded frames");
 
 
             mediasource_test(function(test, mediaElement, mediaSource)
@@ -100,7 +100,7 @@
                         });
                     });
                 });
-            }, "Duration truncation throws an InvalidStateError exception when some coded frames first need to be removed");
+            }, "MediaSource.duration: Truncating the duration throws an InvalidStateError exception when new duration is less than the highest starting time for at least some buffered coded frames");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-duration-buffered.html
+++ b/media-source/mediasource-duration-buffered.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Duration truncation with buffered coded frames</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+            var subType = MediaSourceUtil.getSubType(MediaSourceUtil.AUDIO_ONLY_TYPE);
+            var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
+            var manifestFilenameVideo = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
+
+            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+            {
+                var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+                test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
+                sourceBuffer.appendBuffer(initSegment);
+                test.waitForExpectedEvents(function()
+                {
+                    sourceBuffer.duration = segmentInfo.duration;
+                    var midSegment = segmentInfo.media[2];
+                    var newDuration = midSegment.timecode + 1;
+                    var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
+                    test.expectEvent(sourceBuffer, "updateend");
+                    sourceBuffer.appendBuffer(midData);
+                    test.waitForExpectedEvents(function()
+                    {
+                        assert_equals(sourceBuffer.buffered.length, 1);
+                        assert_less_than(sourceBuffer.buffered.start(0), newDuration);
+                        mediaSource.duration = newDuration;
+                        assert_equals(mediaSource.duration, newDuration);
+                        test.done();
+                    });
+                });
+            }, "Duration truncation succeeds when coded frames do not first need to be removed");
+
+
+            mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+            {
+                var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+                test.expectEvent(sourceBuffer, "updateend", "Init segment appended to SourceBuffer.");
+                sourceBuffer.appendBuffer(initSegment);
+                test.waitForExpectedEvents(function()
+                {
+                    sourceBuffer.duration = segmentInfo.duration;
+                    var midSegment = segmentInfo.media[segmentInfo.media.length-1];
+                    var newDuration = midSegment.timecode / 2.0;
+                    var midData = MediaSourceUtil.extractSegmentData(mediaData, midSegment);
+                    test.expectEvent(sourceBuffer, "updateend");
+                    sourceBuffer.appendBuffer(midData);
+                    test.waitForExpectedEvents(function()
+                    {
+                        assert_equals(sourceBuffer.buffered.length, 1);
+                        assert_greater_than(sourceBuffer.buffered.start(0), newDuration);
+                        assert_throws("InvalidStateError", function ()
+                        {
+                            mediaSource.duration = newDuration;
+                        });
+                        test.done();
+                    });
+                });
+            }, "Duration truncation throws an InvalidStateError exception when coded frames first need to be removed");
+
+
+            mediasource_test(function(test, mediaElement, mediaSource)
+            {
+                mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+                MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function (typeAudio, dataAudio)
+                {
+                    MediaSourceUtil.fetchManifestAndData(test, manifestFilenameVideo, function (typeVideo, dataVideo)
+                    {
+                        var sourceBufferAudio = mediaSource.addSourceBuffer(typeAudio);
+                        var sourceBufferVideo = mediaSource.addSourceBuffer(typeVideo);
+                        var newDuration = 1.2;
+
+                        sourceBufferAudio.appendWindowEnd = 2.0;
+                        sourceBufferAudio.appendWindowStart = newDuration / 2.0;
+                        sourceBufferAudio.appendBuffer(dataAudio);
+
+                        sourceBufferVideo.appendWindowEnd = 2.0;
+                        sourceBufferVideo.appendWindowStart = newDuration * 1.3;
+                        sourceBufferVideo.appendBuffer(dataVideo);
+
+                        test.expectEvent(sourceBufferAudio, "updateend");
+                        test.expectEvent(sourceBufferVideo, "updateend");
+                        test.waitForExpectedEvents(function()
+                        {
+                            assert_equals(sourceBufferAudio.buffered.length, 1);
+                            assert_equals(sourceBufferVideo.buffered.length, 1);
+                            assert_less_than(sourceBufferAudio.buffered.start(0), newDuration);
+                            assert_greater_than(sourceBufferVideo.buffered.start(0), newDuration);
+                            assert_throws("InvalidStateError", function ()
+                            {
+                                mediaSource.duration = newDuration;
+                            });
+                            test.done();
+                        });
+                    });
+                });
+            }, "Duration truncation throws an InvalidStateError exception when some coded frames first need to be removed");
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -32,7 +32,6 @@
                       assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
 
                       test.expectEvent(mediaElement, 'seeking', 'seeking to seekTo');
-                      test.expectEvent(mediaElement, 'timeupdate', 'timeupdate while seeking to seekTo');
                       test.expectEvent(mediaElement, 'seeked', 'seeked to seekTo');
                       mediaElement.currentTime = seekTo;
                       assert_true(mediaElement.seeking, 'mediaElement.seeking (to seekTo)');
@@ -51,19 +50,10 @@
 
                       mediaSource.duration = truncatedDuration;
 
-                      assert_true(sourceBuffer.updating, 'sourceBuffer.updating');
-                      test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-                      test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-                      test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-
+                      assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
                       assert_true(mediaElement.seeking, 'Seeking after setting truncatedDuration');
-                  });
-
-                  test.waitForExpectedEvents(function()
-                  {
                       assert_equals(mediaElement.currentTime, truncatedDuration,
                                     'Playback time is truncatedDuration while seeking');
-                      assert_true(mediaElement.seeking, 'mediaElement.seeking while seeking to truncatedDuration');
                       assert_equals(mediaElement.duration, truncatedDuration,
                                     'mediaElement truncatedDuration during seek to it');
                       assert_equals(mediaSource.duration, truncatedDuration,
@@ -75,13 +65,68 @@
               }, description, options);
           }
 
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              mediaSource.duration = 2;
+              assert_false(sourceBuffer.updating,
+                'No SourceBuffer update when duration is set');
+              test.done();
+          }, 'MediaSource.duration: setting the duration does not trigger any SourceBuffer update');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_less_than(segmentInfo.duration, 60, 'Sufficient test media duration');
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media data appended to the SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  mediaSource.duration = 60;
+                  assert_false(sourceBuffer.updating,
+                    'No SourceBuffer update when duration is increased');
+                  test.done();
+              });
+          }, 'MediaSource.duration: Increasing the duration does not trigger any SourceBuffer update');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media data appended to the SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  mediaSource.duration = 1;
+                  assert_false(sourceBuffer.updating,
+                    'No SourceBuffer update when duration is truncated');
+                  test.done();
+              });
+          }, 'MediaSource.duration: Truncating the duration does not trigger any SourceBuffer update');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
+              mediaElement.play();
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media data appended to the SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  mediaSource.duration = 1;
+                  assert_false(sourceBuffer.updating,
+                    'No SourceBuffer update when duration is truncated');
+                  test.done();
+              });
+          }, 'MediaSource.duration: Truncating the duration during media playback does not trigger any SourceBuffer update');
+
           mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
                                                             mediaData, truncatedDuration)
           {
               // Tests that duration truncation below current playback position
               // starts seek to new duration.
               test.done();
-          }, 'Test seek starts on duration truncation below currentTime');
+          }, 'MediaSource.duration: Truncating the duration triggers a seek if new duration is below currentTime');
 
           mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
                                                             mediaData, truncatedDuration)
@@ -110,7 +155,7 @@
 
                   test.done();
               });
-          }, 'Test appendBuffer completes previous seek to truncated duration');
+          }, 'MediaSource.duration: Adding more data after truncating the duration completes the seek triggered by the truncation');
 
           mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
                                                             mediaData, truncatedDuration)
@@ -137,7 +182,7 @@
 
                   test.done();
               });
-          }, 'Test endOfStream completes previous seek to truncated duration');
+          }, 'MediaSource.duration: Calling endOfStream() after truncating the duration completes the seek triggered by the truncation');
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
@@ -173,18 +218,9 @@
 
                   assert_false(sourceBuffer.updating, "updating");
 
-                  // Truncate duration. This should result in one 'durationchange' fired.
+                  // Truncate duration. This should result in one 'durationchange' event fired.
                   mediaSource.duration = newDuration;
-
-                  assert_true(sourceBuffer.updating, "updating");
-                  test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-              });
-
-              test.waitForExpectedEvents(function()
-              {
-                  assert_false(sourceBuffer.updating, "updating");
+                  assert_equals(mediaSource.duration, newDuration);
 
                   // Set duration again to make sure it does not trigger another 'durationchange' event.
                   mediaSource.duration = newDuration;
@@ -193,11 +229,10 @@
                   test.expectEvent(mediaSource, 'sourceended', 'endOfStream acknowledged');
                   mediaSource.endOfStream();
 
-                  // endOfStream can change duration downwards slightly.
+                  // endOfStream can change duration slightly.
                   // Allow for one more 'durationchange' event only in this case.
                   var currentDuration = mediaSource.duration;
                   if (currentDuration != newDuration) {
-                      assert_true(currentDuration > 0 && currentDuration < newDuration, 'adjusted duration');
                       newDuration = currentDuration;
                       ++expectedDurationChangeEventCount;
                   }
@@ -211,7 +246,7 @@
                       test.done();
                   });
               });
-          }, 'Test setting same duration multiple times does not fire duplicate durationchange');
+          }, 'MediaSource.duration: Setting the same duration multiple times does not fire duplicate durationchange events');
         </script>
     </body>
 </html>

--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -9,63 +9,6 @@
     <body>
         <div id="log"></div>
         <script>
-          function mediasource_truncated_duration_seek_test(testFunction, description, options)
-          {
-              return mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-              {
-                  assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-
-                  var fullDuration = segmentInfo.duration;
-                  var seekTo = fullDuration / 2.0;
-                  var truncatedDuration = seekTo / 2.0;
-
-                  mediaElement.play();
-
-                  // Append all the segments
-                  test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-                  test.expectEvent(mediaElement, 'playing', 'Playing triggered');
-                  sourceBuffer.appendBuffer(mediaData);
-
-                  test.waitForExpectedEvents(function()
-                  {
-                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration');
-                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
-
-                      test.expectEvent(mediaElement, 'seeking', 'seeking to seekTo');
-                      test.expectEvent(mediaElement, 'seeked', 'seeked to seekTo');
-                      mediaElement.currentTime = seekTo;
-                      assert_true(mediaElement.seeking, 'mediaElement.seeking (to seekTo)');
-                  });
-
-                  test.waitForExpectedEvents(function()
-                  {
-                      assert_greater_than_equal(mediaElement.currentTime, seekTo, 'Playback time has reached seekTo');
-                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration after seekTo');
-                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration after seekTo');
-                      assert_false(mediaElement.seeking, 'mediaElement.seeking after seeked to seekTo');
-
-                      test.expectEvent(mediaElement, 'seeking', 'Seeking to truncated duration');
-
-                      assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
-
-                      mediaSource.duration = truncatedDuration;
-
-                      assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
-                      assert_true(mediaElement.seeking, 'Seeking after setting truncatedDuration');
-                      assert_equals(mediaElement.currentTime, truncatedDuration,
-                                    'Playback time is truncatedDuration while seeking');
-                      assert_equals(mediaElement.duration, truncatedDuration,
-                                    'mediaElement truncatedDuration during seek to it');
-                      assert_equals(mediaSource.duration, truncatedDuration,
-                                    'mediaSource truncatedDuration during seek to it');
-
-                      testFunction(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData,
-                                   truncatedDuration);
-                  });
-              }, description, options);
-          }
-
-
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
               mediaSource.duration = 2;
@@ -92,104 +35,25 @@
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
               assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-              sourceBuffer.appendBuffer(mediaData);
-              test.expectEvent(sourceBuffer, 'updateend',
-                'Media data appended to the SourceBuffer');
-              test.waitForExpectedEvents(function()
-              {
-                  mediaSource.duration = 1;
-                  assert_false(sourceBuffer.updating,
-                    'No SourceBuffer update when duration is truncated');
-                  test.done();
-              });
-          }, 'MediaSource.duration: Truncating the duration does not trigger any SourceBuffer update');
-
-          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-          {
-              assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
               mediaElement.play();
               sourceBuffer.appendBuffer(mediaData);
               test.expectEvent(sourceBuffer, 'updateend',
                 'Media data appended to the SourceBuffer');
               test.waitForExpectedEvents(function()
               {
-                  mediaSource.duration = 1;
+                  mediaSource.duration = 60;
                   assert_false(sourceBuffer.updating,
                     'No SourceBuffer update when duration is truncated');
                   test.done();
               });
-          }, 'MediaSource.duration: Truncating the duration during media playback does not trigger any SourceBuffer update');
-
-          mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
-                                                            mediaData, truncatedDuration)
-          {
-              // Tests that duration truncation below current playback position
-              // starts seek to new duration.
-              test.done();
-          }, 'MediaSource.duration: Truncating the duration triggers a seek if new duration is below currentTime');
-
-          mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
-                                                            mediaData, truncatedDuration)
-          {
-              // The duration has been truncated at this point, and there is an
-              // outstanding seek pending.
-              test.expectEvent(sourceBuffer, 'updateend', 'updateend after appending more data');
-
-              test.expectEvent(mediaElement, 'timeupdate', 'timeupdate while finishing seek to truncatedDuration');
-              test.expectEvent(mediaElement, 'seeked', 'seeked to truncatedDuration');
-
-              // Allow seek to complete by appending more data beginning at the
-              // truncated duration timestamp.
-              sourceBuffer.timestampOffset = truncatedDuration;
-              sourceBuffer.appendBuffer(mediaData);
-
-              test.waitForExpectedEvents(function()
-              {
-                  assert_greater_than_equal(mediaElement.currentTime, truncatedDuration,
-                                            'Playback time has reached truncatedDuration');
-                  assert_approx_equals(mediaElement.duration, truncatedDuration + segmentInfo.duration, 0.05,
-                                       'mediaElement duration increased by new append');
-                  assert_equals(mediaSource.duration, mediaElement.duration,
-                                'mediaSource duration increased by new append');
-                  assert_false(mediaElement.seeking, 'mediaElement.seeking after seeked to truncatedDuration');
-
-                  test.done();
-              });
-          }, 'MediaSource.duration: Adding more data after truncating the duration completes the seek triggered by the truncation');
-
-          mediasource_truncated_duration_seek_test(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer,
-                                                            mediaData, truncatedDuration)
-          {
-              // The duration has been truncated at this point, and there is an
-              // outstanding seek pending.
-              test.expectEvent(mediaSource, 'sourceended', 'endOfStream acknowledged');
-
-              test.expectEvent(mediaElement, 'timeupdate', 'timeupdate while finishing seek to truncatedDuration');
-              test.expectEvent(mediaElement, 'seeked', 'seeked to truncatedDuration');
-
-              // Call endOfStream() to complete the pending seek.
-              mediaSource.endOfStream();
-
-              test.waitForExpectedEvents(function()
-              {
-                  assert_equals(mediaElement.currentTime, truncatedDuration,
-                                'Playback time has reached truncatedDuration');
-                  assert_equals(mediaElement.duration, truncatedDuration,
-                                'mediaElement truncatedDuration after seek to it');
-                  assert_equals(mediaSource.duration, truncatedDuration,
-                                'mediaSource truncatedDuration after seek to it');
-                  assert_false(mediaElement.seeking, 'mediaElement.seeking after seeked to truncatedDuration');
-
-                  test.done();
-              });
-          }, 'MediaSource.duration: Calling endOfStream() after truncating the duration completes the seek triggered by the truncation');
+          }, 'MediaSource.duration: Increasing the duration during media playback does not trigger any SourceBuffer update');
 
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
               assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
 
               var fullDuration = segmentInfo.duration;
-              var newDuration = 0.5;
+              var newDuration = fullDuration + 0.5;
 
               var expectedDurationChangeEventCount = 1;
               var durationchangeEventCounter = 0;
@@ -222,6 +86,9 @@
                   mediaSource.duration = newDuration;
                   assert_equals(mediaSource.duration, newDuration);
 
+                  // Skip media to "near the end" to make test take less time
+                  mediaElement.currentTime = mediaSource.duration - 0.5;
+
                   // Set duration again to make sure it does not trigger another 'durationchange' event.
                   mediaSource.duration = newDuration;
 
@@ -236,6 +103,7 @@
                       newDuration = currentDuration;
                       ++expectedDurationChangeEventCount;
                   }
+
 
                   // Allow media to play to end while counting 'durationchange' events.
                   test.expectEvent(mediaElement, 'ended', 'Playback ended');

--- a/media-source/mediasource-play.html
+++ b/media-source/mediasource-play.html
@@ -26,15 +26,6 @@
                   assert_greater_than(mediaSource.duration, 1, "duration");
 
                   mediaSource.duration = 1;
-
-                  assert_true(sourceBuffer.updating, "updating");
-                  test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
-                  test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
-              });
-
-              test.waitForExpectedEvents(function()
-              {
                   mediaSource.endOfStream();
                   mediaElement.play();
               });

--- a/media-source/mediasource-play.html
+++ b/media-source/mediasource-play.html
@@ -23,9 +23,7 @@
               test.waitForExpectedEvents(function()
               {
                   assert_false(sourceBuffer.updating, "updating");
-                  assert_greater_than(mediaSource.duration, 1, "duration");
 
-                  mediaSource.duration = 1;
                   mediaSource.endOfStream();
                   mediaElement.play();
               });

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -359,6 +359,9 @@
         return media_test(function(test)
         {
             var mediaTag = document.createElement("video");
+            if (!document.body) {
+                document.body = document.createElement("body");
+            }
             document.body.appendChild(mediaTag);
 
             test.removeMediaElement_ = true;


### PR DESCRIPTION
New test cases ensure that implementations throw an InvalidStateError exception when the new duration is less than the highest starting presentation timestamp of any buffered coded frames.

Some test cases took for granted that setting the duration would set the SourceBuffer.updating attribute. This is no longer the case. Tests updated accordingly.

One the test cases assumed that endOfStream() could only adjust the duration downwards. That seems no longer true either.

Also, some duration tests assumed that a "timeupdate" event would only be fired after the "seeking" event. However, "timeupdate" events are regularly issued during playback and thus such an event could fire _before_ the "seeking" event.
