### PR TITLE
Add a wpt test verifying Cache API Response objects can be cloned and read.

### DIFF
--- a/service-workers/cache-storage/script-tests/cache-match.js
+++ b/service-workers/cache-storage/script-tests/cache-match.js
@@ -189,4 +189,28 @@ prepopulated_cache_test(simple_entries, function(cache, entries) {
         });
   }, 'Cache.match with a network error Response');
 
+cache_test(function(cache) {
+    // This test validates that we can get a Response from the Cache API,
+    // clone it, and read just one side of the clone.  This was previously
+    // bugged in FF for Responses with large bodies.
+    var data = [];
+    data.length = 80 * 1024;
+    data.fill('F');
+    var response;
+    return cache.put('/', new Response(data.toString()))
+      .then(function(result) {
+          return cache.match('/');
+        })
+      .then(function(r) {
+          // Make sure the original response is not GC'd.
+          response = r;
+          // Return only the clone.  We purposefully test that the other
+          // half of the clone does not need to be read here.
+          return response.clone().text();
+        })
+      .then(function(text) {
+          assert_equals(text, data.toString(), 'cloned body text can be read correctly');
+        })
+  }, 'Cache produces large Responses that can be cloned and read correctly.');
+
 done();


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1320871