### PR TITLE
followup.  Fix web platform tests that either depended on the old spec's behavior or were asserting that we fail the new one.

### DIFF
--- a/proximity/DeviceProximityEvent_tests.js
+++ b/proximity/DeviceProximityEvent_tests.js
@@ -128,16 +128,18 @@
 
     test(function() {
         var date = new Date();
-        assert_throws(new TypeError(), function() {
-            new DeviceProximityEvent('test', date);
-        });
+        var event = new DeviceProximityEvent('test', date);
+        assert_equals(event.value, Infinity);
+        assert_equals(event.min, -Infinity);
+        assert_equals(event.max, Infinity);
     }, 'eventInitDict argument is Date object');
 
     test(function() {
         var regexp = /abc/;
-        assert_throws(new TypeError(), function() {
-            new DeviceProximityEvent('test', regexp);
-        });
+        var event = new DeviceProximityEvent('test', regexp);
+        assert_equals(event.value, Infinity);
+        assert_equals(event.min, -Infinity);
+        assert_equals(event.max, Infinity);
     }, 'eventInitDict argument is RegExp object');
 
     test(function() {

--- a/proximity/UserProximityEvent_tests.js
+++ b/proximity/UserProximityEvent_tests.js
@@ -124,16 +124,14 @@
 
     test(function() {
         var date = new Date();
-        assert_throws(new TypeError(), function() {
-            new UserProximityEvent('test', date);
-        });
+        var event = new UserProximityEvent('test', date);
+        assert_false(event.near);
     }, 'eventInitDict argument is Date object');
 
     test(function() {
         var regexp = /abc/;
-        assert_throws(new TypeError(), function() {
-            new UserProximityEvent('test', regexp);
-        });
+        var event = new UserProximityEvent('test', regexp);
+        assert_false(event.near);
     }, 'eventInitDict argument is RegExp object');
 
     test(function() {


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1315135