### PR TITLE
URL: add an IPv6 trailing zeros test

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -4738,5 +4738,21 @@
     "pathname": "/",
     "search": "",
     "hash": ""
+  },
+  "# IPv6 trailing zeros test",
+  {
+    "input": "http://[1:0::]",
+    "base": "http://example.net/",
+    "href": "http://[1::]/",
+    "origin": "http://[1::]",
+    "protocol": "http:",
+    "username": "",
+    "password": "",
+    "host": "[1::]",
+    "hostname": "[1::]",
+    "port": "",
+    "pathname": "/",
+    "search": "",
+    "hash": ""
   }
 ]


### PR DESCRIPTION
Via https://github.com/jsdom/whatwg-url/pull/66.

Reviewed upstream in jsdom/whatwg-url. Will merge after CI finishes.