### PR TITLE
[eme] Update playback-retrieve-persistent-license test

### DIFF
--- a/encrypted-media/resources/drm-retrieve-persistent-license.html
+++ b/encrypted-media/resources/drm-retrieve-persistent-license.html
@@ -43,8 +43,14 @@
 
         function onTimeupdate(event) {
             if ( config.video.currentTime > ( config.duration || 1 ) ) {
+                config.video.removeEventListener('timeupdate', onTimeupdate);
                 config.video.pause();
+
+                _mediaKeySession.closed
+                    .then(onComplete)
+                    .catch(onFailure);
                 _mediaKeySession.close()
+                    .catch(onFailure);
             }
         }
 
@@ -53,9 +59,8 @@
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
             config.video.setMediaKeys(mediaKeys);
-            config.video.addEventListener('timeupdate', onTimeupdate, true);
+            config.video.addEventListener('timeupdate', onTimeupdate);
             _mediaKeySession = mediaKeys.createSession( 'persistent-license' );
-            _mediaKeySession.closed.then(onComplete);
             return _mediaKeySession.load(event.data.sessionId);
         }).then(function( success ) {
             if ( !success ) throw new DOMException( 'Could not load session' );

--- a/encrypted-media/scripts/playback-retrieve-persistent-license.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-license.js
@@ -49,7 +49,7 @@ function runTest(config,qualifier) {
         function onPlaying(event) {
             // Not using waitForEventAndRunStep() to avoid too many
             // EVENT(onTimeUpdate) logs.
-            _video.addEventListener('timeupdate', onTimeupdate, true);
+            _video.addEventListener('timeupdate', onTimeupdate);
         }
 
         function onTimeupdate(event) {
@@ -57,16 +57,20 @@ function runTest(config,qualifier) {
                 _video.removeEventListener('timeupdate', onTimeupdate);
                 _video.pause();
                 _video.removeAttribute('src');
-                _video.load()
+                _video.load();
 
-                _mediaKeySession.closed.then(test.step_func(onClosed));
-                _mediaKeySession.close();
+                _mediaKeySession.closed
+                    .then(test.step_func(onClosed))
+                    .catch(onFailure);
+                _mediaKeySession.close()
+                    .catch(onFailure);
             }
         }
 
         function onClosed() {
             // Open a new window in which we will attempt to play with the persisted license
             var win = window.open(config.windowscript);
+            assert_not_equals(win, null, "Popup windows not allowed?");
 
             // Lisen for an event from the new window containing its test assertions
             window.addEventListener('message', test.step_func(function(messageEvent) {


### PR DESCRIPTION
Add check for window.open() failing, and remove the 'timeupdate'
listener when closing the session in the new window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4242)
<!-- Reviewable:end -->
