### PR TITLE
Add tests for focus fixup rule one

### DIFF
--- a/html/editing/focus/processing-model/focus-fixup-rule-one-no-dialogs.html
+++ b/html/editing/focus/processing-model/focus-fixup-rule-one-no-dialogs.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Focus fixup rule one (no &lt;dialog>s involved)</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule-one">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div>
+  <button id="button1">Button 1</button>
+  <button id="button2">Button 2</button>
+  <button id="button3">Button 3</button>
+  <div id="div" tabindex="0">Div</div>
+</div>
+
+<script>
+"use strict";
+
+async_test(t => {
+  const button = document.querySelector("#button1");
+  button.focus();
+
+  assert_equals(document.activeElement, button, "Sanity check: the button must start focused");
+
+  button.disabled = true;
+
+  assert_not_equals(document.activeElement, button, "After disabling, the button must no longer be focused");
+  assert_equals(document.activeElement, document.body, "After disabling, the body must be focused");
+
+}, "Disabling the active element (making it expressly inert)");
+
+test(() => {
+  const button = document.querySelector("#button2");
+  button.focus();
+
+  assert_equals(document.activeElement, button, "Sanity check: the button must start focused");
+
+  button.hidden = true;
+
+  assert_not_equals(document.activeElement, button, "After hiding, the button must no longer be focused");
+  assert_equals(document.activeElement, document.body, "After hiding, the body must be focused");
+
+}, "Hiding the active element");
+
+test(() => {
+  const button = document.querySelector("#button3");
+  button.focus();
+
+  assert_equals(document.activeElement, button, "Sanity check: the button must start focused");
+
+  button.remove();
+
+  assert_not_equals(document.activeElement, button, "After removing, the button must no longer be focused");
+  assert_equals(document.activeElement, document.body, "After removing, the body must be focused");
+
+}, "Removing the active element from the DOM");
+
+test(() => {
+  const div = document.querySelector("#div");
+  div.focus();
+
+  assert_equals(document.activeElement, div, "Sanity check: the div must start focused");
+
+  div.removeAttribute("tabindex");
+
+  assert_not_equals(document.activeElement, div, "After removing tabindex, the div must no longer be focused");
+  assert_equals(document.activeElement, document.body, "After removing tabindex, the body must be focused");
+
+}, "Removing the tabindex attribute from a div");
+
+</script>


### PR DESCRIPTION
See https://github.com/whatwg/html/issues/1972.

- Everyone passes the "Removing the active element from the DOM" test. The spec says this should not be special though. It's just weird to treat that case special from the other ways of making something un-focusable.
- Chrome will pass all these tests if you make them async and give it a few milliseconds to switch activeElement, but will not pass them as-is.
- Edge also passes the "disabling the active element (making it expressly inert)" test.