### PR TITLE
Streams: Test pipeTo with undefined rejections

### DIFF
--- a/streams/OWNERS
+++ b/streams/OWNERS
@@ -4,3 +4,4 @@
 @youennf
 @calvaris
 @wanderview
+@ricea

--- a/streams/piping/general.js
+++ b/streams/piping/general.js
@@ -163,7 +163,10 @@ for (const preventAbort of [true, false]) {
       }
     }, { preventAbort });
 
-    return promise_rejects(t, null, rs.pipeTo(new WritableStream()), 'promise should be rejected');
+    return rs.pipeTo(new WritableStream()).then(
+        () => assert_unreached('pipeTo promise should be rejected'),
+        value => assert_equals(value, undefined, 'rejection value should be undefined'));
+
   }, `an undefined rejection from pull should cause pipeTo() to reject when preventAbort is ${preventAbort}`);
 }
 
@@ -182,7 +185,9 @@ for (const preventCancel of [true, false]) {
       }
     });
 
-    return promise_rejects(t, null, rs.pipeTo(ws), 'promise should be rejected');
+    return rs.pipeTo(ws).then(
+         () => assert_unreached('pipeTo promise should be rejected'),
+        value => assert_equals(value, undefined, 'rejection value should be undefined'));
 
   }, `an undefined rejection from write should cause pipeTo() to reject when preventCancel is ${preventCancel}`);
 }

--- a/streams/piping/general.js
+++ b/streams/piping/general.js
@@ -154,4 +154,37 @@ promise_test(() => {
 
 }, 'Piping from a ReadableStream for which a chunk becomes asynchronously readable after the pipeTo');
 
+for (const preventAbort of [true, false]) {
+  promise_test(t => {
+
+    const rs = new ReadableStream({
+      pull() {
+        return Promise.reject(undefined);
+      }
+    }, { preventAbort });
+
+    return promise_rejects(t, null, rs.pipeTo(new WritableStream()), 'promise should be rejected');
+  }, `an undefined rejection from pull should cause pipeTo() to reject when preventAbort is ${preventAbort}`);
+}
+
+for (const preventCancel of [true, false]) {
+  promise_test(t => {
+
+    const rs = new ReadableStream({
+      pull(controller) {
+        controller.enqueue(0);
+      }
+    }, { preventCancel });
+
+    const ws = new WritableStream({
+      write() {
+        return Promise.reject(undefined);
+      }
+    });
+
+    return promise_rejects(t, null, rs.pipeTo(ws), 'promise should be rejected');
+
+  }, `an undefined rejection from write should cause pipeTo() to reject when preventCancel is ${preventCancel}`);
+}
+
 done();


### PR DESCRIPTION
When the source or destination returns a rejection the promise returned
from ReadableStream.pipeTo should also reject. Verify that this works
correctly when the value of the rejection is undefined.