### PR TITLE
Add tests for fullscreenchange and fullscreenerror event timing


### DIFF
--- a/fullscreen/api/document-exit-fullscreen-timing-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-timing-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Document#exitFullscreen() timing</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+async_test(t => {
+  const div = document.querySelector('div');
+  trusted_request(div);
+
+  document.onfullscreenchange = t.step_func(() => {
+    // We are now in fullscreen. Exit again.
+    assert_equals(document.fullscreenElement, div);
+    document.exitFullscreen();
+
+    // If fullscreenchange is an animation frame event, then animation frame
+    // callbacks should be run after it is fired, before the timer callback.
+    // The resize event should fire before the fullscreenchange event.
+    const events = [];
+    const callback = t.step_func(event => {
+      events.push(event.type);
+      if (event.type == 'fullscreenchange') {
+        setTimeout(t.unreached_func('timer callback'));
+        requestAnimationFrame(t.step_func_done(() => {
+          assert_array_equals(events, ['resize', 'fullscreenchange'], 'event order');
+        }));
+      }
+    });
+    document.onfullscreenchange = window.onresize = callback;
+  });
+}, 'Timing of fullscreenchange and resize events');
+</script>

--- a/fullscreen/api/element-request-fullscreen-timing-manual.html
+++ b/fullscreen/api/element-request-fullscreen-timing-manual.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>Element#requestFullscreen() timing</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../trusted-click.js"></script>
+<div id="log"></div>
+<script>
+async_test(t => {
+  trusted_request(document.querySelector('div'));
+
+  // If fullscreenchange is an animation frame event, then animation frame
+  // callbacks should be run after it is fired, before the timer callback.
+  // The resize event should fire before the fullscreenchange event.
+  const events = [];
+  const callback = t.step_func(event => {
+    events.push(event.type);
+    if (event.type == 'fullscreenchange') {
+      setTimeout(t.unreached_func('timer callback'));
+      requestAnimationFrame(t.step_func_done(() => {
+        assert_array_equals(events, ['resize', 'fullscreenchange'], 'event order');
+      }));
+    }
+  });
+  document.onfullscreenchange = window.onresize = callback;
+}, 'Timing of fullscreenchange and resize events');
+
+async_test(t => {
+  document.createElement('a').requestFullscreen();
+
+  // If fullscreenerror is an animation frame event, then animation frame
+  // callbacks should be run after it is fired, before the timer callback.
+  document.onfullscreenerror = t.step_func(() => {
+    setTimeout(t.unreached_func('timer callback'));
+    requestAnimationFrame(t.step_func_done());
+  });
+}, 'Timing of fullscreenerror event');
+</script>


### PR DESCRIPTION
Although HTML does not yet define animation frame tasks as used by
Fullscreen, it does have "run the fullscreen rendering steps". That's
the old hook, making the timing of these events relative to resize and
animation frame callbacks unambiguous:
https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model

Spec issue: https://github.com/whatwg/html/issues/707

document-exit-fullscreen-timing-manual.html consistently matches
-expected.txt, with (accidentally) correct timing but no resize event.

element-request-fullscreen-timing-manual.html usually matches
-expected.txt, with incorrect timing, but can accidentally get the
timing right and instead fail due to no resize event.

Both are marked as flaky to be safe, and will be enabled in a coming CL.

Note: This CL is also a test for the WPT export process.

Firefox passes both fullscreechange event tests, but fails the
fullscreenerror test. (Implementation preceded spec changes.)

BUG=402376,672436

Review-Url: https://codereview.chromium.org/2564543002
Cr-Commit-Position: refs/heads/master@{#437283}

