### PR TITLE
EE: Splitting Host Source tests

### DIFF
--- a/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-hosts.html
+++ b/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-hosts.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Embedded Enforcement: Subsumption Algorithm - Host parts in host source expressions.</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="../support/testharness-helper.sub.js"></script>
+</head>
+<body>
+  <script>
+    var tests = [
+      { "name": "Host must match.", 
+        "required_csp": "img-src http://c.com", 
+        "returned_csp": "img-src http://b.com",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "Hosts without wildcards must match.", 
+        "required_csp": "img-src http://c.com:* http://inner.b.com", 
+        "returned_csp": "img-src http://b.com",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "More specific subdomain should not match.", 
+        "required_csp": "img-src http://c.com:* http://b.com", 
+        "returned_csp": "img-src http://inner.b.com",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "Specified host should not match a wildcard host.", 
+        "required_csp": "img-src http://c.com:* http://inner.b.com", 
+        "returned_csp": "img-src http://*.b.com",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "A wildcard host should match a more specific host.", 
+        "required_csp": "img-src http://c.com:* http://*.b.com", 
+        "returned_csp": "img-src https://inner.b.com",
+        "expected": IframeLoad.EXPECT_LOAD },
+    ];
+
+    tests.forEach(test => {
+      async_test(t =>  {
+        var url = generateUrlWithPolicies(Host.CROSS_ORIGIN, test.returned_csp);
+        assert_iframe_with_csp(t, url, test.required_csp, test.expected, test.name, null);
+      }, test.name);
+    });
+  </script>
+</body>
+</html>

--- a/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-paths.html
+++ b/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-paths.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Embedded Enforcement: Subsumption Algorithm - Path parts in host source expressions.</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="../support/testharness-helper.sub.js"></script>
+</head>
+<body>
+  <script>
+    var tests = [
+      { "name": "Returned CSP must specify a path.", 
+        "required_csp": "img-src http://c.com:* http://b.com/example.html", 
+        "returned_csp": "img-src http://b.com", 
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "Returned CSP has a more specific path.", 
+        "required_csp": "img-src http://c.com:* http://b.com", 
+        "returned_csp": "img-src http://b.com/example.html", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "Matching paths.", 
+        "required_csp": "img-src http://c.com:* http://b.com/example.html",
+        "returned_csp": "img-src http://b.com/example.html",
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "Empty path is not subsumed by specified paths.", 
+        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html",
+        "returned_csp": "img-src http://b.com/",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "All specific paths match except the order.", 
+        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html", 
+        "returned_csp": "img-src http://b.com/page2.html http://b.com/page3.html http://b.com/page1.html", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "Returned CSP allows only one path.", 
+        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html", 
+        "returned_csp": "img-src http://b.com/page2.html", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "`/` path should be subsumed by an empty path.", 
+        "required_csp": "img-src http://b.com", 
+        "returned_csp": "img-src http://b.com/", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "Unspecified path should be subsumed by `/`.", 
+        "required_csp": "img-src http://b.com/", 
+        "returned_csp": "img-src http://b.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "That should not be true when required csp specifies a specific page.", 
+        "required_csp": "img-src http://b.com/path.html", 
+        "returned_csp": "img-src http://b.com", 
+        "expected": IframeLoad.EXPECT_BLOCK },
+    ];
+
+    tests.forEach(test => {
+      async_test(t =>  {
+        var url = generateUrlWithPolicies(Host.CROSS_ORIGIN, test.returned_csp);
+        assert_iframe_with_csp(t, url, test.required_csp, test.expected, test.name, null);
+      }, test.name);
+    });
+  </script>
+</body>
+</html>

--- a/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-ports.html
+++ b/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-ports.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Embedded Enforcement: Subsumption Algorithm - Basic implementation.</title>
+<title>Embedded Enforcement: Subsumption Algorithm - Port parts in host source expressions.</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="../support/testharness-helper.sub.js"></script>
@@ -9,41 +9,6 @@
 <body>
   <script>
     var tests = [
-      // Protocols.
-      { "name": "`https` is more restrictive than `http`.", 
-        "required_csp": "img-src http://c.com:* https://b.com", 
-        "returned_csp": "img-src http://b.com",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "The reverse allows iframe be to be loaded.", 
-        "required_csp": "img-src http://c.com:* http://b.com", 
-        "returned_csp": "img-src https://b.com",
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "Matching `https` protocols.", 
-        "required_csp": "img-src http://c.com:* https://b.com", 
-        "returned_csp": "img-src https://b.com", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      // Hosts.
-      { "name": "Host must match.", 
-        "required_csp": "img-src http://c.com", 
-        "returned_csp": "img-src http://b.com",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "Hosts without wildcards must match.", 
-        "required_csp": "img-src http://c.com:* http://inner.b.com", 
-        "returned_csp": "img-src http://b.com",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "More specific subdomain should not match.", 
-        "required_csp": "img-src http://c.com:* http://b.com", 
-        "returned_csp": "img-src http://inner.b.com",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "Specified host should not match a wildcard host.", 
-        "required_csp": "img-src http://c.com:* http://inner.b.com", 
-        "returned_csp": "img-src http://*.b.com",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "A wildcard host should match a more specific host.", 
-        "required_csp": "img-src http://c.com:* http://*.b.com", 
-        "returned_csp": "img-src https://inner.b.com",
-        "expected": IframeLoad.EXPECT_LOAD },
-      // Ports.
       { "name": "Specified ports must match.", 
         "required_csp": "img-src http://c.com:* http://b.com:80", 
         "returned_csp": "img-src http://b.com:36", 
@@ -103,43 +68,6 @@
       { "name": "Wildcard port should not be subsumed by a spcified port.", 
         "required_csp": "img-src http://c.com:* ws://b.com:80", 
         "returned_csp": "img-src ws://b.com:*", 
-        "expected": IframeLoad.EXPECT_BLOCK },
-      // Paths.
-      { "name": "Returned CSP must specify a path.", 
-        "required_csp": "img-src http://c.com:* http://b.com/example.html", 
-        "returned_csp": "img-src http://b.com", 
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "Returned CSP has a more specific path.", 
-        "required_csp": "img-src http://c.com:* http://b.com", 
-        "returned_csp": "img-src http://b.com/example.html", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "Matching paths.", 
-        "required_csp": "img-src http://c.com:* http://b.com/example.html",
-        "returned_csp": "img-src http://b.com/example.html",
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "Empty path is not subsumed by specified paths.", 
-        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html",
-        "returned_csp": "img-src http://b.com/",
-        "expected": IframeLoad.EXPECT_BLOCK },
-      { "name": "All specific paths match except the order.", 
-        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html", 
-        "returned_csp": "img-src http://b.com/page2.html http://b.com/page3.html http://b.com/page1.html", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "Returned CSP allows only one path.", 
-        "required_csp": "img-src http://b.com/page1.html http://b.com/page2.html http://b.com/page3.html", 
-        "returned_csp": "img-src http://b.com/page2.html", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "`/` path should be subsumed by an empty path.", 
-        "required_csp": "img-src http://b.com", 
-        "returned_csp": "img-src http://b.com/", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "Unspecified path should be subsumed by `/`.", 
-        "required_csp": "img-src http://b.com/", 
-        "returned_csp": "img-src http://b.com", 
-        "expected": IframeLoad.EXPECT_LOAD },
-      { "name": "That should not be true when required csp specifies a specific page.", 
-        "required_csp": "img-src http://b.com/path.html", 
-        "returned_csp": "img-src http://b.com", 
         "expected": IframeLoad.EXPECT_BLOCK },
     ];
 

--- a/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-protocols.html
+++ b/content-security-policy/embedded-enforcement/subsumption_algorithm-host_sources-protocols.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Embedded Enforcement: Subsumption Algorithm - Scheme parts in host source expressions.</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="../support/testharness-helper.sub.js"></script>
+</head>
+<body>
+  <script>
+    var tests = [
+      { "name": "`https` is more restrictive than `http`.", 
+        "required_csp": "img-src http://c.com:* https://b.com", 
+        "returned_csp": "img-src http://b.com",
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "The reverse allows iframe be to be loaded.", 
+        "required_csp": "img-src http://c.com:* http://b.com", 
+        "returned_csp": "img-src https://b.com",
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "Matching `https` protocols.", 
+        "required_csp": "img-src http://c.com:* https://b.com", 
+        "returned_csp": "img-src https://b.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "`http:` should subsume all host source expressions with this protocol.", 
+        "required_csp": "img-src http:", 
+        "returned_csp": "img-src http://c.com:* https://b.com http://c.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "`http:` should subsume all host source expressions with `https:`.", 
+        "required_csp": "img-src http:", 
+        "returned_csp": "img-src https://c.com:* https://b.com http://c.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "`http:` does not subsume other protocols.", 
+        "required_csp": "img-src http:", 
+        "returned_csp": "img-src https://c.com:* wss://b.com http://c.com", 
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "If scheme source is present in returned csp, it must be specified in required csp too.", 
+        "required_csp": "img-src https://c.com:* wss://b.com http://c.com", 
+        "returned_csp": "img-src http:", 
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "`http:` subsumes other `http:` source expression.", 
+        "required_csp": "img-src http:", 
+        "returned_csp": "img-src http: https://c.com:* https://b.com http://c.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "`http:` subsumes other `https:` source expression and expressions with `http:`.", 
+        "required_csp": "img-src http:", 
+        "returned_csp": "img-src https: https://c.com:* http://b.com", 
+        "expected": IframeLoad.EXPECT_LOAD },
+      { "name": "All scheme sources must be subsumed.", 
+        "required_csp": "img-src http: wss:", 
+        "returned_csp": "img-src https: ws:", 
+        "expected": IframeLoad.EXPECT_BLOCK },
+      { "name": "All scheme sources are subsumed by their stronger variants.", 
+        "required_csp": "img-src http: wss:", 
+        "returned_csp": "img-src https: wss:", 
+        "expected": IframeLoad.EXPECT_LOAD },
+    ];
+
+    tests.forEach(test => {
+      async_test(t =>  {
+        var url = generateUrlWithPolicies(Host.CROSS_ORIGIN, test.returned_csp);
+        assert_iframe_with_csp(t, url, test.required_csp, test.expected, test.name, null);
+      }, test.name);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
I realized the other file for host source expressions was too big so some tests were sometimes timing out before getting a post message. 
I split the tests and added more cases for scheme checks.