### PR TITLE
Drop style.scoped attribute testing from HTML reflection test

### DIFF
--- a/html/dom/elements-metadata.js
+++ b/html/dom/elements-metadata.js
@@ -34,7 +34,6 @@ var metadataElements = {
   style: {
     media: "string",
     type: "string",
-    scoped: "boolean",
   },
 };
 


### PR DESCRIPTION
Drop style.scoped attribute testing from HTML reflection test as it is no
longer part of the HTML specification.
