### PR TITLE
Add disconnected tests

### DIFF
--- a/dom/events/Event-dispatch-click.html
+++ b/dom/events/Event-dispatch-click.html
@@ -169,4 +169,36 @@ async_test(function(t) {
 
   t.done()
 }, "disabled checkbox still has activation behavior, part 2")
+
+async_test(function(t) {
+  var input = document.createElement("input")
+  input.type = "checkbox"
+  input.onclick = t.step_func_done(function() {
+    assert_true(input.checked)
+  })
+  input.click()
+}, "disconnected checkbox should be checked")
+
+async_test(function(t) {
+  var input = document.createElement("input")
+  input.type = "radio"
+  input.onclick = t.step_func_done(function() {
+    assert_true(input.checked)
+  })
+  input.click()
+}, "disconnected radio should be checked")
+
+async_test(function(t) {
+  var form = document.createElement("form")
+  var didSubmit = false
+  form.onsubmit = t.step_func(() => {
+    didSubmit = true
+    return false
+  })
+  var input = form.appendChild(document.createElement("input"))
+  input.type = "submit"
+  input.click()
+  assert_false(didSubmit)
+  t.done()
+}, "disconnected form should not submit")
 </script>


### PR DESCRIPTION
Closes https://github.com/whatwg/html/issues/1893 as it turns out only Firefox was not following the specification for radio/checkbox, even though it’s a little weird they behave differently from `<form>`. But you know, it’s the web.
