### PR TITLE
An invalid or revoked MediaSource URI can't be trace to a MediaSource object.

### DIFF
--- a/media-source/mediasource-preload.html
+++ b/media-source/mediasource-preload.html
@@ -64,11 +64,9 @@
 
             errorWithPreloadTest("auto", "revoked");
             errorWithPreloadTest("metadata", "revoked");
-            errorWithPreloadTest("none", "revoked");
 
             errorWithPreloadTest("auto", "corrupted");
             errorWithPreloadTest("metadata", "corrupted");
-            errorWithPreloadTest("none", "corrupted");
         </script>
     </body>
 </html>


### PR DESCRIPTION
https://w3c.github.io/media-source/index.html#mediasource-attach: "If the resource fetch algorithm absolute URL matches the MediaSource object URL, ignore any preload attribute of the media element, skip any optional steps for when preload equals none"
A dummy URL or a revoked one no longer matches the MediaSource object URL, as such, the preload attribute isn't to be ignored.

MozReview-Commit-ID: EW5TOv9SSf

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
