### PR TITLE
Fix step validation test for <input type="month">

### DIFF
--- a/html/semantics/forms/constraints/form-validation-validity-valid.html
+++ b/html/semantics/forms/constraints/form-validation-validity-valid.html
@@ -62,7 +62,8 @@
       testData: [
         {conditions: {max: "2000-01", value: "2001-01"}, expected: false, name: "[target] validity.valid must be false if validity.rangeOverflow is true"},
         {conditions: {min: "2001-01", value: "2000-01"}, expected: false, name: "[target] validity.valid must be false if validity.rangeUnderflow is true"},
-        {conditions: {step: 2 * 1 * 1, value: "2001-03"}, expected: false, name: "[target] validity.valid must be false if validity.stepMismatch is true"},
+        // Step checks that "months since Jan 1970" is evenly divisible by `step`
+        {conditions: {step: 3, value: "2001-02"}, expected: false, name: "[target] validity.valid must be false if validity.stepMismatch is true"},
         {conditions: {required: true, value: ""}, expected: false, name: "[target] validity.valid must be false if validity.valueMissing is true"}
       ]
     },


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#month-state-(type=month):attr-input-step
and https://html.spec.whatwg.org/multipage/#month-state-(type=month):concept-input-value-string-number
and https://html.spec.whatwg.org/multipage/#the-step-attribute ,
an `<input type="month">` suffers from a step mismatch when the difference (in months) between the selected month and January 1970 is not an integral multiple of the step value.

* Old broken test:
  * `<input>` validity expectation: Invalid
  * step = 2
  * value = 2001-March
  * "months since Jan 1970" = (2001-1970)\*(12 months/year) + (January - March) = 31\*12 + 2 = 374
  * 374 % 2 = 0 ➡️️ Valid
  * Valid ≠ Invalid
  * ❌ Fail!
* Corrected test:
  * `<input>` validity expectation: Invalid
  * step = 3
  * value = 2001-February
  * "months since Jan 1970" = (2001-1970)\*(12 months/year) + (January - February) = 31\*12 + 1 = 373
  * 373 % 3 = 1 ➡️️ Invalid
  * Invalid == Invalid
  * ✅ Pass.