### PR TITLE
Fix addSourceBuffer(null) test case expectation

### DIFF
--- a/media-source/mediasource-addsourcebuffer.html
+++ b/media-source/mediasource-addsourcebuffer.html
@@ -29,7 +29,7 @@
 
           mediasource_test(function(test, mediaElement, mediaSource)
           {
-              assert_throws(new TypeError(),
+              assert_throws("NotSupportedError",
                           function() { mediaSource.addSourceBuffer(null); },
                           "addSourceBuffer() threw an exception when passed null.");
               test.done();


### PR DESCRIPTION
A null value passed to a non-nullable method DOMString argument is
converted to a DOMString "null". Therefore, it is not an empty string,
and the addSourceBuffer() implementation should instead throw a
NotSupportedException per the spec:

"If type contains a MIME type that is not supported or contains a MIME
type that is not supported with the types specified for the other
SourceBuffer objects in sourceBuffers, then throw a NotSupportedError
exception and abort these steps."
