### PR TITLE
errorMessage was not being put into output

### DIFF
--- a/annotation-model/scripts/JSONtest.js
+++ b/annotation-model/scripts/JSONtest.js
@@ -317,7 +317,7 @@ JSONtest.prototype = {
       assertions.forEach( function(assert, num) {
 
         var expected = assert.hasOwnProperty('expectedResult') ? assert.expectedResult : 'valid' ;
-        var message = assert.hasOwnProperty('message') ? assert.message : "Result was not " + expected;
+        var message = assert.hasOwnProperty('errorMessage') ? assert.errorMessage : "Result was not " + expected;
 
         // first - what is the type of the assert
         if (typeof assert === "object" && !Array.isArray(assert)) {


### PR DESCRIPTION
If an assertion has an explicit errorMessage, that message was
not being included in the 'message' that is attached to the test output.

@bigbluehat and @tcole3 can you please review?
