### PR TITLE
Upstream 'worker-src' tests.

### DIFF
--- a/content-security-policy/support/ping.js
+++ b/content-security-policy/support/ping.js
@@ -1,0 +1,12 @@
+if (typeof ServiceWorkerGlobalScope === "function") {
+  self.onmessage = function (e) { e.source.postMessage("ping"); };
+} else if (typeof SharedWorkerGlobalScope === "function") {
+  onconnect = function (e) {
+    var port = e.ports[0];
+
+    port.onmessage = function () { port.postMessage("ping"); }
+    port.postMessage("ping");
+  };
+} else if (typeof DedicatedWorkerGlobalScope === "function") {
+  self.postMessage("ping");
+}

--- a/content-security-policy/support/testharness-helper.js
+++ b/content-security-policy/support/testharness-helper.js
@@ -1,0 +1,131 @@
+function assert_no_csp_event_for_url(test, url) {
+  document.addEventListener("securitypolicyviolation", test.step_func(e => {
+    if (e.blockedURI !== url)
+      return;
+    assert_unreached("SecurityPolicyViolation event fired for " + url);
+  }));
+}
+
+function assert_no_event(test, obj, name) {
+  obj.addEventListener(name, test.unreached_func("The '" + name + "' event should not have fired."));
+}
+
+function waitUntilCSPEventForURL(test, url) {
+  return new Promise((resolve, reject) => {
+    document.addEventListener("securitypolicyviolation", test.step_func(e => {
+      if (e.blockedURI == url)
+        resolve(e);
+    }));
+  });
+}
+
+function waitUntilEvent(obj, name) {
+  return new Promise((resolve, reject) => {
+    obj.addEventListener(name, resolve);
+  });
+}
+
+// Given the URL of a worker that pings its opener upon load, this
+// function builds a test that asserts that the ping is received,
+// and that no CSP event fires.
+function assert_worker_is_loaded(url, description) {
+  async_test(t => {
+    assert_no_csp_event_for_url(t, url);
+    var w = new Worker(url);
+    assert_no_event(t, w, "error");
+    waitUntilEvent(w, "message")
+      .then(t.step_func_done(e => {
+        assert_equals(e.data, "ping");
+      }));
+  }, description);
+}
+
+function assert_shared_worker_is_loaded(url, description) {
+  async_test(t => {
+    assert_no_csp_event_for_url(t, url);
+    var w = new SharedWorker(url);
+    assert_no_event(t, w, "error");
+    waitUntilEvent(w.port, "message")
+      .then(t.step_func_done(e => {
+        assert_equals(e.data, "ping");
+      }));
+    w.port.start();
+  }, description);
+}
+
+function assert_service_worker_is_loaded(url, description) {
+  promise_test(t => {
+    assert_no_csp_event_for_url(t, url);
+    return Promise.all([
+      waitUntilEvent(navigator.serviceWorker, "message")
+        .then(e => {
+          assert_equals(e.data, "ping");
+        }),
+      navigator.serviceWorker.register(url, { scope: url })
+        .then(r => {
+          var sw = r.active || r.installing || r.waiting;
+          t.add_cleanup(_ => r.unregister());
+          sw.postMessage("pong?");
+        })
+    ]);
+  }, description);
+}
+
+// Given the URL of a worker that pings its opener upon load, this
+// function builds a test that asserts that the constructor throws
+// a SecurityError, and that a CSP event fires.
+function assert_worker_is_blocked(url, description) {
+  async_test(t => {
+    // If |url| is a blob, it will be stripped down to "blob" for reporting.
+    var reportedURL = new URL(url).protocol == "blob:" ? "blob" : url;
+    waitUntilCSPEventForURL(t, reportedURL)
+      .then(t.step_func_done(e => {
+        assert_equals(e.blockedURI, reportedURL);
+        assert_equals(e.violatedDirective, "worker-src");
+        assert_equals(e.effectiveDirective, "worker-src");
+      }));
+
+    // TODO(mkwst): We shouldn't be throwing here. We should be firing an
+    // `error` event on the Worker. https://crbug.com/663298
+    assert_throws("SecurityError", function () {
+      var w = new Worker(url);
+    });
+  }, description);
+}
+
+function assert_shared_worker_is_blocked(url, description) {
+  async_test(t => {
+    // If |url| is a blob, it will be stripped down to "blob" for reporting.
+    var reportedURL = new URL(url).protocol == "blob:" ? "blob" : url;
+    waitUntilCSPEventForURL(t, reportedURL)
+      .then(t.step_func_done(e => {
+        assert_equals(e.blockedURI, reportedURL);
+        assert_equals(e.violatedDirective, "worker-src");
+        assert_equals(e.effectiveDirective, "worker-src");
+      }));
+
+    // TODO(mkwst): We shouldn't be throwing here. We should be firing an
+    // `error` event on the SharedWorker. https://crbug.com/663298
+    assert_throws("SecurityError", function () {
+      var w = new SharedWorker(url);
+    });
+  }, description);
+}
+
+function assert_service_worker_is_blocked(url, description) {
+  promise_test(t => {
+    assert_no_event(t, navigator.serviceWorker, "message");
+    // If |url| is a blob, it will be stripped down to "blob" for reporting.
+    var reportedURL = new URL(url).protocol == "blob:" ? "blob" : url;
+    return Promise.all([
+      waitUntilCSPEventForURL(t, reportedURL)
+        .then(t.step_func_done(e => {
+          assert_equals(e.blockedURI, reportedURL);
+          assert_equals(e.violatedDirective, "worker-src");
+          assert_equals(e.effectiveDirective, "worker-src");
+        })),
+      promise_rejects(t, "SecurityError", navigator.serviceWorker.register(url, { scope: url }))
+    ]);
+  }, description);
+}
+

--- a/content-security-policy/worker-src/dedicated-child.sub.html
+++ b/content-security-policy/worker-src/dedicated-child.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="child-src http://{{host}}:{{ports[http][0]}} blob:">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_worker_is_loaded(url, "Same-origin dedicated worker allowed by host-source expression.");
+
+  var b = new Blob(["postMessage('ping');"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/dedicated-fallback.sub.html
+++ b/content-security-policy/worker-src/dedicated-fallback.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}} blob:; child-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_worker_is_loaded(url, "Same-origin dedicated worker allowed by host-source expression.");
+
+  var b = new Blob(["postMessage('ping');"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/dedicated-list.sub.html
+++ b/content-security-policy/worker-src/dedicated-list.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}} blob:">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_worker_is_loaded(url, "Same-origin dedicated worker allowed by host-source expression.");
+
+  var b = new Blob(["postMessage('ping');"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/dedicated-none.sub.html
+++ b/content-security-policy/worker-src/dedicated-none.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_worker_is_blocked(url, "Same-origin dedicated worker blocked by host-source expression.");
+
+  var b = new Blob(["postMessage('ping');"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_worker_is_blocked(url, "blob: dedicated worker blocked by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/dedicated-self.sub.html
+++ b/content-security-policy/worker-src/dedicated-self.sub.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'self'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_worker_is_loaded(url, "Same-origin dedicated worker allowed by 'self'.");
+</script>

--- a/content-security-policy/worker-src/service-child.https.sub.html
+++ b/content-security-policy/worker-src/service-child.https.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="child-src http://{{host}}:{{ports[http][0]}}">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_service_worker_is_loaded(url, "Same-origin service worker allowed by host-source expression.");
+</script>
+

--- a/content-security-policy/worker-src/service-fallback.https.sub.html
+++ b/content-security-policy/worker-src/service-fallback.https.sub.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}}; child-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_service_worker_is_loaded(url, "Same-origin service worker allowed by host-source expression.");
+</script>

--- a/content-security-policy/worker-src/service-list.https.sub.html
+++ b/content-security-policy/worker-src/service-list.https.sub.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}}">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_service_worker_is_loaded(url, "Same-origin service worker allowed by host-source expression.");
+</script>

--- a/content-security-policy/worker-src/service-none.https.sub.html
+++ b/content-security-policy/worker-src/service-none.https.sub.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_service_worker_is_blocked(url, "Same-origin service worker blocked by 'none'.");
+</script>

--- a/content-security-policy/worker-src/service-self.https.sub.html
+++ b/content-security-policy/worker-src/service-self.https.sub.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'self'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_service_worker_is_loaded(url, "Same-origin service worker allowed by 'self'.");
+</script>

--- a/content-security-policy/worker-src/shared-child.sub.html
+++ b/content-security-policy/worker-src/shared-child.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="child-src http://{{host}}:{{ports[http][0]}} blob:">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_shared_worker_is_loaded(url, "Same-origin dedicated worker allowed by 'self'.");
+
+  var b = new Blob(["onconnect = e => { e.ports[0].postMessage('ping'); }"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_shared_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/shared-fallback.sub.html
+++ b/content-security-policy/worker-src/shared-fallback.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}} blob:; child-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_shared_worker_is_loaded(url, "Same-origin dedicated worker allowed by 'self'.");
+
+  var b = new Blob(["onconnect = e => { e.ports[0].postMessage('ping'); }"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_shared_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/shared-list.sub.html
+++ b/content-security-policy/worker-src/shared-list.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src http://{{host}}:{{ports[http][0]}} blob:">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_shared_worker_is_loaded(url, "Same-origin dedicated worker allowed by 'self'.");
+
+  var b = new Blob(["onconnect = e => { e.ports[0].postMessage('ping'); }"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_shared_worker_is_loaded(url, "blob: dedicated worker allowed by 'blob:'.");
+</script>

--- a/content-security-policy/worker-src/shared-none.sub.html
+++ b/content-security-policy/worker-src/shared-none.sub.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'none'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_shared_worker_is_blocked(url, "Same-origin shared worker blocked by 'none'.");
+
+  var b = new Blob(["onconnect = e => { e.ports[0].postMessage('ping'); }"], {type: "text/javascript"});
+  var url = URL.createObjectURL(b);
+  assert_shared_worker_is_blocked(url, "blob: shared worker blocked by 'none'.");
+</script>

--- a/content-security-policy/worker-src/shared-self.sub.html
+++ b/content-security-policy/worker-src/shared-self.sub.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../support/testharness-helper.js"></script>
+<meta http-equiv="Content-Security-Policy" content="worker-src 'self'">
+<script>
+  var url = new URL("../support/ping.js", document.baseURI).toString();
+  assert_shared_worker_is_loaded(url, "Same-origin dedicated worker allowed by 'self'.");
+</script>
+


### PR DESCRIPTION
This patch upstreams Blink tests from [1] for the 'worker-src'
CSP directive. The only changes are mechanical, shifting directory
structure, and changing explicit hostnames to wptserve pipes.

[1]: https://codereview.chromium.org/2480303002