### PR TITLE
Add tests for <textarea> cloning steps

### DIFF
--- a/html/semantics/forms/the-textarea-element/cloning-steps.html
+++ b/html/semantics/forms/the-textarea-element/cloning-steps.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cloning of textarea elements</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone-ext">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-node-clone-ext">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const textarea = document.createElement("textarea");
+  textarea.value = "foo bar";
+
+  const copy = textarea.cloneNode();
+  assert_equals(copy.value, "foo bar");
+}, "textarea element's value should be cloned");
+
+test(() => {
+  const textarea = document.createElement("textarea");
+  textarea.value = "foo bar";
+
+  const copy = textarea.cloneNode();
+  copy.setAttribute("value", "something else");
+
+  assert_equals(copy.value, "foo bar");
+}, "textarea element's dirty value flag should be cloned, so setAttribute doesn't affect the cloned textarea's value");
+
+</script>


### PR DESCRIPTION
These were added in https://github.com/whatwg/html/commit/957fd0c91c6ee3abd77538be3a2b4c5531754f62.
