### PR TITLE
Fix expected computedOffset for 'a single keyframe sequence with string offset' test

### DIFF
--- a/web-animations/resources/keyframe-utils.js
+++ b/web-animations/resources/keyframe-utils.js
@@ -259,7 +259,7 @@ var gKeyframeSequenceTests = [
                left: "10px" }] },
   { desc:   "a single keyframe sequence with string offset",
     input:  [{ offset: '0.5', left: "10px" }],
-    output: [{ offset: 0.5, computedOffset: 1, easing: "linear",
+    output: [{ offset: 0.5, computedOffset: 0.5, easing: "linear",
                left: "10px" }] },
   { desc:   "a one property keyframe sequence with some omitted offsets",
     input:  [{ offset: 0.00, left: "10px" },


### PR DESCRIPTION

MozReview-Commit-ID: H2WeL1h7bDT

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1325308