### PR TITLE
Fix "Duplicate test name" error

### DIFF
--- a/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html
@@ -41,7 +41,7 @@ test(function() {
     input.setSelectionRange(input.value.length+1,1)
     assert_equals(input.selectionStart, 1, "If end is less than or equal to start then the start of the selection and the end of the selection must both be placed immediately before the character with offset end");
     assert_equals(input.selectionEnd, 1, "element.selectionEnd should be 1");
-  },'input setSelectionRange(input.value.length+1,input.value.length+1)');
+  },'input setSelectionRange(input.value.length+1,1)');
 
   test(function() {
     input.setSelectionRange(2,2)


### PR DESCRIPTION
Lines 38 and 44 were both specifying the same test name, presumably due to a copy-paste-o.