### PR TITLE
Add tests for calculating animation effect phases;

### DIFF
--- a/web-animations/timing-model/animation-effects/phases-and-states.html
+++ b/web-animations/timing-model/animation-effects/phases-and-states.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Tests for phases and states</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#animation-effect-phases-and-states">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+// --------------------------------------------------------------------
+//
+// Phases
+//
+// --------------------------------------------------------------------
+
+function assert_phase_at_time(animation, phase, currentTime) {
+  animation.currentTime = currentTime;
+
+  if (phase === 'active') {
+    // If the fill mode is 'none', then progress will only be non-null if we
+    // are in the active phase.
+    animation.effect.timing.fill = 'none';
+    assert_not_equals(animation.effect.getComputedTiming().progress, null,
+                      'Animation effect is in active phase when current time'
+                      + ' is ' + currentTime + 'ms');
+  } else {
+    // The easiest way to distinguish between the 'before' phase and the 'after'
+    // phase is to toggle the fill mode. For example, if the progress is null
+    // will the fill node is 'none' but non-null when the fill mode is
+    // 'backwards' then we are in the before phase.
+    animation.effect.timing.fill = 'none';
+    assert_equals(animation.effect.getComputedTiming().progress, null,
+                  'Animation effect is in ' + phase + ' phase when current time'
+                  + ' is ' + currentTime + 'ms'
+                  + ' (progress is null with \'none\' fill mode)');
+
+    animation.effect.timing.fill = phase === 'before'
+                                   ? 'backwards'
+                                   : 'forwards';
+    assert_not_equals(animation.effect.getComputedTiming().progress, null,
+                      'Animation effect is in ' + phase + ' phase when current'
+                      + ' time is ' + currentTime + 'ms'
+                      + ' (progress is non-null with appropriate fill mode)');
+  }
+}
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, 1);
+
+  [ { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'active' },
+    { currentTime:  1, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for a simple animation effect');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1, delay: 1 });
+
+  [ { currentTime: 0, phase: 'before' },
+    { currentTime: 1, phase: 'active' },
+    { currentTime: 2, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a positive start delay');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1, delay: -1 });
+
+  [ { currentTime: -2, phase: 'before' },
+    { currentTime: -1, phase: 'active' },
+    { currentTime:  0, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative start delay');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1, endDelay: 1 });
+
+  [ { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'active' },
+    { currentTime:  1, phase: 'after'  },
+    { currentTime:  2, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a positive end delay');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 2, endDelay: -1 });
+
+  [ { currentTime: -1,   phase: 'before' },
+    { currentTime:  0,   phase: 'active' },
+    { currentTime:  0.9, phase: 'active' },
+    { currentTime:  1,   phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative end delay lesser'
+   + ' in magnitude than the active duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1, endDelay: -1 });
+
+  [ { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'after'  },
+    { currentTime:  1, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative end delay equal'
+   + ' in magnitude to the active duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1, endDelay: -2 });
+
+  [ { currentTime: -2, phase: 'before' },
+    { currentTime: -1, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative end delay'
+   + ' greater in magnitude than the active duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 2,
+                                               delay: 1,
+                                               endDelay: -1 });
+
+  [ { currentTime: 0,   phase: 'before' },
+    { currentTime: 1,   phase: 'active' },
+    { currentTime: 2, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a positive start delay'
+   + ' and a negative end delay lesser in magnitude than the active duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1,
+                                               delay: -1,
+                                               endDelay: -1 });
+
+  [ { currentTime: -2,   phase: 'before' },
+    { currentTime: -1,   phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative start delay'
+   + ' and a negative end delay equal in magnitude to the active duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, { duration: 1,
+                                               delay: -1,
+                                               endDelay: -2 });
+
+  [ { currentTime: -3,   phase: 'before' },
+    { currentTime: -2,   phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for an animation effect with a negative start delay'
+   + ' and a negative end delay equal greater in magnitude than the active'
+   + ' duration');
+
+test(function(t) {
+  var animation = createDiv(t).animate(null, 1);
+  animation.playbackRate = -1;
+
+  [ { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'before' },
+    { currentTime:  1, phase: 'active' },
+    { currentTime:  2, phase: 'after'  } ]
+  .forEach(function(test) {
+    assert_phase_at_time(animation, test.phase, test.currentTime);
+  });
+}, 'Phase calculation for a simple animation effect with negative playback'
+   + ' rate');
+
+</script>
+</body>


### PR DESCRIPTION
This test overlaps somewhat with the tests in
web-animations/timing-model/animation-effects/simple-iteration-progress.html.
However, these tests are more specific to just covering the phase calculation
algorithm. Ultimately the tests in simple-iteration-progress.html should be
broken down into separate tests for the different algorithms being tested.

There is also some redundancy in these tests. For example, instead of writing:

  .forEach(function(test) {
    assert_phase_at_time(animation, test.phase, test.currentTime);
  });

we could just define an assert_phases_at_times function that takes the array of
test cases and iterates over them. However, I think writing the test like this
makes it easier to read since it requires less imagination about what
assert_phases_at_times might be doing.

One concern is that this test requires the setter for AnimationEffectTiming.fill
to be implemented. We could rewrite this to create a new animation with the
appropriate fill mode each time but I think this is probably ok.

MozReview-Commit-ID: 82uvBB8bizI

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1286476
