### PR TITLE
Correct wrong closing tags of WebIDL blocks in service-workers.

### DIFF
--- a/service-workers/stub-3.1-service-worker-obj.html
+++ b/service-workers/stub-3.1-service-worker-obj.html
@@ -30,7 +30,7 @@ enum ServiceWorkerState {
   "activated",
   "redundant"
 };
-</pre>
+</script>
 
 <!--
 The `ServiceWorker` interface represents the document-side view of a Service
@@ -45,7 +45,7 @@ provide meaningful functionality.
     <script type=text/plain id="untested_idls">
         interface EventHandler {};
         interface Worker {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-3.2-navigator-service-worker.html
+++ b/service-workers/stub-3.2-navigator-service-worker.html
@@ -64,7 +64,7 @@ interface ReloadPageEvent : Event {
         interface EventHandler {};
         interface EventTarget {};
         interface Event {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.1-service-worker-global-scope.html
+++ b/service-workers/stub-4.1-service-worker-global-scope.html
@@ -37,7 +37,7 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
 
   // close() method inherited from WorkerGlobalScope is not exposed.
 };
-</pre>
+</script>
 
 <!--
 The `ServiceWorkerGlobalScope` interface represents the global execution
@@ -58,7 +58,7 @@ synchronous requests MUST NOT be initiated inside of a Service Worker.
         interface ScalarValueString {};
         interface EventHandler {};
         interface WorkerGlobalScope {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.2-client.html
+++ b/service-workers/stub-4.2-client.html
@@ -19,7 +19,7 @@ interface Client {
   void postMessage(any message, DOMString targetOrigin,
                    optional sequence<Transferable> transfer);
 };
-</pre>
+</script>
 
 <!--
 The `Client` interface represents the window or the worker (defined as client)
@@ -44,7 +44,7 @@ targetOrigin, transfer)` method of a `[Client][3]`, when called, causes a
 
     <script type=text/plain id="untested_idls">
         interface Transferable {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.3-service-worker-clients.html
+++ b/service-workers/stub-4.3-service-worker-clients.html
@@ -19,7 +19,7 @@ interface ServiceWorkerClients {
   Promise<sequence<Client>?> getServiced();
   Promise<any> reloadAll();
 };
-</pre>
+</script>
 
 <!--
 The `ServiceWorkerClients` interface represents a container for a list of
@@ -31,7 +31,7 @@ The `ServiceWorkerClients` interface represents a container for a list of
 
     <script type=text/plain id="untested_idls">
         interface Client {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.4-request-objects.html
+++ b/service-workers/stub-4.4-request-objects.html
@@ -49,7 +49,7 @@ enum Mode {
 [MapClass(DOMString, DOMString)]
 interface HeaderMap {
 };
-</pre>
+</script>
 
 
 

--- a/service-workers/stub-4.5-response-objects.html
+++ b/service-workers/stub-4.5-response-objects.html
@@ -47,14 +47,14 @@ dictionary ResponseInit {
   ByteString statusText = "OK";
   HeaderMap headers;
 };
-</pre>
+</script>
 
 
 
     <script type=text/plain id="untested_idls">
         interface HeaderMap {};
         interface Blob {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.6.2-cache.html
+++ b/service-workers/stub-4.6.2-cache.html
@@ -37,7 +37,7 @@ dictionary CacheBatchOperation {
   Response response;
   CacheQueryOptions options;
 };
-</pre>
+</script>
 
 
 
@@ -45,7 +45,7 @@ dictionary CacheBatchOperation {
         interface AbstractResponse {};
         interface Request {};
         interface ScalarValueString {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.6.3-cache-storage.html
+++ b/service-workers/stub-4.6.3-cache-storage.html
@@ -29,7 +29,7 @@ interface CacheStorage {
 };
 
 callback CacheStorageIterationCallback = void (Cache value, DOMString key, CacheStorage map);
-</pre>
+</script>
 
 <!--
 **Note**:[CacheStorage][1]interface is designed to largely conform
@@ -44,7 +44,7 @@ convenience methods.
     <script type=text/plain id="untested_idls">
         interface ScalarValueString {};
         interface Cache {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.7.1-install-phase-event.html
+++ b/service-workers/stub-4.7.1-install-phase-event.html
@@ -16,7 +16,7 @@
 interface InstallPhaseEvent : Event {
   Promise<any> waitUntil(Promise<any> f);
 };
-</pre>
+</script>
 
 <!--
 Service Workers have two [Lifecycle events][1], `[install][2]` and
@@ -34,7 +34,7 @@ from the `[InstallPhaseEvent][4]` interface, for `[install][2]` event.
 
     <script type=text/plain id="untested_idls">
         interface Event {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.7.2.1-install-event-section.html
+++ b/service-workers/stub-4.7.2.1-install-event-section.html
@@ -17,7 +17,7 @@ interface InstallEvent : InstallPhaseEvent {
   readonly attribute ServiceWorker? activeWorker;
   void replace();
 };
-</pre>
+</script>
 
 <!--
 Service Workers use the `[InstallEvent][1]` interface for `[install][2]` event.
@@ -30,7 +30,7 @@ Service Workers use the `[InstallEvent][1]` interface for `[install][2]` event.
     <script type=text/plain id="untested_idls">
         interface ServiceWorker {};
         interface InstallPhaseEvent {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();

--- a/service-workers/stub-4.7.4.1-fetch-event-section.html
+++ b/service-workers/stub-4.7.4.1-fetch-event-section.html
@@ -37,7 +37,7 @@ enum Context {
   "child",
   "navigate"
 };
-</pre>
+</script>
 
 <!--
 Service Workers use the `[FetchEvent][1]` interface for `[fetch][2]` event.
@@ -53,7 +53,7 @@ Service Workers use the `[FetchEvent][1]` interface for `[fetch][2]` event.
         interface AbstractResponse {};
         interface ScalarValueString {};
         interface Event {};
-    </pre>
+    </script>
 
     <script>
         var idl_array = new IdlArray();


### PR DESCRIPTION
The following commit fixed only tags at the beginning. This patch fixes
the closing tags to work properly.
https://github.com/w3c/web-platform-tests/commit/d7072b6f4d04ca90fb4f3a545d3bcb0dd55feac8
which has been fixed at #1053.
