### PR TITLE
Remove WebDriver navigation test HTTP fixture

### DIFF
--- a/webdriver/navigation.py
+++ b/webdriver/navigation.py
@@ -1,5 +1,3 @@
-import contextlib
-import httplib
 import json
 import pytest
 import types
@@ -16,32 +14,6 @@ alert_doc = inline("<script>window.alert()</script>")
 frame_doc = inline("<p>frame")
 one_frame_doc = inline("<iframe src='%s'></iframe>" % frame_doc)
 two_frames_doc = inline("<iframe src='%s'></iframe>" % one_frame_doc)
-
-
-class HTTPRequest(object):
-    def __init__(self, host, port):
-        self.host = host
-        self.port = port
-
-    def head(self, path):
-        return self._request("HEAD", path)
-
-    def get(self, path):
-        return self._request("GET", path)
-
-    @contextlib.contextmanager
-    def _request(self, method, path):
-        conn = httplib.HTTPConnection(self.host, self.port)
-        try:
-            conn.request(method, path)
-            yield conn.getresponse()
-        finally:
-            conn.close()
-
-
-@pytest.fixture
-def http(request, session):
-    return HTTPRequest(session.transport.host, session.transport.port)
 
 
 @pytest.fixture


### PR DESCRIPTION
https://github.com/w3c/wptrunner/pull/211 introduces the http fixture to
the wptrunner harness, meaning it will be accessible to all wdspec tests.
