### PR TITLE
Import tests for MathML in SVG and for MathML links.

### DIFF
--- a/mathml/relations/html5-tree/href-click-1-ref.html
+++ b/mathml/relations/html5-tree/href-click-1-ref.html
@@ -7,7 +7,7 @@
 <body>
 
   <p>This test passes if you see a green square.</p>
-  
+
   <div style="width: 150px; height: 150px; background: green">
   </div>
 

--- a/mathml/relations/html5-tree/href-click-1-ref.html
+++ b/mathml/relations/html5-tree/href-click-1-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>href click (reference)</title>
+</head>
+<body>
+
+  <p>This test passes if you see a green square.</p>
+  
+  <div style="width: 150px; height: 150px; background: green">
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/href-click-1.html
+++ b/mathml/relations/html5-tree/href-click-1.html
@@ -17,7 +17,7 @@
 <body onload="test()">
 
   <p>This test passes if you see a green square.</p>
-  
+
   <div style="width: 150px; height: 150px; overflow: hidden">
     <math>
       <mrow id="link" href="#target">

--- a/mathml/relations/html5-tree/href-click-1.html
+++ b/mathml/relations/html5-tree/href-click-1.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>href click</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2">
+<link rel="match" href="href-click-1-ref.html"/>
+<meta name="assert" content="Verify that a click on a link moves to the target.">
+<script type="text/javascript">
+  function test()
+  {
+    var event = new MouseEvent('click', {bubbles: true, cancelable: true});
+    document.getElementById('link').dispatchEvent(event);
+  }
+</script>
+</head>
+<body onload="test()">
+
+  <p>This test passes if you see a green square.</p>
+  
+  <div style="width: 150px; height: 150px; overflow: hidden">
+    <math>
+      <mrow id="link" href="#target">
+        <mspace id="space" width="150px" height="150px" mathbackground="red"/>
+      </mrow>
+    </math>
+    <div style="height: 500px;"></div>
+    <math id="target">
+      <mspace width="150px" height="150px" mathbackground="green"/>
+    </math>
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/href-click-2-ref.html
+++ b/mathml/relations/html5-tree/href-click-2-ref.html
@@ -7,7 +7,7 @@
 <body>
 
   <p>This test passes if you see a green square.</p>
-  
+
   <div style="width: 150px; height: 150px; background: green">
   </div>
 

--- a/mathml/relations/html5-tree/href-click-2-ref.html
+++ b/mathml/relations/html5-tree/href-click-2-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>href click (reference)</title>
+</head>
+<body>
+
+  <p>This test passes if you see a green square.</p>
+  
+  <div style="width: 150px; height: 150px; background: green">
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/href-click-2.html
+++ b/mathml/relations/html5-tree/href-click-2.html
@@ -17,7 +17,7 @@
 <body onload="test()">
 
   <p>This test passes if you see a green square.</p>
-  
+
   <div style="width: 150px; height: 150px; overflow: hidden">
     <math>
       <mrow href="#target">

--- a/mathml/relations/html5-tree/href-click-2.html
+++ b/mathml/relations/html5-tree/href-click-2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>href click</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2">
+<link rel="match" href="href-click-2-ref.html"/>
+<meta name="assert" content="Verify that a click on an element bubbles to an ancestor link.">
+<script type="text/javascript">
+  function test()
+  {
+    var event = new MouseEvent('click', {bubbles: true, cancelable: true});
+    document.getElementById('space').dispatchEvent(event);
+  }
+</script>
+</head>
+<body onload="test()">
+
+  <p>This test passes if you see a green square.</p>
+  
+  <div style="width: 150px; height: 150px; overflow: hidden">
+    <math>
+      <mrow href="#target">
+        <mrow>
+          <mrow>
+            <mspace id="space" width="150px" height="150px" mathbackground="red"/>
+          </mrow>
+        </mrow>
+      </mrow>
+    </math>
+    <div style="height: 500px;"></div>
+    <math id="target">
+      <mspace width="150px" height="150px" mathbackground="green"/>
+    </math>
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/href-manual.html
+++ b/mathml/relations/html5-tree/href-manual.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Manual click on a link</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({explicit_timeout: true})
+function handler() {
+document.body.insertAdjacentHTML("beforeend",
+  "<span style='background: green; color: white;'>PASS</span>");
+}
+</script>
+</head>
+<body>
+  <p>Click on the one asterisk which is a link. If a "PASS" result appears the
+    test passes, otherwise it fails.</p>
+  <p>
+    <math style="font-size: 3em;">
+      <mtext>*****</mtext>
+      <mtext href="javascript:handler()">*</mtext>
+      <mtext>*****</mtext>
+    </math>
+  </p>
+</body>
+</html>

--- a/mathml/relations/html5-tree/required-extensions-1.html
+++ b/mathml/relations/html5-tree/required-extensions-1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>SVG requiredExtensions</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1">
+<meta name="assert" content="Verify whether the MathML namespace is recognized as a required extensions of SVG foreignObject when using the hasExtension javascript function.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  test(function() {
+  assert_true(document.createElementNS("http://www.w3.org/2000/svg", "foreignObject").hasExtension("http://www.w3.org/1998/Math/MathML"))
+  }, "Testing foreignObject.hasExtension('http://www.w3.org/1998/Math/MathML')");
+</script>

--- a/mathml/relations/html5-tree/required-extensions-2-ref.html
+++ b/mathml/relations/html5-tree/required-extensions-2-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>SVG requiredExtensions (reference)</title>
+</head>
+<body>
+  <p>Test passes if there is a green square and no red.</p>
+  <svg width="200px" height="200px">
+    <rect width="200px" height="200px" fill="green"/>
+  </svg>
+</body>
+</html>

--- a/mathml/relations/html5-tree/required-extensions-2.html
+++ b/mathml/relations/html5-tree/required-extensions-2.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>SVG requiredExtensions</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS1"/>
+<link rel="match" href="required-extensions-2-ref.html"/>
+<meta name="assert" content="Verify that a foreignObject with MathML used as a requiredExtensions value is selected for display in a SVG switch element.">
+</head>
+<body>
+  <p>Test passes if there is a green square and no red.</p>
+  <svg width="200px" height="200px">
+    <rect width="200px" height="100px" fill="red"/>
+    <switch>
+      <foreignObject width="200px" height="200px"
+                     requiredExtensions="http://www.w3.org/1998/Math/MathML">
+        <div style="width: 200px; height: 200px; background: green"></div>
+      </foreignObject>
+      <rect y="100px" width="200px" height="100px" fill="red"/>
+    </switch>
+  </svg>
+</body>
+</html>


### PR DESCRIPTION
@jgraham : This is a second commit which imports tests of each kind (manual, reftest, script).

These tests have been verified and accepted by WebKit reviewers: https://trac.webkit.org/browser/trunk/LayoutTests/imported/mathml-in-html5/mathml/relations/html5-tree

FYI, I checked with the test runner that the tests pass on WebKit and Gecko.
