### PR TITLE
Move URL origin tests to new file

### DIFF
--- a/url/a-element-origin-xhtml.xhtml
+++ b/url/a-element-origin-xhtml.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>URL Test</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <base id="base"/>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script src="a-element-origin.js"></script>
+  </body>
+</html>

--- a/url/a-element-origin.html
+++ b/url/a-element-origin.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset=utf-8>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<base id=base>
+<div id=log></div>
+<script src=a-element-origin.js></script>

--- a/url/a-element-origin.js
+++ b/url/a-element-origin.js
@@ -1,0 +1,35 @@
+var setup = async_test("Loading data…")
+setup.step(function() {
+  var request = new XMLHttpRequest()
+  request.open("GET", "urltestdata.json")
+  request.send()
+  request.responseType = "json"
+  request.onload = setup.step_func(function() {
+    runURLTests(request.response)
+    setup.done()
+  })
+})
+
+function setBase(base) {
+  document.getElementById("base").href = base
+}
+
+function bURL(url, base) {
+  base = base || "about:blank"
+  setBase(base)
+  var a = document.createElement("a")
+  a.setAttribute("href", url)
+  return a
+}
+
+function runURLTests(urltests) {
+  for(var i = 0, l = urltests.length; i < l; i++) {
+    var expected = urltests[i]
+    if (typeof expected === "string" || !("origin" in expected)) continue
+
+    test(function() {
+      var url = bURL(expected.input, expected.base)
+      assert_equals(url.origin, expected.origin, "origin")
+    }, "Parsing origin: <" + expected.input + "> against <" + expected.base + ">")
+  }
+}

--- a/url/a-element.js
+++ b/url/a-element.js
@@ -38,9 +38,6 @@ function runURLTests(urltests) {
       }
 
       assert_equals(url.href, expected.href, "href")
-      if ("origin" in expected) {
-        assert_equals(url.origin, expected.origin, "origin")
-      }
       assert_equals(url.protocol, expected.protocol, "protocol")
       assert_equals(url.username, expected.username, "username")
       assert_equals(url.password, expected.password, "password")

--- a/url/url-constructor.html
+++ b/url/url-constructor.html
@@ -37,9 +37,6 @@ function runURLTests(urltests) {
 
       var url = bURL(expected.input, expected.base)
       assert_equals(url.href, expected.href, "href")
-      if ("origin" in expected) {
-        assert_equals(url.origin, expected.origin, "origin")
-      }
       assert_equals(url.protocol, expected.protocol, "protocol")
       assert_equals(url.username, expected.username, "username")
       assert_equals(url.password, expected.password, "password")

--- a/url/url-origin.html
+++ b/url/url-origin.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<meta charset=utf-8>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+function runURLOriginTests() {
+  var setup = async_test("Loading data…")
+  setup.step(function() {
+    var request = new XMLHttpRequest()
+    request.open("GET", "urltestdata.json")
+    request.send()
+    request.responseType = "json"
+    request.onload = setup.step_func(function() {
+      runURLTests(request.response)
+      setup.done()
+    })
+  })
+}
+
+function bURL(url, base) {
+  return new URL(url, base || "about:blank")
+}
+
+function runURLTests(urltests) {
+  for(var i = 0, l = urltests.length; i < l; i++) {
+    var expected = urltests[i]
+    if (typeof expected === "string" || !("origin" in expected)) continue
+
+    test(function() {
+      var url = bURL(expected.input, expected.base)
+      assert_equals(url.origin, expected.origin, "origin")
+    }, "Origin parsing: <" + expected.input + "> against <" + expected.base + ">")
+  }
+}
+runURLOriginTests()
+</script>


### PR DESCRIPTION
Origin differences cover up parser differences in the results.  Origin conformance is implemented differently than other attributes in the constructor test