### PR TITLE
P4 Verify that unregister waits for active worker to go idle.

### DIFF
--- a/service-workers/service-worker/activation.https.html
+++ b/service-workers/service-worker/activation.https.html
@@ -145,4 +145,35 @@ promise_test(t => {
           assert_equals(registration.active, new_worker);
         });
   }, 'skipWaiting bypasses no controllee requirement');
+
+// This test is not really about activation, but otherwise is very
+// similar to the other tests here.
+promise_test(t => {
+    var scope = 'resources/unregister';
+    var worker_url = 'resources/mint-new-worker.py';
+    var registration;
+    var iframe;
+    var new_worker;
+    return setup_activation_test(t, scope, worker_url)
+      .then(result => {
+          registration = result.registration;
+          iframe = result.iframe;
+          // Remove the iframe.
+          iframe.remove();
+          return registration.unregister();
+        })
+      .then(() => {
+          // The unregister operation should wait for the active worker to
+          // finish processing its events before clearing the registration.
+          new_worker = registration.waiting;
+          var reached_redundant = wait_for_state(t, new_worker, 'redundant');
+          registration.active.postMessage('go');
+          return reached_redundant;
+        })
+      .then(() => {
+          assert_equals(registration.installing, null);
+          assert_equals(registration.waiting, null);
+          assert_equals(registration.active, null);
+        });
+  }, 'finishing a request triggers unregister');
 </script>


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1290116
