### PR TITLE
Drop input.valueLow / valueHigh from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1611,8 +1611,6 @@ interface HTMLInputElement : HTMLElement {
   [TreatNullAs=EmptyString] attribute DOMString value;
            attribute Date? valueAsDate;
            attribute unrestricted double valueAsNumber;
-           attribute double valueLow;
-           attribute double valueHigh;
            attribute unsigned long width;
 
   void stepUp(optional long n = 1);


### PR DESCRIPTION
Drop input.valueLow / valueHigh from html/dom/interfaces.html to match the
HTML specification after:
https://github.com/whatwg/html/commit/b598d4f873fb8c27d4b23b033837108edfbc3d75
