### PR TITLE
New Presentation API tests on allow-presentation (sandboxing)

### DIFF
--- a/presentation-api/controlling-ua/getAvailability_sandboxing_error.html
+++ b/presentation-api/controlling-ua/getAvailability_sandboxing_error.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: Retrieving display availability from a nested context fails when allow-presentation is not set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-getavailability">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        function startWhenReady(ev) {
+            var childFrame = document.getElementById('childFrame');
+            if (ev.data === 'ready') {
+                window.removeEventListener('message', startWhenReady);
+                childFrame.contentWindow.postMessage('getAvailability', '*');
+                window.addEventListener('message', t.step_func(function (ev) {
+                    assert_equals(ev.data, 'SecurityError',
+                        'Presentation sandboxing did not work as expected.');
+                    t.done();
+                }));
+            }
+        }
+
+        window.addEventListener('message', startWhenReady);
+    });
+</script>
+<iframe id="childFrame" sandbox="allow-scripts" style="display:none" src="support/iframe.html"></iframe>

--- a/presentation-api/controlling-ua/getAvailability_sandboxing_success.html
+++ b/presentation-api/controlling-ua/getAvailability_sandboxing_success.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: Retrieving display availability from a nested context succeeds when allow-presentation is set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-getavailability">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        function startWhenReady(ev) {
+            var childFrame = document.getElementById('childFrame');
+            if (ev.data === 'ready') {
+                window.removeEventListener('message', startWhenReady);
+                childFrame.contentWindow.postMessage('getAvailability', '*');
+                window.addEventListener('message', t.step_func(function (ev) {
+                    assert_equals(ev.data, 'success',
+                        'Presentation sandboxing did not work as expected.');
+                    t.done();
+                }));
+            }
+        }
+        window.addEventListener('message', startWhenReady);
+    });
+</script>
+<iframe id="childFrame" sandbox="allow-scripts allow-presentation" style="display:none" src="support/iframe.html"></iframe>

--- a/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_error.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_error.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: Reconnecting a presentation from a nested context fails when allow-presentation is not set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-reconnect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        function startWhenReady(ev) {
+            var childFrame = document.getElementById('childFrame');
+            if (ev.data === 'ready') {
+                window.removeEventListener('message', startWhenReady);
+                childFrame.contentWindow.postMessage('reconnect', '*');
+                window.addEventListener('message', t.step_func(function (ev) {
+                    assert_equals(ev.data, 'SecurityError',
+                        'Presentation sandboxing did not work as expected.');
+                    t.done();
+                }));
+            }
+        }
+
+        window.addEventListener('message', startWhenReady);
+    });
+</script>
+<iframe id="childFrame" sandbox="allow-scripts" style="display:none" src="support/iframe.html"></iframe>

--- a/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_sandboxing_success.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: Reconnecting a presentation from a nested context succeeds when allow-presentation is set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-reconnect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        function startWhenReady(ev) {
+            var childFrame = document.getElementById('childFrame');
+            if (ev.data === 'ready') {
+                window.removeEventListener('message', startWhenReady);
+                childFrame.contentWindow.postMessage('reconnect', '*');
+                window.addEventListener('message', t.step_func(function (ev) {
+                    assert_equals(ev.data, 'NotFoundError',
+                        'Presentation sandboxing did not work as expected.');
+                    t.done();
+                }));
+            }
+        }
+        window.addEventListener('message', startWhenReady);
+    });
+</script>
+<iframe id="childFrame" sandbox="allow-scripts allow-presentation" style="display:none" src="support/iframe.html"></iframe>

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
@@ -11,7 +11,7 @@
 <button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
 
 <script>
-    setup({explicit_timeout: true}); 
+    setup({explicit_timeout: true});
 
     var presentBtn = document.getElementById('presentBtn');
     var childFrame = document.getElementById('childFrame');

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: starting a presentation from a nested context fails when allow-presentation is not set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="childFrame" sandbox="allow-scripts" style="display:none" src="support/iframe.html"></iframe>
+<p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
+<button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
+
+<script>
+    setup({explicit_timeout: true}); 
+
+    var presentBtn = document.getElementById('presentBtn');
+    var childFrame = document.getElementById('childFrame');
+
+    function startPresentationTest() {
+        presentBtn.disabled = true;
+        async_test(function (t) {
+            childFrame.contentWindow.postMessage('start', '*');
+            window.onmessage = t.step_func(function (ev) {
+                assert_equals(ev.data, 'SecurityError',
+                    'Presentation sandboxing did not work as expected.');
+                t.done();
+            });
+        });
+    }
+</script>
+

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_error-manual.html
@@ -20,11 +20,11 @@
         presentBtn.disabled = true;
         async_test(function (t) {
             childFrame.contentWindow.postMessage('start', '*');
-            window.onmessage = t.step_func(function (ev) {
+            window.addEventListener('message', t.step_func(function (ev) {
                 assert_equals(ev.data, 'SecurityError',
                     'Presentation sandboxing did not work as expected.');
                 t.done();
-            });
+            }));
         });
     }
 </script>

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
@@ -11,7 +11,7 @@
 <button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
 
 <script>
-    setup({explicit_timeout: true}); 
+    setup({explicit_timeout: true});
 
     var presentBtn = document.getElementById('presentBtn');
     var childFrame = document.getElementById('childFrame');

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
@@ -20,11 +20,11 @@
         presentBtn.disabled = true;
         async_test(function (t) {
             childFrame.contentWindow.postMessage('start', '*');
-            window.onmessage = t.step_func(function (ev) {
+            window.addEventListener('message', t.step_func(function (ev) {
                 assert_equals(ev.data, 'success',
                     'Presentation could not be started from nested frame.');
                 t.done();
-            });
+            }));
         });
     }
 </script>

--- a/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_sandboxing_success-manual.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sandboxing: starting a presentation from a nested context succeeds when allow-presentation is set</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="childFrame" sandbox="allow-scripts allow-presentation" style="display:none" src="support/iframe.html"></iframe>
+<p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
+<button id="presentBtn" onclick="startPresentationTest()">Start Presentation Test</button>
+
+<script>
+    setup({explicit_timeout: true}); 
+
+    var presentBtn = document.getElementById('presentBtn');
+    var childFrame = document.getElementById('childFrame');
+
+    function startPresentationTest() {
+        presentBtn.disabled = true;
+        async_test(function (t) {
+            childFrame.contentWindow.postMessage('start', '*');
+            window.onmessage = t.step_func(function (ev) {
+                assert_equals(ev.data, 'success',
+                    'Presentation could not be started from nested frame.');
+                t.done();
+            });
+        });
+    }
+</script>
+

--- a/presentation-api/controlling-ua/support/iframe.html
+++ b/presentation-api/controlling-ua/support/iframe.html
@@ -6,8 +6,8 @@
 <script>
     window.onmessage = function (ev) {
       try {
+        var request = new PresentationRequest('presentation.html');;
         if (ev.data === 'start') {
-          var request = new PresentationRequest('presentation.html');
           request.start()
             .then(function () {
               parent.window.postMessage('success', '*');
@@ -26,10 +26,34 @@
               }
             });
         }
+        else if (ev.data === 'reconnect') {
+          request.reconnect('someid')
+            .then(function () {
+              parent.window.postMessage('success', '*');
+            })
+            .catch(function (err) {
+              parent.window.postMessage(err.name, '*');
+            });
+        }
+        else if (ev.data === 'getAvailability') {
+          request.getAvailability()
+            .then(function () {
+              parent.window.postMessage('success', '*');
+            })
+            .catch(function (err) {
+              if (err.name === 'NotSupportedError') {
+                parent.window.postMessage('success', '*');
+              }
+              else {
+                parent.window.postMessage(err.name, '*');
+              }
+            });
+        }
       }
       catch (err) {
         parent.window.postMessage('Could not create PresentationRequest', '*');
       }
     }
+    parent.window.postMessage('ready', '*');
 </script>
 

--- a/presentation-api/controlling-ua/support/iframe.html
+++ b/presentation-api/controlling-ua/support/iframe.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Presentation API - controlling ua - sandboxing</title>
+<link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script>
+    window.onmessage = function (ev) {
+      try {
+        if (ev.data === 'start') {
+          var request = new PresentationRequest('presentation.html');
+          request.start()
+            .then(function () {
+              parent.window.postMessage('success', '*');
+            })
+            .catch(function (err) {
+              if ((err.name === 'NotFoundError') ||
+                  (err.name === 'NotAllowedError')) {
+                // These errors either mean that the user dismissed the dialog
+                // box or that the UA could not find any available or suitable
+                // screen. This is equivalent of succeeding for the purpose of
+                // iframe tests.
+                parent.window.postMessage('success', '*');
+              }
+              else {
+                parent.window.postMessage(err.name, '*');
+              }
+            });
+        }
+      }
+      catch (err) {
+        parent.window.postMessage('Could not create PresentationRequest', '*');
+      }
+    }
+</script>
+


### PR DESCRIPTION
Two new manual tests that embed a nested iframe and start a presentation from the nested iframe. One test sets the `allow-presentation` attribute and expects the start process to succeed, the other does not and expects the start process to fail with a `SecurityError`.

Note that the start process is considered to succeed even if it reports a `NotFoundError` or a `NotAllowedError`, since the goal of these tests is merely to ensure that the call to `start` passes the "Prohibits Mixed Security Contexts" check.
