### PR TITLE
Extra percent encoding test for URL fragments

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -4356,5 +4356,22 @@
     "search": "",
     "searchParams": "",
     "hash": ""
+  },
+  "# Percent encoding of fragments",
+  {
+    "input": "http://foo.bar/baz?qux#foo\bbar",
+    "base": "about:blank",
+    "href": "http://foo.bar/baz?qux#foo%08bar",
+    "origin": "http://foo.bar",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "foo.bar",
+    "hostname": "foo.bar",
+    "port": "",
+    "pathname": "/baz",
+    "search": "?qux",
+    "searchParams": "",
+    "hash": "#foo%08bar"
   }
 ]


### PR DESCRIPTION
Added an extra test specifically for this change in https://github.com/servo/rust-url/pull/248 , thought I'd sync it upwards


(already reviewed by @SimonSapin)


r? @annevk