### PR TITLE
webref] P7. Fix mimetype.

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -299,7 +299,7 @@ onload = function() {
     async_test(function() {
       var elm = document.createElement(tag);
       var video_ext = '';
-      if (elm.canPlayType('video/ogg; codecs="theora,vorbis"')) {
+      if (elm.canPlayType('video/ogg; codecs="theora,flac"')) {
         video_ext = 'ogv';
       } else if (elm.canPlayType('video/mp4; codecs="avc1.42E01E,mp4a.40.2"')) {
         video_ext = 'mp4';


### PR DESCRIPTION
The ogg file contains a theora video track with a flac audio track, not vorbis.
The new OggDemuxer properly ignore the tracks it knows nothing about.
This will cause the tests to use MP4 with h264/aac instead which isn't available on Windows XP, so we mark those tests are expected to fail.

MozReview-Commit-ID: 4UowUS6rQt3

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1288329
