### PR TITLE
support focusin/focusout based on webkit/blink

### DIFF
--- a/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
+++ b/pointerevents/pointerevent_releasepointercapture_release_right_after_capture-manual.html
@@ -20,7 +20,7 @@
                     detected_pointertypes[event.pointerType] = true;
                     target0.setPointerCapture(event.pointerId);
                     target0.releasePointerCapture(event.pointerId);
-                    assert_equals(target0.hasPointerCapture(e.pointerId), false, "After target0.releasePointerCapture, target0.hasPointerCapture should be false");
+                    assert_equals(target0.hasPointerCapture(event.pointerId), false, "After target0.releasePointerCapture, target0.hasPointerCapture should be false");
                 });
 
                 on_event(target0, "gotpointercapture", function (event) {

--- a/service-workers/cache-storage/script-tests/cache-add.js
+++ b/service-workers/cache-storage/script-tests/cache-add.js
@@ -84,12 +84,33 @@ cache_test(function(cache) {
   }, 'Cache.add with request with null body (not consumed)');
 
 cache_test(function(cache, test) {
+    return assert_promise_rejects(
+      test,
+      new TypeError(),
+      cache.add('../resources/fetch-status.py?status=206'),
+      'Cache.add should reject on partial response');
+  }, 'Cache.add with 206 response');
+
+cache_test(function(cache, test) {
+    var urls = ['../resources/fetch-status.py?status=206',
+                '../resources/fetch-status.py?status=200'];
+    var requests = urls.map(function(url) {
+        return new Request(url);
+      });
+    return promise_rejects(
+      new TypeError(),
+      cache.addAll(requests),
+      'Cache.addAll should reject with TypeError if any request fails');
+  }, 'Cache.addAll with 206 response');
+
+cache_test(function(cache, test) {
     return promise_rejects(
       test,
       new TypeError(),
       cache.add('this-does-not-exist-please-dont-create-it'),
       'Cache.add should reject if response is !ok');
   }, 'Cache.add with request that results in a status of 404');
+
 
 cache_test(function(cache, test) {
     return promise_rejects(

--- a/service-workers/cache-storage/script-tests/cache-put.js
+++ b/service-workers/cache-storage/script-tests/cache-put.js
@@ -103,6 +103,19 @@ cache_test(function(cache) {
   }, 'Cache.put with an empty response body');
 
 cache_test(function(cache) {
+    var request = new Request(test_url);
+    var response = new Response('', {
+        status: 206,
+        headers: [['Content-Type', 'text/plain']]
+      });
+
+    return assert_promise_rejects(
+      cache.put(request, response),
+      new TypeError(),
+      'Cache.put should reject 206 Responses with a TypeError.');
+  }, 'Cache.put with 206 response');
+
+cache_test(function(cache) {
     var test_url = new URL('../resources/fetch-status.py?status=500', location.href).href;
     var request = new Request(test_url);
     var response;

--- a/uievents/order-of-events/focus-events/focus-automated-blink-webkit.html
+++ b/uievents/order-of-events/focus-events/focus-automated-blink-webkit.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<!-- Modified from Chris Rebert's manual version -->
+<!-- This documents the behavior according to blink's implementation -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Focus-related events should fire in the correct order</title>
+    <link rel="help" href="https://w3c.github.io/uievents/#events-focusevent-event-order">
+    <meta name="flags" content="interact">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body id="body">
+    <input type="text" id="a" value="First">
+    <input type="text" id="b" value="Second">
+    <br>
+    <input type="text" id="c" value="Third">
+    <iframe id="iframe">
+    </iframe>
+    <br>
+    <script>
+
+    var test_id = 0;
+    var tests = ['normal', 'iframe']
+
+    function record(evt) {
+      if (done && (evt.type == 'focusin' || evt.type == 'focus') && (evt.target == c)) {
+          startNext();
+      }
+      if (!done) {
+          var activeElement = document.activeElement ?
+            (document.activeElement.tagName === 'IFRAME' ?
+            document.activeElement.contentDocument.activeElement.id :
+            document.activeElement.id) : null;
+          events[tests[test_id]].push(evt.type);
+          targets[tests[test_id]].push(evt.target.id);
+          focusedElements[tests[test_id]].push(activeElement);
+          relatedTargets[tests[test_id]].push(evt.relatedTarget ? evt.relatedTarget.id : null);
+      }
+    }
+    function startNext() {
+        done = false;
+        test_id++;
+    }
+    function finish() {
+        done = true;
+    }
+    var relevantEvents = [
+      'focus',
+      'blur',
+      'focusin',
+      'focusout'
+    ];
+
+    var iframe = document.getElementById('iframe');
+    var a = document.getElementById('a');
+    var b = document.getElementById('b');
+    var c = document.getElementById('c');
+    var d = document.createElement('input');
+
+    d.setAttribute('id', 'd');
+    d.setAttribute('type', 'text');
+    d.setAttribute('value', 'Fourth');
+
+    var events = {'normal': [], 'iframe': []};
+    var targets = {'normal': [], 'iframe': []};
+    var focusedElements = {'normal': [], 'iframe': []};
+    var relatedTargets = {'normal': [], 'iframe': []};
+    var done = false;
+
+    var async_test_normal = async_test('Focus-related events should fire in the correct order (same DocumentOwner)');
+    var async_test_iframe_static = async_test('Focus-related events should fire in the correct order (different DocumentOwner)');
+
+    window.onload = function(evt) {
+
+        iframe.contentDocument.body.appendChild(d);
+
+        var inputs = [a, b, c, d];
+
+        for (var i = 0; i < inputs.length; i++) {
+          for (var k = 0; k < relevantEvents.length; k++) {
+            inputs[i].addEventListener(relevantEvents[k], record, false);
+          }
+        }
+
+        a.addEventListener('focusin', function() { b.focus(); }, false);
+        b.addEventListener('focusin', function() {
+            console.log(events['normal']);
+            console.log(targets['normal']);
+            console.log(relatedTargets['normal']);
+            console.log(focusedElements['normal']);
+
+            async_test_normal.step( function() {
+                assert_array_equals(
+                  events['normal'],
+                  ['focus', 'focusin', 'blur', 'focusout', 'focus', 'focusin'],
+                  'Focus-related events should fire in this order: focusin, focus, focusout, focusin, blur, focus'
+                );
+
+                assert_array_equals(
+                  targets['normal'],
+                  [      'a',     'a',        'a',       'a',    'b',     'b'],
+                  'Focus-related events should fire at the correct targets'
+                );
+
+                assert_array_equals(
+                  relatedTargets['normal'],
+                  [    null,    null,         'b',       'b',    'a',     'a'],
+                  'Focus-related events should reference correct relatedTargets'
+                );
+
+                assert_array_equals(
+                  focusedElements['normal'],
+                  [   'a',     'a',        'body',    'body',    'b',     'b'],
+                  'Focus-related events should fire at the correct time relative to actual focus changes'
+                );
+
+                async_test_normal.done();
+                });
+
+            b.addEventListener('focusout', function() { finish(); c.focus(); });
+            b.blur();
+
+            }, false);
+
+        c.addEventListener('focusin', function() {d.focus();});
+        d.addEventListener('focusin', function() {
+            console.log(events['iframe']);
+            console.log(targets['iframe']);
+            console.log(relatedTargets['iframe']);
+            console.log(focusedElements['iframe']);
+
+            async_test_iframe_static.step(function() {
+                assert_array_equals(
+                  events['iframe'],
+                  ['focus', 'focusin', 'blur', 'focusout', 'focus', 'focusin'],
+                  'Focus-related events should fire in this order: focusin, focus, focusout, focusin, blur, focus'
+                );
+
+                assert_array_equals(
+                  targets['iframe'],
+                  [      'c',     'c',        'c',       'c',    'd',     'd'],
+                  'Focus-related events should fire at the correct targets'
+                );
+
+                assert_array_equals(
+                  relatedTargets['iframe'],
+                  [    null,    null,        null,      null,   null,    null],
+                  'Focus-related events should reference correct relatedTargets'
+                );
+
+                assert_array_equals(
+                  focusedElements['iframe'],
+                  [   'c',     'c',        'body',      'body', 'd',     'd'],
+                  'Focus-related events should fire at the correct time relative to actual focus changes'
+                );
+
+                async_test_iframe_static.done();
+                });
+
+            d.addEventListener('focusout', function() { finish();});
+
+          }, false);
+
+        a.focus();
+    }
+
+    </script>
+  </body>
+</html>

--- a/web-animations/animation-model/animation-types/spacing-keyframes-shapes.html
+++ b/web-animations/animation-model/animation-types/spacing-keyframes-shapes.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Keyframe spacing tests on shapes</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#spacing-keyframes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+// Help function for testing the computed offsets by the distance array.
+function assert_animation_offsets(anim, dist) {
+  const frames = anim.effect.getKeyframes();
+  const cumDist = dist.reduce( (prev, curr) => {
+    prev.push(prev.length == 0 ? curr : curr + prev[prev.length - 1]);
+    return prev;
+  }, []);
+
+  const total = cumDist[cumDist.length - 1];
+  for (var i = 0; i < frames.length; ++i) {
+    assert_equals(frames[i].computedOffset, cumDist[i] / total,
+                  'computedOffset of frame ' + i);
+  }
+}
+
+test(function(t) {
+  var anim =
+    createDiv(t).animate([ { clipPath: 'circle(20px)' },
+                           { clipPath: 'ellipse(10px 20px)' },
+                           { clipPath: 'polygon(50px 0px, 100px 50px, ' +
+                                       '        50px 100px, 0px 50px)' },
+                           { clipPath: 'inset(20px round 10px)' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  const frames = anim.effect.getKeyframes();
+  const slots = frames.length - 1;
+  for (var i = 0; i < frames.length; ++i) {
+    assert_equals(frames[i].computedOffset, i / slots,
+                  'computedOffset of frame ' + i);
+  }
+}, 'Test falling back to distribute spacing when using different basic shapes');
+
+test(function(t) {
+  var anim =
+    createDiv(t).animate([ { clipPath: 'circle(10px)' },
+                           { clipPath: 'circle(20px) content-box' },
+                           { clipPath: 'circle(70px)' },
+                           { clipPath: 'circle(10px) padding-box' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  const frames = anim.effect.getKeyframes();
+  const slots = frames.length - 1;
+  for (var i = 0; i < frames.length; ++i) {
+    assert_equals(frames[i].computedOffset, i / slots,
+                  'computedOffset of frame ' + i);
+  }
+}, 'Test falling back to distribute spacing when using different ' +
+   'reference boxes');
+
+test(function(t) {
+  // 1st: circle(calc(20px) at  calc(20px + 0%)  calc(10px + 0%))
+  // 2nd: circle(calc(50px) at  calc(10px + 0%)  calc(10px + 0%))
+  // 3rd: circle(70px at  calc(10px + 0%)  calc(50px + 0%))
+  // 4th: circle(10px at  calc(50px + 0%)  calc(30px + 0%))
+  var anim =
+    createDiv(t).animate([ { clipPath: 'circle(calc(10px + 10px) ' +
+                                       '       at 20px 10px)' },
+                           { clipPath: 'circle(calc(20px + 30px) ' +
+                                       '       at 10px 10px)' },
+                           { clipPath: 'circle(70px at 10px 50px)' },
+                           { clipPath: 'circle(10px at 50px 30px)' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  var dist = [ 0,
+               Math.sqrt(30 * 30 + 10 * 10),
+               Math.sqrt(20 * 20 + 40 * 40),
+               Math.sqrt(60 * 60 + 40 * 40 + 20 * 20) ];
+  assert_animation_offsets(anim, dist);
+}, 'Test spacing on circle' );
+
+test(function(t) {
+  // 1st: ellipse(20px calc(20px) at  calc(0px + 50%)  calc(0px + 50%))
+  // 2nd: ellipse(20px calc(50px) at  calc(0px + 50%)  calc(0px + 50%))
+  // 3rd: ellipse(30px 70px at  calc(0px + 50%)  calc(0px + 50%))
+  // 4th: ellipse(30px 10px at  calc(0px + 50%)  calc(0px + 50%))
+  var anim =
+    createDiv(t).animate([ { clipPath: 'ellipse(20px calc(10px + 10px))' },
+                           { clipPath: 'ellipse(20px calc(20px + 30px))' },
+                           { clipPath: 'ellipse(30px 70px)' },
+                           { clipPath: 'ellipse(30px 10px)' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  var dist = [ 0,
+               Math.sqrt(30 * 30),
+               Math.sqrt(10 * 10 + 20 * 20),
+               Math.sqrt(60 * 60) ];
+  assert_animation_offsets(anim, dist);
+}, 'Test spacing on ellipse' );
+
+test(function(t) {
+  // 1st: polygon(nonzero, 50px 0px, 100px 50px, 50px 100px, 0px 50px)
+  // 2nd: polygon(nonzero, 40px 0px, 100px 70px, 10px 100px, 0px 70px)
+  // 3rd: polygon(nonzero, 100px 0px, 100px 100px, 10px 80px, 0px 50px)
+  // 4th: polygon(nonzero, 100px 100px, -10px 100px, 20px 80px, 20px 50px)
+  var anim =
+    createDiv(t).animate([ { clipPath: 'polygon(50px 0px, 100px 50px, ' +
+                                       '        50px 100px, 0px 50px)' },
+                           { clipPath: 'polygon(40px 0px, 100px 70px, ' +
+                                       '        10px 100px, 0px 70px)' },
+                           { clipPath: 'polygon(100px 0px, 100px 100px, ' +
+                                       '        10px 80px, 0px 50px)' },
+                           { clipPath: 'polygon(100px 100px, -10px 100px, ' +
+                                       '        20px 80px, 20px 50px)' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  var dist = [ 0,
+               Math.sqrt(10 * 10 + 20 * 20 + 40 * 40 + 20 * 20),
+               Math.sqrt(60 * 60 + 30 * 30 + 20 * 20 + 20 * 20),
+               Math.sqrt(100 * 100 + 110 * 110 + 10 * 10 + 20 * 20) ];
+  assert_animation_offsets(anim, dist);
+}, 'Test spacing on polygon' );
+
+test(function(t) {
+  // Note: Rounding corners are 4 CSS pair values and
+  //       each pair has x & y components.
+  // 1st: inset(5px 5px 5px 5px round 40px 30px 20px 5px / 40px 30px 20px 5px)
+  // 2nd: inset(10px 5px 10px 5px round 50px 60px / 50px 60px)
+  // 3rd: inset(40px 40px 40px 40px round 10px / 10px)
+  // 4th: inset(30px 40px 30px 40px round 20px / 20px)
+  var anim =
+    createDiv(t).animate([ { clipPath: 'inset(5px 5px 5px 5px ' +
+                                       '      round 40px 30px 20px 5px)' },
+                           { clipPath: 'inset(10px 5px round 50px 60px)' },
+                           { clipPath: 'inset(40px 40px round 10px)' },
+                           { clipPath: 'inset(30px 40px round 20px)' } ],
+                         { spacing: 'paced(clip-path)' });
+
+  var dist = [ 0,
+               Math.sqrt(5 * 5 * 2 + (50 - 40) * (50 - 40) * 2 +
+                                     (60 - 30) * (60 - 30) * 2 +
+                                     (50 - 20) * (50 - 20) * 2 +
+                                     (60 - 5) * (60 - 5) * 2),
+               Math.sqrt(30 * 30 * 2 + 35 * 35 * 2 + (50 - 10) * (50 - 10) * 4 +
+                                                     (60 - 10) * (60 - 10) * 4),
+               Math.sqrt(10 * 10 * 2 + (20 - 10) * (20 - 10) * 8) ];
+  assert_animation_offsets(anim, dist);
+}, 'Test spacing on inset' );
+
+</script>
+</body>


### PR DESCRIPTION

Blink and webkit launch focusin after focus and focusout after blur. Despite
this contradiction with the spec, it is best to mirror this new way, as there
is little guidance or existing code to clarify implementation amiguities that
can arise from the spec.

If focus/blur is fired on a window or document, or the event triggers a change
of focus, do not fire the corresponding focusin/focusout. Otherwise, always
fire the corresponding event.

Additionally, add a mochitest and a w3c-platform-test.

MozReview-Commit-ID: AgQ8JBxKIqK

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=687787