### PR TITLE
Refactor and fix HTMLTrackElement/src.html

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/src.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/src.html
@@ -17,7 +17,7 @@ function resolve(url) {
 }
 
 var tests = [
-  {input:'', expectedIDL:'', desc:'empty string'},
+  {input:'', expectedIDL:resolve(''), desc:'empty string'},
   {input:'http://foo bar', expectedIDL:'http://foo bar', desc:'unresolvable value'},
   {input:'test', expectedIDL:resolve('test'), desc:'resolvable value'},
   // Leading and trailing C0 controls and space is stripped per url spec.

--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/src.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLTrackElement/src.html
@@ -5,73 +5,39 @@
 <div id=log></div>
 <script>
 test(function(){
-    var track = document.createElement('track');
-    assert_equals(track.src, '');
-    assert_equals(track.getAttribute('src'), null);
+  var track = document.createElement('track');
+  assert_equals(track.src, '');
+  assert_equals(track.getAttribute('src'), null);
 }, document.title + ' missing value');
 
-test(function(){
-    var track = document.createElement('track');
-    track.setAttribute('src', '');
-    assert_equals(track.src, '');
-    assert_equals(track.getAttribute('src'), '');
-}, document.title + ' empty string in content attribute');
+function resolve(url) {
+  var link = document.createElement('a');
+  link.setAttribute('href', url);
+  return link.href;
+}
 
-test(function(){
-    var track = document.createElement('track');
-    track.src = '';
-    assert_equals(track.src, '');
-    assert_equals(track.getAttribute('src'), '');
-}, document.title + ' empty string in IDL attribute');
+var tests = [
+  {input:'', expectedIDL:'', desc:'empty string'},
+  {input:'http://foo bar', expectedIDL:'http://foo bar', desc:'unresolvable value'},
+  {input:'test', expectedIDL:resolve('test'), desc:'resolvable value'},
+  // Leading and trailing C0 controls and space is stripped per url spec.
+  {input:'\u0000', expectedIDL:resolve(''), desc:'\\u0000'},
+  {input:'foo\u0000bar', expectedIDL:resolve('foo%00bar'), desc:'foo\\u0000bar'},
+];
 
-test(function(){
-    var track = document.createElement('track');
-    track.setAttribute('src', 'http://foo bar');
-    assert_equals(track.src, 'http://foo bar');
-    assert_equals(track.getAttribute('src'), 'http://foo bar');
-}, document.title + ' unresolvable value in content attribute');
+tests.forEach(function(t) {
+  test(function(){
+      var track = document.createElement('track');
+      track.setAttribute('src', t.input);
+      assert_equals(track.src, t.expectedIDL);
+      assert_equals(track.getAttribute('src'), t.input);
+  }, [document.title, t.desc, 'in content attribute'].join(' '));
 
-test(function(){
-    var track = document.createElement('track');
-    track.setAttribute('src', 'test');
-    var link = document.createElement('a');
-    link.setAttribute('href', 'test');
-    assert_equals(track.src, link.href);
-    assert_equals(track.getAttribute('src'), 'test');
-}, document.title + ' resolvable value in content attribute');
-
-test(function(){
-    var track = document.createElement('track');
-    track.setAttribute('src', '\u0000');
-    var link = document.createElement('a');
-    link.setAttribute('href', '%00');
-    assert_equals(track.src, link.href);
-    assert_equals(track.getAttribute('src'), '\u0000');
-}, document.title + ' \\u0000 in content attribute');
-
-test(function(){
-    var track = document.createElement('track');
-    track.src = 'http://foo bar';
-    assert_equals(track.src, 'http://foo bar');
-    assert_equals(track.getAttribute('src'), 'http://foo bar');
-}, document.title + ' assigning unresolvable value to IDL attribute');
-
-test(function(){
-    var track = document.createElement('track');
-    track.src = 'test';
-    var link = document.createElement('a');
-    link.setAttribute('href', 'test');
-    assert_equals(track.src, link.href);
-    assert_equals(track.getAttribute('src'), 'test');
-}, document.title + ' assigning resolvable value to IDL attribute');
-
-test(function(){
-    var track = document.createElement('track');
-    track.src = '\u0000';
-    var link = document.createElement('a');
-    link.setAttribute('href', '%00');
-    assert_equals(track.src, link.href);
-    assert_equals(track.getAttribute('src'), '\u0000');
-}, document.title + ' assigning \\u0000 to IDL attribute');
-
+  test(function(){
+      var track = document.createElement('track');
+      track.src = t.input;
+      assert_equals(track.src, t.expectedIDL);
+      assert_equals(track.getAttribute('src'), t.input);
+  }, [document.title, 'assigning', t.desc, 'to IDL attribute'].join(' '));
+});
 </script>


### PR DESCRIPTION
Reflecting USVString attributes containing a URL should return
the empty string if the content attribute's value is empty.
Ref. https://github.com/whatwg/html/issues/859

A single \u0000 character gets stripped by the URL parser;
"Remove any leading and trailing C0 controls and space from input."

Fixes #2125. Closes #2663.

---

cc @tkent-google @bzbarsky 
