### PR TITLE
Promise rejection won't be caught by this try / catch block.

### DIFF
--- a/encrypted-media/scripts/syntax-mediakeysession.js
+++ b/encrypted-media/scripts/syntax-mediakeysession.js
@@ -180,12 +180,10 @@ function runTest(config) {
     // allows for an NotSupportedError to be generated and treated as a
     // success, if allowed. See comment above kCreateSessionTestCases.
     function test_generateRequest(testCase, mediaKeys, type, initData) {
-        try {
-            var mediaKeySession = testCase.func.call(null, mediaKeys);
-            return mediaKeySession.generateRequest(type, initData);
-        } catch (e) {
+        var mediaKeySession = testCase.func.call(null, mediaKeys);
+        return mediaKeySession.generateRequest(type, initData).catch(function (e) {
             assert_true(testCase.isNotSupportedAllowed);
-        }
+        });
     }
     function generateRequestForVariousSessions(){
         return new Promise(function(resolve, reject){


### PR DESCRIPTION
This try/catch block is not going to successfully catch the rejection and to call assert_true(testCase.isNotSupportedAllowed) here.  

The exception will be caught later [here](https://github.com/w3c/web-platform-tests/blob/d0129e5f586821fd6076cc2b0d35cc431d468aab/encrypted-media/scripts/syntax-mediakeysession.js#L205-L206) because that's how **[Promise.all(iterable)](http://www.ecma-international.org/ecma-262/6.0/#sec-promise.all)** behaves .

The test coverage of this fix should be consistent with the original one.
