### PR TITLE
Test that form data name/values are converted to USVs

### DIFF
--- a/html/semantics/forms/form-submission-0/form-data-set-usv-form.html
+++ b/html/semantics/forms/form-submission-0/form-data-set-usv-form.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>This is the form that will be submitted</title>
+
+<form action="form-echo.py" method="post" enctype="text/plain">
+  <input id="input1" type="text">
+  <select id="input2">
+    <option selected>option
+  </select>
+  <input id="input3" type="radio" checked>
+  <input id="input4" type="checkbox" checked>
+</form>
+
+<script>
+"use strict";
+
+const form = document.querySelector("form");
+
+for (let el of Array.from(form.querySelectorAll("input"))) { // Firefox/Edge support
+  el.name = el.id + "\uDC01";
+  el.value = el.id + "\uDC01";
+}
+
+const select = document.querySelector("select");
+select.name = select.id + "\uDC01";
+select.firstElementChild.value = select.id + "\uDC01";
+</script>

--- a/html/semantics/forms/form-submission-0/form-data-set-usv.html
+++ b/html/semantics/forms/form-submission-0/form-data-set-usv.html
@@ -20,12 +20,18 @@ async_test(t => {
     iframe.onload = t.step_func_done(() => {
       const result = iframe.contentWindow.document.body.textContent;
 
-      // trim() since there are unrelated bugs in Chrome (which does not append \r\n when doing
-      // text/plain serialization)
-      assert_equals(result.trim(), `input1\uFFFD=input1\uFFFD
-input2\uFFFD=input2\uFFFD
-input3\uFFFD=input3\uFFFD
-input4\uFFFD=input4\uFFFD`);
+      assert_equals(result,
+        "69 6e 70 75 74 31 ef bf bd 3d 69 6e 70 75 74 31 ef bf bd " + // input1\uFFFD=input1\uFFFD
+        "0d 0a "                                                    + // \r\n
+        "69 6e 70 75 74 32 ef bf bd 3d 69 6e 70 75 74 32 ef bf bd " + // input2\uFFFD=input2\uFFFD
+        "0d 0a "                                                    + // \r\n
+        "69 6e 70 75 74 33 ef bf bd 3d 69 6e 70 75 74 33 ef bf bd " + // input3\uFFFD=input3\uFFFD
+        "0d 0a "                                                    + // \r\n
+        "69 6e 70 75 74 34 ef bf bd 3d 69 6e 70 75 74 34 ef bf bd " + // input4\uFFFD=input4\uFFFD
+        "0d 0a"                                                       // \r\n
+      );
+
+      // ef bf bd is the UTF-8 encoding of U+FFFD
     });
 
     form.submit();

--- a/html/semantics/forms/form-submission-0/form-data-set-usv.html
+++ b/html/semantics/forms/form-submission-0/form-data-set-usv.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Submitting a form data set that contains unpaired surrogates must convert to Unicode scalar values</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/forms.html#constructing-form-data-set">
+<link rel="help" href="https://github.com/whatwg/html/issues/1490">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="testframe" src="form-data-set-usv-form.html"></iframe>
+
+<script>
+"use strict";
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const iframe = document.querySelector("#testframe");
+    const form = iframe.contentWindow.document.querySelector("form");
+
+    iframe.onload = t.step_func_done(() => {
+      const result = iframe.contentWindow.document.body.textContent;
+
+      // trim() since there are unrelated bugs in Chrome (which does not append \r\n when doing
+      // text/plain serialization)
+      assert_equals(result.trim(), `input1\uFFFD=input1\uFFFD
+input2\uFFFD=input2\uFFFD
+input3\uFFFD=input3\uFFFD
+input4\uFFFD=input4\uFFFD`);
+    });
+
+    form.submit();
+  });
+});
+</script>

--- a/html/semantics/forms/form-submission-0/form-echo.py
+++ b/html/semantics/forms/form-submission-0/form-echo.py
@@ -1,5 +1,7 @@
 def main(request, response):
+    bytes = bytearray(request.raw_input.read())
+    bytes_string = " ".join("%02x" % b for b in bytes)
     return (
         [("Content-Type", "text/plain")],
-        request.body
+        bytes_string
     )

--- a/html/semantics/forms/form-submission-0/form-echo.py
+++ b/html/semantics/forms/form-submission-0/form-echo.py
@@ -1,0 +1,5 @@
+def main(request, response):
+    return (
+        [("Content-Type", "text/plain")],
+        request.body
+    )


### PR DESCRIPTION
Tests https://github.com/whatwg/html/pull/2124, which is a fix for
https://github.com/whatwg/html/issues/1490.

---

These pass in Firefox and Chrome but Edge fails by somehow adding three `\uFFFD` replacement characters instead of one.

I am pretty sure Python and the text/plain serialization is not messing with things, but careful review would be appreciated.