### PR TITLE
Fire load event for external stylesheets

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-load-event.html
+++ b/html/semantics/document-metadata/the-link-element/link-load-event.html
@@ -10,12 +10,9 @@ var t = async_test("Check if the stylesheet's load event blocks the document loa
 document.getElementById('style_test').onload = t.step_func(function() {
   saw_link_onload = true;
 });
-window.addEventListener('load', function() {
-  t.step_func(function() {
-    assert_true(saw_link_onload);
-  });
-  t.done();
-}, false);
+window.addEventListener('load', t.step_func_done(function() {
+  assert_true(saw_link_onload);
+}));
 </script>
 </head>
 </html>

--- a/html/semantics/document-metadata/the-link-element/link-style-error-01.html
+++ b/html/semantics/document-metadata/the-link-element/link-style-error-01.html
@@ -40,6 +40,7 @@ tText.step(function() {
     assert_true(true, "Got error event for 404 error.")
     tText.done()
   })
+  elt.onload = tText.unreached_func("load event should not be fired");
   elt.rel = "stylesheet";
   elt.href = "../../../../../common/css-red.txt";
   document.getElementsByTagName("head")[0].appendChild(elt);


### PR DESCRIPTION
Do not load stylesheets with the wrong Content-Type

Fixes #11912, #11910
