### PR TITLE
Request audio instead of video for MediaStreamTrackEvent test

### DIFF
--- a/mediacapture-streams/MediaStreamTrackEvent-constructor.https.html
+++ b/mediacapture-streams/MediaStreamTrackEvent-constructor.https.html
@@ -31,7 +31,7 @@ test(function() {
 
 // a MediaStreamTrack instance is needed to test, any instance will do.
 promise_test(function() {
-  return navigator.mediaDevices.getUserMedia({ video: true })
+  return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(function(stream) {
       var track = stream.getTracks()[0];
       assert_true(track instanceof MediaStreamTrack);


### PR DESCRIPTION
It turns out that when testing in BrowserStack, requesting video fails
in Edge and Firefox, but requesting audio works. It doesn't matter what
kind of MediaStreamTrack is used, so go with audio.

Follow-up to 37153a1fe0517e79074e70e47d4067f879b9b2d4.
