### PR TITLE
[eme] Fix #4279: Don't expect empty configuration to pass

### DIFF
--- a/encrypted-media/scripts/requestmediakeysystemaccess.js
+++ b/encrypted-media/scripts/requestmediakeysystemaccess.js
@@ -84,7 +84,7 @@ function runTest(config, qualifier) {
 
     // Tests for trivial configurations.
     expect_error(config.keysystem, [], 'TypeError', 'Empty supportedConfigurations');
-    expect_config(config.keysystem, [{}], {}, 'Empty configuration');
+    expect_error(config.keysystem, [{}], 'NotSupportedError', 'Empty configuration');
 
     // Various combinations of supportedConfigurations.
     expect_config(config.keysystem, [{
@@ -155,15 +155,28 @@ function runTest(config, qualifier) {
         ],
     }], 'NotSupportedError', 'Mismatched audio container/codec (%audiocontenttype)');
 
-    expect_config(config.keysystem, [
-        {initDataTypes: ['fakeidt']},
-        {initDataTypes: [config.initDataType]}
-    ], {initDataTypes: [config.initDataType]}, 'Two configurations, one supported');
+    expect_config(config.keysystem, [{
+        initDataTypes: ['fakeidt'],
+        videoCapabilities: [{contentType: config.videoType}]
+      }, {
+        initDataTypes: [config.initDataType],
+        videoCapabilities: [{contentType: config.videoType}]
+      }
+    ], {
+        initDataTypes: [config.initDataType],
+        videoCapabilities: [{contentType: config.videoType}]
+    }, 'Two configurations, one supported');
 
-    expect_config(config.keysystem, [
-        {initDataTypes: [config.initDataType]},
-        {}
-    ], {initDataTypes: [config.initDataType]}, 'Two configurations, both supported');
+    expect_config(config.keysystem, [{
+        initDataTypes: [config.initDataType],
+        videoCapabilities: [{contentType: config.videoType}]
+      }, {
+        videoCapabilities: [{contentType: config.videoType}]
+      }
+    ], {
+        initDataTypes: [config.initDataType],
+        videoCapabilities: [{contentType: config.videoType}]
+    }, 'Two configurations, both supported');
 
     // Audio MIME type does not support video codecs.
     expect_error(config.keysystem, [{


### PR DESCRIPTION
The spec states that one of 'audioCapabilities' or 'videoCapabilities' must be provided, so expect failure if one is not provided. Update 2 other tests to include 'videoCapabilities' so that they continue to succeed on implementations that match the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
