### PR TITLE
Add tests for body property handling in Request constructor

### DIFF
--- a/fetch/api/request/request-disturbed.html
+++ b/fetch/api/request/request-disturbed.html
@@ -16,8 +16,17 @@
       };
 
       var noBodyConsumed = new Request("");
-      noBodyConsumed.blob();
       var bodyConsumed = new Request("", initValuesDict);
+
+      test(() => {
+        assert_equals(noBodyConsumed.body, null, "body's default value is null");
+        assert_false(noBodyConsumed.bodyUsed , "bodyUsed is false when request is not disturbed");
+        assert_not_equals(bodyConsumed.body, null, "non-null body");
+        assert_true(bodyConsumed.body instanceof ReadableStream, "non-null body type");
+        assert_false(noBodyConsumed.bodyUsed, "bodyUsed is false when request is not disturbed");
+      }, "Request's body: initial state");
+
+      noBodyConsumed.blob();
       bodyConsumed.blob();
 
       test(function() {
@@ -39,7 +48,7 @@
         assert_throws(new TypeError(), function() { new Request(bodyConsumed); });
       }, "Check creating a new request from a disturbed request");
 
-      test(function() {
+      promise_test(function() {
         var bodyRequest = new Request("", initValuesDict);
         const originalBody = bodyRequest.body;
         assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");
@@ -48,6 +57,10 @@
         assert_equals(bodyRequest.body, originalBody, "body should not change");
         assert_not_equals(originalBody, undefined, "body should not be undefined");
         assert_not_equals(originalBody, null, "body should not be null");
+        assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
+        return requestFromRequest.text(text => {
+          assert_equals(text, "Request's body");
+        });
       }, "Input request used for creating new request became disturbed");
 
       promise_test(() => {
@@ -59,6 +72,7 @@
         assert_equals(bodyRequest.body, originalBody, "body should not change");
         assert_not_equals(originalBody, undefined, "body should not be undefined");
         assert_not_equals(originalBody, null, "body should not be null");
+        assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
 
         return requestFromRequest.text(text => {
           assert_equals(text, "init body");

--- a/fetch/api/request/request-disturbed.html
+++ b/fetch/api/request/request-disturbed.html
@@ -41,10 +41,29 @@
 
       test(function() {
         var bodyRequest = new Request("", initValuesDict);
+        const originalBody = bodyRequest.body;
         assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");
         var requestFromRequest = new Request(bodyRequest);
         assert_true(bodyRequest.bodyUsed , "bodyUsed is true when request is disturbed");
+        assert_equals(bodyRequest.body, originalBody, "body should not change");
+        assert_not_equals(originalBody, undefined, "body should not be undefined");
+        assert_not_equals(originalBody, null, "body should not be null");
       }, "Input request used for creating new request became disturbed");
+
+      promise_test(() => {
+        const bodyRequest = new Request("", initValuesDict);
+        const originalBody = bodyRequest.body;
+        assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");
+        const requestFromRequest = new Request(bodyRequest, { body : "init body" });
+        assert_true(bodyRequest.bodyUsed , "bodyUsed is true when request is disturbed");
+        assert_equals(bodyRequest.body, originalBody, "body should not change");
+        assert_not_equals(originalBody, undefined, "body should not be undefined");
+        assert_not_equals(originalBody, null, "body should not be null");
+
+        return requestFromRequest.text(text => {
+          assert_equals(text, "init body");
+        });
+      }, "Input request used for creating new request became disturbed even if body is not used");
 
       promise_test(function(test) {
         assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");

--- a/fetch/api/request/request-idl.html
+++ b/fetch/api/request/request-idl.html
@@ -18,6 +18,7 @@
       [NoInterfaceObject,
       Exposed=(Window,Worker)]
       interface Body {
+        readonly attribute ReadableStream? body;
         readonly attribute boolean bodyUsed;
         [NewObject] Promise<ArrayBuffer> arrayBuffer();
         [NewObject] Promise<Blob> blob();
@@ -45,7 +46,6 @@
         readonly attribute RequestCache cache;
         readonly attribute RequestRedirect redirect;
         readonly attribute DOMString integrity;
-        readonly attribute ReadableStream? body;
 
         [NewObject] Request clone();
       };

--- a/fetch/api/request/request-idl.html
+++ b/fetch/api/request/request-idl.html
@@ -45,6 +45,7 @@
         readonly attribute RequestCache cache;
         readonly attribute RequestRedirect redirect;
         readonly attribute DOMString integrity;
+        readonly attribute ReadableStream? body;
 
         [NewObject] Request clone();
       };

--- a/fetch/api/response/response-idl.html
+++ b/fetch/api/response/response-idl.html
@@ -18,6 +18,7 @@
       [NoInterfaceObject,
       Exposed=(Window,Worker)]
       interface Body {
+        readonly attribute ReadableStream? body;
         readonly attribute boolean bodyUsed;
         [NewObject] Promise<ArrayBuffer> arrayBuffer();
         [NewObject] Promise<Blob> blob();
@@ -40,7 +41,6 @@
         readonly attribute boolean ok;
         readonly attribute ByteString statusText;
         [SameObject] readonly attribute Headers headers;
-        readonly attribute ReadableStream? body;
 
         [NewObject] Response clone();
       };


### PR DESCRIPTION
This change is for https://github.com/whatwg/fetch/pull/425 and https://github.com/whatwg/fetch/pull/458.