### PR TITLE
Update webref MSE tests according to updated spec.

### DIFF
--- a/media-source/mediasource-seek-beyond-duration.html
+++ b/media-source/mediasource-seek-beyond-duration.html
@@ -63,6 +63,15 @@
                 {
                     assert_equals(mediaElement.duration, segmentInfo.duration);
                     assert_greater_than_equal(mediaElement.duration, 2.0, 'Duration is >2.0s.');
+
+                    test.expectEvent(sourceBuffer, "updateend");
+                    sourceBuffer.remove(1.5, Infinity);
+                    assert_true(sourceBuffer.updating, "updating");
+                });
+
+                test.waitForExpectedEvents(function()
+                {
+                    assert_false(sourceBuffer.updating, "updating");
                     test.waitForCurrentTimeChange(mediaElement, function()
                     {
                         // Update duration.


### PR DESCRIPTION
```
See w3c/MSE Issue 19, 20 & 26.

Changing the duration now can never call the range removal algorithm. An explicit call to remove must be used for range removal.
This spec change performed the following:
- Require remove() for all Range Removals
```

MozReview-Commit-ID: 860PnQ9yrbc

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1128069
