### PR TITLE
Test that load events are not fired for inline scripts

### DIFF
--- a/html/semantics/scripting-1/the-script-element/load-event.html
+++ b/html/semantics/scripting-1/the-script-element/load-event.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#execute-the-script-block">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script>
+"use strict";
+
+async_test(function(t) {
+    window.scriptExecuting = function () {
+        setTimeout(t.step_func_done(() => {
+            assert_equals(window.onloadHappened, undefined);
+        }), 0);
+    };
+}, "load events should not be fired for inline scripts");
+</script>
+
+
+<script onload="window.onloadHappened = true;">
+"use strict";
+window.scriptExecuting();
+</script>


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/1816 and https://github.com/whatwg/html/issues/1757.
