### PR TITLE
Drop ParentNode.query / queryAll to match the latest DOM specification

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -84,8 +84,6 @@ interface ParentNode {
   [Unscopable] void prepend((Node or DOMString)... nodes);
   [Unscopable] void append((Node or DOMString)... nodes);
 
-  [Unscopable] Element? query(DOMString relativeSelectors);
-  [NewObject, Unscopable] Elements queryAll(DOMString relativeSelectors);
   Element? querySelector(DOMString selectors);
   [NewObject] NodeList querySelectorAll(DOMString selectors);
 };


### PR DESCRIPTION
Drop ParentNode.query / queryAll to match the latest DOM specification
after:
https://github.com/whatwg/dom/commit/10b6cf1ba02806220d5461a3bdb7939728b73635
