### PR TITLE
Add IDL tests for SecurityPolicyViolationEvent.

### DIFF
--- a/content-security-policy/reporting/securitypolicyviolation-idl.html
+++ b/content-security-policy/reporting/securitypolicyviolation-idl.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SecurityPolicyViolationEvent IDL Tests</title>
+<link rel="author" title="Louay Bassbouss" href="http://www.fokus.fraunhofer.de">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+
+<script id="idl" type="text/plain">
+[Constructor(DOMString type, optional SecurityPolicyViolationEventInit eventInitDict)]
+interface SecurityPolicyViolationEvent : Event {
+    readonly    attribute DOMString      documentURI;
+    readonly    attribute DOMString      referrer;
+    readonly    attribute DOMString      blockedURI;
+    readonly    attribute DOMString      violatedDirective;
+    readonly    attribute DOMString      effectiveDirective;
+    readonly    attribute DOMString      originalPolicy;
+    readonly    attribute DOMString      disposition;
+    readonly    attribute DOMString      sourceFile;
+    readonly    attribute unsigned short statusCode;
+    readonly    attribute long           lineNumber;
+    readonly    attribute long           columnNumber;
+};
+
+dictionary SecurityPolicyViolationEventInit : EventInit {
+    DOMString      documentURI;
+    DOMString      referrer;
+    DOMString      blockedURI;
+    DOMString      violatedDirective;
+    DOMString      effectiveDirective;
+    DOMString      originalPolicy;
+    DOMString      disposition;
+    DOMString      sourceFile;
+    unsigned short statusCode;
+    long           lineNumber;
+    long           columnNumber;
+};
+</script>
+<script>
+    (function() {
+        var idl_array = new IdlArray();
+        var idls = document.getElementById('idl').textContent;
+        idl_array.add_idls(idls);
+
+        window.event_to_test = new SecurityPolicyViolationEvent({});
+
+        idl_array.add_objects({
+          SecurityPolicyViolationEvent: ['event_to_test']
+        });
+        idl_array.test();
+    })();
+</script>


### PR DESCRIPTION
As defined in https://w3c.github.io/webappsec-csp/#securitypolicyviolationevent.

Chrome passes 24/29. Firefox doesn't (yet) implement the interface.
