### PR TITLE
Drop XMLDocument.prototype.load from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -972,10 +972,6 @@ partial /*sealed*/ interface Document {
 };
 Document implements GlobalEventHandlers;
 
-partial interface XMLDocument {
-  boolean load(DOMString url);
-};
-
 interface HTMLElement : Element {
   // metadata attributes
            attribute DOMString title;


### PR DESCRIPTION
Drop XMLDocument.prototype.load from html/dom/interfaces.html to match the
HTML specification after:
https://github.com/whatwg/html/commit/523f7a8773d2ab8a1eb0da6510651e8c5d2a7531
