### PR TITLE
Correct mediasource-duration.html

### DIFF
--- a/media-source/mediasource-duration.html
+++ b/media-source/mediasource-duration.html
@@ -29,9 +29,6 @@
 
                   test.waitForExpectedEvents(function()
                   {
-                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration');
-                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
-
                       test.expectEvent(mediaElement, 'seeking', 'seeking to seekTo');
                       test.expectEvent(mediaElement, 'timeupdate', 'timeupdate while seeking to seekTo');
                       test.expectEvent(mediaElement, 'seeked', 'seeked to seekTo');
@@ -56,9 +53,9 @@
 
                   test.waitForExpectedEvents(function()
                   {
+                      // remove will not remove partial frames. The truncated duration is as such the highest end time.
+                      truncatedDuration = sourceBuffer.buffered.end(sourceBuffer.buffered.length-1);
                       assert_greater_than_equal(mediaElement.currentTime, seekTo, 'Playback time has reached seekTo');
-                      assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration after seekTo');
-                      assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration after seekTo');
                       test.expectEvent(mediaElement, 'seeking', 'Seeking to truncated duration');
 
                       assert_false(sourceBuffer.updating, 'sourceBuffer.updating');
@@ -136,8 +133,10 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_equals(mediaElement.currentTime, truncatedDuration,
+                  assert_greater_than_equal(mediaElement.currentTime, truncatedDuration,
                                 'Playback time has reached truncatedDuration');
+                  // The mediaSource.readyState is "ended". Buffered ranges have been adjusted to the longest track.
+                  truncatedDuration = sourceBuffer.buffered.end(sourceBuffer.buffered.length-1);
                   assert_equals(mediaElement.duration, truncatedDuration,
                                 'mediaElement truncatedDuration after seek to it');
                   assert_equals(mediaSource.duration, truncatedDuration,
@@ -159,8 +158,10 @@
               var durationchangeEventCounter = 0;
               var durationchangeEventHandler = test.step_func(function(event)
               {
-                  assert_equals(mediaElement.duration, newDuration, 'mediaElement newDuration');
-                  assert_equals(mediaSource.duration, newDuration, 'mediaSource newDuration');
+                  assert_equals(mediaElement.duration, mediaSource.duration, 'mediaElement newDuration');
+                  // Final duration may be greater than originally set as per MSE's 2.4.6 Duration change
+                  // Adjust newDuration accordingly.
+                  assert_less_than_equal(newDuration, mediaSource.duration, 'mediaSource newDuration');
                   durationchangeEventCounter++;
               });
 
@@ -173,8 +174,6 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration');
-                  assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
                   assert_less_than(mediaElement.currentTime, newDuration / 2, 'mediaElement currentTime');
 
                   assert_false(sourceBuffer.updating, "updating");
@@ -190,10 +189,6 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_equals(mediaElement.duration, fullDuration, 'mediaElement fullDuration');
-                  assert_equals(mediaSource.duration, fullDuration, 'mediaSource fullDuration');
-                  assert_less_than(mediaElement.currentTime, newDuration / 2, 'mediaElement currentTime');
-
                   // Media load also fires 'durationchange' event, so only start counting them now.
                   mediaElement.addEventListener('durationchange', durationchangeEventHandler);
 
@@ -201,11 +196,6 @@
 
                   // Truncate duration. This should result in one 'durationchange' fired.
                   mediaSource.duration = newDuration;
-              });
-
-              test.waitForExpectedEvents(function()
-              {
-                  assert_false(sourceBuffer.updating, "updating");
 
                   // Final duration may be greater than originally set as per MSE's 2.4.6 Duration change
                   // Adjust newDuration accordingly.


### PR DESCRIPTION
- The WebM file manifest correctly indicates the duration as reported in the metadata. However, the last frame has an end time 0f 6.05s which would adjust the duration. As such it is incorrect to assume that after a full appendBuffer the duration will remain the same as set in the metadata.
  (source: https://w3c.github.io/media-source/index.html#sourcebuffer-coded-frame-processing "5. If the media segment contains data beyond the current duration, then run the duration change algorithm with new duration set to the maximum of the current duration and the group end timestamp")
- When setting the duration, the actual final duration may be different to what was set as it will be aligned to the highest end time
  (source: https://w3c.github.io/media-source/index.html#duration-change-algorithm ("4.1 Update new duration to the highest end time reported by the buffered attribute across all SourceBuffer objects in sourceBuffers.")

MozReview-Commit-ID: EpzSaSg8pWW

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
