### PR TITLE
Import MathML tests for the id and class attributes.

### DIFF
--- a/mathml/relations/html5-tree/class-1-ref.html
+++ b/mathml/relations/html5-tree/class-1-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Class (reference)</title>
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+  <math>
+    <mtext style="background: green; color: white;">PASS</mtext>
+  </math>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/class-1.html
+++ b/mathml/relations/html5-tree/class-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Class</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2"/>
+<link rel="match" href="class-1-ref.html"/>
+<meta name="assert" content="Verify that the class attribute affects CSS selectors.">
+<style>
+  mtext.fail { display: none; }
+  mtext.pass { background: green; }
+</style>
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+  <math>
+    <mtext class="fail" style="background: red; color: white;">FAIL</mtext>
+    <mtext class="pass" style="color: white;">PASS</mtext>
+  </math>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/class-2.html
+++ b/mathml/relations/html5-tree/class-2.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Class</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2">
+<meta name="assert" content="Verify whether the getElementsByClassName() works for MathML elements.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("DOMContentLoaded", function() {
+    var mtext = document.getElementsByClassName("cl");
+    test(function() {
+      assert_equals(mtext.length, 3);
+      var mtext_ref = document.body.firstElementChild.firstElementChild;
+      mtext_ref = mtext_ref.nextElementSibling.nextElementSibling
+      assert_equals(mtext[0], mtext_ref);
+      mtext_ref = mtext_ref.nextElementSibling.nextElementSibling;
+      assert_equals(mtext[1], mtext_ref);
+      mtext_ref = mtext_ref.nextElementSibling.nextElementSibling;
+      assert_equals(mtext[2], mtext_ref);
+    }, "getElementsByClassName()");
+    done();
+  });
+</script>
+</head>
+<body>
+  <math>
+    <mtext class="cl_"></mtext>
+    <mtext class="c"></mtext>
+    <mtext class="cl"></mtext>
+    <mtext class="cl_"></mtext>
+    <mtext class="cl"></mtext>
+    <mtext class="c"></mtext>
+    <mtext class="cl"></mtext>
+    <mtext class="cl_"></mtext>
+  </math>
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-1-iframe.html
+++ b/mathml/relations/html5-tree/unique-identifier-1-iframe.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique Identifier (iframe)</title>
+</head>
+<body>
+
+  <div style="width: 100px; height: 500px;">
+    <math><mtext style="background: red; color: white;">FAIL</mtext></math>
+  </div>
+  <div style="width: 100px; height: 500px;">
+    <math><mtext style="background: green; color: white;"
+                 id="PASS">PASS</mtext></math>
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-1-ref-iframe.html
+++ b/mathml/relations/html5-tree/unique-identifier-1-ref-iframe.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique Identifier (iframe reference)</title>
+</head>
+<body>
+
+  <div style="width: 100px; height: 500px;">
+    <math><mtext style="background: green; color: white;"
+                 id="PASS" class="pass">PASS</mtext></math>
+  </div>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-1-ref.html
+++ b/mathml/relations/html5-tree/unique-identifier-1-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique identifier (reference)</title>
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+
+  <iframe width="100" height="100" frameborder="0" scrolling="no"
+          marginheight="0" marginwidth="0"
+          src="unique-identifier-1-ref-iframe.html#PASS"></iframe>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-1.html
+++ b/mathml/relations/html5-tree/unique-identifier-1.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique identifier</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2"/>
+<link rel="match" href="unique-identifier-1-ref.html"/>
+<meta name="assert" content="Verify that the id on a MathML element can be used as a fragment identifier in order to force initial scrolling.">
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+
+  <iframe width="100" height="100" frameborder="0" scrolling="no"
+          marginheight="0" marginwidth="0"
+          src="unique-identifier-1-iframe.html#PASS"></iframe>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-2.html
+++ b/mathml/relations/html5-tree/unique-identifier-2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Unique Identifier</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2">
+<meta name="assert" content="Verify whether the getElementById() works for MathML elements.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  setup({ explicit_done: true });
+  window.addEventListener("DOMContentLoaded", function() {
+    var mtext = document.getElementById("MTEXT");
+    test(function() {
+      assert_equals(mtext, document.body.firstElementChild.lastElementChild);
+    }, "getElementById()");
+    done();
+  });
+</script>
+</head>
+<body>
+  <math>
+    <mtext id="MTEXT_"></mtext>
+    <mtext id="MTEX"></mtext>
+    <mtext id="MTEXT"></mtext>
+  </math>
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-3-ref.html
+++ b/mathml/relations/html5-tree/unique-identifier-3-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique identifier 3 (reference)</title>
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+  <math>
+    <mtext style="background: green; color: white;">PASS</mtext>
+  </math>
+
+</body>
+</html>

--- a/mathml/relations/html5-tree/unique-identifier-3.html
+++ b/mathml/relations/html5-tree/unique-identifier-3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<title>Unique Identifier</title>
+<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS1.SSS2"/>
+<link rel="match" href="unique-identifier-3-ref.html"/>
+<meta name="assert" content="Verify that the id attribute affects CSS selectors.">
+<style>
+  #fail { display: none; }
+  #pass { background: green; }
+</style>
+</head>
+<body>
+
+  <p>Test passes if you see the text "PASS".</p>
+  <math>
+    <mtext id="fail" style="background: red; color: white;">FAIL</mtext>
+    <mtext id="pass" style="color: white;">PASS</mtext>
+  </math>
+
+</body>
+</html>


### PR DESCRIPTION
This commit imports tests from the MathML in HTML5 test suite to check the use
of id and class attributes on MathML elements:
- Javascript (getElementById and getElementsByClassName)
- CSS selectors (#id and .class)
- id used as a fragment identifier in URIs

@jgraham Yet another series of tests. Reviewed and integrated into WebKit testsuite (https://trac.webkit.org/browser/trunk/LayoutTests/imported/mathml-in-html5/mathml/relations/html5-tree). They currently pass on Gecko and WebKit.
