### PR TITLE
DOMException should be passed as argument in DecodeErrorCallback - WPT,

### DIFF
--- a/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
@@ -26,7 +26,7 @@ interface EventListener {};
 </pre>
 
    <pre id="audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
-callback DecodeErrorCallback = void ();
+callback DecodeErrorCallback = void (DOMException error);
 
 [Constructor]
 interface AudioContext : EventTarget {

--- a/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
@@ -27,7 +27,7 @@ interface EventListener {};
 </pre>
 
    <pre id="audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
-callback DecodeErrorCallback = void ();
+callback DecodeErrorCallback = void (DOMException error);
 
 [Constructor]
 interface AudioContext : EventTarget {

--- a/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
@@ -28,7 +28,7 @@ interface EventListener {};
 </pre>
 
    <pre id="audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
-callback DecodeErrorCallback = void ();
+callback DecodeErrorCallback = void (DOMException error);
 
 [Constructor]
 interface AudioContext : EventTarget {

--- a/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
@@ -28,7 +28,7 @@ interface EventListener {};
 </pre>
 
    <pre id="audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
-callback DecodeErrorCallback = void ();
+callback DecodeErrorCallback = void (DOMException error);
 
 [Constructor]
 interface AudioContext : EventTarget {


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1322982