### PR TITLE
When type="number", HTMLInputElement.value uses strict parsing & doesn't clamp

### DIFF
--- a/html/semantics/forms/the-input-element/number.html
+++ b/html/semantics/forms/the-input-element/number.html
@@ -29,14 +29,14 @@
     {value: "Infinity", expected: "", testname: " value = Infinity"},
     {value: "-Infinity", expected: "", testname: "value = -Infinity"},
     {value: "NaN", expected: "", testname: "value = NaN"},
-    {value: "9007199254740993", expected: "9007199254740992", testname: "value = 2^53+1"},
+    {value: "9007199254740993", expected: "9007199254740993", testname: "value = 2^53+1"},
     {value: "2e308", expected: "", testname: "value >= Number.MAX_VALUE"},
     {value: "1e", expected: "", testname: "value = 1e"},
-    {value: "+1", expected: "1", testname: "value = +1"},
+    {value: "+1", expected: "", testname: "value = +1"},
     {value: "+", expected: "", testname: "value = '+'"},
     {value: "-", expected: "", testname: "value = '-'"},
-    {value: " 1", expected: "1", testname: "value with a leading whitespace"},
-    {value: "1trailing junk", expected: "1", testname: "value = 1trailing junk"}
+    {value: " 1", expected: "", testname: "value with a leading whitespace"},
+    {value: "1trailing junk", expected: "", testname: "value = 1trailing junk"}
   ];
   for (var i = 0; i < numbers.length; i++) {
     var w = numbers[i];


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#number-state-(type=number):dom-input-value-2
`HTMLInputElement.value` uses the "value" mode when the `<input>` is of `type="number"`.

Per https://html.spec.whatwg.org/multipage/#dom-input-value-value
> On setting, it must set the element's value to the new value, [...], invoke the **value sanitization algorithm**, [...]

Per https://html.spec.whatwg.org/multipage/#number-state-(type=number):value-sanitization-algorithm
> The **value sanitization algorithm** is as follows: If the value of the element is not a **valid floating-point number**, then set it to the empty string instead.

Per https://html.spec.whatwg.org/multipage/#valid-floating-point-number
the grammar for **valid floating-point number** does not allow:
* Trailing gibberish
* Leading plus signs
* Leading whitespace

So the 3 related tests' values are invalid and should get sanitized to the empty string.

And neither the **value sanitization algorithm** nor AFAICT any prose in
https://html.spec.whatwg.org/multipage/#number-state-(type=number)
requires number string values to get clamped/rounded like the 2^53+1 test seems to expect.