### PR TITLE
Close coverage gaps identified in review of PR #823

### DIFF
--- a/media-source/mediasource-addsourcebuffer.html
+++ b/media-source/mediasource-addsourcebuffer.html
@@ -29,7 +29,7 @@
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
-              assert_throws("NotSupportedError",
+              assert_throws(new TypeError(),
                           function() { mediaSource.addSourceBuffer(null); },
                           "addSourceBuffer() threw an exception when passed null.");
               test.done();

--- a/media-source/mediasource-is-type-supported.html
+++ b/media-source/mediasource-is-type-supported.html
@@ -5,6 +5,7 @@
         <title>MediaSource.isTypeSupported() test cases.</title>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
+        <script src="mediasource-util.js"></script>
     </head>
     <body>
         <div id="log"></div>
@@ -36,6 +37,12 @@
           ], false, 'Test invalid MIME format');
 
           test_type_support([
+              'xxx',
+              'text/html',
+              'image/jpeg'
+          ], false, 'Test invalid MSE MIME media type');
+
+          test_type_support([
               'audio/webm;codecs="vp8"',
               'audio/mp4;codecs="avc1.4d001e"',
           ], false, 'Test invalid mismatch between major type and codec ID');
@@ -46,7 +53,6 @@
               'video/mp4;codecs="vp8"',
               'video/webm;codecs="mp4a.40.2"',
               'video/mp4;codecs="vorbis"',
-              'video/webm;codecs="mp4a.40.2"',
           ], false, 'Test invalid mismatch between minor type and codec ID');
 
           test_type_support([
@@ -76,6 +82,17 @@
               'video/mp4;codecs="mp4a.40.2 , avc1.4d001e "',
               'video/mp4;codecs="avc1.4d001e,mp4a.40.5"',
           ], true, 'Test valid MP4 type');
+
+          mediasource_test(function(test, mediaElement, mediaSource)
+          {
+              var mimetype = MediaSourceUtil.AUDIO_VIDEO_TYPE;
+              assert_true(MediaSource.isTypeSupported(mimetype));
+
+              var canPlayResult = mediaElement.canPlayType(mimetype);
+
+              assert_true(canPlayResult == "maybe" || canPlayResult == "probably");
+              test.done();
+          }, "isTypeSupported(mime) returning true implies that canPlayType(mime) is either 'probably' or 'maybe'");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-is-type-supported.html
+++ b/media-source/mediasource-is-type-supported.html
@@ -82,17 +82,6 @@
               'video/mp4;codecs="mp4a.40.2 , avc1.4d001e "',
               'video/mp4;codecs="avc1.4d001e,mp4a.40.5"',
           ], true, 'Test valid MP4 type');
-
-          mediasource_test(function(test, mediaElement, mediaSource)
-          {
-              var mimetype = MediaSourceUtil.AUDIO_VIDEO_TYPE;
-              assert_true(MediaSource.isTypeSupported(mimetype));
-
-              var canPlayResult = mediaElement.canPlayType(mimetype);
-
-              assert_true(canPlayResult == "maybe" || canPlayResult == "probably");
-              test.done();
-          }, "isTypeSupported(mime) returning true implies that canPlayType(mime) is either 'probably' or 'maybe'");
         </script>
     </body>
 </html>

--- a/media-source/mediasource-removesourcebuffer.html
+++ b/media-source/mediasource-removesourcebuffer.html
@@ -42,10 +42,45 @@
 
               assert_throws("NotFoundError",
                   function() { mediaSource.removeSourceBuffer(sourceBuffer); },
-                  "removeSourceBuffer() threw an exception when a SourceBuffer that was already removed.");
+                  "removeSourceBuffer() threw an exception for a SourceBuffer that was already removed.");
 
               test.done();
           }, "Test calling removeSourceBuffer() twice with the same object.");
+
+          mediasource_test(function(test, mediaElement1, mediaSource1)
+          {
+              var sourceBuffer1 = mediaSource1.addSourceBuffer(MediaSourceUtil.AUDIO_ONLY_TYPE);
+              assert_class_string(sourceBuffer1, "SourceBuffer", "New SourceBuffer returned");
+
+              var mediaElement2 = document.createElement("video");
+              document.body.appendChild(mediaElement2);
+              test.add_cleanup(function() { document.body.removeChild(mediaElement2); });
+
+              var mediaSource2 = new MediaSource();
+              var mediaSource2URL = URL.createObjectURL(mediaSource2);
+              mediaElement2.src = mediaSource2URL;
+              test.expectEvent(mediaSource2, "sourceopen", "Second MediaSource opened");
+              test.waitForExpectedEvents(function()
+              {
+                  URL.revokeObjectURL(mediaSource2URL);
+
+                  var sourceBuffer2 = mediaSource2.addSourceBuffer(MediaSourceUtil.VIDEO_ONLY_TYPE);
+                  assert_class_string(sourceBuffer2, "SourceBuffer", "Second new SourceBuffer returned");
+                  assert_not_equals(mediaSource1, mediaSource2, "MediaSources are different instances");
+                  assert_not_equals(sourceBuffer1, sourceBuffer2, "SourceBuffers are different instances");
+                  assert_equals(mediaSource1.sourceBuffers[0], sourceBuffer1);
+                  assert_equals(mediaSource2.sourceBuffers[0], sourceBuffer2);
+                  assert_throws("NotFoundError",
+                      function() { mediaSource1.removeSourceBuffer(sourceBuffer2); },
+                      "MediaSource1.removeSourceBuffer() threw an exception for SourceBuffer2");
+                  assert_throws("NotFoundError",
+                      function() { mediaSource2.removeSourceBuffer(sourceBuffer1); },
+                      "MediaSource2.removeSourceBuffer() threw an exception for SourceBuffer1");
+                  mediaSource1.removeSourceBuffer(sourceBuffer1);
+                  mediaSource2.removeSourceBuffer(sourceBuffer2);
+                  test.done();
+              });
+          }, "Test calling removeSourceBuffer() for a sourceBuffer belonging to a different mediaSource instance.");
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {


### PR DESCRIPTION
1. addSourceBuffer(null) should result in TypeError (not
   NotSupportedError as currently expected by
   mediasource-addsourcebuffer.html)
   Note, https://crbug.com/623781 tracks fixing the Chrome M54
   compliance issue behind at least the failure of 2 TypeError subtests
   in mediasource-addsourcebuffer.html.
2. isTypeSupported(mime) returning true should mean that
   canPlayType(mime) is either "maybe" or "probably".
3. Explicitly test isTypeSupported for each of: "xxx", "text/html",
   "image/jpeg" result in false.
4. Explicitly test sourceBuffers added to distinct MediaSource objects
   give error when they are used in removeSourceBuffer to the wrong
   MediaSource. This can be added to mediasource-removesourcebuffer.html

This commit also removes a duplicated invalid type test from
mediasource-is-type-supported.html.
