### PR TITLE
Fix a streams test that forgot to return a promise

### DIFF
--- a/streams/readable-streams/count-queuing-strategy-integration.js
+++ b/streams/readable-streams/count-queuing-strategy-integration.js
@@ -162,7 +162,7 @@ promise_test(() => {
   assert_equals(controller.desiredSize, -2, '0 reads, 6 enqueues: desiredSize should be -2');
 
 
-  reader.read()
+  return reader.read()
     .then(result => {
       assert_object_equals(result, { value: 'a', done: false },
                            '1st read gives back the 1st chunk enqueued (queue now contains 5 chunks)');


### PR DESCRIPTION
Caught by the latest testharness.js.

@isonmad maybe you can rubber-stamp this?