### PR TITLE
[eme] Expect TypeError for empty array parameters

### DIFF
--- a/encrypted-media/scripts/syntax-mediakeysession.js
+++ b/encrypted-media/scripts/syntax-mediakeysession.js
@@ -50,8 +50,10 @@ function runTest(config) {
                 return mk5.createSession().generateRequest(type, 1);
             }
         },
+        // (new Uint8Array(0)) returns empty array. So 'TypeError' should
+        // be returned.
         {
-            exception: 'InvalidAccessError',
+            exception: 'TypeError',
             func: function (mk6, type) {
                 return mk6.createSession().generateRequest(type, new Uint8Array(0));
             }
@@ -247,8 +249,10 @@ function runTest(config) {
                 return s.update(1);
             }
         },
+        // (new Uint8Array(0)) returns empty array. So 'TypeError' should
+        // be returned.
         {
-            exception: 'InvalidAccessError',
+            exception: 'TypeError',
             func: function (s) {
                 return s.update(new Uint8Array(0));
             }


### PR DESCRIPTION
Convert things to the expected type.

When calling **MediaKeySession.generateRequest**, according to current EME spec algorithm [1], 
'''5. If initData is an empty array, return a promise rejected with a newly created **TypeError**. '''

When calling **MediaKeySession.update**, according to current EME spec algorithm, 
'''3. If response is an empty array, return a promise rejected with a newly created **TypeError**.'''

[1] [[W3C Editor's Draft 20 September 2016]](https://w3c.github.io/encrypted-media/#dom-mediakeysession-update)
