### PR TITLE
Sort arrays before comparison in html/dom/documents/dom-tree-accessor…

### DIFF
--- a/html/dom/documents/dom-tree-accessors/document.forms.html
+++ b/html/dom/documents/dom-tree-accessors/document.forms.html
@@ -53,7 +53,7 @@ test(function() {
   for (var p in document.forms) {
     result.push(p);
   }
-  assert_array_equals(result, ["0", "1", "2", "item", "namedItem", "length"])
+  assert_array_equals(result.sort(), ["0", "1", "2", "item", "namedItem", "length"].sort())
 }, "document.forms iteration")
 
 test(function() {


### PR DESCRIPTION
…s/document.forms.html

Sort arrays before comparison in html/dom/documents/dom-tree-accessors/document.forms.html.
The test expected the HTMLCollection properties to be enumerated in the following order:
"item", "namedItem", "length". I am not aware of any particular reason why these need to
be in this specific order (even though they are in Firefox).

In WebKit, for example, those are in the following order: "length", "item", "namedItem",
which corresponds to the order in which they are in the specification's IDL:
- https://dom.spec.whatwg.org/#htmlcollection
