### PR TITLE
IndexedDB: Tests for IDBKeyRange and IDBRequest exceptions

### DIFF
--- a/IndexedDB/idbkeyrange.htm
+++ b/IndexedDB/idbkeyrange.htm
@@ -23,6 +23,7 @@
         assert_throws('DataError', function() { IDBKeyRange.only({}); }, 'Object is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.only(Symbol()); }, 'Symbol is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.only(true); }, 'boolean is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.only(() => {}); }, 'function is not a valid key');
     }, "IDBKeyRange.only() - throws on invalid keys");
 
     // lowerBound
@@ -46,6 +47,7 @@
         assert_throws('DataError', function() { IDBKeyRange.lowerBound({}); }, 'Object is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.lowerBound(Symbol()); }, 'Symbol is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.lowerBound(true); }, 'boolean is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound(() => {}); }, 'function is not a valid key');
     }, "IDBKeyRange.lowerBound() - throws on invalid keys");
 
     // upperBound
@@ -69,6 +71,7 @@
         assert_throws('DataError', function() { IDBKeyRange.upperBound({}); }, 'Object is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.upperBound(Symbol()); }, 'Symbol is not a valid key');
         assert_throws('DataError', function() { IDBKeyRange.upperBound(true); }, 'boolean is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.upperBound(() => {}); }, 'function is not a valid key');
     }, "IDBKeyRange.upperBound() - throws on invalid keys");
 
     // bound

--- a/IndexedDB/idbkeyrange.htm
+++ b/IndexedDB/idbkeyrange.htm
@@ -17,6 +17,14 @@
         assert_false(keyRange.upperOpen, "keyRange.upperOpen");
     }, "IDBKeyRange.only() - returns an IDBKeyRange and the properties are set correctly");
 
+    test( function() {
+        assert_throws('DataError', function() { IDBKeyRange.only(undefined); }, 'undefined is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.only(null); }, 'null is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.only({}); }, 'Object is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.only(Symbol()); }, 'Symbol is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.only(true); }, 'boolean is not a valid key');
+    }, "IDBKeyRange.only() - throws on invalid keys");
+
     // lowerBound
     test( function() {
         var keyRange = IDBKeyRange.lowerBound(1, true)
@@ -32,6 +40,14 @@
         assert_false(keyRange.lowerOpen, "keyRange.lowerOpen");
     }, "IDBKeyRange.lowerBound() - 'open' parameter has correct default set");
 
+    test( function() {
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound(undefined); }, 'undefined is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound(null); }, 'null is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound({}); }, 'Object is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound(Symbol()); }, 'Symbol is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.lowerBound(true); }, 'boolean is not a valid key');
+    }, "IDBKeyRange.lowerBound() - throws on invalid keys");
+
     // upperBound
     test( function() {
             var keyRange = IDBKeyRange.upperBound(1, true);
@@ -46,6 +62,14 @@
         var keyRange = IDBKeyRange.upperBound(1);
         assert_false(keyRange.upperOpen, "keyRange.upperOpen");
     }, "IDBKeyRange.upperBound() - 'open' parameter has correct default set");
+
+    test( function() {
+        assert_throws('DataError', function() { IDBKeyRange.upperBound(undefined); }, 'undefined is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.upperBound(null); }, 'null is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.upperBound({}); }, 'Object is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.upperBound(Symbol()); }, 'Symbol is not a valid key');
+        assert_throws('DataError', function() { IDBKeyRange.upperBound(true); }, 'boolean is not a valid key');
+    }, "IDBKeyRange.upperBound() - throws on invalid keys");
 
     // bound
     test( function() {

--- a/IndexedDB/idbrequest_error.html
+++ b/IndexedDB/idbrequest_error.html
@@ -17,8 +17,7 @@ async_test(t => {
     var request = db.transaction('store').objectStore('store').get(0);
 
     assert_equals(request.readyState, 'pending');
-    assert_throws('InvalidStateError',
-                  function() { request.error; },
+    assert_throws('InvalidStateError', () => request.error,
                   'IDBRequest.error should throw if request is pending');
     t.done();
   });

--- a/IndexedDB/idbrequest_error.html
+++ b/IndexedDB/idbrequest_error.html
@@ -14,7 +14,7 @@ async_test(t => {
   });
   open.onsuccess = t.step_func(e => {
     var db = e.target.result;
-    var request = db.transaction("store").objectStore("store").get(0);
+    var request = db.transaction('store').objectStore('store').get(0);
 
     assert_equals(request.readyState, 'pending');
     assert_throws('InvalidStateError',

--- a/IndexedDB/idbrequest_error.html
+++ b/IndexedDB/idbrequest_error.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>IDBRequest.error</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+
+<script>
+async_test(function(t) {
+  var open = createdb(t);
+  open.onupgradeneeded = t.step_func(function(e) {
+    var db = e.target.result;
+    db.createObjectStore('store');
+  });
+  open.onsuccess = t.step_func(function(e) {
+    var db = e.target.result;
+    var request = db.transaction("store").objectStore("store").get(0);
+
+    assert_equals(request.readyState, 'pending');
+    assert_throws('InvalidStateError',
+                  function() { request.error; },
+                  'IDBRequest.error should throw if request is pending');
+    t.done();
+  });
+}, 'IDBRequest.error throws if ready state is pending');
+</script>

--- a/IndexedDB/idbrequest_error.html
+++ b/IndexedDB/idbrequest_error.html
@@ -6,13 +6,13 @@
 <script src=support.js></script>
 
 <script>
-async_test(function(t) {
+async_test(t => {
   var open = createdb(t);
-  open.onupgradeneeded = t.step_func(function(e) {
+  open.onupgradeneeded = t.step_func(e => {
     var db = e.target.result;
     db.createObjectStore('store');
   });
-  open.onsuccess = t.step_func(function(e) {
+  open.onsuccess = t.step_func(e => {
     var db = e.target.result;
     var request = db.transaction("store").objectStore("store").get(0);
 

--- a/IndexedDB/idbrequest_result.html
+++ b/IndexedDB/idbrequest_result.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>IDBRequest.result</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+
+<script>
+async_test(function(t) {
+  var open = createdb(t);
+  open.onupgradeneeded = t.step_func(function(e) {
+    var db = e.target.result;
+    db.createObjectStore('store');
+  });
+  open.onsuccess = t.step_func(function(e) {
+    var db = e.target.result;
+    var request = db.transaction("store").objectStore("store").get(0);
+
+    assert_equals(request.readyState, 'pending');
+    assert_throws('InvalidStateError',
+                  function() { request.result; },
+                  'IDBRequest.result should throw if request is pending');
+    t.done();
+  });
+}, 'IDBRequest.result throws if ready state is pending');
+</script>

--- a/IndexedDB/idbrequest_result.html
+++ b/IndexedDB/idbrequest_result.html
@@ -17,8 +17,7 @@ async_test(t => {
     var request = db.transaction('store').objectStore('store').get(0);
 
     assert_equals(request.readyState, 'pending');
-    assert_throws('InvalidStateError',
-                  function() { request.result; },
+    assert_throws('InvalidStateError', () => request.result,
                   'IDBRequest.result should throw if request is pending');
     t.done();
   });

--- a/IndexedDB/idbrequest_result.html
+++ b/IndexedDB/idbrequest_result.html
@@ -14,7 +14,7 @@ async_test(t => {
   });
   open.onsuccess = t.step_func(e => {
     var db = e.target.result;
-    var request = db.transaction("store").objectStore("store").get(0);
+    var request = db.transaction('store').objectStore('store').get(0);
 
     assert_equals(request.readyState, 'pending');
     assert_throws('InvalidStateError',

--- a/IndexedDB/idbrequest_result.html
+++ b/IndexedDB/idbrequest_result.html
@@ -6,13 +6,13 @@
 <script src=support.js></script>
 
 <script>
-async_test(function(t) {
+async_test(t => {
   var open = createdb(t);
-  open.onupgradeneeded = t.step_func(function(e) {
+  open.onupgradeneeded = t.step_func(e => {
     var db = e.target.result;
     db.createObjectStore('store');
   });
-  open.onsuccess = t.step_func(function(e) {
+  open.onsuccess = t.step_func(e => {
     var db = e.target.result;
     var request = db.transaction("store").objectStore("store").get(0);
 


### PR DESCRIPTION
A few cases not handled by existing tests, as identified by code
coverage analysis.

* IDBKeyRange.only()/lowerBound()/upperBound() with invalid keys
* IDBRequest.result/error getters accessed while request was pending