### PR TITLE
Update pointerevents README and add myself as an OWNER

### DIFF
--- a/pointerevents/OWNERS
+++ b/pointerevents/OWNERS
@@ -5,3 +5,4 @@
 @plehegar
 @scottgonzalez
 @staktrace
+@RByers

--- a/pointerevents/README.md
+++ b/pointerevents/README.md
@@ -1,6 +1,6 @@
 Directory for Pointer Events Tests
 
-Latest Editor's Draft: https://dvcs.w3.org/hg/pointerevents/raw-file/tip/pointerEvents.html
+Latest Editor's Draft: https://w3c.github.io/pointerevents/
 
 Latest W3C Technical Report: http://www.w3.org/TR/pointerevents/
 


### PR DESCRIPTION
I've already been pushing commits to pointerevents tests based on the "reviewed upstream" policy.  Might as well avoid confusion by explicitly listing myself in the OWNERS file.
