### PR TITLE
Log an additional empty line after the results tables.

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -415,6 +415,7 @@ def table(headings, data, log):
     log("|%s|" % "|".join("-" * max_widths[i] for i in cols))
     for row in data:
         log("|%s|" % "|".join(" %s" % row[i].ljust(max_widths[i] - 1) for i in cols))
+    log("")
 
 
 def write_inconsistent(inconsistent, iterations):


### PR DESCRIPTION
I believe this will make the emails easier to read if there are results for
multiple tests.
