### PR TITLE
[presentation-api] update a test to check start() event order

### DIFF
--- a/bluetooth/bluetooth-helpers.js
+++ b/bluetooth/bluetooth-helpers.js
@@ -1,0 +1,147 @@
+'use strict';
+
+// Bluetooth UUID constants:
+// Services:
+var blacklist_test_service_uuid = "611c954a-263b-4f4a-aab6-01ddb953f985";
+var request_disconnection_service_uuid = "01d7d889-7451-419f-aeb8-d65e7b9277af";
+// Characteristics:
+var blacklist_exclude_reads_characteristic_uuid = "bad1c9a2-9a5b-4015-8b60-1579bbbf2135";
+var request_disconnection_characteristic_uuid = "01d7d88a-7451-419f-aeb8-d65e7b9277af";
+// Descriptors:
+var blacklist_exclude_reads_descriptor_uuid = "aaaaaaaa-aaaa-1181-0510-810819516110";
+var blacklist_descriptor_uuid = "07711111-6104-0970-7011-1107105110aaa";
+var characteristic_user_description_uuid = "00002901-0000-1000-8000-00805f9b34fb";
+
+// Bluetooth Adapter types:
+var adapter_type = {
+    not_present: 'NotPresentAdapter',
+    not_powered: 'NotPoweredAdapter',
+    empty: 'EmptyAdapter',
+    heart_rate: 'HeartRateAdapter',
+    two_heart_rate: 'TwoHeartRateServicesAdapter',
+    empty_name_heart_rate: 'EmptyNameHeartRateAdapter',
+    no_name_heart_rate: 'NoNameHeartRateAdapter',
+    glucose_heart_rate: 'GlucoseHeartRateAdapter',
+    unicode_device: 'UnicodeDeviceAdapter',
+    blacklist: 'BlacklistTestAdapter',
+    missing_characteristic_heart_rate: 'MissingCharacteristicHeartRateAdapter',
+    missing_service_heart_rate: 'MissingServiceHeartRateAdapter',
+    missing_descriptor_heart_rate: 'MissingDescriptorHeartRateAdapter'
+};
+
+var mock_device_name = {
+    heart_rate: 'Heart Rate Device',
+    glucose: 'Glucose Device'
+};
+
+var wrong = {
+    name: 'wrong_name',
+    service: 'wrong_service'
+};
+
+// Sometimes we need to test that using either the name, alias, or UUID
+// produces the same result. The following objects help us do that.
+var generic_access = {
+    alias: 0x1800,
+    name: 'generic_access',
+    uuid: '00001800-0000-1000-8000-00805f9b34fb'
+};
+
+var device_name = {
+    alias: 0x2a00,
+    name: 'gap.device_name',
+    uuid: '00002a00-0000-1000-8000-00805f9b34fb'
+};
+
+var reconnection_address = {
+    alias: 0x2a03,
+    name: 'gap.reconnection_address',
+    uuid: '00002a03-0000-1000-8000-00805f9b34fb'
+};
+
+var heart_rate = {
+    alias: 0x180d,
+    name: 'heart_rate',
+    uuid: '0000180d-0000-1000-8000-00805f9b34fb'
+};
+
+var heart_rate_measurement = {
+    alias: 0x2a37,
+    name: 'heart_rate_measurement',
+    uuid: '00002a37-0000-1000-8000-00805f9b34fb'
+};
+
+var body_sensor_location = {
+    alias: 0x2a38,
+    name: 'body_sensor_location',
+    uuid: '00002a38-0000-1000-8000-00805f9b34fb'
+};
+
+var glucose = {
+    alias: 0x1808,
+    name: 'glucose',
+    uuid: '00001808-0000-1000-8000-00805f9b34fb'
+};
+
+var battery_service = {
+    alias: 0x180f,
+    name: 'battery_service',
+    uuid: '0000180f-0000-1000-8000-00805f9b34fb'
+};
+
+var battery_level = {
+    alias: 0x2a19,
+    name: 'battery_level',
+    uuid: '00002a19-0000-1000-8000-00805f9b34fb'
+};
+
+var tx_power = {
+    alias: 0x1804,
+    name: 'tx_power',
+    uuid: '00001804-0000-1000-8000-00805f9b34fb'
+};
+
+var human_interface_device = {
+    alias: 0x1812,
+    name: 'human_interface_device',
+    uuid: '00001812-0000-1000-8000-00805f9b34fb'
+};
+
+var device_information = {
+    alias: 0x180a,
+    name: 'device_information',
+    uuid: '0000180a-0000-1000-8000-00805f9b34fb'
+};
+
+var peripherial_privacy_flag = {
+    alias: 0x2a02,
+    name: 'gap.peripheral_privacy_flag',
+    uuid: '00002a02-0000-1000-8000-00805f9b34fb'
+};
+
+var serial_number_string = {
+    alias: 0x2a25,
+    name: 'serial_number_string',
+    uuid: '00002a25-0000-1000-8000-00805f9b34fb'
+};
+
+var client_characteristic_configuration = {
+    alias: 0x2902,
+    name: 'gatt.client_characteristic_configuration',
+    uuid: '00002902-0000-1000-8000-00805f9b34fb'
+};
+
+var number_of_digitals = {
+    alias: 0x2909,
+    name: 'number_of_digitals',
+    uuid: '00002909-0000-1000-8000-00805f9b34fb'
+};
+
+// Helper function for converting strings to an array of bytes.
+function asciiToDecimal(bytestr) {
+    var result = [];
+    for(var i = 0; i < bytestr.length; i++) {
+        result[i] = bytestr.charCodeAt(i) ;
+    }
+    return result;
+}

--- a/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_eval.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_eval.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `eval` are allowed with `strict-dynamic` with `unsafe-eval`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'unsafe-eval' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `eval` are allowed with `strict-dynamic` with `unsafe-eval`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var evalScriptRan = false;
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.unreached_func('No CSP violation report has fired.'));
+            try {
+                eval("evalScriptRan = true;");
+            } catch (e) {
+                assert_unreached("`eval` should be allowed with `strict-dynamic` with `unsafe-eval`.");
+            }
+            assert_true(evalScriptRan);
+            t.done();
+        }, "Script injected via `eval` is allowed with `strict-dynamic` with `unsafe-eval`.");
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_eval.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_eval.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'unsafe-eval'

--- a/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_new_function.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_new_function.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `new Function()` are allowed with `strict-dynamic` with `unsafe-eval`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'unsafe-eval' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `new Function()` are allowed with `strict-dynamic` with `unsafe-eval`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var newFunctionScriptRan = false;
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.unreached_func('No CSP violation report has fired.'));
+            try {
+                new Function('newFunctionScriptRan = true;')();
+            } catch (e) {
+                assert_unreached("`new Function()` should be allowed with `strict-dynamic` with `unsafe-eval`.");
+            }
+            assert_true(newFunctionScriptRan);
+            t.done();
+        }, "Script injected via `new Function()` is allowed with `strict-dynamic` with `unsafe-eval`.");
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_new_function.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_and_unsafe_eval_new_function.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'unsafe-eval'

--- a/content-security-policy/script-src/script-src-strict_dynamic_discard_whitelist.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_discard_whitelist.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Whitelists are discarded with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'self' 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Whitelists are discarded with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'whitelistedScript') {
+                    assert_unreached('Whitelisted script without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+                assert_equals(e.effectiveDirective, 'script-src');
+            }));
+        }, 'Whitelisted script without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+    <script id='whitelistedScript' src='simpleSourcedScript.js'></script>
+
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_discard_whitelist.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_discard_whitelist.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'self' 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>A separate policy with more nonces works correctly with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served:
+    1) Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+    2) Content-Security-Policy: script-src 'nonce-dummy' 'nonce-dummy2'
+    -->
+</head>
+
+<body>
+    <h1>A separate policy with more nonces works correctly with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'unNonced-appendChild') {
+                    assert_unreached('Unnonced script injected via `appendChild` is not allowed with `strict-dynamic` + a nonce-only double policy.');
+                }
+            }));
+
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'unNonced-appendChild') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            var e = document.createElement('script');
+            e.id = 'unNonced-appendChild';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onload = t.unreached_func('OnLoad should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Unnonced script injected via `appendChild` is not allowed with `strict-dynamic` + a nonce-only double policy.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'nonced-appendChild') {
+                    t.done();
+                }
+            }));
+
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'nonced-appendChild') {
+                    return;
+                }
+                assert_unreached('No CSP violation report has fired.');
+            }));
+
+            var e = document.createElement('script');
+            e.setAttribute('nonce', 'dummy2');
+            e.id = 'nonced-appendChild';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` with a correct nonce is allowed with `strict-dynamic` + a nonce-only double policy.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_different_nonce.html.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+Content-Security-Policy: script-src 'nonce-dummy' 'nonce-dummy2'

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_whitelist.sub.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_whitelist.sub.html
@@ -1,0 +1,61 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Whitelists in a separate policy are honored with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served:
+    1) Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+    2) Content-Security-Policy: script-src 'self' 'nonce-dummy'
+    -->
+</head>
+
+<body>
+    <h1>Whitelists in a separate policy are honored with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'whitelisted-appendChild') {
+                    t.done();
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'whitelisted-appendChild') {
+                    return;
+                }
+                assert_unreached('Script injected via `appendChild` is allowed with `strict-dynamic` + a nonce+whitelist double policy.');
+            }));
+
+            var e = document.createElement('script');
+            e.id = 'whitelisted-appendChild';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic` + a nonce+whitelist double policy.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'nonWhitelisted-appendChild') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                assert_equals(violation.originalPolicy, "script-src 'self' 'nonce-dummy'");
+                t.done();
+            }));
+
+            var e = document.createElement('script');
+            e.id = 'nonWhitelisted-appendChild';
+            e.src = '{{location[scheme]}}://{{domains[www2]}}:{{ports[http][0]}}/nonexisting.js?' + e.id;
+            e.onload = t.unreached_func('OnLoad should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Non-whitelisted script injected via `appendChild` is not allowed with `strict-dynamic` + a nonce+whitelist double policy.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_whitelist.sub.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_honor_whitelist.sub.html.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+Content-Security-Policy: script-src 'self' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_report_only.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_report_only.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>A separate Report-Only policy does not influence `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served:
+    1) Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+    2) Content-Security-Policy-Report-Only: script-src 'none'
+    -->
+</head>
+
+<body>
+    <h1>A separate Report-Only policy does not influence `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild-reportOnly') {
+                    t.done();
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'appendChild-reportOnly') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                // Check that the violation comes from the Report-Only policy.
+                assert_equals(violation.originalPolicy, "script-src 'none'");
+                t.done();
+            }));
+            var e = document.createElement('script');
+            e.id = 'appendChild-reportOnly';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic` + Report-Only `script-src \'none\'` policy.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_double_policy_report_only.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_double_policy_report_only.html.headers
@@ -1,0 +1,6 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'
+Content-Security-Policy-Report-Only: script-src 'none'

--- a/content-security-policy/script-src/script-src-strict_dynamic_eval.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_eval.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `eval` are not allowed with `strict-dynamic` without `unsafe-eval`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `eval` are not allowed with `strict-dynamic` without `unsafe-eval`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var evalScriptRan = false;
+
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+                assert_false(evalScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+            }));
+
+            assert_throws(new Error(),
+                function() {
+                    try {
+                        eval("evalScriptRan = true;");
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Script injected via `eval` is not allowed with `strict-dynamic` without `unsafe-eval`.");
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_eval.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_eval.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html
@@ -1,0 +1,52 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>`strict-dynamic` allows scripts matching hashes present in the policy.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o=' -->
+</head>
+
+<body>
+    <h1>`strict-dynamic` allows scripts matching hashes present in the policy.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var hashScriptRan = false;
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+    </script>
+
+    <!-- Hash: 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' -->
+    <script>
+        hashScriptRan = true;
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            assert_true(hashScriptRan);
+            t.done();
+        }, "Script matching SHA256 hash is allowed with `strict-dynamic`.");
+    </script>
+
+    <!-- Hash: 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o=' -->
+    <script>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'hashScript') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.id = 'hashScript';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` from a script matching SHA256 hash is allowed with `strict-dynamic`.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_hashes.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy' 'sha256-yU6Q7nD1TCBB9JvY06iIJ8ONLOPU4g8ml5JCDgXkv+M=' 'sha256-IFt1v6itHgqlrtInbPm/y7qyWcAlDbPgZM+92C5EZ5o='

--- a/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>`strict-dynamic` does not drop whitelists in `img-src`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: img-src 'strict-dynamic' 'self' -->
+</head>
+
+<body>
+    <h1>`strict-dynamic` does not drop whitelists in `img-src`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+
+        async_test(function(t) {
+            var e = document.createElement('img');
+            e.id = 'whitelistedImage';
+            e.src = '/content-security-policy/support/pass.png';
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            e.onload = t.step_func_done();
+            document.body.appendChild(e);
+        }, '`strict-dynamic` does not drop whitelists in `img-src`.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_in_img-src.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: img-src 'strict-dynamic' 'self'

--- a/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>A `strict-dynamic` policy can be served in a META tag.</title>
+    <meta http-equiv="Content-Security-Policy" content="script-src 'strict-dynamic' 'nonce-dummy'">
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>A `strict-dynamic` policy can be served in a META tag.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.id = 'appendChild';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild-incorrectNonce') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.id = 'appendChild-incorrectNonce';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.setAttribute('nonce', 'wrong');
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic`, even if it carries an incorrect nonce.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.appendChildViaTextContent = t.step_func_done();
+            var e = document.createElement('script');
+            e.id = 'appendChild-textContent';
+            e.textContent = "appendChildViaTextContent();";
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` populated via `textContent` is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.appendChildViaTextContentIncorrectNonce = t.step_func_done();
+            var e = document.createElement('script');
+            e.id = 'appendChild-textContent-incorrectNonce';
+            e.setAttribute('nonce', 'wrong');
+            e.textContent = "appendChildViaTextContentIncorrectNonce();";
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` populated via `textContent` is allowed with `strict-dynamic`, even if it carries an incorrect nonce.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_meta_tag.html.headers
@@ -1,0 +1,4 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache

--- a/content-security-policy/script-src/script-src-strict_dynamic_new_function.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_new_function.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts injected via `new Function()` are not allowed with `strict-dynamic` without `unsafe-eval`.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Scripts injected via `new Function()` are not allowed with `strict-dynamic` without `unsafe-eval`.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        var newFunctionScriptRan = false;
+
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+                assert_false(newFunctionScriptRan);
+                assert_equals(e.effectiveDirective, 'script-src');
+            }));
+
+            assert_throws(new Error(),
+                function() {
+                    try {
+                        new Function('newFunctionScriptRan = true;')();
+                    } catch (e) {
+                        throw new Error();
+                    }
+                });
+        }, "Script injected via 'eval' is not allowed with 'strict-dynamic' without 'unsafe-eval'.");
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_new_function.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_new_function.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html
@@ -1,0 +1,76 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Nonced and non parser-inserted scripts should run with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Nonced and non parser-inserted scripts should run with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.id = 'appendChild';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'appendChild-incorrectNonce') {
+                    t.done();
+                }
+            }));
+            var e = document.createElement('script');
+            e.id = 'appendChild-incorrectNonce';
+            e.src = 'simpleSourcedScript.js?' + e.id;
+            e.setAttribute('nonce', 'wrong');
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` is allowed with `strict-dynamic`, even if it carries an incorrect nonce.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.appendChildViaTextContent = t.step_func_done();
+            var e = document.createElement('script');
+            e.id = 'appendChild-textContent';
+            e.textContent = "appendChildViaTextContent();";
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` populated via `textContent` is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.appendChildViaTextContentIncorrectNonce = t.step_func_done();
+            var e = document.createElement('script');
+            e.id = 'appendChild-textContent-incorrectNonce';
+            e.setAttribute('nonce', 'wrong');
+            e.textContent = "appendChildViaTextContentIncorrectNonce();";
+            e.onerror = t.unreached_func('Error should not be triggered.');
+            document.body.appendChild(e);
+        }, 'Script injected via `appendChild` populated via `textContent` is allowed with `strict-dynamic`, even if it carries an incorrect nonce.');
+    </script>
+
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_incorrect_nonce.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_incorrect_nonce.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Scripts without a correct nonce should not run with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Scripts without a correct nonce should not run with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func_done(function(e) {
+                assert_equals(e.effectiveDirective, 'script-src');
+            }));
+        }, 'All the expected CSP violation reports have been fired.');
+    </script>
+
+    <script nonce='wrong'>
+        assert_unreached('Inline script with an incorrect nonce should not be executed.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_incorrect_nonce.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_non_parser_inserted_incorrect_nonce.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html
@@ -1,0 +1,205 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Parser-inserted scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Parser-inserted scripts without a correct nonce are not allowed with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite') {
+                    assert_unreached('Parser-inserted script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWrite') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.write('<scr' + 'ipt id="documentWrite" src="simpleSourcedScript.js?documentWrite"></scr' + 'ipt>');
+        }, 'Parser-inserted script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln') {
+                    assert_unreached('Parser-inserted script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWriteln') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.writeln('<scr' + 'ipt id="documentWriteln" src="simpleSourcedScript.js?documentWriteln"></scr' + 'ipt>');
+        }, 'Parser-inserted script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-deferred') {
+                    assert_unreached('Parser-inserted deferred script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWrite-deferred') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.write('<scr' + 'ipt defer id="documentWrite-deferred" src="simpleSourcedScript.js?documentWrite-deferred"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-deferred') {
+                    assert_unreached('Parser-inserted deferred script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWriteln-deferred') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.writeln('<scr' + 'ipt defer id="documentWriteln-deferred" src="simpleSourcedScript.js?documentWriteln-deferred"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-async') {
+                    assert_unreached('Parser-inserted async script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWrite-async') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.write('<scr' + 'ipt async id="documentWrite-async" src="simpleSourcedScript.js?documentWrite-async"></scr' + 'ipt>');
+        }, 'Parser-inserted async script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-async') {
+                    assert_unreached('Parser-inserted async script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWriteln-async') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.writeln('<scr' + 'ipt async id="documentWriteln-async" src="simpleSourcedScript.js?documentWriteln-async"></scr' + 'ipt>');
+        }, 'Parser-inserted async script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-deferred-async') {
+                    assert_unreached('Parser-inserted deferred async script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWrite-deferred-async') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.write('<scr' + 'ipt defer async id="documentWrite-deferred-async" src="simpleSourcedScript.js?documentWrite-deferred-async"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred async script via `document.write` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-deferred-async') {
+                    assert_unreached('Parser-inserted deferred async script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+                }
+            }));
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.blockedURI.split('?')[1] !== 'documentWriteln-deferred-async') {
+                    return;
+                }
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            document.writeln('<scr' + 'ipt defer async id="documentWriteln-deferred-async " src="simpleSourcedScript.js?documentWriteln-deferred-async "></scr' + 'ipt>');
+        }, 'Parser-inserted deferred async script via `document.writeln` without a correct nonce is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        var innerHTMLScriptRan = false;
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.target.id !== 'innerHTML') {
+                    return;
+                }
+                assert_false(innerHTMLScriptRan);
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            var e = document.createElement('div');
+            e.innerHTML = "<img id='innerHTML' src='/nonexisting.jpg' onerror='innerHTMLScriptRan = true;' style='display:none'>";
+            document.body.appendChild(e);
+        }, 'Script injected via `innerHTML` is not allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        var insertAdjacentHTMLScriptRan = false;
+        async_test(function(t) {
+            window.addEventListener('securitypolicyviolation', t.step_func(function(violation) {
+                if (violation.target.id !== 'insertAdjacentHTML') {
+                    return;
+                }
+                assert_false(insertAdjacentHTMLScriptRan);
+                assert_equals(violation.effectiveDirective, 'script-src');
+                t.done();
+            }));
+
+            var e = document.createElement('div');
+            e.insertAdjacentHTML('afterbegin', "<img id='insertAdjacentHTML' src='/nonexisting.jpg' onerror='insertAdjacentHTMLScriptRan = true;' style='display:none'>");
+            document.body.appendChild(e);
+        }, 'Script injected via `insertAdjacentHTML` is not allowed with `strict-dynamic`.');
+    </script>
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html
@@ -1,0 +1,110 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Parser-inserted scripts with a correct nonce are allowed with `strict-dynamic` in the script-src directive.</title>
+    <script src='/resources/testharness.js' nonce='dummy'></script>
+    <script src='/resources/testharnessreport.js' nonce='dummy'></script>
+
+    <!-- CSP served: script-src 'strict-dynamic' 'nonce-dummy' -->
+</head>
+
+<body>
+    <h1>Parser-inserted scripts with a correct nonce are allowed with `strict-dynamic` in the script-src directive.</h1>
+    <div id='log'></div>
+
+    <script nonce='dummy'>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            assert_unreached('No CSP violation report has fired.');
+        });
+
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite') {
+                    t.done();
+                }
+            }));
+            document.write('<scr' + 'ipt nonce="dummy" id="documentWrite" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted script via `document.write` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln') {
+                    t.done();
+                }
+            }));
+            document.writeln('<scr' + 'ipt nonce="dummy" id="documentWriteln" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted script via `document.writeln` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-defer') {
+                    t.done();
+                }
+            }));
+            document.write('<scr' + 'ipt defer nonce="dummy" id="documentWrite-defer" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred script via `document.write` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-defer') {
+                    t.done();
+                }
+            }));
+            document.writeln('<scr' + 'ipt defer nonce="dummy" id="documentWriteln-defer" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred script via `document.writeln` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-async') {
+                    t.done();
+                }
+            }));
+            document.write('<scr' + 'ipt async nonce="dummy" id="documentWrite-async" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted async script via `document.write` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-async') {
+                    t.done();
+                }
+            }));
+            document.writeln('<scr' + 'ipt async nonce="dummy" id="documentWriteln-async" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted async script via `document.writeln` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWrite-defer-async') {
+                    t.done();
+                }
+            }));
+            document.write('<scr' + 'ipt defer async nonce="dummy" id="documentWrite-defer-async" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred async script via `document.write` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+    <script nonce='dummy'>
+        async_test(function(t) {
+            window.addEventListener('message', t.step_func(function(e) {
+                if (e.data === 'documentWriteln-defer-async') {
+                    t.done();
+                }
+            }));
+            document.writeln('<scr' + 'ipt defer async nonce="dummy" id="documentWriteln-defer-async" src="simpleSourcedScript.js"></scr' + 'ipt>');
+        }, 'Parser-inserted deferred async script via `document.writeln` with a correct nonce is allowed with `strict-dynamic`.');
+    </script>
+
+</body>
+
+</html>

--- a/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html.headers
+++ b/content-security-policy/script-src/script-src-strict_dynamic_parser_inserted_correct_nonce.html.headers
@@ -1,0 +1,5 @@
+Expires: Mon, 26 Jul 1997 05:00:00 GMT
+Cache-Control: no-store, no-cache, must-revalidate
+Cache-Control: post-check=0, pre-check=0, false
+Pragma: no-cache
+Content-Security-Policy: script-src 'strict-dynamic' 'nonce-dummy'

--- a/content-security-policy/script-src/simpleSourcedScript.js
+++ b/content-security-policy/script-src/simpleSourcedScript.js
@@ -1,0 +1,1 @@
+window.postMessage(document.currentScript.id, "*");

--- a/dom/nodes/Element-closest.html
+++ b/dom/nodes/Element-closest.html
@@ -56,10 +56,11 @@
   do_test(":first-child"               , "test12", "test3");
   do_test(":invalid"                   , "test11", "test2");
 
-  do_test(":scope"                     , "test4",  "test4");
-  do_test("select > :scope"            , "test4",  "test4");
-  do_test("div > :scope"               , "test4",  "");
-  do_test(":has(> :scope)"             , "test4",  "test3");
+  do_scope_test(":scope"               , "test4");
+  do_scope_test("select > :scope"      , "test4");
+  do_scope_test("div > :scope"         , "test4");
+  do_scope_test(":has(> :scope)"       , "test4");
+
 function do_test(aSelector, aElementId, aTargetId) {
   test(function() {
     var el = document.getElementById(aElementId).closest(aSelector);
@@ -69,5 +70,14 @@ function do_test(aSelector, aElementId, aTargetId) {
       assert_equals(el.id, aTargetId, aSelector);
     }
   }, "Element.closest with context node '" + aElementId + "' and selector '" + aSelector + "'");
+}
+
+function do_scope_test(aSelector, aElementId) {
+  test(function() {
+    var el = document.getElementById(aElementId);
+    assert_throws("SYNTAX_ERR", function() {
+      el.closest(aSelector);
+    });
+  }, "Element.closest with context node '" + aElementId + "' and selector '" + aSelector + "' should throw");
 }
 </script>

--- a/fetch/api/response/response-consume.html
+++ b/fetch/api/response/response-consume.html
@@ -12,17 +12,49 @@
   </head>
   <body>
     <script>
-    function checkBodyText(response, expectedBody) {
+    function responsePromise(body, responseInit) {
+      return new Promise(function(resolve, reject) {
+        resolve(new Response(body, responseInit));
+      });
+    }
+
+    function responseStringToMultipartFormTextData(response, name, value) {
+        assert_true(response.headers.has("Content-Type"), "Response contains Content-Type header");
+        var boundaryMatches = response.headers.get("Content-Type").match(/;\s*boundary=("?)([^";\s]*)\1/);
+        assert_true(!!boundaryMatches, "Response contains boundary parameter");
+        return stringToMultipartFormTextData(boundaryMatches[2], name, value);
+    }
+
+    function streamResponsePromise(streamData, responseInit) {
+      return new Promise(function(resolve, reject) {
+        var stream = new ReadableStream({
+          start: function(controller) {
+            controller.enqueue(stringToArray(streamData));
+            controller.close();
+          }
+        });
+        resolve(new Response(stream, responseInit));
+      });
+    }
+
+    function stringToMultipartFormTextData(multipartBoundary, name, value) {
+      return ('--' + multipartBoundary + '\r\n' +
+              'Content-Disposition: form-data;name="' + name + '"\r\n' +
+              '\r\n' +
+              value + '\r\n' +
+              '--' + multipartBoundary + '--\r\n');
+    }
+
+    function checkBodyText(test, response, expectedBody) {
       return response.text().then( function(bodyAsText) {
         assert_equals(bodyAsText, expectedBody, "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as text: bodyUsed turned true");
       });
     }
 
-    function checkBodyBlob(response, expectedBody, checkContentType) {
+    function checkBodyBlob(test, response, expectedBody, expectedType) {
       return response.blob().then(function(bodyAsBlob) {
-        if (checkContentType)
-          assert_equals(bodyAsBlob.type, "text/plain", "Blob body type should be computed from the response Content-Type");
+        assert_equals(bodyAsBlob.type, expectedType || "text/plain", "Blob body type should be computed from the response Content-Type");
 
         var promise = new Promise( function (resolve, reject) {
           var reader = new FileReader();
@@ -41,14 +73,14 @@
       });
     }
 
-    function checkBodyArrayBuffer(response, expectedBody) {
+    function checkBodyArrayBuffer(test, response, expectedBody) {
       return response.arrayBuffer().then( function(bodyAsArrayBuffer) {
         validateBufferFromString(bodyAsArrayBuffer, expectedBody, "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as arrayBuffer: bodyUsed turned true");
       });
     }
 
-    function checkBodyJSON(response, expectedBody) {
+    function checkBodyJSON(test, response, expectedBody) {
       return response.json().then(function(bodyAsJSON) {
         var strBody = JSON.stringify(bodyAsJSON)
         assert_equals(strBody, expectedBody, "Retrieve and verify response's body");
@@ -56,80 +88,122 @@
       });
     }
 
-    function checkBodyFormData(response, expectedBody) {
+    function checkBodyFormDataMultipart(test, response, expectedBody) {
       return response.formData().then(function(bodyAsFormData) {
         assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
+        var entryName = "name";
+        var strBody = responseStringToMultipartFormTextData(response, entryName, bodyAsFormData.get(entryName));
+        assert_equals(strBody, expectedBody, "Retrieve and verify response's body");
         assert_true(response.bodyUsed, "body as formData: bodyUsed turned true");
      });
     }
 
-    function checkResponseBody(body, bodyType, bodyConsumingType, checkFunction) {
-      promise_test(function(test) {
-        var response = new Response(body, { "headers": [["Content-Type", "text/PLAIN"]] });
-        assert_false(response.bodyUsed, "bodyUsed is false at init");
-        return checkFunction(response, body);
-      }, "Consume " + bodyType + " response's body as " + bodyConsumingType);
+    function checkBodyFormDataUrlencoded(test, response, expectedBody) {
+      return response.formData().then(function(bodyAsFormData) {
+        assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
+        var entryName = "name";
+        var strBody = entryName + "=" + bodyAsFormData.get(entryName);
+        assert_equals(strBody, expectedBody, "Retrieve and verify response's body");
+        assert_true(response.bodyUsed, "body as formData: bodyUsed turned true");
+     });
     }
 
-    var formData = new FormData();
-    formData.append("name", "value");
+    function checkBodyFormDataError(test, response, expectedBody) {
+      return promise_rejects(test, new TypeError(), response.formData()).then(function() {
+        assert_true(response.bodyUsed, "body as formData: bodyUsed turned true");
+      });
+    }
+
+    function checkResponseBody(responsePromise, expectedBody, checkFunction, bodyTypes) {
+      promise_test(function(test) {
+        return responsePromise.then(function(response) {
+          assert_false(response.bodyUsed, "bodyUsed is false at init");
+          return checkFunction(test, response, expectedBody);
+        });
+      }, "Consume response's body: " + bodyTypes);
+    }
+
     var textData = JSON.stringify("This is response's body");
-    var blob = new Blob([textData], { "type" : "text/plain" });
+    var textResponseInit = { "headers": [["Content-Type", "text/PLAIN"]] };
+    var blob = new Blob([textData], { "type": "application/octet-stream" });
+    var multipartBoundary = "boundary-" + Math.random();
+    var formData = new FormData();
+    var formTextResponseInit = { "headers": [["Content-Type", 'multipart/FORM-data; boundary="' + multipartBoundary + '"']] };
+    var formTextData = stringToMultipartFormTextData(multipartBoundary, "name", textData);
+    var formBlob = new Blob([formTextData]);
     var urlSearchParamsData = "name=value";
     var urlSearchParams = new URLSearchParams(urlSearchParamsData);
+    var urlSearchParamsType = "application/x-www-form-urlencoded;charset=UTF-8";
+    var urlSearchParamsResponseInit = { "headers": [["Content-Type", urlSearchParamsType]] };
+    var urlSearchParamsBlob = new Blob([urlSearchParamsData], { "type": urlSearchParamsType });
+    formData.append("name", textData);
 
-    checkResponseBody(textData, "text", "text", checkBodyText);
-    checkResponseBody(textData, "text", "blob", function(response, body) { return checkBodyBlob(response, body, true); });
-    checkResponseBody(textData, "text", "arrayBuffer", checkBodyArrayBuffer);
-    checkResponseBody(textData, "text", "json", checkBodyJSON);
-    checkResponseBody(formData, "formdata", "formData", checkBodyFormData);
-    checkResponseBody(urlSearchParams, "URLSearchParams", "text", function(response) { return checkBodyText(response, urlSearchParamsData); });
-    checkResponseBody(urlSearchParams, "URLSearchParams", "blob", function(response, body) { return checkBodyBlob(response, urlSearchParamsData, false); });
-    checkResponseBody(urlSearchParams, "URLSearchParams", "arrayBuffer", function(response) { return checkBodyArrayBuffer(response, urlSearchParamsData); });
+    checkResponseBody(responsePromise(textData, textResponseInit), textData, checkBodyText, "from text to text");
+    checkResponseBody(responsePromise(textData, textResponseInit), textData, checkBodyBlob, "from text to blob");
+    checkResponseBody(responsePromise(textData, textResponseInit), textData, checkBodyArrayBuffer, "from text to arrayBuffer");
+    checkResponseBody(responsePromise(textData, textResponseInit), textData, checkBodyJSON, "from text to json");
+    checkResponseBody(responsePromise(formTextData, formTextResponseInit), formTextData, checkBodyFormDataMultipart, "from text with correct multipart type to formData");
+    checkResponseBody(responsePromise(formTextData, textResponseInit), undefined, checkBodyFormDataError, "from text without correct multipart type to formData (error case)");
+    checkResponseBody(responsePromise(urlSearchParamsData, urlSearchParamsResponseInit), urlSearchParamsData, checkBodyFormDataUrlencoded, "from text with correct urlencoded type to formData");
+    checkResponseBody(responsePromise(urlSearchParamsData, textResponseInit), undefined, checkBodyFormDataError, "from text without correct urlencoded type to formData (error case)");
 
-    function checkBlobResponseBody(blobBody, blobData, bodyType, checkFunction) {
+    checkResponseBody(responsePromise(blob, textResponseInit), textData, checkBodyBlob, "from blob to blob");
+    checkResponseBody(responsePromise(blob), textData, checkBodyText, "from blob to text");
+    checkResponseBody(responsePromise(blob), textData, checkBodyArrayBuffer, "from blob to arrayBuffer");
+    checkResponseBody(responsePromise(blob), textData, checkBodyJSON, "from blob to json");
+    checkResponseBody(responsePromise(formBlob, formTextResponseInit), formTextData, checkBodyFormDataMultipart, "from blob with correct multipart type to formData");
+    checkResponseBody(responsePromise(formBlob, textResponseInit), undefined, checkBodyFormDataError, "from blob without correct multipart type to formData (error case)");
+    checkResponseBody(responsePromise(urlSearchParamsBlob, urlSearchParamsResponseInit), urlSearchParamsData, checkBodyFormDataUrlencoded, "from blob with correct urlencoded type to formData");
+    checkResponseBody(responsePromise(urlSearchParamsBlob, textResponseInit), undefined, checkBodyFormDataError, "from blob without correct urlencoded type to formData (error case)");
+
+    function checkFormDataResponseBody(responsePromise, expectedName, expectedValue, checkFunction, bodyTypes) {
       promise_test(function(test) {
-        var response = new Response(blobBody);
-        assert_false(response.bodyUsed, "bodyUsed is false at init");
-        return checkFunction(response, blobData);
-      }, "Consume blob response's body as " + bodyType);
-    }
-
-    checkBlobResponseBody(blob, textData, "blob", checkBodyBlob);
-    checkBlobResponseBody(blob, textData, "text", checkBodyText);
-    checkBlobResponseBody(blob, textData, "json", checkBodyJSON);
-    checkBlobResponseBody(blob, textData, "arrayBuffer", checkBodyArrayBuffer);
-
-    function checkReadableStreamResponseBody(streamData, bodyType, checkFunction) {
-      promise_test(function(test) {
-        var stream = new ReadableStream({
-          start: function(controller) {
-            controller.enqueue((stringToArray(streamData)));
-            controller.close();
-          }
-        });
-        var response = new Response(stream);
-        assert_false(response.bodyUsed, "bodyUsed is false at init");
-        return checkFunction(response, streamData);
-      }, "Consume stream response's body as " + bodyType);
-    }
-
-    checkReadableStreamResponseBody(textData, "blob", checkBodyBlob);
-    checkReadableStreamResponseBody(textData, "text", checkBodyText);
-    checkReadableStreamResponseBody(textData, "json", checkBodyJSON);
-    checkReadableStreamResponseBody(textData, "arrayBuffer", checkBodyArrayBuffer);
-
-    function checkFetchedResponseBody(bodyType, checkFunction) {
-      return promise_test(function(test) {
-        return fetch("../resources/top.txt").then(function(response) {
+        return responsePromise.then(function(response) {
           assert_false(response.bodyUsed, "bodyUsed is false at init");
-          return checkFunction(response, "top");
+          var expectedBody = responseStringToMultipartFormTextData(response, expectedName, expectedValue);
+          return Promise.resolve().then(function() {
+            if (checkFunction === checkBodyFormDataMultipart)
+              return expectedBody;
+            // Modify expectedBody to use the same spacing for
+            // Content-Disposition parameters as Response and FormData does.
+            var response2 = new Response(formData);
+            return response2.text().then(function(formDataAsText) {
+              var reName = /[ \t]*;[ \t]*name=/;
+              var nameMatches = formDataAsText.match(reName);
+              return expectedBody.replace(reName, nameMatches[0]);
+            });
+          }).then(function(expectedBody) {
+            return checkFunction(test, response, expectedBody);
+          });
         });
-      }, "Consume fetched response's body as " + bodyType);
+      }, "Consume response's body: " + bodyTypes);
     }
-    checkFetchedResponseBody("blob", checkBodyBlob);
-    checkFetchedResponseBody("text", checkBodyText);
-    checkFetchedResponseBody("arrayBuffer", checkBodyArrayBuffer);
+
+    checkFormDataResponseBody(responsePromise(formData), "name", textData, checkBodyFormDataMultipart, "from FormData to formData");
+    checkResponseBody(responsePromise(formData, textResponseInit), undefined, checkBodyFormDataError, "from FormData without correct type to formData (error case)");
+    checkFormDataResponseBody(responsePromise(formData), "name", textData, function(test, response, expectedBody) { return checkBodyBlob(test, response, expectedBody, response.headers.get('Content-Type').toLowerCase()); }, "from FormData to blob");
+    checkFormDataResponseBody(responsePromise(formData), "name", textData, checkBodyText, "from FormData to text");
+    checkFormDataResponseBody(responsePromise(formData), "name", textData, checkBodyArrayBuffer, "from FormData to arrayBuffer");
+
+    checkResponseBody(responsePromise(urlSearchParams), urlSearchParamsData, checkBodyFormDataUrlencoded, "from URLSearchParams to formData");
+    checkResponseBody(responsePromise(urlSearchParams, textResponseInit), urlSearchParamsData, checkBodyFormDataError, "from URLSearchParams without correct type to formData (error case)");
+    checkResponseBody(responsePromise(urlSearchParams), urlSearchParamsData, function(test, response, expectedBody) { return checkBodyBlob(test, response, expectedBody, "application/x-www-form-urlencoded;charset=utf-8"); }, "from URLSearchParams to blob");
+    checkResponseBody(responsePromise(urlSearchParams), urlSearchParamsData, checkBodyText, "from URLSearchParams to text");
+    checkResponseBody(responsePromise(urlSearchParams), urlSearchParamsData, checkBodyArrayBuffer, "from URLSearchParams to arrayBuffer");
+
+    checkResponseBody(streamResponsePromise(textData, textResponseInit), textData, checkBodyBlob, "from stream to blob");
+    checkResponseBody(streamResponsePromise(textData), textData, checkBodyText, "from stream to text");
+    checkResponseBody(streamResponsePromise(textData), textData, checkBodyArrayBuffer, "from stream to arrayBuffer");
+    checkResponseBody(streamResponsePromise(textData), textData, checkBodyJSON, "from stream to json");
+    checkResponseBody(streamResponsePromise(formTextData, formTextResponseInit), formTextData, checkBodyFormDataMultipart, "from stream with correct multipart type to formData");
+    checkResponseBody(streamResponsePromise(formTextData), formTextData, checkBodyFormDataError, "from stream without correct multipart type to formData (error case)");
+    checkResponseBody(streamResponsePromise(urlSearchParamsData, urlSearchParamsResponseInit), urlSearchParamsData, checkBodyFormDataUrlencoded, "from stream with correct urlencoded type to formData");
+    checkResponseBody(streamResponsePromise(urlSearchParamsData), urlSearchParamsData, checkBodyFormDataError, "from stream without correct urlencoded type to formData (error case)");
+
+    checkResponseBody(fetch("../resources/top.txt"), "top", checkBodyBlob, "from fetch to blob");
+    checkResponseBody(fetch("../resources/top.txt"), "top", checkBodyText, "from fetch to text");
+    checkResponseBody(fetch("../resources/top.txt"), "top", checkBodyArrayBuffer, "from fetch to arrayBuffer");
+    checkResponseBody(fetch("../resources/top.txt"), "top", checkBodyFormDataError, "from fetch without correct type to formData (error case)");
 
     </script>
   </body>

--- a/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-src.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function-src.html
@@ -6,12 +6,13 @@
 <div id=log></div>
 <iframe src="support/set-parent-src.html"></iframe>
 <script>
-  onload = function() {
+async_test(function() {
+  onload = this.step_func(function() {
     var fr = document.querySelector("iframe")
     fr.contentWindow.go()
-    fr.onload = function() {
+    fr.onload = this.step_func_done(function() {
       assert_equals(fr.contentDocument.referrer, document.URL)
-      done()
-    }
-  }
+    })
+  })
+})
 </script>

--- a/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function.html
+++ b/html/browsers/browsing-the-web/navigating-across-documents/source/navigate-child-function.html
@@ -6,13 +6,14 @@
 <div id=log></div>
 <iframe src="support/location-set.html"></iframe>
 <script>
-  onload = function() {
+async_test(function() {
+  onload = this.step_func(function() {
     var fr = document.querySelector("iframe")
     var url = fr.contentDocument.URL
     fr.contentWindow.go()
-    fr.onload = function() {
+    fr.onload = this.step_func_done(function() {
       assert_equals(fr.contentDocument.referrer, url)
-      done()
-    }
-  }
+    })
+  })
+})
 </script>

--- a/html/browsers/history/the-location-interface/location_reload-iframe.html
+++ b/html/browsers/history/the-location-interface/location_reload-iframe.html
@@ -1,4 +1,4 @@
 <script>
   parent._ping(window.location.href)
-  location.reload();
+  if (parent._pingCount < 5) { location.reload(); }
 </script>

--- a/html/browsers/history/the-location-interface/location_reload.html
+++ b/html/browsers/history/the-location-interface/location_reload.html
@@ -15,18 +15,17 @@
     async_test(function(t) {
 
       var url = new URL("./location_reload-iframe.html", window.location).href;
-      var pingCount = 0;
 
+      window._pingCount = 0;
       window._ping = t.step_func(function(innerURL) {
           // Some browsers keep 'about:blank' in the session history
-          if (pingCount == 0) {
+          if (_pingCount == 0) {
             history_length = history.length;
           }
-          assert_equals(url, innerURL, "iframe url (" + pingCount + ")");
-          assert_equals(history_length, history.length, "history length (" + pingCount + ")");
-          pingCount++;
-          if (pingCount == 5) {
-            iframe.src = 'about:blank';
+          assert_equals(url, innerURL, "iframe url (" + _pingCount + ")");
+          assert_equals(history_length, history.length, "history length (" + _pingCount + ")");
+          _pingCount++;
+          if (_pingCount == 5) {
             t.done();
           }
       });

--- a/html/infrastructure/common-dom-interfaces/collections/htmlallcollection.html
+++ b/html/infrastructure/common-dom-interfaces/collections/htmlallcollection.html
@@ -3,7 +3,8 @@
 <head>
 <title>HTMLAllCollection Tests</title>
 <link rel="author" title="Dan Druta" href="mailto:dan.druta@att.com"/>
-<link rel="help" href="2.7.2.1 - Common Infrastructure/Common DOM Interfaces/Collections/HTMLAllCollection"/>
+<link rel="author" title="Philip Jägenstedt" href="mailto:philip@foolip.org"/>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/infrastructure.html#the-htmlallcollection-interface"/>
 <meta name="flags" content="TOKENS" />
 <meta name="assert" content="TEST ASSERTION"/>
 <script src="/resources/testharness.js"></script>
@@ -13,34 +14,249 @@
 <img src="../../../../images/green.png" name="picture">
 <a name="foo"></a>
 <a name="foo"></a>
+<span id="42"></span>
+<span id="043"></span>
+<div id="4294967294"></div>
+<div id="4294967295"></div>
+<div id="4294967296"></div>
 <script>
-test(function(){ assert_equals(document.all.length,14)}, "Test for HTMLAllCollection size");
+var anchors = document.querySelectorAll("a");
+var divs = document.querySelectorAll("div");
+var scripts = document.querySelectorAll("script");
+var spans = document.querySelectorAll("span");
 
-test(function(){ assert_equals(document.all.item(0).tagName,"HTML")}, "Test lookup by index using ()");
+test(function() {
+  assert_true(document.all instanceof HTMLAllCollection);
+}, "document.all is an HTMLAllCollection");
 
-test(function(){ assert_equals(document.all[0].tagName,"HTML")}, "Test lookup by index using []");
+test(function() {
+  assert_equals(document.all.length, 20);
+}, "length attribute");
 
-test(function(){ assert_equals(document.all.item("picture").nodeName,"IMG")}, "Test lookup IMG by name");
+// indexed property getter
 
-test(function(){ assert_equals(document.all.namedItem("picture").nodeName,"IMG")}, "Test lookup IMG by namedItem ");
+test(function() {
+  assert_equals(document.all[0], document.documentElement);
+  assert_equals(document.all[19], scripts[2]);
+}, "indexed property getter");
 
-test(function(){ assert_equals(document.all("picture").nodeName,"IMG")}, "Test lookup IMG in collection using ()");
+test(function() {
+  assert_equals(document.all[-1], undefined);
+  assert_equals(document.all[20], undefined);
+  assert_equals(document.all[42], undefined);
+  assert_equals(document.all[43], undefined);
+  assert_equals(document.all[4294967294], undefined);
+  assert_equals(document.all[4294967295], divs[1]);
+  assert_equals(document.all[4294967296], divs[2]);
+}, "indexed property getter out of range");
 
-test(function(){ assert_equals(document.all["picture"].nodeName,"IMG")}, "Test lookup IMG in collection using []");
-
-test(function(){ assert_equals(document.all.picture.nodeName,"IMG")}, "Test lookup IMG in collection using .");
-
-test(function(){ assert_equals(document.all.tags.id,"tags")}, "Test lookup tags in collection using .");
+// named property getter
 
 test(function() {
   assert_equals(document.all["root"], document.documentElement);
-}, "Should find root element too");
+  assert_equals(document.all["flags"].content, "TOKENS");
+  assert_equals(document.all["picture"].tagName, "IMG");
+}, "named property getter");
 
 test(function() {
-  assert_equals(document.all["foo"].length, 2);
-}, "Should find both anchors and produce a list");
+  assert_equals(document.all.root, document.documentElement);
+  assert_equals(document.all.flags.content, "TOKENS");
+  assert_equals(document.all.picture.tagName, "IMG");
+}, "named property getter with dot syntax");
 
-test
+test(function() {
+  assert_equals(document.all["noname"], undefined);
+  assert_equals(document.all.noname, undefined);
+}, "named property getter with invalid name");
+
+test(function() {
+  var collection = document.all["foo"];
+  assert_equals(collection.length, 2);
+  assert_equals(collection[0], anchors[0]);
+  assert_equals(collection[1], anchors[1]);
+}, "named property getter returning collection");
+
+test(function() {
+  assert_equals(document.all["0"], document.documentElement);
+  assert_equals(document.all["19"], document.scripts[2]);
+  assert_equals(document.all["20"], undefined);
+  assert_equals(document.all["42"], undefined);
+  assert_equals(document.all["43"], undefined);
+}, "named property getter with \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all["00"], undefined);
+  assert_equals(document.all["042"], undefined);
+  assert_equals(document.all["043"], spans[1]);
+  assert_equals(document.all["4294967294"], undefined);
+  assert_equals(document.all["4294967295"], divs[1]);
+  assert_equals(document.all["4294967296"], divs[2]);
+}, "named property getter with invalid \"array index property name\"");
+
+// namedItem method
+
+test(function() {
+  assert_equals(document.all.namedItem("root"), document.documentElement);
+  assert_equals(document.all.namedItem("flags").content, "TOKENS");
+  assert_equals(document.all.namedItem("picture").tagName, "IMG");
+}, "namedItem method");
+
+test(function() {
+  assert_equals(document.all.namedItem("noname"), null);
+}, "namedItem method with invalid name");
+
+test(function() {
+  var collection = document.all.namedItem("foo");
+  assert_equals(collection.length, 2);
+  assert_equals(collection[0], anchors[0]);
+  assert_equals(collection[1], anchors[1]);
+}, "namedItem method returning collection");
+
+test(function() {
+  assert_equals(document.all.namedItem("0"), null);
+  assert_equals(document.all.namedItem("19"), null);
+  assert_equals(document.all.namedItem("20"), null);
+  assert_equals(document.all.namedItem("42"), spans[0]);
+  assert_equals(document.all.namedItem("43"), null);
+}, "namedItem method with \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all.namedItem("00"), null);
+  assert_equals(document.all.namedItem("042"), null);
+  assert_equals(document.all.namedItem("043"), spans[1]);
+  assert_equals(document.all.namedItem("4294967294"), divs[0]);
+  assert_equals(document.all.namedItem("4294967295"), divs[1]);
+  assert_equals(document.all.namedItem("4294967296"), divs[2]);
+}, "namedItem method with invalid \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all.namedItem.length, 1);
+  assert_throws(new TypeError, function() {
+    document.all.namedItem();
+  });
+}, "namedItem method with no argument");
+
+// legacy caller
+
+test(function() {
+  assert_equals(document.all("root"), document.documentElement);
+  assert_equals(document.all("flags").content, "TOKENS");
+  assert_equals(document.all("picture").tagName, "IMG");
+}, "legacy caller");
+
+test(function() {
+  assert_equals(document.all("noname"), null);
+}, "legacy caller with invalid name");
+
+test(function() {
+  var collection = document.all("foo");
+  assert_equals(collection.length, 2);
+  assert_equals(collection[0], anchors[0]);
+  assert_equals(collection[1], anchors[1]);
+}, "legacy caller returning collection");
+
+test(function() {
+  assert_equals(document.all("0"), document.documentElement);
+  assert_equals(document.all("19"), document.scripts[2]);
+  assert_equals(document.all("20"), null);
+  assert_equals(document.all("42"), null);
+  assert_equals(document.all("43"), null);
+}, "legacy caller with \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all(0), document.documentElement);
+  assert_equals(document.all(19), document.scripts[2]);
+  assert_equals(document.all(20), null);
+  assert_equals(document.all(42), null);
+  assert_equals(document.all(43), null);
+}, "legacy caller with \"array index property name\" as number");
+
+test(function() {
+  assert_equals(document.all("00"), null);
+  assert_equals(document.all("042"), null);
+  assert_equals(document.all("043"), spans[1]);
+  assert_equals(document.all("4294967294"), null);
+  assert_equals(document.all("4294967295"), divs[1]);
+  assert_equals(document.all("4294967296"), divs[2]);
+}, "legacy caller with invalid \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all(), null);
+}, "legacy caller with no argument");
+
+// item method
+
+test(function() {
+  assert_equals(document.all.item("root"), document.documentElement);
+  assert_equals(document.all.item("flags").content, "TOKENS");
+  assert_equals(document.all.item("picture").tagName, "IMG");
+}, "item method");
+
+test(function() {
+  assert_equals(document.all.item("noname"), null);
+}, "item method with invalid name");
+
+test(function() {
+  var collection = document.all.item("foo");
+  assert_equals(collection.length, 2);
+  assert_equals(collection[0], anchors[0]);
+  assert_equals(collection[1], anchors[1]);
+}, "item method returning collection");
+
+test(function() {
+  assert_equals(document.all.item("0"), document.documentElement);
+  assert_equals(document.all.item("19"), document.scripts[2]);
+  assert_equals(document.all.item("20"), null);
+  assert_equals(document.all.item("42"), null);
+  assert_equals(document.all.item("43"), null);
+}, "item method with \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all.item(0), document.documentElement);
+  assert_equals(document.all.item(19), document.scripts[2]);
+  assert_equals(document.all.item(20), null);
+  assert_equals(document.all.item(42), null);
+  assert_equals(document.all.item(43), null);
+}, "item method with \"array index property name\" as number");
+
+test(function() {
+  assert_equals(document.all.item("00"), null);
+  assert_equals(document.all.item("042"), null);
+  assert_equals(document.all.item("043"), spans[1]);
+  assert_equals(document.all.item("4294967294"), null);
+  assert_equals(document.all.item("4294967295"), divs[1]);
+  assert_equals(document.all.item("4294967296"), divs[2]);
+}, "item method with invalid \"array index property name\"");
+
+test(function() {
+  assert_equals(document.all.item.length, 0);
+  assert_equals(document.all.item(), null);
+}, "item method with no argument");
+
+// live HTMLCollection
+
+test(function() {
+  var collections = [
+    document.all["foo"],
+    document.all.namedItem("foo"),
+    document.all("foo"),
+    document.all.item("foo"),
+  ];
+  // a new HTMLCollection is created for each call
+  for (var i = 0; i < collections.length; i++) {
+    assert_true(collections[i] instanceof HTMLCollection);
+    for (var j = i + 1; j < collections.length; j++) {
+      assert_not_equals(collections[i], collections[j]);
+    }
+  }
+  for (var c of collections) {
+    assert_equals(c.length, 2);
+  }
+  anchors[0].name = "bar";
+  for (var c of collections) {
+    assert_equals(c.length, 1);
+  }
+}, "collections are new live HTMLCollection instances");
 </script>
 <div id="log"></div>
 </body>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-refetest-no-list-owner-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-refetest-no-list-owner-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If no ancestors generate CSS boxes, the list item has no owner, and thus gets numbered as 0</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<style>
+  html, body {
+    display: contents;
+  }
+
+  li {
+    list-style-type: decimal;
+    margin-left: 50px;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>0. A
+0. B
+0. C</pre>
+
+<hr>
+
+<li value="0">A</li>
+<li value="0">B</li>
+<li value="0">C</li>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-001-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-001-ref.html
@@ -11,9 +11,7 @@
     <h1>Description</h1>
     <p>This test continues to validate the li element.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"If the parent element is an ol element, then the li element has an ordinal value. The value attribute is processed relative to the element's parent ol element (q.v.), if there is one. If there is not, the attribute has no effect."</blockquote>
-    <p>This reftest verifies that the value attribute has no effect when applied to a list item NOT having an ol parent.</p>
+    <p>This reftest verifies that the value attribute has no effect when applied to a list item NOT having an ol parent and not marked as display: list-item.</p>
     <p>A reftest is necessary because the values of li elements as calculated by the user agent are NOT available programatically. Only explicitly-set values are then available programatically.</p>
     <p>This reftest passes if you see NO sequencing information on any of the items below.</p>
 

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-001.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-001.html
@@ -12,9 +12,7 @@
     <h1>Description</h1>
     <p>This test continues to validate the li element.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"If the parent element is an ol element, then the li element has an ordinal value. The value attribute is processed relative to the element's parent ol element (q.v.), if there is one. If there is not, the attribute has no effect."</blockquote>
-    <p>This reftest verifies that the value attribute has no effect when applied to a list item NOT having an ol parent.</p>
+    <p>This reftest verifies that the value attribute has no effect when applied to a list item NOT having an ol parent and not marked as display: list-item.</p>
     <p>A reftest is necessary because the values of li elements as calculated by the user agent are NOT available programatically.  Only explicitly-set values are then available programatically.</p>
     <p>This reftest passes if you see NO sequencing information on any of the items below.</p>
 

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002-ref.html
@@ -15,8 +15,6 @@
     <h1>Description</h1>
     <p>This test continues to validate the li element.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"If the parent element is an ol element, then the li element has an ordinal value. The value attribute is processed relative to the element's parent ol element (q.v.), if there is one. If there is not, the attribute has no effect."</blockquote>
     <p>This reftest verifies that the value attribute has an effect when applied to a list item with an ol parent.</p>
     <p>A reftest is necessary because the values of li elements as calculated by the user agent are NOT available programatically.  Only explicitly-set values are then available programatically.</p>
     <p>This reftest passes if you see the numbers 1. 2. 3. below the words "Ordered List"</p>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-002.html
@@ -18,8 +18,6 @@
     <h1>Description</h1>
     <p>This test continues to validate the li element.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"If the parent element is an ol element, then the li element has an ordinal value. The value attribute is processed relative to the element's parent ol element (q.v.), if there is one. If there is not, the attribute has no effect."</blockquote>
     <p>This reftest verifies that the value attribute has an effect when applied to a list item with an ol parent.</p>
     <p>A reftest is necessary because the values of li elements as calculated by the user agent are NOT available programatically.  Only explicitly-set values are then available programatically.</p>
     <p>This reftest passes if you see the numbers 1. 2. 3. below the words "Ordered List"</p>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-display-list-item-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-display-list-item-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>display: list-item on non-&lt;li> elements</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<style>
+  .list-item {
+    display: list-item;
+    list-style-type: decimal;
+  }
+
+  .list-item[hidden] {
+    display: none;
+  }
+</style>
+
+<p>This test matches if both lists display similar to the following:</p>
+
+<pre>1. A
+2. B
+   D
+3. E</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <span>D</span>
+  <li value="3">E</li>
+</ol>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <span>D</span>
+  <li value="3">E</li>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-display-list-item.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-display-list-item.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>display: list-item on non-&lt;li> elements</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-display-list-item-ref.html">
+
+<style>
+  .list-item {
+    display: list-item;
+    list-style-type: decimal;
+  }
+
+  .list-item[hidden] {
+    display: none;
+  }
+</style>
+
+<p>This test matches if both lists display similar to the following:</p>
+
+<pre>1. A
+2. B
+   D
+3. E</pre>
+
+<hr>
+
+<ul>
+  <span class="list-item">A</span>
+  <span class="list-item">B</span>
+  <span class="list-item" hidden>C</span>
+  <span>D</span>
+  <span class="list-item">E</span>
+</ul>
+
+<ol>
+  <div class="list-item">A</div>
+  <div class="list-item">B</div>
+  <div class="list-item" hidden>C</div>
+  <div>D</div>
+  <div class="list-item">E</div>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-menu-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-menu-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be narest ancestor menu if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <ol>
+    <li value="1">F</li>
+    <li value="2">G</li>
+  </ol>
+  <li value="6">H</li>
+  <ol>
+    <li value="1">I</li>
+    <li value="2">
+      J
+      <ol>
+        <li value="1">K</li>
+        <li value="2">L</li>
+      </ol>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-menu.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-menu.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be narest ancestor menu if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-menu-ref.html">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<menu>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <menu>
+      <li>F</li>
+      <li>G</li>
+    </menu>
+  </div>
+  <li>H</li>
+  <menu>
+    <li>I</li>
+    <li>
+      J
+      <menu>
+        <li>K</li>
+        <li>L</li>
+      </menu>
+    </li>
+  </menu>
+</menu>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-mixed-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-mixed-ref.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be nearest ancestor ul or ul (but not dir) if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          3. K
+          4. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <ol>
+    <li value="1">F</li>
+    <li value="2">G</li>
+  </ol>
+  <li value="6">H</li>
+  <ol>
+    <li value="1">I</li>
+    <li value="2">
+      J
+      <dir>
+        <li value="3">K</li>
+        <li value="4">L</li>
+      </dir>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-mixed.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-mixed.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be nearest ancestor ul or ul (but not dir) if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-mixed-ref.html">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+
+  .list-item {
+    display: list-item;
+    list-style-type: decimal;
+  }
+
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          3. K
+          4. L</pre>
+
+<hr>
+
+<ul>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <ol>
+      <li>F</li>
+      <span class="list-item">G</span>
+    </ol>
+  </div>
+  <li>H</li>
+  <ol>
+    <li>I</li>
+    <li>
+      J
+      <dir>
+        <li>K</li>
+        <li>L</li>
+      </dir>
+    </li>
+  </ol>
+</ul>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-not-dir-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-not-dir-ref.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The dir element is not treated specially when calculating list owners</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     6. F
+     7. G
+8. H
+     9. I
+     10. J
+          11. K
+          12. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <dir>
+    <li value="6">F</li>
+    <li value="7">G</li>
+  </dir>
+  <li value="8">H</li>
+  <dir>
+    <li value="9">I</li>
+    <li value="10">
+      J
+      <dir>
+        <li value="11">K</li>
+        <li value="12">L</li>
+      </dir>
+    </li>
+  </dir>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-not-dir.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-not-dir.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The dir element is not treated specially when calculating list owners</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-not-dir-ref.html">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     6. F
+     7. G
+8. H
+     9. I
+     10. J
+          11. K
+          12. L</pre>
+
+<hr>
+
+<ol>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <dir>
+      <li>F</li>
+      <li>G</li>
+    </dir>
+  </div>
+  <li>H</li>
+  <dir>
+    <li>I</li>
+    <li>
+      J
+      <dir>
+        <li>K</li>
+        <li>L</li>
+      </dir>
+    </li>
+  </dir>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ol-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ol-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be narest ancestor ol if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <ol>
+    <li value="1">F</li>
+    <li value="2">G</li>
+  </ol>
+  <li value="6">H</li>
+  <ol>
+    <li value="1">I</li>
+    <li value="2">
+      J
+      <ol>
+        <li value="1">K</li>
+        <li value="2">L</li>
+      </ol>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ol.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ol.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be narest ancestor ol if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-ol-ref.html">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<ol>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <ol>
+      <li>F</li>
+      <li>G</li>
+    </ol>
+  </div>
+  <li>H</li>
+  <ol>
+    <li>I</li>
+    <li>
+      J
+      <ol>
+        <li>K</li>
+        <li>L</li>
+      </ol>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-parent-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-parent-ref.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be the parent if there is no ancestor ul/ol/menu</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<style>
+  li {
+    list-style-type: decimal;
+    list-style-position: inside;
+  }
+
+  ol {
+    padding: 50px;
+    margin: 0;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+1. C
+1. D
+       1. E
+3. F</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="1">C</li>
+  <li value="1">D</li>
+  <blockquote>
+    <li value="1">E</li>
+  </blockquote>
+  <li value="3">F</li>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-parent.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-parent.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be the parent if there is no ancestor ul/ol/menu</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-parent-ref.html">
+
+<style>
+  li {
+    list-style-type: decimal;
+    list-style-position: inside;
+  }
+
+  .container {
+    padding: 50px;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+1. C
+1. D
+       1. E
+3. F</pre>
+
+<hr>
+
+<div class="container">
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+    </span>
+  </div>
+  <blockquote>
+    <li>E</li>
+  </blockquote>
+  <li>F</li>
+</div>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-skip-no-boxes-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-skip-no-boxes-ref.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner calculation skips elements that do not generate layout boxes</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+6. F
+7. G
+8. H
+9. I
+10. J
+     1. K
+     2. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <li value="6">F</li>
+  <li value="7">G</li>
+  <li value="8">H</li>
+  <li value="9">I</li>
+  <li value="10">
+    J
+    <ol>
+      <li value="1">K</li>
+      <li value="2">L</li>
+    </ol>
+  </li>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-skip-no-boxes.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-skip-no-boxes.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner calculation skips elements that do not generate layout boxes</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-skip-no-boxes-ref.html">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+6. F
+7. G
+8. H
+9. I
+10. J
+     1. K
+     2. L</pre>
+
+<hr>
+
+<ol>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <ol style="display: contents;">
+      <li>F</li>
+      <li>G</li>
+    </ol>
+  </div>
+  <li>H</li>
+  <ol style="display: contents;">
+    <li>I</li>
+    <li>
+      J
+      <ol>
+        <li>K</li>
+        <li>L</li>
+      </ol>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ul-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ul-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be nearest ancestor ul if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">C</li>
+  <li value="4">D</li>
+  <li value="5">E</li>
+  <ol>
+    <li value="1">F</li>
+    <li value="2">G</li>
+  </ol>
+  <li value="6">H</li>
+  <ol>
+    <li value="1">I</li>
+    <li value="2">
+      J
+      <ol>
+        <li value="1">K</li>
+        <li value="2">L</li>
+      </ol>
+    </li>
+  </ol>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ul.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-list-owner-ul.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>list owner is calculated to be nearest ancestor ul if it exists</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-list-owner-ul-ref.html">
+
+<style>
+  li {
+    list-style-type: decimal;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. C
+4. D
+5. E
+     1. F
+     2. G
+6. H
+     1. I
+     2. J
+          1. K
+          2. L</pre>
+
+<hr>
+
+<ul>
+  <li>A</li>
+  <li>B</li>
+  <div>
+    <li>C</li>
+    <span>
+      <li>D</li>
+      <li>E</li>
+    </span>
+    <ul>
+      <li>F</li>
+      <li>G</li>
+    </ul>
+  </div>
+  <li>H</li>
+  <ul>
+    <li>I</li>
+    <li>
+      J
+      <ul>
+        <li>K</li>
+        <li>L</li>
+      </ul>
+    </li>
+  </ul>
+</ul>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-no-list-owner.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-no-list-owner.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>If no ancestors generate CSS boxes, the list item has no owner, and thus gets numbered as 0</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-no-list-owner-ref.html">
+
+<style>
+  html, body {
+    display: contents;
+  }
+
+  li {
+    list-style-type: decimal;
+    margin-left: 50px;
+  }
+</style>
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>0. A
+0. B
+0. C</pre>
+
+<hr>
+
+<li>A</li>
+<li>B</li>
+<li>C</li>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-not-being-rendered-ref.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-not-being-rendered-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>List items that are not being rendered do not participate in numbering</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. D
+4. E
+5. G</pre>
+
+<hr>
+
+<ol>
+  <li value="1">A</li>
+  <li value="2">B</li>
+  <li value="3">D</li>
+  <li value="4">E</li>
+  <li value="5">G</li>
+</ol>

--- a/html/semantics/grouping-content/the-li-element/grouping-li-reftest-not-being-rendered.html
+++ b/html/semantics/grouping-content/the-li-element/grouping-li-reftest-not-being-rendered.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>List items that are not being rendered do not participate in numbering</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#ordinal-value">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#list-owner">
+
+<link rel="match" href="grouping-li-reftest-not-being-rendered-ref.html">
+
+<p>This test matches if the list displays similar to the following</p>
+
+<pre>1. A
+2. B
+3. D
+4. E
+5. G</pre>
+
+<hr>
+
+<ol>
+  <li>A</li>
+  <li>B</li>
+  <li hidden>C</li>
+  <li>D</li>
+  <div>
+    <li>E</li>
+    <li hidden>F</li>
+    <li>G</li>
+  </div>
+</ol>

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-rev-reftest-001-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-rev-reftest-001-ref.html
@@ -17,9 +17,6 @@
 
     <p>These reftests are necessary because the values of the ol's li children as calculated by the user agent are NOT available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"The reversed attribute is a boolean attribute. If present, it indicates that the list is a descending list (..., 3, 2, 1). If the attribute is omitted, the list is an ascending list (1, 2, 3, ...)."</blockquote>
-
     <p><strong>This reftest passes if you see an ascending list followed by two descending lists.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-rev-reftest-001.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-rev-reftest-001.html
@@ -20,9 +20,6 @@
 
     <p>These reftests are necessary because the values of the ol's li children as calculated by the user agent are NOT available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote>"The reversed attribute is a boolean attribute. If present, it indicates that the list is a descending list (..., 3, 2, 1). If the attribute is omitted, the list is an ascending list (1, 2, 3, ...)."</blockquote>
-
     <p><strong>This reftest passes if you see an ascending list followed by two descending lists.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-001-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-001-ref.html
@@ -14,10 +14,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The first item in the list has the ordinal value given by the ol element's start attribute, unless that li element has a value attribute with a value that can be successfully parsed, in which case it has the ordinal value given by that value attribute.</p>
-                <p>Each subsequent item in the list has the ordinal value given by its value attribute, if it has one, or, if it doesn't, the ordinal value of the previous item, plus one if the reversed is absent, or minus one if it is present.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are numbered identically to the horizontal sequence immediately above those list items.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-001.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-001.html
@@ -17,10 +17,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The first item in the list has the ordinal value given by the ol element's start attribute, unless that li element has a value attribute with a value that can be successfully parsed, in which case it has the ordinal value given by that value attribute.</p>
-                <p>Each subsequent item in the list has the ordinal value given by its value attribute, if it has one, or, if it doesn't, the ordinal value of the previous item, plus one if the reversed is absent, or minus one if it is present.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are numbered identically to the horizontal sequence immediately above those list items.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-002-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-002-ref.html
@@ -14,10 +14,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The first item in the list has the ordinal value given by the ol element's start attribute, unless that li element has a value attribute with a value that can be successfully parsed, in which case it has the ordinal value given by that value attribute.</p>
-                <p>Each subsequent item in the list has the ordinal value given by its value attribute, if it has one, or, if it doesn't, the ordinal value of the previous item, plus one if the reversed is absent, or minus one if it is present.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are numbered identically to the horizontal sequence immediately above those list items.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-002.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-start-reftest-002.html
@@ -17,10 +17,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The first item in the list has the ordinal value given by the ol element's start attribute, unless that li element has a value attribute with a value that can be successfully parsed, in which case it has the ordinal value given by that value attribute.</p>
-                <p>Each subsequent item in the list has the ordinal value given by its value attribute, if it has one, or, if it doesn't, the ordinal value of the previous item, plus one if the reversed is absent, or minus one if it is present.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are numbered identically to the horizontal sequence immediately above those list items.</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001-ref.html
@@ -14,9 +14,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The type attribute represents the state given in the cell in the second column of the row whose first cell matches the attribute's value; if none of the cells match, or if the attribute is omitted, then the attribute represents the decimal state.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-001.html
@@ -16,9 +16,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote><p>The type attribute represents the state given in the cell in the second column of the row whose first cell matches the attribute's value; if none of the cells match, or if the attribute is omitted, then the attribute represents the decimal state.</p></blockquote>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-002-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-002-ref.html
@@ -14,9 +14,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote>User agents should render the items of the list in a manner consistent with the state of the type attribute of the ol element.</blockquote>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-002.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-002.html
@@ -16,9 +16,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states:</p>
-    <blockquote>User agents should render the items of the list in a manner consistent with the state of the type attribute of the ol element.</blockquote>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-003-ref.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-003-ref.html
@@ -14,8 +14,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states: Numbers less than or equal to zero should always use the decimal system regardless of the type attribute.</p>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-003.html
+++ b/html/semantics/grouping-content/the-ol-element/grouping-ol-type-reftest-003.html
@@ -16,8 +16,6 @@
 <body>
     <p>This test continues to validate the ol element. This reftest is necessary because the values of the ol's li children as calculated and displayed by the user agent are NOT systematically available programatically. Only explicitly-set values are available programatically. Therefore, we need to check actual rendering against expected rendering.</p>
 
-    <p>The spec states: Numbers less than or equal to zero should always use the decimal system regardless of the type attribute.</p>
-
     <p><strong>This reftest passes if each list's items are labelled identically to the horizontal sequence immediately above those list items:</strong></p>
     <p>(Note: each list item has no content; only the sequencing should appear.)</p>
 

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -1,43 +1,58 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API, testing to start a new presentation with an default request setup. (success - manual)</title>
+<title>[Optional] Starting a presentation from the browser using a default presentation request.</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
-<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentation-defaultrequest">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="common.js"></script>
 
-<p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
-<p>If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+<p>
+    Click the button or the menu item for presentation on your browser (for example, "Cast"), <br>
+    to start the manual test, and select a presentation display when prompted to do so.<br>
+    The test passes if a "PASS" result appears.
+</p>
+<p id="notice">
+    If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+</p>
 
 <script>
     // disable the timeout function for the tests
     // and call 'done()' when the tests cases are finished.
     setup({explicit_timeout: true});
 
-    // -------------------
-    // defaultRequest init
-    // -------------------
-    navigator.presentation.defaultRequest = new PresentationRequest(presentationUrls);
+    // -----------
+    // DOM Element
+    // -----------
+    var button = document.getElementById('notsupported'),
+        notice = document.getElementById('notice');
 
     // ------------------------------
     // Start New Presentation with
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
-        navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
+        // clean up the instruction notice when the test ends
+        t.add_cleanup(function() {
+            notice.parentNode.removeChild(notice);
+        });
+        // set an event handler to make the test fail when the button is clicked
+        button.onclick = t.step_func_done(function() {
+            assert_unreached('This browser does not support defaultRequest.');
+        });
+        // set up a default presentation request
+        var request = new PresentationRequest(presentationUrls);
+        navigator.presentation.defaultRequest = request;
+        request.onconnectionavailable = t.step_func_done(function (evt) {
             var connection = evt.connection;
-
+            // check the presentation connection and its attributes
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
             assert_true(!connection.id, 'The connection ID is set.');
             assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });
-        document.getElementById('notsupported').onclick = t.step_func_done(function() {
-            assert_unreached('This browser does not support defaultRequest.');
-        });
-    }, '[Optional] The presentation was started successfully.');
+    });
     // ----------------------------
     // Start New Presentation with
     // 'default request' Test - END

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -34,7 +34,14 @@
     presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
-            var phase = -1, actual = -1;
+            var request = new PresentationRequest(presentationUrls);
+            return new Promise(function(resolve, reject) {
+                request.onconnectionavailable = t.step_func(function(evt) {
+                    // Check the order #2: "connectionavailable" event fires
+                    assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
+                    step++;
+                    assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event handler receive the same presentation connection.');
+                });
 
             // increment the count in the actual event order
             var count = function(evt) { actual++; return evt; };

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -48,13 +48,15 @@
                         assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
                         // Check the order #3: "connected" event fires
                         connection.onconnect = function() {
-                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connect event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
-                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
+                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connected event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
+                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connected" event fires.');
                             resolve();
                         };
+
                         t.step_timeout(function() {
                             reject('A "connect" event did not fire when the presentation connection was established.')
                         }, 5000);
+
                         // Check, if the connection ID is set
                         assert_true(!!connection.id, 'The connection ID is set.');
                         // Check the type of the connection.id

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Checking the chain of events when starting a new presentation</title>
+<title>Presentation API, start new presentation tests for Controlling User Agent (success - manual test)</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
@@ -13,76 +13,57 @@
 
 
 <script>
-    // description of event order
-    var description = [
-        "Phase #1: Promise is resolved",
-        "Phase #2: 'connectionavailable' event fired",
-        "Phase #3: 'connect' event fired"
-    ];
+    // check event order
+    var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
     var step = 0;
-
     // presentation connection
     var connection;
-
     // disable the timeout function for the tests
     setup({explicit_timeout: true});
-
     // ----------
     // DOM Object
     // ----------
     var presentBtn = document.getElementById("presentBtn");
-
     // ---------------------------------------------
     // Start New Presentation Test (success) - begin
     // ---------------------------------------------
     presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
-            var phase = -1, actual = -1;
-
-            // increment the count in the actual event order
-            var count = function(evt) { actual++; return evt; };
-            // increment the count in the expected event order and compare it with the actual event order
-            var checkPhase = function(evt) { phase++; assert_equals(description[actual], description[phase], 'Event order is incorrect.'); return evt; };
-
             var request = new PresentationRequest(presentationUrls);
-            var eventWatcher = new EventWatcher(t, request, 'connectionavailable');
-            var waitConnectionavailable = eventWatcher.wait_for('connectionavailable').then(count);
-            var waitConnect;
-
-            return request.start().then(count)
-                .then(checkPhase).then(function (c) {
-                    // Phase #1: Promise is resolved
-                    connection = c;
-
-                    // No more user input needed, re-enable timeout
-                    t.step_timeout(function() {
-                        t.force_timeout();
-                        t.done();
-                    }, 5000);
-
-                    // Check the initial state of the presentation connection
-                    assert_equals(connection.state, 'connecting', 'Check the initial state of the presentation connection.');
-                    assert_true(!!connection.id, 'The connection ID is set.');
-                    assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-                    assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
-
-                    var eventWatcher = new EventWatcher(t, connection, 'connect');
-                    waitConnect = eventWatcher.wait_for('connect').then(count);
-
-                    return waitConnectionavailable;
-                })
-                .then(checkPhase).then(function (evt) {
-                    // Phase #2: "connectionavailable" event fired
+            return new Promise(function(resolve, reject) {
+                request.onconnectionavailable = t.step_func(function(evt) {
+                    // Check the order #2: "connectionavailable" event fires
+                    assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
+                    step++;
                     assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event handler receive the same presentation connection.');
-
-                    return waitConnect;
-                })
-                .then(checkPhase).then(function () {
-                    // Phase #3: "connect" event fired
-                    assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
                 });
-        });
+                request.start()
+                    .then(t.step_func(function (c) {
+                        connection = c;
+                        // Check the order #1: Promise from start() resolves
+                        assert_equals(order[step], 'RESOLVE_START', 'Promise from PresentationRequest.start() resolves before connectionavailable event is fired.');
+                        step++;
+                        // Check the initial state of a presentation connection
+                        assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+                        // Check the order #3: "connected" event fires
+                        connection.onconnect = function() {
+                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connect event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
+                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
+                            resolve();
+                        };
+                        t.step_timeout(function() {
+                            reject('A "connect" event did not fire when the presentation connection was established.')
+                        }, 5000);
+                        // Check, if the connection ID is set
+                        assert_true(!!connection.id, 'The connection ID is set.');
+                        // Check the type of the connection.id
+                        assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+                        // Check the instance of the connection
+                        assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+                    }), function(e) { reject(e); });
+            });
+        }, "The presentation was started successfully.");
     }
     // -------------------------------------------
     // Start New Presentation Test (success) - end

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -13,12 +13,8 @@
 
 
 <script>
-    // description of event order
-    var description = [
-        "Phase #1: Promise is resolved",
-        "Phase #2: 'connectionavailable' event fired",
-        "Phase #3: 'connect' event fired"
-    ];
+    // check event order
+    var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
     var step = 0;
 
     // presentation connection

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -9,10 +9,22 @@
 <script src="common.js"></script>
 
 <p>Click the button below and select the available presentation display, to start the manual test.</p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 
 <script>
+    // check event order 
+    var RESOLVE_START = 1,
+        FIRE_CONNECTIONAVAILABLE = 2,
+        FIRE_CONNECTED = 3;
+    var step = 1;
+
+    // presentation connection
+    var connection;
+
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
@@ -21,15 +33,35 @@
     // ---------------------------------------------
     // Start New Presentation Test (success) - begin
     // ---------------------------------------------
-    var startPresentation = function () {
+    presentBtn.onclick = function () {
         presentBtn.disabled = true;
-        promise_test(function () {
+        promise_test(function (t) {
             var request = new PresentationRequest(presentationUrls);
-            return request.start()
-                    .then(function (connection) {
+            return new Promise(function(resolve, reject) {
+                request.onconnectionavailable = t.step_func(function(evt) {
+                    // Check the order #2: "connectionavailable" event fires
+                    assert_equals(step, FIRE_CONNECTIONAVAILABLE, 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
+                    step++;
+                    assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event listener receive the same presentation connection.');
+                });
+
+                request.start()
+                    .then(t.step_func(function (c) {
+                        connection = c;
+
+                        // Check the order #1: Promise from start() resolves
+                        assert_equals(step, RESOLVE_START, 'Promise from PresentationRequest.start() resolves before connectionavailable event is fired.');
+                        step++;
 
                         // Check the initial state of a presentation connection
                         assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+
+                        // Check the order #3: "connected" event fires
+                        connection.onconnect = function() {
+                            assert_equals(step, FIRE_CONNECTED, 'A connected event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
+                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connected" event fires.');
+                            resolve();
+                        };
 
                         // Check, if the connection ID is set
                         assert_true(!!connection.id, 'The connection ID is set.');
@@ -39,11 +71,11 @@
 
                         // Check the instance of the connection
                         assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
-                    });
+                    }), function(e) { reject(e); });
+            });
         }, "The presentation was started successfully.");
     }
     // -------------------------------------------
     // Start New Presentation Test (success) - end
     // -------------------------------------------
 </script>
-

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -14,10 +14,8 @@
 
 <script>
     // check event order 
-    var RESOLVE_START = 1,
-        FIRE_CONNECTIONAVAILABLE = 2,
-        FIRE_CONNECTED = 3;
-    var step = 1;
+    var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
+    var step = 0;
 
     // presentation connection
     var connection;
@@ -40,7 +38,7 @@
             return new Promise(function(resolve, reject) {
                 request.onconnectionavailable = t.step_func(function(evt) {
                     // Check the order #2: "connectionavailable" event fires
-                    assert_equals(step, FIRE_CONNECTIONAVAILABLE, 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
+                    assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
                     step++;
                     assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event listener receive the same presentation connection.');
                 });
@@ -50,7 +48,7 @@
                         connection = c;
 
                         // Check the order #1: Promise from start() resolves
-                        assert_equals(step, RESOLVE_START, 'Promise from PresentationRequest.start() resolves before connectionavailable event is fired.');
+                        assert_equals(order[step], 'RESOLVE_START', 'Promise from PresentationRequest.start() resolves before connectionavailable event is fired.');
                         step++;
 
                         // Check the initial state of a presentation connection
@@ -58,7 +56,7 @@
 
                         // Check the order #3: "connected" event fires
                         connection.onconnect = function() {
-                            assert_equals(step, FIRE_CONNECTED, 'A connected event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
+                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connected event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
                             assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connected" event fires.');
                             resolve();
                         };

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -13,7 +13,7 @@
 
 
 <script>
-    // check event order 
+    // check event order
     var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
     var step = 0;
 

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -40,7 +40,7 @@
                     // Check the order #2: "connectionavailable" event fires
                     assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
                     step++;
-                    assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event listener receive the same presentation connection.');
+                    assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event handler receive the same presentation connection.');
                 });
 
                 request.start()

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API, start new presentation tests for Controlling User Agent (success - manual test)</title>
+<title>Checking the chain of events when starting a new presentation</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
@@ -13,8 +13,12 @@
 
 
 <script>
-    // check event order
-    var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
+    // description of event order
+    var description = [
+        "Phase #1: Promise is resolved",
+        "Phase #2: 'connectionavailable' event fired",
+        "Phase #3: 'connect' event fired"
+    ];
     var step = 0;
 
     // presentation connection
@@ -34,47 +38,51 @@
     presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
+            var phase = -1, actual = -1;
+
+            // increment the count in the actual event order
+            var count = function(evt) { actual++; return evt; };
+            // increment the count in the expected event order and compare it with the actual event order
+            var checkPhase = function(evt) { phase++; assert_equals(description[actual], description[phase], 'Event order is incorrect.'); return evt; };
+
             var request = new PresentationRequest(presentationUrls);
-            return new Promise(function(resolve, reject) {
-                request.onconnectionavailable = t.step_func(function(evt) {
-                    // Check the order #2: "connectionavailable" event fires
-                    assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
-                    step++;
+            var eventWatcher = new EventWatcher(t, request, 'connectionavailable');
+            var waitConnectionavailable = eventWatcher.wait_for('connectionavailable').then(count);
+            var waitConnect;
+
+            return request.start().then(count)
+                .then(checkPhase).then(function (c) {
+                    // Phase #1: Promise is resolved
+                    connection = c;
+
+                    // No more user input needed, re-enable timeout
+                    t.step_timeout(function() {
+                        t.force_timeout();
+                        t.done();
+                    }, 5000);
+
+                    // Check the initial state of the presentation connection
+                    assert_equals(connection.state, 'connecting', 'Check the initial state of the presentation connection.');
+                    assert_true(!!connection.id, 'The connection ID is set.');
+                    assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+                    assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+
+                    var eventWatcher = new EventWatcher(t, connection, 'connect');
+                    waitConnect = eventWatcher.wait_for('connect').then(count);
+
+                    return waitConnectionavailable;
+                })
+                .then(checkPhase).then(function (evt) {
+                    // Phase #2: "connectionavailable" event fired
                     assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event handler receive the same presentation connection.');
+
+                    return waitConnect;
+                })
+                .then(checkPhase).then(function () {
+                    // Phase #3: "connect" event fired
+                    assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
                 });
-
-                request.start()
-                    .then(t.step_func(function (c) {
-                        connection = c;
-
-                        // Check the order #1: Promise from start() resolves
-                        assert_equals(order[step], 'RESOLVE_START', 'Promise from PresentationRequest.start() resolves before connectionavailable event is fired.');
-                        step++;
-
-                        // Check the initial state of a presentation connection
-                        assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-
-                        // Check the order #3: "connected" event fires
-                        connection.onconnect = function() {
-                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connect event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
-                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
-                            resolve();
-                        };
-                        t.step_timeout(function() {
-                            reject('A "connect" event did not fire when the presentation connection was established.')
-                        }, 5000);
-
-                        // Check, if the connection ID is set
-                        assert_true(!!connection.id, 'The connection ID is set.');
-
-                        // Check the type of the connection.id
-                        assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-
-                        // Check the instance of the connection
-                        assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
-                    }), function(e) { reject(e); });
-            });
-        }, "The presentation was started successfully.");
+        });
     }
     // -------------------------------------------
     // Start New Presentation Test (success) - end

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -53,10 +53,6 @@
                             resolve();
                         };
 
-                        t.step_timeout(function() {
-                            reject('A "connect" event did not fire when the presentation connection was established.')
-                        }, 5000);
-
                         // Check, if the connection ID is set
                         assert_true(!!connection.id, 'The connection ID is set.');
                         // Check the type of the connection.id

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -13,8 +13,12 @@
 
 
 <script>
-    // check event order
-    var order = ['RESOLVE_START', 'FIRE_CONNECTIONAVAILABLE', 'FIRE_CONNECTED'];
+    // description of event order
+    var description = [
+        "Phase #1: Promise is resolved",
+        "Phase #2: 'connectionavailable' event fired",
+        "Phase #3: 'connect' event fired"
+    ];
     var step = 0;
 
     // presentation connection
@@ -34,14 +38,7 @@
     presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
-            var request = new PresentationRequest(presentationUrls);
-            return new Promise(function(resolve, reject) {
-                request.onconnectionavailable = t.step_func(function(evt) {
-                    // Check the order #2: "connectionavailable" event fires
-                    assert_equals(order[step], 'FIRE_CONNECTIONAVAILABLE', 'A "connectionavailable" event fires after Promise from PresentationRequest.start() resolves.');
-                    step++;
-                    assert_equals(connection, evt.connection, 'Both Promise from PresentationRequest() and a "connectionavailable" event handler receive the same presentation connection.');
-                });
+            var phase = -1, actual = -1;
 
             // increment the count in the actual event order
             var count = function(evt) { actual++; return evt; };

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -56,10 +56,13 @@
 
                         // Check the order #3: "connected" event fires
                         connection.onconnect = function() {
-                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connected event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
-                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connected" event fires.');
+                            assert_equals(order[step], 'FIRE_CONNECTED', 'A connect event fires after Promise from PresentationRequest.start() resolves and a "connectionavailable" event fires.');
+                            assert_equals(connection.state, 'connected', 'The state of the presentation connection is "connected" when a "connect" event fires.');
                             resolve();
                         };
+                        t.step_timeout(function() {
+                            reject('A "connect" event did not fire when the presentation connection was established.')
+                        }, 5000);
 
                         // Check, if the connection ID is set
                         assert_true(!!connection.id, 'The connection ID is set.');


### PR DESCRIPTION
This PR fixes #4168. startNewPresentation_success-manual.html is modified to check the following event order:

1. Promise from start() resolves
2. connectionavailable fires and then state is `connecting`
3. connect fires and then state is `connected`