### PR TITLE
SharedWorker no longer throws URLMismatchError

### DIFF
--- a/workers/constructors/SharedWorker/URLMismatchError.htm
+++ b/workers/constructors/SharedWorker/URLMismatchError.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Web Workers: SharedWorker - throw URLMismatchError</title>
+<title>Web Workers: SharedWorker - same name, different URL</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -10,9 +10,8 @@
   test(function() {
     var worker = new SharedWorker('shared-worker.js', 'name');
 
-    assert_throws("URLMismatchError", function() {
-      new SharedWorker('some-other-url.js', 'name');
-    });
+    // This used to throw "URLMismatchError", but the standard changed
+    var worker2 = new SharedWorker('some-other-url.js', 'name');
 
   }, "Create SharedWorker with different URLs but same name");
 

--- a/workers/constructors/SharedWorker/URLMismatchError.htm
+++ b/workers/constructors/SharedWorker/URLMismatchError.htm
@@ -6,13 +6,25 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
+var counter = 0
+function maybeDone() {
+  if(counter) {
+    done()
+  }
+  counter++
+}
 
-  test(function() {
-    var worker = new SharedWorker('shared-worker.js', 'name');
+var worker = new SharedWorker('shared-worker.js', 'name');
+worker.port.postMessage("trigger a response")
+worker.port.onmessage = (e) => {
+  assert_equals(e.data, "ping")
+  maybeDone()
+}
 
-    // This used to throw "URLMismatchError", but the standard changed
-    var worker2 = new SharedWorker('some-other-url.js', 'name');
-
-  }, "Create SharedWorker with different URLs but same name");
-
+// This used to throw "URLMismatchError", but the standard changed
+var worker2 = new SharedWorker('1', 'name');
+worker2.port.onmessage = (e) => {
+  assert_array_equals(e.data, ["1", "name"])
+  maybeDone()
+}
 </script>


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/175 for details.
