### PR TITLE
Add tests for DOMStringList

### DIFF
--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>DOMStringList IDL tests</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+
+<h1>DOMStringList IDL tests</h1>
+<div id=log></div>
+
+<script>
+"use strict";
+async_test(function(t) {
+  var request = new XMLHttpRequest();
+  request.open("GET", "domstringlist.idl");
+  request.send();
+  request.onload = t.step_func(function() {
+    var idlArray = new IdlArray();
+    var idls = request.responseText;
+
+    idlArray.add_idls(idls);
+
+    idlArray.add_objects({
+      DOMStringList: [],
+    });
+
+    idlArray.test();
+    t.done();
+  });
+});
+</script>

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
@@ -22,7 +22,7 @@ async_test(function(t) {
     idlArray.add_idls(idls);
 
     idlArray.add_objects({
-      DOMStringList: [location.ancestorOrigins],
+      DOMStringList: ['location.ancestorOrigins'],
     });
 
     idlArray.test();

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.html
@@ -22,7 +22,7 @@ async_test(function(t) {
     idlArray.add_idls(idls);
 
     idlArray.add_objects({
-      DOMStringList: [],
+      DOMStringList: [location.ancestorOrigins],
     });
 
     idlArray.test();

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.worker.js
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist-interface.worker.js
@@ -1,0 +1,24 @@
+"use strict";
+
+importScripts("/resources/testharness.js");
+importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
+
+async_test(function(t) {
+  var request = new XMLHttpRequest();
+  request.open("GET", "domstringlist.idl");
+  request.send();
+  request.onload = t.step_func(function() {
+    var idlArray = new IdlArray();
+    var idls = request.responseText;
+
+    idlArray.add_idls(idls);
+
+    idlArray.add_objects({
+      DOMStringList: [],
+    });
+    idlArray.test();
+    t.done();
+  });
+});
+
+done();

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist.html
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<title>DOMStringList</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+// Returns a promise that resolves to a DOMStringList with
+// the requested entries. Relies on Indexed DB.
+function createDOMStringList(entries) {
+  return new Promise((resolve, reject) => {
+    const dbname = String(self.location + Math.random());
+    const request = indexedDB.open(dbname);
+    request.onerror = () => reject(request.error);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      entries.forEach(entry => db.createObjectStore(entry));
+      const dsl = db.objectStoreNames;
+      resolve(dsl);
+      request.transaction.abort();
+    }
+  });
+}
+
+function dsl_test(entries, func, description) {
+  promise_test(t => createDOMStringList(entries).then(dsl => func(t, dsl)),
+               description);
+}
+
+dsl_test(['a', 'b', 'c'], (t, dsl) => {
+  assert_equals(dsl.length, 3, 'length attribute');
+}, 'DOMStringList: length attribute');
+
+dsl_test(['a', 'b', 'c'], (t, dsl) => {
+  assert_equals(dsl.item(0), 'a', 'item method');
+  assert_equals(dsl.item(1), 'b', 'item method');
+  assert_equals(dsl.item(2), 'c', 'item method');
+  assert_equals(dsl.item(3), null, 'item method out of range');
+  assert_equals(dsl.item(-1), null, 'item method out of range');
+  assert_throws(TypeError(), () => dsl.item(),
+                'item method should throw if called without enough args');
+}, 'DOMStringList: item() method');
+
+dsl_test(['a', 'b', 'c'], (t, dsl) => {
+  assert_equals(dsl[0], 'a', 'indexed getter');
+  assert_equals(dsl[1], 'b', 'indexed getter');
+  assert_equals(dsl[2], 'c', 'indexed getter');
+  assert_equals(dsl[3], undefined, 'indexed getter out of range');
+  assert_equals(dsl[-1], undefined, 'indexed getter out of range');
+}, 'DOMStringList: indexed getter');
+
+dsl_test(['a', 'b', 'c'], (t, dsl) => {
+  assert_true(dsl.contains('a'), 'contains method matched');
+  assert_true(dsl.contains('b'), 'contains method matched');
+  assert_true(dsl.contains('c'), 'contains method matched');
+  assert_false(dsl.contains(''), 'contains method unmatched');
+  assert_false(dsl.contains('d'), 'contains method unmatched');
+  assert_throws(TypeError(), () => dsl.contains(),
+    'contains method should throw if called without enough args');
+}, 'DOMStringList: contains() method');
+
+</script>

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist.idl
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist.idl
@@ -1,0 +1,5 @@
+interface DOMStringList {
+  readonly attribute unsigned long length;
+  getter DOMString? item(unsigned long index);
+  boolean contains(DOMString string);
+};

--- a/html/infrastructure/common-dom-interfaces/collections/domstringlist.idl
+++ b/html/infrastructure/common-dom-interfaces/collections/domstringlist.idl
@@ -1,3 +1,4 @@
+[Exposed=(Window,Worker)]
 interface DOMStringList {
   readonly attribute unsigned long length;
   getter DOMString? item(unsigned long index);


### PR DESCRIPTION
For https://github.com/w3c/web-platform-tests/issues/4522 to unblock https://github.com/whatwg/html/pull/2192

Not the most extensive test suite in the world and the dependency on IndexedDB is unfortunate, but it was handy.

Should the idlharness test remain stand-alone or be merged into `html/dom/interfaces.html` ?