### PR TITLE
Drop map.images attribute from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1467,7 +1467,6 @@ dictionary TrackEventInit : EventInit {
 interface HTMLMapElement : HTMLElement {
            attribute DOMString name;
   readonly attribute HTMLCollection areas;
-  readonly attribute HTMLCollection images;
 };
 
 interface HTMLAreaElement : HTMLElement {


### PR DESCRIPTION
Drop map.images attribute from html/dom/interfaces.html to match the HTML
specification after:
https://github.com/whatwg/html/commit/ee8fd32ed0cb11bc395e9c03a03234527674c085
