### PR TITLE
Change default paragraph separator from <p> to <div>

### DIFF
--- a/editing/data/delete.js
+++ b/editing/data/delete.js
@@ -73,7 +73,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["delete",""]],
     "<p>foo{}bar</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"delete":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"delete":[false,false,"",false,false,""]}],
 ["<p>foo</p><p>[]bar</p>",
     [["defaultparagraphseparator","p"],["delete",""]],
     "<p>foo{}bar</p>",

--- a/editing/data/formatblock.js
+++ b/editing/data/formatblock.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["formatblock","<div>"]],
     "<div>foo[]bar</div><p>extra</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"formatblock":[false,false,"",false,false,"div"]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"formatblock":[false,false,"",false,false,"div"]}],
 ["foo[]bar<p>extra",
     [["defaultparagraphseparator","p"],["formatblock","<div>"]],
     "<div>foo[]bar</div><p>extra</p>",

--- a/editing/data/forwarddelete.js
+++ b/editing/data/forwarddelete.js
@@ -88,7 +88,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["forwarddelete",""]],
     "<p>foo{}bar</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"forwarddelete":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"forwarddelete":[false,false,"",false,false,""]}],
 ["<p>foo[]</p><p>bar</p>",
     [["defaultparagraphseparator","p"],["forwarddelete",""]],
     "<p>foo{}bar</p>",

--- a/editing/data/inserthorizontalrule.js
+++ b/editing/data/inserthorizontalrule.js
@@ -103,7 +103,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["inserthorizontalrule",""]],
     "<p>foo</p><hr>{}<p>baz</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"inserthorizontalrule":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"inserthorizontalrule":[false,false,"",false,false,""]}],
 ["<p>foo<p>[bar]<p>baz",
     [["defaultparagraphseparator","p"],["inserthorizontalrule",""]],
     "<p>foo</p><hr>{}<p>baz</p>",

--- a/editing/data/inserthtml.js
+++ b/editing/data/inserthtml.js
@@ -138,7 +138,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["inserthtml","<p>abc"]],
     "<p>foo</p><p>abc</p>{}<p>baz</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"inserthtml":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"inserthtml":[false,false,"",false,false,""]}],
 ["<p>foo[bar]baz",
     [["defaultparagraphseparator","p"],["inserthtml","<p>abc"]],
     "<p>foo</p><p>abc</p>{}<p>baz</p>",

--- a/editing/data/insertimage.js
+++ b/editing/data/insertimage.js
@@ -128,7 +128,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["insertimage","/img/lion.svg"]],
     "<p>foo</p><img src=\"/img/lion.svg\">{}<p>baz</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"insertimage":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"insertimage":[false,false,"",false,false,""]}],
 ["<p>foo</p>{<p>bar</p>}<p>baz</p>",
     [["defaultparagraphseparator","p"],["insertimage","/img/lion.svg"]],
     "<p>foo</p><img src=\"/img/lion.svg\">{}<p>baz</p>",

--- a/editing/data/insertlinebreak.js
+++ b/editing/data/insertlinebreak.js
@@ -333,7 +333,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["insertlinebreak",""]],
     "<h1>foo<br>{}quz</h1>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"insertlinebreak":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"insertlinebreak":[false,false,"",false,false,""]}],
 ["<h1>foo[bar</h1><p>baz]quz</p>",
     [["defaultparagraphseparator","p"],["insertlinebreak",""]],
     "<h1>foo<br>{}quz</h1>",

--- a/editing/data/insertorderedlist.js
+++ b/editing/data/insertorderedlist.js
@@ -73,7 +73,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["insertorderedlist",""]],
     "<p>foo</p><ol><li>[bar]</li></ol><p>baz</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"insertorderedlist":[false,false,"",false,true,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"insertorderedlist":[false,false,"",false,true,""]}],
 ["<p>foo<p>[bar]<p>baz",
     [["defaultparagraphseparator","p"],["insertorderedlist",""]],
     "<p>foo</p><ol><li>[bar]</li></ol><p>baz</p>",

--- a/editing/data/insertparagraph.js
+++ b/editing/data/insertparagraph.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["insertparagraph",""]],
     "<div>foo</div><div>{}baz</div>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"insertparagraph":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"insertparagraph":[false,false,"",false,false,""]}],
 ["foo[bar]baz",
     [["defaultparagraphseparator","p"],["insertparagraph",""]],
     "<p>foo</p><p>{}baz</p>",

--- a/editing/data/inserttext.js
+++ b/editing/data/inserttext.js
@@ -23,7 +23,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["inserttext","\n"]],
     "<div>foo</div><div>{}bar</div>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"inserttext":[false,false,"",false,false,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"inserttext":[false,false,"",false,false,""]}],
 ["foo[]bar",
     [["defaultparagraphseparator","p"],["inserttext","\n"]],
     "<p>foo</p><p>{}bar</p>",

--- a/editing/data/insertunorderedlist.js
+++ b/editing/data/insertunorderedlist.js
@@ -73,7 +73,7 @@ var browserTests = [
     [["defaultparagraphseparator","div"],["insertunorderedlist",""]],
     "<p>foo</p><ul><li>[bar]</li></ul><p>baz</p>",
     [true,true],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"],"insertunorderedlist":[false,false,"",false,true,""]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"],"insertunorderedlist":[false,false,"",false,true,""]}],
 ["<p>foo<p>[bar]<p>baz",
     [["defaultparagraphseparator","p"],["insertunorderedlist",""]],
     "<p>foo</p><ul><li>[bar]</li></ul><p>baz</p>",

--- a/editing/data/justifycenter.js
+++ b/editing/data/justifycenter.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["stylewithcss","true"],["defaultparagraphseparator","div"],["justifycenter",""]],
     "<div style=\"text-align:center\">foo[]bar</div><p>extra</p>",
     [true,true,true],
-    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"p",false,false,"div"],"justifycenter":[false,false,"left",false,true,"center"]}],
+    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"div",false,false,"div"],"justifycenter":[false,false,"left",false,true,"center"]}],
 ["foo[]bar<p>extra",
     [["stylewithcss","false"],["defaultparagraphseparator","div"],["justifycenter",""]],
     "<div style=\"text-align:center\">foo[]bar</div><p>extra</p>",

--- a/editing/data/justifyfull.js
+++ b/editing/data/justifyfull.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["stylewithcss","true"],["defaultparagraphseparator","div"],["justifyfull",""]],
     "<div style=\"text-align:justify\">foo[]bar</div><p>extra</p>",
     [true,true,true],
-    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"p",false,false,"div"],"justifyfull":[false,false,"left",false,true,"justify"]}],
+    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"div",false,false,"div"],"justifyfull":[false,false,"left",false,true,"justify"]}],
 ["foo[]bar<p>extra",
     [["stylewithcss","false"],["defaultparagraphseparator","div"],["justifyfull",""]],
     "<div style=\"text-align:justify\">foo[]bar</div><p>extra</p>",

--- a/editing/data/justifyleft.js
+++ b/editing/data/justifyleft.js
@@ -53,7 +53,7 @@ var browserTests = [
     [["stylewithcss","true"],["defaultparagraphseparator","div"],["justifyleft",""]],
     "<center><div style=\"text-align:left\"><p>[foo]</p></div><p>bar</p></center><p>extra</p>",
     [true,true,true],
-    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"p",false,false,"div"],"justifyleft":[false,false,"center",false,true,"left"]}],
+    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"div",false,false,"div"],"justifyleft":[false,false,"center",false,true,"left"]}],
 ["<center><p>[foo]<p>bar</center><p>extra",
     [["stylewithcss","false"],["defaultparagraphseparator","div"],["justifyleft",""]],
     "<center><div style=\"text-align:left\"><p>[foo]</p></div><p>bar</p></center><p>extra</p>",

--- a/editing/data/justifyright.js
+++ b/editing/data/justifyright.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["stylewithcss","true"],["defaultparagraphseparator","div"],["justifyright",""]],
     "<div style=\"text-align:right\">foo[]bar</div><p>extra</p>",
     [true,true,true],
-    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"p",false,false,"div"],"justifyright":[false,false,"left",false,true,"right"]}],
+    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"div",false,false,"div"],"justifyright":[false,false,"left",false,true,"right"]}],
 ["foo[]bar<p>extra",
     [["stylewithcss","false"],["defaultparagraphseparator","div"],["justifyright",""]],
     "<div style=\"text-align:right\">foo[]bar</div><p>extra</p>",

--- a/editing/data/misc.js
+++ b/editing/data/misc.js
@@ -3,7 +3,7 @@ var browserTests = [
     [["defaultparagraphseparator",""]],
     "foo[bar]baz",
     [false],
-    {"defaultparagraphseparator":[false,false,"p",false,false,"div"]}],
+    {"defaultparagraphseparator":[false,false,"div",false,false,"div"]}],
 ["foo[bar]baz",
     [["defaultparagraphseparator","div"]],
     "foo[bar]baz",

--- a/editing/data/outdent.js
+++ b/editing/data/outdent.js
@@ -83,7 +83,7 @@ var browserTests = [
     [["stylewithcss","true"],["defaultparagraphseparator","div"],["outdent",""]],
     "<div class=\"webkit-indent-blockquote\"><p>foo[bar]</p><blockquote><p>baz</p></blockquote></div><p>extra</p>",
     [true,true,true],
-    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"p",false,false,"div"],"outdent":[false,false,"",false,false,""]}],
+    {"stylewithcss":[false,false,"",false,true,""],"defaultparagraphseparator":[false,false,"div",false,false,"div"],"outdent":[false,false,"",false,false,""]}],
 ["<blockquote class=\"webkit-indent-blockquote\" style=\"margin: 0 0 0 40px; border: none; padding: 0px;\"><p>foo[bar]</p><p>baz</p></blockquote><p>extra",
     [["stylewithcss","false"],["defaultparagraphseparator","div"],["outdent",""]],
     "<div class=\"webkit-indent-blockquote\"><p>foo[bar]</p><blockquote><p>baz</p></blockquote></div><p>extra</p>",

--- a/editing/include/implementation.js
+++ b/editing/include/implementation.js
@@ -4,7 +4,7 @@ var htmlNamespace = "http://www.w3.org/1999/xhtml";
 
 var cssStylingFlag = false;
 
-var defaultSingleLineContainerName = "p";
+var defaultSingleLineContainerName = "div";
 
 // This is bad :(
 var globalRange = null;

--- a/editing/include/tests.js
+++ b/editing/include/tests.js
@@ -4639,7 +4639,7 @@ var defaultValues = {
     inserthtml: "ab<b>c</b>d",
     insertimage: "/img/lion.svg",
     inserttext: "a",
-    defaultparagraphseparator: "p",
+    defaultparagraphseparator: "div",
     stylewithcss: "true",
     usecss: "true",
 };


### PR DESCRIPTION
Edge, Blink, and WebKit all now do this, and I think Gecko will be
changing shortly.  In contrast, at the time I wrote the spec there was
no consensus behavior.

@Ms2ger @jgraham @zcorpan @domenic Someone rubber-stamp this, please?
