### PR TITLE
[eme] Fix comment and spacing in generate-request-disallowed-input.js

### DIFF
--- a/encrypted-media/scripts/generate-request-disallowed-input.js
+++ b/encrypted-media/scripts/generate-request-disallowed-input.js
@@ -1,23 +1,23 @@
 function runTest(config,qualifier) {
 
-    // Create a session and call generateRequest() temporary,  |initDataType|
-    // and |initData|. generateRequest() should fail temporary,  an
-    // InvalidAccessError. Returns a promise that resolves successfully
-    // if the error happened, rejects otherwise.
-    function test_session(keysystem,initDataType, initData)
+    // Create a "temporary" session for |keysystem| and call generateRequest()
+    // with the provided initData. generateRequest() should fail with an
+    // InvalidAccessError. Returns a promise that is resolved
+    // if the error occurred and rejected otherwise.
+    function test_session(keysystem, initDataType, initData)
     {
         return isInitDataTypeSupported(initDataType).then(function(result) {
             // If |initDataType| is not supported, simply succeed.
             if (!result)
                 return Promise.resolve('Not supported');
 
-            return navigator.requestMediaKeySystemAccess( keysystem, getSimpleConfigurationForInitDataType(initDataType)).then(function(access) {
+            return navigator.requestMediaKeySystemAccess(keysystem, getSimpleConfigurationForInitDataType(initDataType)).then(function(access) {
                 return access.createMediaKeys();
             }).then(function(mediaKeys) {
-                var mediaKeySession = mediaKeys.createSession();
+                var mediaKeySession = mediaKeys.createSession("temporary");
                 return mediaKeySession.generateRequest(initDataType, initData);
             }).then(function() {
-                assert_unreached('generateRequest() succeeded');
+                assert_unreached('generateRequest() succeeded unexpectedly');
             }, function(error) {
                 assert_equals(error.name, 'InvalidAccessError');
                 return Promise.resolve('success');
@@ -28,19 +28,19 @@ function runTest(config,qualifier) {
     promise_test(function()
     {
         var initData = new Uint8Array(70000);
-        return test_session(config.keysystem,'webm', initData);
+        return test_session(config.keysystem, 'webm', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, webm, initData longer than 64Kb characters');
 
     promise_test(function()
     {
         var initData = new Uint8Array(70000);
-        return test_session(config.keysystem,'cenc', initData);
+        return test_session(config.keysystem, 'cenc', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, cenc, initData longer than 64Kb characters');
 
     promise_test(function()
     {
         var initData = new Uint8Array(70000);
-        return test_session(config.keysystem,'keyids', initData);
+        return test_session(config.keysystem, 'keyids', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, keyids, initData longer than 64Kb characters');
 
     promise_test(function()
@@ -56,7 +56,7 @@ function runTest(config,qualifier) {
             0xAC, 0xE3, 0x3C, 0x1E, 0x52, 0xE2, 0xFB, 0x4B,
             0x00, 0x00, 0x00, 0x00                           // datasize
         ]);
-        return test_session(config.keysystem,'cenc', initData);
+        return test_session(config.keysystem, 'cenc', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, cenc, invalid initdata (invalid pssh)');
 
     promise_test(function()
@@ -71,7 +71,7 @@ function runTest(config,qualifier) {
             0xAC, 0xE3, 0x3C, 0x1E, 0x52, 0xE2, 0xFB, 0x4B,
             0x00, 0x00, 0x00, 0x00                           // datasize
         ]);
-        return test_session(config.keysystem,'cenc', initData);
+        return test_session(config.keysystem, 'cenc', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, cenc, invalid initdata (not pssh)');
 
     promise_test(function()
@@ -79,7 +79,7 @@ function runTest(config,qualifier) {
         // Valid key ID size must be at least 1 character for keyids.
         var keyId = new Uint8Array(0);
         var initData = stringToUint8Array(createKeyIDs(keyId));
-        return test_session(config.keysystem,'keyids', initData);
+        return test_session(config.keysystem, 'keyids', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, keyids, invalid initdata (too short key ID)');
 
     promise_test(function()
@@ -87,6 +87,6 @@ function runTest(config,qualifier) {
         // Valid key ID size must be less than 512 characters for keyids.
         var keyId = new Uint8Array(600);
         var initData = stringToUint8Array(createKeyIDs(keyId));
-        return test_session(config.keysystem,'keyids', initData);
+        return test_session(config.keysystem, 'keyids', initData);
     }, testnamePrefix( qualifier, config.keysystem ) + ', temporary, keyids, invalid initdata (too long key ID)');
 }


### PR DESCRIPTION
The comment appears to have been affected by search-and-replace in
https://github.com/w3c/web-platform-tests/commit/92c08bb21ecab7aa9ad7bf968fafdf20cf945642#diff-7e43fcd74010af0826b44fc88922ac61.

Also makes the use of "temporary" sessions more explicit and clarifies the failure message.
