### PR TITLE
Update reflection tests around URLs

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -135,7 +135,7 @@ var embeddedElements = {
     shape: "string",
     target: "string",
     download: "string",
-    ping: "urls",
+    ping: "string",
     rel: "string",
     relList: {type: "tokenlist", domAttrName: "rel"},
     hreflang: "string",

--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -142,7 +142,7 @@ var embeddedElements = {
     type: "string",
 
     // HTMLHyperlinkElementUtils
-    href: "hyperlink href",
+    href: "url",
 
     // Obsolete
     noHref: "boolean"

--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -142,7 +142,7 @@ var embeddedElements = {
     type: "string",
 
     // HTMLHyperlinkElementUtils
-    href: "url",
+    href: "hyperlink href",
 
     // Obsolete
     noHref: "boolean"

--- a/html/dom/elements-text.js
+++ b/html/dom/elements-text.js
@@ -11,7 +11,7 @@ var textElements = {
     type: "string",
 
     // HTMLHyperlinkElementUtils
-    href: "hyperlink href",
+    href: "url",
 
     // Obsolete
     coords: "string",

--- a/html/dom/elements-text.js
+++ b/html/dom/elements-text.js
@@ -4,14 +4,14 @@ var textElements = {
     // Conforming
     target: "string",
     download: "string",
-    ping: "urls",
+    ping: "string",
     rel: "string",
     relList: {type: "tokenlist", domAttrName: "rel"},
     hreflang: "string",
     type: "string",
 
     // HTMLHyperlinkElementUtils
-    href: "url",
+    href: "hyperlink href",
 
     // Obsolete
     coords: "string",

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -25,30 +25,6 @@ ReflectionTests.start = new Date().getTime();
  */
 ReflectionTests.resolveUrl = function(url) {
     url = String(url);
-    if (url === "") {
-      return url;
-    }
-    return ReflectionTests.hyperlinkHref(url);
-};
-
-/**
- * HTMLHyperLinkElementUtils href
- *
- * The href attribute's getter must run these steps:
- *
- * 1. Reinitialize url.
- * 2. Let url be this element's url.
- * 3. If url is null and this element has no href content attribute, return the
- *    empty string.
- * 4. Otherwise, if url is null, return this element's href content attribute's
- *    value.
- * 5. Return url, serialized.
- *
- * The href attribute's setter must set this element's href content attribute's
- * value to the given value.
- */
-ReflectionTests.hyperlinkHref = function(url) {
-    url = String(url);
     var el = document.createElement("a");
     el.href = url;
     var ret = el.protocol + "//" + el.host + el.pathname + el.search + el.hash;
@@ -185,6 +161,8 @@ ReflectionTests.typeMap = {
      * value of the content attribute must be returned instead, converted to a
      * USVString. On setting, the content attribute must be set to the specified
      * new value."
+     *
+     * Also HTMLHyperLinkElementUtils href, used by a.href and area.href
      */
     "url": {
         "jsType": "string",
@@ -196,20 +174,6 @@ ReflectionTests.typeMap = {
                      {"valueOf":function(){return "test-valueOf";}, toString:null}],
         "domExpected": ReflectionTests.resolveUrl,
         "idlIdlExpected": ReflectionTests.resolveUrl
-    },
-    /**
-     * HTMLHyperLinkElementUtils href, used by a.href and area.href
-     */
-    "hyperlink href": {
-        "jsType": "string",
-        "defaultVal": "",
-        "domTests": ["", " foo   ", "http://site.example/ foo  bar   baz",
-                     "//site.example/path???@#l", binaryString, undefined, 7, 1.5, true,
-                     false, {"test": 6}, NaN, +Infinity, -Infinity, "\0", null,
-                     {"toString":function(){return "test-toString";}},
-                     {"valueOf":function(){return "test-valueOf";}, toString:null}],
-        "domExpected": ReflectionTests.hyperlinkHref,
-        "idlIdlExpected": ReflectionTests.hyperlinkHref
     },
     /**
      * "If a reflecting IDL attribute is a DOMString whose content attribute is

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -10,9 +10,8 @@ ReflectionTests.start = new Date().getTime();
  * algorithm here, because we're not concerned with its correctness -- we're
  * only testing HTML reflection, not Web Addresses.
  *
- * Return "" if the URL couldn't be resolved, since this is really for
- * reflected URL attributes, and those are supposed to return "" if the URL
- * couldn't be resolved.
+ * Return the input if the URL couldn't be resolved, per the spec for
+ * reflected URL attributes.
  *
  * It seems like IE9 doesn't implement URL decomposition attributes correctly
  * for <a>, which causes all these tests to fail.  Ideally I'd do this in some
@@ -25,39 +24,39 @@ ReflectionTests.start = new Date().getTime();
  * special cases for all the values we test.
  */
 ReflectionTests.resolveUrl = function(url) {
-    var el = document.createElement("a");
-    el.href = String(url);
-    var ret = el.protocol + "//" + el.host + el.pathname + el.search + el.hash;
-    if (ret == "//") {
-        return "";
-    } else {
-        return ret;
+    url = String(url);
+    if (url === "") {
+      return url;
     }
+    return ReflectionTests.hyperlinkHref(url);
 };
 
 /**
- * Given some input, convert to a multi-URL value for IDL get per the spec.
+ * HTMLHyperLinkElementUtils href
+ *
+ * The href attribute's getter must run these steps:
+ *
+ * 1. Reinitialize url.
+ * 2. Let url be this element's url.
+ * 3. If url is null and this element has no href content attribute, return the
+ *    empty string.
+ * 4. Otherwise, if url is null, return this element's href content attribute's
+ *    value.
+ * 5. Return url, serialized.
+ *
+ * The href attribute's setter must set this element's href content attribute's
+ * value to the given value.
  */
-ReflectionTests.urlsExpected = function(urls) {
-    var expected = "";
-    // TODO: Test other whitespace?
-    urls = urls + "";
-    var split = urls.split(" ");
-    for (var j = 0; j < split.length; j++) {
-        if (split[j] == "") {
-            continue;
-        }
-        var append = ReflectionTests.resolveUrl(split[j]);
-        if (append == "") {
-            continue;
-        }
-        if (expected == "") {
-            expected = append;
-        } else {
-            expected += " " + append;
-        }
+ReflectionTests.hyperlinkHref = function(url) {
+    url = String(url);
+    var el = document.createElement("a");
+    el.href = url;
+    var ret = el.protocol + "//" + el.host + el.pathname + el.search + el.hash;
+    if (ret == "//") {
+        return url;
+    } else {
+        return ret;
     }
-    return expected;
 };
 
 /**
@@ -177,14 +176,15 @@ ReflectionTests.typeMap = {
                 ]
     },
     /**
-     * "If a reflecting IDL attribute is a DOMString attribute whose content
-     * attribute is defined to contain a URL, then on getting, the IDL
-     * attribute must resolve the value of the content attribute relative to
-     * the element and return the resulting absolute URL if that was
-     * successful, or the empty string otherwise; and on setting, must set the
-     * content attribute to the specified literal value. If the content
-     * attribute is absent, the IDL attribute must return the default value, if
-     * the content attribute has one, or else the empty string."
+     * "If a reflecting IDL attribute is a USVString attribute whose content
+     * attribute is defined to contain a URL, then on getting, if the content
+     * attribute is absent, the IDL attribute must return the empty string.
+     * Otherwise, the IDL attribute must parse the value of the content
+     * attribute relative to the element's node document and if that is
+     * successful, return the resulting URL string. If parsing fails, then the
+     * value of the content attribute must be returned instead, converted to a
+     * USVString. On setting, the content attribute must be set to the specified
+     * new value."
      */
     "url": {
         "jsType": "string",
@@ -198,20 +198,9 @@ ReflectionTests.typeMap = {
         "idlIdlExpected": ReflectionTests.resolveUrl
     },
     /**
-     * "If a reflecting IDL attribute is a DOMString attribute whose content
-     * attribute is defined to contain one or more URLs, then on getting, the
-     * IDL attribute must split the content attribute on spaces and return the
-     * concatenation of resolving each token URL to an absolute URL relative to
-     * the element, with a single U+0020 SPACE character between each URL,
-     * ignoring any tokens that did not resolve successfully. If the content
-     * attribute is absent, the IDL attribute must return the default value, if
-     * the content attribute has one, or else the empty string. On setting, the
-     * IDL attribute must set the content attribute to the specified literal
-     * value."
-     *
-     * Seems to only be used for ping.
+     * HTMLHyperLinkElementUtils href, used by a.href and area.href
      */
-    "urls": {
+    "hyperlink href": {
         "jsType": "string",
         "defaultVal": "",
         "domTests": ["", " foo   ", "http://site.example/ foo  bar   baz",
@@ -219,8 +208,8 @@ ReflectionTests.typeMap = {
                      false, {"test": 6}, NaN, +Infinity, -Infinity, "\0", null,
                      {"toString":function(){return "test-toString";}},
                      {"valueOf":function(){return "test-valueOf";}, toString:null}],
-        "domExpected": ReflectionTests.urlsExpected,
-        "idlIdlExpected": ReflectionTests.urlsExpected
+        "domExpected": ReflectionTests.hyperlinkHref,
+        "idlIdlExpected": ReflectionTests.hyperlinkHref
     },
     /**
      * "If a reflecting IDL attribute is a DOMString whose content attribute is


### PR DESCRIPTION
Empty string should reflect to empty string for everything except
a.href and area.href; those use HTMLHyperLinkElementUtils.

If a URL fails to resolve, return the input string instead of the
empty string.

Change a.ping to reflect as a normal string.
