### PR TITLE
Fix three Presentation API tests.

### DIFF
--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -29,7 +29,6 @@
           connection.onconnect = t.step_func_done(function() {
             assert_equals(connection.state, "connected");
           });
-          connection.close();
       })
       .catch(function(ex) {
         assert_unreached(ex.name + ":" + ex.message);

--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -28,7 +28,7 @@
           assert_true(connection instanceof PresentationConnection);
           connection.onconnect = t.step_func_done(function() {
             assert_equals(connection.state, "connected");
-            connection.close();
+            connection.terminate();
           });
       })
       .catch(function(ex) {

--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -28,6 +28,7 @@
           assert_true(connection instanceof PresentationConnection);
           connection.onconnect = t.step_func_done(function() {
             assert_equals(connection.state, "connected");
+            connection.close();
           });
       })
       .catch(function(ex) {

--- a/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
@@ -27,8 +27,8 @@
       request.start()
         .then(function(connection) {
           assert_true(connection instanceof PresentationConnection);
-          connection.onconnected = t.step_func(function(evt) {
-            assert_equals(evt.state, "connected");
+          connection.onconnect = t.step_func(function(evt) {
+            assert_equals(connection.state, "connected");
             connection.terminate();
           });
           connection.onterminate = t.step_func_done(function(evt) {

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -48,7 +48,7 @@
             var connection = evt.connection;
             // check the presentation connection and its attributes
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-            assert_true(!connection.id, 'The connection ID is set.');
+            assert_true(!!connection.id, 'The connection ID is set.');
             assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -48,7 +48,7 @@
             var connection = evt.connection;
             // check the presentation connection and its attributes
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-            assert_true(!!connection.id, 'The connection ID is set.');
+            assert_true(!connection.id, 'The connection ID is set.');
             assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
             assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
         });

--- a/presentation-api/controlling-ua/startNewPresentation_error.html
+++ b/presentation-api/controlling-ua/startNewPresentation_error.html
@@ -11,7 +11,7 @@
     // -----------------------------------
     promise_test(function (t) {
       var request = new PresentationRequest('presentation.html');
-      promise_rejects(t, 'InvalidAccessError', request.start());
+      return promise_rejects(t, 'InvalidAccessError', request.start());
     }, "The presentation could not start, because a user gesture is required.");
     // ----------------------------------
     // Launch New Presentation Test - end

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -10,15 +10,16 @@
       this.onmessage = function (evt) {
         this.send(evt.data);
       };
+    };
   };
-  navigator.receiver.connectionList
+
+  navigator.presentation.receiver.connectionList
     .then(function(list) {
-      list.onconnectionavailable = function(connections) {
-        addConnection(connections[connections.length - 1]);
+      list.onconnectionavailable = function(evt) {
+        addConnection(evt.connection);
       };
       list.connections.map(function(connection) {
         addConnection(connection);
       });
     });
-  }
 </script>


### PR DESCRIPTION
- PresentationConnection_onconnected-manual.html: The test was closing the connection before the `connect` event fired.
- PresentationConnection_onterminated-manual.html: Typos
- presentation-api/controlling-ua/support/presentation.html: Bugs

PTAL @tomoyukilabs 
