### PR TITLE
Moved to new Cast app ID, stored in common config file

### DIFF
--- a/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
@@ -7,6 +7,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#interface-presentationconnection">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 <h2>Description</h2>
 <p>
   This test validates that after connection close,<br/>
@@ -15,15 +16,14 @@
 </p>
 <br/>
 <p>Click the button below to start the test.</p>
-<button id="presentStartBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+    document.getElementById('presentBtn').disabled = true;
     async_test(function(t) {
-      var client_id = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
-      var url = "support/presentation.html#__castAppId__=C2335F62/__castClientId__="+ client_id;
-      var request = new PresentationRequest(url);
+      var request = new PresentationRequest(presentationUrls);
       request.start()
         .then(function(connection) {
           assert_true(connection instanceof PresentationConnection, 'the connection is setup');

--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -7,6 +7,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#interface-presentationconnection">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 <h2>Description</h2>
 <p>
   This test validates that after connection starts,<br/>
@@ -14,15 +15,14 @@
 </p>
 <br/>
 <p>Click the button below to start the test.</p>
-<button id="presentStartBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+    document.getElementById('presentBtn').disabled = true;
     async_test(function(t) {
-      var client_id = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
-      var url = "support/presentation.html#__castAppId__=C2335F62/__castClientId__="+ client_id;
-      var request = new PresentationRequest(url);
+      var request = new PresentationRequest(presentationUrls);
       request.start()
         .then(function(connection) {
           assert_true(connection instanceof PresentationConnection);

--- a/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
@@ -7,6 +7,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#starting-a-presentation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 <h2>Description</h2>
 <p>
   This test validates that after connection terminate,<br/>
@@ -15,15 +16,14 @@
 </p>
 <br/>
 <p>Click the button below to start the test.</p>
-<button id="presentStartBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+    document.getElementById('presentBtn').disabled = true;
     async_test(function(t) {
-      var client_id = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
-      var url = "support/presentation.html#__castAppId__=C2335F62/__castClientId__="+ client_id;
-      var request = new PresentationRequest(url);
+      var request = new PresentationRequest(presentationUrls);
       request.start()
         .then(function(connection) {
           assert_true(connection instanceof PresentationConnection);

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://w3c.github.io/presentation-api/#starting-a-presentation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-
+<script src="common.js"></script>
 <p>Click the button below and select the available presentation display, to start the manual test.</p>
 <button id="presentBtn">Start Presentation Test</button>
 
@@ -19,21 +19,16 @@
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
-
     // --------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - begin
     // --------------------------------------------------------------------------
     var startPresentation = function () {
+        presentBtn.disabled = true;
         promise_test(function (t) {
             // Note: During starting a presentation, the connectionavailable event is fired (step 20)
             //       after the promise P is resolved (step 19).
             return new Promise(function(resolve, reject) {
+                var request = new PresentationRequest(presentationUrls);
                 request.onconnectionavailable = function (evt) {
                     resolve(evt.connection);
                 };

--- a/presentation-api/controlling-ua/common.js
+++ b/presentation-api/controlling-ua/common.js
@@ -1,14 +1,18 @@
 (function (window) {
   // Cast ID of the main custom receiver application linked with the test suite
   // That application ID, maintained by W3C team, points at:
-  // https://w3c-test.org/presentation-api/controlling-ua/support/presentation.html
+  // https://[W3C test server]/presentation-api/controlling-ua/support/presentation.html
+  //
+  // NB: this mechanism should be improved later on as tests should not depend
+  // on something that directly or indirectly maps to a resource on the W3C test
+  // server.
   var castAppId = '915D2A2C';
 
   // NB: the Cast-friendly URL will likely need to be adjusted afterwards as
   // well, e.g. to use another scheme.
   var castClientId = String(new Date().getTime()) +
     String(Math.floor(Math.random() * 1e5));
-  var castUrl = 'http://google.com/cast/#' +
+  var castUrl = 'support/presentation.html#' +
     '__castAppId__=' + castAppId +
     '/__castClientId__=' + castClientId;
 

--- a/presentation-api/controlling-ua/common.js
+++ b/presentation-api/controlling-ua/common.js
@@ -1,0 +1,19 @@
+(function (window) {
+  // Cast ID of the main custom receiver application linked with the test suite
+  // That application ID, maintained by W3C team, points at:
+  // https://w3c-test.org/presentation-api/controlling-ua/support/presentation.html
+  var castAppId = '915D2A2C';
+
+  // NB: the Cast-friendly URL will likely need to be adjusted afterwards as
+  // well, e.g. to use another scheme.
+  var castClientId = String(new Date().getTime()) +
+    String(Math.floor(Math.random() * 1e5));
+  var castUrl = 'http://google.com/cast/#' +
+    '__castAppId__=' + castAppId +
+    '/__castClientId__=' + castClientId;
+
+  window.presentationUrls = [
+    'support/presentation.html',
+    castUrl
+  ];
+})(window);

--- a/presentation-api/controlling-ua/common.js
+++ b/presentation-api/controlling-ua/common.js
@@ -7,14 +7,7 @@
   // on something that directly or indirectly maps to a resource on the W3C test
   // server.
   var castAppId = '915D2A2C';
-
-  // NB: the Cast-friendly URL will likely need to be adjusted afterwards as
-  // well, e.g. to use another scheme.
-  var castClientId = String(new Date().getTime()) +
-    String(Math.floor(Math.random() * 1e5));
-  var castUrl = 'support/presentation.html#' +
-    '__castAppId__=' + castAppId +
-    '/__castClientId__=' + castClientId;
+  var castUrl = 'https://google.com/cast#__castAppId__=' + castAppId;
 
   window.presentationUrls = [
     'support/presentation.html',

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -6,6 +6,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
 <p>If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
@@ -18,10 +19,7 @@
     // -------------------
     // defaultRequest init
     // -------------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate;
-
-    navigator.presentation.defaultRequest = new PresentationRequest(validPresURL);
+    navigator.presentation.defaultRequest = new PresentationRequest(presentationUrls);
 
     // ------------------------------
     // Start New Presentation with

--- a/presentation-api/controlling-ua/getAvailability.html
+++ b/presentation-api/controlling-ua/getAvailability.html
@@ -5,15 +5,14 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <script>
     // ---------------------------------
     // Helper Function
     // ---------------------------------
     var createRequestObject = function () {
-        var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-                presUrl = "../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=" + validUnixDate,
-                request = new PresentationRequest(presUrl);
+        var request = new PresentationRequest(presentationUrls);
         return request;
     }
 
@@ -64,19 +63,6 @@
                     assert_true(availability.value);
                 });
     }, "There is an availability.");
-
-
-    // Invalid Presentation URL Test
-    promise_test(function () {
-        var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-                invalidPresUrl = "../receiving-ua/idlharness.html#__castAppId__=3445E44B/__castClientId__=" + validUnixDate,
-                request = new PresentationRequest(invalidPresUrl);
-
-        return request.getAvailability()
-                .then(function (availability) {
-                    assert_false(availability.value);
-                });
-    }, "There is no availability for an invalid presentation URL.");
     // -------------------------------
     // Screen Availability Tests - end
     // -------------------------------

--- a/presentation-api/controlling-ua/reconnectToPresentation_error-manual.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_error-manual.html
@@ -12,10 +12,7 @@
      * Test if reconnect returns a NotFoundError() by wrong presentation ID
      */
 
-    var client_id = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
-    //relative presentation URL
-    var presentation_url = "../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__="+ client_id;
-    var request = new PresentationRequest(presentation_url);
+    var request = new PresentationRequest('presentation.html');
     var wrong_presentationId = null;
 
     var reconnect = function () {

--- a/presentation-api/controlling-ua/reconnectToPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_success-manual.html
@@ -5,6 +5,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <ol>
     <li>Start the presentation with the blue button.</li>
@@ -31,9 +32,7 @@
     // ------------
     // Request init
     // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
+    var request = new PresentationRequest(presentationUrls);
 
 
     // ----------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
@@ -5,6 +5,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <p>Before starting this test, confirm that there are one or more available presentation display on your local network.</p>
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.
@@ -17,18 +18,13 @@
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
-
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
     var startPresentation = function () {
+        presentBtn.disabled = true;
         promise_test(function (t) {
+            var request = new PresentationRequest(presentationUrls);
             return promise_rejects(t, 'NotAllowedError', request.start());
         });
     };

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
@@ -5,6 +5,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <p>Before starting this test, confirm that there is no available presentation display on your local network.</p>
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.
@@ -17,18 +18,13 @@
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
-
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
     var startPresentation = function () {
+        presentBtn.disabled = true;
         promise_test(function (t) {
+            var request = new PresentationRequest(presentationUrls);
             return promise_rejects(t, 'NotFoundError', request.start());
         });
     };

--- a/presentation-api/controlling-ua/startNewPresentation_error.html
+++ b/presentation-api/controlling-ua/startNewPresentation_error.html
@@ -6,19 +6,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-
-
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
-
     // -----------------------------------
     // Start New Presentation Test - begin
     // -----------------------------------
     promise_test(function (t) {
+      var request = new PresentationRequest('presentation.html');
       promise_rejects(t, 'InvalidAccessError', request.start());
     }, "The presentation could not start, because a user gesture is required.");
     // ----------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -6,32 +6,25 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <p>Click the button below and select the available presentation display, to start the manual test.</p>
-<button id="presentBtn">Start Presentation Test</button>
+<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 
 <script>
-    // disable the timeout function for the tests
-    setup({explicit_timeout: true});
-
     // ----------
     // DOM Object
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request = new PresentationRequest(validPresURL);
-
     // ---------------------------------------------
     // Start New Presentation Test (success) - begin
     // ---------------------------------------------
     var startPresentation = function () {
+        presentBtn.disabled = true;
         promise_test(function () {
+            var request = new PresentationRequest(presentationUrls);
             return request.start()
                     .then(function (connection) {
 
@@ -48,8 +41,7 @@
                         assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
                     });
         }, "The presentation was started successfully.");
-    };
-    presentBtn.onclick = startPresentation;
+    }
     // -------------------------------------------
     // Start New Presentation Test (success) - end
     // -------------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.html
@@ -5,6 +5,7 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
 
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
 <button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
@@ -15,19 +16,14 @@
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
-    // ------------
-    // Request init
-    // ------------
-    var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
-            validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate,
-            request1 = new PresentationRequest(validPresURL),
-            request2 = new PresentationRequest(validPresURL);
-
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
     var startPresentation = function () {
+        presentBtn.disabled = true;
         promise_test(function (t) {
+            var request1 = new PresentationRequest(presentationUrls),
+                request2 = new PresentationRequest(presentationUrls);
             request1.start().catch(function(){});
             return promise_rejects(t, 'OperationError', request2.start());
         });

--- a/presentation-api/controlling-ua/support/iframe.html
+++ b/presentation-api/controlling-ua/support/iframe.html
@@ -3,10 +3,11 @@
 <title>Presentation API - controlling ua - sandboxing</title>
 <link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="../common.js"></script>
 <script>
     window.onmessage = function (ev) {
       try {
-        var request = new PresentationRequest('presentation.html');;
+        var request = new PresentationRequest(presentationUrls);
         if (ev.data === 'start') {
           request.start()
             .then(function () {

--- a/presentation-api/controlling-ua/support/iframe.html
+++ b/presentation-api/controlling-ua/support/iframe.html
@@ -7,7 +7,17 @@
 <script>
     window.onmessage = function (ev) {
       try {
-        var request = new PresentationRequest(presentationUrls);
+        // Presentation URLs are relative to the "controlling-ua" folder,
+        // update relative URLs for this folder
+        var urls = presentationUrls.map(function (url) {
+          if (/:\/\//.test(url)) {
+            return url;
+          }
+          else {
+            return '../' + url;
+          }
+        });
+        var request = new PresentationRequest(urls);
         if (ev.data === 'start') {
           request.start()
             .then(function () {


### PR DESCRIPTION
This PR introduces a common.js file that exposes a `presentationUrls` variable which contains the list of valid presentation URLs to use to create `PresentationRequest` objects in tests. An array of two URLs is returned with:
1. a relative link to the main support/presentation.html receiver app
2. a link to the publicly available custom receiver Cast application. Note this Cast app ID is maintained by W3C team.

I haven't tried to solve the "how to run tests in a local environment?" issue (relative links will get resolved to the `web-platform.test` domain name which can only be resolved on the local computer, unless one also updates its LAN DNS server). That needs more thoughts.

The commit also ensures that the action button gets disabled as soon as the user clicks it to avoid running tests more than once (which the test harness does not like).

When possible, calls to the `PresentationRequest` constructor have been moved to within the `async_test` or `promise_test` callback function. This guarantees that the test will fail properly when run in user agents that do not implement the Presentation API at all.

I dropped the invalid presentation URL test from the getAvailability tests, because the test seems invalid: "really invalid" URLs will be caught when the PresentationRequest object is constructed. The behavior of "getAvailability" when an incorrect Cast URL is used is implementation-specific otherwise (and implementations may not support Cast URLs at all in particular).

I think there are a couple of bugs in `PresentationConnection_onxxx-manual.html` tests which I haven't tried to fix in this PR. Also, the `defaultRequest_success-manual.html` would benefit from an update to disable the button, and not crash when `PresentationRequest` is not supported at all. Same thing for `reconnectToPresentation_success-manual.html`. I'll raise separate issues.
