### PR TITLE
Expand on the Touch constructor tests

### DIFF
--- a/touch-events/touch-touchevent-constructor.html
+++ b/touch-events/touch-touchevent-constructor.html
@@ -10,9 +10,38 @@
 <div id="target0"></div>
 <script>
 test(function() {
-    assert_throws(new TypeError(), function() {new Touch();}, "Touch constructor requires initialize dictionary");
-    assert_throws(new TypeError(), function() {new Touch({});}, "Touch constructor requires identifier and target");
-}, "Create a Touch object with insufficient properties");
+    var testIdentifier = 0;
+    var testTarget = document.getElementById('target0');
+
+    assert_throws(new TypeError(), function() {new Touch();}, "Touch constructor with no argument");
+    assert_throws(new TypeError(), function() {new Touch(null);}, "Touch constructor with null argument");
+    assert_throws(new TypeError(), function() {new Touch(undefined);}, "Touch constructor with undefined argument");
+    assert_throws(new TypeError(), function() {new Touch({});}, "Touch constructor with empty object");
+    assert_throws(new TypeError(), function() {new Touch({
+        identifier: testIdentifier
+    });}, "Touch constructor with only identifier");
+    assert_throws(new TypeError(), function() {new Touch({
+        target: testTarget
+    });}, "Touch constructor with only target");
+}, "Touch constructor with insufficient properties");
+
+test(function() {
+    var testIdentifier = 0;
+    var testTarget = document.getElementById('target0');
+
+    assert_throws(new TypeError(), function() {new Touch({
+        identifier: testIdentifier,
+        target: null
+    });}, "Touch constructor with null target");
+    assert_throws(new TypeError(), function() {new Touch({
+        identifier: testIdentifier,
+        target: undefined
+    });}, "Touch constructor with undefined target");
+    assert_throws(new TypeError(), function() {new Touch({
+        identifier: testIdentifier,
+        target: location
+    });}, "Touch constructor with Location target");
+}, "Touch constructor with non-EventTarget target");
 
 test(function() {
     var testIdentifier = 74;


### PR DESCRIPTION
Chrome currently fails the new Touch({ identifier: 0, target: null })
test, while Safari fails even more, allowing even new Touch().
