### PR TITLE
Drop testing for table.sortable attribute from HTML reflection test

### DIFF
--- a/html/dom/elements-tabular.js
+++ b/html/dom/elements-tabular.js
@@ -1,9 +1,6 @@
 // Up-to-date as of 2013-04-12.
 var tabularElements = {
   table: {
-    // Conforming
-    sortable: "boolean",
-
     // Obsolete
     align: "string",
     border: "string",


### PR DESCRIPTION
Drop testing for table.sortable attribute from HTML reflection test given that
it is no longer in the HTML specification.
