### PR TITLE
[html] Reduce the number of tests in reflection-*.html test files.

### DIFF
--- a/html/dom/new-harness.js
+++ b/html/dom/new-harness.js
@@ -11,10 +11,6 @@ ReflectionHarness.test = function(expected, actual, description) {
   return true;
 }
 
-ReflectionHarness.run = function(fun, description) {
-  test(fun, this.getTypeDescription() + ": " + description);
-}
-
 ReflectionHarness.testException = function(exceptionName, fn, description) {
   test(function() {
     assert_throws(exceptionName, fn);

--- a/html/dom/original-harness.js
+++ b/html/dom/original-harness.js
@@ -117,14 +117,6 @@ ReflectionHarness.test = function(expected, actual, description) {
   }
 }
 
-ReflectionHarness.run = function(fun, description) {
-  try {
-    fun();
-  } catch (err) {
-    ReflectionHarness.failure(description);
-  }
-}
-
 /**
  * If calling fn causes a DOMException of the type given by the string
  * exceptionName (e.g., "INDEX_SIZE_ERR"), output a success.  Otherwise, report


### PR DESCRIPTION
Remove "... should not throw" tests by testing it in "... followed by ..."
tests. This change removes 22,044 tests without reducing test coverage.

Background:
In Chromium project, we check in text dump of testharnessreport.js output.  The
text dumps for these test files are too large to handle with our code review
tool, which has 1MB limit for a single file.
