### PR TITLE
Update several DOM event tests after https://github.com/whatwg/dom/is…

### DIFF
--- a/dom/events/Event-propagation.html
+++ b/dom/events/Event-propagation.html
@@ -13,10 +13,11 @@ function testPropagationFlag(ev, expected, desc) {
     var callback = function() { called = true };
     document.head.addEventListener("foo", callback);
     document.head.dispatchEvent(ev);
-    // Gecko resets the flags after dispatching; it will happily dispatch
+    assert_equals(called, expected, "Propagation flag");
+    // dispatchEvent resets the propagation flags so it will happily dispatch
     // the event the second time around.
     document.head.dispatchEvent(ev);
-    assert_equals(called, expected, "Propagation flag");
+    assert_equals(called, true, "Propagation flag after first dispatch");
     document.head.removeEventListener("foo", callback);
   }, desc);
 }


### PR DESCRIPTION
…sues/219

The DOM specification now states that we should now reset the event propagation
flags at the end of dispatchEvent().
