### PR TITLE
Correct XHR web platform test to verify that the last-modified time is set correctly on the response document if it is set in the HTTP headers (or not).

### DIFF
--- a/XMLHttpRequest/resources/last-modified.py
+++ b/XMLHttpRequest/resources/last-modified.py
@@ -1,0 +1,7 @@
+def main(request, response):
+    import datetime, os
+    srcpath = os.path.join(os.path.dirname(__file__), "well-formed.xml")
+    srcmoddt = datetime.datetime.fromtimestamp(os.path.getmtime(srcpath))
+    response.headers.set("Last-Modified", srcmoddt.strftime("%a, %d %b %Y %H:%M:%S GMT"))
+    response.headers.set("Content-Type", "application/xml")
+    return open(srcpath).read()

--- a/XMLHttpRequest/responsexml-document-properties.htm
+++ b/XMLHttpRequest/responsexml-document-properties.htm
@@ -10,6 +10,7 @@
   <body>
     <div id="log"></div>
     <script>
+      var timePreXHR = Math.floor(new Date().getTime() / 1000);
       var client = new XMLHttpRequest()
       client.open("GET", "resources/well-formed.xml", false)
       client.send(null)
@@ -43,8 +44,18 @@
       }
 
       test(function() {
-        assert_true((new Date(client.getResponseHeader('Last-Modified'))).getTime() == (new Date(client.responseXML.lastModified)).getTime(), 'responseXML.lastModified time should be equal to time in response Last-Modified header')
-      }, 'lastModified set according to HTTP header')
+        var lastModified = Math.floor(new Date(client.responseXML.lastModified).getTime() / 1000);
+        var now = Math.floor(new Date().getTime() / 1000);
+        assert_greater_than_equal(lastModified, timePreXHR);
+        assert_less_than_equal(lastModified, now);
+      }, 'lastModified set to time of response if no HTTP header provided')
+
+      test(function() {
+        var client2 = new XMLHttpRequest()
+        client2.open("GET", "resources/last-modified.py", false)
+        client2.send(null)
+        assert_equals((new Date(client2.getResponseHeader('Last-Modified'))).getTime(), (new Date(client2.responseXML.lastModified)).getTime())
+      }, 'lastModified set to related HTTP header if provided')
 
       test(function() {
         client.responseXML.cookie = "thisshouldbeignored"


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1280454
