### PR TITLE
The value of the srclang and language attributes must be a valid BCP 47 language tag.

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/language.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/language.html
@@ -21,9 +21,9 @@ test(function(){
     assert_equals(t2.language, '');
 });
 test(function(){
-    track.srclang = '\u0000a';
-    assert_equals(t2.language, '\u0000a', 'IDL attribute');
-    track.setAttribute('srclang', '\u0000b');
-    assert_equals(t2.language, '\u0000b', 'content attribute');
-}, document.title+', \\u0000');
+    track.srclang = 'zh-Hant-CN-x-private1-private2';
+    assert_equals(t2.language, 'zh-Hant-CN-x-private1-private2', 'IDL attribute');
+    track.setAttribute('srclang', 'i-klingon');
+    assert_equals(t2.language, 'i-klingon', 'content attribute');
+}, document.title+', BCP47 language tag');
 </script>


### PR DESCRIPTION
The srclang attribute: https://html.spec.whatwg.org/multipage/embedded-content.html#attr-track-srclang. The language attribute is a BCP 47 language tag representing the language of the text track's cues: https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-language. BCP 47 does not allow null characters in the language tag: https://tools.ietf.org/html/bcp47#section-2.1.