### PR TITLE
Fullscreen: give trusted_click and trusted_click the test for step_func

### DIFF
--- a/fullscreen/api/document-exit-fullscreen-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-manual.html
@@ -7,7 +7,7 @@
 <script>
 async_test(function(t)
 {
-    trusted_request(document.querySelector("div"));
+    trusted_request(t, document.querySelector("div"));
 
     document.addEventListener("fullscreenchange", t.step_func(function(event)
     {

--- a/fullscreen/api/document-exit-fullscreen-timing-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-timing-manual.html
@@ -7,7 +7,7 @@
 <script>
 async_test(t => {
   const div = document.querySelector('div');
-  trusted_request(div);
+  trusted_request(t, div);
 
   document.onfullscreenchange = t.step_func(() => {
     // We are now in fullscreen. Exit again.

--- a/fullscreen/api/document-exit-fullscreen-twice-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-twice-manual.html
@@ -27,6 +27,6 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 
-  trusted_request(div);
+  trusted_request(t, div);
 });
 </script>

--- a/fullscreen/api/document-fullscreen-element-manual.html
+++ b/fullscreen/api/document-fullscreen-element-manual.html
@@ -22,11 +22,11 @@ async_test(function(t)
         });
     });
 
-    trusted_click(t.step_func(function()
+    trusted_click(t, function()
     {
         assert_equals(document.fullscreenElement, null, "fullscreenElement before requestFullscreen()");
         div.requestFullscreen();
         assert_equals(document.fullscreenElement, null, "fullscreenElement after requestFullscreen()");
-    }), document.body);
+    }, document.body);
 });
 </script>

--- a/fullscreen/api/document-onfullscreenchange-manual.html
+++ b/fullscreen/api/document-onfullscreenchange-manual.html
@@ -10,6 +10,6 @@ async_test(function(t)
     var div = document.querySelector("div");
     assert_equals(document.onfullscreenchange, null, "initial onfullscreenchange");
     document.onfullscreenchange = t.step_func_done();
-    trusted_request(div);
+    trusted_request(t, div);
 });
 </script>

--- a/fullscreen/api/element-ready-check-containing-iframe-manual.html
+++ b/fullscreen/api/element-ready-check-containing-iframe-manual.html
@@ -10,10 +10,10 @@
 async_test(function(t)
 {
     var iframes = document.getElementsByTagName("iframe");
-    trusted_request(iframes[0].contentDocument.body, document.body);
+    trusted_request(t, iframes[0].contentDocument.body, document.body);
     iframes[0].contentDocument.onfullscreenchange = t.step_func(function()
     {
-        trusted_request(iframes[1].contentDocument.body, iframes[0].contentDocument.body);
+        trusted_request(t, iframes[1].contentDocument.body, iframes[0].contentDocument.body);
         iframes[1].contentDocument.onfullscreenchange = t.unreached_func("fullscreenchange event");
         iframes[1].contentDocument.onfullscreenerror = t.step_func_done();
     });

--- a/fullscreen/api/element-ready-check-enabled-flag-not-set-manual.html
+++ b/fullscreen/api/element-ready-check-enabled-flag-not-set-manual.html
@@ -14,6 +14,6 @@ async_test(function(t)
     iframe.contentDocument.onfullscreenchange = t.unreached_func("iframe fullscreenchange event");
     iframe.contentDocument.onfullscreenerror = t.step_func_done();
     assert_false(iframe.contentDocument.fullscreenEnabled, "fullscreen enabled flag");
-    trusted_request(iframe.contentDocument.body, document.body);
+    trusted_request(t, iframe.contentDocument.body, document.body);
 });
 </script>

--- a/fullscreen/api/element-ready-check-fullscreen-element-sibling-manual.html
+++ b/fullscreen/api/element-ready-check-fullscreen-element-sibling-manual.html
@@ -14,10 +14,10 @@ async_test(function(t)
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, a, "fullscreen element");
-        trusted_request(b, a);
+        trusted_request(t, b, a);
         document.onfullscreenchange = t.unreached_func("second fullscreenchange event");
         document.onfullscreenerror = t.step_func_done();
     });
-    trusted_request(a);
+    trusted_request(t, a);
 });
 </script>

--- a/fullscreen/api/element-ready-check-fullscreen-iframe-child-manual.html
+++ b/fullscreen/api/element-ready-check-fullscreen-iframe-child-manual.html
@@ -25,9 +25,9 @@ async_test(t => {
     });
     document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 
-    trusted_request(div, iframe.contentDocument.body);
+    trusted_request(t, div, iframe.contentDocument.body);
   });
 
-  trusted_request(iframe);
+  trusted_request(t, iframe);
 });
 </script>

--- a/fullscreen/api/element-ready-check-iframe-child-manual.html
+++ b/fullscreen/api/element-ready-check-iframe-child-manual.html
@@ -15,6 +15,6 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 
-  trusted_request(div, document.body);
+  trusted_request(t, div, document.body);
 });
 </script>

--- a/fullscreen/api/element-ready-check-not-in-document-manual.html
+++ b/fullscreen/api/element-ready-check-not-in-document-manual.html
@@ -10,6 +10,6 @@ async_test(function(t)
     var div = document.createElement("div");
     document.onfullscreenchange = t.unreached_func("fullscreenchange event");
     document.onfullscreenerror = t.step_func_done();
-    trusted_request(div, document.body);
+    trusted_request(t, div, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-and-exit-iframe-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-exit-iframe-manual.html
@@ -33,6 +33,6 @@ async_test(t => {
   document.onfullscreenerror = t.unreached_func('fullscreenerror event');
   iframeDoc.onfullscreenerror = t.unreached_func('iframe fullscreenerror event');
 
-  trusted_request(iframeBody, document.body);
+  trusted_request(t, iframeBody, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-and-move-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-move-manual.html
@@ -17,9 +17,9 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func("fullscreenchange event");
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     target.requestFullscreen();
     moveTo.appendChild(target);
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-and-move-to-iframe-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-move-to-iframe-manual.html
@@ -19,9 +19,9 @@ async_test(t => {
     assert_equals(iframeDoc.fullscreenElement, null);
   });
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     target.requestFullscreen();
     iframeDoc.body.appendChild(target);
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-and-remove-iframe-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-remove-iframe-manual.html
@@ -15,7 +15,7 @@ async_test(t => {
   iframeDocument.onfullscreenchange = t.unreached_func("iframe fullscreenchange event");
   iframeDocument.onfullscreenerror = t.unreached_func("iframe fullscreenerror event");
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     iframeDocument.body.requestFullscreen();
     iframe.remove();
     // No events will be fired, end test after 100ms.
@@ -23,6 +23,6 @@ async_test(t => {
       assert_equals(document.fullscreenElement, null);
       assert_equals(iframeDocument.fullscreenElement, null);
     }), 100);
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-and-remove-manual.html
+++ b/fullscreen/api/element-request-fullscreen-and-remove-manual.html
@@ -14,9 +14,9 @@ async_test(t => {
     assert_equals(document.fullscreenElement, null);
   });
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     target.requestFullscreen();
     target.remove();
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-manual.html
+++ b/fullscreen/api/element-request-fullscreen-manual.html
@@ -17,6 +17,6 @@ async_test(function(t)
         t.done();
     }));
 
-    trusted_request(div);
+    trusted_request(t, div);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-non-top-manual.html
+++ b/fullscreen/api/element-request-fullscreen-non-top-manual.html
@@ -11,16 +11,16 @@
 async_test(function(t)
 {
     var first = document.getElementById("first");
-    trusted_request(first);
+    trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, first);
         var last = document.getElementById("last");
-        trusted_request(last);
+        trusted_request(t, last);
         document.onfullscreenchange = t.step_func(function()
         {
             assert_equals(document.fullscreenElement, last);
-            trusted_request(first, last);
+            trusted_request(t, first, last);
             document.onfullscreenerror = t.step_func_done();
         });
     });

--- a/fullscreen/api/element-request-fullscreen-same-manual.html
+++ b/fullscreen/api/element-request-fullscreen-same-manual.html
@@ -16,15 +16,15 @@ async_test(t => {
     // doc's fullscreen element, terminate these subsubsteps."
     document.onfullscreenchange = t.unreached_func("fullscreenchange event");
 
-    trusted_click(t.step_func(() => {
+    trusted_click(t, () => {
       target.requestFullscreen();
 
       // Wait until after the next animation frame.
       requestAnimationFrame(t.step_func_done());
-    }), target);
+    }, target);
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 
-  trusted_request(target);
+  trusted_request(t, target);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-svg-rect-manual.html
+++ b/fullscreen/api/element-request-fullscreen-svg-rect-manual.html
@@ -10,7 +10,7 @@ async_test(function(t)
 {
     var rect = document.querySelector("rect");
     assert_true(rect instanceof SVGRectElement);
-    trusted_request(rect, document.body);
+    trusted_request(t, rect, document.body);
     document.onfullscreenchange = t.unreached_func("fullscreenerror event");
     document.onfullscreenerror = t.step_func_done();
 });

--- a/fullscreen/api/element-request-fullscreen-svg-svg-manual.html
+++ b/fullscreen/api/element-request-fullscreen-svg-svg-manual.html
@@ -10,7 +10,7 @@ async_test(function(t)
 {
     var svg = document.querySelector("svg");
     assert_true(svg instanceof SVGSVGElement);
-    trusted_request(svg, document.body);
+    trusted_request(t, svg, document.body);
     document.onfullscreenchange = t.step_func_done();
     document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 });

--- a/fullscreen/api/element-request-fullscreen-timing-manual.html
+++ b/fullscreen/api/element-request-fullscreen-timing-manual.html
@@ -6,7 +6,7 @@
 <div id="log"></div>
 <script>
 async_test(t => {
-  trusted_request(document.querySelector('div'));
+  trusted_request(t, document.querySelector('div'));
 
   // If fullscreenchange is an animation frame event, then animation frame
   // callbacks should be run after it is fired, before the timer callback.

--- a/fullscreen/api/element-request-fullscreen-top-manual.html
+++ b/fullscreen/api/element-request-fullscreen-top-manual.html
@@ -9,12 +9,12 @@
 async_test(function(t)
 {
     var top = document.getElementById("top");
-    trusted_request(top);
+    trusted_request(t, top);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, top);
         document.onfullscreenchange = t.unreached_func("fullscreenchange event");
-        trusted_click(t.step_func(function()
+        trusted_click(t, function()
         {
             top.requestFullscreen();
             // A fullscreenerror event would be fired after an async section
@@ -23,7 +23,7 @@ async_test(function(t)
             {
                 requestAnimationFrame(t.step_func_done());
             }, 0);
-        }), top);
+        }, top);
     });
     document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 });

--- a/fullscreen/api/element-request-fullscreen-twice-manual.html
+++ b/fullscreen/api/element-request-fullscreen-twice-manual.html
@@ -16,12 +16,12 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     // Request fullscreen twice.
     div.requestFullscreen();
     assert_equals(document.fullscreenElement, null, "fullscreenElement after first requestFullscreen()");
     div.requestFullscreen();
     assert_equals(document.fullscreenElement, null, "fullscreenElement after second requestFullscreen()");
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-two-elements-manual.html
+++ b/fullscreen/api/element-request-fullscreen-two-elements-manual.html
@@ -26,9 +26,9 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func('fullscreenerror event');
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     b.requestFullscreen();
     a.requestFullscreen();
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/api/element-request-fullscreen-two-iframes-manual.html
+++ b/fullscreen/api/element-request-fullscreen-two-iframes-manual.html
@@ -28,9 +28,9 @@ async_test(t => {
   });
   document.onfullscreenerror = t.unreached_func('fullscreenerror event');
 
-  trusted_click(t.step_func(() => {
+  trusted_click(t, () => {
     b.contentDocument.body.requestFullscreen();
     a.contentDocument.body.requestFullscreen();
-  }), document.body);
+  }, document.body);
 });
 </script>

--- a/fullscreen/model/remove-child-manual.html
+++ b/fullscreen/model/remove-child-manual.html
@@ -11,7 +11,7 @@
 async_test(function(t)
 {
     var parent = document.getElementById("parent");
-    trusted_request(parent);
+    trusted_request(t, parent);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, parent);

--- a/fullscreen/model/remove-first-manual.html
+++ b/fullscreen/model/remove-first-manual.html
@@ -11,12 +11,12 @@
 async_test(function(t)
 {
     var first = document.getElementById("first");
-    trusted_request(first);
+    trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, first);
         var last = document.getElementById("last");
-        trusted_request(last);
+        trusted_request(t, last);
         document.onfullscreenchange = t.step_func(function()
         {
             assert_equals(document.fullscreenElement, last);

--- a/fullscreen/model/remove-last-manual.html
+++ b/fullscreen/model/remove-last-manual.html
@@ -11,12 +11,12 @@
 async_test(function(t)
 {
     var first = document.getElementById("first");
-    trusted_request(first);
+    trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, first);
         var last = document.getElementById("last");
-        trusted_request(last);
+        trusted_request(t, last);
         document.onfullscreenchange = t.step_func(function()
         {
             assert_equals(document.fullscreenElement, last);

--- a/fullscreen/model/remove-parent-manual.html
+++ b/fullscreen/model/remove-parent-manual.html
@@ -11,7 +11,7 @@
 async_test(function(t)
 {
     var child = document.getElementById("child");
-    trusted_request(child);
+    trusted_request(t, child);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, child);

--- a/fullscreen/model/remove-single-manual.html
+++ b/fullscreen/model/remove-single-manual.html
@@ -19,6 +19,6 @@ async_test(function(t)
             t.done();
         });
     });
-    trusted_request(single);
+    trusted_request(t, single);
 });
 </script>

--- a/fullscreen/trusted-click.js
+++ b/fullscreen/trusted-click.js
@@ -1,6 +1,6 @@
 // Invokes callback from a trusted click event, to satisfy
 // https://html.spec.whatwg.org/#triggered-by-user-activation
-function trusted_click(callback, container)
+function trusted_click(test, callback, container)
 {
     var document = container.ownerDocument;
     var button = document.createElement("button");
@@ -8,17 +8,16 @@ function trusted_click(callback, container)
     button.style.display = "block";
     button.style.fontSize = "20px";
     button.style.padding = "10px";
-    button.onclick = function()
+    button.onclick = test.step_func(function()
     {
         callback();
         container.removeChild(button);
-    };
+    });
     container.appendChild(button);
 }
 
 // Invokes element.requestFullscreen() from a trusted click.
-function trusted_request(element, container)
+function trusted_request(test, element, container)
 {
-    var request = element.requestFullscreen.bind(element);
-    trusted_click(request, container || element.parentNode);
+    trusted_click(test, () => element.requestFullscreen(), container || element.parentNode);
 }


### PR DESCRIPTION
The element.requestFullscreen() is wrapped in an arrow function, which
together with the other changes should make failures more obvious.