### PR TITLE
Remove anchoring from <dialog> WebIDL

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1835,8 +1835,8 @@ dictionary RelatedEventInit : EventInit {
 interface HTMLDialogElement : HTMLElement {
            attribute boolean open;
            attribute DOMString returnValue;
-  void show(optional (MouseEvent or Element) anchor);
-  void showModal(optional (MouseEvent or Element) anchor);
+  void show();
+  void showModal();
   void close(optional DOMString returnValue);
 };
 


### PR DESCRIPTION
https://github.com/whatwg/html/pull/2158 is removing anchoring from dialogs.