### PR TITLE
the-input-element/number.html: Fix broken spec link

### DIFF
--- a/html/semantics/forms/the-input-element/number.html
+++ b/html/semantics/forms/the-input-element/number.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>Form input type=number</title>
 <link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
-<link rel=help href="https://html.spec.whatwg.org/multipage/#password-state-(type=number)">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#number-state-(type=number)">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>


### PR DESCRIPTION
number ≠ password