### PR TITLE
Fix XPathEvaluator constructor test

### DIFF
--- a/domxpath/evaluator-constructor.html
+++ b/domxpath/evaluator-constructor.html
@@ -11,7 +11,6 @@ test(function() {
   assert_true(x instanceof XPathEvaluator);
 }, "Constructor with 'new'");
 test(function() {
-  var x = XPathEvaluator();
-  assert_true(x instanceof XPathEvaluator);
+  assert_throws(new TypeError(), "var x = XPathEvaluator()");
 }, "Constructor without 'new'");
 </script>


### PR DESCRIPTION
Fix XPathEvaluator constructor test as it was expecting that the constructor
can be called without 'new'. Firefox / Chrome and Safari all do not allow
this.
