### PR TITLE
Fix test flakiness caused by not waiting for an iframe to load.

### DIFF
--- a/webmessaging/with-ports/019.html
+++ b/webmessaging/with-ports/019.html
@@ -5,12 +5,14 @@
 <iframe src="../without-ports/019-1.html"></iframe>
 <div id=log></div>
 <script>
-async_test(function() {
-  window[0].postMessage('', location.protocol.toUpperCase() + '//' + location.host.toUpperCase() + '/', []);
-  window[0].onmessage = this.step_func(function(e) {
-    assert_equals(e.origin, location.protocol + '//' + location.host);
-    assert_array_equals(e.ports, []);
-    this.done();
+async_test(function(test) {
+  onload = test.step_func(function() {
+    window[0].postMessage('', location.protocol.toUpperCase() + '//' + location.host.toUpperCase() + '/', []);
+    window[0].onmessage = test.step_func(function(e) {
+      assert_equals(e.origin, location.protocol + '//' + location.host);
+      assert_array_equals(e.ports, []);
+      test.done();
+    });
   });
 });
 </script>

--- a/webmessaging/without-ports/019.html
+++ b/webmessaging/without-ports/019.html
@@ -5,12 +5,14 @@
 <iframe src="../without-ports/019-1.html"></iframe>
 <div id=log></div>
 <script>
-async_test(function() {
-  window[0].postMessage('', location.protocol.toUpperCase() + '//' + location.host.toUpperCase() + '/');
-  window[0].onmessage = this.step_func(function(e) {
-    assert_equals(e.origin, location.protocol + '//' + location.host);
-    assert_array_equals(e.ports, []);
-    this.done();
+async_test(function(test) {
+  onload = test.step_func(function() {
+    window[0].postMessage('', location.protocol.toUpperCase() + '//' + location.host.toUpperCase() + '/');
+    window[0].onmessage = test.step_func(function(e) {
+      assert_equals(e.origin, location.protocol + '//' + location.host);
+      assert_array_equals(e.ports, []);
+      test.done();
+    });
   });
 });
 </script>


### PR DESCRIPTION
If these tests don't wait for onload before proceeding it is possible for
the iframe to load after the postMessage call and onmessage assignment
have been done, but before the task to deliver the message event has been
executed, causing the message to never be delivered.
