### PR TITLE
part2 : correct default value of webidl's property.

### DIFF
--- a/webvtt/webvtt-file-format-parsing/webvtt-file-parsing/001.html
+++ b/webvtt/webvtt-file-format-parsing/webvtt-file-parsing/001.html
@@ -14,8 +14,8 @@ var cueDefaults = {
 "pauseOnExit":false,
 //"vertical":"", (not supported)
 "snapToLines":true,
-"line":-1,
-"position":50,
+"line":"auto",
+"position":"auto",
 "size":100,
 "align":"center"
 }


### PR DESCRIPTION
Line default value : https://w3c.github.io/webvtt/#webvtt-cue-line
Position default value : https://w3c.github.io/webvtt/#webvtt-cue-position

MozReview-Commit-ID: 7S5EXlU2qRF

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1278748
