### PR TITLE
Made utility functions compatible with minimal script test template

### DIFF
--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -359,6 +359,9 @@
         return media_test(function(test)
         {
             var mediaTag = document.createElement("video");
+            if (!document.body) {
+                document.body = document.createElement("body");
+            }
             document.body.appendChild(mediaTag);
 
             test.removeMediaElement_ = true;

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -296,7 +296,7 @@
 
         var i = startingIndex;
         var onAppendDone = function() {
-            if (eventFired)
+            if (eventFired || (i >= (segmentInfo.media.length - 1)))
                 return;
 
             i++;


### PR DESCRIPTION
The minimal script test template does not contain any <body> tag. Browsers will implicitly create one, but only after the script runs. The mediasource_test method now checks for the existence of document.body before appending the <video> tag, and creates the body if needed.
