### PR TITLE
Remove `scope='function'` parameter from fixture

### DIFF
--- a/webdriver/navigation.py
+++ b/webdriver/navigation.py
@@ -39,7 +39,7 @@ class HTTPRequest(object):
             conn.close()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def http(request, session):
     return HTTPRequest(session.transport.host, session.transport.port)
 


### PR DESCRIPTION
Function scope is the default for Pytest fixtures (http://doc.pytest.org/en/latest/builtin.html#_pytest.python.fixture), so the `scope='function'` parameter is unnecessary.
