### PR TITLE
Remove unnecessary configuration

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -270,12 +270,6 @@ class Chrome(Browser):
         return {
             "product": "chrome",
             "binary": self.binary,
-            # Chrome's "sandbox" security feature must be disabled in order to
-            # run the browser in OpenVZ environments such as the one provided
-            # by TravisCI.
-            #
-            # Reference: https://github.com/travis-ci/travis-ci/issues/938
-            "binary_arg": "--no-sandbox",
             "webdriver_binary": "%s/chromedriver" % root,
             "test_types": ["testharness", "reftest"]
         }


### PR DESCRIPTION
The Google Chrome browser implements a "sandbox" feature whose underlying strategy depends on the capabilities of the environment. In environments that did not support advanced kernel-level namespacing features, the browser would use a technology that was incompatible with the Travis CI continuous integration environment.

Historically, the TravisCI continuous integration environment was built from an operating system which did not support these features (namely: the 12.04 release of Ubuntu), so the sandbox needed to be disabled in order for the browser to function.

This project is configured to use a more modern operating system (namely: the 14.04 release of Ubuntu), which likely provides the advanced namespacing features. This obviates the need to disable the browser's sandbox feature.