### PR TITLE
Inherit a fieldset's border-radius down into its content wrapper box, so it doesn't leak out and mess up hit-testing in the corner areas when it has rounded borders.

### DIFF
--- a/cssom-view/elementFromPoint.html
+++ b/cssom-view/elementFromPoint.html
@@ -59,7 +59,9 @@
     <div id="fieldset-div"
          class="size" style="position: absolute; top: 0; left: 0">
     </div>
-    <fieldset class="size" style="position: absolute; top: 100px; left: 100px">
+    <fieldset id="fieldset"
+              class="size"
+              style="position: absolute; top: 100px; left: 100px; border-radius: 100px">
       <!-- Place the child span so the overflow area of the fieldset overlaps
            the div -->
       <span style="position: absolute; top: -100px; left: -100px; height: 1px; width: 1px"></span>
@@ -189,6 +191,14 @@
                                                   divRect.top + divRect.height/2),
                         fieldsetDiv,
                         "The fieldset should not cover up the div it doesn't even overlap");
+
+          var fieldset = document.getElementById("fieldset");
+          var rect = fieldset.getBoundingClientRect();
+          // A point 5px in from topleft will be outside the rounded border.
+          assert_not_equals(document.elementFromPoint(rect.left + 5,
+                                                      rect.top + 5),
+                            fieldset,
+                            "The fieldset should not be hit by hit-tests outside its rounded border");
       }, "Fieldsets");
       done();
     }


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1326163