### PR TITLE
Fix mediasource-endofstream to comply with recent spec change

### DIFF
--- a/media-source/mediasource-endofstream.html
+++ b/media-source/mediasource-endofstream.html
@@ -23,14 +23,20 @@
             mediaSource.endOfStream();
             test.expectEvent(mediaElement, 'canplaythrough',
               'Media element may render the media content until the end');
-            test.waitForExpectedEvents(function()
-            {
-                assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA,
-                  'Media element has enough data to render the content');
-                test.done();
-            });
+        });
+
+        test.waitForExpectedEvents(function()
+        {
+            assert_equals(mediaElement.readyState, HTMLMediaElement.HAVE_ENOUGH_DATA,
+              'Media element has enough data to render the content');
+            test.done();
         });
     }, 'MediaSource.endOfStream(): media element notified that it now has all of the media data');
+
+    function threeDecimalPlaces(number)
+    {
+        return Number(number.toFixed(3));
+    }
 
     mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
     {
@@ -43,31 +49,28 @@
               'Media data properly buffered');
             var highestEndTime = sourceBuffer.buffered.end(0);
 
+            // Note that segmentInfo.duration is expected to also be the
+            // highest track buffer range end time. Therefore, endOfStream() should
+            // not change duration with this media.
+            assert_equals(threeDecimalPlaces(segmentInfo.duration), threeDecimalPlaces(mediaSource.duration));
+            assert_less_than_equal(highestEndTime, mediaSource.duration,
+                'Media duration may be slightly longer than intersected track buffered ranges');
+
+            // Set the duration even higher, then confirm that endOfStream() drops it back to be
+            // the highest track buffer range end time.
+            mediaSource.duration += 10;
             mediaSource.endOfStream();
 
-            assert_equals(sourceBuffer.buffered.end(0), highestEndTime,
-              'Ending the stream does not affect buffered data');
-            test.done();
-        });
-    }, 'MediaSource.endOfStream(): buffered data not modified when endOfStream is called');
-
-    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
-    {
-        assert_less_than(segmentInfo.duration, 60, 'Sufficient test media duration');
-        sourceBuffer.appendBuffer(mediaData);
-        test.expectEvent(sourceBuffer, 'updateend',
-          'Media buffer appended to SourceBuffer');
-        test.waitForExpectedEvents(function()
-        {
             assert_equals(sourceBuffer.buffered.length, 1,
-              'Media data properly buffered');
+              'Media data properly buffered after endOfStream');
 
-            mediaSource.duration = 60;
-            mediaSource.endOfStream();
+            assert_equals(threeDecimalPlaces(segmentInfo.duration), threeDecimalPlaces(mediaSource.duration));
+            assert_less_than_equal(highestEndTime, mediaSource.duration,
+                'Media duration may be slightly longer than intersected track buffered ranges');
+            assert_equals(sourceBuffer.buffered.end(0), mediaSource.duration,
+                'After endOfStream(), highest buffered range end time must be the highest track buffer range end time');
 
-            assert_equals(mediaSource.duration, sourceBuffer.buffered.end(0),
-              'Duration set to the higest end time');
             test.done();
         });
-    }, 'MediaSource.endOfStream(): duration set to the highest end time reported by the buffered attribute');
+    }, 'MediaSource.endOfStream(): duration and buffered range end time before and after endOfStream');
 </script>


### PR DESCRIPTION
w3c/media-source#154 updated the spec to indicate precisely the behavior
for duration and the highest buffered range end time of a media element
upon endOfStream(). This commit updates the test to test the updated
spec behavior.

Note that Chrome currently fails the first subtest, since M54 does not
comply with the recent spec change yet. https://crbug.com/639144 tracks
this issue in Chrome.

Chrome also fails the last subtest when the (default) mp4 segmentInfo is
used, since M54 still conflates PTS with DTS in ISOBMFF streams. Chrome
passes the third subtest when using webm (where there's no distinction
between PTS and DTS). https://crbug.com/373039 is one of a group of bugs
that track the PTS/DTS conflation issue in Chrome.
