### PR TITLE
Streams: add some pipeThrough tests

### DIFF
--- a/streams/piping/pipe-through.https.html
+++ b/streams/piping/pipe-through.https.html
@@ -6,5 +6,6 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script src="../resources/rs-utils.js"></script>
+<script src="../resources/test-utils.js"></script>
 
 <script src="pipe-through.js"></script>

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -6,9 +6,6 @@ if (self.importScripts) {
   self.importScripts('../resources/test-utils.js');
 }
 
-const error1 = new Error('error1!');
-error1.name = 'error1';
-
 function duckTypedPassThroughTransform() {
   let enqueueInReadable;
   let closeReadable;
@@ -44,7 +41,7 @@ promise_test(t => {
   const transform = {
     writable: new WritableStream({
       start(c) {
-        c.error(error1);
+        c.error(new Error('this rejection should not be reported as unhandled'));
       }
     }),
     readable: new ReadableStream()
@@ -90,5 +87,21 @@ test(() => {
   // Test passes if this doesn't throw or crash.
 
 }, 'pipeThrough can handle calling a pipeTo that returns a non-promise object');
+
+test(() => {
+  const dummy = {
+    pipeTo(args) {
+      return {
+        then() {},
+        this: 'is not a real promise'
+      };
+    }
+  };
+
+  ReadableStream.prototype.pipeThrough.call(dummy, { });
+
+  // Test passes if this doesn't throw or crash.
+
+}, 'pipeThrough can handle calling a pipeTo that returns a non-promise thenable object');
 
 done();


### PR DESCRIPTION
This includes tests that the pipeThrough promise is handled; see https://github.com/whatwg/streams/pull/664.