### PR TITLE
Hide the output element once the test is completed to make the test WebKit friendly

### DIFF
--- a/resource-timing/resource-timing.js
+++ b/resource-timing/resource-timing.js
@@ -434,6 +434,21 @@ window.onload =
             output.textContent += text + "\r\n";
         }
 
+        add_completion_callback(function () {
+            var output = document.getElementById("output");
+            var button = document.createElement('button');
+            output.parentNode.insertBefore(button, output);
+            button.onclick = function () {
+                var showButton = output.style.display == 'none';
+                output.style.display = showButton ? null : 'none';
+                button.textContent = showButton ? 'Hide details' : 'Show details';
+            }
+            button.onclick();
+            var iframes = document.querySelectorAll('iframe');
+            for (var i = 0; i < iframes.length; i++)
+                iframes[i].parentNode.removeChild(iframes[i]);
+        });
+
         /** pretty print a resource timeline entry. */
         function logResourceEntry(entry) {
             log("[" + entry.entryType + "] " + entry.name);


### PR DESCRIPTION
Added a button to toggle the visibilit of the detiled output so that the serialized plain text
of the test output will always be the same. This is a useful property for WebKit's automated testing system.
