### PR TITLE
Fix a couple of namespaceURI checks in dom/nodes/Node-properties.html

### DIFF
--- a/dom/nodes/Node-properties.html
+++ b/dom/nodes/Node-properties.html
@@ -226,7 +226,7 @@ var expected = {
         textContent: "do re mi fa so la ti",
 
         // Element
-        namespaceURI: "http://www.w3.org/1999/xhtml",
+        namespaceURI: null,
         prefix: null,
         localName: "igiveuponcreativenames",
         tagName: "igiveuponcreativenames",
@@ -246,7 +246,7 @@ var expected = {
         textContent: "",
 
         // Element
-        namespaceURI: "http://www.w3.org/1999/xhtml",
+        namespaceURI: null,
         prefix: null,
         localName: "everyone-hates-hyphenated-element-names",
         tagName: "everyone-hates-hyphenated-element-names",


### PR DESCRIPTION
According to the DOM specification, the namespaceURI for xmlElement amd
detachedXmlElement should be null, not "http://www.w3.org/1999/xhtml".

Those elements are created using xmlDoc.createElement() amd xmlDoc is
not an HTMLDocument or a document whose content type is
"application/xhtml+xml" [1].

Those 2 checks were failing in Firefox, Chrome and Safari and are now
passing for all these browsers.

[1] https://dom.spec.whatwg.org/#dom-document-createelement
