### PR TITLE
Add tests for <input> cloning steps

### DIFF
--- a/html/semantics/forms/the-input-element/cloning-steps.html
+++ b/html/semantics/forms/the-input-element/cloning-steps.html
@@ -13,39 +13,39 @@
 <script>
 "use strict";
 
-test(() => {
-  const input = document.createElement("input");
+test(function() {
+  var input = document.createElement("input");
   input.value = "foo bar";
 
-  const copy = input.cloneNode();
+  var copy = input.cloneNode();
   assert_equals(copy.value, "foo bar");
 }, "input element's value should be cloned");
 
-test(() => {
-  const input = document.createElement("input");
+test(function() {
+  var input = document.createElement("input");
   input.value = "foo bar";
 
-  const copy = input.cloneNode();
+  var copy = input.cloneNode();
   copy.setAttribute("value", "something else");
 
   assert_equals(copy.value, "foo bar");
 }, "input element's dirty value flag should be cloned, so setAttribute doesn't affect the cloned input's value");
 
-test(() => {
-  const input = document.createElement("input");
+test(function() {
+  var input = document.createElement("input");
   input.setAttribute("type", "radio");
   input.checked = true;
 
-  const copy = input.cloneNode();
+  var copy = input.cloneNode();
   assert_equals(copy.checked, true);
 }, "input element's checkedness should be cloned");
 
-test(() => {
-  const input = document.createElement("input");
+test(function() {
+  var input = document.createElement("input");
   input.setAttribute("type", "radio");
   input.checked = false;
 
-  const copy = input.cloneNode();
+  var copy = input.cloneNode();
   copy.setAttribute("checked", "checked");
 
   assert_equals(copy.checked, false);

--- a/html/semantics/forms/the-input-element/cloning-steps.html
+++ b/html/semantics/forms/the-input-element/cloning-steps.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cloning of input elements</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone-ext">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#the-input-element:concept-node-clone-ext">
+<link rel="author" title="Matthew Phillips" href="mailto:matthew@matthewphillips.info">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const input = document.createElement("input");
+  input.value = "foo bar";
+
+  const copy = input.cloneNode();
+  assert_equals(copy.value, "foo bar");
+}, "input element's value should be cloned");
+
+test(() => {
+  const input = document.createElement("input");
+  input.value = "foo bar";
+
+  const copy = input.cloneNode();
+  copy.setAttribute("value", "something else");
+
+  assert_equals(copy.value, "foo bar");
+}, "input element's dirty value flag should be cloned, so setAttribute doesn't affect the cloned input's value");
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "radio");
+  input.checked = true;
+
+  const copy = input.cloneNode();
+  assert_equals(copy.checked, true);
+}, "input element's checkedness should be cloned");
+
+test(() => {
+  const input = document.createElement("input");
+  input.setAttribute("type", "radio");
+  input.checked = false;
+
+  const copy = input.cloneNode();
+  copy.setAttribute("checked", "checked");
+
+  assert_equals(copy.checked, false);
+}, "input element's dirty checkedness should be cloned, so setAttribute doesn't affect the cloned input's checkedness");
+</script>


### PR DESCRIPTION
Upstreamed from https://github.com/tmpvar/jsdom/blob/13badf0b0cec67b50f019442dafe091230a6b9cb/test/web-platform-tests/to-upstream/dom/nodes/Node-cloneNode-input.html

/cc @matthewp (the original author of the tests)
