### PR TITLE
Assert the correct object in responsexml-basic.htm

### DIFF
--- a/XMLHttpRequest/responsexml-basic.htm
+++ b/XMLHttpRequest/responsexml-basic.htm
@@ -19,7 +19,7 @@
         assert_equals(client.responseXML.documentElement.localName, "html", 'localName is html')
         assert_equals(client.responseXML.documentElement.childNodes.length, 5, 'childNodes is 5')
         assert_equals(client.responseXML.getElementById("n1").localName, client.responseXML.documentElement.childNodes[1].localName)
-        assert_equals(client.responseXML.getElementById("n2"), null, 'getElementById("n2")')
+        assert_equals(client.responseXML.getElementById("n2"), client.responseXML.documentElement.childrenNodes[3], 'getElementById("n2")')
         assert_equals(client.responseXML.getElementsByTagName("p")[1].namespaceURI, "namespacesarejuststrings", 'namespaceURI')
       })
       test(function() {


### PR DESCRIPTION
`well-formed.xml` has the following contents:

``` xml
<html xmlns="http://www.w3.org/1999/xhtml">
  <p id="n&#49;">1</p>
  <p xmlns="namespacesarejuststrings" id="n2">2</p>
</html>
```

So the `assert_equals` function should never expect a null when it gets an element by the ID of n2.
