### PR TITLE
Upstream 2d.gradient.interpolate.colouralpha from WebKit

### DIFF
--- a/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.colouralpha.html
+++ b/2dcontext/fill-and-stroke-styles/2d.gradient.interpolate.colouralpha.html
@@ -24,9 +24,9 @@ g.addColorStop(0, 'rgba(255,255,0, 0)');
 g.addColorStop(1, 'rgba(0,0,255, 1)');
 ctx.fillStyle = g;
 ctx.fillRect(0, 0, 100, 50);
-_assertPixelApprox(canvas, 25,25, 191,191,63,63, "25,25", "191,191,63,63", 3);
-_assertPixelApprox(canvas, 50,25, 127,127,127,127, "50,25", "127,127,127,127", 3);
-_assertPixelApprox(canvas, 75,25, 63,63,191,191, "75,25", "63,63,191,191", 3);
+_assertPixelApprox(canvas, 25,25, 190,190,65,65, "25,25", "190,190,65,65", 3);
+_assertPixelApprox(canvas, 50,25, 126,126,128,128, "50,25", "126,126,128,128", 3);
+_assertPixelApprox(canvas, 75,25, 62,62,192,192, "75,25", "62,62,192,192", 3);
 
 
 });

--- a/2dcontext/tools/tests2d.yaml
+++ b/2dcontext/tools/tests2d.yaml
@@ -1668,9 +1668,9 @@
     g.addColorStop(1, 'rgba(0,0,255, 1)');
     ctx.fillStyle = g;
     ctx.fillRect(0, 0, 100, 50);
-    @assert pixel 25,25 ==~ 191,191,63,63 +/- 3;
-    @assert pixel 50,25 ==~ 127,127,127,127 +/- 3;
-    @assert pixel 75,25 ==~ 63,63,191,191 +/- 3;
+    @assert pixel 25,25 ==~ 190,190,65,65 +/- 3;
+    @assert pixel 50,25 ==~ 126,126,128,128 +/- 3;
+    @assert pixel 75,25 ==~ 62,62,192,192 +/- 3;
   expected: |
     size 100 50
     g = cairo.LinearGradient(0, 0, 100, 0)


### PR DESCRIPTION
When the test samples 25th pixel it expect the value to be exactly 25% interpolation of the color values. However, the sampling location is the center of the pixel, i.e. it should correspond to 25.5% interpolation, which would expect the color of (189.975, 189.75, 65.25, 65.25). The new values are a rounded values of interpolation “by hand” at steps of 25.5%, 50.5% and 75.5%.

This mirrors a fix that landed in WebKit for https://webkit.org/b/160689.

Original fix by Bartosz Ciechanowski.
