### PR TITLE
Add long timeouts to WebCrypto worker tests, a=testonly

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/pbkdf2.worker.js
+++ b/WebCryptoAPI/derive_bits_keys/pbkdf2.worker.js
@@ -1,3 +1,4 @@
+// <meta> timeout=long
 importScripts("/resources/testharness.js");
 importScripts("pbkdf2_vectors.js");
 importScripts("pbkdf2.js");


### PR DESCRIPTION

MozReview-Commit-ID: 3nfbOXZJ3is

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1318666