### PR TITLE
Close coverage gap identified in review of PR #939

### DIFF
--- a/media-source/mediasource-timestamp-offset.html
+++ b/media-source/mediasource-timestamp-offset.html
@@ -17,6 +17,9 @@
                   var segmentInfo = MediaSourceUtil.SEGMENT_INFO;
                   var sourceBuffer = mediaSource.addSourceBuffer(segmentInfo.type);
 
+                  assert_equals(sourceBuffer.timestampOffset, 0,
+                      "Initial timestampOffset of a SourceBuffer is 0");
+
                   if (expected == "TypeError")  {
                       assert_throws({name: "TypeError"},
                           function() { sourceBuffer.timestampOffset = value; },


### PR DESCRIPTION
Adds a trivial assertion that the initial value of a newly added
SourceBuffer.timestampOffset is 0.
