### PR TITLE
Sync requestFullscreen() and exitFullscreen() algorithms with the spec


### DIFF
--- a/fullscreen/api/element-request-fullscreen-and-move-to-iframe-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-move-to-iframe-manual.html
@@ -16,6 +16,7 @@ async_test(t => {
   document.onfullscreenchange = t.unreached_func("fullscreenchange event");
   document.onfullscreenerror = t.step_func_done(() => {
     assert_equals(document.fullscreenElement, null);
+    assert_equals(iframeDoc.fullscreenElement, null);
   });
 
   trusted_click(t.step_func(() => {


### PR DESCRIPTION
The central change is the timing for when the fullscreen element stack
is modified and when the events fire. This makes it possible to make
webkitCurrentFullScreenElement an alias of fullscreenElement, as the old
notion of a single fullscreen element is gone.

Previously, fullscreen requests did:
 1. In Fullscreen::requestFullscreen(), synchronously modify
    m_fullscreenElementStack, visible in document.fullscreenElement, but
    not document.webkitCurrentFullScreenElement. Also enqueue events to
    fire, without starting the timer to fire them.
 2. As soon as the resize happens, in Fullscreen::didEnterFullscreen(),
    set m_currentFullScreenElement, affecting :-webkit-full-screen
    document.webkitCurrentFullScreenElement. Start the event timer.
 3. When the timer fires, events are dispatched. If the tree has changed
    since the events were enqueued, additional events may be fired.

And similarly for exit. For errors, requestFullscreen() would itself
start the timer to fire the events.

Now, fullscreen requests will:
 1. In Fullscreen::requestFullscreen(), append to a list of pending
    requests.
 2. When the resize happens, enqueue an animation frame task for each
    pending request.
 3. In the animation frame task, apply all changes, decide which events
    to fire and then fire them.

TEST=run-webkit-tests fullscreen/ imported/wpt/fullscreen/
     webkit_unit_tests --gtest_filter=*Fullscreen*
     interactive_ui_tests --gtest_filter=SitePerProcessInteractiveBrowserTest.Fullscreen*
BUG=402376,402421
CQ_INCLUDE_TRYBOTS=master.tryserver.chromium.linux:linux_layout_tests_slimming_paint_v2

Review-Url: https://codereview.chromium.org/2573773002
Cr-Commit-Position: refs/heads/master@{#439607}

