### PR TITLE
Update clearkey-mp4-requestmediakeysystemaccess.html to test that pas…

### DIFF
--- a/encrypted-media/scripts/requestmediakeysystemaccess.js
+++ b/encrypted-media/scripts/requestmediakeysystemaccess.js
@@ -41,7 +41,7 @@ function runTest(config, qualifier) {
     }
 
     // Tests for Key System.
-    expect_error('', [{}], 'InvalidAccessError', 'Empty Key System (%ks)');
+    expect_error('', [{}], 'TypeError', 'Empty Key System (%ks)');
     expect_error('com.example.unsupported', [{}], 'NotSupportedError', 'Unsupported Key System (%ks)');
     expect_error(config.keysystem + '.', [{}], 'NotSupportedError', 'Key System ending in "." (%ks)');
     expect_error(config.keysystem.toUpperCase(), [{}], 'NotSupportedError', 'Capitalized Key System (%ks)');
@@ -83,7 +83,7 @@ function runTest(config, qualifier) {
     }
 
     // Tests for trivial configurations.
-    expect_error(config.keysystem, [], 'InvalidAccessError', 'Empty supportedConfigurations');
+    expect_error(config.keysystem, [], 'TypeError', 'Empty supportedConfigurations');
     expect_config(config.keysystem, [{}], {}, 'Empty configuration');
 
     // Various combinations of supportedConfigurations.


### PR DESCRIPTION
…sing

empty keysystem string or empty MediaKeySystemConfiguration array to
navigator.requestMediaKeySystemAccess() throws a TypeError, as required
by the spec.
