### PR TITLE
Upload event listeners have to be registered early, always

### DIFF
--- a/cors/late-upload-events.htm
+++ b/cors/late-upload-events.htm
@@ -10,7 +10,7 @@
 <div id=log></div>
 
 <script>
-function doTest(desc, headers, expectEvents) {
+function doTest(desc, headers) {
     async_test("Late listeners: " + desc).step(function() {
         var client = new XMLHttpRequest();
         var eventCounter = 0;
@@ -24,23 +24,17 @@ function doTest(desc, headers, expectEvents) {
             // Irrelevant if request is not finished
             if (client.readyState < 4) return;
             assert_equals(client.status, 200);
-            if (expectEvents) {
-                assert_true(eventCounter > 3, 'Events did fire');
-            } else {
-                assert_equals(eventCounter, 0, 'No events did fire');
-            }
+            assert_equals(eventCounter, 0, 'Events fired, but should not have');
             this.done();
         });
         client.send((new Array(3000)).join('xo'));
         client.upload.onprogress = client.upload.onloadend = client.upload.onloadstart = client.upload.onload = this.step_func(function(e) {
             eventCounter++;
-            if (!expectEvents) {
-                assert_unreached("Upload events should not fire, but did: " + e.type);
-            }
+            assert_unreached("Upload events should not fire, but did: " + e.type);
         });
     });
 }
 
-doTest("No preflight", {}, false);
-doTest("Preflight", {"custom-header":"test"}, true);
+doTest("No preflight", {});
+doTest("Preflight", {"custom-header":"test"});
 </script>


### PR DESCRIPTION
This will be clarified in the standard as part of fixing
https://www.w3.org/Bugs/Public/show_bug.cgi?id=20322.
