### PR TITLE
Fix #3521: changing the expected presentation connection state into "connecting"

### DIFF
--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -7,10 +7,13 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <p>Click the button below and select the available presentation display, to start the manual test.</p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 
 <script>
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
@@ -27,10 +30,21 @@
     // Start New PresentationRequest.onconnectionavailable Test (success) - begin
     // --------------------------------------------------------------------------
     var startPresentation = function () {
-        async_test(function (t) {
-            request.onconnectionavailable = t.step_func_done(function (evt) {
-                var connection = evt.connection;
-
+        promise_test(function (t) {
+            // Note: During starting a presentation, the connectionavailable event is fired (step 20)
+            //       after the promise P is resolved (step 19).
+            return new Promise(function(resolve, reject) {
+                request.onconnectionavailable = function (evt) {
+                    resolve(evt.connection);
+                };
+                request.start().then(function() {
+                    // This test fails if request.onconnectionavailable is not invoked regardless of starting the presentation
+                    t.step_timeout(function() { reject('The connectionavailable was not fired.') }, 5000);
+                }, function() {
+                    // This test fails if the presentation is not started successfully
+                    reject('The presentation failed to be started.');
+                });
+            }).then(function(connection) {
                 // Check the initial state of a presentation connection
                 assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
 
@@ -43,10 +57,9 @@
                 // Check the instance of the connection
                 assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
             });
-
-            request.start();
-        }, 'The presentation was started successfully.');
+        }, 'The connectionavailable event was fired successfully.');
     }
+    presentBtn.onclick = startPresentation;
     // ------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - end
     // ------------------------------------------------------------------------

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -37,13 +37,11 @@
                 request.onconnectionavailable = function (evt) {
                     resolve(evt.connection);
                 };
+                // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
+                // or the presentation fails to be started
                 request.start().then(function() {
-                    // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
-                    t.step_timeout(function() { reject('The connectionavailable was not fired.') }, 5000);
-                }, function() {
-                    // This test fails if the presentation is not started successfully
-                    reject('The presentation failed to be started.');
-                });
+                    t.step_timeout(function() { assert_unreached('The connectionavailable event was not fired.'); }, 5000);
+                }, reject);
             }).then(function(connection) {
                 // Check the initial state of a presentation connection
                 assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation.onconnectionavailable (manual test)</title>
+<title>PresentationRequest.onconnectionavailable (manual test)</title>
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="https://w3c.github.io/presentation-api/#starting-a-presentation">
 <script src="/resources/testharness.js"></script>

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -32,24 +32,16 @@
                 var connection = evt.connection;
 
                 // Check the initial state of a presentation connection
-                test(function() {
-                    assert_equals(connection.state, 'connecting');
-                }, 'The initial state of the presentation connection is "connecting".');
+                assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
 
                 // Check, if the connection ID is set
-                test(function () {
-                    assert_true(!!connection.id);
-                }, 'The connection ID is set.');
+                assert_true(!!connection.id, 'The connection ID is set.');
 
                 // Check the type of the connection.id
-                test(function () {
-                    assert_true(typeof connection.id === 'string');
-                }, 'The connection ID is a string.');
+                assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
 
                 // Check the instance of the connection
-                test(function () {
-                    assert_true(connection instanceof PresentationConnection);
-                }, 'The connection is an instance of PresentationConnection.');
+                assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
             });
 
             request.start();

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -38,7 +38,7 @@
                     resolve(evt.connection);
                 };
                 request.start().then(function() {
-                    // This test fails if request.onconnectionavailable is not invoked regardless of starting the presentation
+                    // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
                     t.step_timeout(function() { reject('The connectionavailable was not fired.') }, 5000);
                 }, function() {
                     // This test fails if the presentation is not started successfully

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Presentation.onconnectionavailable (manual test)</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
+<link rel="help" href="https://w3c.github.io/presentation-api/#starting-a-presentation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<p>Click the button below and select the available presentation display, to start the manual test.</p>
+<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+
+
+<script>
+    // ----------
+    // DOM Object
+    // ----------
+    var presentBtn = document.getElementById("presentBtn");
+
+    // ------------
+    // Request init
+    // ------------
+    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
+            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
+            request = new PresentationRequest(validPresURL);
+
+    // --------------------------------------------------------------------------
+    // Start New PresentationRequest.onconnectionavailable Test (success) - begin
+    // --------------------------------------------------------------------------
+    var startPresentation = function () {
+        async_test(function (t) {
+            request.onconnectionavailable = t.step_func_done(function (evt) {
+                var connection = evt.connection;
+
+                // Check the initial state of a presentation connection
+                test(function() {
+                    assert_equals(connection.state, 'connecting');
+                }, 'The initial state of the presentation connection is "connecting".');
+
+                // Check, if the connection ID is set
+                test(function () {
+                    assert_true(!!connection.id);
+                }, 'The connection ID is set.');
+
+                // Check the type of the connection.id
+                test(function () {
+                    assert_true(typeof connection.id === 'string');
+                }, 'The connection ID is a string.');
+
+                // Check the instance of the connection
+                test(function () {
+                    assert_true(connection instanceof PresentationConnection);
+                }, 'The connection is an instance of PresentationConnection.');
+            });
+
+            request.start();
+        }, 'The presentation was started successfully.');
+    }
+    // ------------------------------------------------------------------------
+    // Start New PresentationRequest.onconnectionavailable Test (success) - end
+    // ------------------------------------------------------------------------
+</script>
+

--- a/presentation-api/controlling-ua/_Optional_defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/_Optional_defaultRequest_success-manual.html
@@ -8,7 +8,7 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
-<p>If your browser does not support <code>defaultRequest</code>, this test will not begin.</p>
+<p>If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
 
 <script>
     // disable the timeout function for the tests
@@ -31,21 +31,13 @@
         navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
             var connection = evt.connection;
 
-            test(function() {
-                assert_equals(connection.state, 'connecting');
-            }, 'The initial state of the presentation connection is "connecting".');
-
-            test(function() {
-                assert_true(!!connection.id);
-            }, 'The connection ID is set.');
-
-            test(function() {
-                assert_true(typeof connection.id === 'string');
-            }, 'The connection ID is a string.');
-
-            test(function() {
-                assert_true(connection instanceof PresentationConnection);
-            }, 'The connection is an instance of PresentationConnection.');
+            assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+            assert_true(!connection.id, 'The connection ID is set.');
+            assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+            assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+        });
+        document.getElementById('notsupported').onclick = t.step_func_done(function() {
+            assert_unreached('This browser does not support defaultRequest.');
         });
     }, 'The presentation was started successfully.');
     // ----------------------------

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -2,12 +2,13 @@
 <meta charset="utf-8">
 <title>Presentation API, testing to start a new presentation with an default request setup. (success - manual)</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<p>Click the button below and select the available casting device, to start the manual test.</p>
-<button onclick="startPresentation()">Start Presentation Test</button>
+<p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
+<p>If your browser does not support <code>defaultRequest</code>, this test will not begin.</p>
 
 <script>
     // disable the timeout function for the tests
@@ -22,29 +23,31 @@
 
     navigator.presentation.defaultRequest = new PresentationRequest(validPresURL);
 
-    var startPresentation = function () {
-        promise_test(function () {
-            return navigator.presentation.defaultRequest.start();
-        }, "The presentation was started successfully.");
-    }
     // ------------------------------
     // Start New Presentation with
     // 'default request' Test - BEGIN
     // ------------------------------
-    navigator.presentation.defaultRequest.onconnectionavailable = function (evt) {
-        var connection = evt.connection;
+    async_test(function(t) {
+        navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
+            var connection = evt.connection;
 
-        test(function () {
+            test(function() {
+                assert_equals(connection.state, 'connecting');
+            }, 'The initial state of the presentation connection is "connecting".');
 
-            assert_equals(connection.state, "connected", "The presentation has an connected state.");
-            assert_true(!!connection.id, "The connection ID is set.");
-            assert_true(typeof connection.id === 'string', "The connection ID is a string.");
-            assert_true(connection instanceof PresentationConnection, "The connection is an instance of PresentationConnection.");
+            test(function() {
+                assert_true(!!connection.id);
+            }, 'The connection ID is set.');
 
-        }, "The presentation was started successfully.");
+            test(function() {
+                assert_true(typeof connection.id === 'string');
+            }, 'The connection ID is a string.');
 
-        done();
-    };
+            test(function() {
+                assert_true(connection instanceof PresentationConnection);
+            }, 'The connection is an instance of PresentationConnection.');
+        });
+    }, 'The presentation was started successfully.');
     // ----------------------------
     // Start New Presentation with
     // 'default request' Test - END

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -39,7 +39,7 @@
         document.getElementById('notsupported').onclick = t.step_func_done(function() {
             assert_unreached('This browser does not support defaultRequest.');
         });
-    }, 'The presentation was started successfully.');
+    }, '[Optional] The presentation was started successfully.');
     // ----------------------------
     // Start New Presentation with
     // 'default request' Test - END

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -2,11 +2,12 @@
 <meta charset="utf-8">
 <title>Presentation API, start new presentation tests for Controlling User Agent (success - manual test)</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<p>Click the button below and select the available casting device, to start the manual test.</p>
+<p>Click the button below and select the available presentation display, to start the manual test.</p>
 <button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 
@@ -31,8 +32,10 @@
             return request.start()
                     .then(function (connection) {
 
-                        // assert case for the promise_test
-                        assert_equals(connection.state, "connected", "The presentation has an connected state.");
+                        // Check the initial state of a presentation connection
+                        test(function() {
+                            assert_equals(connection.state, 'connecting');
+                        }, 'The initial state of the presentation connection is "connecting".');
 
                         // Check, if the connection ID is set
                         test(function () {

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -33,26 +33,17 @@
                     .then(function (connection) {
 
                         // Check the initial state of a presentation connection
-                        test(function() {
-                            assert_equals(connection.state, 'connecting');
-                        }, 'The initial state of the presentation connection is "connecting".');
+                        assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
 
                         // Check, if the connection ID is set
-                        test(function () {
-                            assert_true(!!connection.id);
-                        }, 'The connection ID is set.');
+                        assert_true(!!connection.id, 'The connection ID is set.');
 
                         // Check the type of the connection.id
-                        test(function () {
-                            assert_true(typeof connection.id === 'string');
-                        }, 'The connection ID is a string.');
+                        assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
 
                         // Check the instance of the connection
-                        test(function () {
-                            assert_true(connection instanceof PresentationConnection);
-                        }, 'The connection is an instance of PresentationConnection.');
+                        assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
                     });
-
         }, "The presentation was started successfully.");
     }
     // -------------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -8,10 +8,13 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <p>Click the button below and select the available presentation display, to start the manual test.</p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 
 <script>
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
@@ -45,7 +48,8 @@
                         assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
                     });
         }, "The presentation was started successfully.");
-    }
+    };
+    presentBtn.onclick = startPresentation;
     // -------------------------------------------
     // Start New Presentation Test (success) - end
     // -------------------------------------------


### PR DESCRIPTION
This PR fixes #3521. Both controlling-ua/startNewPresentation_success-manual.html and controlling-ua/defaultRequest_success-manual.html are modified so that they examine if the initial state of presentation connection is `connecting` or not.

This PR also contains the following additional modifications:
- A test for `PresentationRequest.onconnectionavailable` is added.
- `defaultRequest` test will start via a user gesture on browser's user interface (i.e. "Cast..." menu in the case of Google Chrome).
