### PR TITLE
Cache Storage: Make test setup resilient against buggy implementations

### DIFF
--- a/service-workers/cache-storage/resources/test-helpers.js
+++ b/service-workers/cache-storage/resources/test-helpers.js
@@ -235,3 +235,11 @@ function assert_response_in_array(actual, expected_array, description) {
         }
     }), description);
 }
+
+// Deletes all caches, returning a promise indicating success.
+function delete_all_caches() {
+  return self.caches.keys()
+    .then(function(keys) {
+      return Promise.all(keys.map(self.caches.delete.bind(self.caches)));
+    });
+}

--- a/service-workers/cache-storage/script-tests/cache-storage.js
+++ b/service-workers/cache-storage/script-tests/cache-storage.js
@@ -169,20 +169,28 @@ promise_test(function(t) {
   }, 'CacheStorage.delete with nonexistent cache');
 
 promise_test(function(t) {
-    var bad_name = 'unpaired\uD800';
-    var converted_name = 'unpaired\uFFFD'; // Don't create cache with this name.
-    return self.caches.has(converted_name)
+    var unpaired_name = 'unpaired\uD800';
+    var converted_name = 'unpaired\uFFFD';
+
+    // The test assumes that a cache with converted_name does not
+    // exist, but if the implementation fails the test then such
+    // a cache will be created. Start off in a fresh state by
+    // deleting all caches.
+    return delete_all_caches()
+      .then(function() {
+          return self.caches.has(converted_name);
+      })
       .then(function(cache_exists) {
           assert_false(cache_exists,
                        'Test setup failure: cache should not exist');
       })
-      .then(function() { return self.caches.open(bad_name); })
+      .then(function() { return self.caches.open(unpaired_name); })
       .then(function() { return self.caches.keys(); })
       .then(function(keys) {
-          assert_true(keys.indexOf(bad_name) !== -1,
+          assert_true(keys.indexOf(unpaired_name) !== -1,
                       'keys should include cache with bad name');
       })
-      .then(function() { return self.caches.has(bad_name); })
+      .then(function() { return self.caches.has(unpaired_name); })
       .then(function(cache_exists) {
           assert_true(cache_exists,
                       'CacheStorage names should be not be converted.');


### PR DESCRIPTION
One test asserts that the cache name "unpaired\uD800" does not get mapped to "unpaired\uFFFD", but relies on a cache by that name not existing. If an implementation is buggy it will implicitly create the cache, causing the test to fail the setup checks on subsequent runs, as opposed to hitting the actual test assertions.

Change the test to delete the caches so that it starts with a clean slate regardless of whether or it passes the test.


