### PR TITLE
Adding tests to check Origin header value after redirections in CORS mode

### DIFF
--- a/fetch/api/redirect/redirect-origin-worker.html
+++ b/fetch/api/redirect/redirect-origin-worker.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch in worker: redirect mode handling</title>
+    <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      fetch_tests_from_worker(new Worker("redirect-origin.js"));
+    </script>
+  </body>
+</html>

--- a/fetch/api/redirect/redirect-origin.html
+++ b/fetch/api/redirect/redirect-origin.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch: redirect mode handling</title>
+    <meta name="author" title="Canon Research France" href="https://www.crf.canon.fr">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script src="/common/utils.js"></script>
+    <script src="../resources/utils.js"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="redirect-origin.js"></script>
+  </body>
+</html>

--- a/fetch/api/redirect/redirect-origin.js
+++ b/fetch/api/redirect/redirect-origin.js
@@ -34,6 +34,7 @@ for (var code of [301, 302, 303, 307, 308]) {
     testOriginAfterRedirection("Same origin to same origin redirection " + code, redirectUrl, locationUrl, code, null);
     testOriginAfterRedirection("Same origin to other origin redirection " + code, redirectUrl, corsLocationUrl, code, get_host_info().HTTP_ORIGIN);
     testOriginAfterRedirection("Other origin to other origin redirection " + code, corsRedirectUrl, corsLocationUrl, code, get_host_info().HTTP_ORIGIN);
+    testOriginAfterRedirection("Other origin to same origin redirection " + code, corsRedirectUrl, locationUrl + "&cors", code, "null");
 }
 
 done();

--- a/fetch/api/redirect/redirect-origin.js
+++ b/fetch/api/redirect/redirect-origin.js
@@ -1,0 +1,39 @@
+if (this.document === undefined) {
+    importScripts("/common/utils.js");
+    importScripts("/resources/testharness.js");
+    importScripts("../resources/utils.js");
+    importScripts("../resources/get-host-info.sub.js");
+}
+
+function testOriginAfterRedirection(desc, redirectUrl, redirectLocation, redirectStatus, expectedOrigin) {
+    var uuid_token = token();
+    var url = redirectUrl;
+    var urlParameters = "?token=" + uuid_token + "&max_age=0";
+    urlParameters += "&redirect_status=" + redirectStatus;
+    urlParameters += "&location=" + encodeURIComponent(redirectLocation);
+
+    var requestInit = {"mode": "cors", "redirect": "follow"};
+
+    promise_test(function(test) {
+        return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
+            assert_equals(resp.status, 200, "Clean stash response's status is 200");
+            return fetch(url + urlParameters, requestInit).then(function(response) {
+                assert_equals(response.status, 200, "Inspect header response's status is 200");
+                assert_equals(response.headers.get("x-request-origin"), expectedOrigin, "Check origin header");
+            });
+        });
+    }, desc);
+}
+
+var redirectUrl = RESOURCES_DIR + "redirect.py";
+var corsRedirectUrl = get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
+var locationUrl =  get_host_info().HTTP_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "inspect-headers.py?headers=origin";
+var corsLocationUrl =  get_host_info().HTTP_REMOTE_ORIGIN + dirname(location.pathname) + RESOURCES_DIR + "inspect-headers.py?cors&headers=origin";
+
+for (var code of [301, 302, 303, 307, 308]) {
+    testOriginAfterRedirection("Same origin to same origin redirection " + code, redirectUrl, locationUrl, code, null);
+    testOriginAfterRedirection("Same origin to other origin redirection " + code, redirectUrl, corsLocationUrl, code, get_host_info().HTTP_ORIGIN);
+    testOriginAfterRedirection("Other origin to other origin redirection " + code, corsRedirectUrl, corsLocationUrl, code, get_host_info().HTTP_ORIGIN);
+}
+
+done();

--- a/fetch/api/resources/redirect.py
+++ b/fetch/api/resources/redirect.py
@@ -1,3 +1,6 @@
+from urllib import urlencode
+from urlparse import urlparse
+
 def main(request, response):
     stashed_data = {'count': 0, 'preflight': "0"}
     status = 302
@@ -28,13 +31,16 @@ def main(request, response):
 
     stashed_data['count'] += 1
 
-    #keep url parameters in location
-    url_parameters = "?" + "&".join(map(lambda x: x[0][0] + "=" + x[1][0], request.GET.items()))
-    #make sure location changes during redirection loop
-    url_parameters += "&count=" + str(stashed_data['count'])
-
     if "location" in request.GET:
-        headers.append(("Location", request.GET['location'] + url_parameters))
+        url = request.GET['location']
+        scheme = urlparse(url).scheme
+        if scheme == "" or scheme == "http" or scheme == "https":
+            url += "&" if '?' in url else "?"
+            #keep url parameters in location
+            url += urlencode(request.GET.items())
+            #make sure location changes during redirection loop
+            url += "&count=" + str(stashed_data['count'])
+        headers.append(("Location", url))
 
     if token:
         request.server.stash.put(request.GET.first("token"), stashed_data)


### PR DESCRIPTION
Also fixing redirect.py:
- to allow query strings in the Location.
- to not add additional query strings on non-http URLs
