### PR TITLE
Add tests for service worker inheritance

### DIFF
--- a/service-workers/service-worker/iframe-controller-worker.https.js
+++ b/service-workers/service-worker/iframe-controller-worker.https.js
@@ -1,7 +1,7 @@
-addEventListener('install', function(evt) {
+addEventListener('install', function(e) {
   self.skipWaiting();
 });
 
-addEventListener('activate', function(evt) {
-  evt.waitUntil(clients.claim());
+addEventListener('activate', function(e) {
+  e.waitUntil(clients.claim());
 });

--- a/service-workers/service-worker/iframe-controller-worker.https.js
+++ b/service-workers/service-worker/iframe-controller-worker.https.js
@@ -1,7 +1,7 @@
-addEventListener('install', function(e) {
+addEventListener('install', function(evt) {
   self.skipWaiting();
 });
 
-addEventListener('activate', function(e) {
-  e.waitUntil(clients.claim());
+addEventListener('activate', function(evt) {
+  evt.waitUntil(clients.claim());
 });

--- a/service-workers/service-worker/iframe-controller-worker.https.js
+++ b/service-workers/service-worker/iframe-controller-worker.https.js
@@ -1,0 +1,7 @@
+addEventListener('install', function(e) {
+  self.skipWaiting();
+});
+
+addEventListener('activate', function(e) {
+  e.waitUntil(clients.claim());
+});

--- a/service-workers/service-worker/iframe-controller.https.html
+++ b/service-workers/service-worker/iframe-controller.https.html
@@ -37,6 +37,8 @@ promise_test(t => {
     .then(f => {
         const child_controller
             = f.contentWindow.navigator.serviceWorker.controller;
+        assert_not_equals(child_controller, null,
+                          'Child\'s controller should not be null.');
         assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                       'about:blank Document should inherit parent\'s SW.');
       });
@@ -55,6 +57,8 @@ promise_test(t => {
     .then(f => {
         const child_controller
             = f.contentWindow.navigator.serviceWorker.controller;
+        assert_not_equals(child_controller, null,
+                          'Child\'s controller should not be null.');
         assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                       'Sandboxed iframe with allow-same-origin should ' +
                       'inherit parent\'s SW.');
@@ -68,6 +72,8 @@ promise_test(t => {
     .then(f => {
         const child_controller
             = f.contentWindow.navigator.serviceWorker.controller;
+        assert_not_equals(child_controller, null,
+                          'Child\'s controller should not be null.');
         assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                       'iframe srcdoc should inherit parent\'s SW.');
         return with_iframe('', {srcdoc: '<p>Some HTML</p>',
@@ -84,6 +90,8 @@ promise_test(t => {
     .then(f => {
         const child_controller
             = f.contentWindow.navigator.serviceWorker.controller;
+        assert_not_equals(child_controller, null,
+                          'Child\'s controller should not be null.');
         assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                       'Sandboxed iframe srcdoc with allow-same-origin should ' +
                       'inherit parent\'s SW.');

--- a/service-workers/service-worker/iframe-controller.https.html
+++ b/service-workers/service-worker/iframe-controller.https.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<title>Service worker inheritance</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/test-helpers.sub.js"></script>
+<script>
+
+promise_test(function(t) {
+    var script = 'iframe-controller-worker.https.js';
+    var scope1 = 'iframe-controller.https.html';
+    var scope2 = 'resources/blank.html';
+    var script1 = script + '?for_scope1';
+    var script2 = script + '?for_scope2';
+    var registration1, registration2;
+    var parent_controller, child_controller;
+    return service_worker_unregister_and_register(t, script1, scope1)
+      .then(function(r) {
+          registration1 = r;
+          return wait_for_state(t, registration1.installing, 'activated');
+        })
+      .then(function() {
+          return service_worker_unregister_and_register(t, script2, scope2);
+        })
+      .then(function(r) {
+          registration2 = r;
+          return wait_for_state(t, registration2.installing, 'activated');
+        })
+      .then(function() {
+          // This client's active service worker is set to registration1's
+          // active worker by clients.claim() during the activation.
+          parent_controller = navigator.serviceWorker.controller;
+          return with_iframe('');
+        })
+      .then(function(f) {
+          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                        'about:blank Document should inherit parent\'s SW.');
+        })
+      .then(function() {
+          return with_srcdoc_iframe('<p>Some HTML</p>');
+        })
+      .then(function(f) {
+          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                        'iframe srcdoc should inherit parent\'s SW.');
+          f.remove();
+        })
+      .then(function() {
+          return with_sandboxed_iframe('', '');
+        })
+      .then(function(f) {
+          assert_throws('SecurityError',
+                        function() { f.contentWindow.navigator; },
+                        'Accessing sandboxed iframe should throw.');
+          f.remove();
+        })
+      .then(function() {
+          return with_sandboxed_iframe('', 'allow-same-origin');
+        })
+      .then(function(f) {
+          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                        'Sandboxed iframe with allow-same-origin should ' +
+                        'inherit parent\'s SW.');
+          f.remove();
+        })
+      .then(function() {
+          return with_iframe('resources/blank.html');
+        })
+      .then(function(f) {
+          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+          assert_not_equals(child_controller.scriptURL,
+                            parent_controller.scriptURL,
+                            'Navigating iframe through http fetch should ' +
+                            'replace the inherited SW with the matched SW.');
+        })
+      .then(function() {
+          return with_iframe('resources/other.html');
+        })
+      .then(function(f) {
+          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+          assert_equals(child_controller, null,
+                        'Navigating iframe through http fetch that has no ' +
+                        'matched SW should set the controller to null.');
+        })
+      .then(function() {
+          return service_worker_unregister(t, scope1);
+        })
+      .then(function() {
+          service_worker_unregister_and_done(t, scope2);
+        })
+      .catch(unreached_rejection(t));
+  }, 'SW inheritance for iframe and overriding behavior by navigate match.');
+
+</script>

--- a/service-workers/service-worker/iframe-controller.https.html
+++ b/service-workers/service-worker/iframe-controller.https.html
@@ -32,94 +32,84 @@ promise_test(t => {
         // This client's active service worker is set to scope1's registration's
         // active worker by clients.claim() during the activation.
         parent_controller = navigator.serviceWorker.controller;
-        return with_iframe('')
-          .then(f => {
-              add_completion_callback(_ => f.remove());
-              return f;
-            });
-        })
-      .then(f => {
-          const child_controller
-              = f.contentWindow.navigator.serviceWorker.controller;
-          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
-                        'about:blank Document should inherit parent\'s SW.');
-        });
+        return with_iframe('', {auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                      'about:blank Document should inherit parent\'s SW.');
+      });
   }, 'Service worker inheritance for about:blank Document.');
 
 promise_test(t => {
     return active_workers.then(_ => {
-        return with_srcdoc_iframe('<p>Some HTML</p>')
-          .then(f => {
-              add_completion_callback(_ => f.remove());
-              return f;
-            });
-        })
-      .then(f => {
-          const child_controller
-              = f.contentWindow.navigator.serviceWorker.controller;
-          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
-                        'iframe srcdoc should inherit parent\'s SW.');
-        });
-  }, 'Service worker inheritance for iframe srcdoc.');
-
-promise_test(t => {
-    return active_workers.then(_ => {
-        return with_sandboxed_iframe('', '')
-          .then(f => {
-              add_completion_callback(_ => f.remove());
-              return f;
-            });
-        })
-      .then(f => {
-          assert_throws('SecurityError', _ => f.contentWindow.navigator,
-                        'Accessing sandboxed iframe should throw.');
-        })
-      .then(_ => {
-          return with_sandboxed_iframe('', 'allow-same-origin')
-            .then(f => {
-                add_completion_callback(_ => f.remove());
-                return f;
-              });
-        })
-      .then(f => {
-          const child_controller
-              = f.contentWindow.navigator.serviceWorker.controller;
-          assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
-                        'Sandboxed iframe with allow-same-origin should ' +
-                        'inherit parent\'s SW.');
-        });
+        return with_iframe('', {sandbox: '', auto_remove: true});
+      })
+    .then(f => {
+        assert_throws('SecurityError', _ => f.contentWindow.navigator,
+                      'Accessing sandboxed iframe should throw.');
+        return with_iframe('', {sandbox: 'allow-same-origin',
+                                auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                      'Sandboxed iframe with allow-same-origin should ' +
+                      'inherit parent\'s SW.');
+      });
   }, 'Service worker inheritance for sandboxed iframe.');
 
 promise_test(t => {
     return active_workers.then(_ => {
-        return with_iframe('resources/blank.html')
-          .then(f => {
-              add_completion_callback(_ => f.remove());
-              return f;
-            });
-        })
-      .then(f => {
-          const child_controller
-              = f.contentWindow.navigator.serviceWorker.controller;
-          assert_not_equals(child_controller.scriptURL,
-                            parent_controller.scriptURL,
-                            'Navigating iframe through http fetch should ' +
-                            'replace the inherited SW with the matched SW.');
-        })
-      .then(_ => {
-          return with_iframe('resources/other.html')
-            .then(f => {
-                add_completion_callback(_ => f.remove());
-                return f;
-              });
-        })
-      .then(f => {
-          const child_controller
-              = f.contentWindow.navigator.serviceWorker.controller;
-          assert_equals(child_controller, null,
-                        'Navigating iframe through http fetch that has no ' +
-                        'matched SW should set the controller to null.');
-        });
+        return with_iframe('', {srcdoc: '<p>Some HTML</p>', auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                      'iframe srcdoc should inherit parent\'s SW.');
+        return with_iframe('', {srcdoc: '<p>Some HTML</p>',
+                                sandbox: '',
+                                auto_remove: true});
+      })
+    .then(f => {
+        assert_throws('SecurityError', _ => f.contentWindow.navigator,
+                      'Accessing sandboxed iframe srcdoc should throw.');
+        return with_iframe('', {srcdoc: '<p>Some HTML</p>',
+                                sandbox: 'allow-same-origin',
+                                auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
+                      'Sandboxed iframe srcdoc with allow-same-origin should ' +
+                      'inherit parent\'s SW.');
+      });
+  }, 'Service worker inheritance for iframe srcdoc.');
+
+promise_test(t => {
+    return active_workers.then(_ => {
+        return with_iframe('resources/blank.html', {auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_not_equals(child_controller.scriptURL,
+                          parent_controller.scriptURL,
+                          'Navigating iframe through http fetch should ' +
+                          'replace the inherited SW with the matched SW.');
+        return with_iframe('resources/other.html', {auto_remove: true});
+      })
+    .then(f => {
+        const child_controller
+            = f.contentWindow.navigator.serviceWorker.controller;
+        assert_equals(child_controller, null,
+                      'Navigating iframe through http fetch that has no ' +
+                      'matched SW should set the controller to null.');
+      });
   }, 'Service worker inheritance for navigate match.');
 
 </script>

--- a/service-workers/service-worker/iframe-controller.https.html
+++ b/service-workers/service-worker/iframe-controller.https.html
@@ -5,91 +5,121 @@
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 
-promise_test(function(t) {
-    var script = 'iframe-controller-worker.https.js';
-    var scope1 = 'iframe-controller.https.html';
-    var scope2 = 'resources/blank.html';
-    var script1 = script + '?for_scope1';
-    var script2 = script + '?for_scope2';
-    var registration1, registration2;
-    var parent_controller, child_controller;
-    return service_worker_unregister_and_register(t, script1, scope1)
-      .then(function(r) {
-          registration1 = r;
-          return wait_for_state(t, registration1.installing, 'activated');
+let active_workers;
+let parent_controller;
+
+promise_test(t => {
+    const script = 'iframe-controller-worker.https.js';
+    const scope1 = 'iframe-controller.https.html';
+    const scope2 = 'resources/blank.html';
+    const script1 = script + '?for_scope1';
+    const script2 = script + '?for_scope2';
+
+    active_workers = service_worker_unregister_and_register(t, script1, scope1)
+      .then(r => {
+          add_completion_callback(_ => r.unregister());
+          return wait_for_state(t, r.installing, 'activated');
         })
-      .then(function() {
+      .then(_ => {
           return service_worker_unregister_and_register(t, script2, scope2);
         })
-      .then(function(r) {
-          registration2 = r;
-          return wait_for_state(t, registration2.installing, 'activated');
+      .then(r => {
+          add_completion_callback(_ => r.unregister());
+          return wait_for_state(t, r.installing, 'activated');
+        });
+
+    return active_workers.then(_ => {
+        // This client's active service worker is set to scope1's registration's
+        // active worker by clients.claim() during the activation.
+        parent_controller = navigator.serviceWorker.controller;
+        return with_iframe('')
+          .then(f => {
+              add_completion_callback(_ => f.remove());
+              return f;
+            });
         })
-      .then(function() {
-          // This client's active service worker is set to registration1's
-          // active worker by clients.claim() during the activation.
-          parent_controller = navigator.serviceWorker.controller;
-          return with_iframe('');
-        })
-      .then(function(f) {
-          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+      .then(f => {
+          const child_controller
+              = f.contentWindow.navigator.serviceWorker.controller;
           assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                         'about:blank Document should inherit parent\'s SW.');
+        });
+  }, 'Service worker inheritance for about:blank Document.');
+
+promise_test(t => {
+    return active_workers.then(_ => {
+        return with_srcdoc_iframe('<p>Some HTML</p>')
+          .then(f => {
+              add_completion_callback(_ => f.remove());
+              return f;
+            });
         })
-      .then(function() {
-          return with_srcdoc_iframe('<p>Some HTML</p>');
-        })
-      .then(function(f) {
-          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+      .then(f => {
+          const child_controller
+              = f.contentWindow.navigator.serviceWorker.controller;
           assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                         'iframe srcdoc should inherit parent\'s SW.');
-          f.remove();
+        });
+  }, 'Service worker inheritance for iframe srcdoc.');
+
+promise_test(t => {
+    return active_workers.then(_ => {
+        return with_sandboxed_iframe('', '')
+          .then(f => {
+              add_completion_callback(_ => f.remove());
+              return f;
+            });
         })
-      .then(function() {
-          return with_sandboxed_iframe('', '');
-        })
-      .then(function(f) {
-          assert_throws('SecurityError',
-                        function() { f.contentWindow.navigator; },
+      .then(f => {
+          assert_throws('SecurityError', _ => f.contentWindow.navigator,
                         'Accessing sandboxed iframe should throw.');
-          f.remove();
         })
-      .then(function() {
-          return with_sandboxed_iframe('', 'allow-same-origin');
+      .then(_ => {
+          return with_sandboxed_iframe('', 'allow-same-origin')
+            .then(f => {
+                add_completion_callback(_ => f.remove());
+                return f;
+              });
         })
-      .then(function(f) {
-          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+      .then(f => {
+          const child_controller
+              = f.contentWindow.navigator.serviceWorker.controller;
           assert_equals(child_controller.scriptURL, parent_controller.scriptURL,
                         'Sandboxed iframe with allow-same-origin should ' +
                         'inherit parent\'s SW.');
-          f.remove();
+        });
+  }, 'Service worker inheritance for sandboxed iframe.');
+
+promise_test(t => {
+    return active_workers.then(_ => {
+        return with_iframe('resources/blank.html')
+          .then(f => {
+              add_completion_callback(_ => f.remove());
+              return f;
+            });
         })
-      .then(function() {
-          return with_iframe('resources/blank.html');
-        })
-      .then(function(f) {
-          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+      .then(f => {
+          const child_controller
+              = f.contentWindow.navigator.serviceWorker.controller;
           assert_not_equals(child_controller.scriptURL,
                             parent_controller.scriptURL,
                             'Navigating iframe through http fetch should ' +
                             'replace the inherited SW with the matched SW.');
         })
-      .then(function() {
-          return with_iframe('resources/other.html');
+      .then(_ => {
+          return with_iframe('resources/other.html')
+            .then(f => {
+                add_completion_callback(_ => f.remove());
+                return f;
+              });
         })
-      .then(function(f) {
-          child_controller = f.contentWindow.navigator.serviceWorker.controller;
+      .then(f => {
+          const child_controller
+              = f.contentWindow.navigator.serviceWorker.controller;
           assert_equals(child_controller, null,
                         'Navigating iframe through http fetch that has no ' +
                         'matched SW should set the controller to null.');
-        })
-      .then(function() {
-          return service_worker_unregister(t, scope1);
-        })
-      .then(function() {
-          service_worker_unregister_and_done(t, scope2);
-        })
-      .catch(unreached_rejection(t));
-  }, 'SW inheritance for iframe and overriding behavior by navigate match.');
+        });
+  }, 'Service worker inheritance for navigate match.');
 
 </script>

--- a/service-workers/service-worker/resources/test-helpers.sub.js
+++ b/service-workers/service-worker/resources/test-helpers.sub.js
@@ -47,34 +47,31 @@ function unreached_rejection(test, prefix) {
 }
 
 // Adds an iframe to the document and returns a promise that resolves to the
-// iframe when it finishes loading. The caller is responsible for removing the
-// iframe later if needed.
-function with_iframe(url) {
+// iframe when it finishes loading. The caller can provide options as:
+// - options.sandbox sets the iframe's sandbox attribute to the given value.
+// - options.srcdoc sets the iframe's srcdoc attribute to the given value.
+// - options.auto_remove set to true removes the iframe when test is done
+//   (otherwise, the caller is responsible for removing it, if necessary.)
+function with_iframe(url, options) {
+  if (typeof options === 'undefined')
+    options = {};
+
   return new Promise(function(resolve) {
       var frame = document.createElement('iframe');
       frame.className = 'test-iframe';
       frame.src = url;
+      if (options.sandbox !== undefined)
+        frame.sandbox = options.sandbox;
+      if (options.srcdoc !== undefined)
+        frame.srcdoc = options.srcdoc;
+      // Make sure the iframe stays in the viewport even if the test creates
+      // many of them. Otherwise some iframes may end up being throttled.
+      frame.style.position = 'absolute';
       frame.onload = function() { resolve(frame); };
       document.body.appendChild(frame);
-    });
-}
 
-function with_sandboxed_iframe(url, sandbox) {
-  return new Promise(function(resolve) {
-      var frame = document.createElement('iframe');
-      frame.sandbox = sandbox;
-      frame.src = url;
-      frame.onload = function() { resolve(frame); };
-      document.body.appendChild(frame);
-    });
-}
-
-function with_srcdoc_iframe(srcdoc) {
-  return new Promise(function(resolve) {
-      var frame = document.createElement('iframe');
-      frame.srcdoc = srcdoc;
-      frame.onload = function() { resolve(frame); };
-      document.body.appendChild(frame);
+      if (options.auto_remove)
+        add_completion_callback(function() { frame.remove(); });
     });
 }
 

--- a/service-workers/service-worker/resources/test-helpers.sub.js
+++ b/service-workers/service-worker/resources/test-helpers.sub.js
@@ -59,6 +59,25 @@ function with_iframe(url) {
     });
 }
 
+function with_sandboxed_iframe(url, sandbox) {
+  return new Promise(function(resolve) {
+      var frame = document.createElement('iframe');
+      frame.sandbox = sandbox;
+      frame.src = url;
+      frame.onload = function() { resolve(frame); };
+      document.body.appendChild(frame);
+    });
+}
+
+function with_srcdoc_iframe(srcdoc) {
+  return new Promise(function(resolve) {
+      var frame = document.createElement('iframe');
+      frame.srcdoc = srcdoc;
+      frame.onload = function() { resolve(frame); };
+      document.body.appendChild(frame);
+    });
+}
+
 function normalizeURL(url) {
   return new URL(url, self.location).toString().replace(/#.*$/, '');
 }


### PR DESCRIPTION
Loading an iframe without involving a navigate fetch inherits its
parent's active service worker, if it has one. By this rule:
 - Initial about:blank Document on iframe inherits its parent's SW
 - iframe srcdoc Document inherits its parent's SW

However, the navigate fetch through http fetch still wins. So, if a
client obtains a matched SW during the navigation, the matched SW
replaces the inherited SW.

An exception:
 - Navigating an iframe to a non-initial about:blank Document inherits
   the parent's SW

Related work: https://github.com/whatwg/html/pull/2080.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
