### PR TITLE
Do not write <parsererror> nodes for invalid XML documents in XMLHttpRequests made by web content. r=billm,

### DIFF
--- a/XMLHttpRequest/responsexml-basic.htm
+++ b/XMLHttpRequest/responsexml-basic.htm
@@ -19,7 +19,7 @@
         assert_equals(client.responseXML.documentElement.localName, "html", 'localName is html')
         assert_equals(client.responseXML.documentElement.childNodes.length, 5, 'childNodes is 5')
         assert_equals(client.responseXML.getElementById("n1").localName, client.responseXML.documentElement.childNodes[1].localName)
-        assert_equals(client.responseXML.getElementById("n2"), client.responseXML.documentElement.childrenNodes[3], 'getElementById("n2")')
+        assert_equals(client.responseXML.getElementById("n2"), client.responseXML.documentElement.childNodes[3], 'getElementById("n2")')
         assert_equals(client.responseXML.getElementsByTagName("p")[1].namespaceURI, "namespacesarejuststrings", 'namespaceURI')
       })
       test(function() {

--- a/editing/other/restoration.html
+++ b/editing/other/restoration.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Restoration of style tests</title>
+<!--
+No spec, based on: https://bugzilla.mozilla.org/show_bug.cgi?id=1250805
+If the user presses Ctrl+B and then hits Enter and then types text, the text
+should still be bold.  Hitting Enter shouldn't make it forget.  And so too for
+other commands.
+-->
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div contenteditable></div>
+<script>
+var div = document.querySelector("div");
+
+function doTestInner(cmd, param, startBold) {
+  div.innerHTML = startBold ? "<b>foo</b>bar" : "foobar";
+  getSelection().collapse(startBold ? div.firstChild.firstChild
+                                    : div.firstChild, 3);
+
+  // Set/unset bold, then run command and see if it's still there
+  assert_true(document.execCommand("bold", false, ""),
+              "execCommand needs to return true for bold");
+
+  assert_true(document.execCommand(cmd, false, param),
+              "execCommand needs to return true for " + cmd + " " + param);
+
+  assert_equals(document.queryCommandState("bold"), !startBold,
+               "bold state");
+
+  assert_true(document.execCommand("inserttext", false, "x"),
+              "execCommand needs to return true for inserttext x");
+
+  // Find the new text node and check that it's actually bold (or not)
+  var node = div;
+  while (node) {
+    if (node.nodeType == Node.TEXT_NODE && node.nodeValue.indexOf("x") != -1) {
+      assert_in_array(getComputedStyle(node.parentNode).fontWeight,
+                    !startBold ? ["700", "bold"] : ["400", "normal"],
+                    "font-weight");
+      return;
+    }
+    if (node.firstChild) {
+      node = node.firstChild;
+      continue;
+    }
+    while (node != div && !node.nextSibling) {
+      node = node.parentNode;
+    }
+    if (node == div) {
+      assert_unreached("x not found!");
+      break;
+    }
+    node = node.nextSibling;
+  }
+}
+
+function doTest(cmd, param) {
+  if (param === undefined) {
+    param = "";
+  }
+
+  test(function() {
+    doTestInner(cmd, param, true);
+  }, cmd + " " + param + " starting bold");
+
+  test(function() {
+    doTestInner(cmd, param, false);
+  }, cmd + " " + param + " starting not bold");
+}
+
+doTest("insertparagraph");
+doTest("insertlinebreak");
+doTest("delete");
+doTest("forwarddelete");
+doTest("insertorderedlist");
+doTest("insertunorderedlist");
+doTest("indent");
+// Outdent does nothing here, but should be harmless.
+doTest("outdent");
+doTest("justifyleft");
+doTest("justifyright");
+doTest("justifycenter");
+doTest("justifyfull");
+doTest("formatblock", "div");
+doTest("formatblock", "blockquote");
+doTest("inserthorizontalrule");
+doTest("insertimage", "a");
+doTest("inserttext", "bar");
+</script>

--- a/pointerevents/pointerevent_element_haspointercapture_release_pending_capture-manual.html
+++ b/pointerevents/pointerevent_element_haspointercapture_release_pending_capture-manual.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Element.hasPointerCapture test after the pending pointer capture element releases pointer capture</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script type="text/javascript" src="pointerevent_support.js"></script>
+        <script>
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_pointerEvent = async_test("hasPointerCapture test after the pending pointer capture element releases pointer capture");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (e) {
+                    detected_pointertypes[e.pointerType] = true;
+                    target0.setPointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), true, "After target0.setPointerCapture, target0.hasPointerCapture should return true");
+                    });
+                });
+
+                on_event(target0, "gotpointercapture", function (e) {
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), true, "After target0 received gotpointercapture, target0.hasPointerCapture should return true");
+                    });
+                    target1.setPointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target1.setPointerCapture, target0.hasPointerCapture should return false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), true, "After target1.setPointerCapture, target1.hasPointerCapture should return true");
+                    });
+                    target1.releasePointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target1.releasePointerCapture, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), false, "After target1.releasePointerCapture, target1.hasPointerCapture should be false");
+                    });
+                });
+
+                on_event(target1, "gotpointercapture", function (e) {
+                    test_pointerEvent.step(function () {
+                        assert_true(false, "target1 should never receive gotpointercapture in this test");
+                    });
+                });
+
+                on_event(target0, "lostpointercapture", function (e) {
+                    test_pointerEvent.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Element.hasPointerCapture test after the pending pointer capture element releases pointer capture</h1>
+        <h4>
+            Test Description: This test checks if Element.hasPointerCapture returns value correctly after the pending pointer capture element releases pointer capture
+            <ol>
+                <li> Press black rectangle and do not release
+                <li> Move your pointer to purple rectangle
+                <li> Release the pointer
+            </ol>
+        </h4>
+        <p>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
+++ b/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Release pointer capture right after setpointercapture</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("Release pointer capture right after setpointercapture");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                    target0.releasePointerCapture(event.pointerId);
+                    assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target0.releasePointerCapture, target0.hasPointerCapture should be false");
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_true(false, "target0 shouldn't receive gotpointercapture");
+                    });
+                });
+
+                on_event(target0, "lostpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_true(false, "target0 shouldn't receive lostpointercapture");
+                    });
+                });
+
+                on_event(target0, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Release pointer capture right after setpointercapture</h1>
+        <h4>Test Description:
+            When calling releasePointer right after setPointerCapture method is invoked, the pending pointer capture should be cleared and no element should receive gotpointercapture and lostpointercapture events
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_setpointercapture_override_pending_capture_element-manual.html
+++ b/pointerevents/pointerevent_setpointercapture_override_pending_capture_element-manual.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Test overriding the pending pointer capture element</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("setPointerCapture: override the pending pointer capture element");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Set capture to target0, target0.hasPointerCapture should be true");
+                    });
+                    target1.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), false, "Set capture to target1, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(event.pointerId), true, "Set capture to target1, target1.hasPointerCapture should be true");
+                    });
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    assert_true(false, "target0 shouldn't receive gotpointercapture");
+                });
+
+                on_event(target1, "gotpointercapture", function (event) {
+                    assert_true(true, "target1 should receive gotpointercapture");
+                });
+
+                on_event(target1, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Pointer Event: Test overriding the pending pointer capture element</h1>
+        <h4>Test Description:
+            After an element setPointerCapture, if another element also setPointerCapture and override it, the old pending pointer capture element shouldn't receive any gotpointercapture or lostpointercapture event
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_setpointercapture_to_same_element_twice-manual.html
+++ b/pointerevents/pointerevent_setpointercapture_to_same_element_twice-manual.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+    <head>
+        <title>setPointerCapture() to the element which already captured the pointer</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("setPointerCapture: set to the element which already captured the pointer");
+            var got_pointer_capture = false;
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_equals(got_pointer_capture, false, "Target0 should receive gotpointercapture at the first time it captured the pointer");
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Target 0 received gotpointercapture, target0.hasPointerCapture should be true");
+                    });
+                    got_pointer_capture = true;
+
+                    target0.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Set capture to target0, target0.hasPointerCapture should be true");
+                        assert_equals(target1.hasPointerCapture(event.pointerId), false, "Set capture to target0, target1.hasPointerCapture should be false");
+                    });
+                });
+
+                on_event(target0, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Pointer Event: setPointerCapture to the element which already captured the pointer</h1>
+        <h4>Test Description:
+            When the setPointerCapture method is invoked, if the target element had already captured the pointer, it should not trigger any gotpointercapture or lostpointercapture event
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/web-animations/interfaces/Animation/effect.html
+++ b/web-animations/interfaces/Animation/effect.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Animation.effect tests</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-effect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(function(t) {
+  var anim = new Animation();
+  assert_equals(anim.effect, null, "initial effect is null");
+
+  var newEffect = new KeyframeEffectReadOnly(createDiv(t), null);
+  anim.effect = newEffect;
+  assert_equals(anim.effect, newEffect, "new effect is set");
+}, "effect is set correctly.");
+
+</script>
+</body>

--- a/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Setting the target effect tests</title>
+<link rel='help' href='https://w3c.github.io/web-animations/#setting-the-target-effect'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../../testcommon.js'></script>
+<body>
+<div id='log'></div>
+<script>
+'use strict';
+
+promise_test(function(t) {
+  var anim = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                  100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  var retPromise = anim.ready.then(function() {
+    assert_unreached('ready promise is fulfilled');
+  }).catch(function(err) {
+    assert_equals(err.name, 'AbortError',
+                  'ready promise is rejected with AbortError');
+  });
+
+  anim.effect = null;
+  assert_equals(anim.playState, 'paused');
+
+  return retPromise;
+}, 'If new effect is null and old effect is not null, we reset the pending ' +
+   'tasks and ready promise is rejected');
+
+promise_test(function(t) {
+  var anim = new Animation();
+  anim.pause();
+  assert_equals(anim.playState, 'pending');
+
+  anim.effect = new KeyframeEffectReadOnly(createDiv(t),
+                                           { marginLeft: [ '0px', '100px' ] },
+                                           100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  return anim.ready.then(function() {
+    assert_equals(anim.playState, 'paused');
+  });
+}, 'If animation has a pending pause task, reschedule that task to run ' +
+   'as soon as animation is ready.');
+
+promise_test(function(t) {
+  var anim = new Animation();
+  anim.play();
+  assert_equals(anim.playState, 'pending');
+
+  anim.effect = new KeyframeEffectReadOnly(createDiv(t),
+                                           { marginLeft: [ '0px', '100px' ] },
+                                           100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  return anim.ready.then(function() {
+    assert_equals(anim.playState, 'running');
+  });
+}, 'If animation has a pending play task, reschedule that task to run ' +
+   'as soon as animation is ready to play new effect.');
+
+promise_test(function(t) {
+  var animA = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                   100 * MS_PER_SEC);
+  var animB = new Animation();
+
+  return animA.ready.then(function() {
+    animB.effect = animA.effect;
+    assert_equals(animA.effect, null);
+    assert_equals(animA.playState, 'finished');
+  });
+}, 'When setting the effect of an animation to the effect of an existing ' +
+   'animation, the existing animation\'s target effect should be set to null.');
+
+test(function(t) {
+  var animA = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                   100 * MS_PER_SEC);
+  var animB = new Animation();
+  var effect = animA.effect;
+  animA.currentTime = 50 * MS_PER_SEC;
+  animB.currentTime = 20 * MS_PER_SEC;
+  assert_equals(effect.getComputedTiming().progress, 0.5,
+                'Original timing comes from first animation');
+  animB.effect = effect;
+  assert_equals(effect.getComputedTiming().progress, 0.2,
+                'After setting the effect on a different animation, ' +
+                'it uses the new animation\'s timing');
+}, 'After setting the target effect of animation to the target effect of an ' +
+   'existing animation, the target effect\'s timing is updated to reflect ' +
+   'the current time of the new animation.');
+
+</script>
+</body>

--- a/workers/Worker_ErrorEvent_error.htm
+++ b/workers/Worker_ErrorEvent_error.htm
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+var t1 = async_test("Error handler outside the worker should not see the error value");
+var t2 = async_test("Error handlers inside a worker should see the error value");
+
+test(function() {
+  var worker = new Worker("support/ErrorEvent-error.js");
+  worker.onerror = t1.step_func_done(function(e) {
+    assert_true(/hello/.test(e.message));
+    assert_equals(e.error, null);
+  });
+
+  var messages = 0;
+  worker.onmessage = t2.step_func(function(e) {
+    ++messages;
+    var data = e.data;
+    assert_true(data.source == "onerror" ||
+                data.source == "event listener");
+    assert_equals(data.value, "hello");
+    if (messages == 2) {
+      t2.done();
+    }
+  });
+});
+</script>

--- a/workers/support/ErrorEvent-error.js
+++ b/workers/support/ErrorEvent-error.js
@@ -1,0 +1,9 @@
+onerror = function(message, location, line, col, error) {
+  postMessage({ source: "onerror", value: error });
+}
+
+addEventListener("error", function(e) {
+  postMessage({ source: "event listener", value: e.error });
+});
+
+throw "hello";


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=289714
