### PR TITLE
Drop iframe.seamless attribute checking from HTML reflection test

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -26,7 +26,6 @@ var embeddedElements = {
     srcdoc: "string",
     name: "string",
     sandbox: "settable tokenlist",
-    seamless: "boolean",
     allowFullscreen: "boolean",
     width: "string",
     height: "string",


### PR DESCRIPTION
Drop iframe.seamless attribute checking from HTML reflection test as it is no
longer part of the specification.
