### PR TITLE
New tests for PresentationRequest constructor with sequence of URLs

### DIFF
--- a/presentation-api/controlling-ua/PresentationRequest_error.html
+++ b/presentation-api/controlling-ua/PresentationRequest_error.html
@@ -7,26 +7,33 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 
-    var wrong_presentation_url = null;
-
-    /**
-     *  Test if PresentationRequest constructor returns a TypeError() by missing presentation URL
-     */
-
     test(function() {
         assert_throws(new TypeError(), function() {
             new PresentationRequest();
         });
     }, 'Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.');
 
-    /**
-     *  Test if PresentationRequest constructor returns a TypeError() by wrong presentation URL
-     */
-
     test(function() {
         assert_throws(new TypeError(), function() {
-            new PresentationRequest(wrong_presentation_url);
+            new PresentationRequest(null);
         });
-    }, 'Call PresentationRequest() constructor with null presentation URL. TypeError Exception expected.');
+    }, 'Call PresentationRequest constructor with null presentation URL. TypeError Exception expected.');
 
+    test(function() {
+        assert_throws('NotSupportedError', function() {
+            new PresentationRequest([]);
+        });
+    }, 'Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.');
+
+    test(function() {
+        assert_throws('SyntaxError', function() {
+            new PresentationRequest(':invalid');
+        });
+    }, 'Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.');
+
+    test(function() {
+        assert_throws('SyntaxError', function() {
+            new PresentationRequest(['presentation.html', ':invalid']);
+        });
+    }, 'Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.');
 </script>

--- a/presentation-api/controlling-ua/PresentationRequest_success.html
+++ b/presentation-api/controlling-ua/PresentationRequest_success.html
@@ -7,23 +7,37 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
-
-    var client_id = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
-    //relative presentation URL
-    var presentation_url = "../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__="+ client_id;
-
-    /**
-     *  Test if PresentationRequest constructor returns a SyntaxError() by missing presentation URL
-     */
-
     test(function() {
-        try{
-            var request = new PresentationRequest(presentation_url);
+        try {
+            var request = new PresentationRequest('presentation.html');
             assert_true(request instanceof PresentationRequest);
         }
-        catch (ex){
-            assert_unreached("Call PresentationRequest() constructor with valid presentation URL....????");
+        catch (ex) {
+            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
         }
-    }, 'Call PresentationRequest() constructor with valid presentation URL. No Exception expected.');
+    }, 'Call PresentationRequest constructor with a valid relative presentation URL. No Exception expected.');
+
+    test(function() {
+        try {
+            var request = new PresentationRequest('http://example.org/');
+            assert_true(request instanceof PresentationRequest);
+        }
+        catch (ex) {
+            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
+        }
+    }, 'Call PresentationRequest constructor with a valid absolute presentation URL. No Exception expected.');
+
+    test(function() {
+        try {
+            var request = new PresentationRequest([
+                'presentation.html',
+                'http://example.org/presentation/'
+            ]);
+            assert_true(request instanceof PresentationRequest);
+        }
+        catch (ex) {
+            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
+        }
+    }, 'Call PresentationRequest constructor with a set of valid presentation URLs. No Exception expected.');
 
 </script>


### PR DESCRIPTION
This completes the existing tests on the PresentationRequest interface with
tests on the constructor that takes multiple URLs as input.

The update also contains a couple of tests that call the constructors with
invalid URLs to detect SyntaxError exceptions, and a couple of editorial
updates to test descriptions.

@louaybassbouss, for review
