### PR TITLE
Extend timeout on all DRM tests that were not already long timeouts.

### DIFF
--- a/encrypted-media/clearkey-mp4-setmediakeys.html
+++ b/encrypted-media/clearkey-mp4-setmediakeys.html
@@ -17,8 +17,6 @@
     <!-- Content metadata -->
     <script src=/encrypted-media/content/content-metadata.js></script>
 
-    <!-- Message handler for Clear Key -->
-    <script src=/encrypted-media/util/clearkey-messagehandler.js></script>
 
     <!-- The script for this specific test -->
     <script src=/encrypted-media/scripts/setmediakeys.js></script>

--- a/encrypted-media/clearkey-not-callable-after-createsession.html
+++ b/encrypted-media/clearkey-not-callable-after-createsession.html
@@ -14,9 +14,6 @@
     <script src=/encrypted-media/util/utf8.js></script>
     <script src=/encrypted-media/util/fetch.js></script>
 
-    <!-- Message handler for Clear Key -->
-    <script src=/encrypted-media/util/clearkey-messagehandler.js></script>
-
     <!-- The script for this specific test -->
     <script src=/encrypted-media/scripts/not-callable-after-createsession.js></script>
 

--- a/encrypted-media/drm-events.html
+++ b/encrypted-media/drm-events.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Events with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-expiration.html
+++ b/encrypted-media/drm-expiration.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Expiration with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-keystatuses-multiple-sessions.html
+++ b/encrypted-media/drm-keystatuses-multiple-sessions.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4, multiple keys for audio/video</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-keystatuses.html
+++ b/encrypted-media/drm-keystatuses.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Verify MediaKeySession.keyStatuses with multiple sessions, DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-destroy-persistent-license.html
+++ b/encrypted-media/drm-mp4-playback-destroy-persistent-license.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, persistent-license session with DRM, mp4, destroy the license</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-persistent-license-events.html
+++ b/encrypted-media/drm-mp4-playback-persistent-license-events.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, persistent-license session with DRM, mp4, event sequence</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-persistent-license.html
+++ b/encrypted-media/drm-mp4-playback-persistent-license.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, persistent-license session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-persistent-usage-record-events.html
+++ b/encrypted-media/drm-mp4-playback-persistent-usage-record-events.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, persistent-usage-record session with DRM, mp4, event sequence</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-retrieve-persistent-usage-record.html
+++ b/encrypted-media/drm-mp4-playback-retrieve-persistent-usage-record.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: persistent-usage-record, playback and retrieve record in new window,  DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-clear-encrypted.html
+++ b/encrypted-media/drm-mp4-playback-temporary-clear-encrypted.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4, clear then encrypted</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-encrypted-clear.html
+++ b/encrypted-media/drm-mp4-playback-temporary-encrypted-clear.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4, encrypted then clear</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-multikey.html
+++ b/encrypted-media/drm-mp4-playback-temporary-multikey.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful playback, temporary session with DRM, mp4, multiple keys</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-multisession.html
+++ b/encrypted-media/drm-mp4-playback-temporary-multisession.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Verify MediaKeySession.keyStatuses with multiple sessions, DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-src.html
+++ b/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-src.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-update.html
+++ b/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-after-update.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-immediately.html
+++ b/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-immediately.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-onencrypted.html
+++ b/encrypted-media/drm-mp4-playback-temporary-setMediaKeys-onencrypted.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-two-videos.html
+++ b/encrypted-media/drm-mp4-playback-temporary-two-videos.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4, two videos</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary-waitingforkey.html
+++ b/encrypted-media/drm-mp4-playback-temporary-waitingforkey.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Verify MediaKeySession.keyStatuses with multiple sessions, DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-playback-temporary.html
+++ b/encrypted-media/drm-mp4-playback-temporary.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-requestmediakeysystemaccess.html
+++ b/encrypted-media/drm-mp4-requestmediakeysystemaccess.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset=utf-8>
-    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: requestMediaKeySystemAccess tests, DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-again-after-playback.html
+++ b/encrypted-media/drm-mp4-setmediakeys-again-after-playback.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys again after playback with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-again-after-resetting-src.html
+++ b/encrypted-media/drm-mp4-setmediakeys-again-after-resetting-src.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys again after resetting src attribute on video element with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-at-same-time.html
+++ b/encrypted-media/drm-mp4-setmediakeys-at-same-time.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys multiple at same time with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-multiple-times-with-different-mediakeys.html
+++ b/encrypted-media/drm-mp4-setmediakeys-multiple-times-with-different-mediakeys.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys multiple times with different mediakeys with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-multiple-times-with-the-same-mediakeys.html
+++ b/encrypted-media/drm-mp4-setmediakeys-multiple-times-with-the-same-mediakeys.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys multiple times with the same mediakeys with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys-to-multiple-video-elements.html
+++ b/encrypted-media/drm-mp4-setmediakeys-to-multiple-video-elements.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys to multiple video elements with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys.html
+++ b/encrypted-media/drm-mp4-setmediakeys.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-mp4-setmediakeys.html
+++ b/encrypted-media/drm-mp4-setmediakeys.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset=utf-8>
-    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: setMediaKeys with DRM</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 
@@ -17,9 +16,6 @@
 
     <!-- Content metadata -->
     <script src=/encrypted-media/content/content-metadata.js></script>
-
-    <!-- Message handler for DRM servers -->
-    <script src=/encrypted-media/util/drm-messagehandler.js></script>
 
     <!-- The script for this specific test -->
     <script src=/encrypted-media/scripts/setmediakeys.js></script>

--- a/encrypted-media/drm-mp4-waiting-for-a-key.html
+++ b/encrypted-media/drm-mp4-waiting-for-a-key.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions - Waiting for a key for DRM, mp4</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-not-callable-after-createsession.html
+++ b/encrypted-media/drm-not-callable-after-createsession.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset=utf-8>
-    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Test MediaKeySession not callable immediately after CreateSession(), DRM.</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 
@@ -14,9 +13,6 @@
     <script src=/encrypted-media/util/utils.js></script>
     <script src=/encrypted-media/util/utf8.js></script>
     <script src=/encrypted-media/util/fetch.js></script>
-
-    <!-- Message handler for DRM server -->
-    <script src=/encrypted-media/util/drm-messagehandler.js></script>
 
     <!-- The script for this specific test -->
     <script src=/encrypted-media/scripts/not-callable-after-createsession.js></script>

--- a/encrypted-media/drm-not-callable-after-createsession.html
+++ b/encrypted-media/drm-not-callable-after-createsession.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Test MediaKeySession not callable immediately after CreateSession(), DRM.</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 

--- a/encrypted-media/drm-temporary-license-type.html
+++ b/encrypted-media/drm-temporary-license-type.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset=utf-8>
+    <meta name="timeout" content="long">
     <title>Encrypted Media Extensions: Test that persistent license cannot be ingested into temporary session</title>
     <link rel="help" href="https://w3c.github.io/encrypted-media/">
 


### PR DESCRIPTION
Extend the timeouts on DRM tests to long if they were not already. This reduces
issues with racy timeouts in the tests due to network conditions. This is
relevant to the DRM tests specifically because they always hit remote machines
to fetch licenses.