### PR TITLE
[eme] Fix #3430: Use correct PSSH box sizes

### DIFF
--- a/encrypted-media/Google/encrypted-media-generate-request-disallowed-input.html
+++ b/encrypted-media/Google/encrypted-media-generate-request-disallowed-input.html
@@ -67,13 +67,13 @@
                     0x00, 0x00, 0x00, 0x00                           // datasize
                 ]);
                 return test_session('cenc', initData);
-            }, 'generateRequest() with invalid pssh data.');
+            }, 'generateRequest() with invalid pssh box size.');
 
             promise_test(function()
             {
                 // Invalid data as type = 'psss'.
                 var initData = new Uint8Array([
-                    0x00, 0x00, 0x00, 0x00,                          // size = 0
+                    0x00, 0x00, 0x00, 0x20,                          // size = 32
                     0x70, 0x73, 0x73, 0x73,                          // 'psss'
                     0x00,                                            // version = 0
                     0x00, 0x00, 0x00,                                // flags

--- a/encrypted-media/Google/encrypted-media-utils.js
+++ b/encrypted-media/Google/encrypted-media-utils.js
@@ -34,7 +34,7 @@ function getInitData(initDataType)
 
   if (initDataType == 'cenc') {
       return new Uint8Array([
-          0x00, 0x00, 0x00, 0x00,                          // size = 0
+          0x00, 0x00, 0x00, 0x34,                          // size = 52
           0x70, 0x73, 0x73, 0x68,                          // 'pssh'
           0x01,                                            // version = 1
           0x00, 0x00, 0x00,                                // flags


### PR DESCRIPTION
Applies changes from Blink revisions c13a1d8e190dd8f433480f17eaba4fcb288c52ae
and 6f80411ef54d4d6e716b6d2781855e2eeeb66d8b.
