### PR TITLE
[html] HTMLFieldSetElement.prototype.elements should return HTMLColle…

### DIFF
--- a/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html
+++ b/html/semantics/forms/the-fieldset-element/HTMLFieldSetElement.html
@@ -38,9 +38,9 @@ test(function () {
 }, "The form attribute must return the fieldset's form owner");
 
 test(function () {
-  assert_true(children_outer instanceof HTMLFormControlsCollection,
-              "The elements attribute should be an HTMLFormControlsCollection object");
-}, "The elements must return an HTMLFormControlsCollection object");
+  assert_equals(children_outer.constructor, HTMLCollection,
+              "The elements attribute should be an HTMLCollection object");
+}, "The elements must return an HTMLCollection object");
 
 test(function () {
   var fs_inner = document.getElementById("fs_inner");


### PR DESCRIPTION
…ction.

Follow a specification change [1]. The test passes with Firefox, and fails with
Google Chrome 56.

Note that |children_outer instanceof HTMLCollection| doesn't work because
HTMLFormControlsCollections inherits from HTMLCollection.

[1] https://github.com/whatwg/html/commit/934887d313305448b7ba6dd3af6f7434e1b600c8