### PR TITLE
[presentation-api] Fix handling when PresentationRequest not found

### DIFF
--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -37,9 +37,6 @@
             assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });
-        document.getElementById('notsupported').onclick = t.step_func_done(function() {
-            assert_unreached('This browser does not support defaultRequest.');
-        });
         button.onclick = t.step_func_done(function() {
             button.disabled = true;
             assert_unreached('This browser does not support defaultRequest.');

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -1,15 +1,21 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API, testing to start a new presentation with an default request setup. (success - manual)</title>
+<title>[Optional] Starting a presentation from the browser using a default presentation request. (success - manual)</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
-<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentation-defaultrequest">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="common.js"></script>
 
-<p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
-<p id="notice">If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+<p>
+    Click the button or the menu item for presentation on your browser (for example, "Cast"), <br>
+    to start the manual test, and select a presentation display when prompted to do so.<br>
+    The test passes if a "PASS" result appears.
+</p>
+<p id="notice">
+    If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+</p>
 
 <script>
     // disable the timeout function for the tests
@@ -27,35 +33,30 @@
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
-        var request = new PresentationRequest(presentationUrls);
-        if('defaultRequest' in navigator.presentation) {
-            navigator.presentation.defaultRequest = request;
-
-            if('onconnectionavailable' in request) {
-                request.onconnectionavailable = t.step_func_done(function (evt) {
-                    var connection = evt.connection;
-                    notice.parentNode.removeChild(notice);
-
-                    assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-                    assert_true(!connection.id, 'The connection ID is set.');
-                    assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-                    assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
-                });
-                button.onclick = t.step_func_done(function() {
-                    button.disabled = true;
-                    assert_unreached('This browser does not support defaultRequest.');
-                });
-            }
-            else {
-                notice.parentNode.removeChild(notice);
-                assert_unreached('This browser does not support connectionavailable event.');
-            }
-        }
-        else {
+        // clean up the instruction notice when the test ends
+        t.add_cleanup(function() {
             notice.parentNode.removeChild(notice);
+        });
+        // set an event handler to make the test fail when the button is clicked
+        button.onclick = t.step_func_done(function() {
             assert_unreached('This browser does not support defaultRequest.');
-        }
-    }, '[Optional] The presentation was started successfully.');
+        });
+        // check if defaultRequest is an instance of PresentationRequest or null
+        var defaultRequest = navigator.presentation.defaultRequest;
+        assert_true(defaultRequest instanceof PresentationRequest || defaultRequest === null,
+            'navigator.presentation.defaultRequest must be an instance of PresentationRequest or null.');
+        // set up a default presentation request
+        var request = new PresentationRequest(presentationUrls);
+        navigator.presentation.defaultRequest = request;
+        request.onconnectionavailable = t.step_func_done(function (evt) {
+            var connection = evt.connection;
+            // check the presentation connection and its attributes
+            assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+            assert_true(!connection.id, 'The connection ID is set.');
+            assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+            assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+        });
+    });
     // ----------------------------
     // Start New Presentation with
     // 'default request' Test - END

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -32,9 +32,9 @@
             navigator.presentation.defaultRequest = request;
 
             if('onconnectionavailable' in request) {
-                notice.parentNode.removeChild(notice);
                 request.onconnectionavailable = t.step_func_done(function (evt) {
                     var connection = evt.connection;
+                    notice.parentNode.removeChild(notice);
 
                     assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
                     assert_true(!connection.id, 'The connection ID is set.');

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -9,25 +9,28 @@
 <script src="common.js"></script>
 
 <p>Click the button or the menu item for presentation on your browser (for example, "Cast"), to start the manual test.</p>
-<p>If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
+<p id="notice">If your browser does not support <code>defaultRequest</code>, please click this button: <button id="notsupported">Not Supported</button>
 
 <script>
     // disable the timeout function for the tests
     // and call 'done()' when the tests cases are finished.
     setup({explicit_timeout: true});
 
-    // -------------------
-    // defaultRequest init
-    // -------------------
-    navigator.presentation.defaultRequest = new PresentationRequest(presentationUrls);
+    // -----------
+    // DOM Element
+    // -----------
+    var button = document.getElementById('notsupported'),
+        notice = document.getElementById('notice');
 
     // ------------------------------
     // Start New Presentation with
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
+        navigator.presentation.defaultRequest = new PresentationRequest(presentationUrls);
         navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
             var connection = evt.connection;
+            notice.parentNode.removeChild(notice);
 
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
             assert_true(!connection.id, 'The connection ID is set.');
@@ -35,6 +38,10 @@
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });
         document.getElementById('notsupported').onclick = t.step_func_done(function() {
+            assert_unreached('This browser does not support defaultRequest.');
+        });
+        button.onclick = t.step_func_done(function() {
+            button.disabled = true;
             assert_unreached('This browser does not support defaultRequest.');
         });
     }, '[Optional] The presentation was started successfully.');

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>[Optional] Starting a presentation from the browser using a default presentation request. (success - manual)</title>
+<title>[Optional] Starting a presentation from the browser using a default presentation request.</title>
 <link rel="author" title="Marius Wessel" href="http://www.fokus.fraunhofer.de">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentation-defaultrequest">
@@ -41,10 +41,6 @@
         button.onclick = t.step_func_done(function() {
             assert_unreached('This browser does not support defaultRequest.');
         });
-        // check if defaultRequest is an instance of PresentationRequest or null
-        var defaultRequest = navigator.presentation.defaultRequest;
-        assert_true(defaultRequest instanceof PresentationRequest || defaultRequest === null,
-            'navigator.presentation.defaultRequest must be an instance of PresentationRequest or null.');
         // set up a default presentation request
         var request = new PresentationRequest(presentationUrls);
         navigator.presentation.defaultRequest = request;

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -27,20 +27,34 @@
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
-        navigator.presentation.defaultRequest = new PresentationRequest(presentationUrls);
-        navigator.presentation.defaultRequest.onconnectionavailable = t.step_func_done(function (evt) {
-            var connection = evt.connection;
-            notice.parentNode.removeChild(notice);
+        var request = new PresentationRequest(presentationUrls);
+        if('defaultRequest' in navigator.presentation) {
+            navigator.presentation.defaultRequest = request;
 
-            assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-            assert_true(!connection.id, 'The connection ID is set.');
-            assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-            assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
-        });
-        button.onclick = t.step_func_done(function() {
-            button.disabled = true;
+            if('onconnectionavailable' in request) {
+                notice.parentNode.removeChild(notice);
+                request.onconnectionavailable = t.step_func_done(function (evt) {
+                    var connection = evt.connection;
+
+                    assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+                    assert_true(!connection.id, 'The connection ID is set.');
+                    assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+                    assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+                });
+                button.onclick = t.step_func_done(function() {
+                    button.disabled = true;
+                    assert_unreached('This browser does not support defaultRequest.');
+                });
+            }
+            else {
+                notice.parentNode.removeChild(notice);
+                assert_unreached('This browser does not support connectionavailable event.');
+            }
+        }
+        else {
+            notice.parentNode.removeChild(notice);
             assert_unreached('This browser does not support defaultRequest.');
-        });
+        }
     }, '[Optional] The presentation was started successfully.');
     // ----------------------------
     // Start New Presentation with


### PR DESCRIPTION
This PR fixes #4039.

* `new PresentationRequest()` is moved within `async_test()`.
* The "Not Supported" button is disabled or the whole "If your browser does not support" text is hidden when unnecessary.