### PR TITLE
Add tests that <a>/<area> can be downloaded without user interaction

### DIFF
--- a/html/semantics/embedded-content/the-area-element/area-download-click.html
+++ b/html/semantics/embedded-content/the-area-element/area-download-click.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Clicking on an &lt;area> element with a download attribute must not throw an exception</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-area-element:activation-behaviour">
+<link rel="help" href="https://github.com/whatwg/html/issues/2116">
+
+<img src="/images/threecolors.png" usemap="#x" id="img" width="300" height="300">
+<map name="x">
+  <area id="blob-url" download="foo.html" coords="0,0,300,300">
+</map>
+
+<script>
+"use strict";
+
+const string = "test";
+const blob = new Blob([string], { type: "text/html" });
+
+const link = document.querySelector("#blob-url");
+link.href = URL.createObjectURL(blob);
+
+link.click();
+</script>

--- a/html/semantics/embedded-content/the-area-element/area-download-click.html
+++ b/html/semantics/embedded-content/the-area-element/area-download-click.html
@@ -4,6 +4,8 @@
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-area-element:activation-behaviour">
 <link rel="help" href="https://github.com/whatwg/html/issues/2116">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 
 <img src="/images/threecolors.png" usemap="#x" id="img" width="300" height="300">
 <map name="x">
@@ -20,4 +22,6 @@ const link = document.querySelector("#blob-url");
 link.href = URL.createObjectURL(blob);
 
 link.click();
+
+done();
 </script>

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Clicking on an &lt;a> element with a download attribute must not throw an exception</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour">
+<link rel="help" href="https://github.com/whatwg/html/issues/2116">
+
+<a id="blob-url" download="foo.html">Click me</a>
+
+<script>
+"use strict";
+
+const string = "test";
+const blob = new Blob([string], { type: "text/html" });
+
+const link = document.querySelector("#blob-url");
+link.href = URL.createObjectURL(blob);
+
+link.click();
+</script>

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click.html
@@ -4,6 +4,8 @@
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour">
 <link rel="help" href="https://github.com/whatwg/html/issues/2116">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 
 <a id="blob-url" download="foo.html">Click me</a>
 
@@ -17,4 +19,6 @@ const link = document.querySelector("#blob-url");
 link.href = URL.createObjectURL(blob);
 
 link.click();
+
+done();
 </script>


### PR DESCRIPTION
That is, that calling .click() does not throw at least, as it used to
per-spec. Matches the HTML change at
https://github.com/whatwg/html/pull/2136 per the HTML bug report at
https://github.com/whatwg/html/issues/2116.

/cc @cdumez 