### PR TITLE
Correctly test initEvent unsetting propagation flags

### DIFF
--- a/dom/events/Event-initEvent.html
+++ b/dom/events/Event-initEvent.html
@@ -13,7 +13,7 @@ booleans.forEach(function(bubbles) {
       e.initEvent("type", bubbles, cancelable)
 
       // Step 3.
-      // Can't test the stop propagation flag and stop immediate propagation flag.
+      // Stop (immediate) propagation flag is tested later
       assert_equals(e.defaultPrevented, false, "defaultPrevented")
       // Step 4.
       assert_equals(e.isTrusted, false, "isTrusted")
@@ -78,30 +78,27 @@ async_test(function() {
   this.done()
 }, "Calling initEvent must not have an effect during dispatching.")
 
-async_test(function() {
+test(function() {
   var e = document.createEvent("Event")
-  e.initEvent("type", false, false)
   e.stopPropagation()
-
-  var target = document.createElement("div")
-  target.addEventListener("type", this.step_func(function() {
-    assert_unreached("")
-  }), false)
-  assert_equals(target.dispatchEvent(e), true, "dispatchEvent must return true")
-  assert_equals(target.dispatchEvent(e), true, "dispatchEvent must return true")
-
   e.initEvent("type", false, false)
-  var called = false
   var target = document.createElement("div")
-  target.addEventListener("type", this.step_func(function() {
-    called = true
-  }), false)
-  assert_false(called)
-  assert_equals(target.dispatchEvent(e), true, "dispatchEvent must return true")
-  assert_true(called)
-
-  this.done()
+  var called = false
+  target.addEventListener("type", function() { called = true }, false)
+  assert_true(target.dispatchEvent(e), "dispatchEvent must return true")
+  assert_true(called, "Listener must be called")
 }, "Calling initEvent must unset the stop propagation flag.")
+
+test(function() {
+  var e = document.createEvent("Event")
+  e.stopImmediatePropagation()
+  e.initEvent("type", false, false)
+  var target = document.createElement("div")
+  var called = false
+  target.addEventListener("type", function() { called = true }, false)
+  assert_true(target.dispatchEvent(e), "dispatchEvent must return true")
+  assert_true(called, "Listener must be called")
+}, "Calling initEvent must unset the stop immediate propagation flag.")
 
 async_test(function() {
   var e = document.createEvent("Event")


### PR DESCRIPTION
There was previously never any test for unsetting the immediate
propagation flag.  There was one for the propagation flag, but it called
dispatchEvent() in between initEvent() and the actual test, and since
whatwg/dom#219, dispatchEvent() clears these flags as well, so the test
is now incorrect.  (Before that the test was also not very good, because
Gecko always cleared the flags in dispatchEvent() but not initEvent(),
so it was incorrectly passing the test.)

This will need merging with #3469, which edits the removed test.  The changes to the removed code can be safely thrown away.
