### PR TITLE
Add more CEReactions tests for autonomous custom elements.

### DIFF
--- a/custom-elements/reactions/Document.html
+++ b/custom-elements/reactions/Document.html
@@ -110,6 +110,45 @@ test_with_window(function (contentWindow, contentDocument) {
     assert_array_equals(element.takeLog().types(), ['connected']);
 }, 'body on Document must enqueue connectedCallback when inserting a custom element');
 
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = '<custom-element></custom-element>';
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    contentDocument.open();
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'open on Document must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = '<custom-element></custom-element>';
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    contentDocument.write('');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'write on Document must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentWindow.document.write('<custom-element></custom-element>');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+}, 'write on Document must enqueue connectedCallback after constructing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = '<custom-element></custom-element>';
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    contentDocument.writeln('');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'writeln on Document must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentWindow.document.writeln('<custom-element></custom-element>');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+}, 'writeln on Document must enqueue connectedCallback after constructing a custom element');
+
 </script>
 </body>
 </html>

--- a/custom-elements/reactions/HTMLAnchorElement.html
+++ b/custom-elements/reactions/HTMLAnchorElement.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLAnchorElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="text of HTMLAnchorElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<a><custom-element>hello</custom-element></a>`;
+    const anchor = contentDocument.querySelector('a');
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(anchor.innerHTML, '<custom-element>hello</custom-element>');
+
+    anchor.text = 'world';
+    assert_equals(anchor.innerHTML, 'world');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'text on HTMLAnchorElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLOptionElement.html
+++ b/custom-elements/reactions/HTMLOptionElement.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLOptionElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="text of HTMLOptionElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+    const instance = document.createElement('custom-element');
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    option.text = 'world';
+    assert_equals(option.innerHTML, 'world');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'text on HTMLOptionElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLOptionsCollection.html
+++ b/custom-elements/reactions/HTMLOptionsCollection.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLOptionsCollection interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="length, the indexed setter, add, and remove of HTMLOptionsCollection interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.options[0], option);
+    select.options.length = 0;
+    assert_equals(select.firstChild, null);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'length on HTMLOptionsCollection must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select></select>`;
+    const select = contentDocument.querySelector('select');
+
+    const option = contentDocument.createElement('option');
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    assert_equals(select.options.length, 0);
+    select.options[0] = option;
+    assert_equals(select.options.length, 1);
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'The indexed setter on HTMLOptionsCollection must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.options[0], option);
+    select.options[0] = null;
+    assert_equals(select.options.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'The indexed setter on HTMLOptionsCollection must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select></select>`;
+    const select = contentDocument.querySelector('select');
+
+    const option = contentDocument.createElement('option');
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    assert_equals(select.options.length, 0);
+    select.options.add(option);
+    assert_equals(select.options.length, 1);
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'add on HTMLOptionsCollection must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.options[0], option);
+    select.options.remove(0);
+    assert_equals(select.options.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'remove on HTMLOptionsCollection must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLOutputElement.html
+++ b/custom-elements/reactions/HTMLOutputElement.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLOutputElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="value and defaultValue of HTMLOutputElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<output><custom-element>hello</custom-element></output>`;
+    const anchor = contentDocument.querySelector('output');
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(anchor.innerHTML, '<custom-element>hello</custom-element>');
+
+    anchor.value = 'world';
+    assert_equals(anchor.innerHTML, 'world');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'value on HTMLOutputElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<output><custom-element>hello</custom-element></output>`;
+    const anchor = contentDocument.querySelector('output');
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(anchor.innerHTML, '<custom-element>hello</custom-element>');
+
+    anchor.defaultValue = 'world';
+    assert_equals(anchor.innerHTML, 'world');
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'defaultValue on HTMLOutputElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLSelectElement.html
+++ b/custom-elements/reactions/HTMLSelectElement.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLSelectElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="length, add, remove, and the setter of HTMLSelectElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.length, 1);
+    select.length = 0;
+    assert_equals(select.firstChild, null);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'length on HTMLSelectElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select></select>`;
+    const select = contentDocument.querySelector('select');
+
+    const option = contentDocument.createElement('option');
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    assert_equals(select.options.length, 0);
+    select[0] = option;
+    assert_equals(select.options.length, 1);
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'The indexed setter on HTMLSelectElement must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.options[0], option);
+    select[0] = null;
+    assert_equals(select.options.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'The indexed setter on HTMLSelectElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select></select>`;
+    const select = contentDocument.querySelector('select');
+
+    const option = contentDocument.createElement('option');
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    assert_equals(select.options.length, 0);
+    select.add(option);
+    assert_equals(select.options.length, 1);
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'add on HTMLSelectElement must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+
+    const contentDocument = contentWindow.document;
+    contentDocument.body.innerHTML = `<select><option></option></select>`;
+    const option = contentDocument.querySelector('option');
+
+    const instance = contentDocument.createElement(element.name);
+    option.appendChild(instance);
+    instance.textContent = 'hello';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(option.innerHTML, '<custom-element>hello</custom-element>');
+
+    const select = contentDocument.querySelector('select');
+    assert_equals(select.options[0], option);
+    select.remove(0);
+    assert_equals(select.options.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'remove on HTMLSelectElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLTableElement.html
+++ b/custom-elements/reactions/HTMLTableElement.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLTableElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="caption, deleteCaption, thead, deleteTHead, tFoot, deleteTFoot, and deleteRow of HTMLTableElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table></table>`;
+    const table = contentDocument.querySelector('table');
+
+    const caption = contentDocument.createElement('caption');
+    caption.innerHTML = '<custom-element>hello</custom-element>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(caption.innerHTML, '<custom-element>hello</custom-element>');
+
+    assert_equals(table.caption, null);
+    table.caption = caption;
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'caption on HTMLTableElement must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><caption><custom-element>hello</custom-element></caption></table>`;
+    const caption = contentDocument.querySelector('caption');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(caption.innerHTML, '<custom-element>hello</custom-element>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.caption, caption);
+    const newCaption = contentDocument.createElement('caption');
+    table.caption = newCaption; // Chrome doesn't support setting to null.
+    assert_equals(table.caption, newCaption);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'caption on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><caption><custom-element>hello</custom-element></caption></table>`;
+    const caption = contentDocument.querySelector('caption');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(caption.innerHTML, '<custom-element>hello</custom-element>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.caption, caption);
+    const newCaption = contentDocument.createElement('caption');
+    table.deleteCaption();
+    assert_equals(table.caption, null);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteCaption() on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table></table>`;
+    const table = contentDocument.querySelector('table');
+
+    const thead = contentDocument.createElement('thead');
+    thead.innerHTML = '<tr><td><custom-element>hello</custom-element></td></tr>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(thead.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    assert_equals(table.tHead, null);
+    table.tHead = thead;
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'tHead on HTMLTableElement must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><thead><tr><td><custom-element>hello</custom-element></td></tr></thead></table>`;
+    const thead = contentDocument.querySelector('thead');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(thead.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tHead, thead);
+    const newThead = contentDocument.createElement('thead');
+    table.tHead = newThead; // Chrome doesn't support setting to null.
+    assert_equals(table.tHead, newThead);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'tHead on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><thead><tr><td><custom-element>hello</custom-element></td></tr></thead></table>`;
+    const thead = contentDocument.querySelector('thead');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(thead.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tHead, thead);
+    table.deleteTHead();
+    assert_equals(table.tHead, null);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteTHead() on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table></table>`;
+    const table = contentDocument.querySelector('table');
+
+    const tfoot = contentDocument.createElement('tfoot');
+    tfoot.innerHTML = '<tr><td><custom-element>hello</custom-element></td></tr>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+    assert_equals(tfoot.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    assert_equals(table.tFoot, null);
+    table.tFoot = tfoot;
+    assert_array_equals(element.takeLog().types(), ['connected']);
+}, 'tFoot on HTMLTableElement must enqueue connectedCallback when inserting a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><tfoot><tr><td><custom-element>hello</custom-element></td></tr></tfoot></table>`;
+    const tfoot = contentDocument.querySelector('tfoot');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(tfoot.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tFoot, tfoot);
+    const newThead = contentDocument.createElement('tfoot');
+    table.tFoot = newThead; // Chrome doesn't support setting to null.
+    assert_equals(table.tFoot, newThead);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'tFoot on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><tfoot><tr><td><custom-element>hello</custom-element></td></tr></tfoot></table>`;
+    const tfoot = contentDocument.querySelector('tfoot');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(tfoot.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tFoot, tfoot);
+    table.deleteTFoot();
+    assert_equals(table.tFoot, null);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteTFoot() on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><tr><td><custom-element>hello</custom-element></td></tr></table>`;
+    const tr = contentDocument.querySelector('tr');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(tr.innerHTML, '<td><custom-element>hello</custom-element></td>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.rows.length, 1);
+    assert_equals(table.rows[0], tr);
+    table.deleteRow(0);
+    assert_equals(table.rows.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteRow() on HTMLTableElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLTableRowElement.html
+++ b/custom-elements/reactions/HTMLTableRowElement.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLTableRowElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="deleteCell of HTMLTableRowElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><tr><td><custom-element>hello</custom-element></td></tr></table>`;
+    const td = contentDocument.querySelector('td');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(td.innerHTML, '<custom-element>hello</custom-element>');
+
+    const table = contentDocument.querySelector('table');
+    const row = table.rows[0];
+    assert_equals(row.cells[0], td);
+    row.deleteCell(0);
+    assert_equals(row.cells.length, 0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteCell() on HTMLTableRowElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLTableSectionElement.html
+++ b/custom-elements/reactions/HTMLTableSectionElement.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLTableSectionElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="deleteRow of HTMLTableSectionElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><thead><tr><td><custom-element>hello</custom-element></td></tr></thead></table>`;
+    const thead = contentDocument.querySelector('thead');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(thead.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tHead, thead);
+    table.tHead.deleteRow(0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteRow() on HTMLTableSectionElement on thead must enqueue disconnectedCallback when removing a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    contentDocument.body.innerHTML = `<table><tfoot><tr><td><custom-element>hello</custom-element></td></tr></tfoot></table>`;
+    const tfoot = contentDocument.querySelector('tfoot');
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+    assert_equals(tfoot.innerHTML, '<tr><td><custom-element>hello</custom-element></td></tr>');
+
+    const table = contentDocument.querySelector('table');
+    assert_equals(table.tFoot, tfoot);
+    table.tFoot.deleteRow(0);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'deleteRow() on HTMLTableSectionElement on tfoot must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/HTMLTitleElement.html
+++ b/custom-elements/reactions/HTMLTitleElement.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on HTMLTitleElement interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="text of HTMLTitleElement interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const instance = contentWindow.document.createElement(element.name);
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+
+    contentWindow.document.title = 'hello';
+    const titleElement = contentDocument.querySelector('title');
+    titleElement.appendChild(instance);
+    assert_array_equals(element.takeLog().types(), ['connected']);
+    assert_equals(titleElement.childNodes.length, 2);
+
+    titleElement.text = 'world';
+    assert_equals(titleElement.childNodes.length, 1);
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+}, 'text on HTMLTitleElement must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>

--- a/custom-elements/reactions/ShadowRoot.html
+++ b/custom-elements/reactions/ShadowRoot.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Custom Elements: CEReactions on ShadowRoot interface</title>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<meta name="assert" content="innerHTML of ShadowRoot interface must have CEReactions">
+<meta name="help" content="https://dom.spec.whatwg.org/#node">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed']);
+}, 'innerHTML on ShadowRoot must upgrade a custom element');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    contentDocument.body.appendChild(host);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+}, 'innerHTML on ShadowRoot must enqueue connectedCallback on newly upgraded custom elements when the shadow root is connected');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
+    const host = contentDocument.createElement('div');
+    contentDocument.body.appendChild(host);
+
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<custom-element></custom-element>';
+    assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+
+    shadowRoot.innerHTML = '';
+    assert_array_equals(element.takeLog().types(), ['disconnected']);
+
+}, 'innerHTML on ShadowRoot must enqueue disconnectedCallback when removing a custom element');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Import the remaining custom elments reactions tests from WebKit.
Trunk WebKit passes all the tests and Chrome fails one test case for HTMLOptionsCollection.length.
