### PR TITLE
Make sure the parser insertion point is defined when firing the load event for external <scripts> or firing the error event on a failed external script load (but not other cases, like bogus script URL).

### DIFF
--- a/XMLHttpRequest/responsexml-basic.htm
+++ b/XMLHttpRequest/responsexml-basic.htm
@@ -19,7 +19,7 @@
         assert_equals(client.responseXML.documentElement.localName, "html", 'localName is html')
         assert_equals(client.responseXML.documentElement.childNodes.length, 5, 'childNodes is 5')
         assert_equals(client.responseXML.getElementById("n1").localName, client.responseXML.documentElement.childNodes[1].localName)
-        assert_equals(client.responseXML.getElementById("n2"), client.responseXML.documentElement.childrenNodes[3], 'getElementById("n2")')
+        assert_equals(client.responseXML.getElementById("n2"), client.responseXML.documentElement.childNodes[3], 'getElementById("n2")')
         assert_equals(client.responseXML.getElementsByTagName("p")[1].namespaceURI, "namespacesarejuststrings", 'namespaceURI')
       })
       test(function() {

--- a/editing/other/restoration.html
+++ b/editing/other/restoration.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Restoration of style tests</title>
+<!--
+No spec, based on: https://bugzilla.mozilla.org/show_bug.cgi?id=1250805
+If the user presses Ctrl+B and then hits Enter and then types text, the text
+should still be bold.  Hitting Enter shouldn't make it forget.  And so too for
+other commands.
+-->
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div contenteditable></div>
+<script>
+var div = document.querySelector("div");
+
+function doTestInner(cmd, param, startBold) {
+  div.innerHTML = startBold ? "<b>foo</b>bar" : "foobar";
+  getSelection().collapse(startBold ? div.firstChild.firstChild
+                                    : div.firstChild, 3);
+
+  // Set/unset bold, then run command and see if it's still there
+  assert_true(document.execCommand("bold", false, ""),
+              "execCommand needs to return true for bold");
+
+  assert_true(document.execCommand(cmd, false, param),
+              "execCommand needs to return true for " + cmd + " " + param);
+
+  assert_equals(document.queryCommandState("bold"), !startBold,
+               "bold state");
+
+  assert_true(document.execCommand("inserttext", false, "x"),
+              "execCommand needs to return true for inserttext x");
+
+  // Find the new text node and check that it's actually bold (or not)
+  var node = div;
+  while (node) {
+    if (node.nodeType == Node.TEXT_NODE && node.nodeValue.indexOf("x") != -1) {
+      assert_in_array(getComputedStyle(node.parentNode).fontWeight,
+                    !startBold ? ["700", "bold"] : ["400", "normal"],
+                    "font-weight");
+      return;
+    }
+    if (node.firstChild) {
+      node = node.firstChild;
+      continue;
+    }
+    while (node != div && !node.nextSibling) {
+      node = node.parentNode;
+    }
+    if (node == div) {
+      assert_unreached("x not found!");
+      break;
+    }
+    node = node.nextSibling;
+  }
+}
+
+function doTest(cmd, param) {
+  if (param === undefined) {
+    param = "";
+  }
+
+  test(function() {
+    doTestInner(cmd, param, true);
+  }, cmd + " " + param + " starting bold");
+
+  test(function() {
+    doTestInner(cmd, param, false);
+  }, cmd + " " + param + " starting not bold");
+}
+
+doTest("insertparagraph");
+doTest("insertlinebreak");
+doTest("delete");
+doTest("forwarddelete");
+doTest("insertorderedlist");
+doTest("insertunorderedlist");
+doTest("indent");
+// Outdent does nothing here, but should be harmless.
+doTest("outdent");
+doTest("justifyleft");
+doTest("justifyright");
+doTest("justifycenter");
+doTest("justifyfull");
+doTest("formatblock", "div");
+doTest("formatblock", "blockquote");
+doTest("inserthorizontalrule");
+doTest("insertimage", "a");
+doTest("inserttext", "bar");
+</script>

--- a/html/browsers/history/the-location-interface/location_hash.html
+++ b/html/browsers/history/the-location-interface/location_hash.html
@@ -7,6 +7,8 @@
   </head>
   <body>
     <div id="log"></div>
+    <iframe id="srcdoc-iframe"
+       srcdoc="<div style='height: 200vh'></div><div id='test'></div>"></iframe>
     <script>
     test(function () {
       window.history.pushState(1, document.title, '#x=1');
@@ -15,6 +17,17 @@
       assert_equals(hash, "#x=1", "hash");
 
     }, "location hash");
+
+    var t = async_test("Setting location.hash on srcdoc iframe");
+    addEventListener("load", t.step_func_done(function() {
+      var frameWin = document.getElementById("srcdoc-iframe").contentWindow;
+      assert_equals(frameWin.location.href, "about:srcdoc");
+      assert_equals(frameWin.scrollY, 0, "Should not have scrolled yet");
+      frameWin.location.hash = "test";
+      assert_equals(frameWin.location.href, "about:srcdoc#test");
+      assert_true(frameWin.scrollY > frameWin.innerHeight,
+                  "Should have scrolled by more than one viewport height");
+    }));
     </script>
   </body>
 </html>

--- a/html/semantics/forms/the-form-element/form-nameditem.html
+++ b/html/semantics/forms/the-form-element/form-nameditem.html
@@ -115,6 +115,11 @@ test(function() {
   var button = document.getElementsByTagName("input")[0]
   assert_equals(button.type, "button")
   assert_equals(form.button, button)
+  var desc = Object.getOwnPropertyDescriptor(form, "button");
+  assert_equals(desc.value, button);
+  assert_false(desc.writable);
+  assert_true(desc.configurable);
+  assert_false(desc.enumerable);
   assert_equals(form.button.length, undefined)
 }, "Name for a single element should work")
 
@@ -221,6 +226,12 @@ test(function() {
   var input2 = document.getElementsByName("d")[1]
   assert_equals(input2.localName, "input")
   assert_equals(input2.getAttribute("form"), "c")
+
+  var desc = Object.getOwnPropertyDescriptor(form, "d");
+  assert_equals(desc.value, form.d);
+  assert_false(desc.writable);
+  assert_true(desc.configurable);
+  assert_false(desc.enumerable);
 
   assert_true(form.d instanceof NodeList, "form.d should be a NodeList")
   assert_array_equals(form.d, [input1, input2])

--- a/html/semantics/scripting-1/the-script-element/script-onerror-insertion-point-1.html
+++ b/html/semantics/scripting-1/the-script-element/script-onerror-insertion-point-1.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that the insertion point is defined in the error event of a parser-inserted script that actually started a fetch (but just had it fail).</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  var t = async_test("");
+  var writeDone = t.step_func_done(function(text) {
+    assert_equals(text, "Some text");
+  });
+</script>
+<iframe src="support/script-onerror-insertion-point-1-helper.html"></iframe>

--- a/html/semantics/scripting-1/the-script-element/script-onerror-insertion-point-2.html
+++ b/html/semantics/scripting-1/the-script-element/script-onerror-insertion-point-2.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that the insertion point is not defined in the error event of a
+  parser-inserted script that has an unparseable URL</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  var t = async_test("");
+  var writeDone = t.step_func_done(function(text) {
+    assert_equals(text, "text");
+  });
+</script>
+<iframe src="support/script-onerror-insertion-point-2-helper.html"></iframe>

--- a/html/semantics/scripting-1/the-script-element/script-onload-insertion-point.html
+++ b/html/semantics/scripting-1/the-script-element/script-onload-insertion-point.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that the insertion point is defined in the load event of a parser-inserted script.</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  var t = async_test("");
+  var writeDone = t.step_func_done(function(text) {
+    assert_equals(text, "Some text");
+  });
+</script>
+<iframe src="support/script-onload-insertion-point-helper.html"></iframe>

--- a/html/semantics/scripting-1/the-script-element/support/script-onerror-insertion-point-1-helper.html
+++ b/html/semantics/scripting-1/the-script-element/support/script-onerror-insertion-point-1-helper.html
@@ -1,0 +1,2 @@
+Some <script src="nosuchscripthere.js"
+             onerror="document.write('text'); parent.writeDone(document.documentElement.textContent)"></script>

--- a/html/semantics/scripting-1/the-script-element/support/script-onerror-insertion-point-2-helper.html
+++ b/html/semantics/scripting-1/the-script-element/support/script-onerror-insertion-point-2-helper.html
@@ -1,0 +1,2 @@
+Some <script src="http://this is not parseable"
+             onerror="document.write('text'); parent.writeDone(document.documentElement.textContent)"></script>

--- a/html/semantics/scripting-1/the-script-element/support/script-onload-insertion-point-helper.html
+++ b/html/semantics/scripting-1/the-script-element/support/script-onload-insertion-point-helper.html
@@ -1,0 +1,2 @@
+Some <script src="script-onload-insertion-point-helper.js"
+             onload="document.write('xt'); parent.writeDone(document.documentElement.textContent)"></script>

--- a/html/semantics/scripting-1/the-script-element/support/script-onload-insertion-point-helper.js
+++ b/html/semantics/scripting-1/the-script-element/support/script-onload-insertion-point-helper.js
@@ -1,0 +1,1 @@
+document.write("te");

--- a/html/semantics/selectors/pseudo-classes/indeterminate.html
+++ b/html/semantics/selectors/pseudo-classes/indeterminate.html
@@ -24,7 +24,7 @@
   testSelectorIdsMatch(":indeterminate", ["radio4", "radio5", "progress1"], "dynamically check a radio input in a radio button group");
 
   document.getElementById("radio4").click();
-  testSelectorIdsMatch(":indeterminate", ["checkbox1", "progress2"], "click on radio4 which is in the indeterminate state");
+  testSelectorIdsMatch(":indeterminate", ["progress1"], "click on radio4 which is in the indeterminate state");
 
   document.getElementById("progress1").setAttribute("value", "20");
   testSelectorIdsMatch(":indeterminate", [], "adding a value to progress1 should put it in a determinate state");

--- a/pointerevents/pointerevent_element_haspointercapture-manual.html
+++ b/pointerevents/pointerevent_element_haspointercapture-manual.html
@@ -35,6 +35,8 @@
                     test_pointerEvent.step(function () {
                         assert_equals(target0.hasPointerCapture(e.pointerId), false,
                                       "after target1.setPointerCapture, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), true,
+                                      "after target1.setPointerCapture, target1.hasPointerCapture should be true");
                     });
                     target0.setPointerCapture(e.pointerId);
                     set_capture_to_target0 = true;
@@ -49,6 +51,8 @@
                     test_pointerEvent.step(function () {
                         assert_equals(target0.hasPointerCapture(e.pointerId), false,
                                       "after target0.releasePointerCapture, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), false,
+                                      "after target0.releasePointerCapture, target1.hasPointerCapture should be false");
                     });
                     target0.setPointerCapture(e.pointerId);
                     set_capture_to_target0 = true;
@@ -89,6 +93,13 @@
                         assert_equals(target0.hasPointerCapture(e.pointerId), false,
                                       "pointerup target0.hasPointerCapture should be false");
                     });
+                });
+
+                on_event(target1, "pointerup", function (e) {
+                    test_pointerEvent.step(function () {
+                        assert_equals(target1.hasPointerCapture(e.pointerId), false,
+                                      "pointerup target1.hasPointerCapture should be false");
+                    });
                     test_pointerEvent.done();
                 });
             }
@@ -99,14 +110,15 @@
         <h4>
             Test Description: This test checks if Element.hasPointerCapture returns value correctly
             <ol>
-                <li> Press black rectangle and do not release.
-                <li> Move your pointer to yellow rectangle.
-                <li> Release the pointer with no other move after that.
+                <li> Press black rectangle and do not release
+                <li> Move your pointer to purple rectangle
+                <li> Release the pointer
+                <li> Click purple rectangle
             </ol>
         </h4>
         <p>
-        <div id="target0" style="background:black"></div>
-        <div id="target1" style="background:yellow"></div>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
         <div id="complete-notice">
             <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
         </div>

--- a/pointerevents/pointerevent_element_haspointercapture_release_pending_capture-manual.html
+++ b/pointerevents/pointerevent_element_haspointercapture_release_pending_capture-manual.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Element.hasPointerCapture test after the pending pointer capture element releases pointer capture</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script type="text/javascript" src="pointerevent_support.js"></script>
+        <script>
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_pointerEvent = async_test("hasPointerCapture test after the pending pointer capture element releases pointer capture");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (e) {
+                    detected_pointertypes[e.pointerType] = true;
+                    target0.setPointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), true, "After target0.setPointerCapture, target0.hasPointerCapture should return true");
+                    });
+                });
+
+                on_event(target0, "gotpointercapture", function (e) {
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), true, "After target0 received gotpointercapture, target0.hasPointerCapture should return true");
+                    });
+                    target1.setPointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target1.setPointerCapture, target0.hasPointerCapture should return false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), true, "After target1.setPointerCapture, target1.hasPointerCapture should return true");
+                    });
+                    target1.releasePointerCapture(e.pointerId);
+                    test_pointerEvent.step(function () {
+                        assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target1.releasePointerCapture, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(e.pointerId), false, "After target1.releasePointerCapture, target1.hasPointerCapture should be false");
+                    });
+                });
+
+                on_event(target1, "gotpointercapture", function (e) {
+                    test_pointerEvent.step(function () {
+                        assert_true(false, "target1 should never receive gotpointercapture in this test");
+                    });
+                });
+
+                on_event(target0, "lostpointercapture", function (e) {
+                    test_pointerEvent.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Element.hasPointerCapture test after the pending pointer capture element releases pointer capture</h1>
+        <h4>
+            Test Description: This test checks if Element.hasPointerCapture returns value correctly after the pending pointer capture element releases pointer capture
+            <ol>
+                <li> Press black rectangle and do not release
+                <li> Move your pointer to purple rectangle
+                <li> Release the pointer
+            </ol>
+        </h4>
+        <p>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
+++ b/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Release pointer capture right after setpointercapture</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("Release pointer capture right after setpointercapture");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                    target0.releasePointerCapture(event.pointerId);
+                    assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target0.releasePointerCapture, target0.hasPointerCapture should be false");
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_true(false, "target0 shouldn't receive gotpointercapture");
+                    });
+                });
+
+                on_event(target0, "lostpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_true(false, "target0 shouldn't receive lostpointercapture");
+                    });
+                });
+
+                on_event(target0, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Release pointer capture right after setpointercapture</h1>
+        <h4>Test Description:
+            When calling releasePointer right after setPointerCapture method is invoked, the pending pointer capture should be cleared and no element should receive gotpointercapture and lostpointercapture events
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_setpointercapture_override_pending_capture_element-manual.html
+++ b/pointerevents/pointerevent_setpointercapture_override_pending_capture_element-manual.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Test overriding the pending pointer capture element</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("setPointerCapture: override the pending pointer capture element");
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Set capture to target0, target0.hasPointerCapture should be true");
+                    });
+                    target1.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), false, "Set capture to target1, target0.hasPointerCapture should be false");
+                        assert_equals(target1.hasPointerCapture(event.pointerId), true, "Set capture to target1, target1.hasPointerCapture should be true");
+                    });
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    assert_true(false, "target0 shouldn't receive gotpointercapture");
+                });
+
+                on_event(target1, "gotpointercapture", function (event) {
+                    assert_true(true, "target1 should receive gotpointercapture");
+                });
+
+                on_event(target1, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Pointer Event: Test overriding the pending pointer capture element</h1>
+        <h4>Test Description:
+            After an element setPointerCapture, if another element also setPointerCapture and override it, the old pending pointer capture element shouldn't receive any gotpointercapture or lostpointercapture event
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/pointerevents/pointerevent_setpointercapture_to_same_element_twice-manual.html
+++ b/pointerevents/pointerevent_setpointercapture_to_same_element_twice-manual.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+    <head>
+        <title>setPointerCapture() to the element which already captured the pointer</title>
+        <meta name="viewport" content="width=device-width">
+        <link rel="stylesheet" type="text/css" href="pointerevent_styles.css">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script src="pointerevent_support.js"></script>
+        <script type="text/javascript">
+            var detected_pointertypes = {};
+            add_completion_callback(showPointerTypes);
+            var test_setPointerCapture = async_test("setPointerCapture: set to the element which already captured the pointer");
+            var got_pointer_capture = false;
+
+            function run() {
+                var target0 = document.getElementById("target0");
+                var target1 = document.getElementById("target1");
+
+                on_event(target0, "pointerdown", function (event) {
+                    detected_pointertypes[event.pointerType] = true;
+                    target0.setPointerCapture(event.pointerId);
+                });
+
+                on_event(target0, "gotpointercapture", function (event) {
+                    test_setPointerCapture.step(function () {
+                        assert_equals(got_pointer_capture, false, "Target0 should receive gotpointercapture at the first time it captured the pointer");
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Target 0 received gotpointercapture, target0.hasPointerCapture should be true");
+                    });
+                    got_pointer_capture = true;
+
+                    target0.setPointerCapture(event.pointerId);
+                    test_setPointerCapture.step(function () {
+                        assert_equals(target0.hasPointerCapture(event.pointerId), true, "Set capture to target0, target0.hasPointerCapture should be true");
+                        assert_equals(target1.hasPointerCapture(event.pointerId), false, "Set capture to target0, target1.hasPointerCapture should be false");
+                    });
+                });
+
+                on_event(target0, "pointerup", function (event) {
+                    test_setPointerCapture.done();
+                });
+            }
+        </script>
+    </head>
+    <body onload="run()">
+        <h1>Pointer Event: setPointerCapture to the element which already captured the pointer</h1>
+        <h4>Test Description:
+            When the setPointerCapture method is invoked, if the target element had already captured the pointer, it should not trigger any gotpointercapture or lostpointercapture event
+            <ol>
+                <li>Press and hold left mouse button over black box
+                <li>Move mouse and release mouse button
+            </ol>
+        </h4>
+        <br>
+        <div id="target0" touch-action:none></div>
+        <div id="target1" touch-action:none></div>
+        <div id="complete-notice">
+            <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+        </div>
+        <div id="log"></div>
+    </body>
+</html>

--- a/svg/linking/reftests/href-a-element-attr-change.html
+++ b/svg/linking/reftests/href-a-element-attr-change.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="retest-wait">
+<meta charset="utf-8">
+<title>href - a element</title>
+<meta name="assert"
+      content="The a element should keep its link status after removing href if there is still xlink:href">
+<link rel="match" href="href-a-element-ref.html">
+<style>
+a:link rect {
+  fill: lime;
+}
+</style>
+<body>
+  <svg width="100" height="100" viewBox="0 0 100 100"
+       xmlns:xlink="http://www.w3.org/1999/xlink" onload="loaded();">
+    <a id="link" href="abc.html" xlink:href="def.html">
+      <rect width="100%" height="100%" fill="red"/>
+    </a>
+  </svg>
+</body>
+<script>
+  function loaded() {
+    document.getElementById('link').removeAttribute('href');
+    requestAnimationFrame(function() {
+      document.documentElement.classList.remove("reftest-wait");
+    });
+  }
+</script>
+</html>

--- a/svg/linking/reftests/href-a-element-ref.html
+++ b/svg/linking/reftests/href-a-element-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - a element reference</title>
+<body>
+  <svg width="100" height="100" viewBox="0 0 100 100">
+    <rect width="100%" height="100%" fill="lime"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-feImage-element-ref.html
+++ b/svg/linking/reftests/href-feImage-element-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - feImage element reference</title>
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="Fitted" primitiveUnits="objectBoundingBox">
+      <feImage xlink:href="/images/rgrg-256x256.png"
+               x="0" y="0" width="100%" height="100%"
+               preserveAspectRatio="none"/>
+    </filter>
+    <rect x="20" y="25" width="100" height="110" filter="url(#Fitted)"/>
+    <rect x="20" y="25" width="100" height="110" fill="none" stroke="green"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-feImage-element.html
+++ b/svg/linking/reftests/href-feImage-element.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - feImage element</title>
+<meta name="assert" content="The feImage element should accept href">
+<link rel="match" href="href-feImage-element-ref.html">
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="Fitted" primitiveUnits="objectBoundingBox">
+      <feImage href="/images/rgrg-256x256.png"
+               xlink:href="/images/grgr-256x256.png"
+               x="0" y="0" width="100%" height="100%"
+               preserveAspectRatio="none"/>
+    </filter>
+    <rect x="20" y="25" width="100" height="110" filter="url(#Fitted)"/>
+    <rect x="20" y="25" width="100" height="110" fill="none" stroke="green"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-filter-element-ref.html
+++ b/svg/linking/reftests/href-filter-element-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - filter element reference</title>
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="blurMe">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5" />
+    </filter>
+    <circle cx="60" cy="60" r="50" fill="green" filter="url(#blurMe)" />
+  </svg>
+</body>

--- a/svg/linking/reftests/href-filter-element.html
+++ b/svg/linking/reftests/href-filter-element.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - filter element</title>
+<meta name="assert" content="The filter element should accept href">
+<link rel="match" href="href-filter-element-ref.html">
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <filter id="blurMe">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="5" />
+    </filter>
+    <filter id="dropShadow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" />
+      <feOffset dx="2" dy="4" />
+      <feMerge>
+        <feMergeNode />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <filter id="Copied" href="#blurMe" xlink:href="#dropShadow">
+    </filter>
+    <circle cx="60" cy="60" r="50" fill="green" filter="url(#Copied)"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-gradient-element-ref.html
+++ b/svg/linking/reftests/href-gradient-element-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - gradient element reference</title>
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="MyGradient">
+      <stop offset="5%"  stop-color="green"/>
+      <stop offset="95%" stop-color="gold"/>
+    </linearGradient>
+    <rect fill="url(#MyGradient)" stroke="black" x="0" y="0"
+          width="100" height="100"/>
+
+    <radialGradient id="MyRadialGradient">
+      <stop offset="0%" stop-color="red"/>
+      <stop offset="100%" stop-color="blue"/>
+    </radialGradient>
+    <rect x="110" y="0" rx="15" ry="15" width="100" height="100"
+          fill="url(#MyRadialGradient)"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-gradient-element.html
+++ b/svg/linking/reftests/href-gradient-element.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - gradient element</title>
+<meta name="assert" content="The gradient element should accept href">
+<link rel="match" href="href-gradient-element-ref.html">
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="MyGradient">
+      <stop offset="5%"  stop-color="green"/>
+      <stop offset="95%" stop-color="gold"/>
+    </linearGradient>
+    <linearGradient id="MyGradient2">
+      <stop offset="5%"  stop-color="red"/>
+      <stop offset="95%" stop-color="blue"/>
+    </linearGradient>
+    <linearGradient id="CopiedGradient" href="#MyGradient"
+                    xlink:href="#MyGradient2">
+    </linearGradient>
+    <rect fill="url(#CopiedGradient)" stroke="black" x="0" y="0"
+          width="100" height="100"/>
+
+    <radialGradient id="MyRadialGradient">
+      <stop offset="0%" stop-color="red"/>
+      <stop offset="100%" stop-color="blue"/>
+    </radialGradient>
+    <radialGradient id="CopiedRadialGradient" href="#MyRadialGradient"/>
+    <rect x="110" y="0" rx="15" ry="15" width="100" height="100"
+          fill="url(#CopiedRadialGradient)"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-image-element-ref.html
+++ b/svg/linking/reftests/href-image-element-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - image element reference</title>
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <image xlink:href="/images/green.png" width="100px" height="100px"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-image-element.html
+++ b/svg/linking/reftests/href-image-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - image element</title>
+<meta name="assert" content="The image should accept href">
+<link rel="match" href="href-image-element-ref.html">
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <image href="/images/green.png" xlink:href="/images/red.png"
+           width="100px" height="100px"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-pattern-element-ref.html
+++ b/svg/linking/reftests/href-pattern-element-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - pattern element reference</title>
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <pattern id="Pattern" x="0" y="0" width=".25" height=".25">
+      <rect x="0" y="0" width="25" height="25" fill="skyblue"/>
+      <circle cx="25" cy="25" r="20" fill="green" fill-opacity="0.5"/>
+    </pattern>
+    <rect fill="url(#Pattern)" stroke="black" x="0" y="0"
+          width="200" height="200"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-pattern-element.html
+++ b/svg/linking/reftests/href-pattern-element.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - pattern element</title>
+<meta name="assert" content="The pattern element should accept href">
+<link rel="match" href="href-pattern-element-ref.html">
+<body>
+  <svg width="300" height="300" viewBox="0 0 300 300">
+    <pattern id="Pattern" x="0" y="0" width=".25" height=".25">
+      <rect x="0" y="0" width="25" height="25" fill="skyblue"/>
+      <circle cx="25" cy="25" r="20" fill="green" fill-opacity="0.5"/>
+    </pattern>
+    <pattern id="Pattern2" x="0" y="0" width=".25" height=".25">
+      <rect x="0" y="0" width="25" height="25" fill="skyblue"/>
+      <circle cx="25" cy="25" r="20" fill="red" fill-opacity="0.5"/>
+    </pattern>
+    <pattern id="CopiedPattern" href="#Pattern" xlink:href="#Pattern2">
+    </pattern>
+    <rect fill="url(#CopiedPattern)" stroke="black" x="0" y="0"
+          width="200" height="200"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-textPath-element-ref.html
+++ b/svg/linking/reftests/href-textPath-element-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - textPath element reference</title>
+<body>
+  <svg width="100%" height="100%" viewBox="0 0 1000 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+      <path id="MyPath"
+            d="M 100 200
+               C 200 100 300   0 400 100
+               C 500 200 600 300 700 200
+               C 800 100 900 100 900 100" />
+    </defs>
+    <text font-family="Verdana" font-size="40">
+      <textPath xlink:href="#MyPath">
+        We go up, then we go down, then up again
+      </textPath>
+    </text>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-textPath-element.html
+++ b/svg/linking/reftests/href-textPath-element.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - textPath element</title>
+<meta name="assert" content="The textPath element should accept href">
+<link rel="match" href="href-textPath-element-ref.html">
+<body>
+  <svg width="100%" height="100%" viewBox="0 0 1000 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+      <path id="MyPath"
+            d="M 100 200
+               C 200 100 300   0 400 100
+               C 500 200 600 300 700 200
+               C 800 100 900 100 900 100" />
+      <path id="MyPath2" d="M 100 100 L 900 100" />
+    </defs>
+    <text font-family="Verdana" font-size="40">
+      <textPath href="#MyPath" xlink:href="#MyPath2">
+        We go up, then we go down, then up again
+      </textPath>
+    </text>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-use-element-ref.html
+++ b/svg/linking/reftests/href-use-element-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - use element reference</title>
+<body>
+  <svg style="display: none">
+    <rect id='refRect' style="fill: red" width="100" height="100" />
+  </svg>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use xlink:href="#refRect"/>
+  </svg>
+</body>

--- a/svg/linking/reftests/href-use-element.html
+++ b/svg/linking/reftests/href-use-element.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>href - use element</title>
+<meta name="assert" content="The use element should accept href">
+<link rel="match" href="href-use-element-ref.html">
+<body>
+  <svg style="display: none">
+    <circle id="refCircle" style="fill: orange" cx="50px" cy="50px" r="50px" />
+    <rect id='refRect' style="fill: red" width="100" height="100" />
+  </svg>
+  <svg width="300" height="300" viewBox="0 0 300 300"
+       xmlns:xlink="http://www.w3.org/1999/xlink">
+    <use href="#refRect" xlink:href="#refCircle"/>
+  </svg>
+</body>

--- a/svg/linking/scripted/href-animate-element.html
+++ b/svg/linking/scripted/href-animate-element.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Href - animate element tests</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='testcommon.js'></script>
+<body>
+<div id='log'></div>
+<svg id='svg' width='100' height='100' viewBox='0 0 100 100'></svg>
+<script>
+'use strict';
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var rect1 = createSVGElement(t, 'rect', svg,
+                               { 'width': '10px',
+                                 'height': '10px',
+                                 'id': 'rect1' });
+  var rect2 = createSVGElement(t, 'rect', svg,
+                               { 'width': '10px',
+                                 'height': '10px',
+                                 'id': 'rect2' });
+  var animate = createSVGElement(t, 'animate', svg,
+                                 { 'attributeName': 'x',
+                                   'from': '0',
+                                   'to': '100',
+                                   'dur': '10s' });
+  animate.setAttribute('href', '#rect1');
+  animate.setAttributeNS(XLINKNS, 'xlink:href', '#rect2');
+  assert_equals(animate.targetElement, rect1);
+
+  return waitEvent(animate, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    assert_equals(rect1.x.animVal.value, 50);
+    assert_equals(rect2.x.animVal.value, 0);
+  });
+}, 'Test for animate element when setting both href and xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var rect1 = createSVGElement(t, 'rect', svg,
+                               { 'width': '10px',
+                                 'height': '10px',
+                                 'id': 'rect1' });
+  var rect2 = createSVGElement(t, 'rect', svg,
+                               { 'width': '10px',
+                                 'height': '10px',
+                                 'id': 'rect2' });
+  var transform = createSVGElement(t, 'animateTransform', svg,
+                                   { 'attributeName': 'transform',
+                                     'type': 'translate',
+                                     'from': '0',
+                                     'to': '100',
+                                     'dur': '10s' });
+
+  transform.setAttribute('href', '#rect1');
+  transform.setAttributeNS(XLINKNS, 'xlink:href', '#rect2');
+  assert_equals(transform.targetElement, rect1);
+
+  return waitEvent(transform, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    assert_equals(rect1.getCTM().e, 50);
+    assert_equals(rect2.getCTM().e, 0);
+  });
+}, 'Test for animateTransform element when setting both href and xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var circle1 = createSVGElement(t, 'circle', svg,
+                                 { 'cx': '50',
+                                   'cy': '50',
+                                   'r': '40',
+                                   'id': 'circle1' });
+  var circle2 = createSVGElement(t, 'circle', svg,
+                                 { 'cx': '50',
+                                   'cy': '50',
+                                   'r': '40',
+                                   'id': 'circle2' });
+  var animate = createSVGElement(t, 'animate', svg,
+                                 { 'attributeName': 'cx',
+                                   'from': '50',
+                                   'to': '150',
+                                   'dur': '10s' });
+  animate.setAttribute('href', '#circle1');
+  animate.setAttributeNS(XLINKNS, 'xlink:href', '#circle2');
+  assert_equals(animate.targetElement, circle1);
+
+  return waitEvent(animate, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    assert_equals(circle1.cx.animVal.value, 100);
+    assert_equals(circle2.cx.animVal.value, 50);
+
+    animate.removeAttribute('href');
+    assert_equals(animate.targetElement, circle2);
+    assert_equals(circle1.cx.animVal.value, 50);
+    assert_equals(circle2.cx.animVal.value, 100);
+  });
+}, 'Test for animate element when removing href but we still have xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var circle1 = createSVGElement(t, 'circle', svg,
+                                 { 'cx': '50',
+                                   'cy': '50',
+                                   'r': '40',
+                                   'id': 'circle1' });
+  var circle2 = createSVGElement(t, 'circle', svg,
+                                 { 'cx': '50',
+                                   'cy': '50',
+                                   'r': '40',
+                                   'id': 'circle2' });
+  var animate = createSVGElement(t, 'animate', svg,
+                                 { 'attributeName': 'cx',
+                                   'from': '50',
+                                   'to': '150',
+                                   'dur': '10s' });
+  animate.setAttribute('href', '#circle1');
+  animate.setAttributeNS(XLINKNS, 'xlink:href', '#circle2');
+  assert_equals(animate.targetElement, circle1);
+
+  return waitEvent(animate, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    assert_equals(circle1.cx.animVal.value, 100);
+    assert_equals(circle2.cx.animVal.value, 50);
+
+    animate.removeAttributeNS(XLINKNS, 'href');
+    assert_equals(animate.targetElement, circle1);
+    assert_equals(circle1.cx.animVal.value, 100);
+    assert_equals(circle2.cx.animVal.value, 50);
+  });
+}, 'Test for animate element when removing xlink:href but we still have href');
+
+</script>
+</body>

--- a/svg/linking/scripted/href-mpath-element.html
+++ b/svg/linking/scripted/href-mpath-element.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Href - mpath element tests</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='testcommon.js'></script>
+<body>
+<div id='log'></div>
+<svg id='svg' width='100' height='100' viewBox='0 0 100 100'></svg>
+<script>
+'use strict';
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var path1 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath1', 'd': 'M 0,0 L 100,0' });
+  var path2 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath2', 'd': 'M 0,0 L 0,100' });
+  var rect = createSVGElement(t, 'rect', svg,
+                              { 'width': '10px', 'height': '10px' });
+  var animateMotion = createSVGElement(t, 'animateMotion', rect,
+                                       { 'dur': '10s' });
+  var mpath = createSVGElement(t, 'mpath', animateMotion);
+  mpath.setAttribute('href', '#MyPath1');
+  mpath.setAttributeNS(XLINKNS, 'xlink:href', '#MyPath2');
+  assert_equals(mpath.href.baseVal, '#MyPath1');
+
+  return waitEvent(animateMotion, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(1);
+    var ctm = rect.getCTM();
+    assert_equals(ctm.e, 10);
+    assert_equals(ctm.f, 0);
+
+    svg.setCurrentTime(5);
+    ctm = rect.getCTM();
+    assert_equals(ctm.e, 50);
+    assert_equals(ctm.f, 0);
+  });
+}, 'Test for mpath when setting both href and xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var path1 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath1', 'd': 'M 0,0 L 100,0' });
+  var path2 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath2', 'd': 'M 0,0 L 0,100' });
+  var rect = createSVGElement(t, 'rect', svg,
+                              { 'width': '10px', 'height': '10px' });
+  var animateMotion = createSVGElement(t, 'animateMotion', rect,
+                                       { 'dur': '10s' });
+  var mpath = createSVGElement(t, 'mpath', animateMotion);
+  mpath.setAttribute('href', '#MyPath1');
+  mpath.setAttributeNS(XLINKNS, 'xlink:href', '#MyPath2');
+
+  return waitEvent(animateMotion, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    var ctm = rect.getCTM();
+    assert_equals(ctm.e, 50);
+    assert_equals(ctm.f, 0);
+
+    mpath.removeAttribute('href');
+    assert_equals(mpath.href.baseVal, '#MyPath2');
+
+    ctm = rect.getCTM();
+    assert_equals(ctm.e, 0);
+    assert_equals(ctm.f, 50);
+  });
+}, 'Test for mpath when removing href but we still have xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var path1 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath1', 'd': 'M 0,0 L 100,0' });
+  var path2 = createSVGElement(t, 'path', svg,
+                               { 'id': 'MyPath2', 'd': 'M 0,0 L 0,100' });
+  var rect = createSVGElement(t, 'rect', svg,
+                              { 'width': '10px', 'height': '10px' });
+  var animateMotion = createSVGElement(t, 'animateMotion', rect,
+                                       { 'dur': '10s' });
+  var mpath = createSVGElement(t, 'mpath', animateMotion);
+  mpath.setAttribute('href', '#MyPath1');
+  mpath.setAttributeNS(XLINKNS, 'xlink:href', '#MyPath2');
+
+  return waitEvent(animateMotion, 'begin').then(function() {
+    svg.pauseAnimations();
+    svg.setCurrentTime(5);
+    var ctm = rect.getCTM();
+    assert_equals(ctm.e, 50);
+    assert_equals(ctm.f, 0);
+
+    mpath.removeAttributeNS(XLINKNS, 'href');
+    assert_equals(mpath.href.baseVal, '#MyPath1');
+
+    ctm = rect.getCTM();
+    assert_equals(ctm.e, 50);
+    assert_equals(ctm.f, 0);
+  });
+}, 'Test for mpath when removing xlink:href but we still have href');
+
+</script>
+</body>

--- a/svg/linking/scripted/href-script-element-markup.html
+++ b/svg/linking/scripted/href-script-element-markup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Href - script element tests on markup</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='testcommon.js'></script>
+<body>
+<div id='log'></div>
+<svg id='svg' width='100' height='100' viewBox='0 0 100 100'>
+  <script id='script' href='testScripts/externalScript1.js'
+          xlink:href='testScripts/externalScript2.js'></script>
+</svg>
+<script>
+'use strict';
+
+// Use an independent test file for markup testing because it may affect other
+// tests.
+
+test(function(t) {
+  var script = document.getElementById('script');
+  assert_equals(script.href.baseVal, 'testScripts/externalScript1.js');
+  assert_equals(loadedScript(), 'externalScript1');
+}, 'Test for loading external script by markup when setting both href and ' +
+   'xlink:href');
+
+</script>
+</body>

--- a/svg/linking/scripted/href-script-element.html
+++ b/svg/linking/scripted/href-script-element.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Href - script element tests</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='testcommon.js'></script>
+<body>
+<div id='log'></div>
+<svg id='svg' width='100' height='100' viewBox='0 0 100 100'>
+</svg>
+<script>
+'use strict';
+
+// Note:
+// The order of these tests shouldn't be changed because we don't unload
+// the external script file even if we expect the <script> element will be
+// removed by childNode.remove() and Garbage Collection after a test has been
+// finished. Therefore, I intentionally make them load externalScript1 and
+// externalScript2 alternately, and we can check if the results are changed
+// after reloading the other script.
+// Throughout this test, we periodically need to verify that a script
+// *does not load* after we've made a tweak. To do that, we have to
+// wait "long enough for it to have loaded", and then make sure nothing
+// has changed.  We estimate "long enough" by adding an extra dummy
+// <script> element and watching for its load event.
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var script = createSVGElement(t, 'script', svg);
+
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('href', 'testScripts/externalScript1.js');
+  assert_equals(script.href.baseVal, 'testScripts/externalScript1.js');
+
+  return waitEvent(script, 'load').then(function() {
+    assert_equals(loadedScript(), 'externalScript1',
+                  'Link to correct external script');
+
+    script.setAttributeNS(XLINKNS, 'xlink:href',
+                          'testScripts/externalScript2.js');
+
+    // Load an dummy script to trigger a load event.
+    var dummyScript = createSVGElement(t, 'script', svg);
+    dummyScript.setAttribute('href', 'testScripts/dummyScript.js');
+    return waitEvent(dummyScript, 'load');
+  }).then(function() {
+    assert_equals(script.href.baseVal, 'testScripts/externalScript1.js');
+    assert_equals(loadedScript(), 'externalScript1',
+                  'Still link to the external script from href');
+  });
+}, 'Test for loading external script from href when setting href and ' +
+   'then xlink:href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var script = createSVGElement(t, 'script', svg);
+
+  script.setAttribute('type', 'text/javascript');
+  script.setAttributeNS(XLINKNS, 'xlink:href',
+                        'testScripts/externalScript2.js');
+  assert_equals(script.href.baseVal, 'testScripts/externalScript2.js');
+
+  return waitEvent(script, 'load').then(function() {
+    assert_equals(loadedScript(), 'externalScript2',
+                  'Link to the external script from xlink:href');
+
+    script.setAttribute('href', 'testScripts/externalScript1.js');
+
+    // Load an dummy script to trigger a load event.
+    var dummyScript = createSVGElement(t, 'script', svg);
+    dummyScript.setAttribute('href', 'testScripts/dummyScript.js');
+    return waitEvent(dummyScript, 'load');
+  }).then(function() {
+    assert_equals(script.href.baseVal, 'testScripts/externalScript1.js',
+                  'href() should prefer href attribute over xlink:href');
+    assert_equals(loadedScript(), 'externalScript2',
+                  'Still link to the external script from xlink:href');
+  });
+}, 'Test for loading external script from xlnk:href by adding xlink:href and ' +
+   'then href');
+
+promise_test(function(t) {
+  var svg = document.getElementById('svg');
+  var script = createSVGElement(t, 'script', svg);
+
+  script.setAttribute('type', 'text/javascript');
+  script.setAttribute('href', 'testScripts/externalScript1.js');
+  script.setAttributeNS(XLINKNS, 'xlink:href',
+                        'testScripts/externalScript2.js');
+  assert_equals(script.href.baseVal, 'testScripts/externalScript1.js');
+
+  return waitEvent(script, 'load').then(function() {
+    assert_equals(loadedScript(), 'externalScript1',
+                  'Link to the external script by href');
+
+    script.removeAttribute('href');
+    assert_equals(script.href.baseVal, 'testScripts/externalScript2.js',
+                  'href() returns xlink:href attribute because href was unset');
+
+    // Load an dummy script to trigger a load event.
+    var dummyScript = createSVGElement(t, 'script', svg);
+    dummyScript.setAttribute('href', 'testScripts/dummyScript.js');
+    return waitEvent(dummyScript, 'load');
+  }).then(function() {
+    assert_equals(loadedScript(), 'externalScript1',
+                  'The external script loaded from href is still loaded');
+  });
+}, 'Test for loading external script from href by adding href and ' +
+   'then xlink:href, and then removing href');
+
+</script>
+</body>

--- a/svg/linking/scripted/testScripts/dummyScript.js
+++ b/svg/linking/scripted/testScripts/dummyScript.js
@@ -1,0 +1,3 @@
+function dummyScript() {
+  return "This is a dummy script";
+}

--- a/svg/linking/scripted/testScripts/externalScript1.js
+++ b/svg/linking/scripted/testScripts/externalScript1.js
@@ -1,0 +1,3 @@
+function loadedScript() {
+  return "externalScript1";
+}

--- a/svg/linking/scripted/testScripts/externalScript2.js
+++ b/svg/linking/scripted/testScripts/externalScript2.js
@@ -1,0 +1,3 @@
+function loadedScript() {
+  return "externalScript2";
+}

--- a/svg/linking/scripted/testcommon.js
+++ b/svg/linking/scripted/testcommon.js
@@ -1,0 +1,42 @@
+/**
+ * The const var for SVG and xlink namespaces
+ */
+const SVGNS = 'http://www.w3.org/2000/svg';
+const XLINKNS = 'http://www.w3.org/1999/xlink';
+
+/**
+ * Appends a svg element to the parent.
+ *
+ * @param test The testharness.js Test object. If provided, this will be used
+ *             to register a cleanup callback to remove the div when the test
+ *             finishes.
+ * @param tag The element tag name.
+ * @param parent The parent element of this new created svg element.
+ * @param attrs  A dictionary object with attribute names and values to set on
+ *               the div.
+ */
+function createSVGElement(test, tag, parent, attrs) {
+  var elem = document.createElementNS(SVGNS, tag);
+  if (attrs) {
+    for (var attrName in attrs) {
+      elem.setAttribute(attrName, attrs[attrName]);
+    }
+  }
+  parent.appendChild(elem);
+  test.add_cleanup(function() {
+    elem.remove();
+  });
+  return elem;
+}
+
+/**
+ * Create a Promise object which resolves when a specific event fires.
+ *
+ * @param object The event target.
+ * @param name The event name.
+ */
+function waitEvent(object, name) {
+  return new Promise(function(resolve) {
+    object.addEventListener(name, resolve, { once: true });
+  });
+}

--- a/web-animations/interfaces/Animation/effect.html
+++ b/web-animations/interfaces/Animation/effect.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Animation.effect tests</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-effect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<link rel="stylesheet" href="/resources/testharness.css">
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(function(t) {
+  var anim = new Animation();
+  assert_equals(anim.effect, null, "initial effect is null");
+
+  var newEffect = new KeyframeEffectReadOnly(createDiv(t), null);
+  anim.effect = newEffect;
+  assert_equals(anim.effect, newEffect, "new effect is set");
+}, "effect is set correctly.");
+
+</script>
+</body>

--- a/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
+++ b/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
@@ -107,12 +107,8 @@ test(function(t) {
   assert_equals(getComputedStyle(div).opacity, '0.5',
                 'set currentTime same as endTime');
 
-  anim.currentTime = 9999;
-  assert_equals(getComputedStyle(div).opacity, '0.5',
-                'set currentTime during duration');
-
   anim.currentTime = 10000;
-  assert_equals(getComputedStyle(div).opacity, '0.5',
+  assert_equals(getComputedStyle(div).opacity, '0',
                 'set currentTime after endTime');
 }, 'change currentTime when fill forwards and endDelay is negative');
 

--- a/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
+++ b/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
@@ -189,10 +189,10 @@ var gEndTimeTests = [
   { desc:     "an non-zero duration and negative delay greater than active " +
               "duration",
     input:    { duration: 1000, iterations: 2, delay: -3000 },
-    expected: -1000 },
+    expected: 0 },
   { desc:     "a zero duration and negative delay",
     input:    { duration: 0, iterations: 2, delay: -1000 },
-    expected: -1000 }
+    expected: 0 }
 ];
 
 gEndTimeTests.forEach(function(stest) {

--- a/web-animations/timing-model/animation-effects/active-time.html
+++ b/web-animations/timing-model/animation-effects/active-time.html
@@ -100,7 +100,7 @@ test(function(t) {
   var anim = createDiv(t).animate(null, { duration: 1000,
                                           iterations: 2.3,
                                           delay: 500,
-                                          endDelay: -3000,
+                                          endDelay: -2500,
                                           fill: 'forwards' });
   anim.finish();
   assert_equals(anim.effect.getComputedTiming().currentIteration, 0);

--- a/web-animations/timing-model/animation-effects/phases-and-states.html
+++ b/web-animations/timing-model/animation-effects/phases-and-states.html
@@ -73,7 +73,7 @@ test(function(t) {
   var animation = createDiv(t).animate(null, { duration: 1, delay: -1 });
 
   [ { currentTime: -2, phase: 'before' },
-    { currentTime: -1, phase: 'active' },
+    { currentTime: -1, phase: 'before' },
     { currentTime:  0, phase: 'after'  } ]
   .forEach(function(test) {
     assert_phase_at_time(animation, test.phase, test.currentTime);
@@ -121,7 +121,8 @@ test(function(t) {
   var animation = createDiv(t).animate(null, { duration: 1, endDelay: -2 });
 
   [ { currentTime: -2, phase: 'before' },
-    { currentTime: -1, phase: 'after'  } ]
+    { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'after'  } ]
   .forEach(function(test) {
     assert_phase_at_time(animation, test.phase, test.currentTime);
   });
@@ -133,8 +134,8 @@ test(function(t) {
                                                delay: 1,
                                                endDelay: -1 });
 
-  [ { currentTime: 0,   phase: 'before' },
-    { currentTime: 1,   phase: 'active' },
+  [ { currentTime: 0, phase: 'before' },
+    { currentTime: 1, phase: 'active' },
     { currentTime: 2, phase: 'after'  } ]
   .forEach(function(test) {
     assert_phase_at_time(animation, test.phase, test.currentTime);
@@ -147,8 +148,9 @@ test(function(t) {
                                                delay: -1,
                                                endDelay: -1 });
 
-  [ { currentTime: -2,   phase: 'before' },
-    { currentTime: -1,   phase: 'after'  } ]
+  [ { currentTime: -2, phase: 'before' },
+    { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'after'  } ]
   .forEach(function(test) {
     assert_phase_at_time(animation, test.phase, test.currentTime);
   });
@@ -160,8 +162,10 @@ test(function(t) {
                                                delay: -1,
                                                endDelay: -2 });
 
-  [ { currentTime: -3,   phase: 'before' },
-    { currentTime: -2,   phase: 'after'  } ]
+  [ { currentTime: -3, phase: 'before' },
+    { currentTime: -2, phase: 'before' },
+    { currentTime: -1, phase: 'before' },
+    { currentTime:  0, phase: 'after'  } ]
   .forEach(function(test) {
     assert_phase_at_time(animation, test.phase, test.currentTime);
   });

--- a/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Setting the target effect tests</title>
+<link rel='help' href='https://w3c.github.io/web-animations/#setting-the-target-effect'>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../../testcommon.js'></script>
+<body>
+<div id='log'></div>
+<script>
+'use strict';
+
+promise_test(function(t) {
+  var anim = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                  100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  var retPromise = anim.ready.then(function() {
+    assert_unreached('ready promise is fulfilled');
+  }).catch(function(err) {
+    assert_equals(err.name, 'AbortError',
+                  'ready promise is rejected with AbortError');
+  });
+
+  anim.effect = null;
+  assert_equals(anim.playState, 'paused');
+
+  return retPromise;
+}, 'If new effect is null and old effect is not null, we reset the pending ' +
+   'tasks and ready promise is rejected');
+
+promise_test(function(t) {
+  var anim = new Animation();
+  anim.pause();
+  assert_equals(anim.playState, 'pending');
+
+  anim.effect = new KeyframeEffectReadOnly(createDiv(t),
+                                           { marginLeft: [ '0px', '100px' ] },
+                                           100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  return anim.ready.then(function() {
+    assert_equals(anim.playState, 'paused');
+  });
+}, 'If animation has a pending pause task, reschedule that task to run ' +
+   'as soon as animation is ready.');
+
+promise_test(function(t) {
+  var anim = new Animation();
+  anim.play();
+  assert_equals(anim.playState, 'pending');
+
+  anim.effect = new KeyframeEffectReadOnly(createDiv(t),
+                                           { marginLeft: [ '0px', '100px' ] },
+                                           100 * MS_PER_SEC);
+  assert_equals(anim.playState, 'pending');
+
+  return anim.ready.then(function() {
+    assert_equals(anim.playState, 'running');
+  });
+}, 'If animation has a pending play task, reschedule that task to run ' +
+   'as soon as animation is ready to play new effect.');
+
+promise_test(function(t) {
+  var animA = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                   100 * MS_PER_SEC);
+  var animB = new Animation();
+
+  return animA.ready.then(function() {
+    animB.effect = animA.effect;
+    assert_equals(animA.effect, null);
+    assert_equals(animA.playState, 'finished');
+  });
+}, 'When setting the effect of an animation to the effect of an existing ' +
+   'animation, the existing animation\'s target effect should be set to null.');
+
+test(function(t) {
+  var animA = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
+                                   100 * MS_PER_SEC);
+  var animB = new Animation();
+  var effect = animA.effect;
+  animA.currentTime = 50 * MS_PER_SEC;
+  animB.currentTime = 20 * MS_PER_SEC;
+  assert_equals(effect.getComputedTiming().progress, 0.5,
+                'Original timing comes from first animation');
+  animB.effect = effect;
+  assert_equals(effect.getComputedTiming().progress, 0.2,
+                'After setting the effect on a different animation, ' +
+                'it uses the new animation\'s timing');
+}, 'After setting the target effect of animation to the target effect of an ' +
+   'existing animation, the target effect\'s timing is updated to reflect ' +
+   'the current time of the new animation.');
+
+</script>
+</body>

--- a/workers/Worker_ErrorEvent_error.htm
+++ b/workers/Worker_ErrorEvent_error.htm
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title></title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+var t1 = async_test("Error handler outside the worker should not see the error value");
+var t2 = async_test("Error handlers inside a worker should see the error value");
+
+test(function() {
+  var worker = new Worker("support/ErrorEvent-error.js");
+  worker.onerror = t1.step_func_done(function(e) {
+    assert_true(/hello/.test(e.message));
+    assert_equals(e.error, null);
+  });
+
+  var messages = 0;
+  worker.onmessage = t2.step_func(function(e) {
+    ++messages;
+    var data = e.data;
+    assert_true(data.source == "onerror" ||
+                data.source == "event listener");
+    assert_equals(data.value, "hello");
+    if (messages == 2) {
+      t2.done();
+    }
+  });
+});
+</script>

--- a/workers/support/ErrorEvent-error.js
+++ b/workers/support/ErrorEvent-error.js
@@ -1,0 +1,9 @@
+onerror = function(message, location, line, col, error) {
+  postMessage({ source: "onerror", value: error });
+}
+
+addEventListener("error", function(e) {
+  postMessage({ source: "event listener", value: e.error });
+});
+
+throw "hello";


### PR DESCRIPTION
If we have a creator parser, then we were a parser-inserted script and should
presumably be able to set a valid insertion point when we run or fire our
load/error events.  For the error event case, we do this in
nsScriptElement::ScriptAvailable, so that async error events due to things like
bogus script URLs do not end up with a valid insertion point.  For the load
event case, we just do this in ScriptEvaluated directly.

ScriptEvaluated is called while the scriptloader has our script set as the
current parser-inserted script.  But for the error event case we need to
maintain that state around the ScriptAvailable call that will fire the event.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1297125
