### PR TITLE
Use textContent rather than innerHTML for the fetch IDL tests.

### DIFF
--- a/fetch/api/headers/headers-idl.html
+++ b/fetch/api/headers/headers-idl.html
@@ -27,7 +27,7 @@
     </script>
     <script>
       var idlsArray = new IdlArray();
-      var idl = document.getElementById("headers-idl").innerHTML
+      var idl = document.getElementById("headers-idl").textContent
       idlsArray.add_idls(idl);
       idlsArray.add_objects({ Headers: ['new Headers()'] });
       idlsArray.test();

--- a/fetch/api/request/request-idl.html
+++ b/fetch/api/request/request-idl.html
@@ -74,8 +74,8 @@
     </script>
     <script>
       var idlsArray = new IdlArray();
-      var idl = document.getElementById("body-idl").innerHTML
-      idl += document.getElementById("request-idl").innerHTML
+      var idl = document.getElementById("body-idl").textContent
+      idl += document.getElementById("request-idl").textContent
 
       idlsArray.add_idls(idl);
       idlsArray.add_untested_idls("interface Headers {};");

--- a/fetch/api/response/response-idl.html
+++ b/fetch/api/response/response-idl.html
@@ -56,8 +56,8 @@
     </script>
     <script>
       var idlsArray = new IdlArray();
-      var idl = document.getElementById("body-idl").innerHTML
-      idl += document.getElementById("response-idl").innerHTML
+      var idl = document.getElementById("body-idl").textContent
+      idl += document.getElementById("response-idl").textContent
 
       idlsArray.add_idls(idl);
       idlsArray.add_untested_idls("interface Headers {};");


### PR DESCRIPTION
There is no good reason for the extra complexity of invoking the HTML
serializer here. It might catch bugs in the serializer implementation
(as it does in Servo: <https://github.com/servo/servo/issues/14226>),
but that's out of scope for this test.