### PR TITLE
Don't require pan scrolling all the way to the origin.

### DIFF
--- a/pointerevents/pointerevent_touch-action-pan-left-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-left-css_touch-manual.html
@@ -18,7 +18,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll element DOWN (drag up), then RIGHT (drag left), then LEFT (drag right as far as possible). Tap Complete button under the rectangle when done. Expected: only pans in left direction.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN (drag up), then RIGHT (drag left), then LEFT (drag right). Tap Complete button under the rectangle when done. Expected: only pans in left direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div id="target0">
             <p>
@@ -97,7 +97,7 @@
                     detected_pointertypes[event.pointerType] = true;
                     test_touchaction.step(function() {
                         assert_true(scrollListenerExecuted, "scroll listener should have been executed by the end of the test");
-                        assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
+                        assert_less_than(target0.scrollLeft, 200, "scroll x offset should be less than 200 in the end of the test");
                         assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
                     });
                     test_touchaction.done();

--- a/pointerevents/pointerevent_touch-action-pan-up-css_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-pan-up-css_touch-manual.html
@@ -18,7 +18,7 @@
     </head>
     <body onload="run()">
         <h1>Pointer Events touch-action attribute support</h1>
-        <h4 id="desc">Test Description: Try to scroll element DOWN (drag up), then RIGHT (drag left), then UP (drag down as far as possible). Tap Complete button under the rectangle when done. Expected: only pans in up direction.</h4>
+        <h4 id="desc">Test Description: Try to scroll element DOWN (drag up), then RIGHT (drag left), then UP (drag down). Tap Complete button under the rectangle when done. Expected: only pans in up direction.</h4>
         <p>Note: this test is for touch-devices only</p>
         <div id="target0">
             <p>
@@ -98,7 +98,7 @@
                     test_touchaction.step(function() {
                         assert_true(scrollListenerExecuted, "scroll listener should have been executed by the end of the test");
                         assert_equals(target0.scrollLeft, 0, "scroll x offset should be 0 in the end of the test");
-                        assert_equals(target0.scrollTop, 0, "scroll y offset should be 0 in the end of the test");
+                        assert_less_than(target0.scrollTop, 200, "scroll y offset should be less than 200 in the end of the test");
                     });
                     test_touchaction.done();
                     updateDescriptionComplete();


### PR DESCRIPTION
NavidZ indicates that this is easier for automation in chrome.
