### PR TITLE
Revert "Update current-realm.html test (#4378)"

### DIFF
--- a/WebIDL/current-realm.html
+++ b/WebIDL/current-realm.html
@@ -134,9 +134,6 @@
    test(function() {
      var c = new self[0].FontFace("test", "about:blank"),
          obj = c.load()
-     obj.catch(function(reason) {
-       // Ignore exception when it fails to load because the URL is invalid.
-     });
      assert_global(obj)
 
      obj = FontFace.prototype.load.call(c)


### PR DESCRIPTION
This reverts commit 69856ae8322a9f508803fd06d77825b7abfe1130. Apparently that change was motivated by an issue of the testing framework that Chrome uses. It would be better to solve that problem at the source. See discussion at https://github.com/w3c/web-platform-tests/pull/4378 for details.