### PR TITLE
Correct invalid test.

### DIFF
--- a/media-source/mediasource-play-then-seek-back.html
+++ b/media-source/mediasource-play-then-seek-back.html
@@ -31,7 +31,6 @@
 
                 function finishSeekThenPlay()
                 {
-                    assert_true(mediaElement.seeking, 'mediaElement is seeking');
                     assert_equals(mediaElement.currentTime, 0.0, 'Current time is 0.0');
                     test.expectEvent(mediaElement, 'seeked', 'mediaElement finished seek');
 
@@ -43,6 +42,7 @@
                     assert_greater_than(mediaElement.currentTime, 0.0, 'Playback has started.');
                     test.expectEvent(mediaElement, 'seeking', 'mediaElement');
                     mediaElement.currentTime = 0.0;
+                    assert_true(mediaElement.seeking, 'mediaElement is seeking');
 
                     test.waitForExpectedEvents(finishSeekThenPlay);
                 }


### PR DESCRIPTION
It is incorrect to assume that the seeking attribute will still be true once the seeking event handler gets to run. Seeking may have completed between the time the seeking event was queued and the time the seeking env is fired.

MozReview-Commit-ID: CZFFotMyaIu

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1128069
