### PR TITLE
Add EventHandler stub to interfaces.html

### DIFF
--- a/media-source/interfaces.html
+++ b/media-source/interfaces.html
@@ -12,6 +12,7 @@ interface EventTarget {
   void removeEventListener(DOMString type, EventListener? callback, optional boolean capture /* = false */);
   boolean dispatchEvent(Event event);
 };
+interface EventHandler {};
 interface URL {};
 interface HTMLVideoElement {};
 interface AudioTrack {};


### PR DESCRIPTION
Without an explicit EventHandler entry, the typeof test for MediaSource, SourceBuffer, and SourceBufferList will fail with an "Unrecognized type EventHandler" error.
