### PR TITLE
Clean up reflection tests

### DIFF
--- a/html/dom/new-harness.js
+++ b/html/dom/new-harness.js
@@ -2,7 +2,7 @@
 // original-harness.js.  Polymorphism, kind of.
 ReflectionHarness.catchUnexpectedExceptions = false;
 
-ReflectionHarness.test = function(expected, actual, description) {
+ReflectionHarness.assertEquals = function(expected, actual, description) {
   test(function() {
     assert_equals(expected, actual);
   }, this.getTypeDescription() + ": " + description);
@@ -15,7 +15,7 @@ ReflectionHarness.run = function(fun, description) {
   test(fun, this.getTypeDescription() + ": " + description);
 }
 
-ReflectionHarness.testException = function(exceptionName, fn, description) {
+ReflectionHarness.assertThrows = function(exceptionName, fn, description) {
   test(function() {
     assert_throws(exceptionName, fn);
   }, this.getTypeDescription() + ": " + description);

--- a/html/dom/new-harness.js
+++ b/html/dom/new-harness.js
@@ -1,22 +1,11 @@
 // We override only the things we need to -- the rest we'll just inherit from
 // original-harness.js.  Polymorphism, kind of.
-ReflectionHarness.catchUnexpectedExceptions = false;
+ReflectionHarness.conformanceTesting = true;
 
-ReflectionHarness.assertEquals = function(expected, actual, description) {
-  test(function() {
-    assert_equals(expected, actual);
-  }, this.getTypeDescription() + ": " + description);
-  // This is the test suite that will rate conformance, so we don't want to
-  // bail out early if a test fails -- we want all tests to always run.
-  return true;
-}
-
-ReflectionHarness.run = function(fun, description) {
+ReflectionHarness.test = function(fun, description) {
   test(fun, this.getTypeDescription() + ": " + description);
 }
 
-ReflectionHarness.assertThrows = function(exceptionName, fn, description) {
-  test(function() {
-    assert_throws(exceptionName, fn);
-  }, this.getTypeDescription() + ": " + description);
-}
+ReflectionHarness.assertEquals = assert_equals;
+
+ReflectionHarness.assertThrows = assert_throws;

--- a/html/dom/original-harness.js
+++ b/html/dom/original-harness.js
@@ -5,13 +5,10 @@ ReflectionHarness.passed = document.getElementById("passed");
 ReflectionHarness.failed = document.getElementById("failed");
 
 /**
- * Should we report a failure for unexpected exceptions, or just rethrow them?
- * The original test framework reports an exception, but testharness.js doesn't
- * want that.
- *
- * @public
+ * In conformance testing mode, all tests will be run.  Otherwise, we'll skip
+ * tests for attributes that have an entirely incorrect type.
  */
-ReflectionHarness.catchUnexpectedExceptions = true;
+ReflectionHarness.conformanceTesting = false;
 
 /**
  * Returns a string representing val.  Basically just adds quotes for strings,
@@ -86,12 +83,28 @@ ReflectionHarness.stringRep = function(val) {
 ReflectionHarness.currentTestInfo = {};
 
 /**
- * This is called when we want to test a single element/attribute combination.
- * For the original harness, it does nothing special (just calls the function),
- * but for testharness.js, it can wrap everything in a test() call.
+ * .test() sets this, and it's used by .assertEquals()/.assertThrows().
+ * Calling .test() recursively is an error.
  */
-ReflectionHarness.test = function(fn) {
-  fn();
+ReflectionHarness.currentTestDescription = null;
+
+/**
+ * Run a group of one or more assertions.  If any exceptions are thrown, catch
+ * them and report a failure.
+ */
+ReflectionHarness.test = function(fn, description) {
+  if (this.currentTestDescription) {
+    throw "TEST BUG: test() may not be called recursively!";
+  }
+  this.currentTestDescription = description;
+  try {
+    fn();
+    // Not throwing is a success
+    this.success();
+  } catch(err) {
+    this.failure("Exception thrown during tests with " + description);
+  }
+  this.currentTestDescription = null;
 }
 
 /**
@@ -106,33 +119,25 @@ ReflectionHarness.assertEquals = function(expected, actual, description) {
   // Special-case -0 yay!
   if (expected === 0 && actual === 0 && 1/expected === 1/actual) {
     this.increment(this.passed);
-    return true;
   } else if (expected === actual) {
     this.increment(this.passed);
-    return true;
   } else {
     this.increment(this.failed);
-    this.reportFailure(description + ' (expected ' + this.stringRep(actual) + ', got ' + this.stringRep(expected) + ')');
-    return false;
-  }
-}
-
-ReflectionHarness.run = function(fun, description) {
-  try {
-    fun();
-  } catch (err) {
-    ReflectionHarness.failure(description);
+    this.reportFailure(this.currentTestDescription +
+        (description ? " followed by " + description : "") +
+        ' (expected ' + this.stringRep(actual) + ', got ' +
+        this.stringRep(expected) + ')');
   }
 }
 
 /**
  * If calling fn causes a DOMException of the type given by the string
- * exceptionName (e.g., "INDEX_SIZE_ERR"), output a success.  Otherwise, report
- * a failure with the given description.
+ * exceptionName (e.g., "IndexSizeError"), output a success.  Otherwise, report
+ * a failure.
  *
  * @public
  */
-ReflectionHarness.assertThrows = function(exceptionName, fn, description) {
+ReflectionHarness.assertThrows = function(exceptionName, fn) {
   try {
     fn();
   } catch (e) {
@@ -142,7 +147,8 @@ ReflectionHarness.assertThrows = function(exceptionName, fn, description) {
     }
   }
   this.increment(this.failed);
-  this.reportFailure(description);
+  this.reportFailure(this.currentTestDescription + " must throw " +
+      exceptionName);
   return false;
 }
 
@@ -248,9 +254,9 @@ ReflectionHarness.reportFailure = function(description) {
 }
 
 /**
- * Shorthand function for when we have a failure outside of test().  Generally
- * used when the failure is an exception thrown unexpectedly or such, something
- * not equality-based.
+ * Shorthand function for when we have a failure outside of
+ * assertEquals()/assertThrows().  Generally used when the failure is an
+ * exception thrown unexpectedly or such, something not equality-based.
  *
  * @public
  */
@@ -260,8 +266,8 @@ ReflectionHarness.failure = function(message) {
 }
 
 /**
- * Shorthand function for when we have a success outside of test().  Only
- * called if catchUnexpectedExceptions is true.
+ * Shorthand function for when we have a success outside of
+ * assertEquals()/assertThrows().
  *
  * @public
  */

--- a/html/dom/original-harness.js
+++ b/html/dom/original-harness.js
@@ -90,7 +90,7 @@ ReflectionHarness.currentTestInfo = {};
  * For the original harness, it does nothing special (just calls the function),
  * but for testharness.js, it can wrap everything in a test() call.
  */
-ReflectionHarness.testWrapper = function(fn) {
+ReflectionHarness.test = function(fn) {
   fn();
 }
 
@@ -102,7 +102,7 @@ ReflectionHarness.testWrapper = function(fn) {
  *
  * @public
  */
-ReflectionHarness.test = function(expected, actual, description) {
+ReflectionHarness.assertEquals = function(expected, actual, description) {
   // Special-case -0 yay!
   if (expected === 0 && actual === 0 && 1/expected === 1/actual) {
     this.increment(this.passed);
@@ -132,7 +132,7 @@ ReflectionHarness.run = function(fun, description) {
  *
  * @public
  */
-ReflectionHarness.testException = function(exceptionName, fn, description) {
+ReflectionHarness.assertThrows = function(exceptionName, fn, description) {
   try {
     fn();
   } catch (e) {

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -567,7 +567,7 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
     // probably safe enough.  Just don't read stuff that will change.
     ReflectionHarness.currentTestInfo = {data: data, idlName: idlName, idlObj: idlObj, domName: domName, domObj: domObj};
 
-    ReflectionHarness.testWrapper(function() {
+    ReflectionHarness.test(function() {
         ReflectionTests.doReflects(data, idlName, idlObj, domName, domObj);
     });
 };
@@ -593,7 +593,7 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
     // Test that typeof idlObj[idlName] is correct.  If not, further tests are
     // probably pointless, so bail out.
     var isDefaultValueNull = data.isNullable && data.defaultVal === null;
-    if (!ReflectionHarness.test(typeof idlObj[idlName], isDefaultValueNull ? "object" : typeInfo.jsType, "typeof IDL attribute")) {
+    if (!ReflectionHarness.assertEquals(typeof idlObj[idlName], isDefaultValueNull ? "object" : typeInfo.jsType, "typeof IDL attribute")) {
         return;
     }
 
@@ -603,7 +603,7 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
         defaultVal = typeInfo.defaultVal;
     }
     if (defaultVal !== null || data.isNullable) {
-        ReflectionHarness.test(idlObj[idlName], defaultVal, "IDL get with DOM attribute unset");
+        ReflectionHarness.assertEquals(idlObj[idlName], defaultVal, "IDL get with DOM attribute unset");
     }
 
     var domTests = typeInfo.domTests.slice(0);
@@ -706,8 +706,8 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
             }
             try {
                 domObj.setAttribute(domName, domTests[i]);
-                ReflectionHarness.test(domObj.getAttribute(domName), String(domTests[i]), "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by getAttribute()");
-                ReflectionHarness.test(idlObj[idlName], domExpected[i], "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by IDL get");
+                ReflectionHarness.assertEquals(domObj.getAttribute(domName), String(domTests[i]), "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by getAttribute()");
+                ReflectionHarness.assertEquals(idlObj[idlName], domExpected[i], "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by IDL get");
                 if (ReflectionHarness.catchUnexpectedExceptions) {
                     ReflectionHarness.success();
                 }
@@ -724,7 +724,7 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
     for (var i = 0; i < idlTests.length; i++) {
         if ((data.type == "limited long" && idlTests[i] < 0) ||
             (data.type == "limited unsigned long" && idlTests[i] == 0)) {
-            ReflectionHarness.testException("INDEX_SIZE_ERR", function() {
+            ReflectionHarness.assertThrows("INDEX_SIZE_ERR", function() {
                 idlObj[idlName] = idlTests[i];
             }, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " must throw INDEX_SIZE_ERR");
         } else {
@@ -732,16 +732,16 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
                 idlObj[idlName] = idlTests[i];
                 if (data.type == "boolean") {
                     // Special case yay
-                    ReflectionHarness.test(domObj.hasAttribute(domName), Boolean(idlTests[i]), "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by hasAttribute()");
+                    ReflectionHarness.assertEquals(domObj.hasAttribute(domName), Boolean(idlTests[i]), "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by hasAttribute()");
                 } else if (idlDomExpected[i] !== null || data.isNullable) {
                     var expected = idlDomExpected[i] + "";
                     if (data.isNullable && idlDomExpected[i] === null) {
                         expected = null;
                     }
-                    ReflectionHarness.test(domObj.getAttribute(domName), expected, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by getAttribute()");
+                    ReflectionHarness.assertEquals(domObj.getAttribute(domName), expected, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by getAttribute()");
                 }
                 if (idlIdlExpected[i] !== null || data.isNullable) {
-                    ReflectionHarness.test(idlObj[idlName], idlIdlExpected[i], "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by IDL get");
+                    ReflectionHarness.assertEquals(idlObj[idlName], idlIdlExpected[i], "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by IDL get");
                 }
                 if (ReflectionHarness.catchUnexpectedExceptions) {
                     ReflectionHarness.success();

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -567,15 +567,6 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
     // probably safe enough.  Just don't read stuff that will change.
     ReflectionHarness.currentTestInfo = {data: data, idlName: idlName, idlObj: idlObj, domName: domName, domObj: domObj};
 
-    ReflectionHarness.test(function() {
-        ReflectionTests.doReflects(data, idlName, idlObj, domName, domObj);
-    });
-};
-
-/**
- * Actual implementation of the above.
- */
-ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
     // If we don't recognize the type, testing is impossible.
     if (this.typeMap[data.type] === undefined) {
         if (unimplemented.indexOf(data.type) == -1) {
@@ -591,9 +582,15 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
     }
 
     // Test that typeof idlObj[idlName] is correct.  If not, further tests are
-    // probably pointless, so bail out.
-    var isDefaultValueNull = data.isNullable && data.defaultVal === null;
-    if (!ReflectionHarness.assertEquals(typeof idlObj[idlName], isDefaultValueNull ? "object" : typeInfo.jsType, "typeof IDL attribute")) {
+    // probably pointless, so bail out if we're not running conformance tests.
+    var expectedType = data.isNullable && data.defaultVal === null ? "object"
+                                                                   : typeInfo.jsType;
+    ReflectionHarness.test(function() {
+        ReflectionHarness.assertEquals(typeof idlObj[idlName], expectedType);
+    }, "typeof IDL attribute");
+
+    if (!ReflectionHarness.conformanceTesting &&
+        typeof idlObj[idlName] !== expectedType) {
         return;
     }
 
@@ -603,7 +600,9 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
         defaultVal = typeInfo.defaultVal;
     }
     if (defaultVal !== null || data.isNullable) {
-        ReflectionHarness.assertEquals(idlObj[idlName], defaultVal, "IDL get with DOM attribute unset");
+        ReflectionHarness.test(function() {
+            ReflectionHarness.assertEquals(idlObj[idlName], defaultVal);
+        }, "IDL get with DOM attribute unset");
     }
 
     var domTests = typeInfo.domTests.slice(0);
@@ -704,50 +703,42 @@ ReflectionTests.doReflects = function(data, idlName, idlObj, domName, domObj) {
                 // the test.
                 continue;
             }
-            try {
+            ReflectionHarness.test(function() {
                 domObj.setAttribute(domName, domTests[i]);
-                ReflectionHarness.assertEquals(domObj.getAttribute(domName), String(domTests[i]), "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by getAttribute()");
-                ReflectionHarness.assertEquals(idlObj[idlName], domExpected[i], "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]) + " followed by IDL get");
-                if (ReflectionHarness.catchUnexpectedExceptions) {
-                    ReflectionHarness.success();
-                }
-            } catch (err) {
-                if (ReflectionHarness.catchUnexpectedExceptions) {
-                    ReflectionHarness.failure("Exception thrown during tests with setAttribute() to " + ReflectionHarness.stringRep(domTests[i]));
-                } else {
-                    throw err;
-                }
-            }
+                ReflectionHarness.assertEquals(domObj.getAttribute(domName),
+                    String(domTests[i]), "getAttribute()");
+                ReflectionHarness.assertEquals(idlObj[idlName], domExpected[i],
+                    "IDL get");
+            }, "setAttribute() to " + ReflectionHarness.stringRep(domTests[i]));
         }
     }
 
     for (var i = 0; i < idlTests.length; i++) {
-        if ((data.type == "limited long" && idlTests[i] < 0) ||
-            (data.type == "limited unsigned long" && idlTests[i] == 0)) {
-            ReflectionHarness.assertThrows("INDEX_SIZE_ERR", function() {
-                idlObj[idlName] = idlTests[i];
-            }, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " must throw INDEX_SIZE_ERR");
-        } else {
-            ReflectionHarness.run(function() {
+        ReflectionHarness.test(function() {
+            if ((data.type == "limited long" && idlTests[i] < 0) ||
+                (data.type == "limited unsigned long" && idlTests[i] == 0)) {
+                ReflectionHarness.assertThrows("IndexSizeError", function() {
+                    idlObj[idlName] = idlTests[i];
+                });
+            } else {
                 idlObj[idlName] = idlTests[i];
                 if (data.type == "boolean") {
                     // Special case yay
-                    ReflectionHarness.assertEquals(domObj.hasAttribute(domName), Boolean(idlTests[i]), "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by hasAttribute()");
+                    ReflectionHarness.assertEquals(domObj.hasAttribute(domName),
+                                                   Boolean(idlTests[i]), "hasAttribute()");
                 } else if (idlDomExpected[i] !== null || data.isNullable) {
                     var expected = idlDomExpected[i] + "";
                     if (data.isNullable && idlDomExpected[i] === null) {
                         expected = null;
                     }
-                    ReflectionHarness.assertEquals(domObj.getAttribute(domName), expected, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by getAttribute()");
+                    ReflectionHarness.assertEquals(domObj.getAttribute(domName), expected,
+                                                   "getAttribute()");
                 }
                 if (idlIdlExpected[i] !== null || data.isNullable) {
-                    ReflectionHarness.assertEquals(idlObj[idlName], idlIdlExpected[i], "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " followed by IDL get");
+                    ReflectionHarness.assertEquals(idlObj[idlName], idlIdlExpected[i], "IDL get");
                 }
-                if (ReflectionHarness.catchUnexpectedExceptions) {
-                    ReflectionHarness.success();
-                }
-            }, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]) + " should not throw");
-        }
+            }
+        }, "IDL set to " + ReflectionHarness.stringRep(idlTests[i]));
     }
 };
 


### PR DESCRIPTION
The major change here is using test() in a way that more naturally
matches testharness.js.  Previously, it was used with one test per
assert and did not wrap places where exceptions might be thrown, due to
a simple bug: new-harness.js did not previously override test(), leaving
it as a no-op as in original-harness.js.

As part of the cleanup, exception handling was folded into test() for
the original harness as well, obsoleting catchUnexpectedExceptions and
simplifying reflection.js in a couple of places.

This reduces the number of tests in the testharness.js variant.  In
particular, the asserts for getAttribute() and IDL get are now in the
same test, so if an implementation fails one it will no longer be tested
on the other.  This seems fine to me, in line with normal convention for
testharness.js.  Some tests were removed that should never have been run
to begin with and were just bugs ("should not throw").