### PR TITLE
`select` events are supposed to bubble

### DIFF
--- a/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
@@ -110,7 +110,7 @@
       element.onselect = this.step_func_done(function(e) {
         assert_true(q, "event should be queued");
         assert_true(e.isTrusted, "event is trusted");
-        assert_false(e.bubbles, "event bubbles");
+        assert_true(e.bubbles, "event bubbles");
         assert_false(e.cancelable, "event is not cancelable");
       });
       element.setRangeText("foobar2", 0, 6);


### PR DESCRIPTION
Every "referenced in" backlink for https://html.spec.whatwg.org/#event-select uses the "with the `bubbles` attribute initialized to true" language when firing a `select` event.
Also, https://w3c.github.io/uievents/#event-type-select specs `select` as "Bubbles: Yes".
So we should expect `select` to bubble.
This testcase was previously asserting that `select` should not bubble.