### PR TITLE
Show the line where JSON.parse throw an error

### DIFF
--- a/html/webappapis/scripting/processing-model-2/JSON-runtime-error.html
+++ b/html/webappapis/scripting/processing-model-2/JSON-runtime-error.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html>
+ <head>
+  <title>window.onerror - JSON runtime error in &lt;script></title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+ </head>
+ <body>
+  <div id=log></div>
+  <script>
+    setup({allow_uncaught_exception:true});
+    var t = async_test();
+    var t_col = async_test(document.title+' (column)');
+    var ran = false;
+    var col_value;
+    window.onerror = t.step_func(function(a, b, c, d){
+        ran = true;
+        col_value = d;
+        assert_equals(typeof a, 'string', 'first arg');
+        assert_equals(b, location.href, 'second arg');
+        assert_equals(typeof c, 'number', 'third arg');
+        assert_equals(c, 26);
+    });
+  </script>
+  <script>
+    JSON.parse(undefined);
+  </script>
+  <script>
+    t.step(function(){
+        assert_true(ran, 'ran');
+        t.done();
+    });
+    t_col.step(function(){
+        assert_equals(typeof col_value, 'number', 'fourth arg');
+        t_col.done();
+    });
+  </script>
+ </body>
+</html>


### PR DESCRIPTION
Currently in Chrome and Opera it's not working as expected.
I want to see the line that fired the following error:

  Uncaught (in promise) SyntaxError: Unexpected end of JSON input

Firefox shows correctly the line where this error was originated.