### PR TITLE
Combine headers without extra space, per spec

### DIFF
--- a/fetch/api/headers/headers-combine.html
+++ b/fetch/api/headers/headers-combine.html
@@ -18,8 +18,8 @@
                               ["triple", "tripleValue3"]
       ];
       var expectedDict = {"single": "singleValue",
-                          "double": "doubleValue1, doubleValue2",
-                          "triple": "tripleValue1, tripleValue2, tripleValue3"
+                          "double": "doubleValue1,doubleValue2",
+                          "triple": "tripleValue1,tripleValue2,tripleValue3"
       };
 
       test(function() {
@@ -51,7 +51,7 @@
         for (name in expectedDict) {
           var value = headers.get(name);
           headers.append(name,"newSingleValue");
-          assert_equals(headers.get(name), (value + ", " + "newSingleValue"),
+          assert_equals(headers.get(name), (value + "," + "newSingleValue"),
             "name: " + name + " has value: " + headers.get(name));
         }
       }, "Check append methods when called with already used name");


### PR DESCRIPTION
This came up in https://github.com/servo/servo/pull/13004 when we realized that following the specification for combining header values didn't pass these tests. The specification dictates that header values should be combined with `,`, but the test uses `,[space]`. Firefox and Chrome have not yet updated their respective Headers implementations to match https://github.com/whatwg/fetch/commit/42464c8c3d2fd3437a19fc6afd2438a0fd42dde8 (but FF's is in progress at https://bugzilla.mozilla.org/show_bug.cgi?id=1278275), and I assume Webkit's implementation is passing this test as written (and therefore not following the specification).

cc @youennf @annevk @malisas @jeenalee
