### PR TITLE
Update uievents/keyboard manual tests

### DIFF
--- a/uievents/keyboard/key-101en-us-manual.html
+++ b/uievents/keyboard/key-101en-us-manual.html
@@ -73,11 +73,11 @@ var KeyTable101 = [
     ["ShiftRight",   3,    3,    4,        "Shift",  "Shift",  "Shift"],
 
     ["ControlLeft",  4,    3,    1,        "Control",  "Control",  "Control"],
-    ["OSLeft",       4,    3,    1,        "Meta",     "Meta",     "Meta"],
+    ["MetaLeft",     4,    3,    1,        "Meta",     "Meta",     "Meta"],
     ["AltLeft",      4,    3,    1,        "Alt",      "Alt",      "Alt"],
     ["Space",        4,    0,    5,        "Space",    " ",        " "],
     ["AltRight",     4,    3,    1,        "Alt",      "Alt",      "Alt"],
-    ["OSRight",      4,    3,    1,        "Meta",     "Meta",     "Meta"],
+    ["MetaRight",    4,    3,    1,        "Meta",     "Meta",     "Meta"],
     ["ContextMenu",  4,    0,    1,        "Menu",     "",         ""],
     ["ControlRight", 4,    3,    1,        "Control",  "Control",  "Control"],
 

--- a/uievents/keyboard/key-102fr-fr-manual.html
+++ b/uievents/keyboard/key-102fr-fr-manual.html
@@ -75,11 +75,11 @@ var KeyTable102 = [
     ["ShiftRight",   3,    3,    4,        "Shift",  "Shift",  "Shift"],
 
     ["ControlLeft",  4,    3,    1,        "Control",  "Control",  "Control"],
-    ["OSLeft",       4,    3,    1,        "Meta",     "Meta",     "Meta"],
+    ["MetaLeft",     4,    3,    1,        "Meta",     "Meta",     "Meta"],
     ["AltLeft",      4,    3,    1,        "Alt",      "Alt",      "Alt"],
     ["Space",        4,    0,    5,        "Space",    " ",        " "],
     ["AltRight",     4,    3,    1,        "Alt",      "Alt",      "Alt"],
-    ["OSRight",      4,    3,    1,        "Meta",     "Meta",     "Meta"],
+    ["MetaRight",    4,    3,    1,        "Meta",     "Meta",     "Meta"],
     ["ContextMenu",  4,    0,    1,        "Menu",     "",         ""],
     ["ControlRight", 4,    3,    1,        "Control",  "Control",  "Control"],
 


### PR DESCRIPTION
Update uievents/keyboard manual tests to use MetaLeft / MetaRight instead of
OSLeft / OSRight for the Windows/Command/OS key code.

This is as per the latest specification:
- https://w3c.github.io/uievents-code/#key-alphanumeric-functional
