### PR TITLE
Verify that preloads with a "fetch" `as` value have an empty destination

### DIFF
--- a/preload/fetch_destination.https.html
+++ b/preload/fetch_destination.https.html
@@ -5,7 +5,7 @@
 <script>
 async_test(function(t) {
     var worker_url = 'resources/fetch-destination-worker.js';
-    var scope = 'resources/dummy.xml';
+    var scope = 'resources/empty.html';
     var registration;
 
     function done(registration) {
@@ -21,12 +21,16 @@ async_test(function(t) {
           return with_iframe(scope);
         }))
       .then(t.step_func(function(frame) {
+              console.log(frame);
           var link = frame.contentWindow.document.createElement("link");
           link.as = "fetch";
-          link.href = scope;
+          link.href = "resources/dummy.xml";
           link.rel = "preload";
           link.addEventListener("load", t.step_func(function() { done(registration); }));
-          link.addEventListener("error", t.step_func(function() { assert_unreached("Fetch destination preload errored"); done(registration); }));
+          link.addEventListener("error", t.step_func_done(function() {
+              registration.unregister();
+              assert_unreached("Fetch destination preload errored");
+          }));
           frame.contentWindow.document.body.appendChild(link);
         }))
       .catch(unreached_rejection(t));

--- a/preload/fetch_destination.https.html
+++ b/preload/fetch_destination.https.html
@@ -5,7 +5,7 @@
 <script>
 async_test(function(t) {
     var worker_url = 'resources/fetch-destination-worker.js';
-    var scope = 'resources/empty.html';
+    var scope = 'resources/dummy.xml';
     var registration;
 
     function done(registration) {
@@ -13,23 +13,22 @@ async_test(function(t) {
       t.done();
     }
     service_worker_unregister_and_register(t, worker_url, scope)
-      .then(function(r) {
+      .then(t.step_func(function(r) {
           registration = r;
           return wait_for_state(t, r.installing, 'activated');
-        })
-      .then(function() {
+        }))
+      .then(t.step_func(function() {
           return with_iframe(scope);
-        })
-      .then(function(frame) {
-          var url = "resources/dummy.xml";
+        }))
+      .then(t.step_func(function(frame) {
           var link = frame.contentWindow.document.createElement("link");
           link.as = "fetch";
-          link.href = url;
+          link.href = scope;
           link.rel = "preload";
-          link.addEventListener("load", function() { done(registration); });
-          link.addEventListener("error", function() { assert_unreached("Fetch destination preload errored"); done(registration); });
+          link.addEventListener("load", t.step_func(function() { done(registration); }));
+          link.addEventListener("error", t.step_func(function() { assert_unreached("Fetch destination preload errored"); done(registration); }));
           frame.contentWindow.document.body.appendChild(link);
-        })
+        }))
       .catch(unreached_rejection(t));
 }, 'Fetch destination preload');
 </script>

--- a/preload/fetch_destination.https.html
+++ b/preload/fetch_destination.https.html
@@ -21,7 +21,6 @@ async_test(function(t) {
           return with_iframe(scope);
         }))
       .then(t.step_func(function(frame) {
-              console.log(frame);
           var link = frame.contentWindow.document.createElement("link");
           link.as = "fetch";
           link.href = "resources/dummy.xml";

--- a/preload/fetch_destination.https.html
+++ b/preload/fetch_destination.https.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../service-workers/service-worker/resources/test-helpers.sub.js"></script>
+<script>
+async_test(function(t) {
+    var worker_url = 'resources/fetch-destination-worker.js';
+    var scope = 'resources/empty.html';
+    var registration;
+
+    function done(registration) {
+      registration.unregister();
+      t.done();
+    }
+    service_worker_unregister_and_register(t, worker_url, scope)
+      .then(function(r) {
+          registration = r;
+          return wait_for_state(t, r.installing, 'activated');
+        })
+      .then(function() {
+          return with_iframe(scope);
+        })
+      .then(function(frame) {
+          var url = "resources/dummy.xml";
+          var link = frame.contentWindow.document.createElement("link");
+          link.as = "fetch";
+          link.href = url;
+          link.rel = "preload";
+          link.addEventListener("load", function() { done(registration); });
+          link.addEventListener("error", function() { assert_unreached("Fetch destination preload errored"); done(registration); });
+          frame.contentWindow.document.body.appendChild(link);
+        })
+      .catch(unreached_rejection(t));
+}, 'Fetch destination preload');
+</script>

--- a/preload/fetch_destination.https.html
+++ b/preload/fetch_destination.https.html
@@ -8,10 +8,6 @@ async_test(function(t) {
     var scope = 'resources/empty.html';
     var registration;
 
-    function done(registration) {
-      registration.unregister();
-      t.done();
-    }
     service_worker_unregister_and_register(t, worker_url, scope)
       .then(t.step_func(function(r) {
           registration = r;
@@ -25,7 +21,7 @@ async_test(function(t) {
           link.as = "fetch";
           link.href = "resources/dummy.xml";
           link.rel = "preload";
-          link.addEventListener("load", t.step_func(function() { done(registration); }));
+          link.addEventListener("load", t.step_func_done(function() { registration.unregister(); }));
           link.addEventListener("error", t.step_func_done(function() {
               registration.unregister();
               assert_unreached("Fetch destination preload errored");

--- a/preload/resources/fetch-destination-worker.js
+++ b/preload/resources/fetch-destination-worker.js
@@ -1,11 +1,9 @@
 self.addEventListener('fetch', function(event) {
     if (event.request.url.indexOf('dummy.xml') != -1) {
-        var response = new Response();
-        if (event.request.destination == "")
-            response.status = 200;
+        if (!event.request.destination || event.request.destination == "")
+            event.respondWith(new Response());
         else
-            response.status = 500;
-        event.respondWith(response);
+            event.respondWith(Response.error());
     }
 });
 

--- a/preload/resources/fetch-destination-worker.js
+++ b/preload/resources/fetch-destination-worker.js
@@ -1,0 +1,11 @@
+self.addEventListener('fetch', function(event) {
+    if (event.request.url.indexOf('dummy.xml') != -1) {
+        var response = new Response();
+        if (event.request.destination == "")
+            response.status = 200;
+        else
+            response.status = 500;
+        event.respondWith(response);
+    }
+});
+


### PR DESCRIPTION
@annevk - As discussed on https://github.com/whatwg/fetch/pull/442, here's the corresponding test. Note that it fails in all current implementations.