### PR TITLE
Fix typo in playback-temporary-multikey-sequential.js.

### DIFF
--- a/encrypted-media/scripts/playback-temporary-multikey-sequential.js
+++ b/encrypted-media/scripts/playback-temporary-multikey-sequential.js
@@ -38,7 +38,7 @@ function runTest(config,qualifier) {
             config.messagehandler(event.messageType, event.message, {variantId: event.target.variantId}).then(function(response) {
                 return event.target.update(response);
             }).then(function(){
-                if (!video.src) {
+                if (!_video.src) {
                     _video.src = URL.createObjectURL(_mediaSource);
                     _video.play();
                 } else if (event.target.keyStatuses.size > 0){


### PR DESCRIPTION
This makes clearkey-mp4-playback-temporary-multikey-sequential.html pass
in Firefox Nightly and Chrome.
