### PR TITLE
Ensure that when unblocking the scriptloader we try to process scripts if we have _any_ scripts to process, not just parser-blocking ones.

### DIFF
--- a/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader-subframe.html
+++ b/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader-subframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script>
+  function secondScriptRan() {
+    parent.postMessage("done", "*");
+  }
+
+  function createSecondScript() {
+      var script = document.createElement("script");
+      script.src = "data:application/javascript,secondScriptRan()";
+      document.head.appendChild(script);
+
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", "data:,", false);
+      xhr.send();
+  }
+</script>
+<script src="data:application/javascript,createSecondScript()" defer></script>

--- a/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader.html
+++ b/XMLHttpRequest/xmlhttprequest-sync-not-hang-scriptloader.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Ensure that an async script added during a defer script that then does a
+  sync XHR still runs</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<!--
+  We run the test in a subframe, because something in the testharness stuff
+  interferes with defer scripts -->
+<script>
+  var t = async_test();
+  onmessage = t.step_func_done(function(e) {
+    assert_equals(e.data, "done");
+  });
+</script>
+<iframe src="xmlhttprequest-sync-not-hang-scriptloader-subframe.html"></iframe>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1281366
