### PR TITLE
Fix some nits in annotation protocol tests

### DIFF
--- a/annotation-protocol/files/annotations/annotation.options.headers
+++ b/annotation-protocol/files/annotations/annotation.options.headers
@@ -1,3 +1,2 @@
-Content-Type: text/plain
 Allow: GET,HEAD,OPTIONS,DELETE,PUT
 Vary: Accept

--- a/annotation-protocol/files/annotations/collection.options.headers
+++ b/annotation-protocol/files/annotations/collection.options.headers
@@ -1,3 +1,2 @@
-Content-Type: text/plain
 Allow: POST,GET,OPTIONS,HEAD,DELETE,PUT
 Vary: Accept, Prefer

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -326,7 +326,7 @@ function runTests( container_url, annotation_url ) {
   // SHOULD tests
 
   test(function() {
-    assert_equals("https", container_url.toLowerCase().substr(0,5), "Server is not using HTTPS");
+    assert_equals(container_url.toLowerCase().substr(0,5), "https", "Server is not using HTTPS");
     }, "Annotation server SHOULD use HTTPS rather than HTTP");
 
   var thePrefRequest = request("GET", container_url,

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -63,16 +63,22 @@ function request(method, url, headers, content) {
         resp.text = d;
         // we have it; what is it?
         var type = xhr.getResponseHeader('Content-Type');
-        resp.type = type.split(';')[0];
-        if (resp.type === MEDIA_TYPE) {
-          try {
-            d = JSON.parse(d);
-            resp.body = d;
+        if (type) {
+          resp.type = type.split(';')[0];
+          if (resp.type === MEDIA_TYPE) {
+            try {
+              d = JSON.parse(d);
+              resp.body = d;
+            }
+            catch(err) {
+              resp.body = null;
+            }
           }
-          catch(err) {
-            resp.body = null;
-          }
+        } else {
+          resp.type = null;
+          resp.body = null;
         }
+
       }
       resolve(resp);
     };

--- a/annotation-protocol/tools/protocol-server.py
+++ b/annotation-protocol/tools/protocol-server.py
@@ -312,7 +312,7 @@ def annotation_head(request, response):
         response.status = 404
 
     add_cors_headers(response)
-    response.content = "Annotation Options\n"
+    # response.content = "Annotation Options\n"
 
 @wptserve.handlers.handler
 def annotation_options(request, response):
@@ -331,7 +331,7 @@ def annotation_options(request, response):
         response.status = 404
 
     add_cors_headers(response)
-    response.content = "Annotation Options\n"
+    # response.content = "Annotation Options\n"
 
 
 def create_annotation(body):

--- a/annotation-protocol/tools/protocol-server.py
+++ b/annotation-protocol/tools/protocol-server.py
@@ -409,6 +409,8 @@ def annotation_delete(request, response):
 
 if __name__ == '__main__':
     print 'http://' + myhost + ':{0}/'.format(port)
+    print 'container URI is http://' + myhost + ':{0}/'.format(port) + "/annotations/"
+    print 'example annotation URI is http://' + myhost + ':{0}/'.format(port) + "/annotations/anno1.json"
 
     routes = [
         ("GET", "", wptserve.handlers.file_handler),


### PR DESCRIPTION
CR testers reported that the order of arguments was wrong when checking for use of https.

They also reported that an exception was thrown when an OPTIONS request returned no Content-Type header

@azaroth42 and @BigBlueHat please review and verify these changes so we can merge them up.
