### PR TITLE
Don't assume that all videos start at 0.

### DIFF
--- a/media-source/mediasource-buffered.html
+++ b/media-source/mediasource-buffered.html
@@ -15,14 +15,24 @@
             var manifestFilenameA = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
             var manifestFilenameB = subType + "/test-v-128k-320x240-30fps-10kfr-manifest.json";
 
+            // Audio track expectations
             var expectationsA = {
               webm: "{ [0.000, 2.023) }",
               mp4: "{ [0.000, 2.043) }",
             };
 
+            // Video track expectations
             var expectationsB = {
               webm: "{ [0.000, 2.001) }",
-              mp4: "{ [0.000, 2.000) }",
+              mp4: "{ [0.067, 2.067) }",
+            };
+
+            // Audio and Video intersection expectations.
+            // https://w3c.github.io/media-source/index.html#dom-sourcebuffer-buffered
+            // When mediaSource.readyState is "ended", then set the end time on the last range in track ranges to highest end time.
+            var expectationsC = {
+              webm: ["{ [0.000, 2.001) }", "{ [0.000, 2.023) }"],
+              mp4: ["{ [0.067, 2.043) }", "{ [0.067, 2.067) }"]
             };
 
             function mediaSourceDemuxedTest(callback, description)
@@ -70,15 +80,18 @@
                 test.expectEvent(mediaElement, "loadedmetadata");
                 appendData(test, mediaSource, dataA, dataB, function()
                 {
+                    var expectedBeforeEndOfStreamIntersection = expectationsC[subType][0];
+                    var expectedAfterEndOfStreamIntersection = expectationsC[subType][1];
+
                     assertBufferedEquals(mediaSource.activeSourceBuffers[0], expectationsA[subType], "mediaSource.activeSourceBuffers[0]");
                     assertBufferedEquals(mediaSource.activeSourceBuffers[1], expectationsB[subType], "mediaSource.activeSourceBuffers[1]");
-                    assertBufferedEquals(mediaElement, expectationsB[subType], "mediaElement.buffered");
+                    assertBufferedEquals(mediaElement, expectedBeforeEndOfStreamIntersection, "mediaElement.buffered");
 
                     mediaSource.endOfStream();
 
                     assertBufferedEquals(mediaSource.activeSourceBuffers[0], expectationsA[subType], "mediaSource.activeSourceBuffers[0]");
                     assertBufferedEquals(mediaSource.activeSourceBuffers[1], expectationsB[subType], "mediaSource.activeSourceBuffers[1]");
-                    assertBufferedEquals(mediaElement, expectationsA[subType], "mediaElement.buffered");
+                    assertBufferedEquals(mediaElement, expectedAfterEndOfStreamIntersection, "mediaElement.buffered");
 
                     test.done();
                 });
@@ -100,8 +113,8 @@
                     test.waitForExpectedEvents(function()
                     {
                         var expectationsAV = {
-                            webm: ["{ [0.000, 2.003) }", "{ [0.000, 2.023) }"],
-                            mp4: ["{ [0.000, 2.000) }", "{ [0.000, 2.043) }"],
+                            webm: ["{ [0.003, 2.004) }", "{ [0.003, 2.023) }"],
+                            mp4: ["{ [0.067, 2.043) }", "{ [0.067, 2.067) }"],
                         };
 
                         var expectedBeforeEndOfStream = expectationsAV[subType][0];


### PR DESCRIPTION
The tests incorrectly assume that all videos start at 0. However this is often not the case, in particular for the mp4 files.
The buffered range is the intersection of the audio track and the video track. As such, if the video track starts at a later time than 0, the buffered range of the source buffer can't be starting at 0.

Rather than using different videos, we properly use the correct values; this is done to ensure that buffered range are calculated correctly, regardless of the video content.

timestamps verify with mkvinfo utility for webm and ffprobe for mp4.

See issue https://github.com/w3c/web-platform-tests/issues/1939

MozReview-Commit-ID: AMKgJHEJsWr

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
