### PR TITLE
Ensure setmediakeys.js checks error name against expected error name …

### DIFF
--- a/encrypted-media/scripts/setmediakeys.js
+++ b/encrypted-media/scripts/setmediakeys.js
@@ -30,7 +30,7 @@ function runTest(config, qualifier) {
             assert_unreached('setMediaKeys should fail when setting to wrong kind of object (Date)');
         }, function(error) {
             // The error should be TypeError.
-            assert_equals(error.name, 'setMediaKeys should return a TypeError when setting to wrong kind of object (Date)');
+            assert_equals(error.name, 'TypeError', 'setMediaKeys should return a TypeError when setting to wrong kind of object (Date)');
             return navigator.requestMediaKeySystemAccess(config.keysystem, [configuration]);
         }).then(function(access) {
             assert_equals(access.keySystem, config.keysystem)


### PR DESCRIPTION
…rather than the assertion description string.
