### PR TITLE
Add/Update tests for MessageEvent changes

### DIFF
--- a/html/webappapis/scripting/events/messageevent-constructor.https.html
+++ b/html/webappapis/scripting/events/messageevent-constructor.https.html
@@ -2,6 +2,7 @@
 <title>MessageEvent constructor</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 <script>
 test(function() {
   var ev = new MessageEvent("test")
@@ -74,5 +75,22 @@ test(function() {
     ev.initMessageEvent("test", true, false, "testData", "testOrigin", "testId", window)
   }, "Calling initMessageEvent with only 7 parameters should throw a TypeError")
 }, "All parameters to initMessageEvent should be mandatory")
+
+promise_test(function(t) {
+    var worker_url = '/service-workers/service-worker/resources/empty-worker.js';
+    var scope = '/service-workers/service-worker/resources/';
+    var registration;
+
+    return service_worker_unregister_and_register(t, worker_url, scope)
+      .then(function(r) {
+          registration = r;
+          return wait_for_state(t, r.installing, 'activated');
+        })
+      .then(function() {
+          var ev = new MessageEvent("test", { source: registration.active });
+          assert_equals(ev.source, registration.active, "source attribute should return the ServiceWorker");
+          service_worker_unregister(t, scope);
+        });
+  }, 'Passing ServiceWorker for source member');
 
 </script>

--- a/html/webappapis/scripting/events/messageevent-constructor.https.html
+++ b/html/webappapis/scripting/events/messageevent-constructor.https.html
@@ -77,20 +77,20 @@ test(function() {
 }, "All parameters to initMessageEvent should be mandatory")
 
 promise_test(function(t) {
-    var worker_url = '/service-workers/service-worker/resources/empty-worker.js';
-    var scope = '/service-workers/service-worker/resources/';
+    var worker_url = "/service-workers/service-worker/resources/empty-worker.js";
+    var scope = "/service-workers/service-worker/resources/";
     var registration;
 
     return service_worker_unregister_and_register(t, worker_url, scope)
       .then(function(r) {
           registration = r;
-          return wait_for_state(t, r.installing, 'activated');
+          return wait_for_state(t, r.installing, "activated");
         })
       .then(function() {
           var ev = new MessageEvent("test", { source: registration.active });
           assert_equals(ev.source, registration.active, "source attribute should return the ServiceWorker");
           service_worker_unregister(t, scope);
         });
-  }, 'Passing ServiceWorker for source member');
+  }, "Passing ServiceWorker for source member");
 
 </script>

--- a/service-workers/service-worker/postmessage-to-client.https.html
+++ b/service-workers/service-worker/postmessage-to-client.https.html
@@ -29,10 +29,13 @@ t.step(function() {
     var expected = ['Sending message via clients'];
 
     function onMessage(e) {
-      assert_equals(e.constructor, frame.contentWindow.MessageEvent, 'message events should use MessageEvent interface.');
+      assert_equals(e.constructor, frame.contentWindow.MessageEvent,
+                    'message events should use MessageEvent interface.');
       assert_equals(e.bubbles, false, 'message events should not bubble.');
-      assert_equals(e.cancelable, false, 'message events should not be cancelable.');
-      assert_equals(e.origin, host_info['HTTPS_ORIGIN'], 'message event\'s origin should be set correctly.');
+      assert_equals(e.cancelable, false,
+                    'message events should not be cancelable.');
+      assert_equals(e.origin, host_info['HTTPS_ORIGIN'],
+                    'message event\'s origin should be set correctly.');
       assert_equals(e.source, sw.controller, 'source should be ServiceWorker.');
 
       var message = e.data;

--- a/service-workers/service-worker/postmessage-to-client.https.html
+++ b/service-workers/service-worker/postmessage-to-client.https.html
@@ -29,11 +29,11 @@ t.step(function() {
     var expected = ['Sending message via clients'];
 
     function onMessage(e) {
+      assert_equals(e.constructor, frame.contentWindow.MessageEvent, 'message events should use MessageEvent interface.');
       assert_equals(e.bubbles, false, 'message events should not bubble.');
       assert_equals(e.cancelable, false, 'message events should not be cancelable.');
       assert_equals(e.origin, host_info['HTTPS_ORIGIN'], 'message event\'s origin should be set correctly.');
-// XXXkhuey fixme!
-//      assert_equals(e.source, sw.controller, 'source should be ServiceWorker.');
+      assert_equals(e.source, sw.controller, 'source should be ServiceWorker.');
 
       var message = e.data;
       if (message === 'quit') {

--- a/service-workers/service-worker/serviceworker-message-event-historical.https.html
+++ b/service-workers/service-worker/serviceworker-message-event-historical.https.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>Service Worker: ServiceWorkerMessageEvent</title>
-<script src="../resources/testharness.js"></script>
-<script src="../resources/testharnessreport.js"></script>
-<script src="resources/test-helpers.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
 <script>
 
 promise_test(function(t) {

--- a/service-workers/service-worker/serviceworker-message-event-historical.https.html
+++ b/service-workers/service-worker/serviceworker-message-event-historical.https.html
@@ -19,17 +19,17 @@ promise_test(function(t) {
           var w = frame.contentWindow;
           var worker = w.navigator.serviceWorker.controller;
           assert_equals(
-              ServiceWorkerMessageEvent, undefined,
-              'ServiceWorkerMessageEvent should not be defined');
+              self.ServiceWorkerMessageEvent, undefined,
+              'ServiceWorkerMessageEvent should not be defined.');
           return new Promise(function(resolve) {
               w.navigator.serviceWorker.onmessage = t.step_func(function(e) {
                   assert_true(
                       e instanceof w.MessageEvent,
-                      'message events should use MessageEvent interface');
+                      'message events should use MessageEvent interface.');
                   assert_true(e.source instanceof w.ServiceWorker);
                   assert_equals(e.type, 'message');
                   assert_equals(e.source, worker,
-                                'Source worker should equal to the controller');
+                                'source should equal to the controller.');
                   assert_equals(e.ports.length, 0);
                   resolve();
                 });

--- a/service-workers/service-worker/serviceworker-message-event-historical.https.html
+++ b/service-workers/service-worker/serviceworker-message-event-historical.https.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Service Worker: ServiceWorkerMessageEvent</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="resources/test-helpers.js"></script>
+<script>
+
+promise_test(function(t) {
+    var scope = 'resources/blank.html';
+    var url = 'resources/postmessage-to-client-worker.js';
+    return service_worker_unregister_and_register(t, url, scope)
+      .then(function(r) {
+          return wait_for_state(t, r.installing, 'activated');
+        })
+      .then(function() {
+          return with_iframe(scope);
+        })
+      .then(function(frame) {
+          var w = frame.contentWindow;
+          var worker = w.navigator.serviceWorker.controller;
+          assert_equals(
+              ServiceWorkerMessageEvent, undefined,
+              'ServiceWorkerMessageEvent should not be defined');
+          return new Promise(function(resolve) {
+              w.navigator.serviceWorker.onmessage = t.step_func(function(e) {
+                  assert_true(
+                      e instanceof w.MessageEvent,
+                      'message events should use MessageEvent interface');
+                  assert_true(e.source instanceof w.ServiceWorker);
+                  assert_equals(e.type, 'message');
+                  assert_equals(e.source, worker,
+                                'Source worker should equal to the controller');
+                  assert_equals(e.ports.length, 0);
+                  resolve();
+                });
+              worker.postMessage('PING');
+            });
+        })
+      .then(function() {
+          return service_worker_unregister_and_done(t, scope);
+        });
+  }, 'Test MessageEvent supplants ServiceWorkerMessageEvent.');
+
+</script>


### PR DESCRIPTION
This adds and updates tests for extending MessageEvent to replace
ServiceWorkerMessageEvent: https://github.com/whatwg/html/pull/1944.
Spec suggests adding ServiceWorker as a type of source attribute.

Changes include:
- Add an assertion to check new MessageEvent({source: serviceWorker})
  - Rename messageevent-constructor.html to
    messageevent-constructor.https.html for SW use
  - Worker context is not covered as navigator.serviceWorker hasn't been
    implemeted yet
- Add assertions to check the message events's interface and source
  value
  - Update postmessage-to-client.https.html
- Add a test to check ServiceWorkerMessageEvent is replaced by
  MessageEvent
  - Add serviceworker-message-event-historical.https.html

Related spec change: https://github.com/whatwg/html/pull/1944

* Service worker spec will incorporate necessary changes when HTML
changes land