### PR TITLE
Set timeout on encrypted-clear-sources tests to long.

### DIFF
--- a/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.html
+++ b/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, alternate Encrypted and Clear playbacks, Temporary, mp4, Clear Key</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-encrypted-clear-sources.html
+++ b/encrypted-media/drm-mp4-playback-temporary-encrypted-clear-sources.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, alternate Encrypted and Clear playbacks, Temporary, mp4, DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 


### PR DESCRIPTION
The encrypted-clear-sources tests switch between encrypted and clear sources for
the test media. This results in having to repeat a number of fetches. Network
conditions can lead to these fetches taking variable amounts of time such that
these tests race. This commit adjusts the timeout to long for these tests to
mitigate the race.
