### PR TITLE
EME: Ensure 'audioCapabilities' is always provided

### DIFF
--- a/encrypted-media/Google/encrypted-media-async-creation-with-gc.html
+++ b/encrypted-media/Google/encrypted-media-async-creation-with-gc.html
@@ -18,11 +18,9 @@
                 var initDataType;
                 var initData;
                 var mediaKeySession;
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-async-setcert-with-gc.html
+++ b/encrypted-media/Google/encrypted-media-async-setcert-with-gc.html
@@ -15,7 +15,7 @@
 
             promise_test(function(test)
             {
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     var cert = new Uint8Array(200);

--- a/encrypted-media/Google/encrypted-media-check-init-data-type.html
+++ b/encrypted-media/Google/encrypted-media-check-init-data-type.html
@@ -17,8 +17,7 @@
                     if (!result)
                         return Promise.resolve('Not supported');
 
-                    var options = [ { initDataTypes: [initDataType] } ];
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', options)
+                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfigurationForInitDataType(initDataType))
                         .then(function(access) {
                             return access.createMediaKeys();
                         }).then(function(mediaKeys) {

--- a/encrypted-media/Google/encrypted-media-clear-key-invalid-license.html
+++ b/encrypted-media/Google/encrypted-media-clear-key-invalid-license.html
@@ -27,11 +27,9 @@
                     });
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     var keySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-clearkey-update-non-ascii-input.html
+++ b/encrypted-media/Google/encrypted-media-clearkey-update-non-ascii-input.html
@@ -16,6 +16,7 @@
             async_test(function(test)
             {
                 var initDataType;
+                var initData;
                 var mediaKeySession;
 
                 function processMessage(event)
@@ -34,15 +35,14 @@
                     });
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
+                    initData = getInitData(initDataType);
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();
                     waitForEventAndRunStep('message', mediaKeySession, processMessage, test);
-                    return mediaKeySession.generateRequest(initDataType, getInitData(initDataType));
+                    return mediaKeySession.generateRequest(initDataType, initData);
                 });
             }, 'Clear Key update() with non-ASCII response.');
         </script>

--- a/encrypted-media/Google/encrypted-media-events.html
+++ b/encrypted-media/Google/encrypted-media-events.html
@@ -45,11 +45,9 @@
                     test.done();
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(test.step_func(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-generate-request-disallowed-input.html
+++ b/encrypted-media/Google/encrypted-media-generate-request-disallowed-input.html
@@ -21,7 +21,7 @@
                     if (!result)
                         return Promise.resolve('Not supported');
 
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfigurationForInitDataType(initDataType)).then(function(access) {
                         return access.createMediaKeys();
                     }).then(function(mediaKeys) {
                         var mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-keystatuses-multiple-sessions.html
+++ b/encrypted-media/Google/encrypted-media-keystatuses-multiple-sessions.html
@@ -89,11 +89,9 @@
                     test.done();
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession1 = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-keystatuses-multiple-updates.html
+++ b/encrypted-media/Google/encrypted-media-keystatuses-multiple-updates.html
@@ -61,11 +61,9 @@
                     }
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-keystatuses.html
+++ b/encrypted-media/Google/encrypted-media-keystatuses.html
@@ -15,6 +15,7 @@
                 var mediaKeySession;
                 var initDataType;
                 var initData;
+                var closed = false;
 
                 // Even though key ids are uint8, using printable values so that
                 // they can be verified easily.
@@ -40,7 +41,7 @@
                     });
                 }
 
-                function processKeyStatusesChange(event)
+                function checkKeyStatusFor2Keys()
                 {
                     // Two keys added, so both should show up in |keyStatuses|.
                     assert_equals(mediaKeySession.keyStatuses.size, 2);
@@ -125,15 +126,33 @@
                     invalid6.set(key1, 0);  // Last element will be 0.
                     assert_false(mediaKeySession.keyStatuses.has(invalid6));
                     assert_equals(mediaKeySession.keyStatuses.get(invalid6), undefined);
-
-                    test.done();
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                function processKeyStatusesChange(event)
+                {
+                    if ( !closed )
+                    {
+                        // The first keystatuseschange (caused by update())
+                        // should include both keys.
+                        checkKeyStatusFor2Keys();
+
+                        mediaKeySession.close().catch(function(error) {
+                            forceTestFailureFromPromise(test, error);
+                        });
+                        closed = true;
+                    }
+                    else
+                    {
+                        // The second keystatuseschange (caused by close())
+                        // should not have any keys.
+                        assert_equals(mediaKeySession.keyStatuses.size, 0);
+                        test.done();
+                    }
+                }
+
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-lifetime-mediakeys-with-session.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-mediakeys-with-session.html
@@ -32,12 +32,9 @@
                 }
 
                 // Create a MediaKeys object with a session.
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
-                    assert_equals(access.keySystem, 'org.w3.clearkey');
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-lifetime-mediakeys.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-mediakeys.html
@@ -13,7 +13,7 @@
             async_test(function(test)
             {
                 // Create a MediaKeys object and free immediately.
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     // Do nothing with the created object
@@ -31,7 +31,7 @@
             async_test(function(test)
             {
                 var mediaKeys;
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-reference.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-reference.html
@@ -32,12 +32,9 @@
                     return window.internals.activeDOMObjectCount(document) - startingActiveDOMObjectCount;
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
-                    assert_equals(access.keySystem, 'org.w3.clearkey');
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-release-noreference.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-release-noreference.html
@@ -31,11 +31,10 @@
                 var mediaKeys;
                 var mediaKeySession1;
                 var mediaKeySession2;
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-release.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-mediakeysession-release.html
@@ -31,11 +31,9 @@
                 }
 
                 // Create 2 sessions.
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-lifetime-multiple-mediakeys.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-multiple-mediakeys.html
@@ -25,9 +25,7 @@
                 // with the new MediaKeys object.
                 function createMediaKeys()
                 {
-                    return getSupportedInitDataType().then(function(type) {
-                        return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                    }).then(function(access) {
+                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                         return access.createMediaKeys();
                     }).then(function(mediaKeys) {
                         return mediaKeys;

--- a/encrypted-media/Google/encrypted-media-lifetime-reload.html
+++ b/encrypted-media/Google/encrypted-media-lifetime-reload.html
@@ -14,6 +14,7 @@
             async_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted.webm';
                 var mediaKeySession = null;
                 var hasSessionUpdateSucceeded = false;
                 var encryptedEventCount = 0;
@@ -81,12 +82,12 @@
                     location.reload();
                 }
 
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     waitForEventAndRunStep('encrypted', video, onEncrypted, test);
                     waitForEventAndRunStep('playing', video, onPlaying, test);
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                     return video.setMediaKeys(mediaKeys);
                 }).then(function(result) {
                     video.play();

--- a/encrypted-media/Google/encrypted-media-not-callable-after-createsession.html
+++ b/encrypted-media/Google/encrypted-media-not-callable-after-createsession.html
@@ -15,7 +15,7 @@
 
             promise_test(function()
             {
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     var mediaKeySession = mediaKeys.createSession();
@@ -31,7 +31,7 @@
 
             promise_test(function()
             {
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     var mediaKeySession = mediaKeys.createSession();
@@ -46,7 +46,7 @@
 
             promise_test(function()
             {
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     var mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-onencrypted.html
+++ b/encrypted-media/Google/encrypted-media-onencrypted.html
@@ -19,6 +19,7 @@
             async_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted.webm';
 
                 var onEncrypted = function(event)
                 {
@@ -33,7 +34,7 @@
                 };
 
                 waitForEventAndRunStep('encrypted', video, onEncrypted, test);
-                video.src = 'webm/test-encrypted.webm';
+                video.src = content;
             }, 'encrypted fired on encrypted media file.');
         </script>
     </body>

--- a/encrypted-media/Google/encrypted-media-playback-encrypted-and-clear-sources.html
+++ b/encrypted-media/Google/encrypted-media-playback-encrypted-and-clear-sources.html
@@ -18,6 +18,10 @@
                 var encryptedEventCount = 0;
                 var playbackCount = 0;
 
+                // Content to be played. These files must be the same format.
+                var encryptedContent = 'webm/test-encrypted.webm';
+                var unencryptedContent = 'webm/test.webm';
+
                 var rawKey = new Uint8Array([0xeb, 0xdd, 0x62, 0xf1, 0x68, 0x14, 0xd2, 0x7b,
                                              0x68, 0xef, 0x12, 0x2a, 0xfc, 0xe4, 0xae, 0x3c]);
 
@@ -93,18 +97,20 @@
                 }
 
                 function startPlayback() {
+                    // Alternate between encrypted and unencrypted files.
                     if (playbackCount % 2) {
-                      video.src = 'webm/test.webm';
+                      // Unencrypted files don't require MediaKeys.
+                      video.src = unencryptedContent;
                       video.play();
                       return;
                     }
 
-                    navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                    navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(encryptedContent)).then(function(access) {
                         return access.createMediaKeys();
                     }).then(function(mediaKeys) {
                         return video.setMediaKeys(mediaKeys);
                     }).then(function(result) {
-                        video.src = 'webm/test-encrypted.webm';
+                        video.src = encryptedContent;
                         assert_false(video.mediaKeys === null, "video.mediaKeys is null.");
                         video.play();
                     }).catch(function(error) {

--- a/encrypted-media/Google/encrypted-media-playback-multiple-sessions.html
+++ b/encrypted-media/Google/encrypted-media-playback-multiple-sessions.html
@@ -14,6 +14,7 @@
             async_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted-different-av-keys.webm';
                 var audioMediaKeySession = null;
                 var videoMediaKeySession = null;
                 var audioInitDataType = null;
@@ -121,12 +122,12 @@
                     test.done();
                 }
 
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     waitForEventAndRunStep('encrypted', video, onEncrypted, test);
                     waitForEventAndRunStep('playing', video, onPlaying, test);
-                    video.src = 'webm/test-encrypted-different-av-keys.webm';
+                    video.src = content;
                     return video.setMediaKeys(mediaKeys);
                 }).then(function(result) {
                     video.play();

--- a/encrypted-media/Google/encrypted-media-playback-setmediakeys-after-src.html
+++ b/encrypted-media/Google/encrypted-media-playback-setmediakeys-after-src.html
@@ -14,6 +14,7 @@
             async_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted.webm';
                 var isUpdatePromiseResolved = false;
                 var encryptedEventCount = 0;
 
@@ -72,14 +73,14 @@
                     test.done();
                 }
 
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
 
                     waitForEventAndRunStep('encrypted', video, onEncrypted, test);
                     waitForEventAndRunStep('playing', video, onPlaying, test);
 
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                     return video.setMediaKeys(mediaKeys);
                 }).then(function(result) {
                     video.play();

--- a/encrypted-media/Google/encrypted-media-playback-setmediakeys-before-src.html
+++ b/encrypted-media/Google/encrypted-media-playback-setmediakeys-before-src.html
@@ -14,6 +14,7 @@
             async_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted.webm';
                 var isUpdatePromiseResolved = false;
                 var encryptedEventCount = 0;
 
@@ -72,7 +73,7 @@
                     test.done();
                 }
 
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
 
@@ -81,7 +82,7 @@
 
                     return video.setMediaKeys(mediaKeys);
                 }).then(function(result) {
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                     video.play();
                 }).catch(function(error) {
                     forceTestFailureFromPromise(test, error);

--- a/encrypted-media/Google/encrypted-media-playback-two-videos.html
+++ b/encrypted-media/Google/encrypted-media-playback-two-videos.html
@@ -18,19 +18,20 @@
             var keyId = stringToUint8Array('0123456789012345');
             var rawKey = new Uint8Array([0xeb, 0xdd, 0x62, 0xf1, 0x68, 0x14, 0xd2, 0x7b,
                                          0x68, 0xef, 0x12, 0x2a, 0xfc, 0xe4, 0xae, 0x3c]);
+            var content = 'webm/test-encrypted.webm';
 
             promise_test(function(test)
             {
                 var promises = [
-                    play_video_as_promise(document.getElementById('testVideo'), 'webm/test-encrypted.webm'),
-                    play_video_as_promise(document.getElementById('secondVideo'), 'webm/test-encrypted.webm')
+                    play_video_as_promise(document.getElementById('testVideo'), content),
+                    play_video_as_promise(document.getElementById('secondVideo'), content)
                 ];
                 return Promise.all(promises);
             }, 'Play two videos at the same time.');
 
             function play_video_as_promise(video, content)
             {
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     return video.setMediaKeys(mediaKeys);

--- a/encrypted-media/Google/encrypted-media-reset-src-after-setmediakeys.html
+++ b/encrypted-media/Google/encrypted-media-reset-src-after-setmediakeys.html
@@ -18,6 +18,10 @@
                 var video = document.getElementById('testVideo');
                 assert_not_equals(video, null);
 
+                // Content to be played. These files must be the same format.
+                var content = 'webm/test-encrypted.webm';
+                var alternateContent = 'webm/test-encrypted-different-av-keys.webm';
+
                 var onEncrypted = function(event)
                 {
                     ++encryptedEventIndex;
@@ -28,7 +32,7 @@
                     // for the video stream each time .src is set.
                     if (encryptedEventIndex == 2) {
                         // Finished first video; set src to a different video.
-                        video.src = 'webm/test-encrypted-different-av-keys.webm';
+                        video.src = alternateContent;
                     } else if (encryptedEventIndex == 4) {
                         // Finished second video.
                         test.done();
@@ -36,7 +40,7 @@
                 };
 
                 // Create a MediaKeys object and assign it to video.
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}])
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content))
                 .then(function(access) {
                     assert_equals(access.keySystem, 'org.w3.clearkey');
                     return access.createMediaKeys();
@@ -50,7 +54,7 @@
 
                     // Set src to a video.
                     waitForEventAndRunStep('encrypted', video, onEncrypted, test);
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                 }).catch(function(error) {
                     forceTestFailureFromPromise(test, error);
                 });

--- a/encrypted-media/Google/encrypted-media-session-closed-event.html
+++ b/encrypted-media/Google/encrypted-media-session-closed-event.html
@@ -15,11 +15,10 @@
                 var initDataType;
                 var initData;
                 var mediaKeySession;
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
+
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
                     initData = getInitData(initDataType);
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();

--- a/encrypted-media/Google/encrypted-media-setmediakeys-at-same-time.html
+++ b/encrypted-media/Google/encrypted-media-setmediakeys-at-same-time.html
@@ -56,6 +56,7 @@
             promise_test(function(test)
             {
                 var video = document.getElementById('video');
+                var content = 'webm/test-encrypted.webm';
                 var access;
                 var mediaKeys1;
                 var mediaKeys2;
@@ -65,10 +66,10 @@
 
                 // Start a video now so that it is waiting for MediaKeys
                 // in order to continue.
-                video.src = 'webm/test-encrypted.webm';
+                video.src = content;
                 video.play();
                 return wait_for_encrypted_event(video).then(function() {
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
+                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content));
                 }).then(function(result) {
                     access = result;
                     return access.createMediaKeys();

--- a/encrypted-media/Google/encrypted-media-setmediakeys-multiple-times-with-different-mediakeys.html
+++ b/encrypted-media/Google/encrypted-media-setmediakeys-multiple-times-with-different-mediakeys.html
@@ -14,13 +14,14 @@
             promise_test(function(test)
             {
                 var video = document.getElementById('video');
+                var content = 'webm/test-encrypted.webm';
                 var keySystemAccess;
                 var mediaKeys1;
                 var mediaKeys2;
 
                 assert_equals(video.mediaKeys, null);
 
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     keySystemAccess = access;
                     // Create a mediaKeys.
                     return keySystemAccess.createMediaKeys();
@@ -49,7 +50,7 @@
                 }).then(function() {
                     assert_true(video.mediaKeys === mediaKeys1);
                     // Load the media element to create the WebMediaPlayer.
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                     // Set mediaKeys2 on video (switching MediaKeys) not
                     // supported after WebMediaPlayer is created.
                     return video.setMediaKeys(mediaKeys2);

--- a/encrypted-media/Google/encrypted-media-setmediakeys-multiple-times-with-the-same-mediakeys.html
+++ b/encrypted-media/Google/encrypted-media-setmediakeys-multiple-times-with-the-same-mediakeys.html
@@ -14,11 +14,12 @@
             promise_test(function(test)
             {
                 var video = document.getElementById('video');
+                var content = 'webm/test-encrypted.webm';
                 var mediaKeys;
 
                 assert_equals(video.mediaKeys, null);
 
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;
@@ -33,7 +34,7 @@
                 }).then(function() {
                     assert_true(video.mediaKeys === mediaKeys);
                     // Load the media element to create the WebMediaPlayer.
-                    video.src = 'webm/test-encrypted.webm';
+                    video.src = content;
                     // Set mediaKeys again on video should still return a
                     // resolved promise.
                     return video.setMediaKeys(mediaKeys);

--- a/encrypted-media/Google/encrypted-media-setmediakeys-to-multiple-video-elements.html
+++ b/encrypted-media/Google/encrypted-media-setmediakeys-to-multiple-video-elements.html
@@ -18,7 +18,7 @@
                 var video2 = document.getElementById('video2');
                 var mediaKeys;
 
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(result) {
                     mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-setmediakeys.html
+++ b/encrypted-media/Google/encrypted-media-setmediakeys.html
@@ -34,7 +34,7 @@
                     assert_equals(error.name, 'TypeError');
 
                     // Create a MediaKeys object and assign it to video.
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
+                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration());
                 }).then(function(access) {
                     assert_equals(access.keySystem, 'org.w3.clearkey');
                     return access.createMediaKeys();

--- a/encrypted-media/Google/encrypted-media-unique-origin.html
+++ b/encrypted-media/Google/encrypted-media-unique-origin.html
@@ -36,7 +36,13 @@
                 var script = 'data:text/html,' +
                     '<script>' +
                     '    window.onmessage = function(e) {' +
-                    '        navigator.requestMediaKeySystemAccess(\'org.w3.clearkey\', [{}]).then(function(access) {' +
+                    '        navigator.requestMediaKeySystemAccess(\'org.w3.clearkey\', [{' +
+                    '           initDataTypes: [ \'keyids\' ],' +
+                    '           audioCapabilities: [' +
+                    '               { contentType: \'audio/mp4; codecs="mp4a.40.2"\' },' +
+                    '               { contentType: \'audio/webm; codecs="opus"\' }' +
+                    '           ]' +
+                    '       }]).then(function(access) {' +
                     '            return access.createMediaKeys();' +
                     '        }).then(function(mediaKeys) {' +
                     '            window.parent.postMessage({result: \'allowed\'}, \'*\');' +
@@ -47,7 +53,13 @@
                     '<\/script>';
 
                 // Verify that this page can create a MediaKeys first.
-                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{
+                    initDataTypes: [ 'keyids' ],
+                    audioCapabilities: [
+                        { contentType: 'audio/mp4; codecs="mp4a.40.2"' },
+                        { contentType: 'audio/webm; codecs="opus"' }
+                    ]
+                }]).then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     // Success, so now create the iframe and try there.

--- a/encrypted-media/Google/encrypted-media-update-disallowed-input.html
+++ b/encrypted-media/Google/encrypted-media-update-disallowed-input.html
@@ -16,6 +16,7 @@
             async_test(function(test)
             {
                 var initDataType;
+                var initData;
                 var mediaKeySession;
 
                 function repeat(pattern, count) {
@@ -54,15 +55,14 @@
                     });
                 }
 
-                getSupportedInitDataType().then(function(type) {
-                    initDataType = type;
-                    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]);
-                }).then(function(access) {
+                navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfiguration()).then(function(access) {
+                    initDataType = access.getConfiguration().initDataTypes[0];
+                    initData = getInitData(initDataType);
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     mediaKeySession = mediaKeys.createSession();
                     waitForEventAndRunStep('message', mediaKeySession, processMessage, test);
-                    return mediaKeySession.generateRequest(initDataType, getInitData(initDataType));
+                    return mediaKeySession.generateRequest(initDataType, initData);
                 });
             }, 'update() with response longer than 64Kb characters.');
         </script>

--- a/encrypted-media/Google/encrypted-media-utils.js
+++ b/encrypted-media/Google/encrypted-media-utils.js
@@ -19,23 +19,8 @@ function consoleWrite(text)
 function isInitDataTypeSupported(initDataType)
 {
     return navigator.requestMediaKeySystemAccess(
-                         "org.w3.clearkey", [{ initDataTypes : [initDataType] }])
-        .then(function() { return(true); }, function() { return(false); });
-}
-
-// Returns a promise that is fulfilled with an initDataType that is supported,
-// rejected if none are supported.
-function getSupportedInitDataType()
-{
-    var configuration = [{ initDataTypes : [ 'webm', 'cenc', 'keyids' ] }];
-    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', configuration)
-        .then(function(access) {
-            var initDataTypes = access.getConfiguration().initDataTypes;
-            assert_greater_than(initDataTypes.length, 0);
-            return Promise.resolve(initDataTypes[0]);
-        }, function(error) {
-            return Promise.reject('No supported initDataType.');
-        });
+                        "org.w3.clearkey", getSimpleConfigurationForInitDataType(initDataType))
+        .then(function() { return true; }, function() { return false; });
 }
 
 function getInitData(initDataType)
@@ -71,6 +56,54 @@ function getInitData(initDataType)
   }
 
   throw 'initDataType ' + initDataType + ' not supported.';
+}
+
+// Returns an array of audioCapabilities that includes entries for a set of
+// codecs that should cover all user agents.
+function getPossibleAudioCapabilities()
+{
+    return [
+        { contentType: 'audio/mp4; codecs="mp4a.40.2"' },
+        { contentType: 'audio/webm; codecs="opus"' },
+    ];
+}
+
+// Returns a trivial MediaKeySystemConfiguration that should be accepted,
+// possibly as a subset of the specified capabilities, by all user agents.
+function getSimpleConfiguration()
+{
+    return [ {
+        initDataTypes : [ 'webm', 'cenc', 'keyids' ],
+        audioCapabilities: getPossibleAudioCapabilities()
+    } ];
+}
+
+// Returns a MediaKeySystemConfiguration for |initDataType| that should be
+// accepted, possibly as a subset of the specified capabilities, by all
+// user agents.
+function getSimpleConfigurationForInitDataType(initDataType)
+{
+    return [ {
+        initDataTypes: [ initDataType ],
+        audioCapabilities: getPossibleAudioCapabilities()
+    } ];
+}
+
+// Returns a MediaKeySystemConfiguration for |mediaFile| that specifies
+// both audio and video capabilities for the specified file..
+function getConfigurationForFile(mediaFile)
+{
+    if (mediaFile.toLowerCase().endsWith('webm')) {
+        return [ {
+            initDataTypes: [ 'webm' ],
+            audioCapabilities: [ { contentType: 'audio/webm; codecs="opus"' } ],
+            videoCapabilities: [ { contentType: 'video/webm; codecs="vp8"' } ]
+        } ];
+    }
+
+    // NOTE: Supporting other mediaFormats is not currently implemented as
+    // Chromium only tests with WebM files.
+    throw 'mediaFile ' + mediaFile + ' not supported.';
 }
 
 function waitForEventAndRunStep(eventName, element, func, stepTest)
@@ -270,7 +303,7 @@ function createMediaKeys(keyId, key)
     var request = stringToUint8Array(createKeyIDs(keyId));
     var jwkSet = stringToUint8Array(createJWKSet(createJWK(keyId, key)));
 
-    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+    return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getSimpleConfigurationForInitDataType('keyids')).then(function(access) {
         return access.createMediaKeys();
     }).then(function(result) {
         mediaKeys = result;

--- a/encrypted-media/Google/encrypted-media-waiting-for-a-key.html
+++ b/encrypted-media/Google/encrypted-media-waiting-for-a-key.html
@@ -21,6 +21,7 @@
             promise_test(function(test)
             {
                 var video = document.getElementById('testVideo');
+                var content = 'webm/test-encrypted.webm';
                 var initData;
                 var initDataType;
                 var mediaKeySession;
@@ -44,14 +45,14 @@
                 var rawKey = new Uint8Array([0xeb, 0xdd, 0x62, 0xf1, 0x68, 0x14, 0xd2, 0x7b,
                                              0x68, 0xef, 0x12, 0x2a, 0xfc, 0xe4, 0xae, 0x3c]);
 
-                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', [{}]).then(function(access) {
+                return navigator.requestMediaKeySystemAccess('org.w3.clearkey', getConfigurationForFile(content)).then(function(access) {
                     debugMessage = 'createMediaKeys()';
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {
                     debugMessage = 'setMediaKeys()';
                     return video.setMediaKeys(mediaKeys);
                 }).then(function() {
-                    video.src = 'content/test-encrypted.webm';
+                    video.src = content;
                     video.play();
                     debugMessage = 'wait_for_encrypted_event()';
                     return wait_for_encrypted_event(video);


### PR DESCRIPTION
This also lays the groundwork for user agents that support different types.

I had to manually resolve differences in media file paths.
I also fixed an apparent incorrect path in the WPT version of encrypted-media-waiting-for-a-key.html.

Based on Chromium commit 51111720ce9dc84fce16319a239126b2c69ca6da.
