### PR TITLE
Now does not execute optional subtests that would fail

### DIFF
--- a/annotation-model/CONTRIBUTING.md
+++ b/annotation-model/CONTRIBUTING.md
@@ -53,6 +53,7 @@ Context](JSONtest-v1.jsonld).  That context defines the following terms:
 |description    | string          | A long self-describing paragraph that explains the purpose of the test and the expected input
 |ref            | URI             | An optional reference to the portion of the specification to which the test relates
 |testType       | `automated`, `manual`, `ref` | The type of test - this informs [WPT](https://github.com/w3c/web-platform-tests) how the test should be controlled and presented
+|skipFailures   | list of strings | An optional list of assertionType values that, if present, should have their test skipped if the result would be "unexpected".  Defaults to the empty list.
 |assertions     | list of URI, List @@@ATRISK@@@, or AssertionObject | The ordered collection of tests the input should be run against. See [JSON Schema Usage](#jsonSchema) for the structure of the objects.  URI is relative to the top level folder of the test collection if it has a slash; relative to the current directory if it does not. @@@@ATRISK@@@@ Lists can be nested to define groups of sub-tests.  Assertions / groups can be conditionally skipped.  See [Assertion Lists](#assertionLists) for more details.
 |content        | URI or object   | An object containing content to be checked against the referenced assertions, or a URI from which to retrieve that content
 
@@ -71,9 +72,10 @@ Each test case has a suffix of `.test` and a shape like:
     {
       "$schema": "http://json-schema.org/draft-04/schema#",
       "title": "Verify annotation has target",
-      "type": "object",
+      "assertionType": "must",
       "expectedResult": "valid",
       "errorMessage": "The object was missing a required 'target' property",
+      "type": "object",
       "properties": {
         "target": {
           "anyOf": [

--- a/annotation-model/annotations/annotationOptionals.test
+++ b/annotation-model/annotations/annotationOptionals.test
@@ -4,6 +4,7 @@
   "description": "Web Annotations: <ul> <li>Should include certain properties (keys)</li> <li>May include additional keys</li> <li>should have Annotation key values that conform to model recommended constraints</li> </ul> Note: failing an assertion indicates that a recommended or optional feature has not been implemented or has not been implemented correctly.",
   "testType": "manual",
   "ref": "https://www.w3.org/TR/annotation-model/#other-properties",
+  "skipFailures": [ "should", "may" ],
   "assertions": [
     "annotations/3.3.1-annotationSingleCreatorImplemented.json",
     "annotations/3.3.1-annotationCreatedImplemented.json",

--- a/annotation-model/annotations/annotationsAgentOptionals.test
+++ b/annotation-model/annotations/annotationsAgentOptionals.test
@@ -3,6 +3,7 @@
   "name": "Annotation implements optional keys and meets optional key value constraints for Creator and Generator Agents",
   "description": "Agents (Creators, Generators) involved in an Annotation: <ul> <li>Should include certain properties (keys)</li> <li>May include additional keys</li> <li>should have Agent key values that conform to model recommended constraints</li> </ul> Note: failing an assertion indicates that a recommended or optional feature has not been implemented or has not been implemented correctly.",
   "testType": "manual",
+  "skipFailures": [ "should", "may" ],
   "ref": "https://www.w3.org/TR/annotation-model/#other-properties",
   "assertions":
   [

--- a/annotation-model/scripts/JSONtest.js
+++ b/annotation-model/scripts/JSONtest.js
@@ -514,7 +514,6 @@ JSONtest.prototype = {
 
         if (testAction === 'continue') {
           // a previous test told us to not run this test; skip it
-          // console.log("SKIPPED: " + assert.title);
           // test(function() { }, "SKIPPED: " + assert.title);
           // start an actual sub-test
           var valid = validate(content) ;

--- a/annotation-model/scripts/JSONtest.js
+++ b/annotation-model/scripts/JSONtest.js
@@ -29,6 +29,7 @@ function JSONtest(params) {
   this.Params = null;       // paramaters passed in
   this.Promise = null;             // master Promise that resolves when intialization is complete
   this.Properties = null;   // testharness_properties from the opening window
+  this.SkipFailures = [];   // list of assertionType values that should be skipped if their test would fail
   this.Test = null;         // test being run
   this.AssertionCounter = 0;// keeps track of which assertion is being processed
 
@@ -120,6 +121,10 @@ function JSONtest(params) {
 
       if (test.description) {
         this.DescriptionText = test.description;
+      }
+
+      if (test.hasOwnProperty("skipFailures") && Array.isArray(test.skipFailures) ) {
+        this.SkipFailures = test.skipFailures;
       }
 
       if (test.content) {
@@ -407,7 +412,7 @@ JSONtest.prototype = {
         var message = assert.hasOwnProperty('errorMessage') ?
           assert.errorMessage : "Result was not " + expected;
         var type = assert.hasOwnProperty('assertionType') ?
-          assert.assertionType : "must" ;
+          assert.assertionType.toLowerCase() : "must" ;
         if (!typeMap.hasOwnProperty(type)) {
           type = "must";
         }
@@ -509,37 +514,42 @@ JSONtest.prototype = {
 
         if (testAction !== 'continue') {
           // a previous test told us to not run this test; skip it
-          test(function() { }, "SKIPPED: " + assert.title);
+          console.log("SKIPPED: " + assert.title);
+          // test(function() { }, "SKIPPED: " + assert.title);
         } else {
           // start an actual sub-test
-          test(function() {
-            var valid = validate(content) ;
+          var valid = validate(content) ;
 
-            var result = this.determineResult(assert, valid) ;
+          var theResult = this.determineResult(assert, valid) ;
 
-            // remember the result
-            theResults.push(result);
+          // remember the result
+          theResults.push(theResult);
 
-            var newAction = this.determineAction(assert, result) ;
-            // next time around we will use this action
-            testAction = newAction;
+          var newAction = this.determineAction(assert, theResult) ;
+          // next time around we will use this action
+          testAction = newAction;
 
-            var err = ";";
-            if (validate.errors !== null) {
-              err = "; Errors: " + this.ajv.errorsText(validate.errors) + ";" ;
-            }
-            if (testAction === 'abort') {
-              err += "; Aborting execution of remaining assertions;";
-            } else if (testAction === 'skip') {
-              err += "; Skipping execution of remaining assertions at level " + level + ";";
-            }
-            if (result === false) {
-              // test result was unexpected; use message
-              assert_true(result, typeMap[type] + message + err);
-            } else {
-              assert_true(result, err) ;
-            }
-          }.bind(this), "" + level + ":" + (num+1) + " " + assert.title);
+          // only run the test if we are NOT skipping fails for some types
+          // or the result is expected
+          if ( theResult === true || !this.SkipFailures.includes(type) ) {
+            test(function() {
+              var err = ";";
+              if (validate.errors !== null && !assert.hasOwnProperty("errorMessage")) {
+                err = "; Errors: " + this.ajv.errorsText(validate.errors) + ";" ;
+              }
+              if (testAction === 'abort') {
+                err += "; Aborting execution of remaining assertions;";
+              } else if (testAction === 'skip') {
+                err += "; Skipping execution of remaining assertions at level " + level + ";";
+              }
+              if (theResult === false) {
+                // test result was unexpected; use message
+                assert_true(theResult, typeMap[type] + message + err);
+              } else {
+                assert_true(theResult, err) ;
+              }
+            }.bind(this), "" + level + ":" + (num+1) + " " + assert.title);
+          }
         }
       }.bind(this));
     }

--- a/annotation-model/scripts/JSONtest.js
+++ b/annotation-model/scripts/JSONtest.js
@@ -512,11 +512,10 @@ JSONtest.prototype = {
           return ;
         }
 
-        if (testAction !== 'continue') {
+        if (testAction === 'continue') {
           // a previous test told us to not run this test; skip it
-          console.log("SKIPPED: " + assert.title);
+          // console.log("SKIPPED: " + assert.title);
           // test(function() { }, "SKIPPED: " + assert.title);
-        } else {
           // start an actual sub-test
           var valid = validate(content) ;
 


### PR DESCRIPTION
If a .test file indicates that certain assertionTypes should be
skipped on fail, then those will not have their tests "run" so they
will show up on the results in a more sensible way.
