### PR TITLE
README: Mention proxies when describing the /etc/hosts entries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ following entries are required:
 0.0.0.0     nonexistent-origin.web-platform.test
 ```
 
+If you are behind a proxy, you also need to make sure the domains above are
+excluded from your proxy lookups.
+
 Because web-platform-tests uses git submodules, you must ensure that
 these are up to date. In the root of your checkout, run:
 


### PR DESCRIPTION
People behind proxies need to go through some additional steps for `./serve`
and network lookups to work. The specifics vary depending on how the proxies
are set up, so for now just mention that this needs to be done.