### PR TITLE
Use promise_test instead of async_test

### DIFF
--- a/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
@@ -38,12 +38,15 @@
 
           assert_true(connection instanceof PresentationConnection, 'the connection is setup');
 
-          connection.onclose = function (evt) {
+          const watcher = new EventWatcher(t, connection, 'close');
+
+          watcher.wait_for('close').then(function () {
+            connection.close();
+            return watcher.wait_for('close');
+          }).then(function (evt) {
             assert_equals(evt.type, "close");
             assert_equals(connection.state, "closed");
-          };
-
-          connection.close();
+          });
 
       });
 

--- a/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
@@ -21,28 +21,36 @@
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+
     document.getElementById('presentBtn').disabled = true;
-    async_test(function(t) {
+
+    promise_test(function (t) {
       var request = new PresentationRequest(presentationUrls);
-      request.start()
-        .then(function(connection) {
+
+      return request.start()
+        .then(function (connection) {
 
           // Enable timeout again, cause no user action is needed from here.
-          t.step_timeout(function() {
+          t.step_timeout(function () {
               t.force_timeout();
               t.done();
           }, 5000);
 
           assert_true(connection instanceof PresentationConnection, 'the connection is setup');
-          connection.onclose = t.step_func_done(function(evt) {
+
+          connection.onclose = function (evt) {
             assert_equals(evt.type, "close");
             assert_equals(connection.state, "closed");
-          });
+          };
+
           connection.close();
+
       })
-      .catch(function(ex) {
+      .catch(function (ex) {
         assert_unreached(ex.name + ":" + ex.message);
       });
+
     }, "the onclose is fired and the connection state is closed.");
+
   }
 </script>

--- a/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onclosed-manual.html
@@ -45,9 +45,6 @@
 
           connection.close();
 
-      })
-      .catch(function (ex) {
-        assert_unreached(ex.name + ":" + ex.message);
       });
 
     }, "the onclose is fired and the connection state is closed.");

--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -20,27 +20,34 @@
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+
     document.getElementById('presentBtn').disabled = true;
-    async_test(function(t) {
+
+    promise_test(function (t) {
       var request = new PresentationRequest(presentationUrls);
-      request.start()
-        .then(function(connection) {
+
+      return request.start()
+        .then(function (connection) {
 
           // Enable timeout again, cause no user action is needed from here.
-          t.step_timeout(function() {
+          t.step_timeout(function () {
               t.force_timeout();
               t.done();
           }, 5000);
 
           assert_true(connection instanceof PresentationConnection);
-          connection.onconnect = t.step_func_done(function() {
+
+          connection.onconnect = function () {
             assert_equals(connection.state, "connected");
             connection.terminate();
-          });
+          };
+
       })
-      .catch(function(ex) {
+      .catch(function (ex) {
         assert_unreached(ex.name + ":" + ex.message);
       });
+
     }, "the onconnect is fired and the connection state is connected");
+
   }
 </script>

--- a/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onconnected-manual.html
@@ -42,9 +42,6 @@
             connection.terminate();
           };
 
-      })
-      .catch(function (ex) {
-        assert_unreached(ex.name + ":" + ex.message);
       });
 
     }, "the onconnect is fired and the connection state is connected");

--- a/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
@@ -52,9 +52,6 @@
               assert_unreached("Wrong, the onclose shouldn't be triggered!");
           };
 
-      })
-      .catch(function (ex) {
-        assert_unreached(ex.name + ":" + ex.message);
       });
 
     }, "the onterminate is fired and the connection state is terminated");

--- a/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onterminated-manual.html
@@ -21,34 +21,43 @@
 <script>
   setup({explicit_timeout: true});
   var startPresentation = function () {
+
     document.getElementById('presentBtn').disabled = true;
-    async_test(function(t) {
+
+    promise_test(function (t) {
       var request = new PresentationRequest(presentationUrls);
-      request.start()
-        .then(function(connection) {
+
+      return request.start()
+        .then(function (connection) {
 
           // Enable timeout again, cause no user action is needed from here.
-          t.step_timeout(function() {
+          t.step_timeout(function () {
               t.force_timeout();
               t.done();
           }, 5000);
 
           assert_true(connection instanceof PresentationConnection);
-          connection.onconnect = t.step_func(function(evt) {
+
+          connection.onconnect = function (evt) {
             assert_equals(connection.state, "connected");
             connection.terminate();
-          });
-          connection.onterminate = t.step_func_done(function(evt) {
+          };
+
+          connection.onterminate = function (evt) {
             assert_equals(evt.type, "terminate");
             assert_equals(connection.state, "terminated");
-          });
-          connection.onclose = t.step_func_done(function(evt) {
+          };
+
+          connection.onclose = function (evt) {
               assert_unreached("Wrong, the onclose shouldn't be triggered!");
-          });
+          };
+
       })
-      .catch(function(ex) {
+      .catch(function (ex) {
         assert_unreached(ex.name + ":" + ex.message);
       });
+
     }, "the onterminate is fired and the connection state is terminated");
+
   }
 </script>


### PR DESCRIPTION
The tests use now `promise_test` instead of `async_test`. I also removed the `step_func`s.

The only thing I am not sure is whether to remove the `catch` blocks or not.

ping #4040

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4330)
<!-- Reviewable:end -->
