### PR TITLE
Drop DOMElementMap from html/dom/interfaces.html

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -905,12 +905,6 @@ interface DOMStringMap {
   deleter void (DOMString name);
 };
 
-interface DOMElementMap {
-  getter Element (DOMString name);
-  setter creator void (DOMString name, Element value);
-  deleter void (DOMString name);
-};
-
 typedef (ArrayBuffer or MessagePort) Transferable;
 
 callback FileCallback = void (File file);
@@ -3161,7 +3155,6 @@ window.onload = function() {
     RadioNodeList: [],
     HTMLOptionsCollection: ['document.createElement("select").options'],
     DOMStringMap: ['document.head.dataset'],
-    DOMElementMap: ['document.cssElementMap'],
     Transferable: [],
     Document: ['iframe.contentDocument', 'new Document()'],
     XMLDocument: ['document.implementation.createDocument(null, "", null)'],


### PR DESCRIPTION
Drop DOMElementMap from html/dom/interfaces.html as it is no longer part of
the HTML specification.
