### PR TITLE
Test that <meta> refresh does not work in shadow DOM

### DIFF
--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Meta refresh only applies while in the document tree, not in a shadow tree</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives">
+
+<iframe src="support/ufoo"></iframe>
+
+<script>
+"use strict";
+
+const iframe = document.querySelector("iframe");
+let loadCount = 0;
+
+iframe.onload = () => {
+  ++loadCount;
+  const iDocument = iframe.contentDocument;
+
+  if (loadCount === 1) {
+    const div = iDocument.createElement("div");
+    const shadowRoot = div.attachShadow({ mode: "open" });
+    shadowRoot.innerHTML = `<meta http-equiv="refresh" content="1; url=foo">`;
+    iDocument.body.appendChild(div);
+
+    // Want to make sure no refreshes happen
+    step_timeout(done, 3000);
+  } else {
+    assert_unreached("Got more than 1 load event");
+  }
+};
+</script>

--- a/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
+++ b/html/semantics/document-metadata/the-meta-element/pragma-directives/attr-meta-http-equiv-refresh/not-in-shadow-tree.html
@@ -5,12 +5,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/semantics.html#pragma-directives">
 
-<iframe src="support/ufoo"></iframe>
-
+<div id="log"></div>
 <script>
 "use strict";
 
-const iframe = document.querySelector("iframe");
+const iframe = document.createElement("iframe");
+iframe.src = "support/ufoo";
+
 let loadCount = 0;
 
 iframe.onload = () => {
@@ -19,6 +20,7 @@ iframe.onload = () => {
 
   if (loadCount === 1) {
     const div = iDocument.createElement("div");
+    assert_true('attachShadow' in div, 'attachShadow support');
     const shadowRoot = div.attachShadow({ mode: "open" });
     shadowRoot.innerHTML = `<meta http-equiv="refresh" content="1; url=foo">`;
     iDocument.body.appendChild(div);
@@ -29,4 +31,6 @@ iframe.onload = () => {
     assert_unreached("Got more than 1 load event");
   }
 };
+
+document.body.appendChild(iframe);
 </script>


### PR DESCRIPTION
Per spec, http-equiv pragmas must only be processed when the element is inserted into a document, not when it becomes connected.

Blink currently fails this. Bug filed: https://bugs.chromium.org/p/chromium/issues/detail?id=676092

/cc @hayatoito @rniwa