### PR TITLE
part4 : modify web-platform-test.

### DIFF
--- a/webvtt/interfaces.html
+++ b/webvtt/interfaces.html
@@ -19,7 +19,7 @@ interface VTTCue : TextTrackCue {
            attribute boolean snapToLines;
            attribute (double or AutoKeyword) line;
            attribute AlignSetting lineAlign;
-           attribute double position;
+           attribute (double or AutoKeyword) position;
            attribute AlignSetting positionAlign;
            attribute double size;
            attribute AlignSetting align;


### PR DESCRIPTION
The idl-test-harness can't detect the multiple types in webidl [1], so it doesn't know about the type like "double or AutoKeyword".
The same problem also happen in VTTCue's line property, and we have already expected its fail.
Therefore, we should expect this fail before we fix the problem of idl-test-harness.

[1] http://searchfox.org/mozilla-central/source/dom/imptests/idlharness.js#375
MozReview-Commit-ID: 5XvOwdmqKDP

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1276831
