### PR TITLE
P2 Add wpt verifying fetch() respects a Request object's referrer.

### DIFF
--- a/fetch/api/basic/request-referrer.html
+++ b/fetch/api/basic/request-referrer.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch: fetch() respects Request referrer value</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script src="../resources/utils.js"></script>
+    <script src="request-referrer.js"></script>
+  </body>
+</html>

--- a/fetch/api/basic/request-referrer.js
+++ b/fetch/api/basic/request-referrer.js
@@ -1,0 +1,28 @@
+if (this.document === undefined) {
+  importScripts("/resources/testharness.js");
+  importScripts("../resources/utils.js");
+}
+
+function testReferrer(referrer, expected) {
+  promise_test(function(test) {
+    var url = RESOURCES_DIR + "inspect-headers.py?headers=referer"
+    var req = new Request(url, { referrer: referrer });
+    return fetch(req).then(function(resp) {
+      var actual = resp.headers.get("x-request-referer");
+      if (expected) {
+        assert_equals(actual, expected, "request's referer should be: " + expected);
+        return;
+      }
+      if (actual) {
+        assert_equals(actual, "", "request's referer should be empty");
+      }
+    });
+  });
+}
+
+testReferrer("about:client", window.location.href);
+
+var fooURL = new URL("./foo", window.location).href;
+testReferrer(fooURL, fooURL);
+
+done();


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1285502
