### PR TITLE
Add tangentialPressure and twist properties to PointerEvent on Mac


### DIFF
--- a/pointerevents/pointerevent_constructor.html
+++ b/pointerevents/pointerevent_constructor.html
@@ -33,6 +33,8 @@
             var testButton = 0;
             var testButtons = 1;
             var testPressure = 0.4;
+            var testTangentialPressure = 0.5;
+            var testTwist = 286;
             var testIsPrimary = true;
 
             on_event(target0, "pointerover", this.step_func(function(event) {
@@ -50,10 +52,12 @@
                     ["custom clientY", event.clientY, testClientY],
                     ["custom tiltX", event.tiltX, testTiltX],
                     ["custom tiltY", event.tiltY, testTiltY],
+                    ["custom twist", event.twist, testTwist],
                     ["custom isPrimary", event.isPrimary, testIsPrimary]
                 ]);
                 test(function() {
                     assert_approx_equals(event.pressure, testPressure, 0.00000001, "custom pressure: ");
+                    assert_approx_equals(event.tangentialPressure, testTangentialPressure, 0.00000001, "custom tangential pressure: ");
                 }, "custom pressure: ");
             }));
 
@@ -66,6 +70,8 @@
                     ["default tiltX", event.tiltX, 0],
                     ["default tiltY", event.tiltY, 0],
                     ["default pressure", event.pressure, 0],
+                    ["default tangentialPressure", event.tangentialPressure, 0],
+                    ["default twist", event.twist, 0],
                     ["default isPrimary", event.isPrimary, false]
                 ]);
             }));
@@ -87,6 +93,8 @@
                 button: testButton,
                 buttons: testButtons,
                 pressure: testPressure,
+                tangentialPressure: testTangentialPressure,
+                twist: testTwist,
                 isPrimary: testIsPrimary
                 });
                 // A PointerEvent created with a PointerEvent constructor must have all its attributes set to the corresponding values provided to the constructor.


### PR DESCRIPTION
Set the properties of tangentialPressure and twist for WebMouseEvent of stylus type,
which is created from NSEvent in WebMouseEventBuilder::Build.

Intent to implement and ship: PointerEvent.tangentialPressure and PointerEvent.twist:
https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/-NmHZqP4cQg

BUG=649376

Review-Url: https://codereview.chromium.org/2587393004
Cr-Commit-Position: refs/heads/master@{#444792}

