### PR TITLE
IndexedDB upgrade transaction lifecycle tests.

### DIFF
--- a/IndexedDB/support-promises.js
+++ b/IndexedDB/support-promises.js
@@ -1,42 +1,46 @@
-// Returns an IndexedDB database name likely to be unique to the test case.
-const databaseName = (testCase) => {
+'use strict';
+
+// Returns an IndexedDB database name that is unique to the test case.
+function databaseName(testCase) {
   return 'db' + self.location.pathname + '-' + testCase.name;
-};
+}
 
 // Creates an EventWatcher covering all the events that can be issued by
 // IndexedDB requests and transactions.
-const requestWatcher = (testCase, request) => {
+function requestWatcher(testCase, request) {
   return new EventWatcher(testCase, request,
-      ['error', 'success', 'upgradeneeded']);
-};
+      ['abort', 'blocked', 'complete', 'error', 'success', 'upgradeneeded']);
+}
 
 // Migrates an IndexedDB database whose name is unique for the test case.
 //
 // newVersion must be greater than the database's current version.
 //
 // migrationCallback will be called during a versionchange transaction and will
-// be given the created database and the versionchange transaction.
+// given the created database, the versionchange transaction, and the database
+// open request.
 //
 // Returns a promise. If the versionchange transaction goes through, the promise
 // resolves to an IndexedDB database that must be closed by the caller. If the
 // versionchange transaction is aborted, the promise resolves to an error.
-const migrateDatabase = (testCase, newVersion, migrationCallback) => {
+function migrateDatabase(testCase, newVersion, migrationCallback) {
   return migrateNamedDatabase(
       testCase, databaseName(testCase), newVersion, migrationCallback);
-};
+}
 
 // Migrates an IndexedDB database.
 //
 // newVersion must be greater than the database's current version.
 //
 // migrationCallback will be called during a versionchange transaction and will
-// be given the created database and the versionchange transaction.
+// given the created database, the versionchange transaction, and the database
+// open request.
 //
 // Returns a promise. If the versionchange transaction goes through, the promise
 // resolves to an IndexedDB database that must be closed by the caller. If the
 // versionchange transaction is aborted, the promise resolves to an error.
-const migrateNamedDatabase =
-    (testCase, databaseName, newVersion, migrationCallback) => {
+function migrateNamedDatabase(
+    testCase, databaseName, newVersion, migrationCallback) {
   // We cannot use eventWatcher.wait_for('upgradeneeded') here, because
   // the versionchange transaction auto-commits before the Promise's then
   // callback gets called.
@@ -45,62 +49,78 @@ const migrateNamedDatabase =
     request.onupgradeneeded = testCase.step_func(event => {
       const database = event.target.result;
       const transaction = event.target.transaction;
-      let abortCalled = false;
+      let shouldBeAborted = false;
+      let requestEventPromise = null;
 
       // We wrap IDBTransaction.abort so we can set up the correct event
       // listeners and expectations if the test chooses to abort the
       // versionchange transaction.
       const transactionAbort = transaction.abort.bind(transaction);
       transaction.abort = () => {
-        request.onerror = event => {
-          event.preventDefault();
-          resolve(event);
-        };
-        request.onsuccess = () => reject(new Error(
-            'indexedDB.open should not succeed after the versionchange ' +
-            'transaction is aborted'));
+        transaction._willBeAborted();
         transactionAbort();
-        abortCalled = true;
+      }
+      transaction._willBeAborted = () => {
+        requestEventPromise = new Promise((resolve, reject) => {
+          request.onerror = event => {
+            event.preventDefault();
+            resolve(event);
+          };
+          request.onsuccess = () => reject(new Error(
+              'indexedDB.open should not succeed for an aborted ' +
+              'versionchange transaction'));
+        });
+        shouldBeAborted = true;
       }
 
-      migrationCallback(database, transaction);
-      if (!abortCalled) {
+      // If migration callback returns a promise, we'll wait for it to resolve.
+      // This simplifies some tests.
+      const callbackResult = migrationCallback(database, transaction, request);
+      if (!shouldBeAborted) {
+        request.onerror = null;
         request.onsuccess = null;
-        resolve(requestWatcher(testCase, request).wait_for('success'));
+        requestEventPromise =
+            requestWatcher(testCase, request).wait_for('success');
       }
+
+      // requestEventPromise needs to be the last promise in the chain, because
+      // we want the event that it resolves to.
+      resolve(Promise.resolve(callbackResult).then(() => requestEventPromise));
     });
     request.onerror = event => reject(event.target.error);
     request.onsuccess = () => reject(new Error(
         'indexedDB.open should not succeed without creating a ' +
         'versionchange transaction'));
   }).then(event => event.target.result || event.target.error);
-};
+}
 
 // Creates an IndexedDB database whose name is unique for the test case.
 //
 // setupCallback will be called during a versionchange transaction, and will be
-// given the created database and the versionchange transaction.
+// given the created database, the versionchange transaction, and the database
+// open request.
 //
 // Returns a promise that resolves to an IndexedDB database. The caller must
 // close the database.
-const createDatabase = (testCase, setupCallback) => {
+function createDatabase(testCase, setupCallback) {
   return createNamedDatabase(testCase, databaseName(testCase), setupCallback);
-};
+}
 
 // Creates an IndexedDB database.
 //
 // setupCallback will be called during a versionchange transaction, and will be
-// given the created database and the versionchange transaction.
+// given the created database, the versionchange transaction, and the database
+// open request.
 //
 // Returns a promise that resolves to an IndexedDB database. The caller must
 // close the database.
-const createNamedDatabase = (testCase, databaseName, setupCallback) => {
+function createNamedDatabase(testCase, databaseName, setupCallback) {
   const request = indexedDB.deleteDatabase(databaseName);
   const eventWatcher = requestWatcher(testCase, request);
 
   return eventWatcher.wait_for('success').then(event =>
       migrateNamedDatabase(testCase, databaseName, 1, setupCallback));
-};
+}
 
 // Opens an IndexedDB database without performing schema changes.
 //
@@ -108,7 +128,7 @@ const createNamedDatabase = (testCase, databaseName, setupCallback) => {
 //
 // Returns a promise that resolves to an IndexedDB database. The caller must
 // close the database.
-const openDatabase = (testCase, version) => {
+function openDatabase(testCase, version) {
   return openNamedDatabase(testCase, databaseName(testCase), version);
 }
 
@@ -118,7 +138,7 @@ const openDatabase = (testCase, version) => {
 //
 // Returns a promise that resolves to an IndexedDB database. The caller must
 // close the database.
-const openNamedDatabase = (testCase, databaseName, version) => {
+function openNamedDatabase(testCase, databaseName, version) {
   const request = indexedDB.open(databaseName, version);
   const eventWatcher = requestWatcher(testCase, request);
   return eventWatcher.wait_for('success').then(event => event.target.result);
@@ -142,16 +162,16 @@ const createBooksStore = (testCase, database) => {
   for (let record of BOOKS_RECORD_DATA)
       store.put(record);
   return store;
-};
+}
 
 // Creates a 'not_books' object store used to test renaming into existing or
 // deleted store names.
-const createNotBooksStore = (testCase, database) => {
-    const store = database.createObjectStore('not_books');
-    store.createIndex('not_by_author', 'author');
-    store.createIndex('not_by_title', 'title', { unique: true });
-    return store;
-};
+function createNotBooksStore(testCase, database) {
+  const store = database.createObjectStore('not_books');
+  store.createIndex('not_by_author', 'author');
+  store.createIndex('not_by_title', 'title', { unique: true });
+  return store;
+}
 
 // Verifies that an object store's indexes match the indexes used to create the
 // books store in the test database's version 1.
@@ -159,7 +179,7 @@ const createNotBooksStore = (testCase, database) => {
 // The errorMessage is used if the assertions fail. It can state that the
 // IndexedDB implementation being tested is incorrect, or that the testing code
 // is using it incorrectly.
-const checkStoreIndexes = (testCase, store, errorMessage) => {
+function checkStoreIndexes (testCase, store, errorMessage) {
   assert_array_equals(
       store.indexNames, ['by_author', 'by_title'], errorMessage);
   const authorIndex = store.index('by_author');
@@ -168,7 +188,7 @@ const checkStoreIndexes = (testCase, store, errorMessage) => {
       checkAuthorIndexContents(testCase, authorIndex, errorMessage),
       checkTitleIndexContents(testCase, titleIndex, errorMessage),
   ]);
-};
+}
 
 // Verifies that an object store's key generator is in the same state as the
 // key generator created for the books store in the test database's version 1.
@@ -176,7 +196,7 @@ const checkStoreIndexes = (testCase, store, errorMessage) => {
 // The errorMessage is used if the assertions fail. It can state that the
 // IndexedDB implementation being tested is incorrect, or that the testing code
 // is using it incorrectly.
-const checkStoreGenerator = (testCase, store, expectedKey, errorMessage) => {
+function checkStoreGenerator(testCase, store, expectedKey, errorMessage) {
   const request = store.put(
       { title: 'Bedrock Nights ' + expectedKey, author: 'Barney' });
   const eventWatcher = requestWatcher(testCase, request);
@@ -184,7 +204,7 @@ const checkStoreGenerator = (testCase, store, expectedKey, errorMessage) => {
     const result = request.result;
     assert_equals(result, expectedKey, errorMessage);
   });
-};
+}
 
 // Verifies that an object store's contents matches the contents used to create
 // the books store in the test database's version 1.
@@ -192,7 +212,7 @@ const checkStoreGenerator = (testCase, store, expectedKey, errorMessage) => {
 // The errorMessage is used if the assertions fail. It can state that the
 // IndexedDB implementation being tested is incorrect, or that the testing code
 // is using it incorrectly.
-const checkStoreContents = (testCase, store, errorMessage) => {
+function checkStoreContents(testCase, store, errorMessage) {
   const request = store.get(123456);
   const eventWatcher = requestWatcher(testCase, request);
   return eventWatcher.wait_for('success').then(() => {
@@ -201,7 +221,7 @@ const checkStoreContents = (testCase, store, errorMessage) => {
     assert_equals(result.author, BOOKS_RECORD_DATA[0].author, errorMessage);
     assert_equals(result.title, BOOKS_RECORD_DATA[0].title, errorMessage);
   });
-};
+}
 
 // Verifies that index matches the 'by_author' index used to create the
 // by_author books store in the test database's version 1.
@@ -209,7 +229,7 @@ const checkStoreContents = (testCase, store, errorMessage) => {
 // The errorMessage is used if the assertions fail. It can state that the
 // IndexedDB implementation being tested is incorrect, or that the testing code
 // is using it incorrectly.
-const checkAuthorIndexContents = (testCase, index, errorMessage) => {
+function checkAuthorIndexContents(testCase, index, errorMessage) {
   const request = index.get(BOOKS_RECORD_DATA[2].author);
   const eventWatcher = requestWatcher(testCase, request);
   return eventWatcher.wait_for('success').then(() => {
@@ -217,7 +237,7 @@ const checkAuthorIndexContents = (testCase, index, errorMessage) => {
     assert_equals(result.isbn, BOOKS_RECORD_DATA[2].isbn, errorMessage);
     assert_equals(result.title, BOOKS_RECORD_DATA[2].title, errorMessage);
   });
-};
+}
 
 // Verifies that an index matches the 'by_title' index used to create the books
 // store in the test database's version 1.
@@ -225,7 +245,7 @@ const checkAuthorIndexContents = (testCase, index, errorMessage) => {
 // The errorMessage is used if the assertions fail. It can state that the
 // IndexedDB implementation being tested is incorrect, or that the testing code
 // is using it incorrectly.
-const checkTitleIndexContents = (testCase, index, errorMessage) => {
+function checkTitleIndexContents(testCase, index, errorMessage) {
   const request = index.get(BOOKS_RECORD_DATA[2].title);
   const eventWatcher = requestWatcher(testCase, request);
   return eventWatcher.wait_for('success').then(() => {
@@ -233,4 +253,4 @@ const checkTitleIndexContents = (testCase, index, errorMessage) => {
     assert_equals(result.isbn, BOOKS_RECORD_DATA[2].isbn, errorMessage);
     assert_equals(result.author, BOOKS_RECORD_DATA[2].author, errorMessage);
   });
-};
+}

--- a/IndexedDB/upgrade-transaction-lifecycle-backend-aborted.html
+++ b/IndexedDB/upgrade-transaction-lifecycle-backend-aborted.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<meta charset="utf8">
+<title>IndexedDB: backend-aborted versionchange transaction lifecycle</title>
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#upgrade-transaction-steps">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-deleteobjectstore">
+<link rel="author" href="pwnall@chromium.org" title="Victor Costan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support-promises.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('abort', () => {
+        resolve(new Promise((resolve, reject) => {
+          assert_equals(
+              request.transaction, transaction,
+              "The open request's transaction should be reset after onabort");
+          assert_throws(
+              'InvalidStateError',
+              () => { database.createObjectStore('books2'); },
+              'createObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          assert_throws(
+              'InvalidStateError',
+              () => { database.deleteObjectStore('books'); },
+              'deleteObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          resolve();
+        }));
+      }, false);
+      transaction.objectStore('books').add(BOOKS_RECORD_DATA[0]);
+      transaction._willBeAborted();
+    });
+  }));
+}, 'in the abort event handler for a transaction aborted due to an unhandled ' +
+   'request error');
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('abort', () => {
+        setTimeout(() => {
+          resolve(new Promise((resolve, reject) => {
+            assert_equals(
+                request.transaction, null,
+                "The open request's transaction should be reset after " +
+                'onabort microtasks');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.createObjectStore('books2'); },
+                'createObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.deleteObjectStore('books'); },
+                'deleteObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            resolve();
+          }));
+        }, 0);
+      }, false);
+      transaction.objectStore('books').add(BOOKS_RECORD_DATA[0]);
+      transaction._willBeAborted();
+    });
+  }));
+}, 'in a setTimeout(0) callback after the abort event is fired for a ' +
+   'transaction aborted due to an unhandled request failure');
+
+</script>

--- a/IndexedDB/upgrade-transaction-lifecycle-committed.html
+++ b/IndexedDB/upgrade-transaction-lifecycle-committed.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<meta charset="utf8">
+<title>IndexedDB: committed versionchange transaction lifecycle</title>
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#upgrade-transaction-steps">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-deleteobjectstore">
+<link rel="author" href="pwnall@chromium.org" title="Victor Costan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support-promises.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('complete', () => {
+        resolve(new Promise((resolve, reject) => {
+          assert_equals(
+              request.transaction, transaction,
+              "The open request's transaction should be reset after " +
+              'oncomplete');
+          assert_throws(
+              'InvalidStateError',
+              () => { database.createObjectStore('books2'); },
+              'createObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          assert_throws(
+              'InvalidStateError',
+              () => { database.deleteObjectStore('books'); },
+              'deleteObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          resolve();
+        }));
+      }, false);
+    });
+  })).then(database => { database.close(); });
+}, 'in the complete event handler for a committed transaction');
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('complete', () => {
+        setTimeout(() => {
+          resolve(new Promise((resolve, reject) => {
+            assert_equals(
+                request.transaction, null,
+                "The open request's transaction should be reset after " +
+                'oncomplete microtasks');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.createObjectStore('books2'); },
+                'createObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.deleteObjectStore('books'); },
+                'deleteObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            resolve();
+          }));
+        }, 0);
+      }, false);
+    });
+  })).then(database => { database.close(); });
+}, 'in a setTimeout(0) callback after the complete event is fired for a ' +
+   'committed transaction');
+
+</script>

--- a/IndexedDB/upgrade-transaction-lifecycle-user-aborted.html
+++ b/IndexedDB/upgrade-transaction-lifecycle-user-aborted.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<meta charset="utf8">
+<title>IndexedDB: user-abort()ed versionchange transaction lifecycle</title>
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#upgrade-transaction-steps">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-createobjectstore">
+<link rel="help"
+      href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-deleteobjectstore">
+<link rel="author" href="pwnall@chromium.org" title="Victor Costan">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support-promises.js"></script>
+<script>
+'use strict';
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    transaction.abort();
+    assert_equals(
+        request.transaction, transaction,
+        "The open request's transaction should be reset after onabort");
+
+    assert_throws(
+        'TransactionInactiveError',
+        () => { database.createObjectStore('books2'); },
+        'createObjectStore exception should reflect that the transaction is ' +
+        'still running');
+    assert_throws(
+        'TransactionInactiveError',
+        () => { database.deleteObjectStore('books'); },
+        'deleteObjectStore exception should reflect that the transaction is' +
+        'still running');
+  }));
+}, 'synchronously after abort() is called');
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    let abortFired = false;
+    const abortPromise = new Promise((resolve, reject) => {
+      transaction.addEventListener('abort', () => {
+        abortFired = true;
+        resolve();
+      }, false);
+      transaction.abort();
+    });
+
+    return Promise.resolve().then(() => {
+      assert_false(
+          abortFired,
+          'The abort event should fire after promises are resolved');
+      assert_equals(
+          request.transaction, transaction,
+          "The open request's transaction should be reset after onabort");
+      assert_throws(
+          'TransactionInactiveError',
+          () => { database.createObjectStore('books2'); },
+          'createObjectStore exception should reflect that the transaction ' +
+          'is still running');
+      assert_throws(
+          'TransactionInactiveError',
+          () => { database.deleteObjectStore('books'); },
+          'deleteObjectStore exception should reflect that the transaction ' +
+          'is still running');
+    }).then(() => abortPromise);
+  }));
+}, 'in a promise microtask after abort() is called, before the transaction ' +
+   'abort event is fired');
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('abort', () => {
+        resolve(new Promise((resolve, reject) => {
+          assert_equals(
+              request.transaction, transaction,
+              "The open request's transaction should be reset after onabort");
+          assert_throws(
+              'InvalidStateError',
+              () => { database.createObjectStore('books2'); },
+              'createObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          assert_throws(
+              'InvalidStateError',
+              () => { database.deleteObjectStore('books'); },
+              'deleteObjectStore exception should reflect that the ' +
+              'transaction is no longer running');
+          resolve();
+        }));
+      }, false);
+      transaction.abort();
+    });
+  }));
+}, 'in the abort event handler for a transaction aborted due to an abort() ' +
+   'call');
+
+promise_test(t => {
+  return createDatabase(t, database => {
+    createBooksStore(t, database);
+  }).then(database => {
+    database.close();
+  }).then(() => migrateDatabase(t, 2, (database, transaction, request) => {
+    return new Promise((resolve, reject) => {
+      transaction.addEventListener('abort', () => {
+        setTimeout(() => {
+          resolve(new Promise((resolve, reject) => {
+            assert_equals(
+                request.transaction, null,
+                "The open request's transaction should be reset after " +
+                'onabort microtasks');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.createObjectStore('books2'); },
+                'createObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            assert_throws(
+                'InvalidStateError',
+                () => { database.deleteObjectStore('books'); },
+                'deleteObjectStore exception should reflect that the ' +
+                'transaction is no longer running');
+            resolve();
+          }));
+        }, 0);
+      }, false);
+      transaction.abort();
+    });
+  }));
+}, 'in a setTimeout(0) callback after the abort event is fired for a ' +
+   'transaction aborted due to an abort() call');
+
+</script>


### PR DESCRIPTION
These tests are upstreamed from Blink - https://crrev.com/2556373003

All the tests pass in Chrome Canary.

Firefox Nightly fails one test - `in a promise microtask after abort() is called, before the transaction abort event is fired`. I think this is a reasonable test, because the microtask aspect in it can be ignored. The transaction was aborted by JavaScript by calling abort(), and the `abort` event hasn't fired yet, so object store operations should throw TransactionInactiveError, no matter how microtasks are handled.

/cc @inexorabletash @bevis-tseng 