### PR TITLE
Do not assume that currentTime is still at seeking position when seeking event is fired.

### DIFF
--- a/media-source/mediasource-play-then-seek-back.html
+++ b/media-source/mediasource-play-then-seek-back.html
@@ -31,7 +31,6 @@
 
                 function finishSeekThenPlay()
                 {
-                    assert_equals(mediaElement.currentTime, 0.0, 'Current time is 0.0');
                     test.expectEvent(mediaElement, 'seeked', 'mediaElement finished seek');
 
                     test.waitForExpectedEvents(confirmPlayThenEnd);


### PR DESCRIPTION
The seeking attribute is changed synchronously, however, the seeking event is fired asynchronously. It is possible that by the time the seeking event is fired, the seeking operation has already completed and that the "time marches on", causing currentTime to be past the seeking position.

MozReview-Commit-ID: IB83w6zKCLF

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1293186
