### PR TITLE
Test that removed legacycallers are not supported

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -883,7 +883,7 @@ interface HTMLAllCollection {
 
 interface HTMLFormControlsCollection : HTMLCollection {
   // inherits length and item()
-  legacycaller getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
+  getter (RadioNodeList or Element)? namedItem(DOMString name); // shadows inherited namedItem()
 };
 
 interface RadioNodeList : NodeList {
@@ -891,13 +891,12 @@ interface RadioNodeList : NodeList {
 };
 
 interface HTMLOptionsCollection : HTMLCollection {
-  // inherits item()
-           attribute unsigned long length; // shadows inherited length
-  legacycaller HTMLOptionElement? (DOMString name);
-  setter creator void (unsigned long index, HTMLOptionElement? option);
-  void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
-  void remove(long index);
-           attribute long selectedIndex;
+  // inherits item(), namedItem()
+  attribute unsigned long length; // shadows inherited length
+  [CEReactions] setter void (unsigned long index, HTMLOptionElement? option);
+  [CEReactions] void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+  [CEReactions] void remove(long index);
+  attribute long selectedIndex;
 };
 
 typedef sequence<any> PropertyValueArray;
@@ -1179,7 +1178,6 @@ interface HTMLEmbedElement : HTMLElement {
            attribute DOMString width;
            attribute DOMString height;
   Document getSVGDocument();
-  legacycaller any (any... arguments);
 
   // also has obsolete members
 };
@@ -1202,8 +1200,6 @@ interface HTMLObjectElement : HTMLElement {
   boolean checkValidity();
   boolean reportValidity();
   void setCustomValidity(DOMString error);
-
-  legacycaller any (any... arguments);
 
   // also has obsolete members
 };

--- a/html/infrastructure/common-dom-interfaces/collections/historical.html
+++ b/html/infrastructure/common-dom-interfaces/collections/historical.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>Historical HTML*Collection features should not be supported</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<form id=form><input name=foo></form>
+<select id=select><option name=bar></select>
+<script>
+test(function() {
+  var collection = document.getElementById('form').elements;
+  assert_equals(typeof collection, 'object', 'typeof');
+  assert_throws(new TypeError(), function() {
+    collection('foo');
+  });
+}, 'HTMLFormControlsCollection legacycaller should not be supported');
+
+test(function() {
+  var collection = document.getElementById('select').options;
+  assert_equals(typeof collection, 'object', 'typeof');
+  assert_throws(new TypeError(), function() {
+    collection('bar');
+  });
+}, 'HTMLOptionsCollection legacycaller should not be supported');
+
+</script>

--- a/html/semantics/embedded-content/the-embed-element/historical.html
+++ b/html/semantics/embedded-content/the-embed-element/historical.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Historical embed element features should not be supported</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<embed id=embed>
+<script>
+test(function() {
+  var elm = document.getElementById('embed');
+  assert_equals(typeof elm, 'object', 'typeof');
+  assert_throws(new TypeError(), function() {
+    elm();
+  });
+}, 'embed legacycaller should not be supported');
+</script>

--- a/html/semantics/embedded-content/the-object-element/historical.html
+++ b/html/semantics/embedded-content/the-object-element/historical.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Historical object element features should not be supported</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<object id=object></object>
+<script>
+test(function() {
+  var elm = document.getElementById('object');
+  assert_equals(typeof elm, 'object', 'typeof');
+  assert_throws(new TypeError(), function() {
+    elm();
+  });
+}, 'object legacycaller should not be supported');
+</script>


### PR DESCRIPTION
Test for https://github.com/whatwg/html/pull/1979

Also test the previously-removed legacycallers on
HTMLFormControlsCollection and HTMLOptionsCollection.

---

I found that the added `object` and `embed` tests fail in Chrome...
