### PR TITLE
Headers API constructor and methods

### DIFF
--- a/fetch/api/headers/headers-basic.html
+++ b/fetch/api/headers/headers-basic.html
@@ -66,7 +66,7 @@
           assert_equals(headers2.get(name), String(headerDict[name]),
             "name: " + name + " has value: " + headerDict[name]);
         }
-      }, "Create headers whith existing headers");
+      }, "Create headers with existing headers");
 
       test(function() {
         var headers = new Headers();


### PR DESCRIPTION
- Reworked the append method to support the inner `hyper::header::Headers`'s HashMap `insert` method, which overwrites entries instead of appending.
- Filled out constructor as well as delete, get, has, and set methods.
- Updated relevant test expectations
