### PR TITLE
In automation methods, when startTime is < AudioContext.currentTime, clamp to AudioContext.currentTime;

### DIFF
--- a/webaudio/the-audio-api/the-audioparam-interface/retrospective-exponentialRampToValueAtTime.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/retrospective-exponentialRampToValueAtTime.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<title>Test setValueAtTime with startTime in the past</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<!doctype html>
+<meta charset=utf-8>
+<title>Test exponentialRampToValue with end time in the past</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
 <script>
 function do_test(t, context) {
   var source = context.createConstantSource();
   source.start();
 
-  // Use a ramp of slope 1/sample to measure time.
-  // The end value is the extent of exact precision in single precision float.
-  const rampEnd = Math.pow(2, 24);
-  const rampEndSeconds = rampEnd / context.sampleRate;
   var test = context.createGain();
-  test.gain.setValueAtTime(0.0, 0.5*context.currentTime);
-  test.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  test.gain.exponentialRampToValueAtTime(0.1, 0.5*context.currentTime);
+  test.gain.exponentialRampToValueAtTime(0.9, 2.0);
 
   var reference = context.createGain();
-  reference.gain.setValueAtTime(0.0, context.currentTime);
-  reference.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  reference.gain.exponentialRampToValueAtTime(0.1, context.currentTime);
+  reference.gain.exponentialRampToValueAtTime(0.9, 2.0);
 
   source.connect(test);
   source.connect(reference);
@@ -37,7 +34,7 @@ function do_test(t, context) {
       var referenceValue = e.inputBuffer.getChannelData(1)[0];
 
       assert_equals(testValue, referenceValue,
-                        "ramp value matches expected");
+                        "value matches expected");
     });
 }
 

--- a/webaudio/the-audio-api/the-audioparam-interface/retrospective-linearRampToValueAtTime.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/retrospective-linearRampToValueAtTime.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<title>Test setValueAtTime with startTime in the past</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<!doctype html>
+<meta charset=utf-8>
+<title>Test linearRampToValue with end time in the past</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
 <script>
 function do_test(t, context) {
   var source = context.createConstantSource();
   source.start();
 
-  // Use a ramp of slope 1/sample to measure time.
-  // The end value is the extent of exact precision in single precision float.
-  const rampEnd = Math.pow(2, 24);
-  const rampEndSeconds = rampEnd / context.sampleRate;
   var test = context.createGain();
-  test.gain.setValueAtTime(0.0, 0.5*context.currentTime);
-  test.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  test.gain.linearRampToValueAtTime(0.1, 0.5*context.currentTime);
+  test.gain.linearRampToValueAtTime(0.9, 2.0);
 
   var reference = context.createGain();
-  reference.gain.setValueAtTime(0.0, context.currentTime);
-  reference.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  reference.gain.linearRampToValueAtTime(0.1, context.currentTime);
+  reference.gain.linearRampToValueAtTime(0.9, 2.0);
 
   source.connect(test);
   source.connect(reference);
@@ -37,7 +34,7 @@ function do_test(t, context) {
       var referenceValue = e.inputBuffer.getChannelData(1)[0];
 
       assert_equals(testValue, referenceValue,
-                        "ramp value matches expected");
+                        "value matches expected");
     });
 }
 

--- a/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/retrospective-setTargetAtTime.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html>
-<title>Test setValueAtTime with startTime in the past</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<!doctype html>
+<meta charset=utf-8>
+<title>Test setTargetAtTime with start time in the past</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
 <script>
 function do_test(t, context) {
   var source = context.createConstantSource();
   source.start();
 
-  // Use a ramp of slope 1/sample to measure time.
-  // The end value is the extent of exact precision in single precision float.
-  const rampEnd = Math.pow(2, 24);
-  const rampEndSeconds = rampEnd / context.sampleRate;
   var test = context.createGain();
-  test.gain.setValueAtTime(0.0, 0.5*context.currentTime);
-  test.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  test.gain.setTargetAtTime(0.1, 0.5*context.currentTime, 0.1);
+  test.gain.linearRampToValueAtTime(0.9, 2.0);
 
   var reference = context.createGain();
-  reference.gain.setValueAtTime(0.0, context.currentTime);
-  reference.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  reference.gain.setTargetAtTime(0.1, context.currentTime, 0.1);
+  reference.gain.linearRampToValueAtTime(0.9, 2.0);
 
   source.connect(test);
   source.connect(reference);
@@ -37,7 +34,7 @@ function do_test(t, context) {
       var referenceValue = e.inputBuffer.getChannelData(1)[0];
 
       assert_equals(testValue, referenceValue,
-                        "ramp value matches expected");
+                        "value matches expected");
     });
 }
 

--- a/webaudio/the-audio-api/the-audioparam-interface/retrospective-setValueCurveAtTime.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/retrospective-setValueCurveAtTime.html
@@ -1,23 +1,18 @@
-<!DOCTYPE html>
-<title>Test setValueAtTime with startTime in the past</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<!doctype html>
+<meta charset=utf-8>
+<title>Test SetValueCurve with start time in the past</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
 <script>
 function do_test(t, context) {
   var source = context.createConstantSource();
   source.start();
 
-  // Use a ramp of slope 1/sample to measure time.
-  // The end value is the extent of exact precision in single precision float.
-  const rampEnd = Math.pow(2, 24);
-  const rampEndSeconds = rampEnd / context.sampleRate;
   var test = context.createGain();
-  test.gain.setValueAtTime(0.0, 0.5*context.currentTime);
-  test.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  test.gain.setValueCurveAtTime(new Float32Array([1.0, 0.1]), 0.0, 1.0);
 
   var reference = context.createGain();
-  reference.gain.setValueAtTime(0.0, context.currentTime);
-  reference.gain.linearRampToValueAtTime(rampEnd, rampEndSeconds);
+  reference.gain.setValueCurveAtTime(new Float32Array([1.0, 0.1]), 0.5*context.currentTime, 1.0);
 
   source.connect(test);
   source.connect(reference);
@@ -37,7 +32,7 @@ function do_test(t, context) {
       var referenceValue = e.inputBuffer.getChannelData(1)[0];
 
       assert_equals(testValue, referenceValue,
-                        "ramp value matches expected");
+                        "value matches expected");
     });
 }
 


### PR DESCRIPTION

MozReview-Commit-ID: ImnxgOiIdnG

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1308433