### PR TITLE
Stop using Array.forEach in html/browsers/origin/cross-origin-objects…

### DIFF
--- a/html/browsers/origin/cross-origin-objects/win-documentdomain.sub.html
+++ b/html/browsers/origin/cross-origin-objects/win-documentdomain.sub.html
@@ -19,7 +19,10 @@
         if (++loadCount == 4)
           go();
       }
-      Array.forEach(document.getElementsByTagName('iframe'), function(ifr) { ifr.onload = frameLoaded; });
+      var iframes = document.getElementsByTagName('iframe');
+      for (var i = 0; i < iframes.length; i++) {
+        iframes[i].onload = frameLoaded;
+      }
     }
 
 


### PR DESCRIPTION
…/win-documentdomain.sub.html

This seems to be a Firefox extension and does not work in Chrome or Safari.
This closes issue #3611.
