### PR TITLE
<input type="date"> does not clamp its value

### DIFF
--- a/html/semantics/forms/the-input-element/date.html
+++ b/html/semantics/forms/the-input-element/date.html
@@ -29,8 +29,8 @@
 
       test(function() {
         assert_equals(document.getElementById("valid").value, "2011-11-01");
-        assert_equals(document.getElementById("too_small_value").value, "2011-01-01");
-        assert_equals(document.getElementById("too_large_value").value, "2011-12-31");
+        assert_equals(document.getElementById("too_small_value").value, "1999-01-31");
+        assert_equals(document.getElementById("too_large_value").value, "2099-01-31");
       }, "The value attribute, if specified and not empty, must have a value that is a valid date string.");
 
       test(function() {


### PR DESCRIPTION
For the same reasons as https://github.com/w3c/web-platform-tests/pull/4591 (just s/week/date/g), `<input type="date">` does not clamp its value based on its range limitations from its `min`/`max` attributes.
This test incorrectly expected `<input type="date">` to perform such clamping.