### PR TITLE
[eme] Correct expected readyState value when waitingforkey

### DIFF
--- a/encrypted-media/scripts/playback-temporary-multikey-sequential.js
+++ b/encrypted-media/scripts/playback-temporary-multikey-sequential.js
@@ -56,7 +56,11 @@ function runTest(config,qualifier) {
         function onWaitingForKey(event) {
             _waitingForKey = true;
             if (config.checkReadyState) {
-                assert_equals(_video.readyState, _video.HAVE_METADATA, "Video readyState should be HAVE_METADATA on watingforkey event");
+                // This test does not start playing until the first license has been provided,
+                // so this event should occur when transitioning between keys.
+                // Thus, the frame at the current playback position is available and readyState
+                // should be HAVE_CURRENT_DATA.
+                assert_equals(_video.readyState, _video.HAVE_CURRENT_DATA, "Video readyState should be HAVE_CURRENT_DATA on watingforkey event");
             }
             startNewSession();
         }


### PR DESCRIPTION
https://github.com/w3c/encrypted-media/issues/338 changed the expected
readyState value when the current frame has been decrypted and decoded, which
is the case in this test.
