### PR TITLE
Add a test for custom events in a document without a browsing context

### DIFF
--- a/dom/events/Event-dispatch-other-document.html
+++ b/dom/events/Event-dispatch-other-document.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Custom event on an element in another document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+test(function() {
+  var doc = document.implementation.createHTMLDocument("Demo");
+  var element = doc.createElement("div");
+  var called = false;
+  element.addEventListener("foo", this.step_func(function(ev) {
+    assert_false(called);
+    called = true;
+    assert_equals(ev.target, element);
+  }));
+  doc.body.appendChild(element);
+
+  var event = new Event("foo");
+  element.dispatchEvent(event);
+  assert_true(called);
+});
+</script>


### PR DESCRIPTION
This adds a test for dispatching custom events on documents created with
`document.implementation.createHTMLDocument`. This test passes in Chrome
53, Firefox 49, and fails in Safari 9.1.2.
