### PR TITLE
Fix typo in html/dom/interfaces.html related to TrackEvent testing

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -3246,7 +3246,7 @@ window.onload = function() {
     TextTrackCue: [],
     DataCue: [],
     TimeRanges: ['document.createElement("video").buffered'],
-    TrackEvent: ['new TrackEvent("addtrack"; {track:document.createElement("track").track})'],
+    TrackEvent: ['new TrackEvent("addtrack", {track:document.createElement("track").track})'],
     HTMLTemplateElement: ['document.createElement("template")'],
     HTMLSlotElement: ['document.createElement("slot")'],
     HTMLCanvasElement: ['document.createElement("canvas")'],


### PR DESCRIPTION
The test used a ';' instead of a ','.
