### PR TITLE
step{Up,Down}() reserializes the value, & valid time string allows multiple formats

### DIFF
--- a/html/semantics/forms/the-input-element/time.html
+++ b/html/semantics/forms/the-input-element/time.html
@@ -104,26 +104,56 @@ test(function(){
   _StepTest.value = "12:00";
   _StepTest.step = "3600";
   _StepTest.stepUp();
-  assert_equals(_StepTest.value, "13:00");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00",
+      "13:00:00",
+      "13:00:00.0",
+      "13:00:00.00",
+      "13:00:00.000"],
+    "a valid time string representing 1pm");
 } , "stepUp on step value hour  ");
 test(function(){
   _StepTest.value = "12:00";
   _StepTest.step = "3600";
   _StepTest.stepDown();
-  assert_equals(_StepTest.value, "11:00");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:00",
+      "11:00:00",
+      "11:00:00.0",
+      "11:00:00.00",
+      "11:00:00.000"],
+    "a valid time string representing 11am");
 } , "stepDown on step value hour ");
 
 test(function(){
   _StepTest.value = "12:00";
   _StepTest.step = "1";
   _StepTest.stepUp();
-  assert_equals(_StepTest.value, "12:00:01");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:00:01",
+      "12:00:01.0",
+      "12:00:01.00",
+      "12:00:01.000"],
+    "a valid time string representing 1 second after noon");
 } , "stepUp on step value second ");
 test(function(){
   _StepTest.value = "12:00";
   _StepTest.step = "1";
   _StepTest.stepDown();
-  assert_equals(_StepTest.value, "11:59:59");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:59:59",
+      "11:59:59.0",
+      "11:59:59.00",
+      "11:59:59.000"],
+    "a valid time string representing 1 second before noon");
 } , "stepDown on step value second ");
 
 test(function(){
@@ -143,29 +173,59 @@ test(function(){
   _StepTest.value = "13:00:00";
   _StepTest.step = "1";
   _StepTest.stepUp(2);
-  assert_equals(_StepTest.value, "13:00:02");
-}, "stepUp argment 2 times");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00:02",
+      "13:00:02.0",
+      "13:00:02.00",
+      "13:00:02.000"],
+    "a valid time string representing 2 seconds after 1pm");
+}, "stepUp argument 2 times");
 test(function(){
   _StepTest.value = "13:00:00";
   _StepTest.step = "1";
   _StepTest.stepDown(2);
-  assert_equals(_StepTest.value, "12:59:58");
-}, "stepDown argment 2 times");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:59:58",
+      "12:59:58.0",
+      "12:59:58.00",
+      "12:59:58.000"],
+    "a valid time string representing 2 seconds before 1pm");
+}, "stepDown argument 2 times");
 
 test(function(){
   _StepTest.max = "15:00";
   this.add_cleanup(function() { _StepTest.max = ""; });
   _StepTest.value = "15:00";
   _StepTest.stepUp();
-  assert_equals(_StepTest.value, "15:00");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "15:00",
+      "15:00:00",
+      "15:00:00.0",
+      "15:00:00.00",
+      "15:00:00.000"],
+    "a valid time string representing 3pm");
 } , "stepUp stop because it exceeds the maximum value");
 test(function(){
   _StepTest.min = "13:00";
   this.add_cleanup(function() { _StepTest.min = ""; });
   _StepTest.value = "13:00";
   _StepTest.stepDown();
-  assert_equals(_StepTest.value, "13:00");
-} , "stepDown Stop so lower than the minimum value");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00",
+      "13:00:00",
+      "13:00:00.0",
+      "13:00:00.00",
+      "13:00:00.000"],
+    "a valid time string representing 1pm");
+} , "stepDown stop so lower than the minimum value");
 
 test(function(){
   _StepTest.max = "15:01";
@@ -173,7 +233,15 @@ test(function(){
   _StepTest.value = "15:00";
   _StepTest.step = "120";
   _StepTest.stepUp();
-  assert_equals(_StepTest.value, "15:01");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "15:01",
+      "15:01:00",
+      "15:01:00.0",
+      "15:01:00.00",
+      "15:01:00.000"],
+    "a valid time string representing 1 minute after 3pm");
 } , "stop at border on stepUp");
 test(function(){
   _StepTest.min = "12:59";
@@ -181,14 +249,30 @@ test(function(){
   _StepTest.value = "13:00";
   _StepTest.step = "120";
   _StepTest.stepDown();
-  assert_equals(_StepTest.value, "12:59");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:59",
+      "12:59:00",
+      "12:59:00.0",
+      "12:59:00.00",
+      "12:59:00.000"],
+    "a valid time string representing 1 minute before 2pm");
 } , "stop at border on stepDown");
 
 test(function(){
   _StepTest.value = "";
   _StepTest.step = "60";
   _StepTest.stepUp();
-  assert_equals(_StepTest.value, "00:01");
+  assert_in_array(
+    _StepTest.value,
+    [
+      "00:01",
+      "00:01:00",
+      "00:01:00.0",
+      "00:01:00.00",
+      "00:01:00.000"],
+    "a valid time string representing 1 minute after midnight");
 } , " empty value of stepUp");
 
 


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#dom-input-stepdown , `stepUp()`/`stepDown()` only abort without changing the value when:
* (1) They don't apply to `<input>` based on its `type`.
  * But `stepUp()` and `stepDown()` do apply to `<input type="time">`.
* (2) The element has no *allowed value step*.
  * This is not the case in any of these testcases.
* (3) The element's minimum is greater than its maximum.
  * This is not the case in any of these testcases.
* (4) No value(s) exist which would satisfy the minimum, maximum, and step requirements.
  * This is not the case in any of these testcases.
* (10) If the newly-computed value after stepping would move the value in the opposite direction from that of the name of the method that was invoked.
  * This is not the case in any of these testcases.

Notably for some of these testcases, step (10) does not abort when the new value equals the original value.

Now for the more interesting part. Step (11) of the algorithm is:
> Let *value as string* be the result of running the **algorithm to convert a number to a string**, as defined for the input element's type attribute's current state, on *value*.

For `<input type="time">`:
https://html.spec.whatwg.org/multipage/#time-state-(type=time):concept-input-value-number-string
> The **algorithm to convert a number to a string**, given a number *input*, is as follows: Return a **valid time string** that represents the *time* that is *input* milliseconds after midnight on a day with no time changes.

And in the definition of **valid time string**, we have the following conditionals:
https://html.spec.whatwg.org/multipage/#valid-time-string
> (4) If second is non-zero, or optionally if second is zero: [...]
> (4.3) If second is not an integer, or optionally if second is an integer: [...]
And the following branch with 3 forks:
> (4.3.2) One, two, or three ASCII digits, representing the fractional part of second

Therefore, when `stepUp()` or `stepDown()` are called, and none of the edge-cases causing abortions are encountered, the browser is free to (re-)serialize the time to a string that may or may not include:
* not-strictly-necessary explicit zero seconds ("hh:mm:00")
* one to three digits of non-strictly-necessary explicit zero second fractions ("hh:mm:ss.0", "hh:mm:ss.00", "hh:mm:ss.000")

In particular, https://github.com/w3c/web-platform-tests/blob/84cc590a98e96b8760cfbb2a24fec1edca30037a/html/semantics/forms/the-input-element/time.html#L160 fails in Chrome since `"15:00"` gets reserialized to `"15:00:00"`.

This PR updates the latter half of the testcases. I will send another PR to update the first half if this PR gets approved.