### PR TITLE
Drop table sorting from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1505,8 +1505,6 @@ interface HTMLTableElement : HTMLElement {
   readonly attribute HTMLCollection rows;
   HTMLElement insertRow(optional long index = -1);
   void deleteRow(long index);
-           attribute boolean sortable;
-  void stopSorting();
 
   // also has obsolete members
 };
@@ -2474,7 +2472,6 @@ interface GlobalEventHandlers {
            attribute EventHandler onseeking;
            attribute EventHandler onselect;
            attribute EventHandler onshow;
-           attribute EventHandler onsort;
            attribute EventHandler onstalled;
            attribute EventHandler onsubmit;
            attribute EventHandler onsuspend;


### PR DESCRIPTION
Drop table sorting from html/dom/interfaces.html as it was dropped from the
HTML specification:
https://github.com/whatwg/html/commit/59b7e2466c2b7c5c408a4963b05b13fd808aa07a
