### PR TITLE
initial makeCredential tests

### DIFF
--- a/webauthn/helpers.js
+++ b/webauthn/helpers.js
@@ -1,0 +1,159 @@
+/**
+ * TestCase
+ *
+ * A generic template for test cases
+ * Is intended to be overloaded with subclasses that override testObject, testFunction and argOrder
+ * The testObject is the default arguments for the testFunction
+ * The default testObject can be modified with the modify() method, making it easy to create new tests based on the default
+ * The testFunction is the target of the test and is called by the test() method. test() applies the testObject as arguments via toArgs()
+ * toArgs() uses argOrder to make sure the resulting array is in the right order of the arguments for the testFunction
+ */
+class TestCase {
+    constructor() {
+        this.testFunction = function() {
+            throw new Error("Test Function not implemented");
+        };
+        this.testObject = {};
+        this.argOrder = [];
+    }
+
+    /**
+     * toObject
+     *
+     * return a copy of the testObject
+     */
+    toObject() {
+        return JSON.parse(JSON.stringify(this.testObject)); // cheap clone
+    }
+
+    /**
+     * toArgs
+     *
+     * converts test object to an array that is ordered in the same way as the arguments to the test function
+     */
+    toArgs() {
+        var ret = [];
+        // XXX, TODO: this won't necessarily produce the args in the right order
+        for (let idx of this.argOrder) {
+            ret.push(this.testObject[idx]);
+        }
+        return ret;
+    }
+
+    /**
+     * modify
+     *
+     * update the internal object by a path / value combination
+     * e.g. :
+     * modify ("foo.bar", 3)
+     * accepts three types of args:
+     *    "foo.bar", 3
+     *    {path: "foo.bar", value: 3}
+     *    [{path: "foo.bar", value: 3}, ...]
+     */
+    modify(arg1, arg2) {
+        var mods;
+
+        // check for the two argument scenario
+        if (typeof arg1 === "string" && arg2 !== undefined) {
+            mods = {
+                path: arg1,
+                value: arg2
+            };
+        } else {
+            mods = arg1;
+        }
+
+        // accept a single modification object instead of an array
+        if (!Array.isArray(mods) && typeof mods === "object") {
+            mods = [mods];
+        }
+
+        // iterate through each of the desired modifications, and call recursiveSetObject on them
+        var obj = this.testObject;
+        for (let idx in mods) {
+            var mod = mods[idx];
+            let paths = mod.path.split(".");
+            recursiveSetObject(this.testObject, paths, mod.value);
+        }
+
+        // iterates through nested `obj` using the `pathArray`, creating the path if it doesn't exist
+        // when the final leaf of the path is found, it is assigned the specified value
+        function recursiveSetObject(obj, pathArray, value) {
+            var currPath = pathArray.shift();
+            if (typeof obj[currPath] !== "object") {
+                obj[currPath] = {};
+            }
+            if (pathArray.length > 0) {
+                return recursiveSetObject(obj[currPath], pathArray, value);
+            }
+            obj[currPath] = value;
+        }
+
+        return this;
+    }
+
+    /**
+     * test
+     *
+     * run the test function with the top-level properties of the test object applied as arguments
+     */
+    test() {
+        return this.testFunction(...this.toArgs());
+    }
+
+    /**
+     * testArgs
+     *
+     * calls test() with testObject() and expects it to fail with a TypeError()
+     */
+    testBadArgs(testDesc) {
+        promise_test(function(t) {
+            return promise_rejects(t, new TypeError(), this.test());
+        }.bind(this), testDesc);
+    }
+}
+
+/**
+ * MakeCredentialTest
+ *
+ * tests the WebAuthn makeCredential() interface
+ */
+class MakeCredentialTest extends TestCase {
+    constructor() {
+        // initialize the parent class
+        super();
+
+        // the function to be tested
+        this.testFunction = navigator.authentication.makeCredential;
+
+        // the default object to pass to makeCredential, to be modified with modify() for various tests
+        // var challenge = Uint8Array.from("Y2xpbWIgYSBtb3VudGFpbg");
+        this.testObject = {
+            accountInformation: {
+                rpDisplayName: "PayPal",
+                displayName: "John P. Smith",
+                name: "johnpsmith@gmail.com",
+                id: "1098237235409872",
+                imageUri: "https://pics.paypal.com/00/p/aBjjjpqPb.png"
+            },
+            cryptoParameters: [{
+                type: "ScopedCred",
+                algorithm: "RSASSA-PKCS1-v1_5",
+            }],
+            attestationChallenge: Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]).buffer
+        };
+
+        // how to order the properties of testObject when passing them to makeCredential
+        this.argOrder = [
+            "accountInformation",
+            "cryptoParameters",
+            "attestationChallenge",
+            "options"
+        ];
+
+        // enable the constructor to modify the default testObject
+        // would prefer to do this in the super class, but have to call super() before using `this.*`
+        if (arguments.length) this.modify(...arguments);
+    }
+}

--- a/webauthn/helpers.js
+++ b/webauthn/helpers.js
@@ -131,11 +131,11 @@ class MakeCredentialTest extends TestCase {
         // var challenge = Uint8Array.from("Y2xpbWIgYSBtb3VudGFpbg");
         this.testObject = {
             accountInformation: {
-                rpDisplayName: "PayPal",
+                rpDisplayName: "ACME",
                 displayName: "John P. Smith",
-                name: "johnpsmith@gmail.com",
+                name: "johnpsmith@example.com",
                 id: "1098237235409872",
-                imageUri: "https://pics.paypal.com/00/p/aBjjjpqPb.png"
+                imageUri: "https://pics.acme.com/00/p/aBjjjpqPb.png"
             },
             cryptoParameters: [{
                 type: "ScopedCred",
@@ -157,3 +157,53 @@ class MakeCredentialTest extends TestCase {
         if (arguments.length) this.modify(...arguments);
     }
 }
+
+//************* BEGIN DELETE AFTER 1/1/2017 *************** //
+// XXX for development mode only!!
+// debug() for debugging purposes... we can drop this later if it is considered ugly
+// note that debug is currently an empty function (i.e. - prints no output)
+// and debug only prints output if the polyfill is loaded
+var debug = function() {};
+// if the WebAuthn API doesn't exist load a polyfill for testing
+// note that the polyfill only gets loaded if navigator.authentication doesn't exist
+// AND if the polyfill script is found at the right path (i.e. - the polyfill is opt-in)
+function ensureInterface() {
+    return new Promise(function(resolve, reject) {
+        if (typeof navigator.authentication !== "object") {
+            debug = console.log;
+
+            // dynamic loading of polyfill script by creating new <script> tag and seeing the src=
+            var scriptElem = document.createElement("script");
+            if (typeof scriptElem !== "object") {
+                debug("ensureInterface: Error creating script element while attempting loading polyfill");
+                return reject(new Error("ensureInterface: Error creating script element while loading polyfill"));
+            }
+            scriptElem.type = "application/javascript";
+            scriptElem.onload = function() {
+                debug("!!! XXX - LOADING POLYFILL FOR WEBAUTHN TESTING - XXX !!!");
+                return resolve();
+            };
+            scriptElem.onerror = function() {
+                return reject(new Error("navigator.authentication does not exist"));
+            };
+            scriptElem.src = "/webauthn/webauthn-polyfill/webauthn-polyfill.js";
+            if (document.body) {
+                document.body.appendChild(scriptElem);
+            } else {
+                debug("ensureInterface: DOM has no body");
+                return reject(new Error("ensureInterface: DOM has no body"));
+            }
+        }
+    });
+}
+
+function standardSetup(cb) {
+    return ensureInterface()
+        .then(() => {
+            if (cb) return cb();
+        })
+        .catch((err) => {
+            return (err);
+        });
+}
+//************* END DELETE AFTER 1/1/2017 *************** //

--- a/webauthn/interfaces.https.html
+++ b/webauthn/interfaces.https.html
@@ -16,7 +16,6 @@ standardSetup(function() {
 
     // loads an IDL file from the webserver
     function fetchIdl(idlUrl) {
-        console.log ("fetching idl");
         return new Promise(function(resolve, reject) {
             if (typeof idlUrl !== "string") {
                 return reject("fetchIdl: expected argument to be URL string");

--- a/webauthn/interfaces.https.html
+++ b/webauthn/interfaces.https.html
@@ -5,58 +5,18 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src=helpers.js></script>
 <!-- for testing WebIDL -->
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <body></body>
 <script>
-// IIFE for namespace cleanliness
-(function() {
+standardSetup(function() {
     "use strict";
-
-
-    //************* BEGIN DELETE AFTER 1/1/2017 *************** //
-    // XXX for development mode only!!
-    // debug() for debugging purposes... we can drop this later if it is considered ugly
-    // note that debug is currently an empty function (i.e. - prints no output)
-    // and debug only prints output if the polyfill is loaded
-    var debug = function() {};
-    // if the WebAuthn API doesn't exist load a polyfill for testing
-    // note that the polyfill only gets loaded if navigator.authentication doesn't exist
-    // AND if the polyfill script is found at the right path (i.e. - the polyfill is opt-in)
-    function ensureInterface() {
-        return new Promise(function(resolve, reject) {
-            if (typeof navigator.authentication !== "object") {
-                debug = console.log;
-
-                // dynamic loading of polyfill script by creating new <script> tag and seeing the src=
-                var scriptElem = document.createElement("script");
-                if (typeof scriptElem !== "object") {
-                    debug("ensureInterface: Error creating script element while attempting loading polyfill");
-                    return reject(new Error("ensureInterface: Error creating script element while loading polyfill"));
-                }
-                scriptElem.type = "application/javascript";
-                scriptElem.onload = function() {
-                    debug("!!! XXX - LOADING POLYFILL FOR WEBAUTHN TESTING - XXX !!!");
-                    return resolve();
-                };
-                scriptElem.onerror = function() {
-                    return reject(new Error("navigator.authentication does not exist"));
-                };
-                scriptElem.src = "/webauthn/webauthn-polyfill/webauthn-polyfill.js";
-                if (document.body) {
-                    document.body.appendChild(scriptElem);
-                } else {
-                    debug("ensureInterface: DOM has no body");
-                    return reject(new Error("ensureInterface: DOM has no body"));
-                }
-            }
-        });
-    }
-    //************* END DELETE AFTER 1/1/2017 *************** //
 
     // loads an IDL file from the webserver
     function fetchIdl(idlUrl) {
+        console.log ("fetching idl");
         return new Promise(function(resolve, reject) {
             if (typeof idlUrl !== "string") {
                 return reject("fetchIdl: expected argument to be URL string");
@@ -92,13 +52,10 @@
 
     // test harness function
     window.promise_test(function() {
-        return ensureInterface() // ensure we have navigator.authentication ...
-            .then(function() { // ... then load the IDL file ...
-                return fetchIdl("interfaces.idl");
-            })
-            .then(function(idls) { // ... then run the tests.
-                return runIdlTests(idls);
+        return fetchIdl("interfaces.idl") // load the IDL file ...
+            .then(function(idls) {
+                return runIdlTests(idls); // ... then run the tests.
             });
     }, "Validate WebAuthn IDL");
-}());
+});
 </script>

--- a/webauthn/interfaces.idl
+++ b/webauthn/interfaces.idl
@@ -1,4 +1,4 @@
-[SecureContext, NoInterfaceObject] interface WebAuthentication {
+[SecureContext] interface WebAuthentication {
     Promise < ScopedCredentialInfo > makeCredential (
         Account                                 accountInformation,
         sequence < ScopedCredentialParameters > cryptoParameters,
@@ -12,3 +12,85 @@
     );
 };
 
+[SecureContext]
+interface ScopedCredentialInfo {
+    readonly attribute ScopedCredential     credential;
+    readonly attribute CryptoKey            publicKey;
+    readonly attribute WebAuthnAttestation  attestation;
+};
+
+dictionary Account {
+    required DOMString rpDisplayName;
+    required DOMString displayName;
+    required DOMString id;
+    DOMString          name;
+    DOMString          imageURL;
+};
+
+dictionary ScopedCredentialParameters {
+    required ScopedCredentialType  type;
+    required AlgorithmIdentifier   algorithm;
+};
+
+dictionary ScopedCredentialOptions {
+    unsigned long                             timeoutSeconds;
+    USVString                                 rpId;
+    sequence < ScopedCredentialDescriptor >  excludeList;
+    WebAuthnExtensions                        extensions;
+};
+
+[SecureContext]
+interface WebAuthnAssertion {
+    readonly attribute ScopedCredential  credential;
+    readonly attribute ArrayBuffer       clientData;
+    readonly attribute ArrayBuffer       authenticatorData;
+    readonly attribute ArrayBuffer       signature;
+};
+
+dictionary AssertionOptions {
+    unsigned long                            timeoutSeconds;
+    USVString                                rpId;
+    sequence < ScopedCredentialDescriptor > allowList;
+    WebAuthnExtensions                       extensions;
+};
+
+dictionary WebAuthnExtensions {
+};
+
+[SecureContext]
+interface WebAuthnAttestation {
+    readonly    attribute USVString     format;
+    readonly    attribute ArrayBuffer   clientData;
+    readonly    attribute ArrayBuffer   authenticatorData;
+    readonly    attribute any           attestation;
+};
+
+dictionary ClientData {
+    required DOMString           challenge;
+    required DOMString           origin;
+    required AlgorithmIdentifier hashAlg;
+    DOMString                    tokenBinding;
+    WebAuthnExtensions           extensions;
+};
+
+enum ScopedCredentialType {
+    "ScopedCred"
+};
+
+[SecureContext]
+interface ScopedCredential {
+    readonly attribute ScopedCredentialType type;
+    readonly attribute ArrayBuffer          id;
+};
+
+dictionary ScopedCredentialDescriptor {
+    required ScopedCredentialType type;
+    required BufferSource   id;
+    sequence < Transport >  transports;
+};
+
+enum Transport {
+    "usb",
+    "nfc",
+    "ble"
+};

--- a/webauthn/makecredential-badargs-accountinformation.https.html
+++ b/webauthn/makecredential-badargs-accountinformation.https.html
@@ -5,26 +5,30 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
 <script src=helpers.js></script>
+<body></body>
 <script>
-// accountInformation bad values
-new MakeCredentialTest({path: "accountInformation", value: undefined}).testBadArgs("accountInformation missing");
-new MakeCredentialTest("accountInformation", "hi mom").testBadArgs("accountInformation is string");
-new MakeCredentialTest("accountInformation", {}).testBadArgs("accountInformation is empty object");
-// accountInformation.rpDisplayName
-new MakeCredentialTest({path: "accountInformation.rpDisplayName", value: undefined}).testBadArgs("accountInformation missing rpDisplayName");
-new MakeCredentialTest("accountInformation.rpDisplayName", {}).testBadArgs("Bad accountInformation: rpDisplayName is object");
-new MakeCredentialTest("accountInformation.rpDisplayName", null).testBadArgs("Bad accountInformation: rpDisplayName is null");
-new MakeCredentialTest("accountInformation.rpDisplayName", "").testBadArgs("Bad accountInformation: rpDisplayName is empty String");
-// accountInformation.displayName
-new MakeCredentialTest({path: "accountInformation.displayName", value: undefined}).testBadArgs("accountInformation missing displayName");
-new MakeCredentialTest("accountInformation.displayName", {}).testBadArgs("Bad accountInformation: displayName is object");
-new MakeCredentialTest("accountInformation.displayName", null).testBadArgs("Bad accountInformation: displayName is null");
-new MakeCredentialTest("accountInformation.displayName", "").testBadArgs("Bad accountInformation: displayName is empty String");
-// accountInformation.id
-new MakeCredentialTest({path: "accountInformation.id", value: undefined}).testBadArgs("accountInformation missing id");
-new MakeCredentialTest("accountInformation.id", {}).testBadArgs("Bad accountInformation: id is object");
-new MakeCredentialTest("accountInformation.id", null).testBadArgs("Bad accountInformation: id is null");
-new MakeCredentialTest("accountInformation.id", "").testBadArgs("Bad accountInformation: id is empty String");
+standardSetup(function() {
+    "use strict";
+
+    // accountInformation bad values
+    new MakeCredentialTest({path: "accountInformation", value: undefined}).testBadArgs("accountInformation missing");
+    new MakeCredentialTest("accountInformation", "hi mom").testBadArgs("accountInformation is string");
+    new MakeCredentialTest("accountInformation", {}).testBadArgs("accountInformation is empty object");
+    // accountInformation.rpDisplayName
+    new MakeCredentialTest({path: "accountInformation.rpDisplayName", value: undefined}).testBadArgs("accountInformation missing rpDisplayName");
+    new MakeCredentialTest("accountInformation.rpDisplayName", {}).testBadArgs("Bad accountInformation: rpDisplayName is object");
+    new MakeCredentialTest("accountInformation.rpDisplayName", null).testBadArgs("Bad accountInformation: rpDisplayName is null");
+    new MakeCredentialTest("accountInformation.rpDisplayName", "").testBadArgs("Bad accountInformation: rpDisplayName is empty String");
+    // accountInformation.displayName
+    new MakeCredentialTest({path: "accountInformation.displayName", value: undefined}).testBadArgs("accountInformation missing displayName");
+    new MakeCredentialTest("accountInformation.displayName", {}).testBadArgs("Bad accountInformation: displayName is object");
+    new MakeCredentialTest("accountInformation.displayName", null).testBadArgs("Bad accountInformation: displayName is null");
+    new MakeCredentialTest("accountInformation.displayName", "").testBadArgs("Bad accountInformation: displayName is empty String");
+    // accountInformation.id
+    new MakeCredentialTest({path: "accountInformation.id", value: undefined}).testBadArgs("accountInformation missing id");
+    new MakeCredentialTest("accountInformation.id", {}).testBadArgs("Bad accountInformation: id is object");
+    new MakeCredentialTest("accountInformation.id", null).testBadArgs("Bad accountInformation: id is null");
+    new MakeCredentialTest("accountInformation.id", "").testBadArgs("Bad accountInformation: id is empty String");
+});
 </script>

--- a/webauthn/makecredential-badargs-accountinformation.https.html
+++ b/webauthn/makecredential-badargs-accountinformation.https.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebAuthn makeCredential accountInformation Tests</title>
+<link rel="author" title="Adam Powers" href="mailto:adam@fidoalliance.org">
+<link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
+<script src=helpers.js></script>
+<script>
+// accountInformation bad values
+new MakeCredentialTest({path: "accountInformation", value: undefined}).testBadArgs("accountInformation missing");
+new MakeCredentialTest("accountInformation", "hi mom").testBadArgs("accountInformation is string");
+new MakeCredentialTest("accountInformation", {}).testBadArgs("accountInformation is empty object");
+// accountInformation.rpDisplayName
+new MakeCredentialTest({path: "accountInformation.rpDisplayName", value: undefined}).testBadArgs("accountInformation missing rpDisplayName");
+new MakeCredentialTest("accountInformation.rpDisplayName", {}).testBadArgs("Bad accountInformation: rpDisplayName is object");
+new MakeCredentialTest("accountInformation.rpDisplayName", null).testBadArgs("Bad accountInformation: rpDisplayName is null");
+new MakeCredentialTest("accountInformation.rpDisplayName", "").testBadArgs("Bad accountInformation: rpDisplayName is empty String");
+// accountInformation.displayName
+new MakeCredentialTest({path: "accountInformation.displayName", value: undefined}).testBadArgs("accountInformation missing displayName");
+new MakeCredentialTest("accountInformation.displayName", {}).testBadArgs("Bad accountInformation: displayName is object");
+new MakeCredentialTest("accountInformation.displayName", null).testBadArgs("Bad accountInformation: displayName is null");
+new MakeCredentialTest("accountInformation.displayName", "").testBadArgs("Bad accountInformation: displayName is empty String");
+// accountInformation.id
+new MakeCredentialTest({path: "accountInformation.id", value: undefined}).testBadArgs("accountInformation missing id");
+new MakeCredentialTest("accountInformation.id", {}).testBadArgs("Bad accountInformation: id is object");
+new MakeCredentialTest("accountInformation.id", null).testBadArgs("Bad accountInformation: id is null");
+new MakeCredentialTest("accountInformation.id", "").testBadArgs("Bad accountInformation: id is empty String");
+</script>

--- a/webauthn/makecredential-badargs-attestationchallenge.https.html
+++ b/webauthn/makecredential-badargs-attestationchallenge.https.html
@@ -5,12 +5,16 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
 <script src=helpers.js></script>
+<body></body>
 <script>
-// attestationChallenge bad values
-new MakeCredentialTest({path: "attestationChallenge", value: undefined}).testBadArgs("attestationChallenge missing");
-new MakeCredentialTest("attestationChallenge", "hi mom").testBadArgs("accountInformation is string");
-new MakeCredentialTest("attestationChallenge", {}).testBadArgs("accountInformation is empty object");
-new MakeCredentialTest("attestationChallenge", Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])).testBadArgs("accountInformation is Uint8Array");
+standardSetup(function() {
+    "use strict";
+
+    // attestationChallenge bad values
+    new MakeCredentialTest({path: "attestationChallenge", value: undefined}).testBadArgs("attestationChallenge missing");
+    new MakeCredentialTest("attestationChallenge", "hi mom").testBadArgs("accountInformation is string");
+    new MakeCredentialTest("attestationChallenge", {}).testBadArgs("accountInformation is empty object");
+    new MakeCredentialTest("attestationChallenge", Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])).testBadArgs("accountInformation is Uint8Array");
+});
 </script>

--- a/webauthn/makecredential-badargs-attestationchallenge.https.html
+++ b/webauthn/makecredential-badargs-attestationchallenge.https.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebAuthn makeCredential attestationChallenge Tests</title>
+<link rel="author" title="Adam Powers" href="mailto:adam@fidoalliance.org">
+<link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
+<script src=helpers.js></script>
+<script>
+// attestationChallenge bad values
+new MakeCredentialTest({path: "attestationChallenge", value: undefined}).testBadArgs("attestationChallenge missing");
+new MakeCredentialTest("attestationChallenge", "hi mom").testBadArgs("accountInformation is string");
+new MakeCredentialTest("attestationChallenge", {}).testBadArgs("accountInformation is empty object");
+new MakeCredentialTest("attestationChallenge", Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])).testBadArgs("accountInformation is Uint8Array");
+</script>

--- a/webauthn/makecredential-badargs-cryptoparameters.https.html
+++ b/webauthn/makecredential-badargs-cryptoparameters.https.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebAuthn makeCredential cryptoParameters Tests</title>
+<link rel="author" title="Adam Powers" href="mailto:adam@fidoalliance.org">
+<link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
+<script src=helpers.js></script>
+<script>
+// cryptoParameters bad values
+new MakeCredentialTest({path: "cryptoParameters", value: undefined}).testBadArgs("cryptoParameters is missing");
+new MakeCredentialTest("cryptoParameters", "hi mom").testBadArgs("cryptoParameters is String");
+new MakeCredentialTest("cryptoParameters", []).testBadArgs("cryptoParameters is empty Array");
+// cryptoParameters.type
+new MakeCredentialTest({path: "cryptoParameters.0.type", value: undefined}).testBadArgs("cryptoParameters missing type");
+new MakeCredentialTest("cryptoParameters.0.type", {}).testBadArgs("Bad cryptoParameters: type is object");
+new MakeCredentialTest("cryptoParameters.0.type", null).testBadArgs("Bad cryptoParameters: type is null");
+new MakeCredentialTest("cryptoParameters.0.type", "").testBadArgs("Bad cryptoParameters: type is empty String");
+new MakeCredentialTest("cryptoParameters.0.type", "FIDO_2_0").testBadArgs("Bad cryptoParameters: type is not 'ScopedCred'");
+// cryptoParameters.algorithm
+new MakeCredentialTest({path: "cryptoParameters.0.algorithm", value: undefined}).testBadArgs("cryptoParameters missing algorithm");
+new MakeCredentialTest("cryptoParameters.0.algorithm", {}).testBadArgs("Bad cryptoParameters: algorithm is object");
+new MakeCredentialTest("cryptoParameters.0.algorithm", null).testBadArgs("Bad cryptoParameters: algorithm is null");
+new MakeCredentialTest("cryptoParameters.0.algorithm", "").testBadArgs("Bad cryptoParameters: algorithm is empty String");
+// multiple cryptoParameters
+new MakeCredentialTest("cryptoParameters.1", {type: "FIDO_2_0", algorithm: "RSASSA-PKCS1-v1_5"}).testBadArgs("Bad cryptoParameters: second param has invalid type");
+new MakeCredentialTest("cryptoParameters.1", {type: "ScopedCred", algorithm: ""}).testBadArgs("Bad cryptoParameters: second param has algorithm of empty String");
+</script>

--- a/webauthn/makecredential-badargs-cryptoparameters.https.html
+++ b/webauthn/makecredential-badargs-cryptoparameters.https.html
@@ -5,25 +5,29 @@
 <link rel="help" href="https://w3c.github.io/webauthn/#iface-credential">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="webauthn-polyfill/webauthn-polyfill.js"></script>
 <script src=helpers.js></script>
+<body></body>
 <script>
-// cryptoParameters bad values
-new MakeCredentialTest({path: "cryptoParameters", value: undefined}).testBadArgs("cryptoParameters is missing");
-new MakeCredentialTest("cryptoParameters", "hi mom").testBadArgs("cryptoParameters is String");
-new MakeCredentialTest("cryptoParameters", []).testBadArgs("cryptoParameters is empty Array");
-// cryptoParameters.type
-new MakeCredentialTest({path: "cryptoParameters.0.type", value: undefined}).testBadArgs("cryptoParameters missing type");
-new MakeCredentialTest("cryptoParameters.0.type", {}).testBadArgs("Bad cryptoParameters: type is object");
-new MakeCredentialTest("cryptoParameters.0.type", null).testBadArgs("Bad cryptoParameters: type is null");
-new MakeCredentialTest("cryptoParameters.0.type", "").testBadArgs("Bad cryptoParameters: type is empty String");
-new MakeCredentialTest("cryptoParameters.0.type", "FIDO_2_0").testBadArgs("Bad cryptoParameters: type is not 'ScopedCred'");
-// cryptoParameters.algorithm
-new MakeCredentialTest({path: "cryptoParameters.0.algorithm", value: undefined}).testBadArgs("cryptoParameters missing algorithm");
-new MakeCredentialTest("cryptoParameters.0.algorithm", {}).testBadArgs("Bad cryptoParameters: algorithm is object");
-new MakeCredentialTest("cryptoParameters.0.algorithm", null).testBadArgs("Bad cryptoParameters: algorithm is null");
-new MakeCredentialTest("cryptoParameters.0.algorithm", "").testBadArgs("Bad cryptoParameters: algorithm is empty String");
-// multiple cryptoParameters
-new MakeCredentialTest("cryptoParameters.1", {type: "FIDO_2_0", algorithm: "RSASSA-PKCS1-v1_5"}).testBadArgs("Bad cryptoParameters: second param has invalid type");
-new MakeCredentialTest("cryptoParameters.1", {type: "ScopedCred", algorithm: ""}).testBadArgs("Bad cryptoParameters: second param has algorithm of empty String");
+standardSetup(function() {
+    "use strict";
+
+    // cryptoParameters bad values
+    new MakeCredentialTest({path: "cryptoParameters", value: undefined}).testBadArgs("cryptoParameters is missing");
+    new MakeCredentialTest("cryptoParameters", "hi mom").testBadArgs("cryptoParameters is String");
+    new MakeCredentialTest("cryptoParameters", []).testBadArgs("cryptoParameters is empty Array");
+    // cryptoParameters.type
+    new MakeCredentialTest({path: "cryptoParameters.0.type", value: undefined}).testBadArgs("cryptoParameters missing type");
+    new MakeCredentialTest("cryptoParameters.0.type", {}).testBadArgs("Bad cryptoParameters: type is object");
+    new MakeCredentialTest("cryptoParameters.0.type", null).testBadArgs("Bad cryptoParameters: type is null");
+    new MakeCredentialTest("cryptoParameters.0.type", "").testBadArgs("Bad cryptoParameters: type is empty String");
+    new MakeCredentialTest("cryptoParameters.0.type", "FIDO_2_0").testBadArgs("Bad cryptoParameters: type is not 'ScopedCred'");
+    // cryptoParameters.algorithm
+    new MakeCredentialTest({path: "cryptoParameters.0.algorithm", value: undefined}).testBadArgs("cryptoParameters missing algorithm");
+    new MakeCredentialTest("cryptoParameters.0.algorithm", {}).testBadArgs("Bad cryptoParameters: algorithm is object");
+    new MakeCredentialTest("cryptoParameters.0.algorithm", null).testBadArgs("Bad cryptoParameters: algorithm is null");
+    new MakeCredentialTest("cryptoParameters.0.algorithm", "").testBadArgs("Bad cryptoParameters: algorithm is empty String");
+    // multiple cryptoParameters
+    new MakeCredentialTest("cryptoParameters.1", {type: "FIDO_2_0", algorithm: "RSASSA-PKCS1-v1_5"}).testBadArgs("Bad cryptoParameters: second param has invalid type");
+    new MakeCredentialTest("cryptoParameters.1", {type: "ScopedCred", algorithm: ""}).testBadArgs("Bad cryptoParameters: second param has algorithm of empty String");
+});
 </script>


### PR DESCRIPTION
Create helper classes `TestCase` and `MakeCredentialTest` which enables testing all kinds of iterations of bad arguments to `makeCredential`. The files `makecredential-badargs-*` implement the tests for the `accountInformation`, `cryptoParameters`, and `attestationChallenge` arguments, respectively.
