### PR TITLE
the-input-element/date.html: Fix typo in min value

### DIFF
--- a/html/semantics/forms/the-input-element/date.html
+++ b/html/semantics/forms/the-input-element/date.html
@@ -16,7 +16,7 @@
       <input id="too_large_value" type="date" value="2099-01-31" min="2011-01-01" max="2011-12-31"/>
       <input id="invalid_min" type="date" value="2011-01-01" min="1999-1" max="2011-12-31"/>
       <input id="invalid_max" type="date" value="2011-01-01" min="2011-01-01" max="2011-13-162-777"/>
-      <input id="min_larger_than_max" type="date" value="2011-01-01" min="2099-01" max="2011-12-31"/>
+      <input id="min_larger_than_max" type="date" value="2011-01-01" min="2099-01-01" max="2011-12-31"/>
       <input id="invalid_value" type="date" value="invalid-date" min="2011-01-01" max="2011-12-31"/>
     </div>
 
@@ -40,7 +40,7 @@
 
       test(function() {
         assert_equals(document.getElementById("valid").max, "2011-12-31"),
-        assert_equals(document.getElementById("min_larger_than_max").max, "2099-01"),
+        assert_equals(document.getElementById("min_larger_than_max").max, "2099-01-01"),
         assert_equals(document.getElementById("invalid_max").max, "")
       },"The max attribute, if specified, must have a value that is a valid date string.");
 


### PR DESCRIPTION
The malformation of the `min` value in this case seems to be an accident, as opposed to the `#invalid_*` cases which are deliberately invalid.

(I think the assertion has other problems, but I'll leave that to a future PR.)