### PR TITLE
Update fetch cors tests to limit the use of www/www1 URLs

### DIFF
--- a/fetch/api/basic/integrity.js
+++ b/fetch/api/basic/integrity.js
@@ -24,7 +24,7 @@ var invalidSha256 = "sha256-dKUcPOn/AlUjWIwcHeHNqYXPlvyGiq+2dWOdFcE+24I=";
 var invalidSha512 = "sha512-oUceBRNxPxnY60g/VtPCj2syT4wo4EZh2CgYdWy9veW8+OsReTXoh7dizMGZafvx9+QhMS39L/gIkxnPIn41Zg==";
 
 var url = "../resources/top.txt";
-var corsUrl = "http://www1.{{host}}:{{ports[http][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "top.txt";
+var corsUrl = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "top.txt";
 /* Enable CORS*/
 corsUrl += "?pipe=header(Access-Control-Allow-Origin,*)";
 

--- a/fetch/api/basic/mode-no-cors.js
+++ b/fetch/api/basic/mode-no-cors.js
@@ -25,7 +25,7 @@ function fetchNoCors(url, isOpaqueFiltered) {
 fetchNoCors(RESOURCES_DIR + "top.txt", false);
 fetchNoCors("http://{{host}}:{{ports[http][0]}}/fetch/api/resources/top.txt", false);
 fetchNoCors("https://{{host}}:{{ports[https][0]}}/fetch/api/resources/top.txt", true);
-fetchNoCors("http://{{domains[www]}}:{{ports[http][0]}}/fetch/api/resources/top.txt", true);
+fetchNoCors("http://{{host}}:{{ports[http][1]}}/fetch/api/resources/top.txt", true);
 
 done();
 

--- a/fetch/api/cors/cors-basic.js
+++ b/fetch/api/cors/cors-basic.js
@@ -36,10 +36,10 @@ function cors(desc, scheme, subdomain, port) {
   }, desc + " [cors mode]");
 }
 
-cors("Cross domain basic usage", "http", "www1");
 cors("Same domain different port", "http", undefined, "{{ports[http][1]}}");
+cors("Same domain different protocol different port", "https", undefined, "{{ports[https][0]}}");
+cors("Cross domain basic usage", "http", "www1");
 cors("Cross domain different port", "http", "www1", "{{ports[http][1]}}");
 cors("Cross domain different protocol", "https", "www1", "{{ports[https][0]}}");
-cors("Same domain different protocol different port", "https", undefined, "{{ports[https][0]}}");
 
 done();

--- a/fetch/api/cors/cors-cookies.js
+++ b/fetch/api/cors/cors-cookies.js
@@ -48,11 +48,11 @@ var local = "{{host}}";
 var remote = "www.{{host}}";
 var remote1 = "www1.{{host}}";
 
+corsCookies("Omit mode: no cookie sent", local, local, "omit", ["g=7"]);
 corsCookies("Include mode: 1 cookie", remote, remote, "include", ["a=1"]);
 corsCookies("Include mode: local cookies are not sent with remote request", local, remote, "include", ["c=3"]);
 corsCookies("Include mode: remote cookies are not sent with local request", remote, local, "include", ["d=4"]);
 corsCookies("Include mode: remote cookies are not sent with other remote request", remote, remote1, "include", ["e=5"]);
 corsCookies("Same-origin mode: cookies are discarded in cors request", remote, remote, "same-origin", ["f=6"]);
-corsCookies("Omit mode: no cookie sent", local, local, "omit", ["g=7"]);
 
 done();

--- a/fetch/api/cors/cors-filtering.js
+++ b/fetch/api/cors/cors-filtering.js
@@ -40,7 +40,7 @@ function corsExposeFilter(corsUrl, headerName, headerValue, isForbidden) {
   }, "CORS filter on " + headerName + " header, header is exposed");
 }
 
-var url = "http://www1.{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "top.txt";
+var url = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "top.txt";
 
 corsFilter(url, "Cache-Control", "no-cache", false);
 corsFilter(url, "Content-Language", "fr", false);

--- a/fetch/api/cors/cors-multiple-origins.js
+++ b/fetch/api/cors/cors-multiple-origins.js
@@ -5,7 +5,7 @@ if (this.document === undefined) {
 
 function corsMultipleOrigins(desc, originList, shouldPass) {
   var urlParameters = "?origin=" + encodeURIComponent(originList.join(", "));
-  var url = "http://www1.{{host}}:{{ports[http][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+  var url = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
   if (shouldPass) {
     promise_test(function(test) {

--- a/fetch/api/cors/cors-redirect-credentials.js
+++ b/fetch/api/cors/cors-redirect-credentials.js
@@ -24,7 +24,7 @@ var remoteRedirect = "http://{{host}}:{{ports[http][1]}}" + redirPath;
 
 var localLocation = "http://{{host}}:{{ports[http][0]}}" + preflightPath;
 var remoteLocation = "http://{{host}}:{{ports[http][1]}}" + preflightPath;
-var remoteLocation2 = "https://{{host}}:{{ports[https][0]}}" + preflightPath;
+var remoteLocation2 = "http://www.{{host}}:{{ports[http][0]}}" + preflightPath;
 
 for (var code of [301, 302, 303, 307, 308]) {
   corsRedirectCredentials("Redirect " + code + " from same origin to remote with user and password", localRedirect, remoteLocation, code, "user:password");

--- a/fetch/api/cors/cors-redirect-credentials.js
+++ b/fetch/api/cors/cors-redirect-credentials.js
@@ -20,11 +20,11 @@ var redirPath = dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
 var preflightPath = dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
 var localRedirect = "http://{{host}}:{{ports[http][0]}}" + redirPath;
-var remoteRedirect = "http://www1.{{host}}:{{ports[http][0]}}" + redirPath;
+var remoteRedirect = "http://{{host}}:{{ports[http][1]}}" + redirPath;
 
 var localLocation = "http://{{host}}:{{ports[http][0]}}" + preflightPath;
-var remoteLocation = "http://www1.{{host}}:{{ports[http][0]}}" + preflightPath;
-var remoteLocation2 = "http://www.{{host}}:{{ports[http][0]}}" + preflightPath;
+var remoteLocation = "http://{{host}}:{{ports[http][1]}}" + preflightPath;
+var remoteLocation2 = "https://{{host}}:{{ports[https][0]}}" + preflightPath;
 
 for (var code of [301, 302, 303, 307, 308]) {
   corsRedirectCredentials("Redirect " + code + " from same origin to remote with user and password", localRedirect, remoteLocation, code, "user:password");
@@ -35,13 +35,13 @@ for (var code of [301, 302, 303, 307, 308]) {
   corsRedirectCredentials("Redirect " + code + " from remote to same origin with user", remoteRedirect, localLocation, code, "user:");
   corsRedirectCredentials("Redirect " + code + " from remote to same origin with password", remoteRedirect, localLocation, code, ":password");
 
-  corsRedirectCredentials("Redirect " + code + " from remote to another remote with user and password", remoteRedirect, remoteLocation2, code, "user:password");
-  corsRedirectCredentials("Redirect " + code + " from remote to another remote with user", remoteRedirect, remoteLocation2, code, "user:");
-  corsRedirectCredentials("Redirect " + code + " from remote to another remote with password", remoteRedirect, remoteLocation2, code, ":password");
-
   corsRedirectCredentials("Redirect " + code + " from remote to same remote with user and password", remoteRedirect, remoteLocation, code, "user:password");
   corsRedirectCredentials("Redirect " + code + " from remote to same remote with user", remoteRedirect, remoteLocation, code, "user:");
   corsRedirectCredentials("Redirect " + code + " from remote to same remote with password", remoteRedirect, remoteLocation, code, ":password");
+
+  corsRedirectCredentials("Redirect " + code + " from remote to another remote with user and password", remoteRedirect, remoteLocation2, code, "user:password");
+  corsRedirectCredentials("Redirect " + code + " from remote to another remote with user", remoteRedirect, remoteLocation2, code, "user:");
+  corsRedirectCredentials("Redirect " + code + " from remote to another remote with password", remoteRedirect, remoteLocation2, code, ":password");
 }
 
 done();


### PR DESCRIPTION
These changes would allow greater execution of the tests in WebKit environments where access to www/www1 URLs always fails.
Change is not done for cookies as different ports might not be different enough.
