### PR TITLE
Use Symbol.iterator instead of values() to get Iterator prototype.

### DIFF
--- a/fetch/api/headers/headers-basic.html
+++ b/fetch/api/headers/headers-basic.html
@@ -127,7 +127,7 @@
         return value.toLowerCase();
       }).sort();
 
-      var iteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([].values()));
+      var iteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
       function checkIteratorProperties(iterator) {
         var prototype = Object.getPrototypeOf(iterator);
         assert_equals(Object.getPrototypeOf(prototype), iteratorPrototype);


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1299593
