### PR TITLE
Re-sync HTMLStyleElement from spec in html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1045,9 +1045,9 @@ interface HTMLMetaElement : HTMLElement {
 };
 
 interface HTMLStyleElement : HTMLElement {
-           attribute DOMString media;
-           attribute DOMString type;
-           attribute boolean scoped;
+  [CEReactions] attribute DOMString media;
+  [CEReactions] attribute DOMString nonce;
+  [CEReactions] attribute DOMString type;
 };
 HTMLStyleElement implements LinkStyle;
 


### PR DESCRIPTION
Re-sync HTMLStyleElement from spec in html/dom/interfaces.html. In particular,
the 'scoped' attribute is now dropped and the 'nonce' one is added.
