### PR TITLE
Update the expectation of document.currentScript in shadow root.

### DIFF
--- a/shadow-dom/Document-prototype-currentScript.html
+++ b/shadow-dom/Document-prototype-currentScript.html
@@ -20,7 +20,7 @@ function testInlineScript(mode)
         var host = document.createElement('div');
         var shadowRoot = host.attachShadow({mode: mode});
         var scriptElement = document.createElement('script');
-        scriptElement.textContent = 'assert_equals(document.currentScript, outerScriptElement)';
+        scriptElement.textContent = 'assert_equals(document.currentScript, null)';
         shadowRoot.appendChild(scriptElement);
 
         assert_equals(document.currentScript, outerScriptElement,


### PR DESCRIPTION
According to
https://html.spec.whatwg.org/multipage/scripting.html#execute-the-script-block

In 5. "Switch on the script's type:" -> "classic",

> If the script element's root is not a shadow root, ... Otherwise, set
> it to null.

While script in a shadow tree is running, document.currentScript should
not return the previous (top on the stack) currentScript, but should
return null.
