### PR TITLE
Fix handling when PresentationRequest not found

### DIFF
--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -8,12 +8,18 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
-<p>If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+<p id="notice">If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
 
 <script>
     // disable the timeout function for the tests
     // and call 'done()' when the tests cases are finished.
     setup({explicit_timeout: true});
+
+    // -----------
+    // DOM Element
+    // -----------
+    var button = document.getElementById('notsupported'),
+        notice = document.getElementById('notice');
 
     // -------------------
     // defaultRequest init
@@ -21,22 +27,23 @@
     var validUnixDate = new Date().getTime() + String(Math.floor(Math.random() * 1e5)),
             validPresURL = '../receiving-ua/idlharness.html#__castAppId__=2334D33A/__castClientId__=' + validUnixDate;
 
-    navigator.presentation.defaultRequest = new PresentationRequest(validPresURL);
-
     // ------------------------------
     // Start New Presentation with
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
+        navigator.presentation.defaultRequest = new PresentationRequest(validPresURL);
         navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
             var connection = evt.connection;
+            notice.parentNode.removeChild(notice);
 
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
             assert_true(!connection.id, 'The connection ID is set.');
             assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });
-        document.getElementById('notsupported').onclick = t.step_func_done(function() {
+        button.onclick = t.step_func_done(function() {
+            button.disabled = true;
             assert_unreached('This browser does not support defaultRequest.');
         });
     }, '[Optional] The presentation was started successfully.');


### PR DESCRIPTION
This PR fixes #4039.
- `new PresentationRequest()` is moved to `async_test(function(t){ ... })` for proper error report.
- The "Not Supported" button is disabled when the button is clicked.
- The whole "If your browser does not support" text including the button is hidden when the `connectionavailable` event is fired.
