### PR TITLE
Update test using new manifest details.

### DIFF
--- a/media-source/mediasource-seek-during-pending-seek.html
+++ b/media-source/mediasource-seek-during-pending-seek.html
@@ -31,7 +31,7 @@
 
                   // Seek to a new position before letting the initial seek to 0 completes.
                   test.expectEvent(mediaElement, 'seeking', 'mediaElement');
-                  mediaElement.currentTime = secondSegmentInfo.timecode;
+                  mediaElement.currentTime = Math.max(secondSegmentInfo.timev, secondSegmentInfo.timea);
                   assert_true(mediaElement.seeking, 'mediaElement is seeking');
 
                   // Append media data for time 0.
@@ -95,7 +95,7 @@
 
                   // Seek to a new position.
                   test.expectEvent(mediaElement, 'seeking', 'mediaElement');
-                  mediaElement.currentTime = secondSegmentInfo.timecode;
+                  mediaElement.currentTime = Math.max(secondSegmentInfo.timev, secondSegmentInfo.timea);
                   assert_true(mediaElement.seeking, 'mediaElement is seeking');
 
               });
@@ -106,7 +106,7 @@
 
                   // Seek to a second position while the first seek is still pending.
                   test.expectEvent(mediaElement, 'seeking', 'mediaElement');
-                  mediaElement.currentTime = thirdSegmentInfo.timecode;
+                  mediaElement.currentTime = Math.max(thirdSegmentInfo.timev, thirdSegmentInfo.timea);
                   assert_true(mediaElement.seeking, 'mediaElement is seeking');
 
                   // Append media data for the first seek position.
@@ -116,7 +116,8 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_true(mediaElement.seeking, 'mediaElement is still seeking');
+                  // Note that we can't assume that the element is still seeking
+                  // when the seeking event is fired as the operation is asynchronous.
 
                   // Append media data for the second seek position.
                   test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');


### PR DESCRIPTION
Do not assume that the element is still seeking when the seeking event is actually fired (the seeking operation is asynchronous)

MozReview-Commit-ID: Ap24kUQK8R2

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
