### PR TITLE
Chromium tests converted to web platform tests

### DIFF
--- a/media-source/mediasource-appendbuffer-quota-exceeded.html
+++ b/media-source/mediasource-appendbuffer-quota-exceeded.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    // Fill up a given SourceBuffer by appending data repeatedly via doAppendDataFunc until
+    // an exception is thrown. The thrown exception is passed to onCaughtExceptionCallback.
+    function fillUpSourceBuffer(test, sourceBuffer, doAppendDataFunc, onCaughtExceptionCallback) {
+        // We are appending data repeatedly in sequence mode, there should be no gaps.
+        assert_false(sourceBuffer.buffered.length > 1, "unexpected gap in buffered ranges.");
+        try {
+            doAppendDataFunc();
+        } catch(ex) {
+            onCaughtExceptionCallback(ex);
+        }
+        test.expectEvent(sourceBuffer, 'updateend', 'append ended.');
+        test.waitForExpectedEvents(function() { fillUpSourceBuffer(test, sourceBuffer, doAppendDataFunc, onCaughtExceptionCallback); });
+    }
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        sourceBuffer.mode = 'sequence';
+        fillUpSourceBuffer(test, sourceBuffer,
+            function () { // doAppendDataFunc
+                sourceBuffer.appendBuffer(mediaData);
+            },
+            function (ex) { // onCaughtExceptionCallback
+                assert_equals(ex.name, 'QuotaExceededError');
+                test.done();
+            });
+    }, 'Appending data repeatedly should fill up the buffer and throw a QuotaExceededError when buffer is full.');
+</script>

--- a/media-source/mediasource-avtracks.html
+++ b/media-source/mediasource-avtracks.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        sourceBuffer.appendBuffer(initSegment);
+        test.expectEvent(sourceBuffer.audioTracks, "addtrack", "sourceBuffer.audioTracks addtrack event");
+        test.expectEvent(sourceBuffer.videoTracks, "addtrack", "sourceBuffer.videoTracks addtrack event");
+        test.expectEvent(mediaElement.audioTracks, "addtrack", "mediaElement.audioTracks addtrack event");
+        test.expectEvent(mediaElement.videoTracks, "addtrack", "mediaElement.videoTracks addtrack event");
+        test.expectEvent(mediaElement, "loadedmetadata", "loadedmetadata done.");
+        test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(sourceBuffer.videoTracks.length, 1, "videoTracks.length");
+            assert_equals(sourceBuffer.videoTracks[0].kind, "main", "videoTrack.kind");
+            assert_equals(sourceBuffer.videoTracks[0].label, "", "videoTrack.label");
+            assert_equals(sourceBuffer.videoTracks[0].language, "eng", "videoTrack.language");
+            assert_equals(sourceBuffer.videoTracks[0].sourceBuffer, sourceBuffer, "videoTrack.sourceBuffer");
+            // The first video track is selected by default.
+            assert_true(sourceBuffer.videoTracks[0].selected, "sourceBuffer.videoTracks[0].selected");
+
+            assert_equals(sourceBuffer.audioTracks.length, 1, "audioTracks.length");
+            assert_equals(sourceBuffer.audioTracks[0].kind, "main", "audioTrack.kind");
+            assert_equals(sourceBuffer.audioTracks[0].label, "", "audioTrack.label");
+            assert_equals(sourceBuffer.audioTracks[0].language, "eng", "audioTrack.language");
+            assert_equals(sourceBuffer.audioTracks[0].sourceBuffer, sourceBuffer, "audioTrack.sourceBuffer");
+            // The first audio track is enabled by default.
+            assert_true(sourceBuffer.audioTracks[0].enabled, "sourceBuffer.audioTracks[0].enabled");
+
+            assert_not_equals(sourceBuffer.audioTracks[0].id, sourceBuffer.videoTracks[0].id, "track ids must be unique");
+
+            assert_equals(mediaElement.videoTracks.length, 1, "videoTracks.length");
+            assert_equals(mediaElement.videoTracks[0], sourceBuffer.videoTracks[0], "mediaElement.videoTrack == sourceBuffer.videoTrack");
+
+            assert_equals(mediaElement.audioTracks.length, 1, "audioTracks.length");
+            assert_equals(mediaElement.audioTracks[0], sourceBuffer.audioTracks[0], "mediaElement.audioTrack == sourceBuffer.audioTrack");
+
+            test.done();
+        });
+    }, "Check that media tracks and their properties are populated properly");
+
+    function verifyTrackRemoval(test, mediaElement, mediaSource, sourceBuffer, trackRemovalAction, successCallback) {
+        assert_equals(sourceBuffer.audioTracks.length, 1, "audioTracks.length");
+        assert_true(sourceBuffer.audioTracks[0].enabled, "sourceBuffer.audioTracks[0].enabled");
+        assert_equals(sourceBuffer.videoTracks.length, 1, "videoTracks.length");
+        assert_true(sourceBuffer.videoTracks[0].selected, "sourceBuffer.videoTracks[0].selected");
+
+        var audioTrack = sourceBuffer.audioTracks[0];
+        var videoTrack = sourceBuffer.videoTracks[0];
+
+        // Verify removetrack events.
+        test.expectEvent(sourceBuffer.audioTracks, "removetrack", "sourceBuffer.audioTracks removetrack event");
+        test.expectEvent(sourceBuffer.videoTracks, "removetrack", "sourceBuffer.videoTracks removetrack event");
+        test.expectEvent(mediaElement.audioTracks, "removetrack", "mediaElement.audioTracks removetrack event");
+        test.expectEvent(mediaElement.videoTracks, "removetrack", "mediaElement.videoTracks removetrack event");
+
+        // Removing enabled audio track and selected video track should fire "change" events on mediaElement track lists.
+        test.expectEvent(mediaElement.audioTracks, "change", "mediaElement.audioTracks changed.");
+        test.expectEvent(mediaElement.videoTracks, "change", "mediaElement.videoTracks changed.");
+
+        trackRemovalAction();
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(mediaSource.sourceBuffers.length, 0, "mediaSource.sourceBuffers.length");
+            assert_equals(mediaElement.videoTracks.length, 0, "videoTracks.length");
+            assert_equals(mediaElement.audioTracks.length, 0, "audioTracks.length");
+            assert_equals(sourceBuffer.videoTracks.length, 0, "videoTracks.length");
+            assert_equals(sourceBuffer.audioTracks.length, 0, "audioTracks.length");
+            // Since audio and video tracks have been removed, their .sourceBuffer property should be null now.
+            assert_equals(audioTrack.sourceBuffer, null, "audioTrack.sourceBuffer");
+            assert_equals(videoTrack.sourceBuffer, null, "videoTrack.sourceBuffer");
+            test.done();
+        });
+    }
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        sourceBuffer.appendBuffer(initSegment);
+        test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+        test.waitForExpectedEvents(function()
+        {
+            verifyTrackRemoval(test, mediaElement, mediaSource, sourceBuffer, test.step_func(function ()
+            {
+                mediaSource.removeSourceBuffer(sourceBuffer);
+            }));
+        });
+    }, "Media tracks must be removed when the SourceBuffer is removed from the MediaSource");
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        sourceBuffer.appendBuffer(initSegment);
+        test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+        test.waitForExpectedEvents(function()
+        {
+            verifyTrackRemoval(test, mediaElement, mediaSource, sourceBuffer, test.step_func(function ()
+            {
+                mediaElement.src = "";
+            }));
+        });
+    }, "Media tracks must be removed when the HTMLMediaElement.src is changed");
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        sourceBuffer.appendBuffer(initSegment);
+        test.expectEvent(sourceBuffer, "updateend", "initSegment append ended.");
+        test.waitForExpectedEvents(function()
+        {
+            verifyTrackRemoval(test, mediaElement, mediaSource, sourceBuffer, test.step_func(function ()
+            {
+                mediaElement.load();
+            }));
+        });
+    }, "Media tracks must be removed when HTMLMediaElement.load() is called");
+</script>

--- a/media-source/mediasource-detach.html
+++ b/media-source/mediasource-detach.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    function mediasource_detach_test(testFunction, description)
+    {
+        mediasource_test(function(test, mediaElement, mediaSource)
+        {
+            var segmentInfo = MediaSourceUtil.SEGMENT_INFO;
+            var sourceBuffer = mediaSource.addSourceBuffer(segmentInfo.type);
+
+            assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+            assert_equals(mediaSource.readyState, 'open');
+
+            mediaSource.addEventListener('sourceclose', test.step_func(function (event)
+            {
+                assert_equals(mediaSource.sourceBuffers.length, 0, 'sourceBuffers is empty');
+                assert_equals(mediaSource.activeSourceBuffers.length, 0, 'activeSourceBuffers is empty');
+                assert_equals(mediaSource.readyState, 'closed', 'readyState is "closed"');
+                assert_true(Number.isNaN(mediaSource.duration), 'duration is NaN');
+                test.done();
+            }));
+
+            MediaSourceUtil.loadBinaryData(test, segmentInfo.url, function(mediaData)
+            {
+                testFunction(test, mediaElement, mediaSource, sourceBuffer, mediaData);
+            });
+        }, description);
+    }
+
+    mediasource_detach_test(function(test, mediaElement, mediaSource, sourceBuffer, mediaData)
+    {
+        mediaElement.load();
+    }, 'Test media.load() before appending data will trigger MediaSource detaching from a media element.');
+
+    mediasource_detach_test(function(test, mediaElement, mediaSource, sourceBuffer, mediaData)
+    {
+        sourceBuffer.addEventListener('updateend', test.step_func(function (event)
+        {
+            assert_greater_than(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING, 'media readyState is greater than "HAVE_NOTHING"')
+            assert_false(sourceBuffer.updating, 'updating attribute is false');
+            mediaElement.load();
+        }));
+
+        sourceBuffer.appendBuffer(mediaData);
+    }, 'Test media.load() after appending data will trigger MediaSource detaching from a media element.');
+</script>

--- a/media-source/mediasource-errors.html
+++ b/media-source/mediasource-errors.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    function ErrorTest(testFunction, description)
+    {
+        mediasource_test(function(test, mediaElement, mediaSource)
+        {
+            var segmentInfo = MediaSourceUtil.SEGMENT_INFO;
+
+            if (!segmentInfo) {
+                assert_unreached("No segment info compatible with this MediaSource implementation.");
+                return;
+            }
+
+            var sourceBuffer = mediaSource.addSourceBuffer(segmentInfo.type);
+            MediaSourceUtil.loadBinaryData(test, segmentInfo.url, function(mediaData)
+            {
+                testFunction(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData);
+            });
+        }, description);
+    }
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+
+        test.expectEvent(sourceBuffer, "error", "sourceBuffer error.");
+        test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+        test.expectEvent(mediaElement, "error", "mediaElement error.");
+        test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+        test.expectEvent(mediaSource, "sourceclose", "mediaSource closed.");
+        sourceBuffer.appendBuffer(mediaSegment);
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+
+            assert_equals(mediaSource.sourceBuffers.length, 0);
+            assert_equals(mediaSource.readyState, "closed");
+            test.done();
+        });
+    }, "Appending media segment before the first initialization segment.");
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+        // Fail if the append error algorithm occurs, since the decode
+        // error will be provided by us directly via endOfStream().
+        sourceBuffer.addEventListener("error", test.unreached_func("'error' should not be fired on sourceBuffer"));
+
+        test.expectEvent(mediaElement, "error", "mediaElement error.");
+        test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+        test.expectEvent(mediaSource, "sourceclose", "mediaSource closed.");
+
+        mediaSource.endOfStream("decode");
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+
+            assert_equals(mediaSource.sourceBuffers.length, 0);
+            assert_equals(mediaSource.readyState, "closed");
+
+            // Give a short time for a broken implementation to errantly fire
+            // "error" on sourceBuffer.
+            test.step_timeout(test.step_func_done(), 0);
+        });
+    }, "Signaling 'decode' error via endOfStream() before initialization segment has been appended.");
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+        // Fail if the append error algorithm occurs, since the network
+        // error will be provided by us directly via endOfStream().
+        sourceBuffer.addEventListener("error", test.unreached_func("'error' should not be fired on sourceBuffer"));
+
+        test.expectEvent(mediaElement, "error", "mediaElement error.");
+        test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+        test.expectEvent(mediaSource, "sourceclose", "mediaSource closed.");
+
+        mediaSource.endOfStream("network");
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED);
+
+            assert_equals(mediaSource.sourceBuffers.length, 0);
+            assert_equals(mediaSource.readyState, "closed");
+
+            // Give a short time for a broken implementation to errantly fire
+            // "error" on sourceBuffer.
+            test.step_timeout(test.step_func_done(), 0);
+        });
+    }, "Signaling 'network' error via endOfStream() before initialization segment has been appended.");
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+        // Fail if the append error algorithm occurs, since the decode
+        // error will be provided by us directly via endOfStream().
+        sourceBuffer.addEventListener("error", test.unreached_func("'error' should not be fired on sourceBuffer"));
+
+        test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+        test.expectEvent(mediaElement, "loadedmetadata", "mediaElement metadata.");
+        sourceBuffer.appendBuffer(initSegment);
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_METADATA);
+
+            test.expectEvent(mediaElement, "error", "mediaElement error.");
+            test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+            mediaSource.endOfStream("decode");
+        });
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_DECODE);
+            assert_equals(mediaSource.readyState, "ended");
+
+            // Give a short time for a broken implementation to errantly fire
+            // "error" on sourceBuffer.
+            test.step_timeout(test.step_func_done(), 0);
+        });
+
+    }, "Signaling 'decode' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA.");
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+        // Fail if the append error algorithm occurs, since the network
+        // error will be provided by us directly via endOfStream().
+        sourceBuffer.addEventListener("error", test.unreached_func("'error' should not be fired on sourceBuffer"));
+
+        test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+        test.expectEvent(mediaElement, "loadedmetadata", "mediaElement metadata.");
+        sourceBuffer.appendBuffer(initSegment);
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_METADATA);
+            test.expectEvent(mediaElement, "error", "mediaElement error.");
+            test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+            mediaSource.endOfStream("network");
+        });
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_NETWORK);
+            assert_equals(mediaSource.readyState, "ended");
+
+            // Give a short time for a broken implementation to errantly fire
+            // "error" on sourceBuffer.
+            test.step_timeout(test.step_func_done(), 0);
+        });
+    }, "Signaling 'network' error via endOfStream() after initialization segment has been appended and the HTMLMediaElement has reached HAVE_METADATA.");
+
+    ErrorTest(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_NOTHING);
+
+        var mediaSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[0]);
+        var index = segmentInfo.init.size + (mediaSegment.length - 1) / 2;
+        // Corrupt the media data from index of mediaData, so it can signal 'decode' error.
+        // Here use mediaSegment to replace the original mediaData[index, index + mediaSegment.length]
+        mediaData.set(mediaSegment, index);
+
+        test.expectEvent(mediaElement, "loadedmetadata", "mediaElement metadata.");
+        test.expectEvent(sourceBuffer, "error", "sourceBuffer error.");
+        test.expectEvent(sourceBuffer, "updateend", "mediaSegment append ended.");
+        test.expectEvent(mediaElement, "error", "mediaElement error.");
+        test.expectEvent(mediaSource, "sourceended", "mediaSource ended.");
+        sourceBuffer.appendBuffer(mediaData);
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_true(mediaElement.error != null);
+            assert_equals(mediaElement.error.code, MediaError.MEDIA_ERR_DECODE);
+            test.done();
+        });
+    }, "Signaling 'decode' error via segment parser loop algorithm after initialization segment and partial media segment has been appended.");
+</script>

--- a/media-source/mediasource-seekable.html
+++ b/media-source/mediasource-seekable.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    mediasource_test(function(test, mediaElement, mediaSource)
+    {
+        mediaElement.addEventListener('error', test.unreached_func("Unexpected event 'error'"));
+        mediaElement.addEventListener('ended', test.step_func_done(function () {}));
+
+        var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+
+        assertSeekableEquals(mediaElement, '{ }', 'mediaElement.seekable');
+        test.done();
+    }, 'Get seekable time ranges when the sourcebuffer is empty.');
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        test.expectEvent(mediaElement, 'durationchange', 'mediaElement got duration');
+        sourceBuffer.appendBuffer(initSegment);
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(mediaElement.duration, segmentInfo.duration);
+            assertSeekableEquals(mediaElement, '{ [0.000, ' + segmentInfo.duration.toFixed(3) + ') }', 'mediaElement.seekable');
+            test.done();
+        });
+    }, 'Get seekable time ranges after init segment received.');
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
+        test.expectEvent(mediaElement, 'durationchange', 'mediaElement got duration after initsegment');
+        sourceBuffer.appendBuffer(initSegment);
+        test.waitForExpectedEvents(function()
+        {
+            test.expectEvent(mediaElement, 'durationchange', 'mediaElement got infinity duration');
+            mediaSource.duration = Infinity;
+            test.waitForExpectedEvents(function()
+            {
+                assertSeekableEquals(mediaElement, '{ }', 'mediaElement.seekable');
+
+                // Append a segment from the middle of the stream to make sure that seekable does not use buffered.start(0) or duration as first or last value
+                var midSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[2]);
+                test.expectEvent(sourceBuffer, 'update');
+                test.expectEvent(sourceBuffer, 'updateend');
+                sourceBuffer.appendBuffer(midSegment);
+                test.waitForExpectedEvents(function()
+                {
+                    assert_equals(mediaElement.seekable.length, 1, 'mediaElement.seekable.length');
+                    assert_equals(mediaElement.buffered.length, 1, 'mediaElement.buffered.length');
+                    assert_not_equals(mediaElement.seekable.start(0), mediaElement.buffered.start(0));
+                    assert_equals(mediaElement.seekable.start(0), 0);
+                    assert_not_equals(mediaElement.seekable.end(0), mediaElement.duration);
+                    assert_not_equals(mediaElement.seekable.end(0), mediaElement.buffered.start(0));
+                    assert_equals(mediaElement.seekable.end(0), mediaElement.buffered.end(0));
+                    test.done();
+                });
+            });
+        });
+    }, 'Get seekable time ranges on an infinite stream.');
+</script>

--- a/media-source/mediasource-sourcebuffer-trackdefaults.html
+++ b/media-source/mediasource-sourcebuffer-trackdefaults.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="mediasource-util.js"></script>
+<script>
+    function sourceBufferTrackDefaultsTest(callback, description)
+    {
+        mediasource_test(function(test, mediaElement, mediaSource)
+        {
+            var sourceBuffer = mediaSource.addSourceBuffer(MediaSourceUtil.AUDIO_VIDEO_TYPE);
+            assert_array_equals(sourceBuffer.trackDefaults, [], "Empty initial SourceBuffer.trackDefaults");
+            callback(test, mediaElement, mediaSource, sourceBuffer);
+        }, description);
+    };
+
+    sourceBufferTrackDefaultsTest(function(test, mediaElement, mediaSource, sourceBuffer)
+    {
+        var emptyList = new TrackDefaultList([]);
+        assert_not_equals(sourceBuffer.trackDefaults, emptyList, "Initial trackDefaults object differs from new empty list");
+
+        sourceBuffer.trackDefaults = emptyList;
+
+        assert_array_equals(sourceBuffer.trackDefaults, [], "Round-tripped empty trackDefaults");
+        assert_equals(sourceBuffer.trackDefaults, emptyList, "Round-tripped the empty TrackDefaultList object");
+        test.done();
+    }, "Test round-trip of empty SourceBuffer.trackDefaults");
+
+    sourceBufferTrackDefaultsTest(function(test, mediaElement, mediaSource, sourceBuffer)
+    {
+        var trackDefault = new TrackDefault("audio", "en-US", "audio label", ["main"], "1");
+        var trackDefaults = new TrackDefaultList([ trackDefault ]);
+
+        sourceBuffer.trackDefaults = trackDefaults;
+
+        assert_array_equals(sourceBuffer.trackDefaults, trackDefaults, "Round-tripped non-empty trackDefaults");
+        assert_equals(sourceBuffer.trackDefaults.length, 1, "Confirmed non-empty trackDefaults");
+        assert_equals(sourceBuffer.trackDefaults, trackDefaults, "Round-tripped the non-empty TrackDefaultList object");
+        test.done();
+    }, "Test round-trip of non-empty SourceBuffer.trackDefaults");
+
+    sourceBufferTrackDefaultsTest(function(test, mediaElement, mediaSource, sourceBuffer)
+    {
+        mediaSource.removeSourceBuffer(sourceBuffer);
+        assert_throws("InvalidStateError",
+                      function() { sourceBuffer.trackDefaults = new TrackDefaultList([]); },
+                      "Exception thrown when setting trackDefaults on SourceBuffer that is removed from MediaSource");
+        test.done();
+    }, "Test setting trackDefaults on an already-removed SourceBuffer");
+
+    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    {
+        assert_array_equals(sourceBuffer.trackDefaults, [], "Empty initial SourceBuffer.trackDefaults");
+        test.expectEvent(sourceBuffer, "updateend", "Append ended");
+        sourceBuffer.appendBuffer(mediaData);
+        assert_true(sourceBuffer.updating, "SourceBuffer is updating");
+
+        assert_throws("InvalidStateError",
+                      function() { sourceBuffer.trackDefaults = new TrackDefaultList([]); },
+                      "Exception thrown when setting trackDefaults on SourceBuffer that is updating");
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_false(sourceBuffer.updating, "SourceBuffer is not updating");
+            sourceBuffer.trackDefaults = new TrackDefaultList([]);
+            test.done();
+        });
+    }, "Test setting trackDefaults on a SourceBuffer that is updating");
+
+    sourceBufferTrackDefaultsTest(function(test, mediaElement, mediaSource, sourceBuffer)
+    {
+        assert_throws(new TypeError(),
+            function() { sourceBuffer.trackDefaults = null; },
+            "null should be disallowed by trackDefaults setter");
+        test.done();
+    }, "Test setting null SourceBuffer.trackDefaults");
+</script>

--- a/media-source/mediasource-trackdefault.html
+++ b/media-source/mediasource-trackdefault.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    function checkConstructionSucceeds(type, language, label, kinds, byteStreamTrackID)
+    {
+        var trackDefault = new TrackDefault(type, language, label, kinds, byteStreamTrackID);
+        assert_equals(trackDefault.type, type, "type");
+        assert_equals(trackDefault.language, language, "language");
+        assert_equals(trackDefault.label, label, "label");
+        assert_equals(trackDefault.byteStreamTrackID, byteStreamTrackID, "byteStreamTrackID");
+        assert_array_equals(trackDefault.kinds, kinds, "kinds");
+    }
+
+    function checkConstructionFails(type, language, label, kinds, byteStreamTrackID)
+    {
+        assert_throws(new TypeError(),
+            function() { new TrackDefault(type, language, label, kinds, byteStreamTrackID); },
+            "TrackDefault construction threw an exception");
+    }
+
+    function trackDefaultConstructionTest(type, language, label, kinds, byteStreamTrackID, expectation, description)
+    {
+        test(function()
+        {
+            if (expectation)
+                checkConstructionSucceeds(type, language, label, kinds, byteStreamTrackID);
+            else
+                checkConstructionFails(type, language, label, kinds, byteStreamTrackID);
+        }, description + ": type '" + type + "', language '" + language + "', label '" + label + "', multiple kinds, byteStreamTrackID '" + byteStreamTrackID + "'");
+
+        // If all of |kinds| are expected to succeed, also test each kind individually.
+        if (!expectation || kinds.length <= 1)
+            return;
+        for (var i = 0; i < kinds.length; ++i) {
+            test(function()
+            {
+                checkConstructionSucceeds(type, language, label, new Array(kinds[i]), byteStreamTrackID);
+            }, description + ": type '" + type + "', language '" + language + "', label '" + label + "', kind '" + kinds[i] + "', byteStreamTrackID '" + byteStreamTrackID + "'");
+        }
+    }
+
+    var VALID_AUDIO_TRACK_KINDS = [
+        "alternative",
+        "descriptions",
+        "main",
+        "main-desc",
+        "translation",
+        "commentary",
+        "",
+    ];
+
+    var VALID_VIDEO_TRACK_KINDS = [
+        "alternative",
+        "captions",
+        "main",
+        "sign",
+        "subtitles",
+        "commentary",
+        "",
+    ];
+
+    var VALID_TEXT_TRACK_KINDS = [
+        "subtitles",
+        "captions",
+        "descriptions",
+        "chapters",
+        "metadata",
+    ];
+
+    trackDefaultConstructionTest("audio", "en-US", "audio label", VALID_AUDIO_TRACK_KINDS, "1", true, "Test valid audio kinds");
+
+    trackDefaultConstructionTest("video", "en-US", "video label", VALID_VIDEO_TRACK_KINDS, "1", true, "Test valid video kinds");
+
+    trackDefaultConstructionTest("text", "en-US", "text label", VALID_TEXT_TRACK_KINDS, "1", true, "Test valid text kinds");
+
+    trackDefaultConstructionTest("audio", "en-US", "audio label", VALID_VIDEO_TRACK_KINDS, "1", false, "Test mixed valid and invalid audio kinds");
+
+    trackDefaultConstructionTest("video", "en-US", "video label", VALID_AUDIO_TRACK_KINDS, "1", false, "Test mixed valid and invalid video kinds");
+
+    trackDefaultConstructionTest("text", "en-US", "text label", VALID_VIDEO_TRACK_KINDS, "1", false, "Test mixed valid and invalid text kinds");
+
+    trackDefaultConstructionTest("invalid type", "en-US", "label", VALID_AUDIO_TRACK_KINDS, "1", false, "Test invalid 'type' parameter type passed to TrackDefault constructor");
+
+    test(function()
+    {
+        checkConstructionFails("audio", "en-US", "label", "this is not a valid sequence", "1");
+    }, "Test invalid 'kinds' parameter type passed to TrackDefault constructor");
+
+    test(function()
+    {
+        var trackDefault = new TrackDefault("audio", "en-US", "label", VALID_AUDIO_TRACK_KINDS, "1");
+        var kinds = trackDefault.kinds;
+        kinds[0] = "invalid kind";
+        assert_equals(kinds[0], "invalid kind", "local kinds is updated");
+        assert_equals(VALID_AUDIO_TRACK_KINDS[0], "alternative", "local original kinds unchanged");
+        assert_array_equals(trackDefault.kinds, VALID_AUDIO_TRACK_KINDS, "trackDefault kinds unchanged");
+    }, "Test updating the retval of TrackDefault.kinds does not modify TrackDefault.kinds");
+</script>

--- a/media-source/mediasource-trackdefaultlist.html
+++ b/media-source/mediasource-trackdefaultlist.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    test(function()
+    {
+        var originalTrackDefaults = [
+            // Same everything, but different byteStreamTrackID, should be allowed by the constructor.
+            new TrackDefault("audio", "en-US", "label", ["main"], ""),
+            new TrackDefault("audio", "en-US", "label", ["main"], "1"),
+            new TrackDefault("audio", "en-US", "label", ["main"], "2"),
+            new TrackDefault("audio", "en-US", "label", [""], "3"),
+
+            // Same everything, but different type, should be allowed by the constructor.
+            new TrackDefault("video", "en-US", "label", ["main"], ""),
+            new TrackDefault("video", "en-US", "label", ["main"], "1"),
+            new TrackDefault("video", "en-US", "label", ["main"], "2"),
+            new TrackDefault("video", "en-US", "label", [""], "3")
+        ];
+
+        // Get a new array containing the same objects as |originalTrackDefaults|.
+        var trackDefaults = originalTrackDefaults.slice();
+
+        var trackDefaultList = new TrackDefaultList(trackDefaults);
+        assert_array_equals(trackDefaultList, originalTrackDefaults, "construction and read-back succeeded");
+        assert_equals(trackDefaultList[trackDefaultList.length], undefined, "out of range indexed property getter result is undefined");
+        assert_equals(trackDefaultList[trackDefaultList.length + 1], undefined, "out of range indexed property getter result is undefined");
+
+        // Introduce same-type, same-empty-string-byteStreamTrackId conflict in trackDefaults[0 vs 4].
+        trackDefaults[4] = new TrackDefault("audio", "en-US", "label", ["main"], "");
+        assert_equals(trackDefaults[0].type, trackDefaults[4].type, "same-type conflict setup");
+        assert_equals(trackDefaults[0].byteStreamTrackID, trackDefaults[4].byteStreamTrackID, "same-byteStreamTrackID conflict setup");
+        assert_throws("InvalidAccessError",
+            function() { new TrackDefaultList(trackDefaults); },
+            "TrackDefaultList construction should throw exception due to same type and byteStreamTrackID across at least 2 items in trackDefaults");
+
+        // Introduce same-type, same-non-empty-string-byteStreamTrackId conflict in trackDefaults[4 vs 5].
+        trackDefaults[4] = new TrackDefault("video", "en-US", "label", ["main"], "1");
+        assert_equals(trackDefaults[4].type, trackDefaults[5].type, "same-type conflict setup");
+        assert_equals(trackDefaults[4].byteStreamTrackID, trackDefaults[5].byteStreamTrackID, "same-byteStreamTrackID conflict setup");
+        assert_throws("InvalidAccessError",
+            function() { new TrackDefaultList(trackDefaults); },
+            "TrackDefaultList construction should throw exception due to same type and byteStreamTrackID across at least 2 items in trackDefaults");
+
+        // Confirm the constructed TrackDefaultList makes a shallow copy of the supplied TrackDefault sequence.
+        assert_array_equals(trackDefaultList, originalTrackDefaults, "read-back of original trackDefaultList unchanged");
+
+    }, "Test track default list construction, length, and indexed property getter");
+
+    test(function()
+    {
+        var trackDefaultList = new TrackDefaultList();
+        assert_array_equals(trackDefaultList, [], "empty list constructable without supplying optional trackDefaults parameter");
+
+        trackDefaultList = new TrackDefaultList([]);
+        assert_array_equals(trackDefaultList, [], "empty list constructable by supplying empty sequence as optional trackDefaults parameter");
+    }, "Test empty track default list construction with and without optional trackDefaults parameter");
+</script>

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -359,6 +359,9 @@
         return media_test(function(test)
         {
             var mediaTag = document.createElement("video");
+            if (!document.body) {
+                document.body = document.createElement("body");
+            }
             document.body.appendChild(mediaTag);
 
             test.removeMediaElement_ = true;


### PR DESCRIPTION
This pull request converts MSE tests from the Chromium test suite. Conversion was mostly straightforward. I updated a couple of tests though:
- `mediasource-appendbuffer-quota-exceeded.html` now uses the usual `test.mp4` or `test.webm` media file.
- `mediasource-avtracks.html` tests are more atomic. Typically, removal now only tests removal and thus no longer fails when the kind, label or language of the tracks are not valid. By the way, the test assumes that the track language will be `eng`, and I'm not clear whether `en`, which Edge reports, is really invalid.

The pull request integrates #3239 as tests use the minimal script test template.

NB: raw Chromium tests should be imported to clear any potential licensing issue.
