### PR TITLE
Drop iframe.seamless attribute from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1167,7 +1167,6 @@ interface HTMLIFrameElement : HTMLElement {
            attribute DOMString srcdoc;
            attribute DOMString name;
   [PutForwards=value] readonly attribute DOMTokenList sandbox;
-           attribute boolean seamless;
            attribute boolean allowFullscreen;
            attribute DOMString width;
            attribute DOMString height;


### PR DESCRIPTION
Drop iframe.seamless attribute from html/dom/interfaces.html as it is no longer
in the latest HTML specification.
