### PR TITLE
Tests for https://github.com/whatwg/fetch/pull/435

### DIFF
--- a/service-workers/service-worker/fetch-event-within-sw-manual.html
+++ b/service-workers/service-worker/fetch-event-within-sw-manual.html
@@ -119,6 +119,11 @@ promise_test(() => {
     return registerSwAndOpenFrame();
   }).then(iframe => {
     return Promise.resolve().then(() => {
+      // In this test, the service worker will ping the 'icon-request' channel
+      // if it intercepts a request for 'notification_icon.py'. If the request
+      // reaches the server it sets the 'notification' cookie to the value given
+      // in the URL. "raceBroadcastAndCookie" monitors both and returns which
+      // happens first.
       const race = raceBroadcastAndCookie('icon-request', 'notification');
       const notification = new iframe.contentWindow.Notification('test', {
         icon: `notification_icon.py?set-cookie-notification=${Math.random()}`
@@ -129,6 +134,8 @@ promise_test(() => {
         assert_true(winner == 'broadcast', 'The service worker intercepted the from-window notification icon request');
       });
     }).then(() => {
+      // Similar race to above, but this time the service worker requests the
+      // notification.
       const race = raceBroadcastAndCookie('icon-request', 'notification');
       iframe.contentWindow.fetch(`show-notification?set-cookie-notification=${Math.random()}`);
 

--- a/service-workers/service-worker/fetch-event-within-sw-manual.html
+++ b/service-workers/service-worker/fetch-event-within-sw-manual.html
@@ -42,14 +42,43 @@ function regReady(reg) {
   });
 }
 
-function closeAllNotifications() {
-
+function getCookies() {
+  return new Map(
+    document.cookie
+      .split(/;/g)
+      .map(c => c.trim().split('=').map(s => s.trim()))
+  );
 }
 
 function registerSwAndOpenFrame() {
   return reset().then(() => navigator.serviceWorker.register(worker, {scope: 'resources/'}))
     .then(reg => regReady(reg))
     .then(() => with_iframe('resources/simple.html'));
+}
+
+function raceBroadcastAndCookie(channel, cookie) {
+  const initialCookie = getCookies().get(cookie);
+  let done = false;
+
+  return Promise.race([
+    new Promise(resolve => {
+      const bc = new BroadcastChannel(channel);
+      bc.onmessage = () => {
+        bc.close();
+        resolve('broadcast');
+      };
+    }),
+    (function checkCookie() {
+      // Stop polling if the broadcast channel won
+      if (done == true) return;
+      if (getCookies().get(cookie) != initialCookie) return 'cookie';
+
+      return wait(200).then(checkCookie);
+    }())
+  ]).then(val => {
+    done = true;
+    return val;
+  });
 }
 
 promise_test(() => {
@@ -89,32 +118,24 @@ promise_test(() => {
     }
     return registerSwAndOpenFrame();
   }).then(iframe => {
-    return Promise.race([
-      new Promise(resolve => {
-        const bc = new BroadcastChannel('icon-request');
-        bc.onmessage = () => {
-          bc.close();
-          resolve();
-        };
+    return Promise.resolve().then(() => {
+      const race = raceBroadcastAndCookie('icon-request', 'notification');
+      const notification = new iframe.contentWindow.Notification('test', {
+        icon: `notification_icon.py?set-cookie-notification=${Math.random()}`
+      });
+      notification.close();
 
-        const notification = new iframe.contentWindow.Notification('test', {
-          icon: 'notification-icon.png'
-        });
-        notification.close();
-      }),
-      wait(1000).then(() => { throw Error(`Did not capture icon request for notification created from page`); })
-    ]).then(() => Promise.race([
-      new Promise(resolve => {
-        const bc = new BroadcastChannel('icon-request');
-        bc.onmessage = () => {
-          bc.close();
-          resolve();
-        };
+      return race.then(winner => {
+        assert_true(winner == 'broadcast', 'The service worker intercepted the from-window notification icon request');
+      });
+    }).then(() => {
+      const race = raceBroadcastAndCookie('icon-request', 'notification');
+      iframe.contentWindow.fetch(`show-notification?set-cookie-notification=${Math.random()}`);
 
-        iframe.contentWindow.fetch('show-notification');
-      }),
-      wait(1000).then(() => { throw Error(`Did not capture icon request for notification created within SW`); })
-    ]));
+      return race.then(winner => {
+        assert_true(winner == 'broadcast', 'The service worker intercepted the from-service-worker notification icon request');
+      });
+    })
   });
 }, `Notification requests intercepted both from window and SW`);
 

--- a/service-workers/service-worker/fetch-event-within-sw-manual.html
+++ b/service-workers/service-worker/fetch-event-within-sw-manual.html
@@ -57,7 +57,7 @@ promise_test(() => {
     return Promise.all([
       iframe.contentWindow.fetch('dummy.txt').then(r => r.text()),
       iframe.contentWindow.caches.open('test')
-        .then(cache => 
+        .then(cache =>
           cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
         ).then(response => {
           if (!response) return 'cache match failed';

--- a/service-workers/service-worker/fetch-event-within-sw-manual.html
+++ b/service-workers/service-worker/fetch-event-within-sw-manual.html
@@ -22,6 +22,8 @@ function reset() {
   });
 }
 
+add_completion_callback(reset);
+
 function regReady(reg) {
   return new Promise((resolve, reject) => {
     if (reg.active) {
@@ -82,36 +84,6 @@ function raceBroadcastAndCookie(channel, cookie) {
 }
 
 promise_test(() => {
-  return registerSwAndOpenFrame().then(iframe => {
-    return Promise.all([
-      iframe.contentWindow.fetch('dummy.txt').then(r => r.text()),
-      iframe.contentWindow.caches.open('test')
-        .then(cache =>
-          cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
-        ).then(response => {
-          if (!response) return 'cache match failed';
-          return response.text();
-        })
-    ])
-  }).then(([fetchText, cacheText]) => {
-    assert_equals(fetchText, 'intercepted', 'fetch intercepted');
-    assert_equals(cacheText, 'intercepted', 'cache.add intercepted');
-  });
-}, 'Service worker intercepts requests from window');
-
-promise_test(() => {
-  return registerSwAndOpenFrame().then(iframe => {
-    return Promise.all([
-      iframe.contentWindow.fetch('dummy.txt-inner-fetch').then(r => r.text()),
-      iframe.contentWindow.fetch('dummy.txt-inner-cache').then(r => r.text())
-    ])
-  }).then(([fetchText, cacheText]) => {
-    assert_equals(fetchText, 'Hello world\n', 'fetch within SW not intercepted');
-    assert_equals(cacheText, 'Hello world\n', 'cache.add within SW not intercepted');
-  });
-}, `Service worker does not intercept fetch/cache requests within service worker`);
-
-promise_test(() => {
   return Notification.requestPermission().then(permission => {
     if (permission != "granted") {
       throw Error('You must allow notifications for this origin before running this test.');
@@ -131,7 +103,7 @@ promise_test(() => {
       notification.close();
 
       return race.then(winner => {
-        assert_true(winner == 'broadcast', 'The service worker intercepted the from-window notification icon request');
+        assert_equals(winner, 'broadcast', 'The service worker intercepted the from-window notification icon request');
       });
     }).then(() => {
       // Similar race to above, but this time the service worker requests the
@@ -140,7 +112,7 @@ promise_test(() => {
       iframe.contentWindow.fetch(`show-notification?set-cookie-notification=${Math.random()}`);
 
       return race.then(winner => {
-        assert_true(winner == 'broadcast', 'The service worker intercepted the from-service-worker notification icon request');
+        assert_equals(winner, 'broadcast', 'The service worker intercepted the from-service-worker notification icon request');
       });
     })
   });

--- a/service-workers/service-worker/fetch-event-within-sw-manual.html
+++ b/service-workers/service-worker/fetch-event-within-sw-manual.html
@@ -82,13 +82,13 @@ promise_test(() => {
   });
 }, `Service worker does not intercept fetch/cache requests within service worker`);
 
-promise_test(t => {
-  return registerSwAndOpenFrame().then(iframe => {
-    if (Notification.permission != "granted") {
-      Notification.requestPermission();
-      t.set_status(this.NOTRUN, 'You must allow notifications for this origin before running this test.');
+promise_test(() => {
+  return Notification.requestPermission().then(permission => {
+    if (permission != "granted") {
       throw Error('You must allow notifications for this origin before running this test.');
     }
+    return registerSwAndOpenFrame();
+  }).then(iframe => {
     return Promise.race([
       new Promise(resolve => {
         const bc = new BroadcastChannel('icon-request');

--- a/service-workers/service-worker/fetch-event-within-sw.html
+++ b/service-workers/service-worker/fetch-event-within-sw.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<body>
+<script>
+const worker = 'resources/fetch-event-within-sw-worker.js';
+
+function wait(ms) {
+  return new Promise(r => setTimeout(r, ms));
+}
+
+function reset() {
+  for (const iframe of [...document.querySelectorAll('.test-iframe')]) {
+    iframe.remove();
+  }
+  return navigator.serviceWorker.getRegistrations().then(registrations => {
+    return Promise.all(registrations.map(r => r.unregister()));
+  }).then(() => caches.keys()).then(cacheKeys => {
+    return Promise.all(cacheKeys.map(c => caches.delete(c)));
+  });
+}
+
+function regReady(reg) {
+  return new Promise((resolve, reject) => {
+    if (reg.active) {
+      resolve();
+      return;
+    }
+    const nextWorker = reg.waiting || reg.installing;
+
+    nextWorker.addEventListener('statechange', () => {
+      if (nextWorker.state == 'redundant') {
+        reject(Error(`Service worker failed to install`));
+        return;
+      }
+      if (nextWorker.state == 'activated') {
+        resolve();
+      }
+    });
+  });
+}
+
+function closeAllNotifications() {
+
+}
+
+function registerSwAndOpenFrame() {
+  return reset().then(() => navigator.serviceWorker.register(worker, {scope: 'resources/'}))
+    .then(reg => regReady(reg))
+    .then(() => with_iframe('resources/simple.html'));
+}
+
+promise_test(() => {
+  return registerSwAndOpenFrame().then(iframe => {
+    return Promise.all([
+      iframe.contentWindow.fetch('dummy.txt').then(r => r.text()),
+      iframe.contentWindow.caches.open('test')
+        .then(cache => 
+          cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
+        ).then(response => {
+          if (!response) return 'cache match failed';
+          return response.text();
+        })
+    ])
+  }).then(([fetchText, cacheText]) => {
+    assert_equals(fetchText, 'intercepted', 'fetch intercepted');
+    assert_equals(cacheText, 'intercepted', 'cache.add intercepted');
+  });
+}, 'Service worker intercepts requests from window');
+
+promise_test(() => {
+  return registerSwAndOpenFrame().then(iframe => {
+    return Promise.all([
+      iframe.contentWindow.fetch('dummy.txt-inner-fetch').then(r => r.text()),
+      iframe.contentWindow.fetch('dummy.txt-inner-cache').then(r => r.text())
+    ])
+  }).then(([fetchText, cacheText]) => {
+    assert_equals(fetchText, 'Hello world\n', 'fetch within SW not intercepted');
+    assert_equals(cacheText, 'Hello world\n', 'cache.add within SW not intercepted');
+  });
+}, `Service worker does not intercept fetch/cache requests within service worker`);
+
+promise_test(t => {
+  return registerSwAndOpenFrame().then(iframe => {
+    if (Notification.permission != "granted") {
+      Notification.requestPermission();
+      t.set_status(this.NOTRUN, 'You must allow notifications for this origin before running this test.');
+      throw Error('You must allow notifications for this origin before running this test.');
+    }
+    return Promise.race([
+      new Promise(resolve => {
+        const bc = new BroadcastChannel('icon-request');
+        bc.onmessage = () => {
+          bc.close();
+          resolve();
+        };
+
+        const notification = new iframe.contentWindow.Notification('test', {
+          icon: 'notification-icon.png'
+        });
+        notification.close();
+      }),
+      wait(1000).then(() => { throw Error(`Did not capture icon request for notification created from page`); })
+    ]).then(() => Promise.race([
+      new Promise(resolve => {
+        const bc = new BroadcastChannel('icon-request');
+        bc.onmessage = () => {
+          bc.close();
+          resolve();
+        };
+
+        iframe.contentWindow.fetch('show-notification');
+      }),
+      wait(1000).then(() => { throw Error(`Did not capture icon request for notification created within SW`); })
+    ]));
+  });
+}, `Notification requests intercepted both from window and SW`);
+
+</script>
+</body>

--- a/service-workers/service-worker/fetch-event-within-sw.html
+++ b/service-workers/service-worker/fetch-event-within-sw.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<body>
+<script>
+const worker = 'resources/fetch-event-within-sw-worker.js';
+
+function reset() {
+  for (const iframe of [...document.querySelectorAll('.test-iframe')]) {
+    iframe.remove();
+  }
+  return navigator.serviceWorker.getRegistrations().then(registrations => {
+    return Promise.all(registrations.map(r => r.unregister()));
+  }).then(() => caches.keys()).then(cacheKeys => {
+    return Promise.all(cacheKeys.map(c => caches.delete(c)));
+  });
+}
+
+add_completion_callback(reset);
+
+function regReady(reg) {
+  return new Promise((resolve, reject) => {
+    if (reg.active) {
+      resolve();
+      return;
+    }
+    const nextWorker = reg.waiting || reg.installing;
+
+    nextWorker.addEventListener('statechange', () => {
+      if (nextWorker.state == 'redundant') {
+        reject(Error(`Service worker failed to install`));
+        return;
+      }
+      if (nextWorker.state == 'activated') {
+        resolve();
+      }
+    });
+  });
+}
+
+function registerSwAndOpenFrame() {
+  return reset().then(() => navigator.serviceWorker.register(worker, { scope: 'resources/' }))
+    .then(reg => regReady(reg))
+    .then(() => with_iframe('resources/simple.html'));
+}
+
+promise_test(() => {
+  return registerSwAndOpenFrame().then(iframe => {
+    return Promise.all([
+      iframe.contentWindow.fetch('dummy.txt').then(r => r.text()),
+      iframe.contentWindow.caches.open('test')
+        .then(cache =>
+          cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
+        ).then(response => {
+          if (!response) return 'cache match failed';
+          return response.text();
+        })
+    ])
+  }).then(([fetchText, cacheText]) => {
+    assert_equals(fetchText, 'intercepted', 'fetch intercepted');
+    assert_equals(cacheText, 'intercepted', 'cache.add intercepted');
+  });
+}, 'Service worker intercepts requests from window');
+
+promise_test(() => {
+  return registerSwAndOpenFrame().then(iframe => {
+    return Promise.all([
+      iframe.contentWindow.fetch('dummy.txt-inner-fetch').then(r => r.text()),
+      iframe.contentWindow.fetch('dummy.txt-inner-cache').then(r => r.text())
+    ])
+  }).then(([fetchText, cacheText]) => {
+    assert_equals(fetchText, 'Hello world\n', 'fetch within SW not intercepted');
+    assert_equals(cacheText, 'Hello world\n', 'cache.add within SW not intercepted');
+  });
+}, `Service worker does not intercept fetch/cache requests within service worker`);
+</script>
+</body>

--- a/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
@@ -25,6 +25,7 @@ addEventListener('fetch', event => {
   }
 
   if (url.pathname.endsWith('/show-notification')) {
+    // Copy the currect search string onto the icon url
     const iconURL = new URL('notification_icon.py', location);
     iconURL.search = url.search;
 

--- a/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
@@ -1,0 +1,44 @@
+skipWaiting();
+
+addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  if (url.origin == location.origin) {
+    if (url.pathname.endsWith('/dummy.txt')) {
+      event.respondWith(new Response('intercepted'));
+      return;
+    }
+
+    if (url.pathname.endsWith('/dummy.txt-inner-fetch')) {
+      event.respondWith(fetch('dummy.txt'));
+      return;
+    }
+
+    if (url.pathname.endsWith('/dummy.txt-inner-cache')) {
+      event.respondWith(
+        caches.open('test-inner-cache').then(cache => 
+          cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
+        )
+      );
+      return;
+    }
+
+    if (url.pathname.endsWith('/show-notification')) {
+      event.respondWith(
+        registration.showNotification('test', {
+          icon: 'notification-icon.png'
+        }).then(() => registration.getNotifications()).then(notifications => {
+          for (const n of notifications) n.close();
+          return new Response('done');
+        })
+      );
+      return;
+    }
+
+    if (url.pathname.endsWith('/notification-icon.png')) {
+      new BroadcastChannel('icon-request').postMessage('yay');
+      event.respondWith(new Response('done'));
+      return;
+    }
+  }
+});

--- a/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
@@ -16,7 +16,7 @@ addEventListener('fetch', event => {
 
     if (url.pathname.endsWith('/dummy.txt-inner-cache')) {
       event.respondWith(
-        caches.open('test-inner-cache').then(cache => 
+        caches.open('test-inner-cache').then(cache =>
           cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
         )
       );

--- a/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-within-sw-worker.js
@@ -3,42 +3,45 @@ skipWaiting();
 addEventListener('fetch', event => {
   const url = new URL(event.request.url);
 
-  if (url.origin == location.origin) {
-    if (url.pathname.endsWith('/dummy.txt')) {
-      event.respondWith(new Response('intercepted'));
-      return;
-    }
+  if (url.origin != location.origin) return;
 
-    if (url.pathname.endsWith('/dummy.txt-inner-fetch')) {
-      event.respondWith(fetch('dummy.txt'));
-      return;
-    }
+  if (url.pathname.endsWith('/dummy.txt')) {
+    event.respondWith(new Response('intercepted'));
+    return;
+  }
 
-    if (url.pathname.endsWith('/dummy.txt-inner-cache')) {
-      event.respondWith(
-        caches.open('test-inner-cache').then(cache =>
-          cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
-        )
-      );
-      return;
-    }
+  if (url.pathname.endsWith('/dummy.txt-inner-fetch')) {
+    event.respondWith(fetch('dummy.txt'));
+    return;
+  }
 
-    if (url.pathname.endsWith('/show-notification')) {
-      event.respondWith(
-        registration.showNotification('test', {
-          icon: 'notification-icon.png'
-        }).then(() => registration.getNotifications()).then(notifications => {
-          for (const n of notifications) n.close();
-          return new Response('done');
-        })
-      );
-      return;
-    }
+  if (url.pathname.endsWith('/dummy.txt-inner-cache')) {
+    event.respondWith(
+      caches.open('test-inner-cache').then(cache =>
+        cache.add('dummy.txt').then(() => cache.match('dummy.txt'))
+      )
+    );
+    return;
+  }
 
-    if (url.pathname.endsWith('/notification-icon.png')) {
-      new BroadcastChannel('icon-request').postMessage('yay');
-      event.respondWith(new Response('done'));
-      return;
-    }
+  if (url.pathname.endsWith('/show-notification')) {
+    const iconURL = new URL('notification_icon.py', location);
+    iconURL.search = url.search;
+
+    event.respondWith(
+      registration.showNotification('test', {
+        icon: iconURL
+      }).then(() => registration.getNotifications()).then(notifications => {
+        for (const n of notifications) n.close();
+        return new Response('done');
+      })
+    );
+    return;
+  }
+
+  if (url.pathname.endsWith('/notification_icon.py')) {
+    new BroadcastChannel('icon-request').postMessage('yay');
+    event.respondWith(new Response('done'));
+    return;
   }
 });

--- a/service-workers/service-worker/resources/notification_icon.py
+++ b/service-workers/service-worker/resources/notification_icon.py
@@ -1,0 +1,9 @@
+import urlparse
+
+def main(req, res):
+  qs_cookie_val = urlparse.parse_qs(req.url_parts.query).get('set-cookie-notification')
+
+  if qs_cookie_val:
+    res.set_cookie('notification', qs_cookie_val[0])
+    
+  return 'not really an icon'

--- a/service-workers/service-worker/resources/notification_icon.py
+++ b/service-workers/service-worker/resources/notification_icon.py
@@ -5,5 +5,5 @@ def main(req, res):
 
   if qs_cookie_val:
     res.set_cookie('notification', qs_cookie_val[0])
-    
+
   return 'not really an icon'

--- a/service-workers/service-worker/resources/test-helpers.sub.js
+++ b/service-workers/service-worker/resources/test-helpers.sub.js
@@ -52,6 +52,7 @@ function unreached_rejection(test, prefix) {
 function with_iframe(url) {
   return new Promise(function(resolve) {
       var frame = document.createElement('iframe');
+      frame.className = 'test-iframe';
       frame.src = url;
       frame.onload = function() { resolve(frame); };
       document.body.appendChild(frame);


### PR DESCRIPTION
Summary of spec changes: Previously any fetches started within a service worker would bypass the service worker fetch event. We're changing this so only particular methods bypass the fetch event.

This PR tests the `fetch`, `cache.all` and notification APIs to ensure they use/bypass the fetch event as required.

No browser passes all the tests - Chrome and Firefox fail on the notification tests.