### PR TITLE
Adding tests checking how preflight is done after same-origin and cross-origin redirections

### DIFF
--- a/fetch/api/cors/cors-redirect-preflight-worker.html
+++ b/fetch/api/cors/cors-redirect-preflight-worker.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch in worker: CORS preflight after redirection</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#http-redirect-fetch">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      fetch_tests_from_worker(new Worker("cors-redirect-preflight.js"));
+    </script>
+  </body>
+</html>

--- a/fetch/api/cors/cors-redirect-preflight.html
+++ b/fetch/api/cors/cors-redirect-preflight.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch: CORS preflight after redirection</title>
+    <meta name="help" href="https://fetch.spec.whatwg.org/#http-redirect-fetch">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script src="/common/utils.js"></script>
+    <script src="../resources/utils.js"></script>
+    <script src="../resources/get-host-info.sub.js"></script>
+    <script src="cors-redirect-preflight.js"></script>
+  </body>
+</html>

--- a/fetch/api/cors/cors-redirect-preflight.js
+++ b/fetch/api/cors/cors-redirect-preflight.js
@@ -1,0 +1,50 @@
+if (this.document === undefined) {
+  importScripts("/resources/testharness.js");
+  importScripts("/common/utils.js");
+  importScripts("../resources/utils.js");
+  importScripts("../resources/get-host-info.sub.js");
+}
+
+function corsRedirect(desc, redirectUrl, redirectLocation, redirectStatus, expectSuccess) {
+  var urlBaseParameters = "&redirect_status=" + redirectStatus;
+  var urlParametersSuccess = urlBaseParameters + "&allow_headers=x-w3c&location=" + encodeURIComponent(redirectLocation + "?allow_headers=x-w3c");
+  var urlParametersFailure = urlBaseParameters + "&location=" + encodeURIComponent(redirectLocation);
+
+  var requestInit = {"mode": "cors", "redirect": "follow", "headers" : [["x-w3c", "test"]]};
+
+  promise_test(function(test) {
+    var uuid_token = token();
+    return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
+      return fetch(redirectUrl + "?token=" + uuid_token + "&max_age=0" + urlParametersSuccess, requestInit).then(function(resp) {
+        assert_equals(resp.status, 200, "Response's status is 200");
+        assert_equals(resp.headers.get("x-did-preflight"), "1", "Preflight request has been made");
+      });
+    });
+  }, desc + " (preflight after redirection success case)");
+  promise_test(function(test) {
+    var uuid_token = token();
+    return fetch(RESOURCES_DIR + "clean-stash.py?token=" + uuid_token).then(function(resp) {
+      return promise_rejects(test, new TypeError(), fetch(redirectUrl + "?token=" + uuid_token + "&max_age=0" + urlParametersFailure, requestInit));
+    });
+  }, desc + " (preflight after redirection failure case)");
+}
+
+var redirPath = dirname(location.pathname) + RESOURCES_DIR + "redirect.py";
+var preflightPath = dirname(location.pathname) + RESOURCES_DIR + "preflight.py";
+
+var host_info = get_host_info();
+
+var localRedirect = host_info.HTTP_ORIGIN + redirPath;
+var remoteRedirect = host_info.HTTP_REMOTE_ORIGIN + redirPath;
+
+var localLocation = host_info.HTTP_ORIGIN + preflightPath;
+var remoteLocation = host_info.HTTP_REMOTE_ORIGIN + preflightPath;
+var remoteLocation2 = host_info.HTTP_ORIGIN_WITH_DIFFERENT_PORT + preflightPath;
+
+for (var code of [301, 302, 303, 307, 308]) {
+  corsRedirect("Redirect " + code + ": same origin to cors", localRedirect, remoteLocation, code);
+  corsRedirect("Redirect " + code + ": cors to same origin", remoteRedirect, localLocation, code);
+  corsRedirect("Redirect " + code + ": cors to another cors", remoteRedirect, remoteLocation2, code);
+}
+
+done();


### PR DESCRIPTION
Tests only work with redirect.py script changed as per https://github.com/w3c/web-platform-tests/pull/3433
