### PR TITLE
parser-uses-constructed-element.html should use assert_true for bools.

### DIFF
--- a/custom-elements/parser/parser-uses-constructed-element.html
+++ b/custom-elements/parser/parser-uses-constructed-element.html
@@ -53,7 +53,7 @@ customElements.define('returns-another-instance', ReturnsAnotherInstance);
 test(function () {
     var instance = document.querySelector('instantiates-itself-before-super');
 
-    assert_equals(instance instanceof InstantiatesItselfBeforeSuper, 'HTML parser must insert the synchronously constructed custom element');
+    assert_true(instance instanceof InstantiatesItselfBeforeSuper, 'HTML parser must insert the synchronously constructed custom element');
     assert_equals(instance, elementCreatedBySuperCall, 'HTML parser must insert the element returned by the custom element constructor');
     assert_not_equals(instance, anotherElementCreatedBeforeSuperCall, 'HTML parser must not insert another instance of the custom element created before super() call');
     assert_equals(anotherElementCreatedBeforeSuperCall.parentNode, null, 'HTML parser must not insert another instance of the custom element created before super() call');
@@ -63,7 +63,7 @@ test(function () {
 test(function () {
     var instance = document.querySelector('returns-another-instance');
 
-    assert_equals(instance instanceof ReturnsAnotherInstance, 'HTML parser must insert the synchronously constructed custom element');
+    assert_true(instance instanceof ReturnsAnotherInstance, 'HTML parser must insert the synchronously constructed custom element');
     assert_equals(instance, anotherInstance, 'HTML parser must insert the element returned by the custom element constructor');
     assert_not_equals(instance, firstInstance, 'HTML parser must not insert the element created by super() call if the constructor returned another element');
     assert_equals(firstInstance.parentNode, null, 'HTML parser must not insert the element created by super() call if the constructor returned another element');


### PR DESCRIPTION
This test does assert_equals(bool_expr, string_expr) when it probably
intends to assert the bool_expr is true, with the string_expr
describing the assertion.