### PR TITLE
Update Shadow DOM event dispatch tests for synthetic events

### DIFF
--- a/shadow-dom/event-composed-path-with-related-target.html
+++ b/shadow-dom/event-composed-path-with-related-target.html
@@ -27,7 +27,7 @@ test(() => {
   let path = ['target', 'test1'];
   assert_event_path_equals(log, [['target', 'target', 'target', path],
                                  ['test1', 'target', 'target', path]]);
-}, 'Event path for an event with a relatedTarget. Event shoul be dispatched if 1) target and relatedTarget are same, and 2) they are not in a shadow tree.');
+}, 'Event path for an event with a relatedTarget. Event should be dispatched even when target and relatedTarget are same.');
 </script>
 
 <div id="test2">
@@ -51,8 +51,10 @@ test(() => {
 test(() => {
   let n = createTestTree(test2);
   let log = dispatchEventWithLog(n, n.target, new FocusEvent('my-focus', { bubbles: true, composed: true, relatedTarget: n.target }));
-  assert_event_path_equals(log, []);
-}, 'Event path for an event with a relatedTarget. Event should not be dispatched if 1) target and relatedTarget are same, and 2) both are in a shadow tree.');
+  let path = ['target', 'sr'];
+  assert_event_path_equals(log, [['target', 'target', 'target', path],
+                                 ['sr', 'target', 'target', path]]);
+}, 'Event path for an event with a relatedTarget which is identical to target. Event should be dispatched and should stop at the shadow root.');
 </script>
 
 <div id="test3_1">
@@ -134,7 +136,9 @@ test(() => {
 test(() => {
   let n = createTestTree(test4);
   let log = dispatchEventWithLog(n, n.host1, new FocusEvent('my-focus', { bubbles: true, composed: true, relatedTarget: n.target }));
-  assert_event_path_equals(log, []);
+  let path = ['host1', 'test4'];
+  assert_event_path_equals(log, [['host1', 'host1', 'host1', path],
+                                 ['test4', 'host1', 'host1', path]]);
 }, 'Event path for an event with a relatedTarget. target is a shadow-including ancestor of relatedTarget.');
 </script>
 


### PR DESCRIPTION
Synthetic events must be dispatched at least until the root of the tree
even when target and relatedTarget are identical.
