### PR TITLE
We decided to make abort() no-op more

### DIFF
--- a/XMLHttpRequest/abort-during-open.js
+++ b/XMLHttpRequest/abort-during-open.js
@@ -7,8 +7,8 @@ test.step(function() {
       assert_unreached()
     })
   }
+  assert_equals(client.readyState, 1, "before abort()")
   client.abort()
-  assert_equals(client.readyState, 0)
-  assert_throws("InvalidStateError", function() { client.send("test") }, "calling send() after abort()")
+  assert_equals(client.readyState, 1, "after abort()")
 })
 test.done()

--- a/XMLHttpRequest/abort-event-abort.htm
+++ b/XMLHttpRequest/abort-event-abort.htm
@@ -4,7 +4,7 @@
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-abort()-method" data-tested-assertations="following-sibling::ol/li[4]/ol/li[5]" />
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <title>XMLHttpRequest: The abort() method: do not fire abort event in OPENED state when send() flag is unset. send() throws after abort().</title>
+    <title>XMLHttpRequest: The abort() method: do not fire abort event in OPENED state when send() flag is unset.</title>
 </head>
 
 <body>
@@ -24,6 +24,7 @@
                     if (xhr.readyState == 1)
                     {
                         xhr.abort();
+                        assert_equals(xhr.readyState, 1, "abort() cannot change readyState when readyState is 1 and send() flag is unset")
                     }
                 });
             };
@@ -37,7 +38,7 @@
             };
 
             xhr.open("GET", "./resources/content.py", true); // This should cause a readystatechange event that calls abort()
-            assert_throws("InvalidStateError", function(){ xhr.send() })
+            xhr.send() // should not throw since abort() was a no-op
             test.done()
         });
     </script>

--- a/XMLHttpRequest/open-during-abort.htm
+++ b/XMLHttpRequest/open-during-abort.htm
@@ -26,6 +26,7 @@
         abort_flag = true
         client.abort()
         assert_array_equals(result, expected)
+        assert_equals(client.readyState, 1) // abort() should only set state to UNSENT when DONE
       })
     </script>
   </body>

--- a/XMLHttpRequest/send-data-unexpected-tostring.htm
+++ b/XMLHttpRequest/send-data-unexpected-tostring.htm
@@ -17,9 +17,8 @@
       client.abort();
     }}
     client.open('POST', 'resources/content.py')
-    assert_throws("InvalidStateError", function(){
-      client.send(objAbortsOnStringification)
-    })
+    client.send(objAbortsOnStringification)
+    assert_equals(client.readyState, 1)
     test1.done()
   });
 


### PR DESCRIPTION
See https://github.com/whatwg/xhr/issues/88 for the discussion that led
to these changes.
