### PR TITLE
Ensure that we don't replace load popup.

### DIFF
--- a/XMLHttpRequest/open-url-multi-window-6.htm
+++ b/XMLHttpRequest/open-url-multi-window-6.htm
@@ -26,8 +26,8 @@
                 client = new ifr.contentWindow.XMLHttpRequest();
                 count++;
                 // Important to do a normal navigation, not a reload.
-                win.location.href = "resources/init.htm";
-              }, 100);
+                win.location.href = "resources/init.htm?avoid-replace";
+              }, 0);
             }
             doc.body.appendChild(ifr);
           } else if(1 == count) {


### PR DESCRIPTION

This makes open-url-multi-window-6.htm always fail, which is intended.

MozReview-Commit-ID: 4OENwxMLUeh

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1316871