### PR TITLE
Modify and Add tests to OffscreenCanvas promise-based commit()

### DIFF
--- a/common/canvas-tests.js
+++ b/common/canvas-tests.js
@@ -35,10 +35,7 @@ function _getPixel(canvas, x,y)
 function _assertPixel(canvas, x,y, r,g,b,a, pos, colour)
 {
     var c = _getPixel(canvas, x,y);
-    assert_equals(c[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
-    assert_equals(c[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
-    assert_equals(c[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
-    assert_equals(c[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+    _assertPixelImageDataArray(c, x,y, r,g,b,a, pos, colour);
 }
 
 function _assertPixelApprox(canvas, x,y, r,g,b,a, pos, colour, tolerance)
@@ -48,6 +45,14 @@ function _assertPixelApprox(canvas, x,y, r,g,b,a, pos, colour, tolerance)
     assert_approx_equals(c[1], g, tolerance, 'Green channel of the pixel at (' + x + ', ' + y + ')');
     assert_approx_equals(c[2], b, tolerance, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
     assert_approx_equals(c[3], a, tolerance, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
+}
+
+function _assertPixelImageDataArray(image_data_arr, x,y, r,g,b,a, pos, colour)
+{
+    assert_equals(image_data_arr[0], r, 'Red channel of the pixel at (' + x + ', ' + y + ')');
+    assert_equals(image_data_arr[1], g, 'Green channel of the pixel at (' + x + ', ' + y + ')');
+    assert_equals(image_data_arr[2], b, 'Blue channel of the pixel at (' + x + ', ' + y + ')');
+    assert_equals(image_data_arr[3], a, 'Alpha channel of the pixel at (' + x + ', ' + y + ')');
 }
 
 function _addTest(testFn)

--- a/offscreen-canvas/the-offscreen-canvas/offscreencanvas.commit.html
+++ b/offscreen-canvas/the-offscreen-canvas/offscreencanvas.commit.html
@@ -14,30 +14,43 @@ function verifyPlaceholder(placeholder, expectedR, expectedG, expectedB, expecte
     _assertPixel(canvas, 5,5, expectedR, expectedG, expectedB, expectedA, "5,5", expectedClrStr);
 }
 
-test(function() {
+promise_test(function() {
     var placeholder = document.createElement('canvas');
     placeholder.width = placeholder.height = 10;
     var offscreenCanvas = placeholder.transferControlToOffscreen();
     var ctx = offscreenCanvas.getContext('2d');
     ctx.fillStyle = "#0f0";
     ctx.fillRect(0, 0, 10, 10);
-    ctx.commit();
+    var promise = ctx.commit();
     // commit() propagation is taken care of by an async task, which means the
     // place holder contents should still be transparent black at this moment.
     verifyPlaceholder(placeholder, 0,0,0,0, "0,0,0,0");
-    // Set timeout acts as a sync barrier to allow commit to propagate
-    setTimeout(function() {
+    // The frame is refreshed once the promise returned by commit() is resolved.
+    return promise.then(function() {
         verifyPlaceholder(placeholder, 0,255,0,255, "0,255,0,255");
-    }, 0);
+    });
 }, "Test that calling OffscreenCanvas's commit pushes its contents to its placeholder.");
 
-test(function() {
+promise_test(function() {
+    var placeholder = document.createElement('canvas');
+    placeholder.width = placeholder.height = 10;
+    var offscreenCanvas = placeholder.transferControlToOffscreen();
+    var ctx = offscreenCanvas.getContext('2d');
+    ctx.fillStyle = "#0f0";
+    ctx.fillRect(0, 0, 10, 10);
+    return ctx.commit().then(function() {
+      _assertPixel(offscreenCanvas, 5,5, 0,255,0,255, "0,255,0,255");
+    });
+}, "Verify that commit() preserves the contents of an OffscreenCanvas with a 2d context.");
+
+promise_test(function() {
     var offscreenCanvas = new OffscreenCanvas(10, 10);
     var ctx = offscreenCanvas.getContext('2d');
     ctx.fillStyle = "#0f0";
     ctx.fillRect(0, 0, 10, 10);
-    assert_throws("InvalidStateError", function() { ctx.commit(); });
-}, "Test that calling commit on an OffscreenCanvas that is not transferred from a HTMLCanvasElement throws an exception.");
+    var p = ctx.commit();
+    return promise_rejects(this, new DOMException("", "InvalidStateError"), p, "Should reject");
+}, "Test that calling commit on an OffscreenCanvas that is not transferred from a HTMLCanvasElement returns a rejected promise with an exception.");
 
 </script>
 

--- a/offscreen-canvas/the-offscreen-canvas/offscreencanvas.commit.w.html
+++ b/offscreen-canvas/the-offscreen-canvas/offscreencanvas.commit.w.html
@@ -11,18 +11,7 @@ function testCommitPushesContents(offscreenCanvas)
     var ctx = offscreenCanvas.getContext('2d');
     ctx.fillStyle = "#0f0";
     ctx.fillRect(0, 0, 10, 10);
-    ctx.commit();
-}
-
-function isInvalidStateError(funcStr, ctx)
-{
-    try {
-        eval(funcStr);
-    } catch (e) {
-        if (e instanceof DOMException && e.name == "InvalidStateError")
-            return true;
-        return false;
-    }
+    return ctx.commit();
 }
 
 function testCommitException()
@@ -31,17 +20,29 @@ function testCommitException()
     var ctx = offscreenCanvas.getContext('2d');
     ctx.fillStyle = "#0f0";
     ctx.fillRect(0, 0, 10, 10);
-    return isInvalidStateError("ctx.commit()", ctx);
+    return ctx.commit();
 }
 
 self.onmessage = function(e) {
     switch (e.data.msg) {
         case 'test1':
-            testCommitPushesContents(e.data.data);
-            self.postMessage('worker finished');
+            testCommitPushesContents(e.data.data).then(function() {
+                self.postMessage('worker finished');
+            });
             break;
         case 'test2':
-            self.postMessage(testCommitException());
+            var offscreenCanvas = e.data.data;
+            testCommitPushesContents(offscreenCanvas).then(function() {
+                var imageData = offscreenCanvas.getContext("2d").getImageData(5,5,1,1).data;
+                self.postMessage(imageData);
+            });
+            break;
+        case 'test3':
+            testCommitException().then(function() {
+                self.postMessage("No Exception");
+            }).catch(function(exception) {
+                self.postMessage(exception.name);
+            });
             break;
     }
 };
@@ -77,11 +78,23 @@ async_test(function(t) {
 }, "Test that calling OffscreenCanvas's commit pushes its contents to its placeholder.");
 
 async_test(function(t) {
+    var placeholder = document.createElement('canvas');
+    placeholder.width = placeholder.height = 10;
+    var offscreenCanvas = placeholder.transferControlToOffscreen();
     var worker = makeWorker(document.getElementById("myWorker").textContent);
     worker.addEventListener('message', t.step_func_done(function(msg) {
-        assert_true(msg.data);
+        var imageData = msg.data;
+        _assertPixelImageDataArray(imageData, 5,5, 0,255,0,255, "5,5", "0,255,0,255");
     }));
-    worker.postMessage({msg: 'test2'});
+    worker.postMessage({msg: 'test2', data: offscreenCanvas}, [offscreenCanvas]);
+}, "Verify that commit() preserves the contents of an OffscreenCanvas with a 2d context.");
+
+async_test(function(t) {
+    var worker = makeWorker(document.getElementById("myWorker").textContent);
+    worker.addEventListener('message', t.step_func_done(function(msg) {
+        assert_equals(msg.data, "InvalidStateError");
+    }));
+    worker.postMessage({msg: 'test3'});
 }, "Test that calling commit on an OffscreenCanvas that is not transferred from a HTMLCanvasElement throws an exception in a worker.");
 
 </script>


### PR DESCRIPTION
@junov: Please review. Thanks!

This pull request mainly modifies the OffscreenCanvas.commit() tests to handle the latest change in [specification about a promise-based commit() in OffscreenCanvas](https://wiki.whatwg.org/wiki/OffscreenCanvas.requestAnimationFrame). The changes include:
1. Modify the two existing tests in offscreencanvas.commit.html and offscreencanvas.commit.w.html to promise_tests. In particular, we test the assert pixels after the promise returned by commit() is resolved.
2. Add one more test that assert the pixels in OffscreenCanvas to be non-zero after commit(). This is an adaptation of [an existing layout test in Chromium](https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-commit-retains-backing.html).