### PR TITLE
Use () => element.requestFullscreen() to make errors more obvious

### DIFF
--- a/fullscreen/trusted-click.js
+++ b/fullscreen/trusted-click.js
@@ -19,6 +19,6 @@ function trusted_click(callback, container)
 // Invokes element.requestFullscreen() from a trusted click.
 function trusted_request(element, container)
 {
-    var request = element.requestFullscreen.bind(element);
+    var request = () => element.requestFullscreen();
     trusted_click(request, container || element.parentNode);
 }


### PR DESCRIPTION
If the unprefixed API isn't supported, it would currently fail with
"TypeError: Unable to get property 'bind' of undefined or null
reference" or similar, obscuring the root cause.