### PR TITLE
Describe OWNERS file policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ because we have to go through all the tests and ensure that they match
 the specification correctly. But we look at all of them, and take
 everything that we can.
 
+OWNERS files are used only to indicate who should be notified of pull
+requests.  If you are interested in receiving notifications of proposed
+changes to tests in a given directory, feel free to add yourself to the
+OWNERS file. Anyone with expertise in the specification under test can
+approve a pull request.  In particular, if a test change has already
+been adequately reviewed "upstream" in another repository, it can be
+pushed here without any further review by supplying a link to the
+upstream review.
+
 Getting Involved
 ================
 


### PR DESCRIPTION
Try to reduce some of the [confusion](https://github.com/w3c/web-platform-tests/pull/2163#issuecomment-260952922) we've seen with people waiting for someone from OWNERS to approve their patch.  Perhaps we should also change the text generated by wpt-pr-bot?