### PR TITLE
HTMLInputElement.max just reflects the content attribute

### DIFF
--- a/html/semantics/forms/the-input-element/date.html
+++ b/html/semantics/forms/the-input-element/date.html
@@ -39,10 +39,10 @@
       }, "The min attribute must be reflected verbatim by the min property.");
 
       test(function() {
-        assert_equals(document.getElementById("valid").max, "2011-12-31"),
-        assert_equals(document.getElementById("min_larger_than_max").max, "2099-01-01"),
-        assert_equals(document.getElementById("invalid_max").max, "")
-      },"The max attribute, if specified, must have a value that is a valid date string.");
+        assert_equals(document.getElementById("valid").max, "2011-12-31");
+        assert_equals(document.getElementById("min_larger_than_max").max, "2011-12-31");
+        assert_equals(document.getElementById("invalid_max").max, "2011-13-162-777");
+      }, "The max attribute must be reflected verbatim by the max property.");
 
       test(function() {
         assert_equals(document.getElementById("invalid_value").value, "");


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#htmlinputelement
```webidl
interface HTMLInputElement : HTMLElement {
  // ...
  [CEReactions] attribute DOMString max;
  // ...
}
```

Per https://html.spec.whatwg.org/multipage/#dom-input-max
> The [...] `max` [...] IDL attributes must **reflect** the respective content attributes of the same name. 

Per https://html.spec.whatwg.org/multipage/#reflect
> Some IDL attributes are defined to **reflect** a particular content attribute. This means that on getting, the IDL attribute returns the current value of the content attribute, and on setting, the IDL attribute changes the value of the content attribute to the given value.
> [...some non-applicable categories...]
> If a reflecting IDL attribute is a `DOMString` or `USVString` attribute but doesn't fall into any of the above categories, then the getting and setting must be done in a transparent, case-preserving manner.

So `HTMLInputElement.max` should just return the `max` content attribute value without doing any sanitization/validation.

I presume that the original test author was thinking of
https://html.spec.whatwg.org/multipage/forms.html#date-state-(type=date):attr-input-max
> The `max` attribute, if specified, must have a value that is a **valid date string**.

when writing this test, but I understand that sentence to be an authoring requirement,
not a User-Agent requirement.

X-Ref: #4595