### PR TITLE
Clean whitespace from incoming URLs

### DIFF
--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -167,6 +167,9 @@ function makePromiseTests( thennable, criteria ) {
 }
 
 function runTests( container_url, annotation_url ) {
+  // trim whitespace from incoming variables
+  container_url = container_url.trim();
+  annotation_url = annotation_url.trim();
 
   // Section 4 has a requirement that the URL end in a slash, so...
   // ensure the url has a length


### PR DESCRIPTION
We received reports that tests were breaking due to at least a `container_url` being passed in with untrimmed white space (i.e. " http://..."). This fixes that.

/cc @halindrome @azaroth42 @iherman
