### PR TITLE
Remove gratuitous metadata and self-loop in reftest graph

### DIFF
--- a/mathml/relations/css-styling/lengths-1-ref.html
+++ b/mathml/relations/css-styling/lengths-1-ref.html
@@ -3,9 +3,6 @@
 <head>
 <meta charset="utf-8"/>
 <title>MathML lengths (reference)</title>
-<link rel="help" href="http://www.mathml-association.org/MathMLinHTML5/S2.html#SS3.SSS1"/>
-<link rel="match" href="lengths-1-ref.html"/>
-<meta name="assert" content="Verify that the syntax for MathML lengths is supported.">
 </head>
 <body>
   <p>Test passes if there is a green square and no red.</p>


### PR DESCRIPTION
Ideally, we'd have a lint for this. Possibly actually walking the graph, as a first step towards doing more complex graph-based lints.