### PR TITLE
Add some tests for the MessagePort.close() method.

### DIFF
--- a/webmessaging/message-channels/close.html
+++ b/webmessaging/message-channels/close.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+async_test(t => {
+    const c = new MessageChannel();
+    c.port1.onmessage = t.unreached_func('Should not have delivered message');
+    c.port1.close();
+    c.port2.postMessage('TEST');
+    setTimeout(t.step_func_done(), 100);
+  }, 'Message sent to closed port should not arrive.');
+
+async_test(t => {
+    const c = new MessageChannel();
+    c.port1.onmessage = t.unreached_func('Should not have delivered message');
+    c.port2.close();
+    c.port2.postMessage('TEST');
+    setTimeout(t.step_func_done(), 100);
+  }, 'Message sent from closed port should not arrive.');
+
+async_test(t => {
+    const c = new MessageChannel();
+    c.port1.onmessage = t.unreached_func('Should not have delivered message');
+    c.port1.close();
+    const c2 = new MessageChannel();
+    c2.port1.onmessage = t.step_func(e => {
+        e.ports[0].postMessage('TESTMSG');
+        setTimeout(t.step_func_done(), 100);
+      });
+    c2.port2.postMessage('TEST', [c.port2]);
+  }, 'Message sent to closed port from transferred port should not arrive.');
+
+async_test(t => {
+    const c = new MessageChannel();
+    c.port1.onmessage = t.unreached_func('Should not have delivered message');
+    c.port2.close();
+    const c2 = new MessageChannel();
+    c2.port1.onmessage = t.step_func(e => {
+        e.ports[0].postMessage('TESTMSG');
+        setTimeout(t.step_func_done(), 100);
+      });
+    c2.port2.postMessage('TEST', [c.port2]);
+  }, 'Message sent from transferred closed port should not arrive.');
+
+async_test(t => {
+    const c = new MessageChannel();
+    let isClosed = false;
+    c.port1.onmessage = t.step_func_done(e => {
+        assert_true(isClosed);
+        assert_equals(e.data, 'TEST');
+      });
+    c.port2.postMessage('TEST');
+    c.port2.close();
+    isClosed = true;
+  }, 'Inflight messages should be delivered even when sending port is closed afterwards.');
+
+async_test(t => {
+    const c = new MessageChannel();
+    c.port1.onmessage = t.step_func_done(e => {
+        if (e.data == 'DONE') t.done();
+        assert_equals(e.data, 'TEST');
+        c.port1.close();
+      });
+    c.port2.postMessage('TEST');
+    c.port2.postMessage('DONE');
+  }, 'Close in onmessage should not cancel inflight messages.');
+
+</script>

--- a/webmessaging/message-channels/close.html
+++ b/webmessaging/message-channels/close.html
@@ -1,14 +1,19 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-close">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
+// How long (in ms) these tests should wait before deciding no further messages
+// will be received.
+const time_to_wait_for_messages = 100;
+
 async_test(t => {
     const c = new MessageChannel();
     c.port1.onmessage = t.unreached_func('Should not have delivered message');
     c.port1.close();
     c.port2.postMessage('TEST');
-    setTimeout(t.step_func_done(), 100);
+    setTimeout(t.step_func_done(), time_to_wait_for_messages);
   }, 'Message sent to closed port should not arrive.');
 
 async_test(t => {
@@ -16,7 +21,7 @@ async_test(t => {
     c.port1.onmessage = t.unreached_func('Should not have delivered message');
     c.port2.close();
     c.port2.postMessage('TEST');
-    setTimeout(t.step_func_done(), 100);
+    setTimeout(t.step_func_done(), time_to_wait_for_messages);
   }, 'Message sent from closed port should not arrive.');
 
 async_test(t => {
@@ -26,7 +31,7 @@ async_test(t => {
     const c2 = new MessageChannel();
     c2.port1.onmessage = t.step_func(e => {
         e.ports[0].postMessage('TESTMSG');
-        setTimeout(t.step_func_done(), 100);
+        setTimeout(t.step_func_done(), time_to_wait_for_messages);
       });
     c2.port2.postMessage('TEST', [c.port2]);
   }, 'Message sent to closed port from transferred port should not arrive.');
@@ -38,7 +43,7 @@ async_test(t => {
     const c2 = new MessageChannel();
     c2.port1.onmessage = t.step_func(e => {
         e.ports[0].postMessage('TESTMSG');
-        setTimeout(t.step_func_done(), 100);
+        setTimeout(t.step_func_done(), time_to_wait_for_messages);
       });
     c2.port2.postMessage('TEST', [c.port2]);
   }, 'Message sent from transferred closed port should not arrive.');


### PR DESCRIPTION
Not a single webmessaging test was calling MessagePort.close(). This adds some basic tests to verify it's behavior. All browsers mostly agree that this is the correct behavior. Among these tests transferring a closed message port is the odd one out. Firefox passes that test, Edge throws an exception when trying to transfer the port, and in Chrome transferring the closed port re-opens the port...

I didn't include tests for what to do when the destination port is closed after postMessage was called on the source port, but before the event loop has run. It's a bit of an edge case, web browsers disagree (only Firefox seems to comply with a strict reading of the spec I believe), and in most cases (where both ports are in different contexts) the difference is indistinguishable anyway.