### PR TITLE
Update audio_constructor.html so that it expects calling Audio() to t…

### DIFF
--- a/html/semantics/embedded-content/the-audio-element/audio_constructor.html
+++ b/html/semantics/embedded-content/the-audio-element/audio_constructor.html
@@ -11,18 +11,12 @@ test(function() {
     valueOf: function() { throw Error() }
   };
   var tests = [
-    [function() { return Audio() }, null, "No arguments, without new"],
-    [function() { return new Audio() }, null, "No arguments, with new"],
-    [function() { return Audio("") }, "", "Empty string argument, without new"],
-    [function() { return new Audio("") }, "", "Empty string argument, with new"],
-    [function() { return Audio("src") }, "src", "Non-empty string argument, without new"],
-    [function() { return new Audio("src") }, "src", "Non-empty string argument, with new"],
-    [function() { return Audio(null) }, "null", "Null argument, without new"],
-    [function() { return new Audio(null) }, "null", "Null argument, with new"],
-    [function() { return Audio(undefined) }, null, "Undefined argument, without new"],
-    [function() { return new Audio(undefined) }, null, "Undefined argument, with new"],
-    [function() { return Audio("", throwingObject) }, "", "Extra argument, without new"],
-    [function() { return new Audio("", throwingObject) }, "", "Extra argument, with new"],
+    [function() { return new Audio() }, null, "No arguments"],
+    [function() { return new Audio("") }, "", "Empty string argument"],
+    [function() { return new Audio("src") }, "src", "Non-empty string argument"],
+    [function() { return new Audio(null) }, "null", "Null argument"],
+    [function() { return new Audio(undefined) }, null, "Undefined argument"],
+    [function() { return new Audio("", throwingObject) }, "", "Extra argument"],
   ];
   tests.forEach(function(t) {
     var fn = t[0], expectedSrc = t[1], description = t[2];
@@ -38,6 +32,11 @@ test(function() {
     }, description);
   });
 });
+test(function() {
+  assert_throws(new TypeError(), function() {
+    Audio();
+  });
+}, "Calling Audio should throw");
 test(function() {
   assert_throws(new TypeError(), function() {
     HTMLAudioElement();


### PR DESCRIPTION
…hrow

Update audio_constructor.html so that it expects calling Audio() to throw
instead of expecting it to constructor an HTMLAudioElement object. I don't
see any reason why calling Audio() without new would work.

I have verified that calling Audio() without new throws in Firefox, Chrome
and Safari.
