### PR TITLE
[eme] Ensure runTest() in unique-origin.js is returning a promise.

### DIFF
--- a/encrypted-media/scripts/unique-origin.js
+++ b/encrypted-media/scripts/unique-origin.js
@@ -44,7 +44,7 @@ function runTest(config) {
           '<\/script>';
 
         // Verify that this page can create a MediaKeys first.
-        navigator.requestMediaKeySystemAccess(config.keysystem, [{
+        return navigator.requestMediaKeySystemAccess(config.keysystem, [{
             initDataTypes: [config.initDataType],
             audioCapabilities: [
                 {contentType: config.audioType},


### PR DESCRIPTION
This ensures that the promise_test() call waits for the test to complete
before finishing the test. So now we'll notice if the test test fails
or passes.

This makes [clearkey-mp4-unique-origin.html](https://w3c-test.org/encrypted-media/clearkey-mp4-unique-origin.html) actually work. I assume Chrome will start passing with this fix; Firefox Nightly won't quite yet due to other issues.
