### PR TITLE
Ensure stability bot uses intended Chrome version

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -264,7 +264,7 @@ class Chrome(Browser):
     def version(self, root):
         """Retrieve the release version of the installed browser."""
         output = call(self.binary, "--version")
-        return re.search(r"[0-9a-z\.]+$", output.strip()).group(0)
+        return re.search(r"[0-9\.]+( [a-z]+)?$", output.strip()).group(0)
 
     def wptrunner_args(self, root):
         return {

--- a/ci_stability.sh
+++ b/ci_stability.sh
@@ -25,7 +25,7 @@ install_chrome() {
     deb_archive=google-chrome-${channel}_current_amd64.deb
     wget https://dl.google.com/linux/direct/$deb_archive
 
-    # If the environments provides an installation of Google Chrome, the
+    # If the environment provides an installation of Google Chrome, the
     # existing binary may take precedence over the one introduced in this
     # script. Remove any previously-existing "alternatives" prior to
     # installation in order to ensure that the new binary is installed as

--- a/ci_stability.sh
+++ b/ci_stability.sh
@@ -25,6 +25,15 @@ install_chrome() {
     deb_archive=google-chrome-${channel}_current_amd64.deb
     wget https://dl.google.com/linux/direct/$deb_archive
 
+    # If the environments provides an installation of Google Chrome, the
+    # existing binary may take precedence over the one introduced in this
+    # script. Remove any previously-existing "alternatives" prior to
+    # installation in order to ensure that the new binary is installed as
+    # intended.
+    if sudo update-alternatives --list google-chrome; then
+        sudo update-alternatives --remove-all google-chrome
+    fi
+
     # Installation will fail in cases where the package has unmet dependencies.
     # When this occurs, attempt to use the system package manager to fetch the
     # required packages and retry.

--- a/url/url-origin.html
+++ b/url/url-origin.html
@@ -3,6 +3,7 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
+
 <script>
 function runURLOriginTests() {
   var setup = async_test("Loading data…")

--- a/url/url-origin.html
+++ b/url/url-origin.html
@@ -3,7 +3,6 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
-
 <script>
 function runURLOriginTests() {
   var setup = async_test("Loading data…")


### PR DESCRIPTION
By default, the TravisCI environment provides a stable build of the Google Chrome web browser. The globally-installed `google-chrome` binary from this installation takes precedence over the version introduced via the stability bot's installation script, and as a result, the provided "stable" release was always used by the bot.

Use the Debian `update-alternatives` tool to ensure that previously-installed binaries are ignored and that the automated stability checks run against the intended version of the browser. Update the "version number" pattern to match the new version format.