### PR TITLE
the-input-element/time.html: Use add_cleanup()

### DIFF
--- a/html/semantics/forms/the-input-element/time.html
+++ b/html/semantics/forms/the-input-element/time.html
@@ -154,34 +154,34 @@ test(function(){
 
 test(function(){
   _StepTest.max = "15:00";
+  this.add_cleanup(function() { _StepTest.max = ""; });
   _StepTest.value = "15:00";
   _StepTest.stepUp();
   assert_equals(_StepTest.value, "15:00");
-  _StepTest.max = "";
 } , "stepUp stop because it exceeds the maximum value");
 test(function(){
   _StepTest.min = "13:00";
+  this.add_cleanup(function() { _StepTest.min = ""; });
   _StepTest.value = "13:00";
   _StepTest.stepDown();
   assert_equals(_StepTest.value, "13:00");
-  _StepTest.min="";
 } , "stepDown Stop so lower than the minimum value");
 
 test(function(){
   _StepTest.max = "15:01";
+  this.add_cleanup(function() { _StepTest.max = ""; });
   _StepTest.value = "15:00";
   _StepTest.step = "120";
   _StepTest.stepUp();
   assert_equals(_StepTest.value, "15:01");
-  _StepTest.max = "";
 } , "stop at border on stepUp");
 test(function(){
   _StepTest.min = "12:59";
+  this.add_cleanup(function() { _StepTest.min = ""; });
   _StepTest.value = "13:00";
   _StepTest.step = "120";
   _StepTest.stepDown();
   assert_equals(_StepTest.value, "12:59");
-  _StepTest.min="";
 } , "stop at border on stepDown");
 
 test(function(){


### PR DESCRIPTION
To ensure that failing tests don't interfere with other tests
Dangling `min`/`max` values were surviving after failed tests and interfering with later tests.
See also http://testthewebforward.org/docs/testharness-library.html#cleanup