### PR TITLE
Fix test cases that checks keyframe composite is not specified but effect composite is specified.

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -110,7 +110,7 @@ test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, {
       left: ["10px", "20px"]
     }, { composite: composite });
-    assert_equals(effect.getKeyframes()[0].composite, composite,
+    assert_equals(effect.getKeyframes()[0].composite, undefined,
                   "resulting composite for '" + composite + "'");
   });
   gBadCompositeValueTests.forEach(function(composite) {
@@ -120,8 +120,8 @@ test(function(t) {
       }, { composite: composite });
     });
   });
-}, "composite values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in KeyframeTimingOptions");
+}, "composite value is absent if the composite operation specified on the " +
+   "keyframe effect is being used");
 
 gPropertyIndexedKeyframesTests.forEach(function(subtest) {
   test(function(t) {


### PR DESCRIPTION

From spec <https://w3c.github.io/web-animations/#dom-keyframeeffectreadonly-getkeyframes>:

composite
    The keyframe-specific composite operation used to combine the values
    specified in this keyframe with the underlying value.
    This member will be absent if the composite operation specified on
    the keyframe effect is being used.

MozReview-Commit-ID: 8ob59Xv6DRL

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1311620