### PR TITLE
Make PresentationConnection.onclose pass

### DIFF
--- a/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
@@ -20,22 +20,24 @@
 
 <script>
   setup({explicit_timeout: true});
+
   var startPresentation = function () {
     document.getElementById('presentBtn').disabled = true;
-    async_test(function(t) {
+
+    promise_test(function(t) {
       var request = new PresentationRequest(presentationUrls);
-      request.start()
-        .then(function(connection) {
+
+      var check = function(connection) {
           assert_true(connection instanceof PresentationConnection, 'the connection is setup');
           connection.onclose = t.step_func_done(function(evt) {
             assert_equals(evt.type, "close");
             assert_equals(connection.state, "closed");
           });
           connection.close();
-      })
-      .catch(function(ex) {
-        assert_unreached(ex.name + ":" + ex.message);
-      });
+        };
+
+      return request.start().then(check);
     }, "the onclose is fired and the connection state is closed.");
-  }
+  };
+
 </script>

--- a/presentation-api/controlling-ua/common.js
+++ b/presentation-api/controlling-ua/common.js
@@ -7,10 +7,11 @@
   // on something that directly or indirectly maps to a resource on the W3C test
   // server.
   var castAppId = '915D2A2C';
-  var castUrl = 'https://google.com/cast#__castAppId__=' + castAppId;
+  var castClientId = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5));
+  var castUrl = 'https://google.com/cast#__castAppId__=' + castAppId + '/__castClientId__=' + castClientId;
 
   window.presentationUrls = [
-    'support/presentation.html',
-    castUrl
+    castUrl,
+    'support/presentation.html'
   ];
 })(window);


### PR DESCRIPTION
This is a PR for #4040 

To make this test pass a `promise_test` is used.

I also changed 2 things in `presentation-api/controlling-ua/common.js`.

1. I fixed the `castUrl`. The `castClientId` was missing. That caused a `ErrorNotFound` rejection.

```
 var castClientId = String(new Date().getTime()) + String(Math.floor(Math.random() * 1e5)); 
  var castUrl = 'https://google.com/cast#__castAppId__=' + castAppId + '/__castClientId__=' + castClientId; 
```

2. I switched the order of urls in the array. So the google cast url comes first. Otherwise Google rejects the url and does not take the second url. 