### PR TITLE
remove releases method from GitHub class in check_stability.py

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -156,10 +156,6 @@ class GitHub(object):
         else:
             self.post(issue_comments_url, data)
 
-    def releases(self):
-        url = urljoin(self.base_url, "releases/latest")
-        return self.get(url)
-
 
 class GitHubCommentHandler(logging.Handler):
     def __init__(self, github, pull_number):


### PR DESCRIPTION
This appears to be dead code. There may be a future use for this I am missing. Feel free to close in that case.