### PR TITLE
Extend the timeout of expired license test to long.

### DIFF
--- a/encrypted-media/drm-mp4-playback-temporary-expired.html
+++ b/encrypted-media/drm-mp4-playback-temporary-expired.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4, expired license</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 


### PR DESCRIPTION
In response to issue #4079

The test currently races against the 10 second normal test timeout. If latency
is introduced by network conditions this test will often fail with a timeout.
Extending this to be a long test mitigates this.
