### PR TITLE
Add IDL test for InputEvent

### DIFF
--- a/input-events/idlharness.html
+++ b/input-events/idlharness.html
@@ -1,0 +1,38 @@
+<title>Input Event IDL tests</title>
+<link rel="help" href="https://w3c.github.io/input-events/#h-interface-inputevent"/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<pre id="untested_idl">
+interface InputEvent {
+};
+</pre>
+
+<pre id='idl'>
+partial interface InputEvent {
+    readonly attribute DOMString     inputType;
+    readonly attribute DataTransfer? dataTransfer;
+    sequence<StaticRange> getTargetRanges();
+};
+
+partial dictionary InputEventInit {
+    DOMString             inputType = "";
+    DataTransfer?         dataTransfer = null;
+    sequence<StaticRange> targetRanges = [];
+};
+</pre>
+
+<script>
+(function(){
+    "use strict";
+    const idl_array = new IdlArray();
+    idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
+    idl_array.add_idls(document.getElementById("idl").textContent);
+    idl_array.add_objects({
+      InputEvent: ['new InputEvent("foo")'],
+    });
+    idl_array.test();
+})();
+</script>


### PR DESCRIPTION
This is the test for partial `InputEvent` IDL only, additional tests should be added later for `StaticRange` and the other part of `InputEvent` interface in `UIEvent`.

Testing results:
  * Passed on Safari Technology Preview Release 18 and Chrome Canary 57 (with `InputEvent` enabled).

References:
1. InputEvent spec: https://w3c.github.io/input-events/#h-interface-inputevent
2. InputEvent in UIEvent spec: https://w3c.github.io/uievents/#interface-inputevent
