### PR TITLE
streams: test 2nd read request with autoAllocateChunkSize

### DIFF
--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -280,6 +280,7 @@ promise_test(() => {
 
   const reader = stream.getReader();
   const readPromise = reader.read();
+  const ignoredReadPromise = reader.read();
 
   assert_equals(pullCount, 0, 'No pull() as start() just finished and is not yet reflected to the state of the stream');
 


### PR DESCRIPTION
This just checks against the erroneous assert removed from the spec in https://github.com/whatwg/streams/pull/651.