### PR TITLE
MSE] P5. Update webref MSE tests according to updated spec. r=gerald,f=jgraham

### DIFF
--- a/media-source/mediasource-config-changes.js
+++ b/media-source/mediasource-config-changes.js
@@ -64,15 +64,25 @@ function mediaSourceConfigChangeTest(directory, idA, idB, description)
                 test.waitForExpectedEvents(function()
                 {
                     assert_false(sourceBuffer.updating, "updating");
-                    assert_greater_than(mediaSource.duration, 2, "duration");
 
                     // Truncate the presentation to a duration of 2 seconds.
-                    mediaSource.duration = 2;
+                    sourceBuffer.remove(2, Infinity);
 
                     assert_true(sourceBuffer.updating, "updating");
                     test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
                     test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
                     test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+                });
+
+                test.waitForExpectedEvents(function()
+                {
+                    assert_false(sourceBuffer.updating, "updating");
+                    assert_greater_than(mediaSource.duration, 2, "duration");
+
+                    // Truncate the presentation to a duration of 2 seconds.
+                    mediaSource.duration = 2;
+
+                    test.expectEvent(mediaElement, "durationchange");
                 });
 
                 test.waitForExpectedEvents(function()

--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -41,20 +41,28 @@
                   test.waitForExpectedEvents(function()
                   {
                       assert_greater_than_equal(mediaElement.currentTime, seekTo, 'Playback time has reached seekTo');
-                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration after seekTo');
-                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration after seekTo');
                       assert_false(mediaElement.seeking, 'mediaElement.seeking after seeked to seekTo');
-
-                      test.expectEvent(mediaElement, 'seeking', 'Seeking to truncated duration');
 
                       assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
 
-                      mediaSource.duration = truncatedDuration;
+                      sourceBuffer.remove(truncatedDuration, Infinity);
 
                       assert_true(sourceBuffer.updating, 'sourceBuffer.updating');
                       test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
                       test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
                       test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+                  });
+
+                  test.waitForExpectedEvents(function()
+                  {
+                      assert_greater_than_equal(mediaElement.currentTime, seekTo, 'Playback time has reached seekTo');
+                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration after seekTo');
+                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration after seekTo');
+                      test.expectEvent(mediaElement, 'seeking', 'Seeking to truncated duration');
+
+                      assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
+
+                      mediaSource.duration = truncatedDuration;
 
                       assert_true(mediaElement.seeking, 'Seeking after setting truncatedDuration');
                   });
@@ -168,13 +176,10 @@
                   assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
                   assert_less_than(mediaElement.currentTime, newDuration / 2, 'mediaElement currentTime');
 
-                  // Media load also fires 'durationchange' event, so only start counting them now.
-                  mediaElement.addEventListener('durationchange', durationchangeEventHandler);
-
                   assert_false(sourceBuffer.updating, "updating");
 
                   // Truncate duration. This should result in one 'durationchange' fired.
-                  mediaSource.duration = newDuration;
+                  sourceBuffer.remove(newDuration, Infinity);
 
                   assert_true(sourceBuffer.updating, "updating");
                   test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
@@ -184,7 +189,27 @@
 
               test.waitForExpectedEvents(function()
               {
+                  assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration');
+                  assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
+                  assert_less_than(mediaElement.currentTime, newDuration / 2, 'mediaElement currentTime');
+
+                  // Media load also fires 'durationchange' event, so only start counting them now.
+                  mediaElement.addEventListener('durationchange', durationchangeEventHandler);
+
                   assert_false(sourceBuffer.updating, "updating");
+
+                  // Truncate duration. This should result in one 'durationchange' fired.
+                  mediaSource.duration = newDuration;
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_false(sourceBuffer.updating, "updating");
+
+                  // Final duration may be greater than originally set as per MSE's 2.4.6 Duration change
+                  // Adjust newDuration accordingly.
+                  assert_true(newDuration <= mediaSource.duration, 'adjusted duration');
+                  newDuration = mediaSource.duration;
 
                   // Set duration again to make sure it does not trigger another 'durationchange' event.
                   mediaSource.duration = newDuration;
@@ -193,11 +218,10 @@
                   test.expectEvent(mediaSource, 'sourceended', 'endOfStream acknowledged');
                   mediaSource.endOfStream();
 
-                  // endOfStream can change duration downwards slightly.
+                  // endOfStream can change duration slightly.
                   // Allow for one more 'durationchange' event only in this case.
                   var currentDuration = mediaSource.duration;
                   if (currentDuration != newDuration) {
-                      assert_true(currentDuration > 0 && currentDuration < newDuration, 'adjusted duration');
                       newDuration = currentDuration;
                       ++expectedDurationChangeEventCount;
                   }

--- a/media-source/mediasource-getvideoplaybackquality.html
+++ b/media-source/mediasource-getvideoplaybackquality.html
@@ -43,14 +43,23 @@
               test.waitForExpectedEvents(function()
               {
                   assert_false(sourceBuffer.updating, "updating");
-                  assert_greater_than(mediaSource.duration, 1, "duration");
 
-                  mediaSource.duration = 1;
+                  sourceBuffer.remove(1, Infinity);
 
                   assert_true(sourceBuffer.updating, "updating");
                   test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
                   test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
                   test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_false(sourceBuffer.updating, "updating");
+                  assert_greater_than(mediaSource.duration, 1, "duration");
+
+                  mediaSource.duration = 1;
+
+                  test.expectEvent(mediaElement, "durationchange");
               });
 
               test.waitForExpectedEvents(function()

--- a/media-source/mediasource-play.html
+++ b/media-source/mediasource-play.html
@@ -23,14 +23,23 @@
               test.waitForExpectedEvents(function()
               {
                   assert_false(sourceBuffer.updating, "updating");
-                  assert_greater_than(mediaSource.duration, 1, "duration");
 
-                  mediaSource.duration = 1;
+                  sourceBuffer.remove(1, Infinity);
 
                   assert_true(sourceBuffer.updating, "updating");
                   test.expectEvent(sourceBuffer, 'updatestart', 'sourceBuffer');
                   test.expectEvent(sourceBuffer, 'update', 'sourceBuffer');
                   test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+              });
+
+              test.waitForExpectedEvents(function()
+              {
+                  assert_false(sourceBuffer.updating, "updating");
+                  assert_greater_than(mediaSource.duration, 1, "duration");
+
+                  mediaSource.duration = 1;
+
+                  test.expectEvent(mediaElement, "durationchange");
               });
 
               test.waitForExpectedEvents(function()

--- a/media-source/mediasource-remove.html
+++ b/media-source/mediasource-remove.html
@@ -136,15 +136,18 @@
               mediaSource.duration = 10;
 
               test.expectEvent(sourceBuffer, "updatestart");
-              test.expectEvent(sourceBuffer, "abort");
+              test.expectEvent(sourceBuffer, "update");
               test.expectEvent(sourceBuffer, "updateend");
               sourceBuffer.remove(1, 2);
 
               assert_true(sourceBuffer.updating, "updating");
 
-              sourceBuffer.abort();
+              assert_throws("InvalidStateError", function()
+              {
+                  sourceBuffer.abort();
+              }, "abort");
 
-              assert_false(sourceBuffer.updating, "updating");
+              assert_true(sourceBuffer.updating, "updating");
 
               test.waitForExpectedEvents(function()
               {


### PR DESCRIPTION
See w3c/MSE Issue 19, 20 & 26.

Changing the duration now can never call the range removal algorithm. An explicit call to remove must be used for range removal.
This spec change performed the following:
- Require remove() for all Range Removals
- Error on Duration Changes that need remove first
- Error on abort() during Range Removals

MozReview-Commit-ID: 1Xy8hi0tr7Q

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1286810
