### PR TITLE
Adds testing of error codes for bogus setRemoteDescription calls.

### DIFF
--- a/webrtc/set-remote-description.html
+++ b/webrtc/set-remote-description.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<!--
+This test does not require fake media devices.
+-->
+
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>RTCPeerConnection.setRemoteDescription exercises</title>
+</head>
+<body>
+  <div id="log"></div>
+  <h2>SetRemoteDescription error handling</h2>
+  <div id="stateinfo">
+  </div>
+
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+      <script src="/common/vendor-prefix.js"
+          data-prefixed-objects=
+              '[{"ancestors":["window"], "name":"RTCPeerConnection"},
+                {"ancestors":["window"], "name":"RTCSessionDescription"},
+                {"ancestors":["window"], "name":"RTCIceCandidate"}]'>
+  </script>
+  <script type="text/javascript">
+  var gFirstConnection = new RTCPeerConnection(null);
+  // This function starts the test.
+  promise_test(function() {
+
+
+      // Bogus SDP
+      return gFirstConnection.setRemoteDescription({'type': 'offer',
+					     'sdp': 'bogus'})
+	  .then(function() {
+	      assert_unreached('Bogus SDP should not be accepted');
+	  })
+	  .catch(function(e) {
+	      assert_equals(e.name, "InvalidAccessError");
+	  });
+  }, 'Bogus SDP');
+  promise_test(function() {
+      // Bogus operation
+      return gFirstConnection.setRemoteDescription({'type': 'bogus',
+					     'sdp': 'bogus'})
+	  .then(function() {
+	      assert_unreached('Bogus operation types should not be accepted');
+	  })
+	  .catch(function(e) {
+	      assert_equals(e.name, "TypeError");
+	  });
+  }, 'Bogus Operation');
+  promise_test(function() {
+      // Bogus operation
+      return gFirstConnection.setRemoteDescription({'type': 'answer',
+					     'sdp': 'bogus'})
+	  .then(function() {
+	      assert_unreached('Answer in "new" state should not be accepted');
+	  })
+	  .catch(function(e) {
+	      assert_equals(e.name, "InvalidStateError");
+	  });
+  }, 'Bogus operation for state');
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This currently has 1 pass and 2 fail on both Firefox and Chrome.
The errors are verified with the Nov 23 version of the spec:

https://w3c.github.io/webrtc-pc/#set-description

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4243)
<!-- Reviewable:end -->
