### PR TITLE
Do not include a, area, or frameset in the window's named properties

### DIFF
--- a/html/browsers/the-window-object/named-access-on-the-window-object/named-objects.html
+++ b/html/browsers/the-window-object/named-access-on-the-window-object/named-objects.html
@@ -33,30 +33,28 @@ test(function() {
 }, "Check if the first nested browsing context is returned by window['c']");
 
 test(function() {
-  assert_equals(window['a'].length, 7, "The length should be 7.");
+  assert_equals(window['a'].length, 5, "The length should be 5.");
   assert_true(window['a'] instanceof HTMLCollection);
-  assert_array_equals(window['a'],
-                      [ document.getElementById('a1'), document.getElementById('app1'),
-                        document.getElementById('area1'), document.getElementById('embed1'),
-                        document.getElementById('form1'), document.getElementById('img1'),
-                        document.getElementById('obj1') ],
-                      "The elements are not in tree order.");
-
-  document.getElementById('a1').setAttribute("name", "");
-  document.getElementById('area1').setAttribute("name", "");
   assert_array_equals(window['a'],
                       [ document.getElementById('app1'), document.getElementById('embed1'),
                         document.getElementById('form1'), document.getElementById('img1'),
                         document.getElementById('obj1') ],
-                      "Window['a'] should not contain the elements with empty name attribute.");
-}, "Check if window['a'] contains all a, applet, area, embed, form, img, and object elements, and their order");
+                      "The elements are not in tree order.");
 
-var t = async_test("Check if window['fs'] return the frameset element with name='fs'");
+  document.getElementById('form1').setAttribute("name", "");
+  document.getElementById('embed1').setAttribute("name", "");
+  assert_array_equals(window['a'],
+                      [ document.getElementById('app1'), document.getElementById('img1'),
+                        document.getElementById('obj1') ],
+                      "Window['a'] should not contain the elements with empty name attribute.");
+}, "Check if window['a'] contains all applet, embed, form, img, and object elements, and their order");
+
+var t = async_test("Check that window['fs'] does not return the frameset element with name='fs' (historical)");
 function on_load () {
   t.step(function () {
     assert_equals(document.getElementById('fm2').contentWindow['fs'],
-                  document.getElementById('fm2').contentDocument.getElementById('fs1'),
-                  "The frameset element should be returned.");
+                  undefined,
+                  "The frameset element should not be returned.");
   });
   t.done();
 }


### PR DESCRIPTION
Aligns the tests with the spec as of https://github.com/whatwg/html/pull/1869. See discussion in https://github.com/whatwg/html/issues/1810.
