### PR TITLE
webrtc: require remote video to be loaded

### DIFF
--- a/webrtc/simplecall.html
+++ b/webrtc/simplecall.html
@@ -34,6 +34,14 @@ instance --use-fake-device-for-media-stream for Chrome.
   var gFirstConnection = null;
   var gSecondConnection = null;
 
+  // if the remote video gets video data that implies the negotiation
+  // as well as the ICE and DTLS connection are up.
+  document.getElementById('remote-view')
+      .addEventListener('loadedmetadata', function() {
+    // Call negotiated: done.
+    test.done();
+  });
+
   function getUserMediaOkCallback(localStream) {
     gFirstConnection = new RTCPeerConnection(null);
     gFirstConnection.onicecandidate = onIceCandidateToFirst;
@@ -76,22 +84,15 @@ instance --use-fake-device-for-media-stream for Chrome.
     var parsedAnswer = new RTCSessionDescription({ type: 'answer',
                                                    sdp: answerSdp });
     gFirstConnection.setRemoteDescription(parsedAnswer);
-
-    // Call negotiated: done.
-    test.done();
   };
 
   var onIceCandidateToFirst = test.step_func(function(event) {
     // If event.candidate is null = no more candidates.
-    if (event.candidate) {
-      gSecondConnection.addIceCandidate(event.candidate);
-    }
+    gSecondConnection.addIceCandidate(event.candidate);
   });
 
   var onIceCandidateToSecond = test.step_func(function(event) {
-    if (event.candidate) {
-      gFirstConnection.addIceCandidate(event.candidate);
-    }
+    gFirstConnection.addIceCandidate(event.candidate);
   });
 
   var onRemoteStream = test.step_func(function(event) {


### PR DESCRIPTION
This changes the test definition slightly and requires that
the remote videos loadedmetadata has been called. This will
only happen when the ICE and DTLS connections are up and the
videos readyState is HAVE_ENOUGH_DATA.

Also adds addIceCandidate(null) to signal end-of-candidates
for Microsoft Edge.
