### PR TITLE
Encoding: Consolidate label tests to one per label

### DIFF
--- a/encoding/textdecoder-labels.html
+++ b/encoding/textdecoder-labels.html
@@ -4,33 +4,32 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/encodings.js"></script>
 <script>
-var tests = [];
-setup(function() {
-  var whitespace = [' ', '\t', '\n', '\f', '\r'];
-  encodings_table.forEach(function(section) {
-    section.encodings.filter(function(encoding) {
-      return encoding.name !== 'replacement';
-    }).forEach(function(encoding) {
-      var name = encoding.name;
-      encoding.labels.forEach(function(label) {
-        tests.push([label, encoding.name]);
+encodings_table.forEach(function(section) {
+  section.encodings.filter(function(encoding) {
+    return encoding.name !== 'replacement';
+  }).forEach(function(encoding) {
+    encoding.labels.forEach(function(label) {
+      test(function(t) {
+        assert_equals(
+          new TextDecoder(label).encoding, encoding.name,
+          'label for encoding should match');
+        assert_equals(
+          new TextDecoder(label.toUpperCase()).encoding, encoding.name,
+          'label matching should be case-insensitive');
+        var whitespace = [' ', '\t', '\n', '\f', '\r'];
         whitespace.forEach(function(ws) {
-          tests.push([ws + label, encoding.name]);
-          tests.push([label + ws, encoding.name]);
-          tests.push([ws + label + ws, encoding.name]);
+          assert_equals(
+            new TextDecoder(ws + label).encoding, encoding.name,
+            'label for encoding with leading whitespace should match');
+          assert_equals(
+            new TextDecoder(label + ws).encoding, encoding.name,
+            'label for encoding with trailing whitespace should match');
+          assert_equals(
+            new TextDecoder(ws + label + ws).encoding, encoding.name,
+            'label for encoding with surrounding whitespace should match');
         });
-      });
+      }, label + " => " + encoding.name);
     });
   });
-});
-
-tests.forEach(function(t) {
-  var input = t[0], output = t[1];
-  test(function() {
-    assert_equals(new TextDecoder(input).encoding, output,
-                  'label for encoding should match');
-    assert_equals(new TextDecoder(input.toUpperCase()).encoding, output,
-                  'label matching should be case-insensitive');
-  }, format_value(input) + " => " + format_value(output));
 });
 </script>

--- a/encoding/textdecoder-labels.html
+++ b/encoding/textdecoder-labels.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/encodings.js"></script>
 <script>
+var whitespace = [' ', '\t', '\n', '\f', '\r'];
 encodings_table.forEach(function(section) {
   section.encodings.filter(function(encoding) {
     return encoding.name !== 'replacement';
@@ -16,7 +17,6 @@ encodings_table.forEach(function(section) {
         assert_equals(
           new TextDecoder(label.toUpperCase()).encoding, encoding.name,
           'label matching should be case-insensitive');
-        var whitespace = [' ', '\t', '\n', '\f', '\r'];
         whitespace.forEach(function(ws) {
           assert_equals(
             new TextDecoder(ws + label).encoding, encoding.name,
@@ -28,7 +28,7 @@ encodings_table.forEach(function(section) {
             new TextDecoder(ws + label + ws).encoding, encoding.name,
             'label for encoding with surrounding whitespace should match');
         });
-      }, label + " => " + encoding.name);
+      }, label + ' => ' + encoding.name);
     });
   });
 });


### PR DESCRIPTION
Restructure the encoding label tests to be one per label (~200) containing multiple assertions, rather than one per assertion (~3000).
