### PR TITLE
Added a two-finger gesture test on 'pan-x pan-y' and 'pinch-zoom'.

### DIFF
--- a/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
+++ b/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Pointer Event: touch-action test for two-finger interaction</title>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+    <link rel="author" title="Google" href="http://www.google.com "/>
+    <meta name="assert" content="Tests that a two-finger pan gesture is cancelled in 'touch-action: pan-x pan-y' but is allowed in 'touch-action: pinch-zoom'"/>
+    <link rel="stylesheet" type="text/css" href="../pointerevent_styles.css">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script type="text/javascript" src="../pointerevent_support.js"></script>
+    <script type="text/javascript">
+      var detected_pointertypes = {};
+      var event_log = [];
+      var active_pointers = 0;
+
+      function resetTestState() {
+        detected_eventTypes = {};
+        event_log = [];
+        active_pointers = 0;
+      }
+
+      function run() {
+        var test_pointer_event = setup_pointerevent_test("touch-action test for two-finger interaction", ["touch"]);
+
+        on_event(document.getElementById("done"), "click", function() {
+          test_pointer_event.step(function () {
+            assert_equals(active_pointers, 0);
+
+            var expected_events =
+              "pointerdown@black, pointerdown@black, pointercancel@black, pointercancel@black, " +
+              "pointerdown@grey, pointerdown@grey, pointerup@grey, pointerup@grey";
+            assert_equals(event_log.join(", "), expected_events);
+          });
+          test_pointer_event.done();
+        });
+
+        var targets = [document.getElementById("black"), document.getElementById("grey")];
+
+        ["pointerdown", "pointerup", "pointercancel"].forEach(function(eventName) {
+          targets.forEach(function(target){
+            on_event(target, eventName, function (event) {
+              detected_pointertypes[event.pointerType] = true;
+              event_log.push(event.type + "@" + event.target.id);
+
+              if (event.type == "pointerdown") {
+                active_pointers++;
+                event.target.setPointerCapture(event.pointerId);
+              } else {
+                active_pointers--;
+              }
+            });
+          });
+        });
+      }
+    </script>
+    <style>
+      .box {
+        width: 200px;
+        height: 150px;
+        float: left;
+        margin: 10px;
+      }
+
+      #black {
+        touch-action: pan-x pan-y;
+        background-color: black;
+      }
+
+      #grey {
+        touch-action: pinch-zoom;
+        background-color: grey;
+      }
+
+      #done {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body onload="run()">
+    <h1>Pointer Event: touch-action test for two-finger interaction<h1>
+    <h2 id="pointerTypeDescription"></h2>
+    <h4>
+      Tests that a two-finger pan gesture is cancelled in 'touch-action: pan-x pan-y' but is allowed in 'touch-action: pinch-zoom'
+    </h4>
+    <ol>
+      <li>Touch on Black with two fingers and drag both fingers down at same speed.</li>
+      <li>Touch on Grey with two fingers and drag both fingers down at same speed.</li>
+      <li>Tap on Green.</li>
+    </ol>
+    <div class="box" id="black"></div>
+    <div class="box" id="grey"></div>
+    <div class="box" id="done"></div>
+    <div id="complete-notice">
+      <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
+      <p>The following events were logged: <span id="event-log"></span>.</p>
+    </div>
+    <div id="log"></div>
+  </body>
+</html>

--- a/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
+++ b/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
@@ -25,15 +25,14 @@
           setup_pointerevent_test("two-finger pan on 'touch-action: pinch-zoom'", ["touch"])
         ];
         var expected_events = [
-          "pointerdown@black, pointerdown@black, pointercancel@black, pointercancel@black",
-          "pointerdown@grey, pointerdown@grey, pointerup@grey, pointerup@grey"
+          "pointerdown@black, pointerdown@black, pointerup@black, pointerup@black",
+          "pointerdown@grey, pointerdown@grey, pointercancel@grey, pointercancel@grey"
         ];
         var current_test_index = 0;
 
         on_event(document.getElementById("done"), "click", function() {
-          assert_equals(active_pointers, 0);
-
           test_pointer_events[current_test_index].step(function () {
+            assert_equals(active_pointers, 0);
             assert_equals(event_log.join(", "), expected_events[current_test_index]);
           });
           event_log = [];
@@ -61,7 +60,7 @@
     </script>
     <style>
       .box {
-        width: 200px;
+        width: 250px;
         height: 150px;
         float: left;
         margin: 10px;
@@ -84,7 +83,7 @@
     </style>
   </head>
   <body onload="run()">
-    <h1>Pointer Event: touch-action test for two-finger interaction<h1>
+    <h1>Pointer Event: touch-action test for two-finger interaction</h1>
     <h2 id="pointerTypeDescription"></h2>
     <h4>
       Tests that a two-finger pan gesture is cancelled in 'touch-action: pan-x pan-y' but is allowed in 'touch-action: pinch-zoom'
@@ -96,7 +95,7 @@
       <li>Tap on Done.</li>
     </ol>
     <div class="box" id="black"></div>
-    <input type="button" id="done" value="Done"></div>
+    <input type="button" id="done" value="Done" />
     <div class="box" id="grey"></div>
     <div id="log"></div>
   </body>

--- a/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
+++ b/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
@@ -10,29 +10,34 @@
     <script src="/resources/testharnessreport.js"></script>
     <script type="text/javascript" src="../pointerevent_support.js"></script>
     <script type="text/javascript">
-      var detected_pointertypes = {};
       var event_log = [];
       var active_pointers = 0;
 
       function resetTestState() {
-        detected_eventTypes = {};
         event_log = [];
         active_pointers = 0;
       }
 
       function run() {
-        var test_pointer_event = setup_pointerevent_test("touch-action test for two-finger interaction", ["touch"]);
+        var test_pointer_events = [
+          setup_pointerevent_test("two-finger pan on 'touch-action: pan-x pan-y'", ["touch"]),
+          setup_pointerevent_test("two-finger pan on 'touch-action: pinch-zoom'", ["touch"])
+        ];
+        var expected_events = [
+          "pointerdown@black, pointerdown@black, pointercancel@black, pointercancel@black",
+          "pointerdown@grey, pointerdown@grey, pointerup@grey, pointerup@grey"
+        ];
+        var current_test_index = 0;
 
         on_event(document.getElementById("done"), "click", function() {
-          test_pointer_event.step(function () {
-            assert_equals(active_pointers, 0);
+          assert_equals(active_pointers, 0);
 
-            var expected_events =
-              "pointerdown@black, pointerdown@black, pointercancel@black, pointercancel@black, " +
-              "pointerdown@grey, pointerdown@grey, pointerup@grey, pointerup@grey";
-            assert_equals(event_log.join(", "), expected_events);
+          test_pointer_events[current_test_index].step(function () {
+            assert_equals(event_log.join(", "), expected_events[current_test_index]);
           });
-          test_pointer_event.done();
+          event_log = [];
+
+          test_pointer_events[current_test_index++].done();
         });
 
         var targets = [document.getElementById("black"), document.getElementById("grey")];
@@ -40,12 +45,11 @@
         ["pointerdown", "pointerup", "pointercancel"].forEach(function(eventName) {
           targets.forEach(function(target){
             on_event(target, eventName, function (event) {
-              detected_pointertypes[event.pointerType] = true;
               event_log.push(event.type + "@" + event.target.id);
 
               if (event.type == "pointerdown") {
                 active_pointers++;
-                event.target.setPointerCapture(event.pointerId);
+
               } else {
                 active_pointers--;
               }
@@ -73,7 +77,8 @@
       }
 
       #done {
-        background-color: green;
+        float: left;
+        padding: 20px;
       }
     </style>
   </head>
@@ -85,16 +90,13 @@
     </h4>
     <ol>
       <li>Touch on Black with two fingers and drag both fingers down at same speed.</li>
+      <li>Tap on Done.</li>
       <li>Touch on Grey with two fingers and drag both fingers down at same speed.</li>
-      <li>Tap on Green.</li>
+      <li>Tap on Done.</li>
     </ol>
     <div class="box" id="black"></div>
+    <input type="button" id="done" value="Done"></div>
     <div class="box" id="grey"></div>
-    <div class="box" id="done"></div>
-    <div id="complete-notice">
-      <p>The following pointer types were detected: <span id="pointertype-log"></span>.</p>
-      <p>The following events were logged: <span id="event-log"></span>.</p>
-    </div>
     <div id="log"></div>
   </body>
 </html>

--- a/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
+++ b/pointerevents/compat/pointerevent_touch-action_two-finger_interaction-manual.html
@@ -4,6 +4,7 @@
     <title>Pointer Event: touch-action test for two-finger interaction</title>
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
     <link rel="author" title="Google" href="http://www.google.com "/>
+    <link rel="help" href="https://compat.spec.whatwg.org/#touch-action" />
     <meta name="assert" content="Tests that a two-finger pan gesture is cancelled in 'touch-action: pan-x pan-y' but is allowed in 'touch-action: pinch-zoom'"/>
     <link rel="stylesheet" type="text/css" href="../pointerevent_styles.css">
     <script src="/resources/testharness.js"></script>

--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_click-manual.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_click-manual.html
@@ -63,7 +63,7 @@
     </style>
   </head>
   <body onload="run()">
-    <h1>Pointer Event: Event sequence at implicit release on click<h1>
+    <h1>Pointer Event: Event sequence at implicit release on click</h1>
     <h2 id="pointerTypeDescription"></h2>
     <h4>
       When a captured pointer is implicitly released after a click, the boundary events should follow the lostpointercapture event.

--- a/pointerevents/pointerevent_sequence_at_implicit_release_on_drag-manual.html
+++ b/pointerevents/pointerevent_sequence_at_implicit_release_on_drag-manual.html
@@ -64,7 +64,7 @@
     </style>
   </head>
   <body onload="run()">
-    <h1>Pointer Event: Event sequence at implicit release on drag<h1>
+    <h1>Pointer Event: Event sequence at implicit release on drag</h1>
     <h2 id="pointerTypeDescription"></h2>
     <h4>
       When a captured pointer is implicitly released after a drag, the boundary events should follow the lostpointercapture event.


### PR DESCRIPTION
Closes https://github.com/w3c/pointerevents/issues/166.

Edge currently passes this test. Chrome doesn't, plans to match Edge ([bug](http://crbug.com/632525)).