### PR TITLE
Added various features to permit running of tests by others

### DIFF
--- a/annotation-model/annotations/annotationOptionals.test
+++ b/annotation-model/annotations/annotationOptionals.test
@@ -3,6 +3,7 @@
   "name": "Annotation implements optional keys and meets optional key value constraints",
   "description": "Web Annotations: <ul> <li>Should include certain properties (keys)</li> <li>May include additional keys</li> <li>should have Annotation key values that conform to model recommended constraints</li> </ul> Note: failing an assertion indicates that a recommended or optional feature has not been implemented or has not been implemented correctly.",
   "testType": "manual",
+  "skipFailures": [ "should", "may" ],
   "ref": "https://www.w3.org/TR/annotation-model/#other-properties",
   "assertions": [
     "annotations/3.3.1-annotationSingleCreatorImplemented.json",

--- a/annotation-model/annotations/annotationsAgentOptionals.test
+++ b/annotation-model/annotations/annotationsAgentOptionals.test
@@ -3,6 +3,7 @@
   "name": "Annotation implements optional keys and meets optional key value constraints for Creator and Generator Agents",
   "description": "Agents (Creators, Generators) involved in an Annotation: <ul> <li>Should include certain properties (keys)</li> <li>May include additional keys</li> <li>should have Agent key values that conform to model recommended constraints</li> </ul> Note: failing an assertion indicates that a recommended or optional feature has not been implemented or has not been implemented correctly.",
   "testType": "manual",
+  "skipFailures": [ "should", "may" ],
   "ref": "https://www.w3.org/TR/annotation-model/#other-properties",
   "assertions":
   [

--- a/annotation-model/definitions/collections.json
+++ b/annotation-model/definitions/collections.json
@@ -291,12 +291,8 @@
       "type": "object",
       "properties": {"partOf":
         { "oneOf": [
-          { "$ref": "id.json#/definitions/stringUri" },
-          { "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "items": { "$ref": "id.json#/definitions/stringUri" }
-          }
+          { "$ref": "id.json#/definitions/arraySingleStringUri" },
+          { "$ref": "id.json#/definitions/idValueFound" }
          ]
         }
       }

--- a/annotation-protocol/files/annotations/cors.headers
+++ b/annotation-protocol/files/annotations/cors.headers
@@ -1,4 +1,4 @@
-Access-Control-Allow-Headers: Content-Type, Prefer
+Access-Control-Allow-Headers: Content-Type, Prefer, If-Match
 Access-Control-Allow-Methods: GET,HEAD,OPTIONS,DELETE,PUT
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: ETag, Allow, Vary, Link, Content-Type, Location, Content-Location, Prefer

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -229,6 +229,9 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
+      if ("object" === typeof(f) && f.hasOwnProperty('id')) {
+        f = f.id;
+      }
       if (f !== undefined && f !== "") {
         request("GET", f).then(function(lres) {
           assert_true(('partOf' in lres.body) || ('id' in lres.body.partOf), "No partOf in response");
@@ -242,6 +245,9 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var l = res.body.last;
+      if ("object" === typeof(l) && l.hasOwnProperty('id')) {
+        l = l.id;
+      }
       request("GET", l).then(function(lres) {
         assert_true(('prev' in lres.body), "No link to the previous page in response");
         });
@@ -251,6 +257,9 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
+      if ("object" === typeof(f) && f.hasOwnProperty('id')) {
+        f = f.id;
+      }
       request("GET", f).then(function(lres) {
         assert_true(('next' in lres.body), "No link to the next page in response");
         });
@@ -265,7 +274,7 @@ function runTests( container_url, annotation_url ) {
       { header: 'Allow', pat: /HEAD/, assertion: "Annotations MUST support HEAD (check Allow on GET)" },
       { header: 'Allow', pat: /OPTIONS/, assertion: "Annotations MUST support OPTIONS (check Allow on GET)" },
       { header: 'Content-Type', pat: MEDIA_TYPE_REGEX, assertion: 'Annotations MUST have a Content-Type header with the application/ld+json media type'},
-      { header: 'Link', string: '<http://www.w3.org/ns/ldp#Resource>; rel="type"', assertion: 'Annotations MUST have a Link header entry where the target IRI is http://www.w3.org/ns/ldp#Resource and the rel parameter value is type'},
+      { header: 'Link', pat: /<http:\/\/www.w3.org\/ns\/ldp#Resource>;[ ]*rel[ ]*=[ ]*"type"/, assertion: 'Annotations MUST have a Link header entry where the target IRI is http://www.w3.org/ns/ldp#Resource and the rel parameter value is type'},
       { header: 'ETag', pat: /(.*)/, assertion: 'Annotations MUST have an ETag header'},
       { header: 'Vary', pat: /Accept/, assertion: 'Annotations MUST have a Vary header with Accept in the value'},
       ] );

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -379,11 +379,11 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
           if (fres.body.items.length) {
             var looksGood = true;
             fres.body.items.forEach(function(item) {
-              if (!item.hasOwnProperty("@context")) {
+              if (!item.hasOwnProperty("type")) {
                 looksGood = false;
               }
             });
-            assert_true(looksGood, "All annotations in returned page contain @context");
+            assert_true(looksGood, "All annotations in returned page contain type Annotation");
           } else {
             assert_true(false, "Returned page contains annotations");
           }

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -318,6 +318,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   // this will get populated when evaluating the creation
 
   var createdAnnotation = null;
+  var createdEtag = null;
 
   theCreation.then(function(res) {
     if (res && typeof res === "object" && res.body && typeof res.body === "object" && res.body.id && typeof res.body.id === "string") {
@@ -339,9 +340,10 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
 
   promise_test(function() {
     return theCreation.then(function(res) {
-      return request("PUT", fixURI(res.body.id), [['Content-Type', MEDIA_TYPE]], theModifiedAnnotation)
+      createdEtag = res.xhr.getResponseHeader("ETag") ;
+      return request("PUT", fixURI(res.body.id), [['Content-Type', MEDIA_TYPE], ['If-Match', createdEtag]], theModifiedAnnotation)
         .then(function(lres) {
-          assert_equals(lres.body.target, newAnnotation.target, "Annotation did not update");
+          assert_equals(lres.body.target, theModifiedAnnotation.target, "Annotation did not update");
         })
         .catch(function(err) {
           assert_true(false, "Update of annotation failed");
@@ -350,7 +352,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   }, "Annotation update must be done with the PUT method");
 
   promise_test(function() {
-    var theDeletion = request("DELETE", fixURI(createdAnnotation));
+    var theDeletion = request("DELETE", fixURI(createdAnnotation), [['If-Match', createdEtag]] );
     return theDeletion.then(function(lres) {
       assert_equals(lres.status, 204, "DELETE of " + createdAnnotation + " did not return a 204 Status" );
     });
@@ -489,7 +491,7 @@ annotations within the container
 under test must permit access to the Allow, Content-Location, Content-Type, ETag, Link, Location, Prefer, and Vary headers.
 Correct CORS access can be achieved with headers like:</p>
 <pre>
-Access-Control-Allow-Headers: Content-Type, Prefer
+Access-Control-Allow-Headers: Content-Type, Prefer, If-Match
 Access-Control-Allow-Methods: GET,HEAD,OPTIONS,DELETE,PUT
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: ETag, Allow, Vary, Link, Content-Type, Location, Content-Location, Prefer

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -309,6 +309,16 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       "type": "TextualBody",
       "value": "I like this page!"
     },
+    "target": TARGET
+  };
+
+  var theAnnotationCanonical = {
+    "@context": "http://www.w3.org/ns/anno.jsonld",
+    "type": "Annotation",
+    "body": {
+      "type": "TextualBody",
+      "value": "I like this page with canonical property!"
+    },
     "target": TARGET,
     "canonical": 'urn:uuid:' + token()
   };
@@ -328,7 +338,6 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
   makePromiseTests( theCreation, [
       { test: function(res) { return ('id' in res.body); }, assertion: "Created Annotation MUST have an id property" },
       { test: function(res) { return (('id' in res.body) && (res.body.id.search(container_url) > -1));}, assertion: "Created Annotation MUST have an id that starts with the Container IRI" },
-      { test: function(res) { return ( 'canonical' in res.body && res.body.canonical === theAnnotation.canonical ); }, assertion: "Created Annotation MUST preserve any canonical IRI" },
       { test: function(res) { return ( res.status === 201 ) ; }, assertion: "Annotation Server MUST respond with a 201 Created code if the creation is successful" },
       { header: "Location", test: function(res) {
           if (res && typeof res === "object" && res.body && typeof res.body === "object" && res.body.id && typeof res.body.id === "string") {
@@ -358,6 +367,26 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       assert_equals(lres.status, 204, "DELETE of " + createdAnnotation + " did not return a 204 Status" );
     });
   }, "Annotation deletion with DELETE method MUST return a 204 status" );
+
+  var theCreationCanonical = request("POST", container, [ [ 'Content-Type', MEDIA_TYPE ] ], theAnnotationCanonical);
+
+  var createdAnnotationCanonical = null;
+
+  theCreationCanonical.then(function(res) {
+    if (res && typeof res === "object" && res.body && typeof res.body === "object" && res.body.id && typeof res.body.id === "string") {
+      createdAnnotationCanonical = res.body.id;
+    }
+  });
+
+  makePromiseTests( theCreationCanonical, [
+      { test: function(res) { return ( 'canonical' in res.body && res.body.canonical === theAnnotationCanonical.canonical ); }, assertion: "Created Annotation MUST preserve any canonical IRI" },
+      { test: function(res) {
+                              if ( res.status === 201 ) {
+                                // the annotation was created... clean it up
+                                request("DELETE", fixURI(res.body.id));
+                              }
+                              return ( res.status === 201 ) ; }, assertion: "Annotation Server MUST respond with a 201 Created code if the creation is successful" },
+      ]);
 
   // SHOULD tests
 

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -63,7 +63,9 @@ function request(method, url, headers, content) {
         resp.text = d;
         // we have it; what is it?
         var type = xhr.getResponseHeader('Content-Type');
-        resp.type = type.split(';')[0];
+        if (type && "string" === typeof type) {
+          resp.type = type.split(';')[0];
+        }
         if (resp.type === MEDIA_TYPE) {
           try {
             d = JSON.parse(d);
@@ -313,12 +315,27 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
 
   var theCreation = request("POST", container, [ [ 'Content-Type', MEDIA_TYPE ] ], theAnnotation);
 
+  // this will get populated when evaluating the creation
+
+  var createdAnnotation = null;
+
+  theCreation.then(function(res) {
+    if (res && typeof res === "object" && res.body && typeof res.body === "object" && res.body.id && typeof res.body.id === "string") {
+      createdAnnotation = res.body.id;
+    }
+  });
+
   makePromiseTests( theCreation, [
       { test: function(res) { return ('id' in res.body); }, assertion: "Created Annotation MUST have an id property" },
       { test: function(res) { return (('id' in res.body) && (res.body.id.search(container_url) > -1));}, assertion: "Created Annotation MUST have an id that starts with the Container IRI" },
       { test: function(res) { return ( 'canonical' in res.body && res.body.canonical === theAnnotation.canonical ); }, assertion: "Created Annotation MUST preserve any canonical IRI" },
       { test: function(res) { return ( res.status === 201 ) ; }, assertion: "Annotation Server MUST respond with a 201 Created code if the creation is successful" },
-      { header: "Location", test: function(res) { return res.body.id === res.xhr.getResponseHeader('location') ; } , assertion: "Location header SHOULD match the id of the new Annotation" },
+      { header: "Location", test: function(res) {
+          if (res && typeof res === "object" && res.body && typeof res.body === "object" && res.body.id && typeof res.body.id === "string") {
+            createdAnnotation = res.body.id;
+          }
+          return res.body.id === res.xhr.getResponseHeader('location') ;
+        } , assertion: "Location header SHOULD match the id of the new Annotation" },
       ]);
 
   promise_test(function() {
@@ -336,11 +353,9 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
   }, "Annotation update must be done with the PUT method");
 
   promise_test(function() {
-    return theCreation.then(function(res) {
-      request("DELETE", fixURI(res.body.id))
-        .then(function(lres) {
-          assert_equals(lres.status, 204, "DELETE of " + res.body.id + " did not return a 204 Status" );
-        });
+    var theDeletion = request("DELETE", fixURI(createdAnnotation));
+    return theDeletion.then(function(lres) {
+      assert_equals(lres.status, 204, "DELETE of " + createdAnnotation + " did not return a 204 Status" );
     });
   }, "Annotation deletion with DELETE method MUST return a 204 status" );
 
@@ -357,14 +372,24 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
     return thePrefRequest
       .then(function(res) {
         var f = res.body.first;
-        request("GET", fixURI(f)).then(function(fres) {
-          fres.body.items.forEach(function(item) {
-            assert_true('@context' in item, "Annotation does not contain `@context`");
+        if ("object" === typeof(f) && f.hasOwnProperty('id')) {
+          f = f.id;
+        }
+        return request("GET", fixURI(f)).then(function(fres) {
+          if (fres.body.items.length) {
+            var looksGood = true;
+            fres.body.items.forEach(function(item) {
+              if (!item.hasOwnProperty("@context")) {
+                looksGood = false;
+              }
             });
-          });
+            assert_true(looksGood, "All annotations in returned page contain @context");
+          } else {
+            assert_true(false, "Returned page contains annotations");
+          }
         });
       }, "SHOULD return the full annotation descriptions");
-
+  });
 
   makePromiseTests( thePrefRequest, [
       { test: function(res) { return ('total' in res.body); }, assertion: "SHOULD include the total property with the total number of annotations in the container" },

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -241,7 +241,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
         f = f.id;
       }
       if (f !== undefined && f !== "") {
-        request("GET", f).then(function(lres) {
+        request("GET", fixURI(f)).then(function(lres) {
           assert_true(('partOf' in lres.body) || ('id' in lres.body.partOf), "No partOf in response");
           });
       } else {
@@ -256,7 +256,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       if ("object" === typeof(l) && l.hasOwnProperty('id')) {
         l = l.id;
       }
-      request("GET", l).then(function(lres) {
+      request("GET", fixURI(l)).then(function(lres) {
         assert_true(('prev' in lres.body), "No link to the previous page in response");
         });
     });
@@ -268,7 +268,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       if ("object" === typeof(f) && f.hasOwnProperty('id')) {
         f = f.id;
       }
-      request("GET", f).then(function(lres) {
+      request("GET", fixURI(f)).then(function(lres) {
         assert_true(('next' in lres.body), "No link to the next page in response");
         });
     });

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -2,6 +2,14 @@
 <html>
 <head>
 <title>Annotation Protocol Must Tests</title>
+<link rel="stylesheet" href="/resources/testharness.css">
+<style>
+.validationError {
+  color: white;
+  background: red;
+  padding-left: 1em;
+}
+</style>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/utils.js"></script>
@@ -168,7 +176,7 @@ function makePromiseTests( thennable, criteria ) {
   });
 }
 
-function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TARGET ) {
+function runTests( container_url, annotation_url, query_string, theAnnotation, theModifiedAnnotation ) {
 
   var fixURI = function(uri) {
     if (query_string && query_string !== "") {
@@ -199,7 +207,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       { header: 'Allow', pat: /HEAD/, assertion: "Containers MUST support HEAD (check Allow on GET)" },
       { header: 'Allow', pat: /OPTIONS/, assertion: "Containers MUST support OPTIONS (check Allow on GET)" },
       { header: 'Content-Type', pat: MEDIA_TYPE_REGEX, assertion: 'Containers MUST have a Content-Type header with the application/ld+json media type'},
-      { header: 'Content-Type', pat: MEDIA_TYPE_REGEX, assertion: 'Containers MUST response with the JSON-LD representation (by default)'},
+      { header: 'Content-Type', pat: MEDIA_TYPE_REGEX, assertion: 'Containers MUST respond with the JSON-LD representation (by default)'},
       { test: function(res) { return ( 'type' in res.body && res.body.type.indexOf('BasicContainer') > -1 ); }, assertion: 'Containers MUST return a description of the container with BasicContainer' },
       { test: function(res) { return ( 'type' in res.body && res.body.type.indexOf('AnnotationCollection') > -1 ); }, assertion: 'Containers MUST return a description of the container with AnnotationCollection' },
       { header: 'Link', pat: /(.*)/, assertion: 'Containers MUST return a Link header (rfc5988) on all responses' },
@@ -302,26 +310,8 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
 
   // creation and deletion tests
 
-  var theAnnotation = {
-    "@context": "http://www.w3.org/ns/anno.jsonld",
-    "type": "Annotation",
-    "body": {
-      "type": "TextualBody",
-      "value": "I like this page!"
-    },
-    "target": TARGET
-  };
-
-  var theAnnotationCanonical = {
-    "@context": "http://www.w3.org/ns/anno.jsonld",
-    "type": "Annotation",
-    "body": {
-      "type": "TextualBody",
-      "value": "I like this page with canonical property!"
-    },
-    "target": TARGET,
-    "canonical": 'urn:uuid:' + token()
-  };
+  var theAnnotationCanonical = theAnnotation;
+  theAnnotationCanonical.canonical = 'urn:uuid:' + token();
 
   var theCreation = request("POST", container, [ [ 'Content-Type', MEDIA_TYPE ] ], theAnnotation);
 
@@ -349,9 +339,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
 
   promise_test(function() {
     return theCreation.then(function(res) {
-      var newAnnotation = res.body ;
-      newAnnotation.target = OTHER_TARGET ;
-      return request("PUT", fixURI(res.body.id), [['Content-Type', MEDIA_TYPE]], newAnnotation)
+      return request("PUT", fixURI(res.body.id), [['Content-Type', MEDIA_TYPE]], theModifiedAnnotation)
         .then(function(lres) {
           assert_equals(lres.body.target, newAnnotation.target, "Annotation did not update");
         })
@@ -385,7 +373,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
                                 // the annotation was created... clean it up
                                 request("DELETE", fixURI(res.body.id));
                               }
-                              return ( res.status === 201 ) ; }, assertion: "Annotation Server MUST respond with a 201 Created code if the creation is successful" },
+                              return ( res.status === 201 ) ; }, assertion: "Annotation Server MUST respond with a 201 Created code if the creation with a canonical URI is successful" },
       ]);
 
   // SHOULD tests
@@ -442,24 +430,54 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
 // set up an event handler one the document is loaded that will run the tests once we
 // have a URI to run against
 on_event(document, "DOMContentLoaded", function() {
-    var serverURI = document.getElementById("uri") ;
-    var annotationURI = document.getElementById("annotation") ;
-    var queryString = document.getElementById("query") ;
-    var targetString = document.getElementById("target") ;
-    var otherTargetString = document.getElementById("other") ;
-    var runButton = document.getElementById("endpoint-submit-button") ;
-    on_event(runButton, "click", function() {
-        // user clicked
-        var URI = serverURI.value;
-        var ANN = annotationURI.value;
-        var QUERY = query.value;
-        runButton.disabled = true;
+  var serverURI = document.getElementById("uri") ;
+  var annotationURI = document.getElementById("annotation") ;
+  var queryString = document.getElementById("query") ;
+  var anno1 = document.getElementById("anno1") ;
+  var anno2 = document.getElementById("anno2") ;
+  var runButton = document.getElementById("endpoint-submit-button") ;
+  var msg = document.getElementById("message");
+  on_event(runButton, "click", function() {
+    msg.innerHTML = "";
+    // user clicked
+    var URI = serverURI.value;
+    var ANN = annotationURI.value;
+    var QUERY = query.value;
+    var errors = "";
+    var anno1val;
+    var anno2val;
 
-        // okay, they clicked.  run the tests with that URI
-        runTests(URI, ANN, QUERY, targetString.value, otherTargetString.value);
-        done();
-        });
-    });
+    if (URI === "") {
+      errors += "<p>Server URI is empty<\/p>";
+    }
+
+    if (ANN === "") {
+      errors += "<p>Annotation URI is empty<\/p>";
+    }
+
+    try {
+      anno1val = JSON.parse(anno1.value);
+    }
+    catch(err) {
+      errors += "<p class='validationError'>Creation Annotation JSON Parsing failed: " + err + "<\/p>";
+    }
+
+    try {
+      anno2val = JSON.parse(anno2.value);
+    }
+    catch(err) {
+      errors += "<p class='validationError'>Modification Annotation JSON Parsing failed: " + err + "<\/p>";
+    }
+
+    if (errors !== "") {
+      msg.innerHTML = "<div class='validationError'>" + errors + "<\/div>";
+    } else {
+      // okay, they clicked.  run the tests with that URI
+      runTests(URI, ANN, QUERY, anno1val, anno2val);
+      done();
+    }
+  });
+});
 </script>
 </head>
 <body>
@@ -476,14 +494,36 @@ Access-Control-Allow-Methods: GET,HEAD,OPTIONS,DELETE,PUT
 Access-Control-Allow-Origin: *
 Access-Control-Expose-Headers: ETag, Allow, Vary, Link, Content-Type, Location, Content-Location, Prefer
 </pre>
+<div id="log"></div>
 <p>Provide endpoint and annotation URIs and select "Go" to start testing.</p>
+<div id="message"></div>
 <form name="endpoint">
+  <p><strong>Required parameters:</strong></p>
   <p><label for="uri">Endpoint URI:</label> <input type="text" size="50" id="uri" name="uri"></p>
   <p><label for="annotation">Annotation URI:</label> <input type="text" size="50" id="annotation" name="annotation"></p>
+  <p><input type="button" id="endpoint-submit-button" value="Go"></p>
+  <p><strong>Tunable parameters (rarely required):</strong></p>
   <p><label for="query">Additional URI parameters:</label> <input type="text" size="50" id="query" name="query"></p>
-  <p><label for="target">Target for created annotation:</label> <input type="text" size="50" id="target" name="target" value="http://www.example.com/index.html"></p>
-  <p><label for="other">Target for modified annotation:</label> <input type="text" size="50" id="other" name="other" value="http://www.example.com/other.html"></p>
-  <input type="button" id="endpoint-submit-button" value="Go">
+  <p><label for="anno1">Annotation to submit for creation tests:</label></p>
+  <textarea name="anno1" id="anno1" rows="9" style="width: 90%">{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "body": {
+    "type": "TextualBody",
+    "value": "I like this page!"
+  },
+  "target": "http://www.example.com/index.html"
+}</textarea>
+  <p><label for="anno2">Annotation to submit for modification tests:</label></p>
+  <textarea name="anno2" id="anno2" rows="9" style="width: 90%">{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "body": {
+    "type": "TextualBody",
+    "value": "I like this page!"
+  },
+  "target": "http://www.example.com/other.html"
+}</textarea>
 </form>
 </body>
 </html>

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -235,8 +235,11 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
-      if (f && f !== '') {
-        request("GET", fixURI(f)).then(function(lres) {
+      if ("object" === typeof(f) && f.hasOwnProperty('id')) {
+        f = f.id;
+      }
+      if (f !== undefined && f !== "") {
+        request("GET", f).then(function(lres) {
           assert_true(('partOf' in lres.body) || ('id' in lres.body.partOf), "No partOf in response");
           });
       } else {
@@ -248,7 +251,10 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
   promise_test(function() {
     return theContainer.then(function(res) {
       var l = res.body.last;
-      request("GET", fixURI(l)).then(function(lres) {
+      if ("object" === typeof(l) && l.hasOwnProperty('id')) {
+        l = l.id;
+      }
+      request("GET", l).then(function(lres) {
         assert_true(('prev' in lres.body), "No link to the previous page in response");
         });
     });
@@ -257,7 +263,10 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
-      request("GET", fixURI(f)).then(function(lres) {
+      if ("object" === typeof(f) && f.hasOwnProperty('id')) {
+        f = f.id;
+      }
+      request("GET", f).then(function(lres) {
         assert_true(('next' in lres.body), "No link to the next page in response");
         });
     });
@@ -271,7 +280,7 @@ function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TA
       { header: 'Allow', pat: /HEAD/, assertion: "Annotations MUST support HEAD (check Allow on GET)" },
       { header: 'Allow', pat: /OPTIONS/, assertion: "Annotations MUST support OPTIONS (check Allow on GET)" },
       { header: 'Content-Type', pat: MEDIA_TYPE_REGEX, assertion: 'Annotations MUST have a Content-Type header with the application/ld+json media type'},
-      { header: 'Link', string: '<http://www.w3.org/ns/ldp#Resource>; rel="type"', assertion: 'Annotations MUST have a Link header entry where the target IRI is http://www.w3.org/ns/ldp#Resource and the rel parameter value is type'},
+      { header: 'Link', pat: /<http:\/\/www.w3.org\/ns\/ldp#Resource>;[ ]*rel[ ]*=[ ]*"type"/, assertion: 'Annotations MUST have a Link header entry where the target IRI is http://www.w3.org/ns/ldp#Resource and the rel parameter value is type'},
       { header: 'ETag', pat: /(.*)/, assertion: 'Annotations MUST have an ETag header'},
       { header: 'Vary', pat: /Accept/, assertion: 'Annotations MUST have a Vary header with Accept in the value'},
       ] );

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -63,22 +63,16 @@ function request(method, url, headers, content) {
         resp.text = d;
         // we have it; what is it?
         var type = xhr.getResponseHeader('Content-Type');
-        if (type) {
-          resp.type = type.split(';')[0];
-          if (resp.type === MEDIA_TYPE) {
-            try {
-              d = JSON.parse(d);
-              resp.body = d;
-            }
-            catch(err) {
-              resp.body = null;
-            }
+        resp.type = type.split(';')[0];
+        if (resp.type === MEDIA_TYPE) {
+          try {
+            d = JSON.parse(d);
+            resp.body = d;
           }
-        } else {
-          resp.type = null;
-          resp.body = null;
+          catch(err) {
+            resp.body = null;
+          }
         }
-
       }
       resolve(resp);
     };
@@ -172,10 +166,22 @@ function makePromiseTests( thennable, criteria ) {
   });
 }
 
-function runTests( container_url, annotation_url ) {
-  // trim whitespace from incoming variables
-  container_url = container_url.trim();
-  annotation_url = annotation_url.trim();
+function runTests( container_url, annotation_url, query_string, TARGET, OTHER_TARGET ) {
+
+  var fixURI = function(uri) {
+    if (query_string && query_string !== "") {
+      if (uri.indexOf('?') > -1) {
+        uri += "&" + query_string;
+      } else {
+        uri += "?" + query_string;
+      }
+    }
+    return uri;
+  };
+
+  var container = fixURI(container_url);
+  var annotation = fixURI(annotation_url);
+
 
   // Section 4 has a requirement that the URL end in a slash, so...
   // ensure the url has a length
@@ -184,7 +190,7 @@ function runTests( container_url, annotation_url ) {
   }, 'Container MUST end in a "/" character');
 
   // Container tests
-  var theContainer = request("GET", container_url);
+  var theContainer = request("GET", container);
 
   makePromiseTests( theContainer, [
       { header: 'Allow', pat: /GET/, assertion: "Containers MUST support GET (check Allow on GET)" },
@@ -207,13 +213,13 @@ function runTests( container_url, annotation_url ) {
 
 
   promise_test(function() {
-      return request("HEAD", container_url).then(function(res) {
+      return request("HEAD", container).then(function(res) {
           assert_equals(res.status, 200, "HEAD request returned " + res.status);
           });
       }, "Containers MUST support HEAD method");
 
   promise_test(function() {
-      return request("OPTIONS", container_url).then(function(res) {
+      return request("OPTIONS", container).then(function(res) {
           assert_equals(res.status, 200, "OPTIONS request returned " + res.status);
           });
       }, "Containers MUST support OPTIONS method");
@@ -229,8 +235,8 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
-      if (f !== undefined && f !== "") {
-        request("GET", f).then(function(lres) {
+      if (f && f !== '') {
+        request("GET", fixURI(f)).then(function(lres) {
           assert_true(('partOf' in lres.body) || ('id' in lres.body.partOf), "No partOf in response");
           });
       } else {
@@ -242,7 +248,7 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var l = res.body.last;
-      request("GET", l).then(function(lres) {
+      request("GET", fixURI(l)).then(function(lres) {
         assert_true(('prev' in lres.body), "No link to the previous page in response");
         });
     });
@@ -251,14 +257,14 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
-      request("GET", f).then(function(lres) {
+      request("GET", fixURI(f)).then(function(lres) {
         assert_true(('next' in lres.body), "No link to the next page in response");
         });
     });
   }, "Annotation Pages MUST have a link to the next page in the sequence, using the next property (if not the last page)");
 
   // Annotation Tests
-  var theRequest = request("GET", annotation_url);
+  var theRequest = request("GET", annotation);
 
   makePromiseTests( theRequest, [
       { header: 'Allow', pat: /GET/, assertion: "Annotations MUST support GET (check Allow on GET)" },
@@ -271,13 +277,13 @@ function runTests( container_url, annotation_url ) {
       ] );
 
   promise_test(function() {
-    return request("HEAD", annotation_url).then(function(res) {
+    return request("HEAD", annotation).then(function(res) {
       assert_equals(res.status, 200, "HEAD request returned " + res.status);
       });
     }, "Annotations MUST support HEAD method");
 
   promise_test(function() {
-    return request("OPTIONS", annotation_url).then(function(res) {
+    return request("OPTIONS", annotation).then(function(res) {
         assert_equals(res.status, 200, "OPTIONS request returned " + res.status);
       });
     }, "Annotations MUST support OPTIONS method");
@@ -292,11 +298,11 @@ function runTests( container_url, annotation_url ) {
       "type": "TextualBody",
       "value": "I like this page!"
     },
-    "target": "http://www.example.com/index.html",
+    "target": TARGET,
     "canonical": 'urn:uuid:' + token()
   };
 
-  var theCreation = request("POST", container_url, [ [ 'Content-Type', MEDIA_TYPE ] ], theAnnotation);
+  var theCreation = request("POST", container, [ [ 'Content-Type', MEDIA_TYPE ] ], theAnnotation);
 
   makePromiseTests( theCreation, [
       { test: function(res) { return ('id' in res.body); }, assertion: "Created Annotation MUST have an id property" },
@@ -309,8 +315,8 @@ function runTests( container_url, annotation_url ) {
   promise_test(function() {
     return theCreation.then(function(res) {
       var newAnnotation = res.body ;
-      newAnnotation.target = "http://other.example/";
-      return request("PUT", res.body.id, [['Content-Type', MEDIA_TYPE]], newAnnotation)
+      newAnnotation.target = OTHER_TARGET ;
+      return request("PUT", fixURI(res.body.id), [['Content-Type', MEDIA_TYPE]], newAnnotation)
         .then(function(lres) {
           assert_equals(lres.body.target, newAnnotation.target, "Annotation did not update");
         })
@@ -322,7 +328,7 @@ function runTests( container_url, annotation_url ) {
 
   promise_test(function() {
     return theCreation.then(function(res) {
-      request("DELETE", res.body.id)
+      request("DELETE", fixURI(res.body.id))
         .then(function(lres) {
           assert_equals(lres.status, 204, "DELETE of " + res.body.id + " did not return a 204 Status" );
         });
@@ -332,17 +338,17 @@ function runTests( container_url, annotation_url ) {
   // SHOULD tests
 
   test(function() {
-    assert_equals(container_url.toLowerCase().substr(0,5), "https", "Server is not using HTTPS");
+    assert_equals("https", container_url.toLowerCase().substr(0,5), "Server is not using HTTPS");
     }, "Annotation server SHOULD use HTTPS rather than HTTP");
 
-  var thePrefRequest = request("GET", container_url,
+  var thePrefRequest = request("GET", container,
       [['Prefer', 'return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"']]);
 
   promise_test(function() {
     return thePrefRequest
       .then(function(res) {
         var f = res.body.first;
-        request("GET", f).then(function(fres) {
+        request("GET", fixURI(f)).then(function(fres) {
           fres.body.items.forEach(function(item) {
             assert_true('@context' in item, "Annotation does not contain `@context`");
             });
@@ -375,15 +381,19 @@ function runTests( container_url, annotation_url ) {
 on_event(document, "DOMContentLoaded", function() {
     var serverURI = document.getElementById("uri") ;
     var annotationURI = document.getElementById("annotation") ;
+    var queryString = document.getElementById("query") ;
+    var targetString = document.getElementById("target") ;
+    var otherTargetString = document.getElementById("other") ;
     var runButton = document.getElementById("endpoint-submit-button") ;
     on_event(runButton, "click", function() {
         // user clicked
         var URI = serverURI.value;
         var ANN = annotationURI.value;
+        var QUERY = query.value;
         runButton.disabled = true;
 
         // okay, they clicked.  run the tests with that URI
-        runTests(URI, ANN);
+        runTests(URI, ANN, QUERY, targetString.value, otherTargetString.value);
         done();
         });
     });
@@ -406,7 +416,10 @@ Access-Control-Expose-Headers: ETag, Allow, Vary, Link, Content-Type, Location, 
 <p>Provide endpoint and annotation URIs and select "Go" to start testing.</p>
 <form name="endpoint">
   <p><label for="uri">Endpoint URI:</label> <input type="text" size="50" id="uri" name="uri"></p>
-  <p><label for="uri">Annotation URI:</label> <input type="text" size="50" id="annotation" name="annotation"></p>
+  <p><label for="annotation">Annotation URI:</label> <input type="text" size="50" id="annotation" name="annotation"></p>
+  <p><label for="query">Additional URI parameters:</label> <input type="text" size="50" id="query" name="query"></p>
+  <p><label for="target">Target for created annotation:</label> <input type="text" size="50" id="target" name="target" value="http://www.example.com/index.html"></p>
+  <p><label for="other">Target for modified annotation:</label> <input type="text" size="50" id="other" name="other" value="http://www.example.com/other.html"></p>
   <input type="button" id="endpoint-submit-button" value="Go">
 </form>
 </body>

--- a/annotation-protocol/server/server-manual.html
+++ b/annotation-protocol/server/server-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>Annotation Protocol Must Tests</title>
+<title>Annotation Protocol Tests</title>
 <link rel="stylesheet" href="/resources/testharness.css">
 <style>
 .validationError {
@@ -195,6 +195,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
 
   // Section 4 has a requirement that the URL end in a slash, so...
   // ensure the url has a length
+  // TEST 1
   test(function() {
     assert_regexp_match(container_url, /\/$/, 'Container URL did not end in a "/" character');
   }, 'Container MUST end in a "/" character');
@@ -202,6 +203,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   // Container tests
   var theContainer = request("GET", container);
 
+  // TESTS 2-13
   makePromiseTests( theContainer, [
       { header: 'Allow', pat: /GET/, assertion: "Containers MUST support GET (check Allow on GET)" },
       { header: 'Allow', pat: /HEAD/, assertion: "Containers MUST support HEAD (check Allow on GET)" },
@@ -222,12 +224,14 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   ] );
 
 
+  // TEST 14
   promise_test(function() {
       return request("HEAD", container).then(function(res) {
           assert_equals(res.status, 200, "HEAD request returned " + res.status);
           });
       }, "Containers MUST support HEAD method");
 
+  // TEST 15
   promise_test(function() {
       return request("OPTIONS", container).then(function(res) {
           assert_equals(res.status, 200, "OPTIONS request returned " + res.status);
@@ -237,11 +241,13 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   // Container representation tests
 
 
+  // TESTS 16-17
   makePromiseTests( theContainer, [
       { header: 'Content-Location', pat: /(.*)/, assertion: "Containers MUST include a Content-Location header with the IRI as its value" },
       { header: 'Content-Location', test: function(res) { if (res.xhr.getResponseHeader('content-location') === res.body.id ) { return true; } else { return false;} }, assertion: "Container's Content-Location and `id` MUST match" }
       ]);
 
+  // TEST 18
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
@@ -258,6 +264,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
     });
   }, "Annotation Pages must have a link to the container they are part of, using the partOf property");
 
+  // TEST 19
   promise_test(function() {
     return theContainer.then(function(res) {
       var l = res.body.last;
@@ -270,6 +277,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
     });
   }, "Annotation Pages MUST have a link to the previous page in the sequence, using the prev property (if not the first page)");
 
+  // TEST 20
   promise_test(function() {
     return theContainer.then(function(res) {
       var f = res.body.first;
@@ -285,6 +293,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   // Annotation Tests
   var theRequest = request("GET", annotation);
 
+  // TESTS 21-27
   makePromiseTests( theRequest, [
       { header: 'Allow', pat: /GET/, assertion: "Annotations MUST support GET (check Allow on GET)" },
       { header: 'Allow', pat: /HEAD/, assertion: "Annotations MUST support HEAD (check Allow on GET)" },
@@ -295,12 +304,14 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
       { header: 'Vary', pat: /Accept/, assertion: 'Annotations MUST have a Vary header with Accept in the value'},
       ] );
 
+  // TEST 28
   promise_test(function() {
     return request("HEAD", annotation).then(function(res) {
       assert_equals(res.status, 200, "HEAD request returned " + res.status);
       });
     }, "Annotations MUST support HEAD method");
 
+  // TEST 29
   promise_test(function() {
     return request("OPTIONS", annotation).then(function(res) {
         assert_equals(res.status, 200, "OPTIONS request returned " + res.status);
@@ -326,6 +337,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
     }
   });
 
+  // TESTS 30-33
   makePromiseTests( theCreation, [
       { test: function(res) { return ('id' in res.body); }, assertion: "Created Annotation MUST have an id property" },
       { test: function(res) { return (('id' in res.body) && (res.body.id.search(container_url) > -1));}, assertion: "Created Annotation MUST have an id that starts with the Container IRI" },
@@ -338,6 +350,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
         } , assertion: "Location header SHOULD match the id of the new Annotation" },
       ]);
 
+  // TEST 34
   promise_test(function() {
     return theCreation.then(function(res) {
       createdEtag = res.xhr.getResponseHeader("ETag") ;
@@ -351,6 +364,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
     });
   }, "Annotation update must be done with the PUT method");
 
+  // TEST 35
   promise_test(function() {
     var theDeletion = request("DELETE", fixURI(createdAnnotation), [['If-Match', createdEtag]] );
     return theDeletion.then(function(lres) {
@@ -368,6 +382,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
     }
   });
 
+  // TESTS 36-37
   makePromiseTests( theCreationCanonical, [
       { test: function(res) { return ( 'canonical' in res.body && res.body.canonical === theAnnotationCanonical.canonical ); }, assertion: "Created Annotation MUST preserve any canonical IRI" },
       { test: function(res) {
@@ -380,6 +395,8 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
 
   // SHOULD tests
 
+
+  // TEST 38
   test(function() {
     assert_equals("https", container_url.toLowerCase().substr(0,5), "Server is not using HTTPS");
     }, "Annotation server SHOULD use HTTPS rather than HTTP");
@@ -387,6 +404,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
   var thePrefRequest = request("GET", container,
       [['Prefer', 'return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"']]);
 
+  // TEST 39
   promise_test(function() {
     return thePrefRequest
       .then(function(res) {
@@ -410,6 +428,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
       }, "SHOULD return the full annotation descriptions");
   });
 
+  // TESTS 40-45
   makePromiseTests( thePrefRequest, [
       { test: function(res) { return ('total' in res.body); }, assertion: "SHOULD include the total property with the total number of annotations in the container" },
       { test: function(res) { return ('first' in res.body); }, assertion: "SHOULD have a link to the first page of its contents using `first`" },
@@ -419,6 +438,7 @@ function runTests( container_url, annotation_url, query_string, theAnnotation, t
       { header: 'Vary', pat: /Prefer/, assertion: "SHOULD include Prefer in the Vary header" }
     ]);
 
+  // TEST 46
   promise_test(function() {
     return thePrefRequest
       .then(function(res) {

--- a/annotation-protocol/tools/protocol-server.py
+++ b/annotation-protocol/tools/protocol-server.py
@@ -263,7 +263,7 @@ def annotation_get(request, response):
 
     if base.startswith("temp-") and tempAnnotations[base]:
         response.headers.update(load_headers_from_file(headers_file))
-        response.headers.set('Etag', hashlib.sha1(base).hexdigest())
+        response.headers.set('ETag', hashlib.sha1(base).hexdigest())
         data = dump_json(tempAnnotations[base])
         if data != "" :
             response.content = data
@@ -279,7 +279,7 @@ def annotation_get(request, response):
         etag = "{0}{1}{2}".format(statinfo.st_ino, statinfo.st_mtime,
                                   statinfo.st_size)
         # obfuscate so we don't leak info; hexdigest for string compatibility
-        response.headers.set('Etag', hashlib.sha1(etag).hexdigest())
+        response.headers.set('ETag', hashlib.sha1(etag).hexdigest())
 
         with open(requested_file, 'r') as data_file:
             data = data_file.read()
@@ -403,8 +403,8 @@ def annotation_delete(request, response):
 
 if __name__ == '__main__':
     print 'http://' + myhost + ':{0}/'.format(port)
-    print 'container URI is http://' + myhost + ':{0}/'.format(port) + "/annotations/"
-    print 'example annotation URI is http://' + myhost + ':{0}/'.format(port) + "/annotations/anno1.json"
+    print 'container URI is http://' + myhost + ':{0}/'.format(port) + "annotations/"
+    print 'example annotation URI is http://' + myhost + ':{0}/'.format(port) + "annotations/anno1.json"
 
     routes = [
         ("GET", "", wptserve.handlers.file_handler),


### PR DESCRIPTION
A tester commented that they need to pass additional parameters to their protocol engine.  Also that their engine limits the scope of targets.  These changes allow for optional specification of those, where the default behavior is as it was earlier.

@BigBlueHat can you verify that this looks okay?  Rob and Hugo have already tested using it.