### PR TITLE
Update interfaces test to match SVG 2

### DIFF
--- a/svg/interfaces.html
+++ b/svg/interfaces.html
@@ -391,8 +391,12 @@ interface SVGGraphicsElement : SVGElement {
 SVGGraphicsElement implements SVGTests;
 
 interface SVGGeometryElement : SVGGraphicsElement {
+  [SameObject] readonly attribute SVGAnimatedNumber pathLength;
+
   boolean isPointInFill(DOMPoint point);
   boolean isPointInStroke(DOMPoint point);
+  float getTotalLength();
+  DOMPoint getPointAtLength(float distance);
 };
 
 interface SVGNumber {
@@ -739,11 +743,6 @@ interface SVGAnimatedPreserveAspectRatio {
 };
 
 interface SVGPathElement : SVGGeometryElement {
-
-  [SameObject] readonly attribute SVGAnimatedNumber pathLength;
-
-  float getTotalLength();
-  DOMPoint getPointAtLength(float distance);
 };
 
 interface SVGRectElement : SVGGeometryElement {


### PR DESCRIPTION
In SVG 2, properties and methods of SVGPathElement have moved to SVGGeometryElement.
Closes https://github.com/w3c/svgwg/issues/292.