### PR TITLE
Fix html/browsers/the-window-object/security-window/window-security.s…

### DIFF
--- a/html/browsers/the-window-object/security-window/window-security.sub.html
+++ b/html/browsers/the-window-object/security-window/window-security.sub.html
@@ -191,7 +191,13 @@ function fr_load() {
 }
 
 </script>
-<iframe id="fr" onload="fr_load()" style="display:none"></iframe>
 <script>
-document.getElementById('fr').setAttribute('src', get_host_info().HTTP_REMOTE_ORIGIN + "/");
+onload = function() {
+  var frame = document.createElement('iframe');
+  frame.id = "fr";
+  frame.setAttribute("style", "display:none");
+  frame.setAttribute('src', get_host_info().HTTP_REMOTE_ORIGIN + "/");
+  frame.setAttribute("onload", "fr_load()");
+  document.body.appendChild(frame);
+}
 </script>


### PR DESCRIPTION
…ub.html

Fix html/browsers/the-window-object/security-window/window-security.sub.html as
fr_load() was being called for "about:blank" URL instead of the cross origin URL.

This regressed in 97b13b6a517c3c33136f9dc9a7a9e3acd8fd51d6.
