### PR TITLE
Issue 13363 - Step 1.2 of compiling event handler

### DIFF
--- a/html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html
+++ b/html/webappapis/scripting/events/uncompiled_event_handler_with_scripting_disabled.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Uncompiled event handler check that scripting is enabled</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  setup({ allow_uncaught_exception: true });
+  test(function() {
+    var invoked = false;
+    window.addEventListener("error", function() {
+      invoked = true;
+    });
+
+    // Make sure that `this_will_error` will in fact error when it's referenced
+    assert_equals(typeof this_will_error, "undefined");
+    var dom = (new DOMParser()).parseFromString("<div id=\"has-event-handler\" onclick=\"this_will_error;\"></div>", "text/html");
+    var click = new MouseEvent("click");
+    dom.getElementById("has-event-handler").dispatchEvent(click);
+    assert_equals(invoked, false);
+  }, "when scripting is disabled, the handler is never compiled");
+</script>


### PR DESCRIPTION

When compiling event handlers, check whether scripting is enabled
and early return None/null if not.

https://html.spec.whatwg.org/multipage/
webappapis.html#getting-the-current-value-of-the-event-handler

Issue 13363 - Fix spec for disabled scripting

The original spec for this PR was bad because it depended on the
DOM without scripting enabled to use Javascript to signal the test's
failure, so it could never fail.

Use an onerror handler on `window` where scripting is enabled, and
use an invalid string of JavaScript for the handler, to detect
whether or not the event handler is *really* being compiled or not.

Condense tests into a single HTML file

Yup, didn't even realize I could do that at the time.

Remove an unnecessary test