### PR TITLE
Remove reference to AnimationPlayerEvent

### DIFF
--- a/dom/nodes/Document-createEvent.html
+++ b/dom/nodes/Document-createEvent.html
@@ -72,7 +72,6 @@ test(function() {
  * interfaces that it is known some UA does or did not throw for.
  */
 var someNonCreateableEvents = [
-  "AnimationPlayerEvent",
   "ApplicationCacheErrorEvent",
   "AudioProcessingEvent",
   "AutocompleteErrorEvent",


### PR DESCRIPTION
https://codereview.chromium.org/2344473002 renames AnimationPlayerEvent
to AnimationPlaybackEvent in Chromium. dom/nodes/Document-createEvent.html
refers to the old name (added by @foolip in
https://github.com/w3c/web-platform-tests/commit/760b8955f804ffbbd4240c185eb109364bb186e1).
On the review of the Chromium patch, foolip suggests removing this line,
noting that new events aren't getting this treatment any more.
