### PR TITLE
Make URLSearchParams nsIXHRSendable as well as clonable, and have XHRs set the correct request content type for them.

### DIFF
--- a/XMLHttpRequest/setrequestheader-content-type.htm
+++ b/XMLHttpRequest/setrequestheader-content-type.htm
@@ -9,19 +9,229 @@
   <body>
     <div id="log"></div>
     <script>
-      function request(value) {
+      function request(inputGenerator, headersToSend, expectedType, title) {
         test(function() {
+          try {
+            var toSend = inputGenerator();
+          } catch(e) {
+            assert_unreached("Skipping test as could not create a " + inputGenerator.name.replace("_", "") + "; ");
+          }
           var client = new XMLHttpRequest()
           client.open("POST", "resources/inspect-headers.py?filter_name=Content-Type", false)
-          client.setRequestHeader('Content-Type', value)
-          client.send("")
-          assert_equals(client.responseText, 'content-type: '+ String(value ? value.trim() : value).toLowerCase()+'\n' )
-        }, document.title + " (" + value + ")")
+          for(header in headersToSend) {
+            if (headersToSend.hasOwnProperty(header)) {
+              client.setRequestHeader(header, headersToSend[header]);
+            }
+          }
+          client.send(toSend)
+
+          var responseType = client.responseText.replace("\n", "").replace("; ", ";").toLowerCase(); // don't care about case or space after semicolon for charset
+          if (expectedType === undefined || expectedType === null) {
+            assert_equals(responseType, "");
+          } else if (expectedType instanceof RegExp) {
+            if (!expectedType.ignoreCase) expectedType = new RegExp(expectedType, "i"); // always ignore case; the regex itself will have to remember to handle the optional space after the semicolon for charset
+            assert_regexp_match(responseType, expectedType);
+          } else {
+            expectedType = "content-type: " + String(expectedType ? expectedType.trim().replace("; ", ";") : expectedType).toLowerCase()
+            assert_equals(responseType, expectedType);
+          }
+        }, title)
       }
-      request("")
-      request(" ")
-      request(null)
-      request(undefined)
+      request(
+        function _String() { return ""; },
+        {"Content-Type": ""},
+        "",
+        'setRequestHeader("") sends a blank string'
+      )
+      request(
+        function _String() { return ""; },
+        {"Content-Type": " "},
+        " ",
+        'setRequestHeader(" ") sends the string " "'
+      )
+      request(
+        function _String() { return ""; },
+        {"Content-Type": null},
+        "null",
+        'setRequestHeader(null) sends the string "null"'
+      )
+      request(
+        function _String() { return ""; },
+        {"Content-Type": undefined},
+        "undefined",
+        'setRequestHeader(undefined) sends the string "undefined"'
+      )
+      request(
+        function _String() { return "test"; },
+        {},
+        "text/plain;charset=UTF-8",
+        'String request has correct default Content-Type of "text/plain;charset=UTF-8"'
+      )
+      request(
+        function _String() { return "test()"; },
+        {"Content-Type": "text/javascript;charset=ASCII"},
+        "text/javascript;charset=UTF-8",
+        "String request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+      )
+      request(
+        function _XMLDocument() { return new DOMParser().parseFromString("<xml/>", "application/xml"); },
+        {"Content-Type": ""},
+        "",
+        'XML Document request respects setRequestHeader("")'
+      )
+      request(
+        function _XMLDocument() { return new DOMParser().parseFromString("<xml/>", "application/xml"); },
+        {},
+        "application/xml;charset=UTF-8",
+        'XML Document request has correct default Content-Type of "application/xml;charset=UTF-8"'
+      )
+      request(
+        function _XMLDocument() { return new DOMParser().parseFromString("<xml/>", "application/xml"); },
+        {"Content-Type": "application/xhtml+xml;charset=ASCII"},
+        "application/xhtml+xml;charset=UTF-8",
+        "XML Document request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+      )
+      request(
+        function _HTMLDocument() { return new DOMParser().parseFromString("<html></html>", "text/html"); },
+        {"Content-Type": ""},
+        "",
+        'HTML Document request respects setRequestHeader("")'
+      )
+      request(
+        function _HTMLDocument() { return new DOMParser().parseFromString("<html></html>", "text/html"); },
+        {},
+        "text/html;charset=UTF-8",
+        'HTML Document request has correct default Content-Type of "text/html;charset=UTF-8"'
+      )
+      request(
+        function _HTMLDocument() { return new DOMParser().parseFromString("<html></html>", "text/html"); },
+        {"Content-Type": "text/html+junk;charset=ASCII"},
+        "text/html+junk;charset=UTF-8",
+        "HTML Document request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+      )
+      request(
+        function _Blob() { return new Blob(["test"]); },
+        {"Content-Type": ""},
+        "",
+        'Blob request respects setRequestHeader("") to be specified'
+      )
+      request(
+        function _Blob() { return new Blob(["test"]); },
+        {},
+        undefined,
+        "Blob request with unset type sends no Content-Type without setRequestHeader() call"
+      )
+      request(
+        function _Blob() { return new Blob(["test"]); },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=ASCII",
+        "Blob request with unset type keeps setRequestHeader() Content-Type and charset"
+      )
+      request(
+        function _Blob() { return new Blob(["<xml/>"], {type : "application/xml;charset=ASCII"}); },
+        {},
+        "application/xml;charset=ASCII",
+        "Blob request with set type uses that it for Content-Type unless setRequestHeader()"
+      )
+      request(
+        function _Blob() { return new Blob(["<xml/>"], {type : "application/xml;charset=UTF8"}); },
+        {"Content-Type": "application/xml+junk;charset=ASCII"},
+        "application/xml+junk;charset=ASCII",
+        "Blob request with set type keeps setRequestHeader() Content-Type and charset"
+      )
+      request(
+        function _ArrayBuffer() { return new ArrayBuffer(10); },
+        {"Content-Type": ""},
+        "",
+        'ArrayBuffer request respects setRequestHeader("")'
+      )
+      request(
+        function _ArrayBuffer() { return new ArrayBuffer(10); },
+        {},
+        undefined,
+        "ArrayBuffer request sends no Content-Type without setRequestHeader() call"
+      )
+      request(
+        function _ArrayBuffer() { return new ArrayBuffer(10); },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=ASCII",
+        "ArrayBuffer request keeps setRequestHeader() Content-Type and charset"
+      )
+      request(
+        function _Uint8Array() { return new Uint8Array(new ArrayBuffer(10)); },
+        {"Content-Type": ""},
+        "",
+        'ArrayBufferView request respects setRequestHeader("")'
+      )
+      request(
+        function _Uint8Array() { return new Uint8Array(new ArrayBuffer(10)); },
+        {},
+        undefined,
+        "ArrayBufferView request sends no Content-Type without setRequestHeader() call"
+      )
+      request(
+        function _Uint8Array() { return new Uint8Array(new ArrayBuffer(10)); },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=ASCII",
+        "ArrayBufferView request keeps setRequestHeader() Content-Type and charset"
+      )
+      request(
+        function _FormData() { return new FormData(); },
+        {"Content-Type": ""},
+        "",
+        'FormData request respects setRequestHeader("")'
+      )
+      request(
+        function _FormData() { return new FormData(); },
+        {},
+        /multipart\/form-data;boundary=(.*)/,
+        'FormData request has correct default Content-Type of "multipart\/form-data;boundary=_"'
+      )
+      request(
+        function _FormData() { return new FormData(); },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=ASCII",
+        "FormData request keeps setRequestHeader() Content-Type and charset"
+      )
+      request(
+        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
+        {"Content-Type": ""},
+        "",
+        'URLSearchParams respects setRequestHeader("")'
+      )
+      request(
+        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
+        {},
+        "application/x-www-form-urlencoded;charset=UTF-8",
+        'URLSearchParams request has correct default Content-Type of "application/x-www-form-urlencoded;charset=UTF-8"'
+      )
+      request(
+        function _URLSearchParams() { return new URLSearchParams("q=testQ&topic=testTopic") },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=UTF-8",
+        "URLSearchParams request keeps setRequestHeader() Content-Type, with charset adjusted to UTF-8"
+        // the default Content-Type for URLSearchParams has a charset specified (utf-8) in
+        // https://fetch.spec.whatwg.org/#bodyinit, so the user's must be changed to match it
+        // as per https://xhr.spec.whatwg.org/#the-send%28%29-method step 4.
+      )
+      request(
+        function _ReadableStream() { return new ReadableStream() },
+        {"Content-Type": ""},
+        "",
+        'ReadableStream request respects setRequestHeader("")'
+      )
+      request(
+        function _ReadableStream() { return new ReadableStream() },
+        {},
+        undefined,
+        "ReadableStream request with under type sends no Content-Type without setRequestHeader() call"
+      )
+      request(
+        function _ReadableStream() { return new ReadableStream() },
+        {"Content-Type": "application/xml;charset=ASCII"},
+        "application/xml;charset=ASCII",
+        "ReadableStream request keeps setRequestHeader() Content-Type and charset"
+      )
     </script>
   </body>
 </html>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1207233
