### PR TITLE
Add multi-global tests for Request/Response

### DIFF
--- a/fetch/api/request/multi-globals/current/current.html
+++ b/fetch/api/request/multi-globals/current/current.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>Current page used as a test helper</title>

--- a/fetch/api/request/multi-globals/incumbent/incumbent.html
+++ b/fetch/api/request/multi-globals/incumbent/incumbent.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="../current/current.html" id="c"></iframe>
+
+<script>
+'use strict';
+
+const current = document.querySelector('#c').contentWindow;
+
+window.createRequest = (...args) => {
+    return new current.Request(...args);
+};
+
+</script>

--- a/fetch/api/request/multi-globals/url-parsing.html
+++ b/fetch/api/request/multi-globals/url-parsing.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Request constructor URL parsing, with multiple globals in play</title>
+<link rel="help" href="https://fetch.spec.whatwg.org/#dom-request">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- This is the entry global -->
+
+<iframe src="incumbent/incumbent.html"></iframe>
+
+<script>
+'use strict';
+
+const loadPromise = new Promise(resolve => {
+    window.addEventListener("load", () => resolve());
+});
+
+promise_test(() => {
+    return loadPromise.then(() => {
+        const req = frames[0].createRequest("url");
+
+        assert_equals(req.url, new URL("current/url", location.href).href);
+    });
+}, "should parse the URL relative to the current settings object");
+
+</script>

--- a/fetch/api/response/multi-globals/current/current.html
+++ b/fetch/api/response/multi-globals/current/current.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>Current page used as a test helper</title>

--- a/fetch/api/response/multi-globals/incumbent/incumbent.html
+++ b/fetch/api/response/multi-globals/incumbent/incumbent.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="../current/current.html" id="c"></iframe>
+<iframe src="../relevant/relevant.html" id="r"></iframe>
+
+<script>
+'use strict';
+
+const current = document.querySelector('#c').contentWindow;
+const relevant = document.querySelector('#r').contentWindow;
+
+window.createRedirectResponse = (...args) => {
+    return current.Response.redirect.call(relevant.Response, ...args);
+};
+
+</script>

--- a/fetch/api/response/multi-globals/relevant/relevant.html
+++ b/fetch/api/response/multi-globals/relevant/relevant.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<title>Relevant page used as a test helper</title>

--- a/fetch/api/response/multi-globals/url-parsing.html
+++ b/fetch/api/response/multi-globals/url-parsing.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>Response.redirect URL parsing, with multiple globals in play</title>
-<link rel="help" href="https://fetch.spec.whatwg.org/#dom-request">
+<link rel="help" href="https://fetch.spec.whatwg.org/#dom-response-redirect">
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/fetch/api/response/multi-globals/url-parsing.html
+++ b/fetch/api/response/multi-globals/url-parsing.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>Response.redirect URL parsing, with multiple globals in play</title>
+<link rel="help" href="https://fetch.spec.whatwg.org/#dom-request">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- This is the entry global -->
+
+<iframe src="incumbent/incumbent.html"></iframe>
+
+<script>
+'use strict';
+
+const loadPromise = new Promise(resolve => {
+    window.addEventListener("load", () => resolve());
+});
+
+promise_test(() => {
+    return loadPromise.then(() => {
+        const res = frames[0].createRedirectResponse("url");
+
+        assert_equals(res.headers.get("Location"), new URL("current/url", location.href).href);
+    });
+}, "should parse the redirect Location URL relative to the current settings object");
+
+</script>


### PR DESCRIPTION
Tests the recent change made in https://github.com/whatwg/fetch/commit/24db2d37e4d952343ce5319a1684cbd0319e144e. Curiously, Chrome already passes these (whereas Gecko fails, per the spec up until recently).

I was unable to find a way to test the change to use the current settings object's HTTPS state, instead of the entry settings object's, as I don't understand how I'd test a Response object's HTTPS state.
