### PR TITLE
Using get-host-info.sub.js on more fetch API tests

### DIFF
--- a/fetch/api/cors/cors-basic-worker.html
+++ b/fetch/api/cors/cors-basic-worker.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-basic.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-basic.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-basic.html
+++ b/fetch/api/cors/cors-basic.html
@@ -13,6 +13,7 @@
   </head>
   <body>
     <script src="../resources/utils.js"></script>
-    <script src="cors-basic.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-basic.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-basic.js
+++ b/fetch/api/cors/cors-basic.js
@@ -1,17 +1,11 @@
 if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("../resources/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
 }
 
-function cors(desc, scheme, subdomain, port) {
-  if (!port)
-    port = location.port;
-  if (subdomain)
-    subdomain = subdomain + ".";
-  else
-    subdomain = "";
-
-  var url = scheme + "://" + subdomain + "{{host}}" + ":" + port + dirname(location.pathname);
+function cors(desc, origin) {
+  var url = origin + dirname(location.pathname);
   var urlParameters = "?pipe=header(Access-Control-Allow-Origin,*)";
 
   promise_test(function(test) {
@@ -36,10 +30,12 @@ function cors(desc, scheme, subdomain, port) {
   }, desc + " [cors mode]");
 }
 
-cors("Same domain different port", "http", undefined, "{{ports[http][1]}}");
-cors("Same domain different protocol different port", "https", undefined, "{{ports[https][0]}}");
-cors("Cross domain basic usage", "http", "www1");
-cors("Cross domain different port", "http", "www1", "{{ports[http][1]}}");
-cors("Cross domain different protocol", "https", "www1", "{{ports[https][0]}}");
+var host_info = get_host_info();
+
+cors("Same domain different port", host_info.HTTP_ORIGIN_WITH_DIFFERENT_PORT);
+cors("Same domain different protocol different port", host_info.HTTPS_ORIGIN);
+cors("Cross domain basic usage", host_info.HTTP_REMOTE_ORIGIN);
+cors("Cross domain different port", host_info.HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT);
+cors("Cross domain different protocol", host_info.HTTPS_REMOTE_ORIGIN);
 
 done();

--- a/fetch/api/cors/cors-preflight-redirect-worker.html
+++ b/fetch/api/cors/cors-preflight-redirect-worker.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-preflight-redirect.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-preflight-redirect.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-redirect.html
+++ b/fetch/api/cors/cors-preflight-redirect.html
@@ -13,6 +13,7 @@
   <body>
     <script src="/common/utils.js"></script>
     <script src="../resources/utils.js"></script>
-    <script src="cors-preflight-redirect.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-preflight-redirect.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-redirect.js
+++ b/fetch/api/cors/cors-preflight-redirect.js
@@ -2,6 +2,7 @@ if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("../resources/utils.js");
   importScripts("/common/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
 }
 
 function corsPreflightRedirect(desc, redirectUrl, redirectLocation, redirectStatus, redirectPreflight) {
@@ -27,8 +28,8 @@ function corsPreflightRedirect(desc, redirectUrl, redirectLocation, redirectStat
   }, desc);
 }
 
-var redirectUrl = "http://www1.{{host}}:{{ports[http][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
-var locationUrl = "http://www1.{{host}}:{{ports[http][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+var redirectUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
+var locationUrl =  get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
 for (var code of [301, 302, 303, 307, 308]) {
   /* preflight should not follow the redirection */

--- a/fetch/api/cors/cors-preflight-referrer-worker.html
+++ b/fetch/api/cors/cors-preflight-referrer-worker.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-preflight-referrer.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-preflight-referrer.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-referrer.html
+++ b/fetch/api/cors/cors-preflight-referrer.html
@@ -13,6 +13,7 @@
   <body>
     <script src="/common/utils.js"></script>
     <script src="../resources/utils.js"></script>
-    <script src="cors-preflight-referrer.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-preflight-referrer.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-status-worker.html
+++ b/fetch/api/cors/cors-preflight-status-worker.html
@@ -12,7 +12,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-preflight-status.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-preflight-status.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-status.html
+++ b/fetch/api/cors/cors-preflight-status.html
@@ -12,6 +12,7 @@
   <body>
     <script src="/common/utils.js"></script>
     <script src="../resources/utils.js"></script>
-    <script src="cors-preflight-status.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-preflight-status.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight-status.js
+++ b/fetch/api/cors/cors-preflight-status.js
@@ -2,6 +2,7 @@ if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("../resources/utils.js");
   importScripts("/common/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
 }
 
 /* Check preflight is ok if status is ok status (200  to 299)*/
@@ -31,7 +32,7 @@ function corsPreflightStatus(desc, corsUrl, preflightStatus) {
   }, desc);
 }
 
-var corsUrl = "http://www1.{{host}}:{{ports[http][0]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+var corsUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 for (status of [200, 201, 202, 203, 204, 205, 206,
                 300, 301, 302, 303, 304, 305, 306, 307, 308,
                 400, 401, 402, 403, 404, 405,

--- a/fetch/api/cors/cors-redirect-worker.html
+++ b/fetch/api/cors/cors-redirect-worker.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-redirect.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-redirect.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-redirect.html
+++ b/fetch/api/cors/cors-redirect.html
@@ -12,6 +12,7 @@
   <body>
     <script src="/common/utils.js"></script>
     <script src="../resources/utils.js"></script>
-    <script src="cors-redirect.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-redirect.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-redirect.js
+++ b/fetch/api/cors/cors-redirect.js
@@ -2,6 +2,7 @@ if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("/common/utils.js");
   importScripts("../resources/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
 }
 
 function corsRedirect(desc, redirectUrl, redirectLocation, redirectStatus, expectedOrigin) {
@@ -27,12 +28,14 @@ function corsRedirect(desc, redirectUrl, redirectLocation, redirectStatus, expec
 var redirPath = dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
 var preflightPath = dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
-var localRedirect = "http://{{host}}:{{ports[http][0]}}" + redirPath;
-var remoteRedirect = "http://www1.{{host}}:{{ports[http][0]}}" + redirPath;
+var host_info = get_host_info();
 
-var localLocation = "http://{{host}}:{{ports[http][0]}}" + preflightPath;
-var remoteLocation = "http://www1.{{host}}:{{ports[http][0]}}" + preflightPath;
-var remoteLocation2 = "http://www.{{host}}:{{ports[http][0]}}" + preflightPath;
+var localRedirect = host_info.HTTP_ORIGIN + redirPath;
+var remoteRedirect = host_info.HTTP_REMOTE_ORIGIN + redirPath;
+
+var localLocation = host_info.HTTP_ORIGIN + preflightPath;
+var remoteLocation = host_info.HTTP_REMOTE_ORIGIN + preflightPath;
+var remoteLocation2 = host_info.HTTP_ORIGIN_WITH_DIFFERENT_PORT + preflightPath;
 
 for (var code of [301, 302, 303, 307, 308]) {
   corsRedirect("Redirect " + code + ": cors to same cors", remoteRedirect, remoteLocation, code, location.origin);

--- a/fetch/api/request/request-cache.html
+++ b/fetch/api/request/request-cache.html
@@ -8,7 +8,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
-    <script src="resources/get-host-info.sub.js"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
   </head>
   <body>
     <script>

--- a/fetch/api/resources/get-host-info.sub.js
+++ b/fetch/api/resources/get-host-info.sub.js
@@ -9,22 +9,26 @@ function get_host_info() {
   var REMOTE_HOST = 'localhost';
   var UNAUTHENTICATED_HOST = 'example.test';
   var HTTP_PORT = 8000;
+  var HTTP_PORT2 = 8080;
   var HTTPS_PORT = 8443;
   try {
     // In W3C test, we can get the hostname and port number in config.json
     // using wptserve's built-in pipe.
     // http://wptserve.readthedocs.org/en/latest/pipes.html#built-in-pipes
     HTTP_PORT = eval('{{ports[http][0]}}');
+    HTTP_PORT2 = eval('{{ports[http][1]}}');
     HTTPS_PORT = eval('{{ports[https][0]}}');
     ORIGINAL_HOST = eval('\'{{host}}\'');
-    REMOTE_HOST = 'www1.' + ORIGINAL_HOST;
+    REMOTE_HOST = (ORIGIN_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
   } catch (e) {
   }
   return {
     HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT,
     HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + ':' + HTTPS_PORT,
     HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTP_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT2,
     HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + ':' + HTTP_PORT,
+    HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + REMOTE_HOST + ':' + HTTP_PORT2,
     HTTPS_REMOTE_ORIGIN: 'https://' + REMOTE_HOST + ':' + HTTPS_PORT,
     HTTPS_REMOTE_ORIGIN_WITH_CREDS: 'https://foo:bar@' + REMOTE_HOST + ':' + HTTPS_PORT,
     UNAUTHENTICATED_ORIGIN: 'http://' + UNAUTHENTICATED_HOST + ':' + HTTP_PORT


### PR DESCRIPTION
Moving get-host-info.sub.js from fetch/api/request/resources to fetch/api/resources.
Updating get-host-info.sub.js to cope with WebKit test environment (use 127.0.0.1 instead of www1.localhost). Adding support for a URL with a second port. 
Updating tests to use get-host-info.sub.js instead of doing piping on each test file.
In fetch/api/cors/cors-redirect.js, replacing www.URL by URL with a different port.
