### PR TITLE
New tests for the End of stream algorithm

### DIFF
--- a/media-source/mediasource-endofstream.html
+++ b/media-source/mediasource-endofstream.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Calls to MediaSource.endOfStream() without error</title>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
+    </head>
+    <body>
+        <div id="log"></div>
+        <script>
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              mediaSource.duration = 2;
+              mediaSource.endOfStream();
+              assert_equals(mediaSource.duration, 0);
+              test.done();
+          }, 'MediaSource.endOfStream(): duration truncated to 0 when there are no buffered coded frames');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media buffer appended to SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  mediaSource.endOfStream();
+                  test.expectEvent(mediaElement, 'canplaythrough',
+                    'Media element may render the media content until the end');
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA,
+                        'Media element has enough data to render the content');
+                      test.done();
+                  });
+              });
+          }, 'MediaSource.endOfStream(): media element notified that it now has all of the media data');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media buffer appended to SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(sourceBuffer.buffered.length, 1,
+                    'Media data properly buffered');
+                  var highestEndTime = sourceBuffer.buffered.end(0);
+
+                  mediaSource.endOfStream();
+
+                  assert_equals(sourceBuffer.buffered.end(0), highestEndTime,
+                    'Ending the stream does not affect buffered data');
+                  test.done();
+              });
+          }, 'MediaSource.endOfStream(): buffered data not modified when endOfStream is called');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_less_than(segmentInfo.duration, 60, 'Sufficient test media duration');
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media buffer appended to SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(sourceBuffer.buffered.length, 1,
+                    'Media data properly buffered');
+
+                  mediaSource.duration = 60;
+                  mediaSource.endOfStream();
+
+                  assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
+                    'Duration set to the higest end time');
+                  test.done();
+              });
+          }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute');
+
+          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+          {
+              assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
+              sourceBuffer.appendBuffer(mediaData);
+              test.expectEvent(sourceBuffer, 'updateend',
+                'Media buffer appended to SourceBuffer');
+              test.waitForExpectedEvents(function()
+              {
+                  assert_equals(sourceBuffer.buffered.length, 1,
+                    'Media data properly buffered');
+                  var highestEndTime = sourceBuffer.buffered.end(0);
+
+                  mediaSource.duration = 1;
+                  mediaSource.endOfStream();
+
+                  assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
+                    'Duration set to the higest end time');
+                  test.done();
+              });
+          }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute even after truncation');
+        </script>
+    </body>
+</html>

--- a/media-source/mediasource-endofstream.html
+++ b/media-source/mediasource-endofstream.html
@@ -70,25 +70,4 @@
             test.done();
         });
     }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute');
-
-    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-    {
-        assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-        sourceBuffer.appendBuffer(mediaData);
-        test.expectEvent(sourceBuffer, 'updateend',
-          'Media buffer appended to SourceBuffer');
-        test.waitForExpectedEvents(function()
-        {
-            assert_equals(sourceBuffer.buffered.length, 1,
-              'Media data properly buffered');
-            var highestEndTime = sourceBuffer.buffered.end(0);
-
-            mediaSource.duration = 1;
-            mediaSource.endOfStream();
-
-            assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
-              'Duration set to the higest end time');
-            test.done();
-        });
-    }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute even after truncation');
 </script>

--- a/media-source/mediasource-endofstream.html
+++ b/media-source/mediasource-endofstream.html
@@ -1,100 +1,94 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Calls to MediaSource.endOfStream() without error</title>
-        <script src="/resources/testharness.js"></script>
-        <script src="/resources/testharnessreport.js"></script>
-        <script src="mediasource-util.js"></script>
-    </head>
-    <body>
-        <div id="log"></div>
-        <script>
-          mediasource_test(function(test, mediaElement, mediaSource)
-          {
-              mediaSource.duration = 2;
-              mediaSource.endOfStream();
-              assert_equals(mediaSource.duration, 0);
-              test.done();
-          }, 'MediaSource.endOfStream(): duration truncated to 0 when there are no buffered coded frames');
+<meta charset="utf-8">
+<title>Calls to MediaSource.endOfStream() without error</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    mediasource_test(function(test, mediaElement, mediaSource)
+    {
+        mediaSource.duration = 2;
+        mediaSource.endOfStream();
+        assert_equals(mediaSource.duration, 0);
+        test.done();
+    }, 'MediaSource.endOfStream(): duration truncated to 0 when there are no buffered coded frames');
 
-          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-          {
-              sourceBuffer.appendBuffer(mediaData);
-              test.expectEvent(sourceBuffer, 'updateend',
-                'Media buffer appended to SourceBuffer');
-              test.waitForExpectedEvents(function()
-              {
-                  mediaSource.endOfStream();
-                  test.expectEvent(mediaElement, 'canplaythrough',
-                    'Media element may render the media content until the end');
-                  test.waitForExpectedEvents(function()
-                  {
-                      assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA,
-                        'Media element has enough data to render the content');
-                      test.done();
-                  });
-              });
-          }, 'MediaSource.endOfStream(): media element notified that it now has all of the media data');
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        sourceBuffer.appendBuffer(mediaData);
+        test.expectEvent(sourceBuffer, 'updateend',
+          'Media buffer appended to SourceBuffer');
+        test.waitForExpectedEvents(function()
+        {
+            mediaSource.endOfStream();
+            test.expectEvent(mediaElement, 'canplaythrough',
+              'Media element may render the media content until the end');
+            test.waitForExpectedEvents(function()
+            {
+                assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA,
+                  'Media element has enough data to render the content');
+                test.done();
+            });
+        });
+    }, 'MediaSource.endOfStream(): media element notified that it now has all of the media data');
 
-          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-          {
-              sourceBuffer.appendBuffer(mediaData);
-              test.expectEvent(sourceBuffer, 'updateend',
-                'Media buffer appended to SourceBuffer');
-              test.waitForExpectedEvents(function()
-              {
-                  assert_equals(sourceBuffer.buffered.length, 1,
-                    'Media data properly buffered');
-                  var highestEndTime = sourceBuffer.buffered.end(0);
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        sourceBuffer.appendBuffer(mediaData);
+        test.expectEvent(sourceBuffer, 'updateend',
+          'Media buffer appended to SourceBuffer');
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(sourceBuffer.buffered.length, 1,
+              'Media data properly buffered');
+            var highestEndTime = sourceBuffer.buffered.end(0);
 
-                  mediaSource.endOfStream();
+            mediaSource.endOfStream();
 
-                  assert_equals(sourceBuffer.buffered.end(0), highestEndTime,
-                    'Ending the stream does not affect buffered data');
-                  test.done();
-              });
-          }, 'MediaSource.endOfStream(): buffered data not modified when endOfStream is called');
+            assert_equals(sourceBuffer.buffered.end(0), highestEndTime,
+              'Ending the stream does not affect buffered data');
+            test.done();
+        });
+    }, 'MediaSource.endOfStream(): buffered data not modified when endOfStream is called');
 
-          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-          {
-              assert_less_than(segmentInfo.duration, 60, 'Sufficient test media duration');
-              sourceBuffer.appendBuffer(mediaData);
-              test.expectEvent(sourceBuffer, 'updateend',
-                'Media buffer appended to SourceBuffer');
-              test.waitForExpectedEvents(function()
-              {
-                  assert_equals(sourceBuffer.buffered.length, 1,
-                    'Media data properly buffered');
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_less_than(segmentInfo.duration, 60, 'Sufficient test media duration');
+        sourceBuffer.appendBuffer(mediaData);
+        test.expectEvent(sourceBuffer, 'updateend',
+          'Media buffer appended to SourceBuffer');
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(sourceBuffer.buffered.length, 1,
+              'Media data properly buffered');
 
-                  mediaSource.duration = 60;
-                  mediaSource.endOfStream();
+            mediaSource.duration = 60;
+            mediaSource.endOfStream();
 
-                  assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
-                    'Duration set to the higest end time');
-                  test.done();
-              });
-          }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute');
+            assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
+              'Duration set to the higest end time');
+            test.done();
+        });
+    }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute');
 
-          mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-          {
-              assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-              sourceBuffer.appendBuffer(mediaData);
-              test.expectEvent(sourceBuffer, 'updateend',
-                'Media buffer appended to SourceBuffer');
-              test.waitForExpectedEvents(function()
-              {
-                  assert_equals(sourceBuffer.buffered.length, 1,
-                    'Media data properly buffered');
-                  var highestEndTime = sourceBuffer.buffered.end(0);
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
+        sourceBuffer.appendBuffer(mediaData);
+        test.expectEvent(sourceBuffer, 'updateend',
+          'Media buffer appended to SourceBuffer');
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(sourceBuffer.buffered.length, 1,
+              'Media data properly buffered');
+            var highestEndTime = sourceBuffer.buffered.end(0);
 
-                  mediaSource.duration = 1;
-                  mediaSource.endOfStream();
+            mediaSource.duration = 1;
+            mediaSource.endOfStream();
 
-                  assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
-                    'Duration set to the higest end time');
-                  test.done();
-              });
-          }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute even after truncation');
-        </script>
-    </body>
-</html>
+            assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
+              'Duration set to the higest end time');
+            test.done();
+        });
+    }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute even after truncation');
+</script>

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -359,6 +359,9 @@
         return media_test(function(test)
         {
             var mediaTag = document.createElement("video");
+            if (!document.body) {
+                document.body = document.createElement("body");
+            }
             document.body.appendChild(mediaTag);
 
             test.removeMediaElement_ = true;


### PR DESCRIPTION
The End of stream algorithm should set the duration to the right value, and notify the media element that it now has all of the media data.

Also, it should no longer touch the coded frames buffers (the range removal algorithm is not triggered anymore).
