### PR TITLE
Test new URLSearchParams constructor features

### DIFF
--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -35,7 +35,7 @@ test(() => {
 
 test(() => {
     params = new URLSearchParams({});
-    assert_equals(params + '', '%5Bobject+Object%5D=');
+    assert_equals(params + '', "");
 }, 'URLSearchParams constructor, {} as argument');
 
 test(function() {
@@ -157,7 +157,7 @@ test(() => {
   }
   let params2 = new URLSearchParams(params)
   assert_equals(params2.get("a"), "b")
-}, "Evil constructor test")
+}, "Custom [Symbol.iterator]")
 </script>
 </head>
 </html>

--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -20,16 +20,23 @@ test(function() {
 test(function() {
     var params = new URLSearchParams()
     assert_equals(params.toString(), "")
+}, "URLSearchParams constructor, no arguments")
 
+test(() => {
     params = new URLSearchParams(DOMException.prototype);
     assert_equals(params.toString(), "Error=")
+}, "URLSearchParams constructor, DOMException.prototype as argument")
 
+test(() => {
     params = new URLSearchParams('');
     assert_true(params != null, 'constructor returned non-null value.');
     assert_equals(params.__proto__, URLSearchParams.prototype, 'expected URLSearchParams.prototype as prototype.');
+}, "URLSearchParams constructor, empty string as argument")
+
+test(() => {
     params = new URLSearchParams({});
     assert_equals(params + '', '%5Bobject+Object%5D=');
-}, 'URLSearchParams constructor, empty and unusual input.');
+}, 'URLSearchParams constructor, {} as argument');
 
 test(function() {
     var params = new URLSearchParams('a=b');
@@ -144,12 +151,12 @@ test(function() {
 })
 
 test(() => {
-  let params1 = new URLSearchParams("a=b"),
-      params2 = new URLSearchParams()
-  params2[Symbol.iterator] = params1[Symbol.iterator]
-  let params3 = new URLSearchParams(params2)
-  assert_equals(params3.get("a"), params1.get("a"))
-  assert_equals(params3.get("a"), "b")
+  params = new URLSearchParams()
+  params[Symbol.iterator] = function *() {
+    yield ["a", "b"]
+  }
+  let params2 = new URLSearchParams(params)
+  assert_equals(params2.get("a"), "b")
 }, "Evil constructor test")
 </script>
 </head>

--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -18,15 +18,18 @@ test(function() {
 }, 'Basic URLSearchParams construction');
 
 test(function() {
-    assert_throws(new TypeError(), function () { URLSearchParams(); },
-                  'Calling \'URLSearchParams\' without \'new\' should throw.');
-    assert_throws(new TypeError(), function () { new URLSearchParams(DOMException.prototype); });
-    var params = new URLSearchParams('');
+    var params = new URLSearchParams()
+    assert_equals(params.toString(), "")
+
+    params = new URLSearchParams(DOMException.prototype);
+    assert_equals(params.toString(), "Error=")
+
+    params = new URLSearchParams('');
     assert_true(params != null, 'constructor returned non-null value.');
     assert_equals(params.__proto__, URLSearchParams.prototype, 'expected URLSearchParams.prototype as prototype.');
     params = new URLSearchParams({});
     assert_equals(params + '', '%5Bobject+Object%5D=');
-}, 'URLSearchParams constructor, empty.');
+}, 'URLSearchParams constructor, empty and unusual input.');
 
 test(function() {
     var params = new URLSearchParams('a=b');
@@ -124,6 +127,30 @@ test(function() {
     params = new URLSearchParams('a%f0%9f%92%a9b=c');
     assert_equals(params.get('a\uD83D\uDCA9b'), 'c');
 }, 'Parse %f0%9f%92%a9');  // Unicode Character 'PILE OF POO' (U+1F4A9)
+
+;[
+  { "input": {"+": "%C2"}, "output": [[" ", "\uFFFD"]], "name": "object with +" },
+  { "input": {c: "x", a: "?"}, "output": [["c", "x"], ["a", "?"]], "name": "object with two keys" },
+  { "input": [["c", "x"], ["a", "?"]], "output": [["c", "x"], ["a", "?"]], "name": "array with two keys" }
+].forEach((val) => {
+    test(() => {
+        let params = new URLSearchParams(val.input),
+            i = 0
+        for (let param of params) {
+            assert_array_equals(param, val.output[i])
+            i++
+        }
+    }, "Construct with " + val.name)
+})
+
+test(() => {
+  let params1 = new URLSearchParams("a=b"),
+      params2 = new URLSearchParams()
+  params2[Symbol.iterator] = params1[Symbol.iterator]
+  let params3 = new URLSearchParams(params2)
+  assert_equals(params3.get("a"), params1.get("a"))
+  assert_equals(params3.get("a"), "b")
+}, "Evil constructor test")
 </script>
 </head>
 </html>


### PR DESCRIPTION
The main thing here is new tests for
https://github.com/whatwg/url/pull/175 but I also found issues
with some existing tests that I’m attempting to fix at the same time.

The current tests assumed the constructor argument was mandatory, but
it’s in fact optional. The other issue was that the current test assume
stringifying DOMException.prototype throws, but I don’t think that’s
the case.