### PR TITLE
elementFromPoint: fix scrolled out of view cases

### DIFF
--- a/cssom-view/elementFromPoint.html
+++ b/cssom-view/elementFromPoint.html
@@ -149,14 +149,23 @@
       }, "No viewport available");
 
       test(function () {
-          // TODO: Is this behavior specified anywhere?  This passes in Chrome but not Firefox
-          // or Safari.
+          // HTML says:
+          // Pointing device interaction with an image associated with a set of layered shapes per
+          // the above algorithm must result in the relevant user interaction events being first
+          // fired to the top-most shape covering the point that the pointing device indicated, if
+          // any, or to the image element itself, if there is no shape covering that point.
+          // https://html.spec.whatwg.org/multipage/embedded-content.html#image-map-processing-model
           var area = document.getElementById('rectG');
+          var image = document.getElementById('dinos');
           area.scrollIntoView();
           var areaRect = area.getBoundingClientRect();
           assert_equals(document.elementFromPoint(areaRect.left + Math.round(areaRect.width/2),
                                                   areaRect.top + Math.round(areaRect.height/2)),
                         area,
+                        "Should have returned the area element");
+          assert_equals(document.elementFromPoint(areaRect.left + 92,
+                                                  areaRect.top + 2),
+                        image,
                         "Should have returned the image element");
       }, "Image Maps");
       done();

--- a/cssom-view/elementFromPoint.html
+++ b/cssom-view/elementFromPoint.html
@@ -100,6 +100,7 @@
 
       test(function () {
              var svg = document.getElementById('squiggle');
+             svg.scrollIntoView();
              var svgRect = svg.getBoundingClientRect();
              assert_equals(document.elementFromPoint(svgRect.left + Math.round(svgRect.width/2),
                                                      svgRect.top + Math.round(svgRect.height/2)),
@@ -109,6 +110,7 @@
 
       test(function () {
               var svg = document.getElementById('svg-transform');
+              svg.scrollIntoView();
               var svgRect = svg.getBoundingClientRect();
               assert_equals(document.elementFromPoint(svgRect.left + Math.round(svgRect.width/2),
                                                       svgRect.top + Math.round(svgRect.height/2)),
@@ -116,6 +118,7 @@
                             "Should have returned SVG with Hello WPT! that has a transform");
 
               var pink = document.getElementById('pink');
+              pink.scrollIntoView();
               var pinkRect = pink.getBoundingClientRect();
               assert_equals(document.elementFromPoint(pinkRect.left + Math.round(pinkRect.width/2),
                                                       pinkRect.top + Math.round(pinkRect.height/2)),
@@ -126,11 +129,12 @@
 
       test(function () {
             var anotherteal = document.getElementById('anotherteal');
+            anotherteal.scrollIntoView();
             var anothertealRect = anotherteal.getBoundingClientRect();
             assert_equals(document.elementFromPoint(anothertealRect.left + Math.round(anothertealRect.width/2),
                                                     anothertealRect.top + Math.round(anothertealRect.height/2)),
                           document.body,
-                          "Should have returned the root");
+                          "Should have returned the root as it has pointer-events:none");
 
             var doc = frames[2].document;
             doc.removeChild(doc.documentElement);
@@ -145,7 +149,10 @@
       }, "No viewport available");
 
       test(function () {
+          // TODO: Is this behavior specified anywhere?  This passes in Chrome but not Firefox
+          // or Safari.
           var area = document.getElementById('rectG');
+          area.scrollIntoView();
           var areaRect = area.getBoundingClientRect();
           assert_equals(document.elementFromPoint(areaRect.left + Math.round(areaRect.width/2),
                                                   areaRect.top + Math.round(areaRect.height/2)),


### PR DESCRIPTION
@AutomatedTester @zcorpan This test was failing in a number of browsers because it was calling `elementFromPoint` for co-ordinates that were scrolled off screen.  I added a number of `scrollIntoView` calls to fix it and it's now passing in Chrome.

However the final test case still fails in Firefox and Safari because `getBoundingClientRect` on an `<area>` returns the rect of the image it's used in, and `elementFromPoint` then just gets the `<img>` not the `<area>`.  I don't see this behavior specified anywhere.  OK to just leave a TODO in the test for now?  I see @AutomatedTester added it explicitly about a year ago - did it work in Firefox at some point?