### PR TITLE
Do not use timer when there's only one callback pending.

### DIFF
--- a/media-source/mediasource-util.js
+++ b/media-source/mediasource-util.js
@@ -87,8 +87,12 @@
             assert_equals(eventInfo.description, expected.description, "Descriptions match for '" +  event.type + "'.");
 
             expectations.shift(1);
-            if (t.waitCallbacks_.length > 0)
+            if (t.waitCallbacks_.length > 1)
                 setTimeout(waitHandler, 0);
+            else if (t.waitCallbacks_.length == 1) {
+                // Immediately call the callback.
+                waitHandler();
+            }
         });
         object.addEventListener(eventName, eventHandler);
     };


### PR DESCRIPTION
It is invalid to assume that no other actions can be performed between the time setTimout is called with a timeout value of 0 and the task actually runs.
This causes events to be regularly missed.

MozReview-Commit-ID: 70dtFsTwETf

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293159
