### PR TITLE
New presentation start tests that trigger a mixed content error

### DIFF
--- a/presentation-api/controlling-ua/getAvailability_mixedcontent.https.html
+++ b/presentation-api/controlling-ua/getAvailability_mixedcontent.https.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Calling "getAvailability" with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-getavailability">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    function getAvailability() {
+        var request = new PresentationRequest('http://example.org/presentation.html');
+        return request.getAvailability();
+    }
+
+    promise_test(function (t) {
+        return promise_rejects(t, 'SecurityError', getAvailability());
+    });
+</script>
+

--- a/presentation-api/controlling-ua/reconnectToPresentation_mixedcontent.https.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_mixedcontent.https.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Calling "reconnect" with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-reconnect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    function reconnectToPresentation() {
+        var request = new PresentationRequest('http://example.org/presentation.html');
+        return request.reconnect('someid');
+    }
+
+    promise_test(function (t) {
+        return promise_rejects(t, 'SecurityError', reconnectToPresentation());
+    });
+</script>
+

--- a/presentation-api/controlling-ua/startNewPresentation_mixedcontent-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_mixedcontent-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API - controlling ua - mixed content - manual test</title>
+<title>Calling "start" with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</title>
 <link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
 <script src="/resources/testharness.js"></script>
@@ -20,9 +20,10 @@
     };
 
     function startPresentationTest() {
+        presentBtn.disabled = true;
         promise_test(function (t) {
             return promise_rejects(t, 'SecurityError', startPresentation());
-        }, 'Calling "start" with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.');
+        });
     }
 </script>
 

--- a/presentation-api/controlling-ua/startNewPresentation_mixedcontent-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_mixedcontent-manual.https.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Presentation API - controlling ua - mixed content - manual test</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
+<button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
+
+<script>
+    setup({explicit_timeout: true});
+
+    var presentBtn = document.getElementById("presentBtn");
+
+    function startPresentation() {
+        var request = new PresentationRequest('http://example.org/presentation.html');
+        return request.start();
+    };
+
+    function startPresentationTest() {
+        promise_test(function (t) {
+            return promise_rejects(t, 'SecurityError', startPresentation());
+        }, 'Calling "start" with an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.');
+    }
+</script>
+

--- a/presentation-api/controlling-ua/startNewPresentation_mixedcontent_multiple-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_mixedcontent_multiple-manual.https.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Presentation API - controlling ua - mixed content (multiple URLs) - manual test</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
+<button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
+
+<script>
+    setup({explicit_timeout: true});
+
+    var presentBtn = document.getElementById("presentBtn");
+
+    function startPresentation() {
+        var request = new PresentationRequest([
+          'presentation.html',
+          'http://example.org/presentation.html'
+        ]);
+        return request.start();
+    };
+
+    function startPresentationTest() {
+        promise_test(function (t) {
+            return promise_rejects(t, 'SecurityError', startPresentation());
+        }, 'Calling "start" with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.');
+    }
+</script>
+

--- a/presentation-api/controlling-ua/startNewPresentation_mixedcontent_multiple-manual.https.html
+++ b/presentation-api/controlling-ua/startNewPresentation_mixedcontent_multiple-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API - controlling ua - mixed content (multiple URLs) - manual test</title>
+<title>Calling "start" with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.</title>
 <link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
 <script src="/resources/testharness.js"></script>
@@ -23,9 +23,10 @@
     };
 
     function startPresentationTest() {
+        presentBtn.disabled = true;
         promise_test(function (t) {
             return promise_rejects(t, 'SecurityError', startPresentation());
-        }, 'Calling "start" with a set of URLs containing an a priori unauthenticated URL in an HTTPS context throws a SecurityError exception.');
+        });
     }
 </script>
 


### PR DESCRIPTION
The tests need to run over HTTPS, hence the `.https.html` extension. They create a `PresentationRequest` with an HTTP URL and ensure that `start` reports a `SecurityError` exception.

Note the tests will pass if they are run over HTTP by mistake (since there would not be any "mixed content" anymore), which could be confusing. A short exchange on IRC suggested that individual test files should not check the protocol themselves, but that the test harness could perhaps be updated to report the error. I prepared a PR on testharness.js accordingly: https://github.com/w3c/testharness.js/pull/207
