### PR TITLE
Replaced references to mxr.mozilla.org in the codebase with dxr.mozilla.org

### DIFF
--- a/dom/traversal/TreeWalker-acceptNode-filter.html
+++ b/dom/traversal/TreeWalker-acceptNode-filter.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/acceptNode-filter.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/acceptNode-filter.js
 -->
 <head>
 <title>TreeWalker: acceptNode-filter</title>

--- a/dom/traversal/TreeWalker-basic.html
+++ b/dom/traversal/TreeWalker-basic.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/TreeWalker-basic.html
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/TreeWalker-basic.html
 -->
 <head>
 <title>TreeWalker: Basic test</title>

--- a/dom/traversal/TreeWalker-currentNode.html
+++ b/dom/traversal/TreeWalker-currentNode.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/resources/TreeWalker-currentNode.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/resources/TreeWalker-currentNode.js
 -->
 <head>
 <title>TreeWalker: currentNode</title>

--- a/dom/traversal/TreeWalker-previousNodeLastChildReject.html
+++ b/dom/traversal/TreeWalker-previousNodeLastChildReject.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/previousNodeLastChildReject.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/previousNodeLastChildReject.js
 -->
 <head>
 <title>TreeWalker: previousNodeLastChildReject</title>

--- a/dom/traversal/TreeWalker-previousSiblingLastChildSkip.html
+++ b/dom/traversal/TreeWalker-previousSiblingLastChildSkip.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/previousSiblingLastChildSkip.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/previousSiblingLastChildSkip.js
 -->
 <head>
 <title>TreeWalker: previousSiblingLastChildSkip</title>

--- a/dom/traversal/TreeWalker-traversal-reject.html
+++ b/dom/traversal/TreeWalker-traversal-reject.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-reject.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-reject.js
 -->
 <head>
 <title>TreeWalker: traversal-reject</title>

--- a/dom/traversal/TreeWalker-traversal-skip-most.html
+++ b/dom/traversal/TreeWalker-traversal-skip-most.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-skip-most.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-skip-most.js
 -->
 <head>
 <title>TreeWalker: traversal-skip-most</title>

--- a/dom/traversal/TreeWalker-traversal-skip.html
+++ b/dom/traversal/TreeWalker-traversal-skip.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <!--
-Test adapted from https://mxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-skip.js
+Test adapted from https://dxr.mozilla.org/chromium/source/src/third_party/WebKit/LayoutTests/fast/dom/TreeWalker/script-tests/traversal-skip.js
 -->
 <head>
 <title>TreeWalker: traversal-skip</title>

--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
@@ -8,7 +8,7 @@ array, and after the playback has stopped, the contents are compared
 to those of a loaded AudioBuffer with the same source.
 
 Somewhat similiar to a test from Mozilla:
-(http://mxr.mozilla.org/mozilla-central/source/content/media/webaudio/test/test_mediaElementAudioSourceNode.html?force=1)
+(http://dxr.mozilla.org/mozilla-central/source/content/media/webaudio/test/test_mediaElementAudioSourceNode.html?force=1)
 -->
 
 <html class="a">

--- a/webgl/conformance-1.0.3/conformance/more/README.md
+++ b/webgl/conformance-1.0.3/conformance/more/README.md
@@ -22,7 +22,7 @@ Want to contribute?
 
   1. Fork this repo
   2. Run <code>gen_tests.rb</code>
-  3. Look into templates/ to see which functions lack tests (also see <a href="../raw/master/methods.txt">methods.txt</a> and <a href="http://mxr.mozilla.org/mozilla-central/source/dom/interfaces/canvas/nsICanvasRenderingContextWebGL.idl">nsICanvasRenderingContextWebGL.idl</a>):
+  3. Look into templates/ to see which functions lack tests (also see <a href="../raw/master/methods.txt">methods.txt</a> and <a href="http://dxr.mozilla.org/mozilla-central/source/dom/interfaces/canvas/nsICanvasRenderingContextWebGL.idl">nsICanvasRenderingContextWebGL.idl</a>):
     1. copy methodName.html to functions/methodName.html and write tests that test the results of valid inputs.
     2. copy methodNameBadArgs.html to functions/methodNameBadArgs.html and write tests to assert that invalid inputs throw exceptions.
     3. If your test causes a segfault, add the following to the top of the script tag: <code>Tests.autorun = false; Tests.message = "Caution: this may crash your browser";</code>


### PR DESCRIPTION
a=release to get around a hook that's catching these comment-only idl changes

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1284887
