### PR TITLE
createMediaElementSource from EME element test

### DIFF
--- a/encrypted-media/drm-mp4-playback-temporary-createmediaelementsource.html
+++ b/encrypted-media/drm-mp4-playback-temporary-createmediaelementsource.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <meta name="timeout" content="long">
+    <title>Encrypted Media Extensions: Successful Playback, Temporary session with DRM, mp4 AudioContext#createMediaElementSource</title>
+    <link rel="help" href="https://w3c.github.io/encrypted-media/">
+
+    <!-- Web Platform Test Harness scripts -->
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+
+    <!-- Helper scripts for Encrypted Media Extensions tests  -->
+    <script src=/encrypted-media/util/utils.js></script>
+    <script src=/encrypted-media/util/utf8.js></script>
+    <script src=/encrypted-media/util/fetch.js></script>
+    <script src=/encrypted-media/util/testmediasource.js></script>
+
+    <!-- Content metadata -->
+    <script src=/encrypted-media/content/content-metadata.js></script>
+
+    <!-- Message handler for DRM servers -->
+    <script src=/encrypted-media/util/drm-messagehandler.js></script>
+
+    <!-- The script for this specific test -->
+    <script src=/encrypted-media/scripts/playback-temporary-createmediaelementsource.js></script>
+
+  </head>
+  <body>
+    <div id='log'></div>
+
+    <div id='video'>
+      <video id="videoelement" width="200px"></video>
+    </div>
+
+    <script>
+        var keysystem = getSupportedKeySystem(),
+            contentitem = content['mp4-basic'],
+            handler = new MessageHandler( keysystem, contentitem ),
+            config = {  video:              document.getElementById('videoelement'),
+                        keysystem:          keysystem,
+                        messagehandler:     handler.messagehandler,
+                        audioPath:          contentitem.audio.path,
+                        videoPath:          contentitem.video.path,
+                        audioType:          contentitem.audio.type,
+                        videoType:          contentitem.video.type,
+                        initDataType:       contentitem.initDataType,
+                        testcase:           'single key, createMediaElementSource' };
+
+        runTest(config);
+    </script>
+  </body>
+</html>

--- a/encrypted-media/scripts/playback-temporary-createmediaelementsource.js
+++ b/encrypted-media/scripts/playback-temporary-createmediaelementsource.js
@@ -1,0 +1,87 @@
+function runTest(config,qualifier) {
+
+    var testname = testnamePrefix(qualifier, config.keysystem)
+                                    + ', temporary, '
+                                    + /video\/([^;]*)/.exec(config.videoType)[1]
+                                    + ', playback, ' + config.testcase;
+
+    var configuration = {   initDataTypes: [ config.initDataType ],
+                            audioCapabilities: [ { contentType: config.audioType } ],
+                            videoCapabilities: [ { contentType: config.videoType } ],
+                            sessionTypes: [ 'temporary' ] };
+
+    async_test(function(test) {
+
+        var _video = config.video,
+            _mediaKeys,
+            _mediaKeySession,
+            _mediaSource,
+            _audioContext,
+            _mediaElementSource;
+
+        function onFailure(error) {
+            forceTestFailureFromPromise(test, error);
+        }
+
+        function onEncrypted(event) {
+            assert_equals(event.target, _video);
+            assert_true(event instanceof window.MediaEncryptedEvent);
+            assert_equals(event.type, 'encrypted');
+
+            // Only create the session for the firs encrypted event
+            if (_mediaKeySession !== undefined) return;
+
+            var initDataType = config.initData ? config.initDataType : event.initDataType;
+            var initData = config.initData || event.initData;
+
+            _mediaKeySession = _mediaKeys.createSession('temporary');
+            waitForEventAndRunStep('message', _mediaKeySession, onMessage, test);
+            _mediaKeySession.generateRequest( initDataType, initData ).catch(onFailure);
+        }
+
+        function onMessage(event) {
+            assert_equals(event.target, _mediaKeySession);
+            assert_true(event instanceof window.MediaKeyMessageEvent);
+            assert_equals(event.type, 'message');
+
+            assert_in_array(event.messageType, ['license-request', 'individualization-request']);
+
+            config.messagehandler(event.messageType, event.message).then(function(response) {
+                return event.target.update(response);
+            }).catch(onFailure);
+        }
+
+        function onPlaying(event) {
+            // Not using waitForEventAndRunStep() to avoid too many
+            // EVENT(onTimeUpdate) logs.
+            _video.addEventListener('timeupdate', onTimeupdate, true);
+        }
+
+        function onTimeupdate(event) {
+            if ( _video.currentTime > (config.duration || 1)) {
+                _video.pause();
+                test.done();
+            }
+        }
+
+        navigator.requestMediaKeySystemAccess(config.keysystem, [configuration]).then(function(access) {
+            return access.createMediaKeys();
+        }).then(function(mediaKeys) {
+            _mediaKeys = mediaKeys;
+            return _video.setMediaKeys(_mediaKeys);
+        }).then(function(){
+            waitForEventAndRunStep('encrypted', _video, onEncrypted, test);
+            waitForEventAndRunStep('playing', _video, onPlaying, test);
+            return testmediasource(config);
+        }).then(function(source) {
+            _mediaSource = source;
+            _video.src = URL.createObjectURL(_mediaSource);
+            return source.done;
+        }).then(function(){
+            _audioContext = new AudioContext();
+            _mediaElementSource = _audioContext.createMediaElementSource(_video);
+            _mediaElementSource.connect(_audioContext.destination);
+            _video.play();
+        }).catch(onFailure);
+    }, testname);
+}


### PR DESCRIPTION
The [spec mentions](https://www.w3.org/TR/encrypted-media/#media-element-restictions):

> Media data processed by a CDM MAY be unavailable through JavaScript APIs in the usual way (for example using the CanvasRenderingContext2D drawImage() method and the AudioContext MediaElementAudioSourceNode). This specification does not define conditions for such non-availability of media data, however, if media data is not available to JavaScript APIs then these APIs MAY behave as if no media data was present at all.


I figured this test would be useful to know which browsers allow this (chrome) and which ones don't (firefox)! Hopefully others do too, but I understand if it's not in the scope of this project.

I basically copy/pasted an existing test, so any recommendations for naming or robustness are most welcome!

<!-- Reviewable:start -->

<!-- Reviewable:end -->
