### PR TITLE
Never attempt to read past end of manifest table.

### DIFF
--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -303,7 +303,10 @@
                 return;
 
             i++;
-            MediaSourceUtil.append(test, sourceBuffer, MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[i]), onAppendDone);
+            if (i < segmentInfo.media.length)
+            {
+                MediaSourceUtil.append(test, sourceBuffer, MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[i]), onAppendDone);
+            }
         };
         MediaSourceUtil.append(test, sourceBuffer, MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.media[i]), onAppendDone);
 


### PR DESCRIPTION
Should the events being waited for take a while to fire, we could have attempted to append more segments than the table contain causing an exception.

MozReview-Commit-ID: HnmLTqNQ5rb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
