### PR TITLE
Revert of Create a change in external/wpt meant to be reverted (patchset #1 id:1 of https://codereview.chromium.org/2651533003/ )


### DIFF
--- a/html/semantics/forms/the-input-element/checkbox.html
+++ b/html/semantics/forms/the-input-element/checkbox.html
@@ -146,7 +146,4 @@
     assert_false(checkbox6.indeterminate);
     checkbox6.click();
   });
-
-  // This is a change meant to be reverted to test the WPT Export
-  // process in Chromium. See https://crbug.com/679951
 </script>


### PR DESCRIPTION
Reason for revert:
This commit was intended to be reverted to test how WPT Export handles reverted changes. See the bug for more context.

Original issue's description:
> Create a change in external/wpt meant to be reverted
>
> This is to test reverted changes in the WPT Export process.
>
> BUG=679951
>
> Review-Url: https://codereview.chromium.org/2651533003
> Cr-Commit-Position: refs/heads/master@{#445651}
> Committed: https://chromium.googlesource.com/chromium/src/+/b156b16a00574a89d85ccb034b30cdfd9cc5676a

TBR=qyearsley@chromium.org
# Skipping CQ checks because original CL landed less than 1 days ago.
NOPRESUBMIT=true
NOTREECHECKS=true
NOTRY=true
BUG=679951

Review-Url: https://codereview.chromium.org/2657613002
Cr-Commit-Position: refs/heads/master@{#445762}

