### PR TITLE
[presentation-api] add a step to terminate presentations when the test stops

### DIFF
--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.html
@@ -25,6 +25,12 @@
     var startPresentation = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
+            var connection;
+            t.add_cleanup(function() {
+                if(connection)
+                    connection.terminate();
+            });
+
             // Note: During starting a presentation, the connectionavailable event is fired (step 20)
             //       after the promise P is resolved (step 19).
             return new Promise(function(resolve, reject) {
@@ -34,20 +40,15 @@
                 };
                 // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
                 // or the presentation fails to be started
-                request.start().then(function() {
+                request.start().then(function(c) {
+                    connection = c;
                     t.step_timeout(function() { assert_unreached('The connectionavailable event was not fired.'); }, 5000);
                 }, reject);
-            }).then(function(connection) {
-                // Check the initial state of a presentation connection
+            }).then(function(c) {
+                connection = c;
                 assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-
-                // Check, if the connection ID is set
                 assert_true(!!connection.id, 'The connection ID is set.');
-
-                // Check the type of the connection.id
                 assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-
-                // Check the instance of the connection
                 assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
             });
         }, 'The connectionavailable event was fired successfully.');

--- a/presentation-api/controlling-ua/defaultRequest_success-manual.html
+++ b/presentation-api/controlling-ua/defaultRequest_success-manual.html
@@ -33,9 +33,12 @@
     // 'default request' Test - BEGIN
     // ------------------------------
     async_test(function(t) {
-        // clean up the instruction notice when the test ends
+        // clean up the presentation and the instruction notice when the test ends
+        var connection;
         t.add_cleanup(function() {
             notice.parentNode.removeChild(notice);
+            if(connection)
+                connection.terminate();
         });
         // set an event handler to make the test fail when the button is clicked
         button.onclick = t.step_func_done(function() {
@@ -45,7 +48,7 @@
         var request = new PresentationRequest(presentationUrls);
         navigator.presentation.defaultRequest = request;
         request.onconnectionavailable = t.step_func_done(function (evt) {
-            var connection = evt.connection;
+            connection = evt.connection;
             // check the presentation connection and its attributes
             assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
             assert_true(!!connection.id, 'The connection ID is set.');

--- a/presentation-api/controlling-ua/reconnectToPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_success-manual.html
@@ -21,7 +21,15 @@
         promise_test(function (t) {
             var request = new PresentationRequest(presentationUrls);
             var presentationId = null;
-            return request.start().then(function (connection) {
+            var connection;
+
+            t.add_cleanup(function() {
+                if(connection)
+                    connection.terminate();
+            });
+
+            return request.start().then(function (c) {
+                connection = c;
                 presentationId = connection.id;
 
                 // No more user input needed, re-enable test timeout
@@ -36,7 +44,8 @@
             }).then(function () {
                 // Connection now closed, let's reconnect to it
                 return request.reconnect(presentationId);
-            }).then(function (connection) {
+            }).then(function (c) {
+                connection = c;
                 assert_equals(connection.state, "connecting", "connection should be in 'connecting' state");
                 assert_equals(connection.id, presentationId, "Ids of old and new connections must be equal");
             });

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
@@ -13,6 +13,9 @@
 <button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
 
 <script>
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
@@ -21,11 +24,19 @@
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
-    var startPresentation = function () {
+    presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
             var request = new PresentationRequest(presentationUrls);
-            return promise_rejects(t, 'NotAllowedError', request.start());
+
+            // terminate the presentation connection when the presentation is started by accident
+            var connection;
+            t.add_cleanup(function() {
+                if(connection)
+                    connection.terminate();
+            })
+
+            return promise_rejects(t, 'NotAllowedError', request.start().then(function(c) { connection = c; }));
         });
     };
     // -----------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
@@ -34,7 +34,7 @@
             t.add_cleanup(function() {
                 if(connection)
                     connection.terminate();
-            })
+            });
 
             return promise_rejects(t, 'NotAllowedError', request.start().then(function(c) { connection = c; }));
         });

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
@@ -34,7 +34,7 @@
             t.add_cleanup(function() {
                 if(connection)
                     connection.terminate();
-            })
+            });
 
             return promise_rejects(t, 'NotFoundError', request.start().then(function(c) { connection = c; }));
         });

--- a/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotfound-manual.html
@@ -10,9 +10,12 @@
 <p>Before starting this test, confirm that there is no available presentation display on your local network.</p>
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.
 </p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 <script>
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
@@ -21,11 +24,19 @@
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
-    var startPresentation = function () {
+    presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
             var request = new PresentationRequest(presentationUrls);
-            return promise_rejects(t, 'NotFoundError', request.start());
+
+            // terminate the presentation connection when the presentation is started by accident
+            var connection;
+            t.add_cleanup(function() {
+                if(connection)
+                    connection.terminate();
+            })
+
+            return promise_rejects(t, 'NotFoundError', request.start().then(function(c) { connection = c; }));
         });
     };
     // -----------------------------------------

--- a/presentation-api/controlling-ua/startNewPresentation_success-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_success-manual.html
@@ -47,8 +47,13 @@
 
             var request = new PresentationRequest(presentationUrls);
             var eventWatcher = new EventWatcher(t, request, 'connectionavailable');
-            var waitConnectionavailable = eventWatcher.wait_for('connectionavailable').then(count);
+            var waitConnectionavailable = eventWatcher.wait_for('connectionavailable').then(count).then(function(evt) { connection = connection || evt.connection; });
             var waitConnect;
+
+            t.add_cleanup(function() {
+                if(connection)
+                    connection.terminate();
+            });
 
             return request.start().then(count)
                 .then(checkPhase).then(function (c) {

--- a/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_unsettledpromise-manual.html
@@ -8,24 +8,34 @@
 <script src="common.js"></script>
 
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.</p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 <script>
+    // disable the timeout function for the tests
+    setup({explicit_timeout: true});
+
     // ----------
     // DOM Object
     // ----------
     var presentBtn = document.getElementById("presentBtn");
 
+    // -----------------------------------------------
+    // Terminate a presentation if started by accident
+    // -----------------------------------------------
+    function terminate(connection) {
+        connection.terminate();
+    }
+
     // -------------------------------------------
     // Start New Presentation Test (error) - begin
     // -------------------------------------------
-    var startPresentation = function () {
+    presentBtn.onclick = function () {
         presentBtn.disabled = true;
         promise_test(function (t) {
             var request1 = new PresentationRequest(presentationUrls),
                 request2 = new PresentationRequest(presentationUrls);
-            request1.start().catch(function(){});
-            return promise_rejects(t, 'OperationError', request2.start());
+            request1.start().then(terminate, function(){});
+            return promise_rejects(t, 'OperationError', request2.start().then(terminate));
         });
     };
     // -----------------------------------------


### PR DESCRIPTION
This PR partially fixes #4258.

* `startNewPresentation_unsettledpromise-manual.html` now terminates a presentation in `request.start().then()`, since the display selection dialog could appear after the test result would be shown.
* The other tests now terminate a presentation in `t.add_cleanup(function)`.