### PR TITLE
SVG 2 marker tests

### DIFF
--- a/svg/painting/marker-009-ref.svg
+++ b/svg/painting/marker-009-ref.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
+    <path d="M50,50 h100 v100 z m150,0 h100 v100 z m150,0 h100 v100 z"
+    fill="none" stroke="black" stroke-width="10"
+    />
+    <circle cx="50" cy="50" r="25" fill="green"/>
+    <circle cx="50" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="150" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="150" cy="150" r="20" fill="skyblue" opacity="0.9"/>
+
+    <circle cx="200" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="200" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="300" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="300" cy="150" r="20" fill="skyblue" opacity="0.9"/>
+
+    <circle cx="350" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="350" cy="50" r="15" fill="maroon" opacity="0.85"/>
+    <circle cx="450" cy="50" r="20" fill="skyblue" opacity="0.9"/>
+    <circle cx="450" cy="150" r="20" fill="skyblue" opacity="0.9"/>
+</svg>

--- a/svg/painting/marker-009.svg
+++ b/svg/painting/marker-009.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" width="500" height="500">
+    <html:link rel="help" href="https://www.w3.org/TR/2016/CR-SVG2-20160915/painting.html#OrientAttribute"/>
+    <html:link rel="match" href="marker-009-ref.svg"/>
+    <html:meta name="assert" content="Tests correct number of markers are drawn on multiple sub-paths"/>
+    <defs>
+        <marker id="m1" markerUnits="userSpaceOnUse" overflow="visible">
+            <circle cx="0" cy="0" r="25" fill="green"/>
+        </marker>
+        <marker id="m2" markerUnits="userSpaceOnUse" overflow="visible">
+            <circle cx="0" cy="0" r="20" fill="skyblue" opacity="0.9"/>
+        </marker>
+        <marker id="m3" markerUnits="userSpaceOnUse" overflow="visible">
+            <circle cx="0" cy="0" r="15" fill="maroon" opacity="0.85"/>
+        </marker>
+    </defs>
+
+    <path d="M50,50 h100 v100 z m150,0 h100 v100 z m150,0 h100 v100 z"
+    fill="none" stroke="black" stroke-width="10"
+    marker-start="url(#m1)"
+    marker-mid="url(#m2)"
+    marker-end="url(#m3)"
+    />
+</svg>

--- a/svg/painting/marker-orient-001-ref.svg
+++ b/svg/painting/marker-orient-001-ref.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
+    <defs>
+        <marker id="arrowNW" orient="225" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowNE" orient="315" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowSE" orient="45" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowSW" orient="135" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowW" orient="180" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowS" orient="90" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+        <marker id="arrowAuto" orient="auto" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+     </defs>
+    <!-- Test path, with markers -->
+    <path d="M 40,40 l140,140 240,240" marker-start="url(#arrowNW)" marker-mid="url(#arrowSE)" marker-end="url(#arrowSE)" stroke="black" stroke-width="2"/>
+    <path d="M 40,400 l100,-100 100,-100" marker-start="url(#arrowSW)" marker-mid="url(#arrowNE)" marker-end="url(#arrowNE)" stroke="black" stroke-width="2"/>
+    <path d="M 160,40 c40,0 40,0 40,40" marker-start="url(#arrowW)" marker-end="url(#arrowS)" stroke="black" fill="none" stroke-width="2"/>
+    <path d="M 260,140 a 100,100 0 1 1 100,100" marker-start="url(#arrowS)" marker-end="url(#arrowW)" stroke="black" fill="none" stroke-width="2"/>
+    <path d="M 340,100 h50 v50 h-50 z" marker-start="url(#arrowSW)" marker-mid="url(#arrowAuto)" marker-end="url(#arrowNE)" stroke="black" fill="none" stroke-width="2"/>
+</svg>

--- a/svg/painting/marker-orient-001.svg
+++ b/svg/painting/marker-orient-001.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" width="500" height="500">
+    <html:link rel="help" href="https://www.w3.org/TR/2016/CR-SVG2-20160915/painting.html#OrientAttribute"/>
+    <html:link rel="match" href="marker-orient-001-ref.svg"/>
+    <html:meta name="assert" content="Ensure orientation of auto and auto-start-reverse markers is correct."/>
+    <defs>
+        <marker id="arrow" orient="auto-start-reverse" markerUnits="userSpaceOnUse" style="overflow:visible">
+            <path d="M25,0 L 0,-25 L0,25 z" fill="green"/>
+        </marker>
+     </defs>
+    <!-- Test path, with markers -->
+    <path d="M 40,40 l140,140 240,240" marker-start="url(#arrow)" marker-mid="url(#arrow)" marker-end="url(#arrow)" stroke="black" stroke-width="2"/>
+    <path d="M 40,400 l100,-100 100,-100" marker-start="url(#arrow)" marker-mid="url(#arrow)" marker-end="url(#arrow)" stroke="black" stroke-width="2"/>
+    <path d="M 160,40 c40,0 40,0 40,40" marker-start="url(#arrow)" marker-mid="url(#arrow)" marker-end="url(#arrow)" stroke="black" fill="none" stroke-width="2"/>
+    <path d="M 260,140 a 100,100 0 1 1 100,100" marker-start="url(#arrow)" marker-mid="url(#arrow)" marker-end="url(#arrow)" stroke="black" fill="none" stroke-width="2"/>
+    <path d="M 340,100 h50 v50 h-50 z" marker-start="url(#arrow)" marker-mid="url(#arrow)" marker-end="url(#arrow)" stroke="black" fill="none" stroke-width="2"/>
+</svg>


### PR DESCRIPTION
Some new tests for SVG 2 markers.

**marker-009** tests that the correct number of overlaid markers are rendered on paths with multiple sub-paths and corresponds to the Figure in [13.7.2. Vertex markers: the ‘marker-start’, ‘marker-mid’ and ‘marker-end’ properties](https://svgwg.org/svg2-draft/painting.html#VertexMarkerProperties).

**marker-orient-001** adds additional tests for the `auto` and `auto-start-reverse` values of the [orient](https://svgwg.org/svg2-draft/painting.html#OrientAttribute) attribute.
Note: Every browser tested currently fails this test for one reason or another.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
