### PR TITLE
Modify some tests under 2dcontext

### DIFF
--- a/2dcontext/compositing/2d.composite.operation.clear.html
+++ b/2dcontext/compositing/2d.composite.operation.clear.html
@@ -21,7 +21,7 @@ _addTest(function(canvas, ctx) {
 
 ctx.globalCompositeOperation = 'xor';
 ctx.globalCompositeOperation = 'clear';
-_assertSame(ctx.globalCompositeOperation, 'xor', "ctx.globalCompositeOperation", "'xor'");
+_assertSame(ctx.globalCompositeOperation, 'clear', "ctx.globalCompositeOperation", "'clear'");
 
 
 });

--- a/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html
+++ b/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html
@@ -25,15 +25,12 @@ ctx.fillRect(0, 0, 100, 50);
 var canvas2 = document.createElement('canvas');
 canvas2.width = 0;
 canvas2.height = 10;
-assert_throws("INVALID_STATE_ERR", function() { ctx.drawImage(canvas2, 0, 0); });
 
 canvas2.width = 10;
 canvas2.height = 0;
-assert_throws("INVALID_STATE_ERR", function() { ctx.drawImage(canvas2, 0, 0); });
 
 canvas2.width = 0;
 canvas2.height = 0;
-assert_throws("INVALID_STATE_ERR", function() { ctx.drawImage(canvas2, 0, 0); });
 
 _assertPixelApprox(canvas, 50,25, 0,255,0,255, "50,25", "0,255,0,255", 2);
 

--- a/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html
+++ b/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerocanvas.html
@@ -25,12 +25,15 @@ ctx.fillRect(0, 0, 100, 50);
 var canvas2 = document.createElement('canvas');
 canvas2.width = 0;
 canvas2.height = 10;
+ctx.drawImage(canvas2, 0, 0);
 
 canvas2.width = 10;
 canvas2.height = 0;
+ctx.drawImage(canvas2, 0, 0);
 
 canvas2.width = 0;
 canvas2.height = 0;
+ctx.drawImage(canvas2, 0, 0);
 
 _assertPixelApprox(canvas, 50,25, 0,255,0,255, "50,25", "0,255,0,255", 2);
 

--- a/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerosource.html
+++ b/2dcontext/drawing-images-to-the-canvas/2d.drawImage.zerosource.html
@@ -8,7 +8,7 @@
 <body class="show_output">
 
 <h1>2d.drawImage.zerosource</h1>
-<p class="desc">drawImage with zero-sized source rectangle throws INDEX_SIZE_ERR</p>
+<p class="desc">drawImage with zero-sized source rectangle draws nothing without exception</p>
 
 
 <p class="output">Actual output:</p>
@@ -16,14 +16,14 @@
 <p class="output expectedtext">Expected output:<p><img src="/images/green-100x50.png" class="output expected" id="expected" alt="">
 <ul id="d"></ul>
 <script>
-var t = async_test("drawImage with zero-sized source rectangle throws INDEX_SIZE_ERR");
+var t = async_test("drawImage with zero-sized source rectangle draws nothing without exception");
 _addTest(function(canvas, ctx) {
 
 ctx.fillStyle = '#0f0';
 ctx.fillRect(0, 0, 100, 50);
-assert_throws("INDEX_SIZE_ERR", function() { ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 1, 0, 0, 100, 50); });
-assert_throws("INDEX_SIZE_ERR", function() { ctx.drawImage(document.getElementById('red.png'), 10, 10, 1, 0, 0, 0, 100, 50); });
-assert_throws("INDEX_SIZE_ERR", function() { ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 0, 0, 0, 100, 50); });
+ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 1, 0, 0, 100, 50);
+ctx.drawImage(document.getElementById('red.png'), 10, 10, 1, 0, 0, 0, 100, 50);
+ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 0, 0, 0, 100, 50);
 _assertPixelApprox(canvas, 50,25, 0,255,0,255, "50,25", "0,255,0,255", 2);
 
 

--- a/2dcontext/tools/spec.yaml
+++ b/2dcontext/tools/spec.yaml
@@ -181,6 +181,8 @@ assertions:
     text: "copy<^><eol>"
   - id: 2d.composite.xor
     text: "xor<^><eol>"
+  - id: 2d.composite.clear
+    text: "clear<^><eol>"
 
   - id: 2d.composite.operation.casesensitive
     text: "These values are all case-sensitive<^> <...> they *must* be used exactly as shown."
@@ -584,9 +586,9 @@ assertions:
     text: "If the image argument is <...> an HTMLVideoElement object whose readyState attribute is either HAVE_NOTHING or HAVE_METADATA<^>, then the implementation *must* return without drawing anything."
   - id: 2d.drawImage.zerocanvas
     previously: [ 10, "dw and dh" ]
-    text: "If the image argument is an HTMLCanvasElement object with either a horizontal dimension or a vertical dimension equal to zero, then the implementation *must* raise an INVALID_STATE_ERR exception<^>."
+    text: "If the image argument is an HTMLCanvasElement object with either a horizontal dimension or a vertical dimension equal to zero, then the implementation *must* return without drawing anything<^>."
   - id: 2d.drawImage.zerosource
-    text: "If one of the sw or sh arguments is zero<^>, the implementation *must* raise an INDEX_SIZE_ERR exception."
+    text: "If one of the sw or sh arguments is zero<^>, the implementation *must* return without drawing anything."
   - id: 2d.drawImage.paint
     text: "When drawImage() is invoked, the region of the image specified by the source rectangle *must* be painted on the region of the canvas specified by the destination rectangle<^>, after applying the current transformation matrix to the points of the destination rectangle."
   - id: 2d.drawImage.original

--- a/2dcontext/tools/tests2d.yaml
+++ b/2dcontext/tools/tests2d.yaml
@@ -9001,12 +9001,15 @@
     var canvas2 = document.createElement('canvas');
     canvas2.width = 0;
     canvas2.height = 10;
+    ctx.drawImage(canvas2, 0, 0);
 
     canvas2.width = 10;
     canvas2.height = 0;
+    ctx.drawImage(canvas2, 0, 0);
 
     canvas2.width = 0;
     canvas2.height = 0;
+    ctx.drawImage(canvas2, 0, 0);
 
     @assert pixel 50,25 ==~ 0,255,0,255;
   expected: green

--- a/2dcontext/tools/tests2d.yaml
+++ b/2dcontext/tools/tests2d.yaml
@@ -1307,7 +1307,7 @@
   code: |
     ctx.globalCompositeOperation = 'xor';
     ctx.globalCompositeOperation = 'clear';
-    @assert ctx.globalCompositeOperation === 'xor';
+    @assert ctx.globalCompositeOperation === 'clear';
 
 - name: 2d.composite.operation.highlight
   testing:
@@ -8772,7 +8772,7 @@
   expected: green
 
 - name: 2d.drawImage.zerosource
-  desc: drawImage with zero-sized source rectangle throws INDEX_SIZE_ERR
+  desc: drawImage with zero-sized source rectangle draws nothing without exception
   testing:
     - 2d.drawImage.zerosource
   images:
@@ -8780,9 +8780,9 @@
   code: |
     ctx.fillStyle = '#0f0';
     ctx.fillRect(0, 0, 100, 50);
-    @assert throws INDEX_SIZE_ERR ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 1, 0, 0, 100, 50);
-    @assert throws INDEX_SIZE_ERR ctx.drawImage(document.getElementById('red.png'), 10, 10, 1, 0, 0, 0, 100, 50);
-    @assert throws INDEX_SIZE_ERR ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 0, 0, 0, 100, 50);
+    ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 1, 0, 0, 100, 50);
+    ctx.drawImage(document.getElementById('red.png'), 10, 10, 1, 0, 0, 0, 100, 50);
+    ctx.drawImage(document.getElementById('red.png'), 10, 10, 0, 0, 0, 0, 100, 50);
     @assert pixel 50,25 ==~ 0,255,0,255;
   expected: green
 
@@ -9001,15 +9001,12 @@
     var canvas2 = document.createElement('canvas');
     canvas2.width = 0;
     canvas2.height = 10;
-    @assert throws INVALID_STATE_ERR ctx.drawImage(canvas2, 0, 0);
 
     canvas2.width = 10;
     canvas2.height = 0;
-    @assert throws INVALID_STATE_ERR ctx.drawImage(canvas2, 0, 0);
 
     canvas2.width = 0;
     canvas2.height = 0;
-    @assert throws INVALID_STATE_ERR ctx.drawImage(canvas2, 0, 0);
 
     @assert pixel 50,25 ==~ 0,255,0,255;
   expected: green


### PR DESCRIPTION
There are some tests under 2dcontext/ that doesn't reflect the specs.

1. 2d.composite.operation.clear.html
    'clear' is a valid globalCompositeOperation, so assign that should change ctx.globalCompositeOperation to be 'clear'.
    spec for clear mode is here: https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_clear

2. 2d.drawImage.zerocanvas.html
    The spec here: https://html.spec.whatwg.org/multipage/scripting.html#drawing-images, says in step 1, that when source canvas size is 0, "returns bad, then abort these steps without drawing anything", so no exception should be thrown.

3. 2d.drawImage.zerosource.html
    The spec link is the same as the above one. In step 3, it states "If one of the sw or sh arguments is zero, abort these steps. Nothing is painted.", so no exception should be thrown.

Notice that Firefox and Edge is likely to fail under this change.

Please see more detailed discussion here:
https://bugs.chromium.org/p/chromium/issues/detail?id=651741

@RByers @foolip Please review since @junov is on vacation.