### PR TITLE
Add tests for attributes limited to > 0

### DIFF
--- a/html/semantics/forms/the-input-element/size.html
+++ b/html/semantics/forms/the-input-element/size.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-input-size">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#limited-to-only-non-negative-numbers-greater-than-zero">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<input>
+
+<script>
+"use strict";
+
+test(() => {
+    const input = document.querySelector("input");
+
+    assert_equals(input.size, 20);
+}, "input's initial default size value must be 20");
+
+test(() => {
+    const input = document.querySelector("input");
+    input.size = 2;
+
+    assert_equals(input.getAttribute("size"), "2");
+}, "setting input's size to 2 sets the relevant content attribute");
+
+test(() => {
+    const input = document.querySelector("input");
+
+    assert_throws("IndexSizeError", () => {
+      input.size = 0;
+    }, "testing throwing behavior");
+
+    assert_equals(input.getAttribute("size"), "2", "testing content attribute");
+    assert_equals(input.size, 2, "testing IDL attribute");
+}, "setting input's size IDL attribute to 0 causes a throw and the values remain the same (content = 2, IDL = 2)");
+
+test(() => {
+    const input = document.querySelector("input");
+    input.size = 2147483649;
+
+    assert_equals(input.getAttribute("size"), "20", "testing content attribute");
+    assert_equals(input.size, 20, "testing IDL attribute");
+}, "setting input's size IDL attribute to 2147483649 causes content = 20, IDL = 20");
+
+test(() => {
+    const input = document.querySelector("input");
+    input.setAttribute("size", "2147483649");
+
+    assert_equals(input.getAttribute("size"), "2147483649", "testing content attribute");
+    assert_equals(input.size, 20, "testing IDL attribute");
+}, "setting input's size content attribute to 2147483649 causes content = 2147483649, IDL = 20");
+
+</script>

--- a/html/semantics/forms/the-textarea-element/rows-and-cols.html
+++ b/html/semantics/forms/the-textarea-element/rows-and-cols.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-textarea-cols">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-textarea-rows">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#limited-to-only-non-negative-numbers-greater-than-zero-with-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<textarea></textarea>
+
+<script>
+"use strict";
+
+const defaults = {
+  cols: 20,
+  rows: 2
+};
+
+for (let attr of Object.keys(defaults)) {
+  const defaultValue = defaults[attr];
+
+  test(() => {
+      const textarea = document.querySelector("textarea");
+
+      assert_equals(textarea[attr], defaultValue);
+  }, `textarea's initial default ${attr} value must be ${defaultValue}`);
+
+  test(() => {
+      const textarea = document.querySelector("textarea");
+      textarea[attr] = 30;
+
+      assert_equals(textarea.getAttribute(attr), "30");
+  }, `setting textarea's ${attr} to 30 sets the relevant content attribute`);
+
+  test(() => {
+      const textarea = document.querySelector("textarea");
+      textarea[attr] = 0;
+
+      assert_equals(textarea.getAttribute(attr), `${defaultValue}`, "testing content attribute");
+      assert_equals(textarea[attr], defaultValue, "testing IDL attribute");
+  }, `setting textarea's ${attr} IDL attribute to 0 causes content = ${defaultValue}, IDL = ${defaultValue}`);
+
+  test(() => {
+      const textarea = document.querySelector("textarea");
+      textarea[attr] = 2147483649;
+
+      assert_equals(textarea.getAttribute(attr), `${defaultValue}`, "testing content attribute");
+      assert_equals(textarea[attr], defaultValue, "testing IDL attribute");
+  }, `setting textarea's ${attr} IDL attribute to 2147483649 causes content = ${defaultValue}, IDL = ${defaultValue}`);
+
+  test(() => {
+      const textarea = document.querySelector("textarea");
+      textarea.setAttribute(attr, "2147483649");
+
+      try {
+        assert_equals(textarea.getAttribute(attr), "2147483649", "testing content attribute");
+        assert_equals(textarea[attr], defaultValue, "testing IDL attribute");
+      } finally {
+        // Otherwise Chrome gets very confused on failure
+        textarea.setAttribute(attr, "30");
+      }
+  }, `setting textarea's ${attr} content attribute to 2147483649 causes content = 2147483649, IDL = ${defaultValue}`);
+}
+
+</script>

--- a/html/semantics/tabular-data/the-col-element/span.html
+++ b/html/semantics/tabular-data/the-col-element/span.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-col-span">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#limited-to-only-non-negative-numbers-greater-than-zero-with-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<table id="sudoku">
+ <colgroup><col><col><col>
+ <colgroup><col><col><col>
+ <colgroup><col><col><col>
+ <tbody>
+  <tr> <td> 1 <td>   <td> 3 <td> 6 <td>   <td> 4 <td> 7 <td>   <td> 9
+  <tr> <td>   <td> 2 <td>   <td>   <td> 9 <td>   <td>   <td> 1 <td>
+  <tr> <td> 7 <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td> 6
+ <tbody>
+  <tr> <td> 2 <td>   <td> 4 <td>   <td> 3 <td>   <td> 9 <td>   <td> 8
+  <tr> <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td>
+  <tr> <td> 5 <td>   <td>   <td> 9 <td>   <td> 7 <td>   <td>   <td> 1
+ <tbody>
+  <tr> <td> 6 <td>   <td>   <td>   <td> 5 <td>   <td>   <td>   <td> 2
+  <tr> <td>   <td>   <td>   <td>   <td> 7 <td>   <td>   <td>   <td>
+  <tr> <td> 9 <td>   <td>   <td> 8 <td>   <td> 2 <td>   <td>   <td> 5
+</table>
+
+<script>
+"use strict";
+
+test(() => {
+    const col = document.querySelector("col");
+
+    assert_equals(col.span, 1);
+}, "col's initial default span value must be 1");
+
+test(() => {
+    const col = document.querySelector("col");
+    col.span = 2;
+
+    assert_equals(col.getAttribute("span"), "2");
+}, "setting col's span to 2 sets the relevant content attribute");
+
+test(() => {
+    const col = document.querySelector("col");
+    col.span = 0;
+
+    assert_equals(col.getAttribute("span"), "1", "testing content attribute");
+    assert_equals(col.span, 1, "testing IDL attribute");
+}, "setting col's span IDL attribute to 0 causes content = 1, IDL = 1");
+
+test(() => {
+    const col = document.querySelector("col");
+    col.span = 2147483649;
+
+    assert_equals(col.getAttribute("span"), "1", "testing content attribute");
+    assert_equals(col.span, 1, "testing IDL attribute");
+}, "setting col's span IDL attribute to 2147483649 causes content = 1, IDL = 1");
+
+test(() => {
+    const col = document.querySelector("col");
+    col.setAttribute("span", "2147483649");
+
+    assert_equals(col.getAttribute("span"), "2147483649", "testing content attribute");
+    assert_equals(col.span, 1, "testing IDL attribute");
+}, "setting col's span content attribute to 2147483649 causes content = 2147483649, IDL = 1");
+
+</script>

--- a/html/semantics/tabular-data/the-colgroup-element/span.html
+++ b/html/semantics/tabular-data/the-colgroup-element/span.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-colgroup-span">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#limited-to-only-non-negative-numbers-greater-than-zero-with-fallback">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<table id="sudoku">
+ <colgroup><col><col><col>
+ <colgroup><col><col><col>
+ <colgroup><col><col><col>
+ <tbody>
+  <tr> <td> 1 <td>   <td> 3 <td> 6 <td>   <td> 4 <td> 7 <td>   <td> 9
+  <tr> <td>   <td> 2 <td>   <td>   <td> 9 <td>   <td>   <td> 1 <td>
+  <tr> <td> 7 <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td> 6
+ <tbody>
+  <tr> <td> 2 <td>   <td> 4 <td>   <td> 3 <td>   <td> 9 <td>   <td> 8
+  <tr> <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td>   <td>
+  <tr> <td> 5 <td>   <td>   <td> 9 <td>   <td> 7 <td>   <td>   <td> 1
+ <tbody>
+  <tr> <td> 6 <td>   <td>   <td>   <td> 5 <td>   <td>   <td>   <td> 2
+  <tr> <td>   <td>   <td>   <td>   <td> 7 <td>   <td>   <td>   <td>
+  <tr> <td> 9 <td>   <td>   <td> 8 <td>   <td> 2 <td>   <td>   <td> 5
+</table>
+
+<script>
+"use strict";
+
+test(() => {
+    const colgroup = document.querySelector("colgroup");
+
+    assert_equals(colgroup.span, 1);
+}, "colgroup's initial default span value must be 1");
+
+test(() => {
+    const colgroup = document.querySelector("colgroup");
+    colgroup.span = 2;
+
+    assert_equals(colgroup.getAttribute("span"), "2");
+}, "setting colgroup's span to 2 sets the relevant content attribute");
+
+test(() => {
+    const colgroup = document.querySelector("colgroup");
+    colgroup.span = 0;
+
+    assert_equals(colgroup.getAttribute("span"), "1", "testing content attribute");
+    assert_equals(colgroup.span, 1, "testing IDL attribute");
+}, "setting colgroup's span IDL attribute to 0 causes content = 1, IDL = 1");
+
+test(() => {
+    const colgroup = document.querySelector("colgroup");
+    colgroup.span = 2147483649;
+
+    assert_equals(colgroup.getAttribute("span"), "1", "testing content attribute");
+    assert_equals(colgroup.span, 1, "testing IDL attribute");
+}, "setting colgroup's span IDL attribute to 2147483649 causes content = 1, IDL = 1");
+
+test(() => {
+    const colgroup = document.querySelector("colgroup");
+    colgroup.setAttribute("span", "2147483649");
+
+    assert_equals(colgroup.getAttribute("span"), "2147483649", "testing content attribute");
+    assert_equals(colgroup.span, 1, "testing IDL attribute");
+}, "setting colgroup's span content attribute to 2147483649 causes content = 2147483649, IDL = 1");
+
+</script>


### PR DESCRIPTION
This reflects the conclusion of https://github.com/whatwg/html/issues/1200 as in https://github.com/whatwg/html/pull/1693.

Only WebKit (tested on Safari Tech Preview) currently passes these.
