### PR TITLE
Add tests for nomodule content attribute on script elements

### DIFF
--- a/html/semantics/scripting-1/the-script-element/nomodule-reflect.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-reflect.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>noModule IDL attribute must reflect nomodule content attribute</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script id="classicWithoutNomodule"></script>
+<script id="classicWithNomodule" nomodule></script>
+<script id="moduleWithoutNomodule" type=module></script>
+<script id="moduleWithNomodule" type=module nomodule></script>
+<script>
+
+test(() => {
+    assert_false(document.getElementById('classicWithoutNomodule').noModule);
+}, 'noModule IDL attribute on a parser created classic script element without nomodule content attribute');
+
+test(() => {
+    assert_true(document.getElementById('classicWithNomodule').noModule);
+}, 'noModule IDL attribute on a parser created classic script element with nomodule content attribute');
+
+test(() => {
+    assert_false(document.getElementById('moduleWithoutNomodule').noModule);
+}, 'noModule IDL attribute on a parser created module script element without nomodule content attribute');
+
+test(() => {
+    assert_true(document.getElementById('moduleWithNomodule').noModule);
+}, 'noModule IDL attribute on a parser created module script element with nomodule content attribute');
+
+
+test(() => {
+    const script = document.createElement('script');
+    assert_false(script.noModule);
+}, 'noModule IDL attribute on a dynamically created script element without nomodule content attribute');
+
+test(() => {
+    const script = document.createElement('script');
+    script.setAttribute('nomodule', 'nomodule');
+    assert_true(script.noModule);
+}, 'noModule IDL attribute on a dynamically created script element after nomodule content attribute is set to "nomodule"');
+
+test(() => {
+    const script = document.createElement('script');
+    script.setAttribute('nomodule', '');
+    assert_true(script.noModule);
+}, 'noModule IDL attribute on a dynamically created script element after nomodule content attribute is set to ""');
+
+test(() => {
+    const script = document.createElement('script');
+    script.setAttribute('nomodule', 'nomodule');
+    assert_true(script.noModule);
+    script.removeAttribute('nomodule');
+    assert_false(script.noModule);
+}, 'noModule IDL attribute on a dynamically created script element after nomodule content attribute had been removed');
+
+test(() => {
+    const script = document.createElement('script');
+    assert_false(script.hasAttribute('nomodule'));
+    script.noModule = true;
+    assert_true(script.hasAttribute('nomodule'));
+}, 'noModule IDL attribute must add nomodule content attribute on setting to true');
+
+test(() => {
+    const script = document.createElement('script');
+    script.setAttribute('nomodule', 'nomodule');
+    script.noModule = false;
+    assert_false(script.hasAttribute('nomodule'));
+}, 'noModule IDL attribute must remove nomodule content attribute on setting to false');
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-async-classic-script.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-async-classic-script.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>External classic scripts with nomodule content attribute must not run</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- Load this script synchronously to ensure test cases below can load it in 200ms -->
+<script src="resources/set-script-executed.js"></script>
+</head>
+<body>
+<script>
+
+waitForLoadEvent = new Promise((resolve) => {
+    window.onload = resolve;
+});
+
+waitForAsyncScript = () => {
+    return new Promise((resolve) => {
+        waitForLoadEvent.then(() => setTimeout(resolve, 200));
+    });
+}
+
+let readyForSecondTest;
+promise_test(() => {
+    window.executed = false;
+    let loaded = false;
+    let errored = false;
+
+    let script = document.createElement('script');
+    script.src = './resources/set-script-executed.js';
+    script.onload = () => loaded = true;
+    script.onerror = () => errored = true;
+    script.noModule = false;
+    document.body.appendChild(script);
+
+    return waitForAsyncScript().then(() => {
+        assert_true(executed);
+        assert_true(loaded);
+        assert_false(errored);
+    });
+}, 'An asynchronously loaded classic script with noModule set to false must run');
+
+promise_test(() => {
+    window.executed = false;
+    let loaded = false;
+    let errored = false;
+
+    let script = document.createElement('script');
+    script.src = './resources/set-script-executed.js';
+    script.onload = () => loaded = true;
+    script.onerror = () => errored = true;
+    script.noModule = true;
+    document.body.appendChild(script);
+
+    return waitForAsyncScript().then(() => {
+        assert_false(executed);
+        assert_false(loaded);
+        assert_false(errored);
+    });
+}, 'An asynchronously loaded classic script with noModule set to true must not run');
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-external-module-script.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-external-module-script.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>An external module script with nomodule must run</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script nomodule type="module" src="./resources/exports-cocoa.js"></script>
+<script>
+
+waitForLoadEvent = new Promise((resolve) => {
+    window.onload = resolve;
+});
+
+promise_test(() => {
+    return waitForLoadEvent.then(() => {
+        assert_equals(typeof cocoa, 'undefined');
+        assert_equals(typeof exportedCocoa, 'object');
+        assert_equals(exportedCocoa.taste(), 'awesome');
+    });
+}, 'An external module script with nomodule content attribute must run');
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-inline-classic-scripts.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-inline-classic-scripts.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Inline classic scripts with nomodule content attribute must not run</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+window.executed = true;
+</script>
+<script>
+
+test(() => {
+    assert_true(executed);
+}, 'An inline classic script without nomodule content attribute must run');
+
+
+window.executed = false;
+</script>
+<script nomodule>
+window.executed = true;
+</script>
+<script>
+
+test(() => {
+    assert_false(executed);
+}, 'An inline classic script with nomodule content attribute must not run');
+
+</script>
+<script>
+
+test(() => {
+    window.executed = false;
+    const element = document.createElement("script");
+    element.noModule = false;
+    element.textContent = `window.executed = true`;
+    document.body.appendChild(element);
+    assert_true(window.executed);
+}, 'An inline classic script element dynamically inserted after noModule was set to false must run.');
+
+test(() => {
+    window.executed = false;
+    const element = document.createElement("script");
+    element.noModule = true;
+    element.textContent = `window.executed = true`;
+    document.body.appendChild(element);
+    assert_false(window.executed);
+}, 'An inline classic script element dynamically inserted after noModule was set to true must not run.');
+
+window.executed = false;
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-inline-module-script.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-inline-module-script.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>An inline module script with nomodule must run</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script nomodule type="module">
+import Cocoa from "./resources/cocoa-module.js";
+var cocoa = new Cocoa();
+window.exportedCocoa = cocoa;
+</script>
+<script>
+
+waitForLoadEvent = new Promise((resolve) => {
+    window.onload = resolve;
+});
+
+promise_test(() => {
+    return waitForLoadEvent.then(() => {
+        assert_equals(typeof cocoa, 'undefined');
+        assert_equals(typeof exportedCocoa, 'object');
+        assert_equals(exportedCocoa.taste(), 'awesome');
+    });
+}, 'An inline module script with nomodule content attribute must run');
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-synchronously-loaded-classic-scripts.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-synchronously-loaded-classic-scripts.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>External classic scripts with nomodule content attribute must not run</title>
+<link rel="author" title="Yusuke Suzuki" href="mailto:utatane.tea@gmail.com">
+<link rel="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+window.executed = false;
+window.loaded = false;
+window.errored = false;
+</script>
+<script src="./resources/set-script-executed.js" onload="loaded = true" onerror="errored = false"></script>
+<script>
+
+test(() => {
+    assert_true(executed);
+    assert_true(loaded);
+    assert_false(errored);
+}, 'A synchronously loaded external classic script without nomodule content attribute must run');
+
+window.executed = false;
+window.loaded = false;
+window.errored = false;
+</script>
+<script nomodule src="./resources/set-script-executed.js" onload="loaded = true" onerror="errored = false"></script>
+<script>
+
+test(() => {
+    assert_false(executed);
+    assert_false(loaded);
+    assert_false(errored);
+}, 'A synchronously loaded external classic script with nomodule content attribute must not run');
+
+
+waitForLoadEvent = new Promise((resolve) => {
+    window.onload = resolve;
+});
+
+</script>
+</body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/resources/cocoa-module.js
+++ b/html/semantics/scripting-1/the-script-element/resources/cocoa-module.js
@@ -1,0 +1,5 @@
+export default class Cocoa {
+    taste() {
+        return "awesome";
+    }
+};

--- a/html/semantics/scripting-1/the-script-element/resources/exports-cocoa.js
+++ b/html/semantics/scripting-1/the-script-element/resources/exports-cocoa.js
@@ -1,0 +1,3 @@
+import Cocoa from "./cocoa-module.js";
+var cocoa = new Cocoa();
+window.exportedCocoa = cocoa;

--- a/html/semantics/scripting-1/the-script-element/resources/set-script-executed.js
+++ b/html/semantics/scripting-1/the-script-element/resources/set-script-executed.js
@@ -1,0 +1,1 @@
+window.executed = true;


### PR DESCRIPTION
This feature is being added in https://github.com/whatwg/html/pull/2261

Converted the tests in https://trac.webkit.org/r211078 to use testharness.js,
refined the test for IDL attribute reflecting content attribute, and re-organized tests.