### PR TITLE
Test innerText = ""/null/undefined

### DIFF
--- a/innerText/setter-tests.js
+++ b/innerText/setter-tests.js
@@ -22,3 +22,6 @@ testText("<div>", "abc ", "abc ", "Trailing whitespace preserved");
 testText("<div>", "abc  def", "abc  def", "Whitespace not compressed");
 testHTML("<div>abc\n\n", "abc", "abc", "Existing text deleted");
 testHTML("<div><br>", "abc", "abc", "Existing <br> deleted");
+testHTML("<div>", "", "", "Assigning the empty string");
+testHTML("<div>", null, "", "Assigning null");
+testHTML("<div>", undefined, "undefined", "Assigning undefined");


### PR DESCRIPTION
In https://github.com/whatwg/html/pull/1678/commits/618de8424d04a57515b603730cbfef1df77a8d9a
innerText was annotated with [TreatNullAs=EmptyString].

---

cc @smaug---- @jfkthame @rocallahan 
