### PR TITLE
Using get-host-info.sub.js to enable cross-origin/cross-domain html tests for constrained test environments.

### DIFF
--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -1,0 +1,19 @@
+function get_host_info() {
+
+  var HTTP_PORT = eval('{{ports[http][0]}}');
+  var HTTP_PORT2 = eval('{{ports[http][1]}}');
+  var HTTPS_PORT = eval('{{ports[https][0]}}');
+  var ORIGINAL_HOST = eval('\'{{host}}\'');
+  var REMOTE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
+
+  return {
+    HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT,
+    HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTP_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT2,
+    HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + ':' + HTTP_PORT,
+    HTTP_REMOTE_ORIGIN_WITH_DIFFERENT_PORT: 'http://' + REMOTE_HOST + ':' + HTTP_PORT2,
+    HTTPS_REMOTE_ORIGIN: 'https://' + REMOTE_HOST + ':' + HTTPS_PORT,
+    HTTPS_REMOTE_ORIGIN_WITH_CREDS: 'https://foo:bar@' + REMOTE_HOST + ':' + HTTPS_PORT,
+  };
+}

--- a/common/get-host-info.sub.js
+++ b/common/get-host-info.sub.js
@@ -1,9 +1,9 @@
 function get_host_info() {
 
-  var HTTP_PORT = eval('{{ports[http][0]}}');
-  var HTTP_PORT2 = eval('{{ports[http][1]}}');
-  var HTTPS_PORT = eval('{{ports[https][0]}}');
-  var ORIGINAL_HOST = eval('\'{{host}}\'');
+  var HTTP_PORT = '{{ports[http][0]}}';
+  var HTTP_PORT2 = '{{ports[http][1]}}';
+  var HTTPS_PORT = '{{ports[https][0]}}';
+  var ORIGINAL_HOST = '{{host}}';
   var REMOTE_HOST = (ORIGINAL_HOST === 'localhost') ? '127.0.0.1' : ('www1.' + ORIGINAL_HOST);
 
   return {

--- a/html/browsers/history/the-location-interface/security_location_0.sub.htm
+++ b/html/browsers/history/the-location-interface/security_location_0.sub.htm
@@ -11,13 +11,17 @@
   <body>
     <p>Access location object from different origins doesn't raise SECURITY_ERR exception</p>
     <div id=log></div>
+    <script src="/common/get-host-info.sub.js"></script>
     <script>
       var runTest = async_test("Accessing location object from different origins doesn't raise SECURITY_ERR exception").step_func_done(function() {
         var frame = document.getElementById('testframe');
         frame.setAttribute('onload', '');
-        frame.contentWindow.location = 'http://{{domains[www1]}}:{{ports[http][0]}}/'
+        frame.contentWindow.location = get_host_info().HTTP_REMOTE_ORIGIN + "/";
       });
     </script>
-    <iframe id='testframe' src="http://{{domains[www]}}:{{ports[http][0]}}/" onload="runTest()">Test Frame</iframe>
+    <iframe id='testframe' onload="runTest()">Test Frame</iframe>
+    <script>
+      document.getElementById('testframe').setAttribute('src', get_host_info().HTTP_REMOTE_ORIGIN + '/');
+    </script>
   </body>
 </html>

--- a/html/browsers/the-window-object/security-window/window-security.sub.html
+++ b/html/browsers/the-window-object/security-window/window-security.sub.html
@@ -12,10 +12,9 @@
 <link rel="help" href="http://dev.w3.org/csswg/cssom-view/#extensions-to-the-window-interface" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <div id="log"></div>
-<iframe id="fr" src="http://{{domains[www1]}}:{{ports[http][0]}}/" onload="fr_load()" style="display:none"></iframe>
 <script>
-
 var t = async_test("Window Security testing");
 
 function fr_load() {
@@ -191,4 +190,8 @@ function fr_load() {
   t.done();
 }
 
+</script>
+<iframe id="fr" onload="fr_load()" style="display:none"></iframe>
+<script>
+document.getElementById('fr').setAttribute('src', get_host_info().HTTP_REMOTE_ORIGIN + "/");
 </script>

--- a/html/browsers/windows/nested-browsing-contexts/frameElement.sub.html
+++ b/html/browsers/windows/nested-browsing-contexts/frameElement.sub.html
@@ -4,6 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com/" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script>
 
 var t1 = async_test("The window's frameElement attribute must return its container element if it is a nested browsing context");
@@ -58,7 +59,7 @@ function on_load() {
   <script>
 
   setup(function () {
-    var src_base = "http://{{domains[www1]}}:{{ports[http][0]}}";
+    var src_base = get_host_info().HTTP_REMOTE_ORIGIN;
     src_base += document.location.pathname.substring(0, document.location.pathname.lastIndexOf("/") + 1);
     document.getElementById("fr2").src = src_base + "test.html";
     document.getElementById("fr5").src = src_base + "testcase3.html";

--- a/html/browsers/windows/targeting-cross-origin-nested-browsing-contexts.sub.html
+++ b/html/browsers/windows/targeting-cross-origin-nested-browsing-contexts.sub.html
@@ -7,6 +7,7 @@
   <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
+  <script src="/common/get-host-info.sub.js"></script>
   <script>
     async_test(function (t) {
       var windowsToClose = [];
@@ -30,7 +31,7 @@
 
       var a = document.body.appendChild(document.createElement('a'));
       a.target = "openee";
-      a.href = "http://{{domains[www2]}}:{{location[port]}}/html/browsers/windows/support-nested-browsing-contexts.html";
+      a.href = get_host_info().HTTP_REMOTE_ORIGIN + "/html/browsers/windows/support-nested-browsing-contexts.html";
       a.click();
     });
   </script>

--- a/html/dom/documents/dom-tree-accessors/Document.currentScript.sub.html
+++ b/html/dom/documents/dom-tree-accessors/Document.currentScript.sub.html
@@ -5,6 +5,7 @@
 <link rel=help href="https://html.spec.whatwg.org/multipage/#execute-the-script-block">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <div id="log"></div>
 <script>
 var data = {
@@ -215,7 +216,7 @@ function testLoadFail() {
 <script>
 var s = document.createElement("script");
 s.id = "cross-origin";
-s.src = "http://{{domains[www1]}}:{{ports[http][1]}}/html/dom/documents/dom-tree-accessors/cross-domain.js"
+s.src = get_host_info(). HTTP_REMOTE_ORIGIN + "/html/dom/documents/dom-tree-accessors/cross-domain.js"
 s.onload = function() {
   verify('cross-origin')
   finish('cross-origin');

--- a/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html
+++ b/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html
@@ -5,7 +5,8 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-base-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<base id="base" href="http://{{domains[www]}}:{{ports[http][0]}}">
+<script src="/common/get-host-info.sub.js"></script>
+<base id="base">
 <div id="log"></div>
 <img id="test" src="test.ico" style="display:none">
 
@@ -13,16 +14,20 @@
   var testElement;
   var baseElement;
 
+  var otherOrigin =get_host_info().HTTP_REMOTE_ORIGIN;
+
   setup(function() {
     testElement = document.getElementById("test");
     baseElement = document.getElementById("base");
+
+    baseElement.setAttribute("href", otherOrigin);
   });
 
   test(function() {
-    assert_equals(baseElement.href, "http://{{domains[www]}}:{{ports[http][0]}}/", "The href attribute of the base element is incorrect.");
+    assert_equals(baseElement.href, otherOrigin + "/", "The href attribute of the base element is incorrect.");
   }, "The href attribute of the base element is specified");
 
   test(function() {
-    assert_equals(testElement.src, "http://{{domains[www]}}:{{ports[http][0]}}/test.ico", "The src attribute of the img element is incorrect.");
+    assert_equals(testElement.src, otherOrigin + "/test.ico", "The src attribute of the img element is incorrect.");
   }, "The src attribute of the img element must relative to the href attribute of the base element");
 </script>

--- a/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html
+++ b/html/semantics/document-metadata/the-base-element/base_href_specified.sub.html
@@ -14,7 +14,7 @@
   var testElement;
   var baseElement;
 
-  var otherOrigin =get_host_info().HTTP_REMOTE_ORIGIN;
+  var otherOrigin = get_host_info().HTTP_REMOTE_ORIGIN;
 
   setup(function() {
     testElement = document.getElementById("test");

--- a/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.drawImage.canvas.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.drawImage.canvas.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -31,5 +32,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.drawImage.image.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.drawImage.image.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -26,5 +27,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.fillStyle.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.canvas.fillStyle.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -33,5 +34,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.strokeStyle.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.canvas.strokeStyle.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -33,5 +34,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.timing.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.canvas.timing.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.canvas.timing.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -36,5 +37,7 @@ _assert(true, "true"); // okay if there was no exception
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.create.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.create.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.create.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -27,5 +28,7 @@ _assert(true, "true"); // okay if there was no exception
 
 });
 </script>
-<img src="http://{{domains[www]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.cross.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.cross.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -34,5 +35,7 @@ ctx2.getImageData(0, 0, 1, 1);
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.image.fillStyle.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.image.fillStyle.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -28,5 +29,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.pattern.image.strokeStyle.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.pattern.image.strokeStyle.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -28,5 +29,7 @@ assert_throws("SECURITY_ERR", function() { ctx.getImageData(0, 0, 1, 1); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>

--- a/html/semantics/embedded-content/the-canvas-element/security.reset.sub.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.reset.sub.html
@@ -3,6 +3,7 @@
 <title>Canvas test: security.reset.sub</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 <script src="/common/canvas-tests.js"></script>
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
@@ -28,5 +29,7 @@ assert_throws("SECURITY_ERR", function() { canvas.toDataURL(); });
 
 });
 </script>
-<img src="http://{{domains[www2]}}:{{ports[http][0]}}/images/yellow.png" id="yellow.png" class="resource">
-
+<img id="yellow.png" class="resource">
+<script>
+document.getElementById('yellow.png').setAttribute("src", get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png");
+</script>


### PR DESCRIPTION
WebKit bots do not support www1.domain/www.domain URLs.
Instead, tests support localhost/127.0.0.1
get-host-info.sub.js allows to support both environments for tests that require no more than two domains.

get-host-info.sub.js comes from fetch/api tests
