### PR TITLE
Test that removed canvas stuff is not supported

### DIFF
--- a/html/semantics/embedded-content/the-canvas-element/historical.html
+++ b/html/semantics/embedded-content/the-canvas-element/historical.html
@@ -9,6 +9,7 @@ var canvas, context;
 setup(function() {
   canvas = document.createElement("canvas");
   context = canvas.getContext('2d');
+  path2d = new Path2D();
 });
 function t(member, obj) {
   var name = obj === canvas ? "Canvas" : String(obj).match(/\[object (\S+)\]/)[1];
@@ -40,4 +41,37 @@ test(function() {
     new CanvasRenderingContext2D(1, 1);
   }, 'with arguments');
 }, "CanvasRenderingContext2D constructors");
+
+// removed in https://github.com/whatwg/html/commit/e1d04f49a38e2254a783c28987457a95a47d9511
+t("addPathByStrokingPath", path2d);
+t("addText", path2d);
+t("addPathByStrokingText", path2d);
+
+// renamed in https://github.com/whatwg/html/commit/fcb0756dd94d96df9b8355741d82fcd5ca0a6154
+test(function() {
+  var canvas = document.createElement('canvas');
+  var context = canvas.getContext('bitmaprenderer');
+  if (context) {
+    assert_false('transferImageBitmap' in context);
+  }
+}, 'ImageBitmapRenderingContext support for transferImageBitmap');
+
+// renamed in https://github.com/whatwg/html/commit/3aec2a7e04a3402201afd29c224b57fa54497517
+t('Path', window);
+
+// removed in https://github.com/whatwg/html/commit/d5759b0435091e4858c9bff90319cbe5b040eda2
+t('toDataURLHD', canvas);
+t('toBlobHD', canvas);
+t('createImageDataHD', context);
+t('getImageDataHD', context);
+t('putImageDataHD', context);
+test(function() {
+  if ('ImageData' in window) {
+    assert_false('resolution' in new ImageData(1, 1));
+  }
+}, 'ImageData support for resolution');
+
+// dropped/renamed in https://github.com/whatwg/html/commit/ff07c6d630fb986f6c4f64b2fb87387b4f89647d
+t('drawSystemFocusRing', context);
+t('drawCustomFocusRing', context);
 </script>


### PR DESCRIPTION
Path2D: addPathByStrokingPath, addText, addPathByStrokingText
ImageBitmapRenderingContext: transferImageBitmap
Window: Path
HTMLCanvasElement: toDataURLHD, toBlobHD
CanvasRenderingContext2D: createImageDataHD, getImageDataHD, putImageDataHD, drawSystemFocusRing, drawCustomFocusRing
ImageData: resolution
