### PR TITLE
Stop streams/w-s/write.https.html timeouts

### DIFF
--- a/streams/writable-streams/write.js
+++ b/streams/writable-streams/write.js
@@ -165,7 +165,7 @@ promise_test(t => {
 }, 'when sink\'s write throws an error, the stream should become errored and the promise should reject');
 
 promise_test(() => {
-  const numberOfWrites = 10000;
+  const numberOfWrites = 1000;
 
   let resolveFirstWritePromise;
   let writeCount = 0;


### PR DESCRIPTION
write.https.html times out on some Chromium bots. Reduce the number of
iterations in the 'a large queue of writes should be processed
completely' test to make the test run faster.

Fixes whatwg/streams#660.