### PR TITLE
WPT Tests update: sendBeacon should not throw if blocked by content policies.

### DIFF
--- a/content-security-policy/blink-contrib/connect-src-beacon-blocked.sub.html
+++ b/content-security-policy/blink-contrib/connect-src-beacon-blocked.sub.html
@@ -22,9 +22,9 @@ connect-src 'self' http://{{host}}:{{ports[http][0]}}; script-src 'self' 'unsafe
         } else {
 	    try {
 	    var es = navigator.sendBeacon("http://www1.{{host}}:{{ports[http][0]}}/security/contentSecurityPolicy/echo-report.php");
-         	log("Fail");
+         	log("Pass");
             } catch (e) {
-            	log("Pass");
+            	log("Fail");
             }
             var report =  document.createElement("script");
             report.src = "../support/checkReport.sub.js?reportExists=true&amp;reportField=violated-directive&amp;reportValue=connect-src%20&apos;self&apos;";


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1234813
