### PR TITLE
AudioNode constructors - part 15 - AudioBuffer,

### DIFF
--- a/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
@@ -73,7 +73,14 @@ interface AudioContext : EventTarget {
 
 };</pre>
 
-   <pre id="audio-buffer-idl">interface AudioBuffer {
+   <pre id="audio-buffer-idl">dictionary AudioBufferOptions {
+             unsigned long numberOfChannels = 1;
+    required unsigned long length;
+             float         sampleRate;
+};
+
+[Constructor(AudioContext context, AudioBufferOptions options)]
+interface AudioBuffer {
 
     readonly attribute float sampleRate;
     readonly attribute long length;


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1322883