### PR TITLE
scrollingElement: fix test timeout

### DIFF
--- a/cssom-view/scrollingElement.html
+++ b/cssom-view/scrollingElement.html
@@ -9,7 +9,7 @@
 <script>
 async_test(function() {
   var quirksFrame = document.getElementById("quirksframe");
-  quirksFrame.onload = this.step_func(function() {
+  quirksFrame.onload = this.step_func_done(function() {
     var quirksDoc = quirksFrame.contentDocument;
     assert_equals(quirksDoc.compatMode, "BackCompat", "Should be in quirks mode.");
     assert_not_equals(quirksDoc.body, null, "Should have a body element");


### PR DESCRIPTION
@Ms2ger when you refactored this test it looks like you omitted a `done` call.  It now passes in Firefox.  I filed [a blink bug](https://bugs.chromium.org/p/chromium/issues/detail?id=665927) to track the remaining failure on Chrome.