### PR TITLE
Provide a mode whenever calling open() in Python.

### DIFF
--- a/2dcontext/tools/gentest.py
+++ b/2dcontext/tools/gentest.py
@@ -128,18 +128,18 @@ if len(sys.argv) > 1 and sys.argv[1] == '--test':
     doctest.testmod()
     sys.exit()
 
-templates = yaml.load(open('templates.yaml').read())
-name_mapping = yaml.load(open('name2dir.yaml').read())
+templates = yaml.load(open('templates.yaml', "r").read())
+name_mapping = yaml.load(open('name2dir.yaml', "r").read())
 
 spec_assertions = []
-for s in yaml.load(open('spec.yaml').read())['assertions']:
+for s in yaml.load(open('spec.yaml', "r").read())['assertions']:
     if 'meta' in s:
         eval(compile(s['meta'], '<meta spec assertion>', 'exec'), {}, {'assertions':spec_assertions})
     else:
         spec_assertions.append(s)
 
 tests = []
-for t in sum([ yaml.load(open(f).read()) for f in ['tests.yaml', 'tests2d.yaml', 'tests2dtext.yaml']], []):
+for t in sum([ yaml.load(open(f, "r").read()) for f in ['tests.yaml', 'tests2d.yaml', 'tests2dtext.yaml']], []):
     if 'DISABLED' in t:
         continue
     if 'meta' in t:
@@ -543,7 +543,7 @@ def write_results():
     if not os.path.exists('results.yaml'):
         print "Can't find results.yaml"
     else:
-        for resultset in yaml.load(open('results.yaml').read()):
+        for resultset in yaml.load(open('results.yaml', "r").read()):
             #title = "%s (%s)" % (resultset['ua'], resultset['time'])
             title = resultset['name']
             #assert title not in uas # don't allow repetitions

--- a/2dcontext/tools/specextract.py
+++ b/2dcontext/tools/specextract.py
@@ -9,7 +9,7 @@ import html5lib.treebuilders.dom
 
 def extract():
     parser = html5lib.html5parser.HTMLParser(tree=html5lib.treebuilders.dom.TreeBuilder)
-    doc = parser.parse(open('current-work'), encoding='utf-8')
+    doc = parser.parse(open('current-work', "r"), encoding='utf-8')
 
     head = doc.getElementsByTagName('head')[0]
     for n in head.childNodes:

--- a/eventsource/resources/cors.py
+++ b/eventsource/resources/cors.py
@@ -22,7 +22,7 @@ def main(request, response):
                    "cache-control"]:
         if handler == "cache-control":
             response.headers.set("Content-Type", "text/event-stream")
-            rv = open(os.path.join(request.doc_root, "eventsource", "resources", "cache-control.event_stream")).read()
+            rv = open(os.path.join(request.doc_root, "eventsource", "resources", "cache-control.event_stream"), "r").read()
             response.content = rv
             pipes.sub(request, response)
             return

--- a/fetch/nosniff/resources/image.py
+++ b/fetch/nosniff/resources/image.py
@@ -3,7 +3,7 @@ import os.path
 def main(request, response):
     type = request.GET.first("type", None)
 
-    body = open(os.path.join(os.path.dirname(__file__), "../../../images/blue96x96.png")).read()
+    body = open(os.path.join(os.path.dirname(__file__), "../../../images/blue96x96.png"), "rb").read()
 
     response.add_required_headers = False
     response.writer.write_status(200)

--- a/html/tools/update_html5lib_tests.py
+++ b/html/tools/update_html5lib_tests.py
@@ -100,7 +100,7 @@ def write_test_file(script_dir, out_dir, tests, file_name, template_file_name):
     file_name = os.path.join(out_dir, file_name + ".html")
     short_name = os.path.split(file_name)[1]
 
-    with open(os.path.join(script_dir, template_file_name)) as f:
+    with open(os.path.join(script_dir, template_file_name), "r") as f:
         template = MarkupTemplate(f)
 
     stream = template.generate(file_name=short_name, tests=tests)

--- a/mixed-content/generic/tools/common_paths.py
+++ b/mixed-content/generic/tools/common_paths.py
@@ -24,7 +24,7 @@ test_file_path_pattern = '%(spec_name)s/' + selection_pattern + \
 
 
 def get_template(basename):
-    with open(os.path.join(template_directory, basename)) as f:
+    with open(os.path.join(template_directory, basename), "r") as f:
         return f.read()
 
 
@@ -45,7 +45,7 @@ def load_spec_json(path_to_spec = None):
       path_to_spec = spec_filename
 
     re_error_location = re.compile('line ([0-9]+) column ([0-9]+)')
-    with open(path_to_spec) as f:
+    with open(path_to_spec, "r") as f:
         try:
           return json.load(f)
         except ValueError, ex:

--- a/referrer-policy/generic/subresource/subresource.py
+++ b/referrer-policy/generic/subresource/subresource.py
@@ -7,7 +7,7 @@ def get_template(template_basename):
                                                       "template"))
     template_filename = os.path.join(template_directory, template_basename);
 
-    with open(template_filename) as f:
+    with open(template_filename, "r") as f:
         return f.read()
 
 # TODO(kristijanburnik): subdomain_prefix is a hardcoded value aligned with

--- a/referrer-policy/generic/tools/common_paths.py
+++ b/referrer-policy/generic/tools/common_paths.py
@@ -23,7 +23,7 @@ test_file_path_pattern = '%(spec_name)s/' + selection_pattern + \
 
 
 def get_template(basename):
-    with open(os.path.join(template_directory, basename)) as f:
+    with open(os.path.join(template_directory, basename), "r") as f:
         return f.read()
 
 
@@ -36,7 +36,7 @@ def read_nth_line(fp, line_number):
 
 def load_spec_json():
     re_error_location = re.compile('line ([0-9]+) column ([0-9]+)')
-    with open(spec_filename) as f:
+    with open(spec_filename, "r") as f:
         try:
           spec_json = json.load(f)
         except ValueError, ex:

--- a/service-workers/tools/blink-import.py
+++ b/service-workers/tools/blink-import.py
@@ -152,7 +152,7 @@ def main():
         out_dir = os.path.dirname(out_path)
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
-        with open(os.path.join(test_path, path)) as in_f:
+        with open(os.path.join(test_path, path), "r") as in_f:
             data = []
             sub = False
             for line in in_f:
@@ -189,7 +189,7 @@ def main():
 
     for path in source_paths(work_path):
         full_path = os.path.join(work_path, path)
-        with open(full_path) as f:
+        with open(full_path, "r") as f:
             data = sub_changed_filenames(filename_changes, f)
         with open(full_path, "w") as f:
             f.write(data)

--- a/webgl/tools/import-conformance-tests.py
+++ b/webgl/tools/import-conformance-tests.py
@@ -49,7 +49,7 @@ def get_tests(base_dir, file_name, tests_list):
 def process_test(test):
     (new, new_path) = tempfile.mkstemp()
     script_tag_found = False
-    with open(test) as test_file:
+    with open(test, "r") as test_file:
         for line in test_file:
             if not script_tag_found and "<script" in line:
                 indent = ' ' * line.index('<')

--- a/webvtt/webvtt-file-format-parsing/webvtt-cue-text-parsing-rules/buildtests.py
+++ b/webvtt/webvtt-file-format-parsing/webvtt-cue-text-parsing-rules/buildtests.py
@@ -32,7 +32,7 @@ for file in files:
     input = ""
     expected = ""
     state = ""
-    f = open('dat/'+file)
+    f = open('dat/'+file, "r")
     while 1:
         line = f.readline()
         if not line:


### PR DESCRIPTION
This is now needed to pass the lint because missing binary mode
has caused repeated problems on Windows
