### PR TITLE
HTMLInputElement.min just reflects the content attribute

### DIFF
--- a/html/semantics/forms/the-input-element/date.html
+++ b/html/semantics/forms/the-input-element/date.html
@@ -34,9 +34,9 @@
       }, "The value attribute, if specified and not empty, must have a value that is a valid date string.");
 
       test(function() {
-        assert_equals(document.getElementById("valid").min, "2011-01-01"),
-        assert_equals(document.getElementById("invalid_min").min, "")
-      }, "The min attribute, if specified, must have a value that is a valid date string.");
+        assert_equals(document.getElementById("valid").min, "2011-01-01");
+        assert_equals(document.getElementById("invalid_min").min, "1999-1");
+      }, "The min attribute must be reflected verbatim by the min property.");
 
       test(function() {
         assert_equals(document.getElementById("valid").max, "2011-12-31"),


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#htmlinputelement
```webidl
interface HTMLInputElement : HTMLElement {
  // ...
  [CEReactions] attribute DOMString min;
  // ...
}
```

Per https://html.spec.whatwg.org/multipage/#dom-input-min
> The [...] `min` [...] IDL attributes must **reflect** the respective content attributes of the same name. 

Per https://html.spec.whatwg.org/multipage/#reflect
> Some IDL attributes are defined to **reflect** a particular content attribute. This means that on getting, the IDL attribute returns the current value of the content attribute, and on setting, the IDL attribute changes the value of the content attribute to the given value.
> [...some non-applicable categories...]
> If a reflecting IDL attribute is a `DOMString` or `USVString` attribute but doesn't fall into any of the above categories, then the getting and setting must be done in a transparent, case-preserving manner.

So `HTMLInputElement.min` should just return the `min` content attribute value without doing any sanitization/validation.

I presume that the original test author was thinking of
> [The `min` attribute, if specified, must have a value that is a *valid date string*.](https://html.spec.whatwg.org/multipage/forms.html#date-state-(type=date):attr-input-min)

when writing this test, but I understand that sentence to be an authoring requirement, not a User-Agent requirement.