### PR TITLE
Test existence and typeof MediaError.message

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1322,6 +1322,7 @@ interface MediaError {
   const unsigned short MEDIA_ERR_DECODE = 3;
   const unsigned short MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
   readonly attribute unsigned short code;
+  readonly attribute DOMString message;
 };
 
 interface AudioTrackList : EventTarget {

--- a/html/semantics/embedded-content/media-elements/error-codes/error.html
+++ b/html/semantics/embedded-content/media-elements/error-codes/error.html
@@ -28,6 +28,7 @@ function error_test(tagName, src) {
       assert_true(e.error instanceof MediaError);
       assert_equals(e.error.code, 4);
       assert_equals(e.error.code, e.error.MEDIA_ERR_SRC_NOT_SUPPORTED);
+      assert_equals(typeof e.error.message, 'string');
       t.done();
     });
   }, tagName + '.error after setting src to the empty string');

--- a/html/semantics/embedded-content/media-elements/error-codes/error.html
+++ b/html/semantics/embedded-content/media-elements/error-codes/error.html
@@ -28,7 +28,7 @@ function error_test(tagName, src) {
       assert_true(e.error instanceof MediaError);
       assert_equals(e.error.code, 4);
       assert_equals(e.error.code, e.error.MEDIA_ERR_SRC_NOT_SUPPORTED);
-      assert_equals(typeof e.error.message, 'string');
+      assert_equals(typeof e.error.message, 'string', 'error.message type');
       t.done();
     });
   }, tagName + '.error after setting src to the empty string');


### PR DESCRIPTION
These may currently pass only on Mozilla nightly/aurora builds. Chrome support for MediaError.message is in-progress. @domenic @foolip @jyavenard  Please review.

@jdsmith3000, @travisleithead  FYI

See related WHATWG spec change https://github.com/whatwg/html/issues/2085 and communication to W3C at https://lists.w3.org/Archives/Public/www-archive/2016Nov/0004.html.