### PR TITLE
Encode URL query string segments to bytes with HTML numeric character references for unmappable characters.

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -14,7 +14,7 @@ onload = function() {
     'utf-16be':'%C3%A5',
     'utf-16le':'%C3%A5',
     'windows-1252':'%E5',
-    'windows-1251':'%3F'
+    'windows-1251':'&%23229;'
   };
   var expected_current = expected_obj[encoding];
   var expected_utf8 = expected_obj['utf-8'];


### PR DESCRIPTION

MozReview-Commit-ID: HDJxSSZZYlw

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1225255