### PR TITLE
Remove a URL fragment from a test expectation of ErrorEvent.filename

### DIFF
--- a/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html
+++ b/workers/interfaces/WorkerGlobalScope/onerror/exception-in-onerror.html
@@ -19,7 +19,7 @@ async_test(function() {
   worker.onerror = this.step_func(function(e) {
     assert_true(e instanceof ErrorEvent, 'e instanceof ErrorEvent');
     assert_equals(typeof e.message, 'string', 'typeof e.message');
-    assert_equals(e.filename, document.URL+'#', 'e.filename');
+    assert_equals(e.filename, document.URL, 'e.filename');
     assert_equals(typeof e.lineno, 'number', 'typeof e.lineno');
     assert_equals(typeof e.colno, 'number', 'typeof e.column');
     e.preventDefault(); // "handled"

--- a/workers/interfaces/WorkerGlobalScope/onerror/handled.html
+++ b/workers/interfaces/WorkerGlobalScope/onerror/handled.html
@@ -19,7 +19,7 @@ async_test(function() {
   var worker = new Worker('#');
   worker.onmessage = this.step_func(function(e) {
     assert_equals(typeof e.data[0], 'string', 'first argument');
-    assert_equals(e.data[1], document.URL+'#', 'second argument');
+    assert_equals(e.data[1], document.URL, 'second argument');
     assert_equals(typeof e.data[2], 'number', 'third argument');
     assert_equals(typeof e.data[3], 'number', 'fourth argument');
     setTimeout(this.step_func(function() {

--- a/workers/interfaces/WorkerGlobalScope/onerror/not-handled.html
+++ b/workers/interfaces/WorkerGlobalScope/onerror/not-handled.html
@@ -19,7 +19,7 @@ async_test(function() {
   worker.onerror = this.step_func(function(e) {
     assert_true(e instanceof ErrorEvent, 'e instanceof ErrorEvent');
     assert_equals(typeof e.message, 'string', 'typeof e.message');
-    assert_equals(e.filename, document.URL+'#', 'e.filename');
+    assert_equals(e.filename, document.URL, 'e.filename');
     assert_equals(typeof e.lineno, 'number', 'typeof e.lineno');
     assert_equals(typeof e.colno, 'number', 'typeof e.column');
     e.preventDefault(); // "handled"

--- a/workers/interfaces/WorkerGlobalScope/onerror/propagate-to-window-onerror.html
+++ b/workers/interfaces/WorkerGlobalScope/onerror/propagate-to-window-onerror.html
@@ -18,7 +18,7 @@ async_test(function() {
   var worker = new Worker('#');
   window.onerror = this.step_func(function(a, b, c, d) {
     assert_equals(typeof a, 'string', 'first argument');
-    assert_equals(b, document.URL+'#', 'second argument');
+    assert_equals(b, document.URL, 'second argument');
     assert_equals(typeof c, 'number', 'third argument');
     assert_equals(typeof d, 'number', 'fourth argument');
     this.done();


### PR DESCRIPTION
ErrorEvent.filename is an absolute URL of the script URL[1], and an absolute URL string does not contain a fragment string[2], so ErrorEvent.filename shouldn't contain a URL fragment.

[1] https://html.spec.whatwg.org/multipage/webappapis.html#dom-errorevent-filename
[2] https://url.spec.whatwg.org/#syntax-url-absolute