### PR TITLE
[eme] Add Event an EventTarget to untested IDLs

### DIFF
--- a/encrypted-media/idlharness.html
+++ b/encrypted-media/idlharness.html
@@ -34,6 +34,8 @@
                 idl_array.add_untested_idls("interface Navigator {};");
                 idl_array.add_untested_idls("interface ArrayBuffer {};");
                 idl_array.add_untested_idls("interface HTMLMediaElement {};");
+                idl_array.add_untested_idls("interface Event {};");
+                idl_array.add_untested_idls("interface EventTarget {};");
 
                 idl_array.add_idls(idls);
 


### PR DESCRIPTION
This fixes the "Cannot read property 'has_extended_attribute' of undefined" errors.
