### PR TITLE
Fix typo in set multiple different mediakeys test.

### DIFF
--- a/encrypted-media/scripts/setmediakeys-multiple-times-with-different-mediakeys.js
+++ b/encrypted-media/scripts/setmediakeys-multiple-times-with-different-mediakeys.js
@@ -57,7 +57,7 @@ function runTest(config, qualifier) {
         }).then(test.step_func(function() {
             // Changing the Media Keys object succeeded
             _usingMediaKeys2 = true;
-            assert_equals(_video2.mediaKeys, _mediaKeys2);
+            assert_equals(_video.mediaKeys, _mediaKeys2);
             // Return something so the promise resolves properly.
             return Promise.resolve();
         }), test.step_func(function(error) {


### PR DESCRIPTION
One of the assertions in the test was checking the media keys on a _video2
variable. This test only deals with setting media keys on a single video,
_video, so this appears to be a typo.
