### PR TITLE
Import tests for parsing and ugprading custom elements from Webkit

### DIFF
--- a/custom-elements/parser/parser-constructs-custom-element-in-document-write.html
+++ b/custom-elements/parser/parser-constructs-custom-element-in-document-write.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must construct custom elements inside document.write">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<link rel="help" href="https://html.spec.whatwg.org/#document.write()">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+class MyCustomElement extends HTMLElement { }
+customElements.define('my-custom-element', MyCustomElement);
+
+document.write('<my-custom-element></my-custom-element>');
+
+test(function () {
+    var instance = document.querySelector('my-custom-element');
+
+    assert_true(instance instanceof HTMLElement);
+    assert_true(instance instanceof MyCustomElement);
+
+}, 'HTML parser must instantiate custom elements inside document.write');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-constructs-custom-element-synchronously.html
+++ b/custom-elements/parser/parser-constructs-custom-element-synchronously.html
@@ -15,14 +15,14 @@
 
 var childElementCountInConstructor;
 var containerChildNodesInConstructor = [];
-var containerNextSilbingInConstructor;
+var containerNextSiblingInConstructor;
 class MyCustomElement extends HTMLElement {
     constructor() {
         super();
         var container = document.getElementById('custom-element-container');
         for (var i = 0; i < container.childNodes.length; i++)
             containerChildNodesInConstructor.push(container.childNodes[i]);
-        containerNextSilbingInConstructor = container.nextSibling;
+        containerNextSiblingInConstructor = container.nextSibling;
     }
 };
 customElements.define('my-custom-element', MyCustomElement);
@@ -42,7 +42,7 @@ test(function () {
     assert_equals(containerChildNodesInConstructor[0], instance.parentNode.firstChild);
     assert_equals(containerChildNodesInConstructor[1], document.getElementById('custom-element-previous-element'));
     assert_equals(containerChildNodesInConstructor[2], instance.previousSibling);
-    assert_equals(containerNextSilbingInConstructor, null);
+    assert_equals(containerNextSiblingInConstructor, null);
 
 }, 'HTML parser must only append nodes that appear before a custom element before instantiating the custom element');
 

--- a/custom-elements/parser/parser-constructs-custom-element-synchronously.html
+++ b/custom-elements/parser/parser-constructs-custom-element-synchronously.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must construct a custom element synchronously">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var childElementCountInConstructor;
+var containerChildNodesInConstructor = [];
+var containerNextSilbingInConstructor;
+class MyCustomElement extends HTMLElement {
+    constructor() {
+        super();
+        var container = document.getElementById('custom-element-container');
+        for (var i = 0; i < container.childNodes.length; i++)
+            containerChildNodesInConstructor.push(container.childNodes[i]);
+        containerNextSilbingInConstructor = container.nextSibling;
+    }
+};
+customElements.define('my-custom-element', MyCustomElement);
+
+</script>
+<div id="custom-element-container">
+    <span id="custom-element-previous-element"></span>
+    <my-custom-element></my-custom-element>
+    <div id="custom-element-next-element"></div>
+</div>
+<script>
+
+test(function () {
+    var instance = document.querySelector('my-custom-element');
+
+    assert_equals(containerChildNodesInConstructor.length, 3);
+    assert_equals(containerChildNodesInConstructor[0], instance.parentNode.firstChild);
+    assert_equals(containerChildNodesInConstructor[1], document.getElementById('custom-element-previous-element'));
+    assert_equals(containerChildNodesInConstructor[2], instance.previousSibling);
+    assert_equals(containerNextSilbingInConstructor, null);
+
+}, 'HTML parser must only append nodes that appear before a custom element before instantiating the custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-constructs-custom-elements.html
+++ b/custom-elements/parser/parser-constructs-custom-elements.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser creates a custom element">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<my-custom-element id="instance1"></my-custom-element>
+<script>
+
+class MyCustomElement extends HTMLElement { };
+
+test(function () {
+    var customElement = document.getElementById('instance1');
+
+    assert_true(customElement instanceof HTMLElement, 'An unresolved custom element must be an instance of HTMLElement');
+    assert_false(customElement instanceof MyCustomElement, 'An unresolved custom element must NOT be an instance of that custom element');
+    assert_equals(customElement.localName, 'my-custom-element');
+    assert_equals(customElement.namespaceURI, 'http://www.w3.org/1999/xhtml', 'A custom element HTML must use HTML namespace');
+
+}, 'HTML parser must NOT create a custom element before customElements.define is called');
+
+customElements.define('my-custom-element', MyCustomElement);
+
+</script>
+<my-custom-element id="instance2"></my-custom-element>
+<script>
+
+test(function () {
+    var customElement = document.getElementById('instance2');
+
+    assert_true(customElement instanceof HTMLElement, 'A resolved custom element must be an instance of HTMLElement');
+    assert_false(customElement instanceof HTMLUnknownElement, 'A resolved custom element must NOT be an instance of HTMLUnknownElement');
+    assert_true(customElement instanceof MyCustomElement, 'A resolved custom element must be an instance of that custom element');
+    assert_equals(customElement.localName, 'my-custom-element');
+    assert_equals(customElement.namespaceURI, 'http://www.w3.org/1999/xhtml', 'A custom element HTML must use HTML namespace');
+
+}, 'HTML parser must create a defined custom element before executing inline scripts');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-fallsback-to-unknown-element.html
+++ b/custom-elements/parser/parser-fallsback-to-unknown-element.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must fallback to creating a HTMLUnknownElement when a custom element construction fails">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+setup({allow_uncaught_exception:true});
+
+class ReturnsTextNode extends HTMLElement {
+    constructor() {
+        super();
+        return document.createTextNode('some text');
+    }
+};
+customElements.define('returns-text', ReturnsTextNode);
+
+class ReturnsNonElementObject extends HTMLElement {
+    constructor() {
+        super();
+        return {};
+    }
+};
+customElements.define('returns-non-element-object', ReturnsNonElementObject);
+
+class LacksSuperCall extends HTMLElement {
+    constructor() { }
+};
+customElements.define('lacks-super-call', LacksSuperCall);
+
+class ThrowsException extends HTMLElement {
+    constructor() {
+        throw 'Bad';
+    }
+};
+customElements.define('throws-exception', ThrowsException);
+
+</script>
+<returns-text></returns-text>
+<returns-non-element-object></returns-non-element-object>
+<lacks-super-call></lacks-super-call>
+<throws-exception></throws-exception>
+<script>
+
+test(function () {
+    var instance = document.querySelector('returns-text');
+
+    assert_false(instance instanceof ReturnsTextNode, 'HTML parser must NOT instantiate a custom element when the constructor returns a Text node');
+    assert_true(instance instanceof HTMLElement, 'The fallback element created by HTML parser must be an instance of HTMLElement');
+    assert_true(instance instanceof HTMLUnknownElement, 'The fallback element created by HTML parser must be an instance of HTMLUnknownElement');
+
+}, 'HTML parser must create a fallback HTMLUnknownElement when a custom element constructor returns a Text node');
+
+test(function () {
+    var instance = document.querySelector('returns-non-element-object');
+
+    assert_false(instance instanceof ReturnsNonElementObject, 'HTML parser must NOT instantiate a custom element when the constructor returns a non-Element object');
+    assert_true(instance instanceof HTMLElement, 'The fallback element created by HTML parser must be an instance of HTMLElement');
+    assert_true(instance instanceof HTMLUnknownElement, 'The fallback element created by HTML parser must be an instance of HTMLUnknownElement');
+
+}, 'HTML parser must create a fallback HTMLUnknownElement when a custom element constructor returns non-Element object');
+
+test(function () {
+    var instance = document.querySelector('lacks-super-call');
+
+    assert_false(instance instanceof LacksSuperCall, 'HTML parser must NOT instantiate a custom element when the constructor does not call super()');
+    assert_true(instance instanceof HTMLElement, 'The fallback element created by HTML parser must be an instance of HTMLElement');
+    assert_true(instance instanceof HTMLUnknownElement, 'The fallback element created by HTML parser must be an instance of HTMLUnknownElement');
+
+}, 'HTML parser must create a fallback HTMLUnknownElement when a custom element constructor does not call super()');
+
+test(function () {
+    var instance = document.querySelector('throws-exception');
+
+    assert_false(instance instanceof ThrowsException, 'HTML parser must NOT instantiate a custom element when the constructor throws an exception');
+    assert_true(instance instanceof HTMLElement, 'The fallback element created by HTML parser must be an instance of HTMLElement');
+    assert_true(instance instanceof HTMLUnknownElement, 'The fallback element created by HTML parser must be an instance of HTMLUnknownElement');
+
+}, 'HTML parser must create a fallback HTMLUnknownElement when a custom element constructor throws an exception');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-sets-attributes-and-children.html
+++ b/custom-elements/parser/parser-sets-attributes-and-children.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must set the attributes and append the children on a custom element">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+var numberOfAttributesInConstructor;
+var numberOfChildNodesInConstructor;
+
+class MyCustomElement extends HTMLElement {
+    constructor(...args) {
+        super(...args);
+        numberOfAttributesInConstructor = this.attributes.length;
+        numberOfChildNodesInConstructor = this.childNodes.length;
+    }
+};
+customElements.define('my-custom-element', MyCustomElement);
+
+</script>
+<my-custom-element id="custom-element-id" class="class1 class2">hello <b>world</b></my-custom-element>
+<script>
+
+var customElement = document.querySelector('my-custom-element');
+
+test(function () {
+    assert_equals(customElement.getAttribute('id'), 'custom-element-id', 'HTML parser must preserve the id attribute');
+    assert_equals(customElement.id, 'custom-element-id', 'HTML parser must preserve the semantics of reflect for the id attribute');
+    assert_equals(customElement.getAttribute('class'), 'class1 class2', 'HTML parser must preserve the class attribute');
+    assert_equals(customElement.classList.length, 2, 'HTML parser must initialize classList on custom elements');
+    assert_equals(customElement.classList[0], 'class1', 'HTML parser must initialize classList on custom elements');
+    assert_equals(customElement.classList[1], 'class2', 'HTML parser must initialize classList on custom elements');
+
+    assert_equals(customElement.childNodes.length, 2, 'HTML parser must append child nodes');
+    assert_equals(customElement.classList[0], 'class1', 'HTML parser must initialize classList on custom elements');
+    assert_equals(customElement.classList[1], 'class2', 'HTML parser must initialize classList on custom elements');
+
+}, 'HTML parser must set the attributes');
+
+test(function () {
+    assert_equals(customElement.childNodes.length, 2, 'HTML parser must append child nodes');
+    assert_true(customElement.firstChild instanceof Text, 'HTML parser must append Text node child to a custom element');
+    assert_equals(customElement.firstChild.data, 'hello ', 'HTML parser must append Text node child to a custom element');
+    assert_true(customElement.lastChild instanceof HTMLElement, 'HTML parser must append a builtin element child to a custom element');
+    assert_true(customElement.lastChild.firstChild instanceof Text, 'HTML parser must preserve grandchild nodes of a custom element');
+    assert_equals(customElement.lastChild.firstChild.data, 'world', 'HTML parser must preserve grandchild nodes of a custom element');
+}, 'HTML parser must append child nodes');
+
+test(function () {
+    assert_equals(numberOfAttributesInConstructor, 0, 'HTML parser must not set attributes on a custom element before invoking the constructor');
+    assert_equals(numberOfChildNodesInConstructor, 0, 'HTML parser must not append child nodes to a custom element before invoking the constructor');
+}, 'HTML parser must set the attributes or append children before calling constructor');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-sets-attributes-and-children.html
+++ b/custom-elements/parser/parser-sets-attributes-and-children.html
@@ -38,11 +38,6 @@ test(function () {
     assert_equals(customElement.classList.length, 2, 'HTML parser must initialize classList on custom elements');
     assert_equals(customElement.classList[0], 'class1', 'HTML parser must initialize classList on custom elements');
     assert_equals(customElement.classList[1], 'class2', 'HTML parser must initialize classList on custom elements');
-
-    assert_equals(customElement.childNodes.length, 2, 'HTML parser must append child nodes');
-    assert_equals(customElement.classList[0], 'class1', 'HTML parser must initialize classList on custom elements');
-    assert_equals(customElement.classList[1], 'class2', 'HTML parser must initialize classList on custom elements');
-
 }, 'HTML parser must set the attributes');
 
 test(function () {

--- a/custom-elements/parser/parser-uses-constructed-element.html
+++ b/custom-elements/parser/parser-uses-constructed-element.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Custom Elements: Changes to the HTML parser</title>
+<title>Custom Elements: HTML parser must construct a custom element instead of upgrading</title>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="HTML parser must construct a custom element instead of upgrading">
 <script src="/resources/testharness.js"></script>

--- a/custom-elements/parser/parser-uses-constructed-element.html
+++ b/custom-elements/parser/parser-uses-constructed-element.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must construct a custom element instead of upgrading">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+let anotherElementCreatedBeforeSuperCall = undefined;
+let elementCreatedBySuperCall = undefined;
+let shouldCreateElementBeforeSuperCall = true;
+class InstantiatesItselfBeforeSuper extends HTMLElement {
+    constructor() {
+        if (shouldCreateElementBeforeSuperCall) {
+            shouldCreateElementBeforeSuperCall = false;
+            anotherElementCreatedBeforeSuperCall = new InstantiatesItselfBeforeSuper();
+        }
+        super();
+        elementCreatedBySuperCall = this;
+    }
+};
+customElements.define('instantiates-itself-before-super', InstantiatesItselfBeforeSuper);
+
+let shouldCreateAnotherInstance = true;
+let anotherInstance = undefined;
+let firstInstance = undefined;
+class ReturnsAnotherInstance extends HTMLElement {
+    constructor() {
+        super();
+        if (shouldCreateAnotherInstance) {
+            shouldCreateAnotherInstance = false;
+            firstInstance = this;
+            anotherInstance = new ReturnsAnotherInstance;
+            return anotherInstance;
+        } else
+            return this;
+    }
+};
+customElements.define('returns-another-instance', ReturnsAnotherInstance);
+
+</script>
+<instantiates-itself-before-super></instantiates-itself-before-super>
+<returns-another-instance></returns-another-instance>
+<script>
+
+test(function () {
+    var instance = document.querySelector('instantiates-itself-before-super');
+
+    assert_equals(instance instanceof InstantiatesItselfBeforeSuper, 'HTML parser must insert the synchronously constructed custom element');
+    assert_equals(instance, elementCreatedBySuperCall, 'HTML parser must insert the element returned by the custom element constructor');
+    assert_not_equals(instance, anotherElementCreatedBeforeSuperCall, 'HTML parser must not insert another instance of the custom element created before super() call');
+    assert_equals(anotherElementCreatedBeforeSuperCall.parentNode, null, 'HTML parser must not insert another instance of the custom element created before super() call');
+
+}, 'HTML parser must use the returned value of the custom element constructor instead of the one created before super() call');
+
+test(function () {
+    var instance = document.querySelector('returns-another-instance');
+
+    assert_equals(instance instanceof ReturnsAnotherInstance, 'HTML parser must insert the synchronously constructed custom element');
+    assert_equals(instance, anotherInstance, 'HTML parser must insert the element returned by the custom element constructor');
+    assert_not_equals(instance, firstInstance, 'HTML parser must not insert the element created by super() call if the constructor returned another element');
+    assert_equals(firstInstance.parentNode, null, 'HTML parser must not insert the element created by super() call if the constructor returned another element');
+
+}, 'HTML parser must use the returned value of the custom element constructor instead using the one created in super() call');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-uses-registry-of-owner-document.html
+++ b/custom-elements/parser/parser-uses-registry-of-owner-document.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Custom Elements: Changes to the HTML parser</title>
+<title>Custom Elements: HTML parser must use the owner document's custom element registry</title>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="HTML parser must use the owner document's custom element registry">
 <link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
@@ -92,6 +92,34 @@ test(function () {
     assert_false(instance instanceof MyCustomElement);
 
 }, 'HTML parser must use the registry of window.document in a document created by document.implementation.createXHTMLDocument()');
+
+test(function () {
+    var windowlessDocument = new Document;
+    windowlessDocument.appendChild(windowlessDocument.createElement('html'));
+    windowlessDocument.documentElement.innerHTML = '<my-custom-element></my-custom-element>';
+
+    var instance = windowlessDocument.querySelector('my-custom-element');
+
+    assert_true(instance instanceof Element);
+    assert_false(instance instanceof MyCustomElement);
+
+}, 'HTML parser must use the registry of window.document in a document created by new Document');
+
+test(function () {
+    new Promise(function (resolve, reject) {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'resources/empty-html-document.html');
+        xhr.overrideMimeType('text/html');
+        xhr.onload = function () { resolve(xhr.responseXML); }
+        xhr.onerror = function () { reject('Failed to fetch the document'); }
+        xhr.send();
+    }).then(function (doc) {
+        doc.write('<my-custom-element></my-custom-element>');
+        var instance = doc.querySelector('my-custom-element');
+        assert_true(instance instanceof Element);
+        assert_false(instance instanceof MyCustomElement);        
+    });
+}, 'HTML parser must use the registry of window.document in a document created by XMLHttpRequest');
 
 </script>
 </body>

--- a/custom-elements/parser/parser-uses-registry-of-owner-document.html
+++ b/custom-elements/parser/parser-uses-registry-of-owner-document.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Changes to the HTML parser</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must use the owner document's custom element registry">
+<link rel="help" href="https://html.spec.whatwg.org/#create-an-element-for-the-token">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+class MyCustomElement extends HTMLElement { };
+customElements.define('my-custom-element', MyCustomElement);
+
+document.write('<template><my-custom-element></my-custom-element></template>');
+
+test(function () {
+    var template = document.querySelector('template');
+    var instance = template.content.firstChild;
+
+    assert_true(instance instanceof HTMLElement,
+        'A custom element inside a template element must be an instance of HTMLElement');
+    assert_false(instance instanceof MyCustomElement,
+        'A custom element must not be instantiated inside a template element using the registry of the template element\'s owner document');
+    assert_equals(instance.ownerDocument, template.content.ownerDocument,
+        'Custom elements inside a template must use the appropriate template contents owner document as the owner document');
+
+}, 'HTML parser must not instantiate custom elements inside template elements');
+
+var iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+iframe.contentDocument.body.innerHTML = '<my-custom-element></my-custom-element>';
+
+test(function () {
+    var instance = iframe.contentDocument.querySelector('my-custom-element');
+
+    assert_true(instance instanceof iframe.contentWindow.HTMLElement);
+    assert_false(instance instanceof MyCustomElement);
+
+}, 'HTML parser must not use the registry of the owner element\'s document inside an iframe');
+
+class ElementInIFrame extends iframe.contentWindow.HTMLElement { };
+iframe.contentWindow.customElements.define('element-in-iframe', ElementInIFrame);
+iframe.contentDocument.body.innerHTML = '<element-in-iframe></element-in-iframe>';
+
+test(function () {
+    var instance = iframe.contentDocument.querySelector('element-in-iframe');
+
+    assert_true(instance instanceof iframe.contentWindow.HTMLElement, 'A custom element inside an iframe must be an instance of HTMLElement');
+    assert_true(instance instanceof ElementInIFrame,
+        'A custom element must be instantiated inside an iframe using the registry of the content document');
+    assert_equals(instance.ownerDocument, iframe.contentDocument,
+        'The owner document of custom elements inside an iframe must be the content document of the iframe');
+
+}, 'HTML parser must use the registry of the content document inside an iframe');
+
+document.write('<element-in-iframe></element-in-iframe>');
+
+test(function () {
+    var instance = document.querySelector('element-in-iframe');
+
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof ElementInIFrame);
+
+}, 'HTML parser must not instantiate a custom element defined inside an frame in frame element\'s owner document');
+
+document.body.removeChild(iframe);
+
+test(function () {
+    var windowlessDocument = document.implementation.createHTMLDocument();
+    windowlessDocument.open();
+    windowlessDocument.write('<my-custom-element></my-custom-element>');
+    windowlessDocument.close();
+
+    var instance = windowlessDocument.querySelector('my-custom-element');
+
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof MyCustomElement);
+
+}, 'HTML parser must use the registry of window.document in a document created by document.implementation.createHTMLDocument()');
+
+test(function () {
+    var windowlessDocument = document.implementation.createDocument ('http://www.w3.org/1999/xhtml', 'html', null);
+    windowlessDocument.documentElement.innerHTML = '<my-custom-element></my-custom-element>';
+
+    var instance = windowlessDocument.querySelector('my-custom-element');
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof MyCustomElement);
+
+}, 'HTML parser must use the registry of window.document in a document created by document.implementation.createXHTMLDocument()');
+
+</script>
+</body>
+</html>

--- a/custom-elements/parser/parser-uses-registry-of-owner-document.html
+++ b/custom-elements/parser/parser-uses-registry-of-owner-document.html
@@ -105,16 +105,16 @@ test(function () {
 
 }, 'HTML parser must use the registry of window.document in a document created by new Document');
 
-test(function () {
-    new Promise(function (resolve, reject) {
+promise_test(function () {
+    return new Promise(function (resolve, reject) {
         var xhr = new XMLHttpRequest();
-        xhr.open('GET', 'resources/empty-html-document.html');
-        xhr.overrideMimeType('text/html');
+        xhr.open('GET', '../resources/empty-html-document.html');
+        xhr.overrideMimeType('text/xml');
         xhr.onload = function () { resolve(xhr.responseXML); }
         xhr.onerror = function () { reject('Failed to fetch the document'); }
         xhr.send();
     }).then(function (doc) {
-        doc.write('<my-custom-element></my-custom-element>');
+        doc.documentElement.innerHTML = '<my-custom-element></my-custom-element>';
         var instance = doc.querySelector('my-custom-element');
         assert_true(instance instanceof Element);
         assert_false(instance instanceof MyCustomElement);        

--- a/custom-elements/upgrading/Node-cloneNode.html
+++ b/custom-elements/upgrading/Node-cloneNode.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Upgrading</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="Node.prototype.cloneNode should upgrade a custom element">
+<link rel="help" href="https://html.spec.whatwg.org/#upgrades">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+function withNewDocumentWithABrowsingContext(callback) {
+    var iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    try {
+        callback(iframe.contentWindow, iframe.contentDocument);        
+    } finally {
+        document.body.removeChild(iframe);
+    }
+}
+
+test(function () {
+    class MyCustomElement extends HTMLElement {}
+    customElements.define('my-custom-element', MyCustomElement);
+
+    var instance = document.createElement('my-custom-element');
+    assert_true(instance instanceof HTMLElement);
+    assert_true(instance instanceof MyCustomElement);
+
+    var clone = instance.cloneNode(false);
+    assert_not_equals(instance, clone);
+    assert_true(clone instanceof HTMLElement,
+        'A cloned custom element must be an instance of HTMLElement');
+    assert_true(clone instanceof MyCustomElement,
+        'A cloned custom element must be an instance of the custom element');
+}, 'Node.prototype.cloneNode(false) must be able to clone a custom element');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        class MyCustomElement extends contentWindow.HTMLElement {}
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = contentDocument.createElement('my-custom-element');
+        assert_true(instance instanceof contentWindow.HTMLElement);
+        assert_true(instance instanceof MyCustomElement);
+
+        var clone = instance.cloneNode(false);
+        assert_not_equals(instance, clone);
+        assert_true(clone instanceof contentWindow.HTMLElement,
+            'A cloned custom element must be an instance of HTMLElement');
+        assert_true(clone instanceof MyCustomElement,
+            'A cloned custom element must be an instance of the custom element');
+    });
+}, 'Node.prototype.cloneNode(false) must be able to clone a custom element inside an iframe');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        class MyCustomElement extends contentWindow.HTMLElement { }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = contentDocument.createElement('my-custom-element');
+        var container = contentDocument.createElement('div');
+        container.appendChild(instance);
+
+        var containerClone = container.cloneNode(true);
+        assert_true(containerClone instanceof contentWindow.HTMLDivElement);
+
+        var clone = containerClone.firstChild;
+        assert_not_equals(instance, clone);
+        assert_true(clone instanceof contentWindow.HTMLElement,
+            'A cloned custom element must be an instance of HTMLElement');
+        assert_true(clone instanceof MyCustomElement,
+            'A cloned custom element must be an instance of the custom element');
+    });
+}, 'Node.prototype.cloneNode(true) must be able to clone a descendent custom element');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        var parentNodeInConstructor;
+        var previousSiblingInConstructor;
+        var nextSiblingInConstructor;
+        class MyCustomElement extends contentWindow.HTMLElement {
+            constructor() {
+                super();
+                parentNodeInConstructor = this.parentNode;
+                previousSiblingInConstructor = this.previousSibling;
+                nextSiblingInConstructor = this.nextSibling;
+            }
+        }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = contentDocument.createElement('my-custom-element');
+        var siblingBeforeInstance = contentDocument.createElement('b');
+        var siblingAfterInstance = contentDocument.createElement('a');
+        var container = contentDocument.createElement('div');
+        container.appendChild(siblingBeforeInstance);
+        container.appendChild(instance);
+        container.appendChild(siblingAfterInstance);
+
+        var containerClone = container.cloneNode(true);
+
+        assert_equals(parentNodeInConstructor, containerClone,
+            'An upgraded element must have its parentNode set before the custom element constructor is called');
+        assert_equals(previousSiblingInConstructor, containerClone.firstChild,
+            'An upgraded element must have its previousSibling set before the custom element constructor is called');
+        assert_equals(nextSiblingInConstructor, containerClone.lastChild,
+            'An upgraded element must have its nextSibling set before the custom element constructor is called');
+    });
+}, 'Node.prototype.cloneNode(true) must be able to clone a descendent custom element');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        class MyCustomElement extends contentWindow.HTMLElement {
+            constructor(doNotCreateItself) {
+                super();
+                if (!doNotCreateItself)
+                    new MyCustomElement(true);
+            }
+        }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = new MyCustomElement(false);
+        var uncaughtError;
+        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+        instance.cloneNode(false);
+        assert_equals(uncaughtError.name, 'InvalidStateError');
+    });
+}, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
+    + ' due to a custom element constructor constructing itself after super() call');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        class MyCustomElement extends contentWindow.HTMLElement {
+            constructor(doNotCreateItself) {
+                if (!doNotCreateItself)
+                    new MyCustomElement(true);
+                super();
+            }
+        }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = new MyCustomElement(false);
+        var uncaughtError;
+        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+        instance.cloneNode(false);
+        assert_equals(uncaughtError.name, 'InvalidStateError');
+    });
+}, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
+    + ' due to a custom element constructor constructing itself before super() call');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+        var returnSpan = false;
+        class MyCustomElement extends contentWindow.HTMLElement {
+            constructor() {
+                super();
+                if (returnSpan)
+                    return contentDocument.createElement('span');
+            }
+        }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+
+        var instance = new MyCustomElement(false);
+        returnSpan = true;
+        var uncaughtError;
+        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+        instance.cloneNode(false);
+        assert_equals(uncaughtError.name, 'InvalidStateError');
+    });
+}, 'Upgrading a custom element must throw InvalidStateError when the custom element\'s constructor returns another element');
+
+test(function () {
+    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+
+        var instance = contentDocument.createElement('my-custom-element');
+        contentDocument.body.appendChild(instance);
+
+        var calls = [];
+        class MyCustomElement extends contentWindow.HTMLElement {
+            constructor() {
+                super();
+                calls.push(this);
+                throw 'bad';
+            }
+        }
+
+        var uncaughtError;
+        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+        assert_equals(uncaughtError, 'bad');
+
+        assert_array_equals(calls, [instance]);
+        contentDocument.body.removeChild(instance);
+        contentDocument.body.appendChild(instance);
+        assert_array_equals(calls, [instance]);
+
+    });
+}, 'Inserting an element must not try to upgrade a custom element when it had already failed to upgrade once');
+
+</script>
+</body>
+</html>

--- a/custom-elements/upgrading/Node-cloneNode.html
+++ b/custom-elements/upgrading/Node-cloneNode.html
@@ -7,20 +7,11 @@
 <link rel="help" href="https://html.spec.whatwg.org/#upgrades">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
 </head>
 <body>
 <div id="log"></div>
 <script>
-
-function withNewDocumentWithABrowsingContext(callback) {
-    var iframe = document.createElement('iframe');
-    document.body.appendChild(iframe);
-    try {
-        callback(iframe.contentWindow, iframe.contentDocument);        
-    } finally {
-        document.body.removeChild(iframe);
-    }
-}
 
 test(function () {
     class MyCustomElement extends HTMLElement {}
@@ -38,166 +29,155 @@ test(function () {
         'A cloned custom element must be an instance of the custom element');
 }, 'Node.prototype.cloneNode(false) must be able to clone a custom element');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        class MyCustomElement extends contentWindow.HTMLElement {}
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+test_with_window(function (contentWindow) {
+    var contentDocument = contentWindow.document;
+    class MyCustomElement extends contentWindow.HTMLElement {}
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = contentDocument.createElement('my-custom-element');
-        assert_true(instance instanceof contentWindow.HTMLElement);
-        assert_true(instance instanceof MyCustomElement);
+    var instance = contentDocument.createElement('my-custom-element');
+    assert_true(instance instanceof contentWindow.HTMLElement);
+    assert_true(instance instanceof MyCustomElement);
 
-        var clone = instance.cloneNode(false);
-        assert_not_equals(instance, clone);
-        assert_true(clone instanceof contentWindow.HTMLElement,
-            'A cloned custom element must be an instance of HTMLElement');
-        assert_true(clone instanceof MyCustomElement,
-            'A cloned custom element must be an instance of the custom element');
-    });
+    var clone = instance.cloneNode(false);
+    assert_not_equals(instance, clone);
+    assert_true(clone instanceof contentWindow.HTMLElement,
+        'A cloned custom element must be an instance of HTMLElement');
+    assert_true(clone instanceof MyCustomElement,
+        'A cloned custom element must be an instance of the custom element');
 }, 'Node.prototype.cloneNode(false) must be able to clone a custom element inside an iframe');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        class MyCustomElement extends contentWindow.HTMLElement { }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+test_with_window(function (contentWindow) {
+    var contentDocument = contentWindow.document;
+    class MyCustomElement extends contentWindow.HTMLElement { }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = contentDocument.createElement('my-custom-element');
-        var container = contentDocument.createElement('div');
-        container.appendChild(instance);
+    var instance = contentDocument.createElement('my-custom-element');
+    var container = contentDocument.createElement('div');
+    container.appendChild(instance);
 
-        var containerClone = container.cloneNode(true);
-        assert_true(containerClone instanceof contentWindow.HTMLDivElement);
+    var containerClone = container.cloneNode(true);
+    assert_true(containerClone instanceof contentWindow.HTMLDivElement);
 
-        var clone = containerClone.firstChild;
-        assert_not_equals(instance, clone);
-        assert_true(clone instanceof contentWindow.HTMLElement,
-            'A cloned custom element must be an instance of HTMLElement');
-        assert_true(clone instanceof MyCustomElement,
-            'A cloned custom element must be an instance of the custom element');
-    });
+    var clone = containerClone.firstChild;
+    assert_not_equals(instance, clone);
+    assert_true(clone instanceof contentWindow.HTMLElement,
+        'A cloned custom element must be an instance of HTMLElement');
+    assert_true(clone instanceof MyCustomElement,
+        'A cloned custom element must be an instance of the custom element');
 }, 'Node.prototype.cloneNode(true) must be able to clone a descendent custom element');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        var parentNodeInConstructor;
-        var previousSiblingInConstructor;
-        var nextSiblingInConstructor;
-        class MyCustomElement extends contentWindow.HTMLElement {
-            constructor() {
-                super();
-                parentNodeInConstructor = this.parentNode;
-                previousSiblingInConstructor = this.previousSibling;
-                nextSiblingInConstructor = this.nextSibling;
-            }
+test_with_window(function (contentWindow) {
+    var parentNodeInConstructor;
+    var previousSiblingInConstructor;
+    var nextSiblingInConstructor;
+    class MyCustomElement extends contentWindow.HTMLElement {
+        constructor() {
+            super();
+            parentNodeInConstructor = this.parentNode;
+            previousSiblingInConstructor = this.previousSibling;
+            nextSiblingInConstructor = this.nextSibling;
         }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+    }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = contentDocument.createElement('my-custom-element');
-        var siblingBeforeInstance = contentDocument.createElement('b');
-        var siblingAfterInstance = contentDocument.createElement('a');
-        var container = contentDocument.createElement('div');
-        container.appendChild(siblingBeforeInstance);
-        container.appendChild(instance);
-        container.appendChild(siblingAfterInstance);
+    var contentDocument = contentWindow.document;
+    var instance = contentDocument.createElement('my-custom-element');
+    var siblingBeforeInstance = contentDocument.createElement('b');
+    var siblingAfterInstance = contentDocument.createElement('a');
+    var container = contentDocument.createElement('div');
+    container.appendChild(siblingBeforeInstance);
+    container.appendChild(instance);
+    container.appendChild(siblingAfterInstance);
 
-        var containerClone = container.cloneNode(true);
+    var containerClone = container.cloneNode(true);
 
-        assert_equals(parentNodeInConstructor, containerClone,
-            'An upgraded element must have its parentNode set before the custom element constructor is called');
-        assert_equals(previousSiblingInConstructor, containerClone.firstChild,
-            'An upgraded element must have its previousSibling set before the custom element constructor is called');
-        assert_equals(nextSiblingInConstructor, containerClone.lastChild,
-            'An upgraded element must have its nextSibling set before the custom element constructor is called');
-    });
-}, 'Node.prototype.cloneNode(true) must be able to clone a descendent custom element');
+    assert_equals(parentNodeInConstructor, containerClone,
+        'An upgraded element must have its parentNode set before the custom element constructor is called');
+    assert_equals(previousSiblingInConstructor, containerClone.firstChild,
+        'An upgraded element must have its previousSibling set before the custom element constructor is called');
+    assert_equals(nextSiblingInConstructor, containerClone.lastChild,
+        'An upgraded element must have its nextSibling set before the custom element constructor is called');
+}, 'Node.prototype.cloneNode(true) must set parentNode, previousSibling, and nextSibling before upgrading custom elements');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        class MyCustomElement extends contentWindow.HTMLElement {
-            constructor(doNotCreateItself) {
-                super();
-                if (!doNotCreateItself)
-                    new MyCustomElement(true);
-            }
+test_with_window(function (contentWindow) {
+    class MyCustomElement extends contentWindow.HTMLElement {
+        constructor(doNotCreateItself) {
+            super();
+            if (!doNotCreateItself)
+                new MyCustomElement(true);
         }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+    }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = new MyCustomElement(false);
-        var uncaughtError;
-        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
-        instance.cloneNode(false);
-        assert_equals(uncaughtError.name, 'InvalidStateError');
-    });
+    var instance = new MyCustomElement(false);
+    var uncaughtError;
+    contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    instance.cloneNode(false);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
 }, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
     + ' due to a custom element constructor constructing itself after super() call');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        class MyCustomElement extends contentWindow.HTMLElement {
-            constructor(doNotCreateItself) {
-                if (!doNotCreateItself)
-                    new MyCustomElement(true);
-                super();
-            }
+test_with_window(function (contentWindow) {
+    class MyCustomElement extends contentWindow.HTMLElement {
+        constructor(doNotCreateItself) {
+            if (!doNotCreateItself)
+                new MyCustomElement(true);
+            super();
         }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+    }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = new MyCustomElement(false);
-        var uncaughtError;
-        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
-        instance.cloneNode(false);
-        assert_equals(uncaughtError.name, 'InvalidStateError');
-    });
+    var instance = new MyCustomElement(false);
+    var uncaughtError;
+    contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    instance.cloneNode(false);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
 }, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
     + ' due to a custom element constructor constructing itself before super() call');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
-        var returnSpan = false;
-        class MyCustomElement extends contentWindow.HTMLElement {
-            constructor() {
-                super();
-                if (returnSpan)
-                    return contentDocument.createElement('span');
-            }
+test_with_window(function (contentWindow) {
+    var contentDocument = contentWindow.document;
+    var returnSpan = false;
+    class MyCustomElement extends contentWindow.HTMLElement {
+        constructor() {
+            super();
+            if (returnSpan)
+                return contentDocument.createElement('span');
         }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
+    }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
 
-        var instance = new MyCustomElement(false);
-        returnSpan = true;
-        var uncaughtError;
-        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
-        instance.cloneNode(false);
-        assert_equals(uncaughtError.name, 'InvalidStateError');
-    });
+    var instance = new MyCustomElement(false);
+    returnSpan = true;
+    var uncaughtError;
+    contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    instance.cloneNode(false);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
 }, 'Upgrading a custom element must throw InvalidStateError when the custom element\'s constructor returns another element');
 
-test(function () {
-    withNewDocumentWithABrowsingContext(function (contentWindow, contentDocument) {
+test_with_window(function (contentWindow) {
+    var contentDocument = contentWindow.document;
+    var instance = contentDocument.createElement('my-custom-element');
+    contentDocument.body.appendChild(instance);
 
-        var instance = contentDocument.createElement('my-custom-element');
-        contentDocument.body.appendChild(instance);
-
-        var calls = [];
-        class MyCustomElement extends contentWindow.HTMLElement {
-            constructor() {
-                super();
-                calls.push(this);
-                throw 'bad';
-            }
+    var calls = [];
+    class MyCustomElement extends contentWindow.HTMLElement {
+        constructor() {
+            super();
+            calls.push(this);
+            throw 'bad';
         }
+    }
 
-        var uncaughtError;
-        contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
-        contentWindow.customElements.define('my-custom-element', MyCustomElement);
-        assert_equals(uncaughtError, 'bad');
+    var uncaughtError;
+    contentWindow.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    contentWindow.customElements.define('my-custom-element', MyCustomElement);
+    assert_equals(uncaughtError, 'bad');
 
-        assert_array_equals(calls, [instance]);
-        contentDocument.body.removeChild(instance);
-        contentDocument.body.appendChild(instance);
-        assert_array_equals(calls, [instance]);
-
-    });
+    assert_array_equals(calls, [instance]);
+    contentDocument.body.removeChild(instance);
+    contentDocument.body.appendChild(instance);
+    assert_array_equals(calls, [instance]);
 }, 'Inserting an element must not try to upgrade a custom element when it had already failed to upgrade once');
 
 </script>

--- a/custom-elements/upgrading/upgrading-parser-created-element.html
+++ b/custom-elements/upgrading/upgrading-parser-created-element.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: Upgrading unresolved elements</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="HTML parser must add an unresolved custom element to the upgrade candidates map">
+<link rel="help" href="https://html.spec.whatwg.org/#upgrades">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<my-custom-element></my-custom-element>
+<instantiates-itself-after-super></instantiates-itself-after-super>
+<instantiates-itself-before-super></instantiates-itself-before-super>
+<my-other-element id="instance"></my-other-element>
+<my-other-element id="otherInstance"></my-other-element>
+<script>
+
+setup({allow_uncaught_exception:true});
+
+test(function () {
+    class MyCustomElement extends HTMLElement { }
+
+    var instance = document.querySelector('my-custom-element');
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof HTMLUnknownElement,
+        'an unresolved custom element should not be an instance of HTMLUnknownElement');
+    assert_false(instance instanceof MyCustomElement);
+
+    customElements.define('my-custom-element', MyCustomElement);
+
+    assert_true(instance instanceof HTMLElement);
+    assert_true(instance instanceof MyCustomElement,
+        'Calling customElements.define must upgrade existing custom elements');
+
+}, 'Element.prototype.createElement must add an unresolved custom element to the upgrade candidates map');
+
+test(function () {
+    class InstantiatesItselfAfterSuper extends HTMLElement {
+        constructor(doNotCreateItself) {
+            super();
+            if (!doNotCreateItself)
+                new InstantiatesItselfAfterSuper(true);
+        }
+    }
+
+    var uncaughtError;
+    window.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    customElements.define('instantiates-itself-after-super', InstantiatesItselfAfterSuper);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
+}, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
+    + ' due to a custom element constructor constructing itself after super() call');
+
+test(function () {
+    class InstantiatesItselfBeforeSuper extends HTMLElement {
+        constructor(doNotCreateItself) {
+            if (!doNotCreateItself)
+                new InstantiatesItselfBeforeSuper(true);
+            super();
+        }
+    }
+
+    var uncaughtError;
+    window.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    customElements.define('instantiates-itself-before-super', InstantiatesItselfBeforeSuper);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
+}, 'HTMLElement constructor must throw an InvalidStateError when the top of the construction stack is marked AlreadyConstructed'
+    + ' due to a custom element constructor constructing itself before super() call');
+
+test(function () {
+    class MyOtherElement extends HTMLElement {
+        constructor() {
+            super();
+            if (this == instance)
+                return otherInstance;
+        }
+    }
+    var instance = document.getElementById('instance');
+    var otherInstance = document.getElementById('otherInstance');
+
+    assert_false(instance instanceof MyOtherElement);
+    assert_false(otherInstance instanceof MyOtherElement);
+
+    var uncaughtError;
+    window.onerror = function (message, url, lineNumber, columnNumber, error) { uncaughtError = error; return true; }
+    customElements.define('my-other-element', MyOtherElement);
+    assert_equals(uncaughtError.name, 'InvalidStateError');
+
+    assert_true(document.createElement('my-other-element') instanceof MyOtherElement,
+        'Upgrading of custom elements must happen after the definition was added to the registry.');
+
+}, 'Upgrading a custom element must throw an InvalidStateError when the returned element is not SameValue as the upgraded element');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
These tests have been reviewed and landed into WebKit: https://trac.webkit.org/browser/trunk/LayoutTests/fast/custom-elements
Almost all test casess pass on both WebKit and Blink.

Both test cases in parser-uses-constructed-element.html fails on Blink because Blink erroneously falls back to creating HTMLUnknownElement when a custom element constructor returns an element different from the one returned by the first call to HTMLElement constructor.

The last test case in parser-uses-registry-of-owner-document.html fails on Blink because Blink erroneously creates a non-HTMLElement Element inside a document created by document.implementation.createDocument with HTML namespace.
