### PR TITLE
[eme] Fix #4026: Have license expire in the near future

### DIFF
--- a/encrypted-media/scripts/playback-temporary-expired.js
+++ b/encrypted-media/scripts/playback-temporary-expired.js
@@ -44,13 +44,20 @@ function runTest(config,qualifier) {
 
             assert_in_array(event.messageType, ['license-request', 'individualization-request']);
 
-            var expiration = Date.now().valueOf();
-            config.messagehandler(event.messageType, event.message, expiration).then(function(response) {
+            var expiration = Date.now().valueOf() + 1000;
+            config.messagehandler(event.messageType, event.message, { expiration: expiration }).then(function(response) {
                 return event.target.update(response);
-            }).then(test.step_func(function(){
+            }).then(test.step_func(function() {
+                // License server may only have second granularity, so check
+                // that session expiration time is close to the desired value.
                 assert_approx_equals(event.target.expiration, expiration, 2000, "expiration attribute should equal provided expiration time");
+
+                // Since the expiration time is in the future, wait 5 seconds
+                // so that the license has expired before calling play().
                 test.step_timeout(function() {
+                    assert_greater_than(Date.now().valueOf(), expiration, "Starting play before license expired");
                     _video.play();
+                    // Wait 2 seconds to ensure that the video does not play.
                     test.step_timeout(function() { test.done(); }, 2000);
                 }, 5000);
             })).catch(onFailure);


### PR DESCRIPTION
I wasn't able to get PR #4045 to work for me. The drmtoday server always returned 403 unless the expiration time was sometime in the future. The license granularity seems to be on the order of seconds, so this change adds 1 second to now() and uses that as the expiration time. Since the test waits 5 seconds before attempting to play, this appears to be enough time for everything to work as expected.
