### PR TITLE
Make update-the-finished-state.html not depend on frame timing;

### DIFF
--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -158,3 +158,19 @@ function waitForAnimationFrames(frameCount) {
     window.requestAnimationFrame(handleFrame);
   });
 }
+
+// Continually calls requestAnimationFrame until |minDelay| has elapsed
+// as recorded using document.timeline.currentTime (i.e. frame time not
+// wall-clock time).
+function waitForAnimationFramesWithDelay(minDelay) {
+  var startTime = document.timeline.currentTime;
+  return new Promise(function(resolve) {
+    (function handleFrame() {
+      if (document.timeline.currentTime - startTime >= minDelay) {
+        resolve();
+      } else {
+        window.requestAnimationFrame(handleFrame);
+      }
+    }());
+  });
+}

--- a/web-animations/timing-model/animations/updating-the-finished-state.html
+++ b/web-animations/timing-model/animations/updating-the-finished-state.html
@@ -43,9 +43,9 @@ promise_test(function(t) {
   // otherwise we don't have a resolved start time. We test the case
   // where the start time is unresolved in a subsequent test.
   return anim.ready.then(function() {
-    // Seek to 1ms before the target end and wait a frame (> 16ms)
+    // Seek to 1ms before the target end and then wait 1ms
     anim.currentTime = 100 * MS_PER_SEC - 1;
-    return waitForAnimationFrames(1);
+    return waitForAnimationFramesWithDelay(1);
   }).then(function() {
     assert_equals(anim.currentTime, 100 * MS_PER_SEC,
                   'Hold time is set to target end clamping current time');
@@ -96,9 +96,9 @@ promise_test(function(t) {
   anim.playbackRate = -1;
   anim.play(); // Make sure animation is not initially finished
   return anim.ready.then(function() {
-    // Seek to 1ms before 0 end and wait a frame (> 16ms)
+    // Seek to 1ms before 0 and then wait 1ms
     anim.currentTime = 1;
-    return waitForAnimationFrames(1);
+    return waitForAnimationFramesWithDelay(1);
   }).then(function() {
     assert_equals(anim.currentTime, 0 * MS_PER_SEC,
                   'Hold time is set to zero clamping current time');


### PR DESCRIPTION
I suspect we're hitting trouble when the refresh driver changes timer and we
end up with less time between frames.

MozReview-Commit-ID: I2dProiJTfh

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1297285
