### PR TITLE
Do not fire one last progress event on XHR errors, to match a spec change.

### DIFF
--- a/XMLHttpRequest/abort-after-send.htm
+++ b/XMLHttpRequest/abort-after-send.htm
@@ -4,6 +4,7 @@
     <title>XMLHttpRequest: abort() after send()</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="resources/xmlhttprequest-event-order.js"></script>
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-abort()-method" data-tested-assertations="following-sibling::ol/li[1] following-sibling::ol/li[3] following-sibling::ol/li[4] following-sibling::ol/li[4]/ol/li[1] following-sibling::ol/li[4]/ol/li[3] following-sibling::ol/li[4]/ol/li[4] following-sibling::ol/li[4]/ol/li[5] following-sibling::ol/li[4]/ol/li[6] following-sibling::ol/li[5]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-responsetext-attribute" data-tested-assertations="following::ol/li[3]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-responsexml-attribute" data-tested-assertations="following::ol/li[3]" />
@@ -19,36 +20,26 @@
       var test = async_test()
       test.step(function() {
         var client = new XMLHttpRequest(),
-            control_flag = false,
-            result = [],
-            expected = [1, 4, 'progress', 'abort', 'loadend'] // open() -> 1, abort() -> 4
-        client.onreadystatechange = function() {
-          test.step(function() {
-            result.push(client.readyState)
-            if(client.readyState == 4) {
-              control_flag = true
-              assert_equals(client.responseXML, null)
-              assert_equals(client.responseText, "")
-              assert_equals(client.status, 0)
-              assert_equals(client.statusText, "")
-              assert_equals(client.getAllResponseHeaders(), "")
-              assert_equals(client.getResponseHeader('Content-Type'), null)
-            }
-          })
-        }
+            control_flag = false;
+        prepare_xhr_for_event_order_test(client);
+        client.addEventListener("readystatechange", test.step_func(function() {
+          if(client.readyState == 4) {
+            control_flag = true
+            assert_equals(client.responseXML, null)
+            assert_equals(client.responseText, "")
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.getAllResponseHeaders(), "")
+            assert_equals(client.getResponseHeader('Content-Type'), null)
+          }
+        }))
         client.open("GET", "resources/well-formed.xml", true)
         client.send(null)
-        client.addEventListener('progress', logEvt)
-        client.addEventListener('abort', logEvt)
-        client.addEventListener('loadend', logEvt)
         client.abort()
         assert_true(control_flag)
         assert_equals(client.readyState, 0)
-        assert_array_equals(result, expected)
+        assert_xhr_event_order_matches([1, "loadstart(0,0,false)", 4, "abort(0,0,false)", "loadend(0,0,false)"])
         test.done()
-        function logEvt (e) {
-          result.push(e.type)
-        }
       })
     </script>
   </body>

--- a/XMLHttpRequest/abort-during-upload.htm
+++ b/XMLHttpRequest/abort-during-upload.htm
@@ -18,7 +18,7 @@
         client.open("POST", "resources/delay.py?ms=1000")
         client.addEventListener("loadend", function(e) {
           test.step(function() {
-            assert_xhr_event_order_matches([1, "loadstart(0,0,false)", "upload.loadstart(0,9999,true)", 4, "upload.progress(0,0,false)", "upload.abort(0,0,false)", "upload.loadend(0,0,false)", "progress(0,0,false)", "abort(0,0,false)", "loadend(0,0,false)"]);
+            assert_xhr_event_order_matches([1, "loadstart(0,0,false)", "upload.loadstart(0,9999,true)", 4, "upload.abort(0,0,false)", "upload.loadend(0,0,false)", "abort(0,0,false)", "loadend(0,0,false)"]);
             test.done()
           })
         });

--- a/XMLHttpRequest/abort-event-order.htm
+++ b/XMLHttpRequest/abort-event-order.htm
@@ -37,7 +37,7 @@
             {
                 test.step(function()
                 {
-                    assert_xhr_event_order_matches([1, "loadstart(0,0,false)", 4, "upload.progress(0,0,false)", "upload.abort(0,0,false)", "upload.loadend(0,0,false)", "progress(0,0,false)", "abort(0,0,false)", "loadend(0,0,false)"]);
+                    assert_xhr_event_order_matches([1, "loadstart(0,0,false)", 4, "upload.abort(0,0,false)", "upload.loadend(0,0,false)", "abort(0,0,false)", "loadend(0,0,false)"]);
 
                     assert_equals(xhr.readyState, 0, 'state should be UNSENT');
                     test.done();

--- a/XMLHttpRequest/event-timeout-order.htm
+++ b/XMLHttpRequest/event-timeout-order.htm
@@ -20,7 +20,7 @@
             prepare_xhr_for_event_order_test(xhr);
             xhr.addEventListener("loadend", function() {
                 test.step(function() {
-                    assert_xhr_event_order_matches([1, "loadstart(0,0,false)", "upload.loadstart(0,12,true)", 4, "upload.progress(0,0,false)", "upload.timeout(0,0,false)", "upload.loadend(0,0,false)", "progress(0,0,false)", "timeout(0,0,false)", "loadend(0,0,false)"]);
+                    assert_xhr_event_order_matches([1, "loadstart(0,0,false)", "upload.loadstart(0,12,true)", 4, "upload.timeout(0,0,false)", "upload.loadend(0,0,false)", "timeout(0,0,false)", "loadend(0,0,false)"]);
                     test.done();
                 });
             });

--- a/XMLHttpRequest/progress-events-response-data-gzip.htm
+++ b/XMLHttpRequest/progress-events-response-data-gzip.htm
@@ -36,17 +36,20 @@
 
           * If lengthComputable is true:
               * Event.total must match Content-length header
-              * event.loaded should be a smaller number while resource is loading
-                and match Content-length when loading is finished
-              * Setting event.loaded to equal event.total for each progress event if the
-                resource is not fully downloaded would be cheating
+              * event.loaded must only ever increase in progress events
+                (and may never repeat its value).
+              * event.loaded must never exceed the Content-length.
 
           * If lengthComputable is false:
               * event.total should be 0
+              * event.loaded must only ever increase in progress events
+                (and may never repeat its value).
               * event.loaded should be the length of the decompressed content, i.e.
                 bigger than Content-length header value when finished loading
 
         */
+        var lastTotal;
+        var lastLoaded = -1;
         client.addEventListener('loadend', test.step_func(function(e){
           var len = parseInt(client.getResponseHeader('content-length'), 10)
           if(e.lengthComputable){
@@ -59,14 +62,17 @@
           test.done();
         }), false)
         client.addEventListener('progress', test.step_func(function(e){
-          if(e.lengthComputable && e.total && e.loaded && e.target.readyState < 4){
-            assert_not_equals(e.total, e.loaded, 'total should not equal loaded while download/decode is incomplete')
-            // We should only do this assertation once
-            // it's theoretically possible that all the data would get in
-            // and a progress event fire before the readyState switches from 3 to 4 -
-            // in this case we might report bogus and random failures. Better to remove the event listener again..
-            client.removeEventListener('progress', arguments.callee, false);
+          if(lastTotal === undefined){
+            lastTotal = e.total;
           }
+          if(e.lengthComputable && e.total && e.loaded){
+            assert_equals(e.total, lastTotal, 'event.total should remain invariant')
+            assert_less_than_equal(e.loaded, lastTotal, 'event.loaded should not exceed content-length')
+          }else{
+            assert_equals(e.total, 0, 'event.total should be 0')
+          }
+          assert_greater_than(e.loaded, lastLoaded, 'event.loaded should only ever increase')
+          lastLoaded = e.loaded;
         }), false)
         // image.gif is 165375 bytes compressed. Sending 45000 bytes at a time with 1 second delay will load it in 4 seconds
         client.open("GET", "resources/image.gif?pipe=gzip|trickle(45000:d1:r2)", true)

--- a/XMLHttpRequest/resources/xmlhttprequest-event-order.js
+++ b/XMLHttpRequest/resources/xmlhttprequest-event-order.js
@@ -21,13 +21,60 @@
     }
   }
 
+  function getNextEvent(arr) {
+    var eventStr = arr.shift();
+
+    // we can only handle strings, numbers (readystates) and undefined
+    if (eventStr === undefined) {
+      return event;
+    }
+    if (typeof eventStr !== "string") {
+      if (Number.isInteger(eventStr)) {
+        eventStr = "readystatechange(" + eventStr + ")";
+      } else {
+        throw "Test error: unexpected event type " + eventStr;
+      }
+    }
+
+    // parse out the general type, loaded and total values
+    var type = eventStr.type = eventStr.split("(")[0].split(".").pop();
+    eventStr.mayFollowOptionalProgressEvents = type == "progress" ||
+      type == "load" || type == "abort" || type == "error";
+    var loadedAndTotal = eventStr.match(/\((\d)+,(\d)+/);
+    if (loadedAndTotal) {
+      eventStr.loaded = parseInt(loadedAndTotal[0]);
+      eventStr.total = parseInt(loadedAndTotal[1]);
+    }
+
+    return eventStr;
+  }
+
   global.assert_xhr_event_order_matches = function(expected) {
-    try {
-      assert_array_equals(recorded_xhr_events, expected);
-    } catch(e) {
-      e.message += "\nRecorded events were:" + recorded_xhr_events.join(", ");
-      e.message += "\nExpected events were:" + expected.join(", ");
-      throw e;
+    var recorded = recorded_xhr_events;
+    var lastRecordedLoaded = -1;
+
+    while(expected.length && recorded.length) {
+      var currentExpected = getNextEvent(expected),
+          currentRecorded = getNextEvent(recorded);
+
+      // skip to the last progress event if we've hit one
+      while (recorded.length && currentRecorded.type == "progress") {
+        assert_greater(currentRecorded.loaded, lastRecordedLoaded,
+                       "progress event 'loaded' values must only increase");
+        lastRecordedLoaded = currentRecorded.loaded;
+        currentRecorded = getNextEvent(recorded);
+      }
+      if (currentRecorded.type == "loadstart") {
+        lastRecordedLoaded = -1;
+      }
+
+      assert_equals(currentRecorded, currentExpected);
+    }
+    if (recorded.length) {
+      throw "\nUnexpected extra events: " + recorded.join(", ");
+    }
+    if (expected.length) {
+      throw "\nExpected more events: " + expected.join(", ");
     }
   }
 }(this));

--- a/XMLHttpRequest/send-response-event-order.htm
+++ b/XMLHttpRequest/send-response-event-order.htm
@@ -12,6 +12,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#switch-done" data-tested-assertations="following::ol[1]/li[3] following::ol[1]/li[4] following::ol[1]/li[5] following::ol[1]/li[6] following::ol[1]/li[7]" />
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
+    <script src="resources/xmlhttprequest-event-order.js"></script>
     <title>XMLHttpRequest: The send() method: event order when synchronous flag is unset</title>
 </head>
 
@@ -24,38 +25,12 @@
         test.step(function()
         {
             var xhr = new XMLHttpRequest();
-            var expect =  ["loadstart", "upload.loadstart", "upload.progress", "upload.load", "upload.loadend", "progress", 4, "load", "loadend"];
-            var actual = [];
+            prepare_xhr_for_event_order_test(xhr);
 
-            xhr.onreadystatechange = function()
-            {
-                test.step(function()
-                {
-                    if (xhr.readyState == 4)
-                    {
-                        actual.push(xhr.readyState);
-                    }
-                });
-            };
-
-            xhr.onloadstart        = function(e){ actual.push(e.type); };
-            xhr.onload             = function(e){ actual.push(e.type); };
-            xhr.onloadend          = function(e){ actual.push(e.type); VerifyResult()};
-            xhr.onprogress         = function(e){ actual.push(e.type);};
-
-            xhr.upload.onloadstart = function(e){ actual.push("upload." + e.type); };
-            xhr.upload.onload      = function(e){ actual.push("upload." + e.type); };
-            xhr.upload.onloadend   = function(e){ actual.push("upload." + e.type);};
-            xhr.upload.onprogress  = function(e){ actual.push("upload." + e.type);};
-
-            function VerifyResult()
-            {
-                test.step(function()
-                {
-                    assert_array_equals(actual, expect);
-                    test.done();
-                });
-            };
+            xhr.addEventListener("loadend", test.step_func(function() {
+                assert_xhr_event_order_matches([1, "loadstart(0,0,false)", "upload.loadstart(0,12,true)", "upload.progress(12,12,true)", "upload.load(12,12,true)", "upload.loadend(12,12,true)", 2, 3, "progress(12,12,true)", 4, "load(12,12,true)", "loadend(12,12,true)"]);
+                test.done();
+            }));
 
             xhr.open("POST", "./resources/content.py", true);
             xhr.send("Test Message");


### PR DESCRIPTION
Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1303121
