### PR TITLE
<input type="time"> does not clamp its value

### DIFF
--- a/html/semantics/forms/the-input-element/time-2.html
+++ b/html/semantics/forms/the-input-element/time-2.html
@@ -23,9 +23,9 @@
     {value: "00:60:00.000", expected: "", testname: "Invalid value: minute > 59. Value should be empty"},
     {value: "00:00:60.000", expected: "", testname: "Invalid value: second > 59. Value should be empty"},
     {value: "12:00:00.001", attributes: { min: "12:00:00.000" }, expected: "12:00:00.001", testname: "Value >= min attribute"},
-    {value: "12:00:00.000", attributes: { min: "12:00:00.001" }, expected: "12:00:00.001", testname: "Value < min attribute"},
+    {value: "12:00:00.000", attributes: { min: "12:00:00.001" }, expected: "12:00:00.000", testname: "Value < min attribute"},
     {value: "12:00:00.000", attributes: { max: "12:00:00.001" }, expected: "12:00:00.000", testname: "Value <= max attribute"},
-    {value: "12:00:00.001", attributes: { max: "12:00:00.000" }, expected: "12:00:00.000", testname: "Value > max attribute"}
+    {value: "12:00:00.001", attributes: { max: "12:00:00.000" }, expected: "12:00:00.001", testname: "Value > max attribute"}
   ];
   for (var i = 0; i < times.length; i++) {
     var w = times[i];


### PR DESCRIPTION
This test assumed that `<input type="time">` cannot have its value set to a value that's outside the interval established by its min/max attributes, which is incorrect.

`<input type="range">` does perform that sort of clamping, using "When the element is suffering from an underflow/overflow" hooks:
https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range):suffering-from-an-underflow

But `<input type="time">`'s section doesn't setup any such hooks AFAICT, nor does its value sanitization algorithm implement any clamping:
https://html.spec.whatwg.org/multipage/forms.html#time-state-(type=time):value-sanitization-algorithm