### PR TITLE
Stamp Chromium+W3C license onto media-source/ files that originated in Blink

### DIFF
--- a/media-source/mediasource-addsourcebuffer.html
+++ b/media-source/mediasource-addsourcebuffer.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.addSourceBuffer() test cases</title>

--- a/media-source/mediasource-append-buffer.html
+++ b/media-source/mediasource-append-buffer.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.appendBuffer() test cases</title>

--- a/media-source/mediasource-appendwindow.html
+++ b/media-source/mediasource-appendwindow.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.appendWindowStart and SourceBuffer.appendWindowEnd test cases.</title>

--- a/media-source/mediasource-buffered.html
+++ b/media-source/mediasource-buffered.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.buffered test cases.</title>

--- a/media-source/mediasource-closed.html
+++ b/media-source/mediasource-closed.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.readyState equals "closed" test cases.</title>

--- a/media-source/mediasource-config-change-mp4-a-bitrate.html
+++ b/media-source/mediasource-config-change-mp4-a-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 audio-only bitrate change.</title>

--- a/media-source/mediasource-config-change-mp4-av-audio-bitrate.html
+++ b/media-source/mediasource-config-change-mp4-av-audio-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 muxed audio &amp; video with an audio bitrate change.</title>

--- a/media-source/mediasource-config-change-mp4-av-framesize.html
+++ b/media-source/mediasource-config-change-mp4-av-framesize.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 muxed audio &amp; video with a video frame size change.</title>

--- a/media-source/mediasource-config-change-mp4-av-video-bitrate.html
+++ b/media-source/mediasource-config-change-mp4-av-video-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 muxed audio &amp; video with a video bitrate change.</title>

--- a/media-source/mediasource-config-change-mp4-v-bitrate.html
+++ b/media-source/mediasource-config-change-mp4-v-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 video-only bitrate change.</title>

--- a/media-source/mediasource-config-change-mp4-v-framerate.html
+++ b/media-source/mediasource-config-change-mp4-v-framerate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 video-only frame rate change.</title>

--- a/media-source/mediasource-config-change-mp4-v-framesize.html
+++ b/media-source/mediasource-config-change-mp4-v-framesize.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MP4 video-only frame size change.</title>

--- a/media-source/mediasource-config-change-webm-a-bitrate.html
+++ b/media-source/mediasource-config-change-webm-a-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM audio-only bitrate change.</title>

--- a/media-source/mediasource-config-change-webm-av-audio-bitrate.html
+++ b/media-source/mediasource-config-change-webm-av-audio-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM muxed audio &amp; video with an audio bitrate change.</title>

--- a/media-source/mediasource-config-change-webm-av-framesize.html
+++ b/media-source/mediasource-config-change-webm-av-framesize.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM muxed audio &amp; video with a video frame size change.</title>

--- a/media-source/mediasource-config-change-webm-av-video-bitrate.html
+++ b/media-source/mediasource-config-change-webm-av-video-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM muxed audio &amp; video with a video bitrate change.</title>

--- a/media-source/mediasource-config-change-webm-v-bitrate.html
+++ b/media-source/mediasource-config-change-webm-v-bitrate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM video-only bitrate change.</title>

--- a/media-source/mediasource-config-change-webm-v-framerate.html
+++ b/media-source/mediasource-config-change-webm-v-framerate.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM video-only frame rate change.</title>

--- a/media-source/mediasource-config-change-webm-v-framesize.html
+++ b/media-source/mediasource-config-change-webm-v-framesize.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>WebM video-only frame size change.</title>

--- a/media-source/mediasource-config-changes.js
+++ b/media-source/mediasource-config-changes.js
@@ -1,3 +1,5 @@
+// Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang).
+
 // Extract & return the resolution string from a filename, if any.
 function resolutionFromFilename(filename)
 {

--- a/media-source/mediasource-duration-boundaryconditions.html
+++ b/media-source/mediasource-duration-boundaryconditions.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.duration boundary condition test cases.</title>

--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.duration &amp; HTMLMediaElement.duration test cases.</title>

--- a/media-source/mediasource-endofstream-invaliderror.html
+++ b/media-source/mediasource-endofstream-invaliderror.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Invalid MediaSource.endOfStream() parameter test cases.</title>

--- a/media-source/mediasource-getvideoplaybackquality.html
+++ b/media-source/mediasource-getvideoplaybackquality.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>HTMLVideoElement.getVideoPlaybackQuality() test cases.</title>

--- a/media-source/mediasource-is-type-supported.html
+++ b/media-source/mediasource-is-type-supported.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.isTypeSupported() test cases.</title>

--- a/media-source/mediasource-multiple-attach.html
+++ b/media-source/mediasource-multiple-attach.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Test Attaching a MediaSource to multiple HTMLMediaElements.</title>

--- a/media-source/mediasource-play-then-seek-back.html
+++ b/media-source/mediasource-play-then-seek-back.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Simple MediaSource playback &amp; seek test case.</title>

--- a/media-source/mediasource-play.html
+++ b/media-source/mediasource-play.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Simple MediaSource playback test case.</title>

--- a/media-source/mediasource-redundant-seek.html
+++ b/media-source/mediasource-redundant-seek.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Test MediaSource behavior when receiving multiple seek requests during a pending seek.</title>

--- a/media-source/mediasource-remove.html
+++ b/media-source/mediasource-remove.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.remove() test cases.</title>

--- a/media-source/mediasource-removesourcebuffer.html
+++ b/media-source/mediasource-removesourcebuffer.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>MediaSource.removeSourceBuffer() test cases.</title>

--- a/media-source/mediasource-seek-beyond-duration.html
+++ b/media-source/mediasource-seek-beyond-duration.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Test MediaSource behavior when seeking beyond the duration of the clip.</title>

--- a/media-source/mediasource-seek-during-pending-seek.html
+++ b/media-source/mediasource-seek-during-pending-seek.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>Test MediaSource behavior when a seek is requested while another seek is pending.</title>

--- a/media-source/mediasource-sequencemode-append-buffer.html
+++ b/media-source/mediasource-sequencemode-append-buffer.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.mode == "sequence" test cases.</title>

--- a/media-source/mediasource-sourcebuffer-mode.html
+++ b/media-source/mediasource-sourcebuffer-mode.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.mode test cases.</title>

--- a/media-source/mediasource-sourcebufferlist.html
+++ b/media-source/mediasource-sourcebufferlist.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBufferList test cases.</title>

--- a/media-source/mediasource-timestamp-offset.html
+++ b/media-source/mediasource-timestamp-offset.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
         <title>SourceBuffer.timestampOffset test cases.</title>

--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -1,3 +1,5 @@
+// Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang).
+
 (function(window) {
     var SEGMENT_INFO_LIST = [
         {


### PR DESCRIPTION
This should ease upcoming import of updated Blink layout tests. Only media-source/*.{html,js} files known from git log to originate in previous import from Blink are stamped with the license in this commit.

I'll merge this shortly.
