### PR TITLE
Only allow valid base64-values for CSP nonce and hash sources, per spec.

### DIFF
--- a/content-security-policy/blink-contrib-2/scriptnonce-allowed.sub.html
+++ b/content-security-policy/blink-contrib-2/scriptnonce-allowed.sub.html
@@ -41,13 +41,13 @@
 
     </script>
     <!-- enforcing policy:
-script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/=nonce'; connect-src 'self';
+script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/nonce='; connect-src 'self';
 -->
     <script nonce="noncynonce">
         alert_assert('PASS (1/2)');
 
     </script>
-    <script nonce="noncy+/=nonce">
+    <script nonce="noncy+/nonce=">
         alert_assert('PASS (2/2)');
 
     </script>

--- a/content-security-policy/blink-contrib-2/scriptnonce-allowed.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/scriptnonce-allowed.sub.html.sub.headers
@@ -3,4 +3,4 @@ Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
 Set-Cookie: scriptnonce-allowed={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
-Content-Security-Policy: script-src 'self' 'nonce-noncynonce' 'nonce-noncy+/=nonce'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}
+Content-Security-Policy: script-src 'self' 'nonce-noncynonce' 'nonce-noncy+/nonce='; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/blink-contrib-2/scriptnonce-ignore-unsafeinline.sub.html
+++ b/content-security-policy/blink-contrib-2/scriptnonce-ignore-unsafeinline.sub.html
@@ -41,7 +41,7 @@
 
     </script>
     <!-- enforcing policy:
-script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/=nonce' 'unsafe-inline'; connect-src 'self';
+script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/nonce=' 'unsafe-inline'; connect-src 'self';
 -->
     <script nonce="noncynonce">
 
@@ -51,7 +51,7 @@ script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/=nonce' 'unsa
         alert_assert('PASS (1/2)');
 
     </script>
-    <script nonce="noncy+/=nonce">
+    <script nonce="noncy+/nonce=">
         alert_assert('PASS (2/2)');
 
     </script>
@@ -66,7 +66,7 @@ script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/=nonce' 'unsa
         This tests that a valid nonce disables inline JavaScript, even if &apos;unsafe-inline&apos; is present.
     </p>
     <div id="log"></div>
-    <script async defer src="../support/checkReport.sub.js?reportExists=true&amp;reportField=violated-directive&amp;reportValue=script-src%20&apos;nonce-noncynonce&apos;%20&apos;nonce-noncy+/=nonce&apos;%20&apos;unsafe-inline&apos;"></script>
+    <script async defer src="../support/checkReport.sub.js?reportExists=true&amp;reportField=violated-directive&amp;reportValue=script-src%20&apos;nonce-noncynonce&apos;%20&apos;nonce-noncy+/nonce=&apos;%20&apos;unsafe-inline&apos;"></script>
 </body>
 
 </html>

--- a/content-security-policy/blink-contrib-2/scriptnonce-ignore-unsafeinline.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/scriptnonce-ignore-unsafeinline.sub.html.sub.headers
@@ -3,4 +3,4 @@ Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
 Set-Cookie: scriptnonce-ignore-unsafeinline={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
-Content-Security-Policy: script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/=nonce' 'unsafe-inline'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}
+Content-Security-Policy: script-src 'self' 'unsafe-inline' 'nonce-noncynonce' 'nonce-noncy+/nonce=' 'unsafe-inline'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}

--- a/content-security-policy/blink-contrib-2/stylenonce-allowed.sub.html
+++ b/content-security-policy/blink-contrib-2/stylenonce-allowed.sub.html
@@ -9,7 +9,7 @@
     <script src="../support/logTest.sub.js?logs=[]"></script>
     <script src="../support/alertAssert.sub.js?alerts=[]"></script>
     <!-- enforcing policy:
-style-src 'self' nonce-noncynonce' 'nonce-noncy+/=nonce'; script-src 'self' 'unsafe-inline'; connect-src 'self';
+style-src 'self' nonce-noncynonce' 'nonce-noncy+/nonce='; script-src 'self' 'unsafe-inline'; connect-src 'self';
 -->
     <script></script>
     <style nonce="noncynonce">
@@ -48,7 +48,7 @@ style-src 'self' nonce-noncynonce' 'nonce-noncy+/=nonce'; script-src 'self' 'uns
     </script>
     <p>Style correctly whitelisted via a 'nonce-*' expression in 'style-src' should be applied to the page.</p>
     <div id="log"></div>
-    <script async defer src="../support/checkReport.sub.js?reportExists=true&amp;reportField=violated-directive&amp;reportValue=style-src%20&apos;nonce-noncynonce&apos;%20&apos;nonce-noncy+/=nonce&apos;"></script>
+    <script async defer src="../support/checkReport.sub.js?reportExists=true&amp;reportField=violated-directive&amp;reportValue=style-src%20&apos;nonce-noncynonce&apos;%20&apos;nonce-noncy+/nonce=&apos;"></script>
 </body>
 
 </html>

--- a/content-security-policy/blink-contrib-2/stylenonce-allowed.sub.html.sub.headers
+++ b/content-security-policy/blink-contrib-2/stylenonce-allowed.sub.html.sub.headers
@@ -3,4 +3,4 @@ Cache-Control: no-store, no-cache, must-revalidate
 Cache-Control: post-check=0, pre-check=0, false
 Pragma: no-cache
 Set-Cookie: stylenonce-allowed={{$id:uuid()}}; Path=/content-security-policy/blink-contrib-2
-Content-Security-Policy: style-src 'self' 'nonce-noncynonce' 'nonce-noncy+/=nonce'; script-src 'self' 'unsafe-inline'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}
+Content-Security-Policy: style-src 'self' 'nonce-noncynonce' 'nonce-noncy+/nonce='; script-src 'self' 'unsafe-inline'; connect-src 'self'; report-uri /content-security-policy/support/report.py?op=put&reportID={{$id}}


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1309219