### PR TITLE
Reduce number of requests in header-values

### DIFF
--- a/fetch/api/headers/header-values.html
+++ b/fetch/api/headers/header-values.html
@@ -6,36 +6,54 @@
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
-for(let i = 0; i < 0x100; i++) {
-  let fail = false
-  if(i === 0 || i === 0x0A || i === 0x0D) {
-    fail = true
-  }
-
-  let val = "x" + String.fromCharCode(i) + "x"
-  async_test((t) => {
+// Invalid values
+[0, 0x0A, 0x0D].forEach(val => {
+  val = "x" + String.fromCharCode(val) + "x"
+  test(() => {
     let xhr = new XMLHttpRequest()
-    xhr.open("POST", "../resources/inspect-headers.py?headers=value-test")
-    if(fail) {
-      assert_throws("SyntaxError", () => xhr.setRequestHeader("value-test", val))
-      t.done()
-    } else {
-      xhr.setRequestHeader("value-test", val)
-      xhr.onload = t.step_func_done(() => {
-        assert_equals(xhr.getResponseHeader("x-request-value-test"), val)
-      })
-      xhr.send()
-    }
-  }, "XMLHttpRequest with value " + encodeURI(val))
+    xhr.open("POST", "/")
+    assert_throws("SyntaxError", () => xhr.setRequestHeader("value-test", val))
+  }, "XMLHttpRequest with value " + encodeURI(val) + " needs to throw")
 
-  promise_test((t) => {
-    if(fail) {
-      return promise_rejects(t, new TypeError(), fetch("about:blank", { headers: {"value-test": val} }))
-    } else {
-      return fetch("../resources/inspect-headers.py?headers=value-test", { headers: {"value-test": val} }).then((res) => {
-        assert_equals(res.headers.get("x-request-value-test"), val)
-      })
-    }
-  }, "fetch() with value " + encodeURI(val))
+  promise_test(t => promise_rejects(t, new TypeError(), fetch("about:blank", { headers: {"value-test": val} })), "fetch() with value " + encodeURI(val) + " needs to throw")
+})
+
+// Valid values
+let headerValues =[]
+for(let i = 0; i < 0x100; i++) {
+  if(i === 0 || i === 0x0A || i === 0x0D) {
+    continue
+  }
+  headerValues.push("x" + String.fromCharCode(i) + "x")
 }
+var url = "../resources/inspect-headers.py?headers="
+headerValues.forEach((_, i) => {
+  url += "val" + i + "|"
+})
+
+async_test((t) => {
+  let xhr = new XMLHttpRequest()
+  xhr.open("POST", url)
+  headerValues.forEach((val, i) => {
+    xhr.setRequestHeader("val" + i, val)
+  })
+  xhr.onload = t.step_func_done(() => {
+    headerValues.forEach((val, i) => {
+      assert_equals(xhr.getResponseHeader("x-request-val" + i), val)
+    })
+  })
+  xhr.send()
+}, "XMLHttpRequest with all valid values")
+
+promise_test((t) => {
+  const headers = new Headers
+  headerValues.forEach((val, i) => {
+    headers.append("val" + i, val)
+  })
+  return fetch(url, { headers }).then((res) => {
+    headerValues.forEach((val, i) => {
+      assert_equals(res.headers.get("x-request-val" + i), val)
+    })
+  })
+}, "fetch() with all valid values")
 </script>


### PR DESCRIPTION
This makes it a little harder to study the results, but I guess that’s
fine as it runs a lot quicker.