### PR TITLE
MSE: Fixed race condition between IDL tests and "load" event on window

### DIFF
--- a/media-source/interfaces.html
+++ b/media-source/interfaces.html
@@ -139,6 +139,7 @@ enum TrackDefaultType {
 </script>
 <script>
 "use strict";
+setup({ explicit_done: true });
 var mediaSource;
 var sourceBuffer;
 var video = document.createElement("video");
@@ -159,6 +160,7 @@ var idlCheck = function() {
     TrackDefaultList: ['sourceBuffer.trackDefaults']
   });
   idlArray.test();
+  done();
 }
 mediaSource = new MediaSource();
 video.src = URL.createObjectURL(mediaSource);


### PR DESCRIPTION
The IDL tests are run asynchronously, when the MediaSource and SourceBuffer objects are ready for action. The problem is that the "load" event will have already fired on Window by that time, and the test harness missed the end of the tests as a result. I'm not entirely clear why the test harness never timed out.

The update tells the test harness explicitly when tests are done being added, which in turn forces the test harness to evaluate tests completion and signal the end.

(Note the IDL tests ran correctly in MS Edge because Edge fails to reset the "delay-the-load-event" flag, and thus does not fire the "load" event as long as the MediaSource object is not properly closed. The test harness now times out in MS Edge because it never gets the "load" event).
