### PR TITLE
Drop area.hreflang / area.type from HTML reflection test

### DIFF
--- a/html/dom/elements-embedded.js
+++ b/html/dom/elements-embedded.js
@@ -137,8 +137,6 @@ var embeddedElements = {
     ping: "urls",
     rel: "string",
     relList: {type: "tokenlist", domAttrName: "rel"},
-    hreflang: "string",
-    type: "string",
 
     // HTMLHyperlinkElementUtils
     href: "url",


### PR DESCRIPTION
Drop area.hreflang / area.type from HTML reflection test given that these attributes are
obsolete and no longer part of the HTML specification.
