### PR TITLE
Run one reflection test per property

### DIFF
--- a/html/dom/new-harness.js
+++ b/html/dom/new-harness.js
@@ -2,21 +2,23 @@
 // original-harness.js.  Polymorphism, kind of.
 ReflectionHarness.catchUnexpectedExceptions = false;
 
+ReflectionHarness.testWrapper = function(fun) {
+  test(fun, this.getTypeDescription());
+}
+
 ReflectionHarness.test = function(expected, actual, description) {
-  test(function() {
-    assert_equals(expected, actual);
-  }, this.getTypeDescription() + ": " + description);
+  assert_equals(expected, actual,
+                this.getTypeDescription() + ": " + description);
   // This is the test suite that will rate conformance, so we don't want to
   // bail out early if a test fails -- we want all tests to always run.
   return true;
 }
 
 ReflectionHarness.run = function(fun, description) {
-  test(fun, this.getTypeDescription() + ": " + description);
+  fun();
 }
 
 ReflectionHarness.testException = function(exceptionName, fn, description) {
-  test(function() {
-    assert_throws(exceptionName, fn);
-  }, this.getTypeDescription() + ": " + description);
+  assert_throws(exceptionName, fn,
+                this.getTypeDescription() + ": " + description);
 }


### PR DESCRIPTION
Blink/WebKit are having trouble with these tests because they're too
big, even after splitting up.  #4078 makes a slight dent, but it looks
like my original intent was that each property should be one test, but I
didn't wind up implementing it.  This cuts the number of tests run by a
factor of something like 80 (e.g., 15,065 to 191 for embedded).

Naturally, it has the disadvantage that if an implementation fails
multiple assertions in a property, there will be no more test coverage
for that property, neither for regressions nor standards conformance.
In some cases a minor bug that's hard for a certain implementation to
fix could indefinitely disable further test coverage for a wide array of
properties.  As such, I'm not sure this is a good idea.  If the problem
that Blink/WebKit have is that the log messages are too verbose, perhaps
they shouldn't print log lines for expected passes/fails, which I
believe is what Mozilla does (speak to jgraham).

If we do want this change, we could also probably recombine the test
files.

@tkent-google This would certainly solve your problem, but might be too drastic, and I'm not sure we want it.
