### PR TITLE
serve: Add empty "aliases" config so that it can be overridden.

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -22,5 +22,6 @@
              "host_cert_path": null
          },
          "none": {}
-        }
+        },
+ "aliases": []
 }


### PR DESCRIPTION
This is a counterpart of https://github.com/w3c/wpt-tools/pull/131
