### PR TITLE
<input type="week"> does not clamp its value

### DIFF
--- a/html/semantics/forms/the-input-element/week.html
+++ b/html/semantics/forms/the-input-element/week.html
@@ -19,9 +19,9 @@
     {value: "-W52", expected: "", testname: "Invalid value: yearless week"},
     {value: "W52", expected: "", testname: "Invalid value: yearless week and no '-' (U+002D)"},
     {value: "2014-W03", attributes: { min: "2014-W02" }, expected: "2014-W03", testname: "Value >= min attribute"},
-    {value: "2014-W01", attributes: { min: "2014-W02" }, expected: "2014-W02", testname: "Value < min attribute"},
+    {value: "2014-W01", attributes: { min: "2014-W02" }, expected: "2014-W01", testname: "Value < min attribute"},
     {value: "2014-W10", attributes: { max: "2014-W11" }, expected: "2014-W10", testname: "Value <= max attribute"},
-    {value: "2014-W12", attributes: { max: "2014-W11" }, expected: "2014-W11", testname: "Value > max attribute"}
+    {value: "2014-W12", attributes: { max: "2014-W11" }, expected: "2014-W12", testname: "Value > max attribute"}
   ];
   for (var i = 0; i < weeks.length; i++) {
     var w = weeks[i];


### PR DESCRIPTION
This test assumed that `<input type="week">` cannot have its value set to a value that's outside the interval established by its min/max attributes, which is incorrect.

`<input type="range">` does perform that sort of clamping, using "When the element is suffering from an underflow/overflow" hooks:
https://html.spec.whatwg.org/multipage/forms.html#range-state-(type=range):suffering-from-an-underflow

But `<input type="week">`'s section doesn't setup any such hooks AFAICT, nor does its value sanitization algorithm implement any clamping:
https://html.spec.whatwg.org/multipage/forms.html#week-state-(type=week):value-sanitization-algorithm

X-Ref: #4582