### PR TITLE
Fix bug in streams/piping/general.js

### DIFF
--- a/streams/piping/general.js
+++ b/streams/piping/general.js
@@ -161,9 +161,9 @@ for (const preventAbort of [true, false]) {
       pull() {
         return Promise.reject(undefined);
       }
-    }, { preventAbort });
+    });
 
-    return rs.pipeTo(new WritableStream()).then(
+    return rs.pipeTo(new WritableStream(), { preventAbort }).then(
         () => assert_unreached('pipeTo promise should be rejected'),
         value => assert_equals(value, undefined, 'rejection value should be undefined'));
 
@@ -177,7 +177,7 @@ for (const preventCancel of [true, false]) {
       pull(controller) {
         controller.enqueue(0);
       }
-    }, { preventCancel });
+    });
 
     const ws = new WritableStream({
       write() {
@@ -185,7 +185,7 @@ for (const preventCancel of [true, false]) {
       }
     });
 
-    return rs.pipeTo(ws).then(
+    return rs.pipeTo(ws, { preventCancel }).then(
          () => assert_unreached('pipeTo promise should be rejected'),
         value => assert_equals(value, undefined, 'rejection value should be undefined'));
 


### PR DESCRIPTION
The test 'an undefined rejection from pull should cause pipeTo() to
reject' was failing to correctly test the case where preventAbort is
true.

The test 'an undefined rejection from write should cause pipeTo() to
reject' was failing to correctly test the case where preventCancel is
true.

Fixed.