### PR TITLE
Improve referenced resource for GitHub issues

### DIFF
--- a/docs/review-process.md
+++ b/docs/review-process.md
@@ -24,7 +24,7 @@ may also be used as long as the review is clearly linked.
 ## Labels
 
 Pull requests get automatically labelled in the GitHub repository. Check
-out the [list of labels in Github][issues]
+out the [list of labels in Github][labels]
 to see the open pull requests for a given specification or a given Working Group.
 
 ## Status
@@ -36,4 +36,4 @@ shows the number of open review requests, and can be filtered by testsuite.
 [format]: ./test-format-guidelines.html
 [style]: ./test-style-guidelines.html
 [review-checklist]: ./review-checklist.html
-[issues]: https://github.com/w3c/web-platform-tests/issues
+[labels]: https://github.com/w3c/web-platform-tests/labels


### PR DESCRIPTION
Previously, the documentation text "list of labels in Github" referenced
that site's listing of issues. GitHub.com provides a dedicated page for
listing labels; that page is more relevant to the documentation in
question.