### PR TITLE
Fix bugs in some CEReactions tests.

### DIFF
--- a/custom-elements/reactions/DOMTokenList.html
+++ b/custom-elements/reactions/DOMTokenList.html
@@ -89,8 +89,10 @@ test(function () {
     instance.setAttribute('class', 'hello world');
     assert_array_equals(element.takeLog().types(), ['constructed', 'attributeChanged']);
     instance.classList.remove('foo');
-    assert_array_equals(element.takeLog().types(), []);
-}, 'remove on DOMTokenList must not enqueue an attributeChanged reaction when removing a non-existent value from an attribute');
+    var logEntries = element.takeLog();
+    assert_array_equals(logEntries.types(), ['attributeChanged']);
+    assert_attribute_log_entry(logEntries.last(), {name: 'class', oldValue: 'hello world', newValue: 'hello world', namespace: null});
+}, 'remove on DOMTokenList must enqueue an attributeChanged reaction even when removing a non-existent value from an attribute');
 
 test(function () {
     var element = define_new_custom_element(['title']);

--- a/custom-elements/reactions/Document.html
+++ b/custom-elements/reactions/Document.html
@@ -23,11 +23,17 @@ test(function () {
     var newDoc = document.implementation.createHTMLDocument();
     newDoc.importNode(instance);
 
-    var logEntries = element.takeLog();
-    assert_array_equals(logEntries.types(), ['constructed']);
-    assert_equals(logEntries.last().oldDocument, document);
-    assert_equals(logEntries.last().newDocument, newDoc);
-}, 'importNode on Document must construct a new custom element when importing a custom element');
+    assert_array_equals(element.takeLog().types(), []);
+}, 'importNode on Document must not construct a new custom element when importing a custom element into a window-less document');
+
+test(function () {
+    var element = define_new_custom_element();
+    var template = document.createElement('template');
+    template.innerHTML = `<${element.name}></${element.name}>`;
+    assert_array_equals(element.takeLog().types(), []);
+    document.importNode(template.content, true);
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+}, 'importNode on Document must construct a new custom element when importing a custom element from a template');
 
 test(function () {
     var element = define_new_custom_element();

--- a/custom-elements/reactions/resources/reactions.js
+++ b/custom-elements/reactions/resources/reactions.js
@@ -73,7 +73,7 @@ function testParsingMarkup(testFunction, name) {
         var element = define_new_custom_element(['id']);
         assert_array_equals(element.takeLog().types(), []);
         var instance = testFunction(document, `<${element.name} id="hello" class="foo"></${element.name}>`);
-        assert_equals(Object.getPrototypeOf(instance.querySelector(element.name)), element.class);
+        assert_equals(Object.getPrototypeOf(instance.querySelector(element.name)), element.class.prototype);
         var logEntries = element.takeLog();
         assert_array_equals(logEntries.types(), ['constructed', 'attributeChanged']);
         assert_attribute_log_entry(logEntries[1], {name: 'id', oldValue: null, newValue: 'hello', namespace: null});


### PR DESCRIPTION
DOMTokenList.html: One of the test cases was erroneously asserting that DOMTokenList shouldn't
enqueue attributeChangedCallback when the removed token doesn't exist. DOMTokenList's remove doesn't check such a condition: https://dom.spec.whatwg.org/#dom-domtokenlist-remove
WebKit will pass the newly asserted behavior once https://webkit.org/b/163653 and Chrome fails.

Document.html: The test about importNode was erroneously asserting that a custom element
imported into a window-less document would be upgraded. Fixed this test case and added a test case for adopting a node from a template content. Both WebKit (after the aforementioned bug) and Chrome pass the newly added test case.

reactions.js: Fixed the assertion for the prototype of custom elements. We need to assert that customElement.**proto** is equal to CustomElement.prototype, not the constructor itself.
