### PR TITLE
Add onauxclick tests

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -2395,6 +2395,7 @@ typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
 [NoInterfaceObject]
 interface GlobalEventHandlers {
            attribute EventHandler onabort;
+           attribute EventHandler onauxclick;
            attribute EventHandler onblur;
            attribute EventHandler oncancel;
            attribute EventHandler oncanplay;

--- a/html/webappapis/scripting/events/event-handler-onauxclick.html
+++ b/html/webappapis/scripting/events/event-handler-onauxclick.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>onauxclick</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#handler-onauxclick">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="auxclickme1" onauxclick="window.auxClick1Happened = true;"></div>
+<div id="auxclickme2" onauxclick="window.auxClick2Happened = true;"></div>
+
+<script>
+"use strict";
+window.auxClick1Happened = false;
+window.auxClick2Happened = false;
+
+test(() => {
+  for (const location of [window, HTMLElement.prototype, SVGElement.prototype, Document.prototype]) {
+    assert_true(location.hasOwnProperty("onauxclick"),
+      `${location.constructor.name} has an own property named "onauxclick"`);
+  }
+}, "onauxclick is on the appropriate locations for GlobalEventHandlers");
+
+test(() => {
+  const htmlElement = document.createElement("span");
+  const svgElement = document.createElementNS("http://www.w3.org/2000/svg", "g");
+
+  for (const location of [window, htmlElement, svgElement, document]) {
+    assert_equals(location.onauxclick, null,
+      `The default value of the property is null for a ${location.constructor.name} instance`);
+  }
+}, "The default value of onauxclick is always null");
+
+test(() => {
+  const element = document.querySelector("#auxclickme1");
+  const compiledHandler = element.onauxclick;
+
+  assert_equals(typeof compiledHandler, "function", "The onauxclick property must be a function");
+  compiledHandler();
+  assert_true(window.auxClick1Happened, "Calling the handler must run the code");
+}, "The onauxclick content attribute must be compiled into the onauxclick property");
+
+test(() => {
+  const element = document.querySelector("#auxclickme2");
+  element.dispatchEvent(new Event("auxclick"));
+
+  assert_true(window.auxClick2Happened, "Dispatching the event must run the code");
+}, "The onauxclick content attribute must execute when an event is dispatched");
+
+test(() => {
+  const element = document.createElement("meta");
+  element.onauxclick = e => {
+    assert_equals(e.currentTarget, element, "The event must be fired at the <meta> element");
+  };
+
+  element.dispatchEvent(new Event("auxclick"));
+}, "dispatching an auxclick event must trigger element.onauxclick");
+
+</script>


### PR DESCRIPTION
For https://github.com/whatwg/html/pull/2088

These do *not* pass in Chrome Canary with experimental features on; they appear to not implement the content attribute. I'll file a bug.