### PR TITLE
Node-isSameNode.html: Fix duplicate test name error

### DIFF
--- a/dom/nodes/Node-isSameNode.html
+++ b/dom/nodes/Node-isSameNode.html
@@ -26,7 +26,7 @@ test(function() {
   assert_false(element1.isSameNode(element2), "same properties");
   assert_false(element1.isSameNode(null), "with null other node");
 
-}, "elements should be compared on reference");
+}, "elements should be compared on reference (namespaced element)");
 
 test(function() {
 
@@ -40,7 +40,7 @@ test(function() {
   assert_false(element1.isSameNode(element2), "same properties");
   assert_false(element1.isSameNode(null), "with null other node");
 
-}, "elements should be compared on reference");
+}, "elements should be compared on reference (namespaced attribute)");
 
 test(function() {
 


### PR DESCRIPTION
Rename "elements should be compared on reference" tests to avoid error from test harness:
> Duplicate test name: elements should be compared on reference