### PR TITLE
Fix willValidate tests for <fieldset> and  <output>

### DIFF
--- a/html/semantics/forms/constraints/form-validation-willValidate.html
+++ b/html/semantics/forms/constraints/form-validation-willValidate.html
@@ -22,16 +22,16 @@
       types: ["button", "reset"],
       testData: [{conditions: {}, expected: false, name: "[target] Must be barred from the constraint validation"}]
     },
-    //FIELDSET, OUTPUT elements should not be barred from the constraint validation
+    // FIELDSET and OUTPUT elements are not "submittable elements" and therefore never validate.
     {
       tag: "fieldset",
       types: [],
-      testData: [{conditions: {}, expected: true, name: "[target] Must not be barred from the constraint validation"}]
+      testData: [{conditions: {}, expected: false, name: "[target] The willValidate attribute must be false since FIELDSET is not a submittable element"}]
     },
     {
       tag: "output",
       types: [],
-      testData: [{conditions: {}, expected: true, name: "[target] Must not be barred from the constraint validation"}]
+      testData: [{conditions: {}, expected: false, name: "[target] The willValidate attribute must be false since OUTPUT is not a submittable element"}]
     },
     //OBJECT, KEYGEN, elements must be barred from the constraint validation
     {


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#dom-cva-willvalidate
> The `willValidate` attribute's getter must return true, if this element is a **candidate for constraint validation**, and false otherwise

Per https://html.spec.whatwg.org/multipage/#candidate-for-constraint-validation
> A **submittable element** is a **candidate for constraint validation** except when [...]

Per https://html.spec.whatwg.org/multipage/#category-submit
> Submittable elements: button, input, object, select, textarea

Since `<fieldset>` and `<output>` are not *submittable elements*, they are never *candidates for constraint validation*, and therefore their `willValidate` properties must always return false.