### PR TITLE
Adding more checks for generation of the Access-Control-Request-Headers header value

### DIFF
--- a/fetch/api/cors/cors-no-preflight.js
+++ b/fetch/api/cors/cors-no-preflight.js
@@ -15,7 +15,7 @@ function corsNoPreflight(desc, baseURL, method, headerName, headerValue) {
     requestInit["headers"][headerName] = headerValue;
 
   promise_test(function(test) {
-    fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
+    return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
       assert_equals(resp.status, 200, "Clean stash response's status is 200");
       return fetch(url + urlParameters, requestInit).then(function(resp) {
         assert_equals(resp.status, 200, "Response's status is 200");
@@ -28,8 +28,8 @@ function corsNoPreflight(desc, baseURL, method, headerName, headerValue) {
 var host_info = get_host_info();
 
 corsNoPreflight("Cross domain basic usage [GET]", host_info.HTTP_REMOTE_ORIGIN, "GET");
-corsNoPreflight("Same domain different port [GET]", host_info.HTTP_ORIGIN_WITH_DIFFERENT_ORIGIN, "GET");
-corsNoPreflight("Cross domain different port [GET]", host_info.HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_ORIGIN, "GET");
+corsNoPreflight("Same domain different port [GET]", host_info.HTTP_ORIGIN_WITH_DIFFERENT_PORT, "GET");
+corsNoPreflight("Cross domain different port [GET]", host_info.HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT, "GET");
 corsNoPreflight("Cross domain different protocol [GET]", host_info.HTTPS_REMOTE_ORIGIN, "GET");
 corsNoPreflight("Same domain different protocol different port [GET]", host_info.HTTPS_ORIGIN, "GET");
 corsNoPreflight("Cross domain [POST]", host_info.HTTP_REMOTE_ORIGIN, "POST");
@@ -41,5 +41,6 @@ corsNoPreflight("Cross domain [GET] [Content-Type: application/x-www-form-urlenc
 corsNoPreflight("Cross domain [GET] [Content-Type: multipart/form-data]", host_info.HTTP_REMOTE_ORIGIN, "GET" , "Content-Type", "multipart/form-data");
 corsNoPreflight("Cross domain [GET] [Content-Type: text/plain]", host_info.HTTP_REMOTE_ORIGIN, "GET" , "Content-Type", "text/plain");
 corsNoPreflight("Cross domain [GET] [Content-Type: text/plain;charset=utf-8]", host_info.HTTP_REMOTE_ORIGIN, "GET" , "Content-Type", "text/plain;charset=utf-8");
+corsNoPreflight("Cross domain [GET] [Content-Type: Text/Plain;charset=utf-8]", host_info.HTTP_REMOTE_ORIGIN, "GET" , "Content-Type", "Text/Plain;charset=utf-8");
 
 done();

--- a/fetch/api/cors/cors-preflight-referrer.js
+++ b/fetch/api/cors/cors-preflight-referrer.js
@@ -1,6 +1,7 @@
 if (this.document === undefined) {
   importScripts("/resources/testharness.js");
   importScripts("/common/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
   importScripts("../resources/utils.js");
 }
 
@@ -21,17 +22,18 @@ function corsPreflightReferrer(desc, corsUrl, referrerPolicy, expectedReferrer) 
         assert_equals(resp.status, 200, "Response's status is 200");
         assert_equals(resp.headers.get("x-did-preflight"), "1", "Preflight request has been made");
         assert_equals(resp.headers.get("x-preflight-referrer"), expectedReferrer, "Preflight's referrer is correct");
-        assert_equals(resp.headers.get("x-referrer"), expectedReferrer, "Request's refferer is correct");
+        assert_equals(resp.headers.get("x-referrer"), expectedReferrer, "Request's referrer is correct");
       });
     });
   }, desc);
 }
 
-var corsUrl = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
-var origin = "http://{{host}}:{{ports[http][0]}}";
+var corsUrl = get_host_info().HTTP_REMOTE_ORIGIN  + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+var origin = get_host_info().HTTP_ORIGIN + "/";
 
 corsPreflightReferrer("Referrer policy: no-referrer", corsUrl, "no-referrer", "");
-corsPreflightReferrer("Referrer policy: \"\"", corsUrl, "", "");
+corsPreflightReferrer("Referrer policy: \"\"", corsUrl, "", location.toString())
+
 corsPreflightReferrer("Referrer policy: origin", corsUrl, "origin", origin);
 corsPreflightReferrer("Referrer policy: origin-when-cross-origin", corsUrl, "origin-when-cross-origin", origin);
 corsPreflightReferrer("Referrer policy: unsafe-url", corsUrl, "unsafe-url", location.toString());

--- a/fetch/api/cors/cors-preflight-worker.html
+++ b/fetch/api/cors/cors-preflight-worker.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <script>
-      fetch_tests_from_worker(new Worker("cors-preflight.js?pipe=sub"));
+      fetch_tests_from_worker(new Worker("cors-preflight.js"));
     </script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight.html
+++ b/fetch/api/cors/cors-preflight.html
@@ -15,6 +15,7 @@
   <body>
     <script src="../resources/utils.js"></script>
     <script src="/common/utils.js"></script>
-    <script src="cors-preflight.js?pipe=sub"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-preflight.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight.html
+++ b/fetch/api/cors/cors-preflight.html
@@ -14,8 +14,8 @@
   </head>
   <body>
     <script src="../resources/utils.js"></script>
-    <script src="/common/utils.js"></script>
     <script src="../resources/get-host-info.sub.js"></script>
+    <script src="/common/utils.js"></script>
     <script src="cors-preflight.js"></script>
   </body>
 </html>

--- a/fetch/api/cors/cors-preflight.js
+++ b/fetch/api/cors/cors-preflight.js
@@ -52,7 +52,7 @@ function corsPreflight(desc, corsUrl, method, allowed, headers, safeHeaders) {
               assert_in_array(header[0].toLowerCase(), actualHeaders, "Preflight asked permission for header: " + header);
 
             let accessControlAllowHeaders = headerNames(headers).sort().join(",");
-            assert_equals(resp.headers.get("x-control-request-headers").replace(" ", ""), accessControlAllowHeaders, "Access-Control-Allow-Headers value");
+            assert_equals(resp.headers.get("x-control-request-headers").replace(new RegExp(" ", "g"), ""), accessControlAllowHeaders, "Access-Control-Allow-Headers value");
             return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token);
           }
         });
@@ -79,11 +79,8 @@ corsPreflight("CORS [NEW], server refuses", corsUrl, "NEW", false);
 corsPreflight("CORS [GET] [x-test-header: allowed], server allows", corsUrl, "GET", true, [["x-test-header1", "allowed"]]);
 corsPreflight("CORS [GET] [x-test-header: refused], server refuses", corsUrl, "GET", false, [["x-test-header1", "refused"]]);
 
-var unsafeHeaderCount = 7;
 var headers = [
-    // Not safe
     ["x-test-header1", "allowedOrRefused"],
-    ["x-test-header2", "allowedOrRefused"],
     ["x-test-header2", "allowedOrRefused"],
     ["X-test-header3", "allowedOrRefused"],
     ["x-test-header-b", "allowedOrRefused"],

--- a/fetch/api/cors/cors-preflight.js
+++ b/fetch/api/cors/cors-preflight.js
@@ -1,7 +1,16 @@
 if (this.document === undefined) {
   importScripts("/resources/testharness.js");
-  importScripts("../resources/utils.js");
   importScripts("/common/utils.js");
+  importScripts("../resources/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
+}
+
+function headerNames(headers)
+{
+    let names = [];
+    for (let header of headers)
+        names.push(header[0].toLowerCase());
+    return names
 }
 
 /*
@@ -9,15 +18,19 @@ if (this.document === undefined) {
   Control if server allows method and headers and check accordingly
   Check control access headers added by UA (for method and headers)
 */
-function corsPreflight(desc, corsUrl, method, allowed, headers) {
+function corsPreflight(desc, corsUrl, method, allowed, headers, safeHeaders) {
   return promise_test(function(test) {
     var uuid_token = token();
     return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(response) {
       var url = corsUrl;
       var urlParameters = "?token=" + uuid_token + "&max_age=0";
       var requestInit = {"mode": "cors", "method": method};
+      var requestHeaders = [];
       if (headers)
-        requestInit["headers"] = headers;
+        requestHeaders.push.apply(requestHeaders, headers);
+      if (safeHeaders)
+        requestHeaders.push.apply(requestHeaders, safeHeaders);
+      requestInit["headers"] = requestHeaders;
 
       if (allowed) {
         urlParameters += "&allow_methods=" + method;
@@ -26,20 +39,22 @@ function corsPreflight(desc, corsUrl, method, allowed, headers) {
           //Server will send back headers from Access-Control-Request-Headers in x-control-request-headers
           urlParameters += "&control_request_headers"
           //Make the server allow the headers
-          urlParameters += "&allow_headers="
-          urlParameters += headers.map(function (x) { return x[0]; }).join("%2C%20");
+          urlParameters += "&allow_headers=" + headerNames(headers).join("%20%2C");
         }
         return fetch(url + urlParameters, requestInit).then(function(resp) {
           assert_equals(resp.status, 200, "Response's status is 200");
           assert_equals(resp.headers.get("x-did-preflight"), "1", "Preflight request has been made");
           if (headers) {
-            var actualHeaders = resp.headers.get("x-control-request-headers").split(",");
+            var actualHeaders = resp.headers.get("x-control-request-headers").toLowerCase().split(",");
             for (var i in actualHeaders)
               actualHeaders[i] = actualHeaders[i].trim();
             for (var header of headers)
-              assert_in_array(header[0], actualHeaders, "Preflight asked permission for header: " + header);
+              assert_in_array(header[0].toLowerCase(), actualHeaders, "Preflight asked permission for header: " + header);
+
+            let accessControlAllowHeaders = headerNames(headers).sort().join(",");
+            assert_equals(resp.headers.get("x-control-request-headers").replace(" ", ""), accessControlAllowHeaders, "Access-Control-Allow-Headers value");
+            return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token);
           }
-          return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token);
         });
       } else {
         return promise_rejects(test, new TypeError(), fetch(url + urlParameters, requestInit)).then(function(){
@@ -50,7 +65,7 @@ function corsPreflight(desc, corsUrl, method, allowed, headers) {
   }, desc);
 }
 
-var corsUrl = "http://{{host}}:{{ports[http][1]}}" + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+var corsUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
 
 corsPreflight("CORS [DELETE], server allows", corsUrl, "DELETE", true);
 corsPreflight("CORS [DELETE], server refuses", corsUrl, "DELETE", false);
@@ -64,12 +79,28 @@ corsPreflight("CORS [NEW], server refuses", corsUrl, "NEW", false);
 corsPreflight("CORS [GET] [x-test-header: allowed], server allows", corsUrl, "GET", true, [["x-test-header1", "allowed"]]);
 corsPreflight("CORS [GET] [x-test-header: refused], server refuses", corsUrl, "GET", false, [["x-test-header1", "refused"]]);
 
-var headers = [["x-test-header1", "allowedOrRefused"],
-               ["x-test-header2", "allowedOrRefused"],
-               ["x-test-header3", "allowedOrRefused"]];
-corsPreflight("CORS [GET] [several headers], server allows", corsUrl, "GET", true, headers);
-corsPreflight("CORS [GET] [several headers], server refuses", corsUrl, "GET", false, headers);
-corsPreflight("CORS [PUT] [several headers], server allows", corsUrl, "PUT", true, headers);
-corsPreflight("CORS [PUT] [several headers], server refuses", corsUrl, "PUT", false, headers);
+var unsafeHeaderCount = 7;
+var headers = [
+    // Not safe
+    ["x-test-header1", "allowedOrRefused"],
+    ["x-test-header2", "allowedOrRefused"],
+    ["x-test-header2", "allowedOrRefused"],
+    ["X-test-header3", "allowedOrRefused"],
+    ["x-test-header-b", "allowedOrRefused"],
+    ["x-test-header-D", "allowedOrRefused"],
+    ["x-test-header-C", "allowedOrRefused"],
+    ["x-test-header-a", "allowedOrRefused"],
+    ["Content-Type", "allowedOrRefused"],
+];
+var safeHeaders= [
+    ["Accept", "*"],
+    ["Accept-Language", "bzh"],
+    ["Content-Language", "eu"],
+];
+
+corsPreflight("CORS [GET] [several headers], server allows", corsUrl, "GET", true, headers, safeHeaders);
+corsPreflight("CORS [GET] [several headers], server refuses", corsUrl, "GET", false, headers, safeHeaders);
+corsPreflight("CORS [PUT] [several headers], server allows", corsUrl, "PUT", true, headers, safeHeaders);
+corsPreflight("CORS [PUT] [several headers], server refuses", corsUrl, "PUT", false, headers, safeHeaders);
 
 done();

--- a/fetch/api/cors/cors-redirect.js
+++ b/fetch/api/cors/cors-redirect.js
@@ -14,7 +14,7 @@ function corsRedirect(desc, redirectUrl, redirectLocation, redirectStatus, expec
 
   var requestInit = {"mode": "cors", "redirect": "follow"};
 
-  promise_test(function(test) {
+  return promise_test(function(test) {
     fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
       return fetch(url + urlParameters, requestInit).then(function(resp) {
         assert_equals(resp.status, 200, "Response's status is 200");


### PR DESCRIPTION
Added more headers to check sorting of headers, lowercasing and safe headers filtering out.
Removed use of map() as it may not be supported everywhere.
Also updated redirect test as the fetch promise was not returned to promise_test.
