### PR TITLE
Navigator.javaEnabled should be an operation, not an attribute

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2571,7 +2571,7 @@ interface NavigatorStorageUtils {
 interface NavigatorPlugins {
   readonly attribute PluginArray plugins;
   readonly attribute MimeTypeArray mimeTypes;
-  readonly attribute boolean javaEnabled;
+  boolean javaEnabled();
 };
 
 interface PluginArray {


### PR DESCRIPTION
Navigator.javaEnabled should be an operation, not an attribute as per:
- https://html.spec.whatwg.org/multipage/webappapis.html#navigatorplugins

I have verified it is an operation in Safari, Chrome and Firefox as well.
