### PR TITLE
Add innerText tests for text-transform support of German double-s and Turkish i vs. dotless-i to web-platform-tests.

### DIFF
--- a/innerText/getter-tests.js
+++ b/innerText/getter-tests.js
@@ -259,6 +259,8 @@ testText("<div>abc<!--comment-->def", "abcdef", "comment ignored");
 /**** text-transform ****/
 
 testText("<div><div style='text-transform:uppercase'>abc", "ABC", "text-transform is applied");
+testText("<div><div style='text-transform:uppercase'>Ma\xDF", "MASS", "text-transform handles es-zet");
+testText("<div><div lang='tr' style='text-transform:uppercase'>i \u0131", "\u0130 I", "text-transform handles Turkish casing");
 
 /**** block-in-inline ****/
 


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1288975
