### PR TITLE
Added type interpretation to output

### DIFF
--- a/annotation-model/tools/template
+++ b/annotation-model/tools/template
@@ -26,14 +26,13 @@ var runningTest = new JSONtest( {
 </script>
 </head>
 <body>
-<p>Fill the textarea below with  JSON output from your annotation client
+<p>Fill the textarea below with JSON output from your annotation client
 implementation that supports the following criteria:</p>
 <div id="testDescription"></div>
 <p>Specifically, the following assertions will be evaluated:</p>
 <div id="assertion"></div>
 <form name="annotation" id="annotation">
-    <textarea name="annotation-input" id="annotation-input" style="width: 90%; height: 10em" >
-    </textarea>
+    <textarea name="annotation-input" id="annotation-input" style="width: 90%; height: 10em" ></textarea>
     <p><input type="button" id="annotation-run" name="Loading..." value="Loading...">
        <input style="display: none" type="button" id="annotation-close"
        name="Close" value="Close"></p>


### PR DESCRIPTION
The assertionType property was not being used in the test output.  It
now is used to augment the title of assertions and the error message
output to assist users with interpretation of the requirements of
the test and the results of running the test.

This is a result of an Annotation Working Group meeting on 12 August.  @bigbluehat and @tcole, can you please review?
