### PR TITLE
Add a travis job for testing PR stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,48 @@
-sudo: false # cause Travis to start builds much faster
+dist: trusty
 language: python
-python:
-  - "2.7"
+addons:
+  hosts:
+    - web-platform.test
+    - www.web-platform.test
+    - www1.web-platform.test
+    - www2.web-platform.test
+    - xn--n8j6ds53lwwkrqhv28a.web-platform.test
+    - xn--lve-6lad.web-platform.test
 before_install:
   - git submodule update --init --recursive
-# command to run tests, e.g. python setup.py test
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+install:
+  - pip install -U setuptools
+matrix:
+  include:
+    - os: linux
+      python: "2.7"
+      env:
+        - SCRIPT=ci_lint.sh
+    - os: linux
+      python: "2.7"
+      addons:
+        apt:
+          packages:
+            - libnss3-tools
+      env:
+        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
+        - SCRIPT=ci_stability.sh
+        - PRODUCT=firefox
+    - os: linux
+      sudo: required
+      python: "2.7"
+      addons:
+        apt:
+          packages:
+            - libappindicator1
+            - fonts-liberation
+      env:
+        - SCRIPT=ci_stability.sh
+        - PRODUCT=chrome
 script:
-  - ./lint
-  - ./manifest
-  - ./diff-manifest.py
+  - bash $SCRIPT
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 install:
   - pip install -U setuptools
+  - pip install -U requests
 matrix:
   include:
     - os: linux
@@ -39,6 +40,7 @@ matrix:
             - libappindicator1
             - fonts-liberation
       env:
+        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
         - SCRIPT=ci_stability.sh
         - PRODUCT=chrome
 script:

--- a/check_stability.py
+++ b/check_stability.py
@@ -1,0 +1,195 @@
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from collections import defaultdict
+
+from wptrunner import wptrunner
+from wptrunner import wptcommandline
+from mozlog import reader
+
+logger = logging.getLogger(os.path.splitext(__file__)[0])
+
+
+def setup_logging():
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter(logging.BASIC_FORMAT, None)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+setup_logging()
+
+
+class Firefox(object):
+    product = "firefox"
+
+    def wptrunner_args(self, root):
+        return {
+            "product": "firefox",
+            "binary": "%s/firefox/firefox" % root,
+            "certutil_binary": "certutil",
+            "webdriver_binary": "%s/geckodriver" % root,
+            "prefs_root": "%s/profiles" % root,
+        }
+
+
+class Chrome(object):
+    product = "chrome"
+
+    def wptrunner_args(self, root):
+        return {
+            "product": "chrome",
+            "binary": "%s/chrome-linux/chrome" % root,
+            "webdriver_binary": "%s/chromedriver" % root,
+            "test_types": ["testharness", "reftest"]
+        }
+
+
+def get_git_cmd(repo_path):
+    def git(cmd, *args):
+        full_cmd = ["git", cmd] + list(args)
+        try:
+            return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            logger.error("Git command exited with status %i" % e.returncode)
+            logger.error(e.output)
+            sys.exit(1)
+    return git
+
+
+def get_files_changed(root):
+    git = get_git_cmd("%s/w3c/web-platform-tests" % root)
+    branch_point = git("merge-base", "HEAD", "master").strip()
+    files = git("diff", "--name-only", "-z", "%s.." % branch_point)
+    assert files[-1] == "\0"
+    return ["%s/w3c/web-platform-tests/%s" % (root, item)
+            for item in files[:-1].split("\0")]
+
+
+def wptrunner_args(root, files_changed, iterations, browser):
+    parser = wptcommandline.create_parser([browser.product])
+    args = vars(parser.parse_args([]))
+    wpt_root = os.path.join(root, "w3c", "web-platform-tests")
+    args.update(browser.wptrunner_args(root))
+    args.update({
+        "tests_root": wpt_root,
+        "metadata_root": wpt_root,
+        "repeat": iterations,
+        "config": "%s/w3c/wptrunner/wptrunner.default.ini" % root,
+        "test_list": files_changed,
+        "restart_on_unexpected": False,
+        "pause_after_test": False
+    })
+    wptcommandline.check_args(args)
+    return args
+
+
+class LogHandler(reader.LogHandler):
+    def __init__(self):
+        self.results = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+    def test_status(self, data):
+        self.results[data["test"]][data.get("subtest")][data["status"]] += 1
+
+    def test_end(self, data):
+        self.results[data["test"]][None][data["status"]] += 1
+
+
+def is_inconsistent(results_dict, iterations):
+    return len(results_dict) > 1 or sum(results_dict.values()) != iterations
+
+
+def err_string(results_dict):
+    rv = []
+    for key, value in sorted(results_dict.items()):
+        rv.append("%s: %i" % (key, value))
+    return " ".join(rv)
+
+
+def check_consistent(log, iterations):
+    inconsistent = []
+    handler = LogHandler()
+    reader.handle_log(reader.read(log), handler)
+    results = handler.results
+    for test, test_results in results.iteritems():
+        parent = test_results.pop(None)
+        if is_inconsistent(parent, iterations):
+            inconsistent.append((test, None, parent))
+            write = logger.error
+        else:
+            write = logger.info
+        write("| %s => %s" % (test, err_string(parent)))
+        for subtest, result in test_results.iteritems():
+            if is_inconsistent(result, iterations):
+                inconsistent.append((test, subtest, result))
+                write = logger.error
+            else:
+                write = logger.info
+            write("| - %s => %s" % (test, err_string(result)))
+    return inconsistent
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root",
+                        action="store",
+                        default=os.path.join(os.path.expanduser("~"), "build"),
+                        help="Root path")
+    parser.add_argument("--iterations",
+                        action="store",
+                        default=10,
+                        type=int,
+                        help="Number of times to run tests")
+    parser.add_argument("browser",
+                        action="store",
+                        help="Browser to run against")
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    browser_cls = {"firefox": Firefox,
+                   "chrome": Chrome}.get(args.browser)
+    if browser_cls is None:
+        logger.critical("Unrecognised browser %s" % args.browser)
+        sys.exit(2)
+
+    # For now just pass the whole list of changed files to wptrunner and
+    # assume that it will run everything that's actually a test
+    files_changed = get_files_changed(args.root)
+
+    logger.info("Files changed:\n  %s" % "\n  ".join(files_changed))
+
+    browser = browser_cls()
+    kwargs = wptrunner_args(args.root,
+                            files_changed,
+                            args.iterations,
+                            browser)
+    with open("raw.log", "wb") as log:
+        wptrunner.setup_logging(kwargs,
+                                {"mach": sys.stdout,
+                                 "raw": log})
+        wptrunner.run_tests(**kwargs)
+
+    logger.info("Test runs done")
+
+    with open("raw.log", "rb") as log:
+        inconsistent = check_consistent(log, args.iterations)
+
+    if inconsistent:
+        logger.error("Got unstable results:")
+        for test, subtest, results in inconsistent:
+            logger.error("%s | %s | %s" % (test,
+                                           subtest if subtest else "(parent)",
+                                           err_string(results)))
+        sys.exit(1)
+    logger.info("All results were stable")
+
+
+if __name__ == "__main__":
+    main()

--- a/check_stability.py
+++ b/check_stability.py
@@ -1,9 +1,13 @@
 import argparse
+import json
 import logging
 import os
 import subprocess
 import sys
+import traceback
 from collections import defaultdict
+
+import requests
 
 from wptrunner import wptrunner
 from wptrunner import wptcommandline
@@ -17,10 +21,55 @@ def setup_logging():
     formatter = logging.Formatter(logging.BASIC_FORMAT, None)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-
+    logger.setLevel(logging.DEBUG)
 
 setup_logging()
+
+
+def setup_github_logging(args):
+    gh_handler = None
+    if args.comment_pr:
+        if args.gh_token:
+            try:
+                pr_number = int(args.comment_pr)
+            except ValueError:
+                pass
+            else:
+                gh_handler = GitHubCommentHandler(args.gh_token, pr_number)
+                logger.debug("Setting up GitHub logging")
+                logger.addHandler(gh_handler)
+        else:
+            logger.error("Must provide --comment-pr and --github-token together")
+    return gh_handler
+
+
+class GitHubCommentHandler(logging.Handler):
+    def __init__(self, token, pull_number):
+        logging.Handler.__init__(self)
+        self.token = token
+        self.pull_number = pull_number
+        self.log_data = []
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            self.log_data.append(msg)
+        except Exception:
+            self.handleError(record)
+
+    def send(self):
+        headers = {"Accept": "application/vnd.github.v3+json"}
+        auth = (self.token, "x-oauth-basic")
+        url = "https://api.github.com/repos/w3c/web-platform-tests/issues/%s/comments" %(
+            self.pull_number,)
+        resp = requests.post(
+            url,
+            data=json.dumps({"body": "\n".join(self.log_data)}),
+            headers=headers,
+            auth=auth
+        )
+        resp.raise_for_status()
+        self.log_data = []
 
 
 class Firefox(object):
@@ -106,30 +155,43 @@ def err_string(results_dict):
     rv = []
     for key, value in sorted(results_dict.items()):
         rv.append("%s: %i" % (key, value))
-    return " ".join(rv)
+    rv = " ".join(rv)
+    if len(results_dict) > 1:
+        rv = "**%s**" % rv
+    return rv
 
 
-def check_consistent(log, iterations):
+def process_results(log, iterations):
     inconsistent = []
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
     for test, test_results in results.iteritems():
-        parent = test_results.pop(None)
-        if is_inconsistent(parent, iterations):
-            inconsistent.append((test, None, parent))
-            write = logger.error
-        else:
-            write = logger.info
-        write("| %s => %s" % (test, err_string(parent)))
         for subtest, result in test_results.iteritems():
             if is_inconsistent(result, iterations):
                 inconsistent.append((test, subtest, result))
-                write = logger.error
-            else:
-                write = logger.info
-            write("| - %s => %s" % (test, err_string(result)))
-    return inconsistent
+    return results, inconsistent
+
+
+def write_inconsistent(inconsistent):
+    logger.error("## Unstable results ##\n")
+    logger.error("| Test | Subtest | Results |")
+    logger.error("|------|---------|---------|")
+    for test, subtest, results in inconsistent:
+        logger.error("%s | %s | %s" % (test,
+                                       subtest if subtest else "(parent)",
+                                       err_string(results)))
+
+
+def write_results(results, iterations):
+    logger.info("## All results ##\n")
+    logger.info("| Test | Subtest | Results |")
+    logger.info("|------|---------|---------|")
+    for test, test_results in results.iteritems():
+        parent = test_results.pop(None)
+        logger.info("| %s |  | %s |" % (test, err_string(parent)))
+        for subtest, result in test_results.iteritems():
+            logger.info("|  | %s | %s |" % (subtest, err_string(result)))
 
 
 def get_parser():
@@ -143,6 +205,12 @@ def get_parser():
                         default=10,
                         type=int,
                         help="Number of times to run tests")
+    parser.add_argument("--gh-token",
+                        action="store",
+                        help="OAuth token to use for accessing GitHub api")
+    parser.add_argument("--comment-pr",
+                        action="store",
+                        help="PR to comment on with stability results")
     parser.add_argument("browser",
                         action="store",
                         help="Browser to run against")
@@ -150,20 +218,25 @@ def get_parser():
 
 
 def main():
+    retcode = 0
     parser = get_parser()
     args = parser.parse_args()
+
+    gh_handler = setup_github_logging(args)
+
+    logger.info("Testing in **%s**" % args.browser.title())
 
     browser_cls = {"firefox": Firefox,
                    "chrome": Chrome}.get(args.browser)
     if browser_cls is None:
         logger.critical("Unrecognised browser %s" % args.browser)
-        sys.exit(2)
+        return 2
 
     # For now just pass the whole list of changed files to wptrunner and
     # assume that it will run everything that's actually a test
     files_changed = get_files_changed(args.root)
 
-    logger.info("Files changed:\n  %s" % "\n  ".join(files_changed))
+    logger.info("Files changed:\n%s" % "".join(" * %s\n" % item for item in files_changed))
 
     browser = browser_cls()
     kwargs = wptrunner_args(args.root,
@@ -176,20 +249,31 @@ def main():
                                  "raw": log})
         wptrunner.run_tests(**kwargs)
 
-    logger.info("Test runs done")
-
     with open("raw.log", "rb") as log:
-        inconsistent = check_consistent(log, args.iterations)
+        results, inconsistent = process_results(log, args.iterations)
 
-    if inconsistent:
-        logger.error("Got unstable results:")
-        for test, subtest, results in inconsistent:
-            logger.error("%s | %s | %s" % (test,
-                                           subtest if subtest else "(parent)",
-                                           err_string(results)))
-        sys.exit(1)
-    logger.info("All results were stable")
+    if results:
+        if inconsistent:
+            write_inconsistent(inconsistent)
+            retcode = 1
+        else:
+            logger.info("All results were stable\n")
+        write_results(results, args.iterations)
+    else:
+        logger.info("No tests run.")
+
+    try:
+        if gh_handler:
+            gh_handler.send()
+    except Exception:
+        logger.error(traceback.format_exc())
+    return retcode
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        retcode = main()
+    except:
+        raise
+    else:
+        sys.exit(retcode)

--- a/ci_lint.sh
+++ b/ci_lint.sh
@@ -1,0 +1,5 @@
+set -ex
+
+./manifest
+./lint
+./diff-manifest.py

--- a/ci_stability.sh
+++ b/ci_stability.sh
@@ -96,7 +96,7 @@ install_chromedriver() {
 
 test_stability() {
     cd $WPT_HOME
-    python check_stability.py --root $BUILD_HOME $PRODUCT
+    python check_stability.py --root $BUILD_HOME --comment-pr ${TRAVIS_PULL_REQUEST} --gh-token ${GH_TOKEN} $PRODUCT
 }
 
 main() {

--- a/ci_stability.sh
+++ b/ci_stability.sh
@@ -1,0 +1,123 @@
+set -e
+
+export BUILD_HOME=$HOME/build
+export WPT_HOME=$BUILD_HOME/w3c/web-platform-tests
+
+hosts_fixup() {
+    echo "== /etc/hosts =="
+    cat /etc/hosts
+    echo "----------------"
+    sudo sed -i 's/^::1\s*localhost/::1/' /etc/hosts
+    sudo sh -c 'echo "
+127.0.0.1 web-platform.test
+127.0.0.1 www.web-platform.test
+127.0.0.1 www1.web-platform.test
+127.0.0.1 www2.web-platform.test
+127.0.0.1 xn--n8j6ds53lwwkrqhv28a.web-platform.test
+127.0.0.1 xn--lve-6lad.web-platform.test
+" >> /etc/hosts'
+    echo "== /etc/hosts =="
+    cat /etc/hosts
+    echo "----------------"
+}
+
+fetch_master() {
+    cd $WPT_HOME
+    git fetch https://github.com/w3c/web-platform-tests.git master:master
+}
+
+build_manifest() {
+    cd $WPT_HOME
+    python manifest
+}
+
+install_wptrunner() {
+    cd $BUILD_HOME
+    if [ ! -d w3c/wptrunner ]; then
+        git clone --depth 1 https://github.com/w3c/wptrunner.git w3c/wptrunner
+        cd  w3c/wptrunner
+    else
+        cd  w3c/wptrunner
+        git fetch https://github.com/w3c/wptrunner.git
+    fi
+    git reset --hard origin/master
+    git submodule update --init --recursive
+    pip install .
+}
+
+install_firefox() {
+    cd $BUILD_HOME
+    pip install -r w3c/wptrunner/requirements_firefox.txt
+    wget https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/firefox-52.0a1.en-US.linux-x86_64.tar.bz2
+    tar -xf firefox-52.0a1.en-US.linux-x86_64.tar.bz2
+
+    if [ ! -d profiles ]; then
+        mkdir profiles
+    fi
+    cd  profiles
+    wget https://hg.mozilla.org/mozilla-central/raw-file/tip/testing/profiles/prefs_general.js
+}
+
+install_geckodriver() {
+    cd $BUILD_HOME
+    local release_url
+    local tmpfile
+    local release_data
+    # Stupid hacky way of getting the release URL from the GitHub API
+    tmpfile=$(mktemp)
+    echo 'import json, sys
+data = json.load(sys.stdin)
+print (item["browser_download_url"] for item in data["assets"]
+       if "linux64" in item["browser_download_url"]).next()' > "$tmpfile"
+    release_data=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest?access_token=$GH_TOKEN)
+    echo $RELEASE_DATA
+    release_url=$(echo $release_data | python $tmpfile)
+    rm "$tmpfile"
+    wget "$release_url"
+    tar xf geckodriver*.tar.gz
+}
+
+install_chrome() {
+    cd $BUILD_HOME
+    local latest
+    pip install -r w3c/wptrunner/requirements_chrome.txt
+    latest=$(curl https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media)
+    curl "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F$latest%2Fchrome-linux.zip?alt=media" > chrome-linux64.zip
+    unzip -q chrome-linux64.zip
+}
+
+install_chromedriver() {
+    cd $BUILD_HOME
+    local latest
+    latest=$(curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+    wget "http://chromedriver.storage.googleapis.com/$latest/chromedriver_linux64.zip"
+    unzip -q chromedriver_linux64.zip
+}
+
+test_stability() {
+    cd $WPT_HOME
+    python check_stability.py --root $BUILD_HOME $PRODUCT
+}
+
+main() {
+    fetch_master
+    build_manifest
+    install_wptrunner
+    case "$PRODUCT" in
+    firefox)
+        install_firefox
+        install_geckodriver
+        ;;
+    chrome)
+        hosts_fixup
+        install_chrome
+        install_chromedriver
+        ;;
+    *)
+        echo "Unrecognised product $PRODUCT"
+        exit 1
+    esac
+    test_stability
+}
+
+main


### PR DESCRIPTION
The purpose of the job is to identify poorly-written, unstable, tests as
early in the cycle as possible. To this end we use wptrunner to run all
the changed tests in the PR in Firefox. If 10 runs of the tests don't
all give a consisent result then the job fails.

Adding runs in Chrome should be quite straightforward, adding Edge and
Safari may be more difficult because of their strict platform dependencies.
