### PR TITLE
Don't assume that once playing event has fired, the earlier appendBuffer has completed.

### DIFF
--- a/media-source/mediasource-seek-during-pending-seek.html
+++ b/media-source/mediasource-seek-during-pending-seek.html
@@ -54,8 +54,22 @@
 
               test.waitForExpectedEvents(function()
               {
-                  test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
-                  mediaSource.endOfStream();
+                  if (sourceBuffer.updating)
+                  {
+                      // The event playing was fired prior to the appendBuffer completing.
+                      test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_false(sourceBuffer.updating, 'append have compleded');
+                          test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
+                          mediaSource.endOfStream();
+                      });
+                  }
+                  else
+                  {
+                      test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
+                      mediaSource.endOfStream();
+                  }
               });
 
               test.waitForExpectedEvents(function()
@@ -120,7 +134,6 @@
                   // when the seeking event is fired as the operation is asynchronous.
 
                   // Append media data for the second seek position.
-                  test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
                   test.expectEvent(mediaElement, 'seeked', 'mediaElement finished seek');
                   MediaSourceUtil.appendUntilEventFires(test, mediaElement, 'seeked', sourceBuffer, mediaData, segmentInfo, segmentIndex);
               });
@@ -129,8 +142,22 @@
               {
                   assert_false(mediaElement.seeking, 'mediaElement is no longer seeking');
 
-                  test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
-                  mediaSource.endOfStream();
+                  if (sourceBuffer.updating)
+                  {
+                      // The event seeked was fired prior to the appendBuffer completing.
+                      test.expectEvent(sourceBuffer, 'updateend', 'sourceBuffer');
+                      test.waitForExpectedEvents(function()
+                      {
+                          assert_false(sourceBuffer.updating, 'append have compleded');
+                          test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
+                          mediaSource.endOfStream();
+                      });
+                  }
+                  else
+                  {
+                      test.expectEvent(mediaSource, 'sourceended', 'mediaSource ended');
+                      mediaSource.endOfStream();
+                  }
               });
 
               test.waitForExpectedEvents(function()


### PR DESCRIPTION
The two operations are asynchronous and independent.

MozReview-Commit-ID: D2woSoIzE6p

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
