### PR TITLE
Fix #3662: Use long timeout and audio-only stream

### DIFF
--- a/media-source/mediasource-appendbuffer-quota-exceeded.html
+++ b/media-source/mediasource-appendbuffer-quota-exceeded.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="mediasource-util.js"></script>
 <script>
+    var subType = MediaSourceUtil.getSubType(MediaSourceUtil.VIDEO_ONLY_TYPE);
+    var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
+
     // Fill up a given SourceBuffer by appending data repeatedly via doAppendDataFunc until
     // an exception is thrown. The thrown exception is passed to onCaughtExceptionCallback.
     function fillUpSourceBuffer(test, sourceBuffer, doAppendDataFunc, onCaughtExceptionCallback) {
@@ -19,16 +23,21 @@
         test.waitForExpectedEvents(function() { fillUpSourceBuffer(test, sourceBuffer, doAppendDataFunc, onCaughtExceptionCallback); });
     }
 
-    mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
+    mediasource_test(function(test, mediaElement, mediaSource)
     {
-        sourceBuffer.mode = 'sequence';
-        fillUpSourceBuffer(test, sourceBuffer,
-            function () { // doAppendDataFunc
-                sourceBuffer.appendBuffer(mediaData);
-            },
-            function (ex) { // onCaughtExceptionCallback
-                assert_equals(ex.name, 'QuotaExceededError');
-                test.done();
-            });
+        mediaElement.addEventListener("error", test.unreached_func("Unexpected event 'error'"));
+        MediaSourceUtil.fetchManifestAndData(test, manifestFilenameAudio, function(typeAudio, dataAudio)
+        {
+            var sourceBuffer = mediaSource.addSourceBuffer(typeAudio);
+            sourceBuffer.mode = 'sequence';
+            fillUpSourceBuffer(test, sourceBuffer,
+                function () { // doAppendDataFunc
+                    sourceBuffer.appendBuffer(dataAudio);
+                },
+                function (ex) { // onCaughtExceptionCallback
+                    assert_equals(ex.name, 'QuotaExceededError');
+                    test.done();
+                });
+        });
     }, 'Appending data repeatedly should fill up the buffer and throw a QuotaExceededError when buffer is full.');
 </script>

--- a/media-source/mediasource-appendbuffer-quota-exceeded.html
+++ b/media-source/mediasource-appendbuffer-quota-exceeded.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="mediasource-util.js"></script>
 <script>
-    var subType = MediaSourceUtil.getSubType(MediaSourceUtil.VIDEO_ONLY_TYPE);
+    var subType = MediaSourceUtil.getSubType(MediaSourceUtil.AUDIO_ONLY_TYPE);
     var manifestFilenameAudio = subType + "/test-a-128k-44100Hz-1ch-manifest.json";
 
     // Fill up a given SourceBuffer by appending data repeatedly via doAppendDataFunc until


### PR DESCRIPTION
If implementations still fail, it's likely their heuristic is
different for determining QuotaExceededError and this test result
might need to be ignored.
