### PR TITLE
Fix html/webappapis/scripting/events/event-handler-attributes-body-wi…

### DIFF
--- a/html/webappapis/scripting/events/event-handler-attributes-body-window.html
+++ b/html/webappapis/scripting/events/event-handler-attributes-body-window.html
@@ -21,4 +21,14 @@ handlers.forEach(function(handler) {
   }, handler);
 });
 
+handlers.forEach(function(handler) {
+    document.body['on' + handler] = null;
+});
+
+handlers.forEach(function(handler) {
+  test(function() {
+    assert_equals(document.body['on' + handler], null);
+    assert_equals(window['on' + handler], null);
+  }, handler + " removal");
+});
 </script>


### PR DESCRIPTION
…ndow.html

Fix html/webappapis/scripting/events/event-handler-attributes-body-window.html so
that it no longer requires user interaction before moving on to the next test.
The test is registering a number of event listeners on the body / window, which
caused a confirmation dialog to be shown on unload.

So that the test can be run in an automated fashion, we now unregister the event
listeners at the end of the test. We now also checks that the event listeners
have properly been unregistered.
