### PR TITLE
don't assume playback won't be finished by the time the seeked event is fired.

### DIFF
--- a/media-source/mediasource-seek-during-pending-seek.html
+++ b/media-source/mediasource-seek-during-pending-seek.html
@@ -74,7 +74,16 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_greater_than(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA, 'Greater than HAVE_CURRENT_DATA');
+              	  // Note: we just completed the seek. However, we only have less than a second worth of data to play. It is possible that
+              	  // playback has reached the end since the seek completed.
+              	  if (!mediaElement.paused)
+              	  {
+                      assert_greater_than_equal(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA, 'Greater or equal than HAVE_CURRENT_DATA');
+                  }
+                  else
+                  {
+                      assert_true(mediaElement.ended);
+                  }
                   test.done();
               });
 
@@ -162,7 +171,16 @@
 
               test.waitForExpectedEvents(function()
               {
-                  assert_greater_than(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA, 'Greater than HAVE_CURRENT_DATA');
+              	  // Note: we just completed the seek. However, we only have less than a second worth of data to play. It is possible that
+              	  // playback has reached the end since the seek completed.
+              	  if (!mediaElement.paused)
+              	  {
+                      assert_greater_than_equal(mediaElement.readyState, mediaElement.HAVE_CURRENT_DATA, 'Greater or equal than HAVE_CURRENT_DATA');
+                  }
+                  else
+                  {
+                      assert_true(mediaElement.ended);
+                  }
                   test.done();
               });
           }, 'Test seeking to a new location during a pending seek.');


### PR DESCRIPTION
The data added in the sourcebuffer is very short (less than one second); it is possible that playback has completed prior the event being fired.

MozReview-Commit-ID: INHAFmEhSut

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293613
