### PR TITLE
Fix #3956: Fail gracefully on media source errors

### DIFF
--- a/encrypted-media/scripts/onencrypted.js
+++ b/encrypted-media/scripts/onencrypted.js
@@ -8,7 +8,7 @@ function runTest(config) {
     var currentData;
 
     async_test(function (test) {
-          var video = config.video,
+        var video = config.video,
             mediaSource,
             onEncrypted = function (event) {
                 currentData = new Uint8Array(event.initData);
@@ -24,14 +24,15 @@ function runTest(config) {
                 }
             };
 
-          waitForEventAndRunStep('encrypted', video, onEncrypted, test);
-          return testmediasource(config).then(test.step_func(function (source) {
-              mediaSource = source;
-              config.video.src = URL.createObjectURL(mediaSource);
-              video.play();
-          }));
-      }, 'encrypted fired on encrypted media file.'
-    );
+        waitForEventAndRunStep('encrypted', video, onEncrypted, test);
+        return testmediasource(config).then(function (source) {
+            mediaSource = source;
+            config.video.src = URL.createObjectURL(mediaSource);
+            return source.done;
+        }).then(function(){
+            video.play();
+        });
+    }, 'encrypted fired on encrypted media file.');
 }
 
 function checkInitData(data, expectedData) {

--- a/encrypted-media/scripts/playback-destroy-persistent-license.js
+++ b/encrypted-media/scripts/playback-destroy-persistent-license.js
@@ -87,6 +87,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-persistent-license-events.js
+++ b/encrypted-media/scripts/playback-persistent-license-events.js
@@ -122,6 +122,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-persistent-license.js
+++ b/encrypted-media/scripts/playback-persistent-license.js
@@ -69,6 +69,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-persistent-usage-record-events.js
+++ b/encrypted-media/scripts/playback-persistent-usage-record-events.js
@@ -107,6 +107,8 @@ function runTest(config,qualifier) {
             return testmediasource(config);
         }).then(function(source) {
             _video.src = URL.createObjectURL(source);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-persistent-usage-record.js
+++ b/encrypted-media/scripts/playback-persistent-usage-record.js
@@ -96,6 +96,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-retrieve-persistent-license.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-license.js
@@ -100,6 +100,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
@@ -102,6 +102,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-temporary-encrypted-clear-sources.js
+++ b/encrypted-media/scripts/playback-temporary-encrypted-clear-sources.js
@@ -95,6 +95,8 @@ function runTest(configEncrypted,configClear,qualifier) {
                 }).then(function(source) {
                     _mediaSource = source;
                     _video.src = URL.createObjectURL(_mediaSource);
+                    return source.done;
+                }).then(function(){
                     _video.play();
                 }).catch(onFailure);
             }

--- a/encrypted-media/scripts/playback-temporary-events.js
+++ b/encrypted-media/scripts/playback-temporary-events.js
@@ -128,6 +128,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-temporary-expired.js
+++ b/encrypted-media/scripts/playback-temporary-expired.js
@@ -79,6 +79,7 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
         }).catch(onFailure);
     }, testname);
 }

--- a/encrypted-media/scripts/playback-temporary-multikey-multisession.js
+++ b/encrypted-media/scripts/playback-temporary-multikey-multisession.js
@@ -85,6 +85,8 @@ function runTest(config,qualifier) {
             return testmediasource(config);
         }).then(function(source) {
             _video.src = URL.createObjectURL(source);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-temporary-multikey-sequential.js
+++ b/encrypted-media/scripts/playback-temporary-multikey-sequential.js
@@ -35,14 +35,20 @@ function runTest(config,qualifier) {
         }
 
         function onMessage(event) {
+            var firstMessage = !video.src;
             config.messagehandler(event.messageType, event.message, {variantId: event.target.variantId}).then(function(response) {
                 return event.target.update(response);
             }).then(function(){
-                if (!video.src) {
+                if (firstMessage) {
                     _video.src = URL.createObjectURL(_mediaSource);
-                    _video.play();
+                    return _mediaSource.done;
                 } else if (event.target.keyStatuses.size > 0){
                     _waitingForKey = false;
+                    return Promise.resolve();
+                }
+            }).then(function(){
+                if (firstMessage) {
+                    _video.play();
                 }
             }).catch(onFailure);
         }

--- a/encrypted-media/scripts/playback-temporary-multisession.js
+++ b/encrypted-media/scripts/playback-temporary-multisession.js
@@ -68,6 +68,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-temporary-setMediaKeys.js
+++ b/encrypted-media/scripts/playback-temporary-setMediaKeys.js
@@ -90,14 +90,16 @@ function runTest(config,qualifier) {
             waitForEventAndRunStep('playing', _video, onPlaying, test);
 
             return testmediasource(config);
-        }).then(test.step_func(function(source) {
+        }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
 
             if (config.testcase === SETMEDIAKEYS_AFTER_SRC) {
                 return _video.setMediaKeys(_mediaKeys);
             }
-        })).catch(onFailure);
+        }).catch(onFailure);
     }, testname);
 }

--- a/encrypted-media/scripts/playback-temporary-two-videos.js
+++ b/encrypted-media/scripts/playback-temporary-two-videos.js
@@ -74,6 +74,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
             return wait_for_timeupdate_message(_video);
         }).catch(onFailure);

--- a/encrypted-media/scripts/playback-temporary-waitingforkey.js
+++ b/encrypted-media/scripts/playback-temporary-waitingforkey.js
@@ -63,6 +63,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/scripts/playback-temporary.js
+++ b/encrypted-media/scripts/playback-temporary.js
@@ -74,6 +74,8 @@ function runTest(config,qualifier) {
         }).then(function(source) {
             _mediaSource = source;
             _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
             _video.play();
         }).catch(onFailure);
     }, testname);

--- a/encrypted-media/util/testmediasource.js
+++ b/encrypted-media/util/testmediasource.js
@@ -16,7 +16,7 @@ function testmediasource(config) {
             // Create media source
             var source = new MediaSource();
             source.done = new Promise(function(resolvesource,rejectsource){
-            
+
                 // Create and fill source buffers when the media source is opened
                 source.addEventListener('sourceopen', onSourceOpen);
                 resolve(source);
@@ -24,13 +24,13 @@ function testmediasource(config) {
                 function onSourceOpen(event) {
                     var audioSourceBuffer = source.addSourceBuffer(config.audioType),
                         videoSourceBuffer = source.addSourceBuffer(config.videoType);
-                        
+
                     audioSourceBuffer.addEventListener('updateend',onUpdateEnd);
                     videoSourceBuffer.addEventListener('updateend',onUpdateEnd);
-                    
+
                     audioSourceBuffer.appendBuffer(config.audioMedia);
                     videoSourceBuffer.appendBuffer(config.videoMedia);
-                    
+
                     function onUpdateEnd(event){
                         event.target.removeEventListener('updateend', onUpdateEnd);
                         if (!audioSourceBuffer.updating && !videoSourceBuffer.updating) {

--- a/encrypted-media/util/testmediasource.js
+++ b/encrypted-media/util/testmediasource.js
@@ -15,29 +15,35 @@ function testmediasource(config) {
 
             // Create media source
             var source = new MediaSource();
+            source.done = new Promise(function(resolvesource,rejectsource){
+            
+                // Create and fill source buffers when the media source is opened
+                source.addEventListener('sourceopen', onSourceOpen);
+                resolve(source);
 
-            // Create and fill source buffers when the media source is opened
-            source.addEventListener('sourceopen', onSourceOpen);
-
-            function onSourceOpen(event) {
-                var audioSourceBuffer = source.addSourceBuffer(config.audioType),
-                    videoSourceBuffer = source.addSourceBuffer(config.videoType);
-
-                audioSourceBuffer.appendBuffer(config.audioMedia);
-                videoSourceBuffer.appendBuffer(config.videoMedia);
-
-                function endOfStream() {
-                    if (audioSourceBuffer.updating || videoSourceBuffer.updating) {
-                        setTimeout(endOfStream, 250);
-                    } else {
-                        source.endOfStream();
+                function onSourceOpen(event) {
+                    var audioSourceBuffer = source.addSourceBuffer(config.audioType),
+                        videoSourceBuffer = source.addSourceBuffer(config.videoType);
+                        
+                    audioSourceBuffer.addEventListener('updateend',onUpdateEnd);
+                    videoSourceBuffer.addEventListener('updateend',onUpdateEnd);
+                    
+                    audioSourceBuffer.appendBuffer(config.audioMedia);
+                    videoSourceBuffer.appendBuffer(config.videoMedia);
+                    
+                    function onUpdateEnd(event){
+                        event.target.removeEventListener('updateend', onUpdateEnd);
+                        if (!audioSourceBuffer.updating && !videoSourceBuffer.updating) {
+                            if (source.readyState !== 'open') {
+                                rejectsource(new Error("Media source error"));
+                            } else {
+                                source.endOfStream();
+                                resolvesource();
+                            }
+                        }
                     }
                 }
-
-                endOfStream();
-            }
-
-            resolve(source);
+            });
         });
     });
 }


### PR DESCRIPTION
Pass media source errors as rejections in the outer promise flow.

The Media Source does not open until it is attached to a media element. At this point, we can create source buffers and append media. This is when an error could occur. Attaching to a media element is handled by the test flow, not the `testmediasource.js` utility.

I don't see an especially elegant way to handle this, so I am attaching a promise to the MediaSource object that will resolve or reject when appending is done. The test flows then need to be adjusted to include this promise.
