### PR TITLE
Add referrer policy test case for srcdoc iframes with own policy

### DIFF
--- a/referrer-policy/generic/common.js
+++ b/referrer-policy/generic/common.js
@@ -111,23 +111,43 @@ function queryIframe(url, callback, referrer_policy) {
   window.addEventListener("message", listener);
 }
 
-function queryImage(url, callback, referrer_policy) {
-  // For images, we'll test both images in a top-level document as well as
-  // images in a `srcdoc` frame to ensure that the latter has the same referrer
-  // as the former.
-  var i = document.createElement('iframe');
-  i.srcdoc = "Hello, world.";
-  i.onload = function () {
+function queryImage(url, callback, attributes, referrerPolicy) {
+  // For images, we'll test:
+  // - images in a `srcdoc` frame to ensure that it uses the referrer
+  //   policy of its parent,
+  // - images in a top-level document,
+  // - and images in a `srcdoc` frame with its own referrer policy to
+  //   override its parent.
+  var iframeWithoutOwnPolicy = document.createElement('iframe');
+  iframeWithoutOwnPolicy.srcdoc = "Hello, world.";
+
+  iframeWithoutOwnPolicy.onload = function () {
     loadImageInWindow(url, function (img) {
       var srcdocData = decodeImageData(extractImageData(img));
-      loadImageInWindow(url, function (img) {
-        var topLevelData = decodeImageData(extractImageData(img));
-        assert_equals(srcdocData.referrer, topLevelData.referrer, "Referrer inside 'srcdoc' should be the same as embedder's referrer.");
-        callback(wrapResult(url, topLevelData), url);
-      }, referrer_policy, window);
-    }, referrer_policy, i.contentWindow);
+      var iframeWithOwnPolicy = document.createElement('iframe');
+      // Give a srcdoc iframe a referrer policy different from the top-level page's policy.
+      var iframePolicy = (referrerPolicy === "no-referrer") ? "unsafe-url" : "no-referrer";
+      iframeWithOwnPolicy.srcdoc = "<meta name='referrer' content='" + iframePolicy + "'>Hello world.";
+
+      iframeWithOwnPolicy.onload = function () {
+        var nextUrl = url + "&cache_destroyer2=" + (new Date()).getTime();
+        loadImageInWindow(nextUrl, function (img) {
+          assert_equals((iframePolicy === "no-referrer" ? undefined : document.location.href), decodeImageData(extractImageData(img)).headers.referer, "Referrer inside 'srcdoc' should use the iframe's policy if it has one");
+
+          nextUrl = url + "&cache_destroyer3=" + (new Date()).getTime();
+          loadImageInWindow(nextUrl, function (img) {
+            var topLevelData = decodeImageData(extractImageData(img));
+            assert_equals(srcdocData.headers.referer, topLevelData.headers.referer, "Referrer inside 'srcdoc' without its own policy should be the same as embedder's referrer.");
+            callback(wrapResult(nextUrl, topLevelData), url);
+          }, attributes, window);
+        }, null, iframeWithOwnPolicy.contentWindow);
+      };
+
+      document.body.appendChild(iframeWithOwnPolicy);
+
+    }, attributes, iframeWithoutOwnPolicy.contentWindow);
   };
-  document.body.appendChild(i);
+  document.body.appendChild(iframeWithoutOwnPolicy);
 }
 
 function queryXhr(url, callback) {

--- a/referrer-policy/generic/referrer-policy-test-case.js
+++ b/referrer-policy/generic/referrer-policy-test-case.js
@@ -85,9 +85,9 @@ function ReferrerPolicyTestCase(scenario, testDescription, sanityChecker) {
       if (delivery_method in elementAttributesForDeliveryMethod) {
         invoker(t._subresourceUrl,
                 callback,
-                elementAttributesForDeliveryMethod[delivery_method]);
+                elementAttributesForDeliveryMethod[delivery_method], t._scenario.referrer_policy);
       } else {
-        invoker(t._subresourceUrl, callback);
+        invoker(t._subresourceUrl, callback, null, t._scenario.referrer_policy);
       }
 
     },

--- a/referrer-policy/generic/subresource-test/image-decoding.html
+++ b/referrer-policy/generic/subresource-test/image-decoding.html
@@ -19,7 +19,7 @@
       var messaging_test = async_test("Image is encoding headers as JSON.");
       var urlPath = '/referrer-policy/generic/subresource/image.py';
       var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
-                urlPath;
+                urlPath + "?cache_destroyer=" + (new Date()).getTime();
       queryImage(url, function(message) {
         var pre = document.getElementById('received_message')
         var headers = message.headers;

--- a/referrer-policy/generic/unsupported-csp-referrer-directive.html
+++ b/referrer-policy/generic/unsupported-csp-referrer-directive.html
@@ -16,7 +16,7 @@
 
     <script>
       var test = async_test("Image has a referrer despite CSP 'referrer' directive");
-      var urlPath = '/referrer-policy/generic/subresource/image.py';
+      var urlPath = '/referrer-policy/generic/subresource/image.py?cache_destroyer=' + (new Date()).getTime();
       var url = location.protocol + "//www1." + location.hostname + ":" + location.port +
                 urlPath;
       queryImage(url, test.step_func(function(message) {


### PR DESCRIPTION
This commit modifies the img-tag referrer policy tests to test a
srcdoc iframe with its own referrer policy set via meta tag, adding
on to the existing tests for srcdoc iframes that inherit the referrer
policy of their parent document.

The corresponding HTML change is
https://github.com/whatwg/html/pull/1871.

This also corrects a bug in
https://github.com/w3c/web-platform-tests/pull/3700, which was
comparing undefined to undefined (using the 'referrer' property of
image data, when it should be headers.referer).