### PR TITLE
IndexedDB: Add tests for HTML monkey patches

### DIFF
--- a/IndexedDB/event-dispatch-active-flag.html
+++ b/IndexedDB/event-dispatch-active-flag.html
@@ -1,25 +1,12 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>Transaction active flag is set during event dispatch</title>
+<link rel="help" href="https://w3c.github.io/IndexedDB/#fire-success-event">
+<link rel="help" href="https://w3c.github.io/IndexedDB/#fire-error-event">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=support.js></script>
 <script>
-
-// Keep the passed transaction alive indefinitely (by making
-// requests against the named store). Returns a function to
-// to let the transaction finish.
-function keep_alive(tx, store_name) {
-  let pin = true;
-  function spin() {
-    if (!pin)
-      return;
-    tx.objectStore(store_name).get(0).onsuccess = spin;
-  }
-  spin();
-
-  return () => { pin = false; }
-}
 
 indexeddb_test(
   (t, db, tx) => {

--- a/IndexedDB/event-dispatch-active-flag.html
+++ b/IndexedDB/event-dispatch-active-flag.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Transaction active flag is set during event dispatch</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+// Keep the passed transaction alive indefinitely (by making
+// requests against the named store). Returns a function to
+// to let the transaction finish.
+function keep_alive(tx, store_name) {
+  let pin = true;
+  function spin() {
+    if (!pin)
+      return;
+    tx.objectStore(store_name).get(0).onsuccess = spin;
+  }
+  spin();
+
+  return () => { pin = false; }
+}
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    const request = tx.objectStore('store').get(0);
+    request.onerror = t.unreached_func('request should succeed');
+    request.onsuccess = () => {
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active during success handler');
+
+      let saw_handler_promise = false;
+      Promise.resolve().then(t.step_func(() => {
+        saw_handler_promise = true;
+        assert_true(is_transaction_active(tx, 'store'),
+                    'Transaction should be active in handlers microtasks');
+      }));
+
+      setTimeout(t.step_func(() => {
+        assert_true(saw_handler_promise);
+        assert_false(is_transaction_active(tx, 'store'),
+                     'Transaction should be inactive in next task');
+        finish();
+        t.done();
+      }), 0);
+    };
+  },
+  'Transactions are active during success handlers');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    const request = tx.objectStore('store').get(0);
+    request.onerror = t.unreached_func('request should succeed');
+    request.addEventListener('success', () => {
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active during success listener');
+
+      let saw_listener_promise = false;
+      Promise.resolve().then(t.step_func(() => {
+        saw_listener_promise = true;
+        assert_true(is_transaction_active(tx, 'store'),
+                    'Transaction should be active in listeners microtasks');
+      }));
+
+      setTimeout(t.step_func(() => {
+        assert_true(saw_listener_promise);
+        assert_false(is_transaction_active(tx, 'store'),
+                     'Transaction should be inactive in next task');
+        finish();
+        t.done();
+      }), 0);
+    });
+  },
+  'Transactions are active during success listeners');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    tx.objectStore('store').put(0, 0);
+    const request = tx.objectStore('store').add(0, 0);
+    request.onsuccess = t.unreached_func('request should fail');
+    request.onerror = e => {
+      e.preventDefault();
+
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active during error handler');
+
+      let saw_handler_promise = false;
+      Promise.resolve().then(t.step_func(() => {
+        saw_handler_promise = true;
+        assert_true(is_transaction_active(tx, 'store'),
+                    'Transaction should be active in handlers microtasks');
+      }));
+
+      setTimeout(t.step_func(() => {
+        assert_true(saw_handler_promise);
+        assert_false(is_transaction_active(tx, 'store'),
+                     'Transaction should be inactive in next task');
+        finish();
+        t.done();
+      }), 0);
+    };
+  },
+  'Transactions are active during error handlers');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    tx.objectStore('store').put(0, 0);
+    const request = tx.objectStore('store').add(0, 0);
+    request.onsuccess = t.unreached_func('request should fail');
+    request.addEventListener('error', e => {
+      e.preventDefault();
+
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active during error listener');
+
+      let saw_listener_promise = false;
+      Promise.resolve().then(t.step_func(() => {
+        saw_listener_promise = true;
+        assert_true(is_transaction_active(tx, 'store'),
+                    'Transaction should be active in listeners microtasks');
+      }));
+
+      setTimeout(t.step_func(() => {
+        assert_true(saw_listener_promise);
+        assert_false(is_transaction_active(tx, 'store'),
+                     'Transaction should be inactive in next task');
+        finish();
+        t.done();
+      }), 0);
+    });
+  },
+  'Transactions are active during error listeners');
+
+</script>

--- a/IndexedDB/event-dispatch-active-flag.html
+++ b/IndexedDB/event-dispatch-active-flag.html
@@ -14,8 +14,6 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    let tx_completed = false;
-    tx.oncomplete = () => { tx_completed = true; };
     const release_tx = keep_alive(tx, 'store');
 
     assert_true(is_transaction_active(tx, 'store'),
@@ -38,7 +36,6 @@ indexeddb_test(
         assert_true(saw_handler_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        assert_false(tx_completed);
         release_tx();
         t.done();
       }), 0);
@@ -52,8 +49,6 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    let tx_completed = false;
-    tx.oncomplete = () => { tx_completed = true; };
     const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
@@ -75,7 +70,6 @@ indexeddb_test(
         assert_true(saw_listener_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        assert_false(tx_completed);
         release_tx();
         t.done();
       }), 0);
@@ -89,8 +83,6 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
-    let tx_completed = false;
-    tx.oncomplete = () => { tx_completed = true; };
     const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
@@ -115,7 +107,6 @@ indexeddb_test(
         assert_true(saw_handler_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        assert_false(tx_completed);
         release_tx();
         t.done();
       }), 0);
@@ -129,8 +120,6 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
-    let tx_completed = false;
-    tx.oncomplete = () => { tx_completed = true; };
     const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
@@ -155,7 +144,6 @@ indexeddb_test(
         assert_true(saw_listener_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        assert_false(tx_completed);
         release_tx();
         t.done();
       }), 0);

--- a/IndexedDB/event-dispatch-active-flag.html
+++ b/IndexedDB/event-dispatch-active-flag.html
@@ -14,7 +14,10 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    const finish = keep_alive(tx, 'store');
+    let tx_completed = false;
+    tx.oncomplete = () => { tx_completed = true; };
+    const release_tx = keep_alive(tx, 'store');
+
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
@@ -28,14 +31,15 @@ indexeddb_test(
       Promise.resolve().then(t.step_func(() => {
         saw_handler_promise = true;
         assert_true(is_transaction_active(tx, 'store'),
-                    'Transaction should be active in handlers microtasks');
+                    'Transaction should be active in handler\'s microtasks');
       }));
 
       setTimeout(t.step_func(() => {
         assert_true(saw_handler_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        finish();
+        assert_false(tx_completed);
+        release_tx();
         t.done();
       }), 0);
     };
@@ -48,7 +52,9 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    const finish = keep_alive(tx, 'store');
+    let tx_completed = false;
+    tx.oncomplete = () => { tx_completed = true; };
+    const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
@@ -62,14 +68,15 @@ indexeddb_test(
       Promise.resolve().then(t.step_func(() => {
         saw_listener_promise = true;
         assert_true(is_transaction_active(tx, 'store'),
-                    'Transaction should be active in listeners microtasks');
+                    'Transaction should be active in listener\'s microtasks');
       }));
 
       setTimeout(t.step_func(() => {
         assert_true(saw_listener_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        finish();
+        assert_false(tx_completed);
+        release_tx();
         t.done();
       }), 0);
     });
@@ -82,7 +89,9 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
-    const finish = keep_alive(tx, 'store');
+    let tx_completed = false;
+    tx.oncomplete = () => { tx_completed = true; };
+    const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
@@ -99,14 +108,15 @@ indexeddb_test(
       Promise.resolve().then(t.step_func(() => {
         saw_handler_promise = true;
         assert_true(is_transaction_active(tx, 'store'),
-                    'Transaction should be active in handlers microtasks');
+                    'Transaction should be active in handler\'s microtasks');
       }));
 
       setTimeout(t.step_func(() => {
         assert_true(saw_handler_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        finish();
+        assert_false(tx_completed);
+        release_tx();
         t.done();
       }), 0);
     };
@@ -119,7 +129,9 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
-    const finish = keep_alive(tx, 'store');
+    let tx_completed = false;
+    tx.oncomplete = () => { tx_completed = true; };
+    const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
@@ -136,14 +148,15 @@ indexeddb_test(
       Promise.resolve().then(t.step_func(() => {
         saw_listener_promise = true;
         assert_true(is_transaction_active(tx, 'store'),
-                    'Transaction should be active in listeners microtasks');
+                    'Transaction should be active in listener\'s microtasks');
       }));
 
       setTimeout(t.step_func(() => {
         assert_true(saw_listener_promise);
         assert_false(is_transaction_active(tx, 'store'),
                      'Transaction should be inactive in next task');
-        finish();
+        assert_false(tx_completed);
+        release_tx();
         t.done();
       }), 0);
     });

--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -166,11 +166,16 @@ function is_transaction_active(tx, store_name) {
   }
 }
 
-// Keep the passed transaction alive indefinitely (by making
-// requests against the named store). Returns a function to
-// to let the transaction finish.
+// Keep the passed transaction alive indefinitely (by making requests
+// against the named store). Returns a function to to let the
+// transaction finish, and asserts that the transaction is not yet
+// finished.
 function keep_alive(tx, store_name) {
+  let completed = false;
+  tx.addEventListener('complete', () => { completed = true; });
+
   let pin = true;
+
   function spin() {
     if (!pin)
       return;
@@ -178,5 +183,8 @@ function keep_alive(tx, store_name) {
   }
   spin();
 
-  return () => { pin = false; };
+  return () => {
+    assert_false(completed, 'Transaction completed while kept alive');
+    pin = false;
+  };
 }

--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -165,3 +165,18 @@ function is_transaction_active(tx, store_name) {
     return false;
   }
 }
+
+// Keep the passed transaction alive indefinitely (by making
+// requests against the named store). Returns a function to
+// to let the transaction finish.
+function keep_alive(tx, store_name) {
+  let pin = true;
+  function spin() {
+    if (!pin)
+      return;
+    tx.objectStore(store_name).get(0).onsuccess = spin;
+  }
+  spin();
+
+  return () => { pin = false; };
+}

--- a/IndexedDB/transaction-deactivation-timing.html
+++ b/IndexedDB/transaction-deactivation-timing.html
@@ -13,14 +13,14 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    const finish = keep_alive(tx, 'store');
+    const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
     setTimeout(t.step_func(() => {
       assert_false(is_transaction_active(tx, 'store'),
                    'Transaction should be inactive in next task');
-      finish();
+      release_tx();
       t.done();
     }), 0);
   },
@@ -32,14 +32,14 @@ indexeddb_test(
   },
   (t, db) => {
     const tx = db.transaction('store');
-    const finish = keep_alive(tx, 'store');
+    const release_tx = keep_alive(tx, 'store');
     assert_true(is_transaction_active(tx, 'store'),
                 'Transaction should be active after creation');
 
     Promise.resolve().then(t.step_func(() => {
       assert_true(is_transaction_active(tx, 'store'),
                   'Transaction should be active in microtask checkpoint');
-      finish();
+      release_tx();
       t.done();
     }));
   },
@@ -50,11 +50,11 @@ indexeddb_test(
     db.createObjectStore('store');
   },
   (t, db) => {
-    let tx, finish;
+    let tx, release_tx;
 
     Promise.resolve().then(t.step_func(() => {
       tx = db.transaction('store');
-      finish = keep_alive(tx, 'store');
+      release_tx = keep_alive(tx, 'store');
       assert_true(is_transaction_active(tx, 'store'),
                   'Transaction should be active after creation');
     }));
@@ -62,7 +62,7 @@ indexeddb_test(
     setTimeout(t.step_func(() => {
       assert_false(is_transaction_active(tx, 'store'),
                    'Transaction should be inactive in next task');
-      finish();
+      release_tx();
       t.done();
     }), 0);
   },
@@ -73,11 +73,11 @@ indexeddb_test(
     db.createObjectStore('store');
   },
   (t, db) => {
-    let tx, finish;
+    let tx, release_tx;
 
     Promise.resolve().then(t.step_func(() => {
       tx = db.transaction('store');
-      finish = keep_alive(tx, 'store');
+      release_tx = keep_alive(tx, 'store');
       assert_true(is_transaction_active(tx, 'store'),
                   'Transaction should be active after creation');
     }));
@@ -85,7 +85,7 @@ indexeddb_test(
     Promise.resolve().then(t.step_func(() => {
       assert_true(is_transaction_active(tx, 'store'),
                   'Transaction should be active in microtask checkpoint');
-      finish();
+      release_tx();
       t.done();
     }));
   },

--- a/IndexedDB/transaction-deactivation-timing.html
+++ b/IndexedDB/transaction-deactivation-timing.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Transactions deactivation timing</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+// Keep the passed transaction alive indefinitely (by making
+// requests against the named store). Returns a function to
+// to let the transaction finish.
+function keep_alive(tx, store_name) {
+  let pin = true;
+  function spin() {
+    if (!pin)
+      return;
+    tx.objectStore(store_name).get(0).onsuccess = spin;
+  }
+  spin();
+
+  return () => { pin = false; }
+}
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    setTimeout(t.step_func(() => {
+      assert_false(is_transaction_active(tx, 'store'),
+                   'Transaction should be inactive in next task');
+      finish();
+      t.done();
+    }), 0);
+  },
+  'New transactions are deactivated before next task');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const finish = keep_alive(tx, 'store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    Promise.resolve().then(t.step_func(() => {
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active in microtask checkpoint');
+      finish();
+      t.done();
+    }));
+  },
+  'New transactions are not deactivated until after the microtask checkpoint');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    let tx, finish;
+
+    Promise.resolve().then(t.step_func(() => {
+      tx = db.transaction('store');
+      finish = keep_alive(tx, 'store');
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active after creation');
+    }));
+
+    setTimeout(t.step_func(() => {
+      assert_false(is_transaction_active(tx, 'store'),
+                   'Transaction should be inactive in next task');
+      finish();
+      t.done();
+    }), 0);
+  },
+  'New transactions from microtask are deactivated before next task');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    let tx, finish;
+
+    Promise.resolve().then(t.step_func(() => {
+      tx = db.transaction('store');
+      finish = keep_alive(tx, 'store');
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active after creation');
+    }));
+
+    Promise.resolve().then(t.step_func(() => {
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active in microtask checkpoint');
+      finish();
+      t.done();
+    }));
+  },
+  'New transactions from microtask are still active through the ' +
+  'microtask checkpoint');
+
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    // This transaction serves as the source of an event seen by multiple
+    // listeners. A DOM event with multiple listeners could be used instead,
+    // but not via dispatchEvent() because (drumroll...) that happens
+    // synchronously so microtasks don't run between steps.
+    const tx = db.transaction('store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active after creation');
+
+    const request = tx.objectStore('store').get(0);
+    let new_tx;
+    let first_listener_ran = false;
+    let microtasks_ran = false;
+    request.addEventListener('success', t.step_func(() => {
+      first_listener_ran = true;
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active in callback');
+
+      // We check to see if this transaction is active across unrelated event
+      // dispatch steps.
+      new_tx = db.transaction('store');
+      assert_true(is_transaction_active(new_tx, 'store'),
+                  'New transaction should be active after creation');
+
+      Promise.resolve().then(t.step_func(() => {
+        microtasks_ran = true;
+        new_tx = db.transaction('store');
+        assert_true(is_transaction_active(new_tx, 'store'),
+                    'New transaction is still active in microtask checkpoint');
+      }));
+
+    }));
+    request.addEventListener('success', t.step_func(() => {
+      assert_true(first_listener_ran, 'first listener ran first');
+      assert_true(microtasks_ran, 'microtasks ran before second listener');
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active in callback');
+      assert_false(is_transaction_active(new_tx, 'store'),
+                   'New transaction should be inactive in unrelated callback');
+      t.done();
+    }));
+  },
+  'Deactivation of new transactions happens at end of invocation');
+
+</script>

--- a/IndexedDB/transaction-deactivation-timing.html
+++ b/IndexedDB/transaction-deactivation-timing.html
@@ -123,7 +123,6 @@ indexeddb_test(
 
       Promise.resolve().then(t.step_func(() => {
         microtasks_ran = true;
-        new_tx = db.transaction('store');
         assert_true(is_transaction_active(new_tx, 'store'),
                     'New transaction is still active in microtask checkpoint');
       }));

--- a/IndexedDB/transaction-deactivation-timing.html
+++ b/IndexedDB/transaction-deactivation-timing.html
@@ -1,25 +1,11 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>Transactions deactivation timing</title>
+<link rel="help" href="https://w3c.github.io/IndexedDB/#dom-idbdatabase-transaction">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=support.js></script>
 <script>
-
-// Keep the passed transaction alive indefinitely (by making
-// requests against the named store). Returns a function to
-// to let the transaction finish.
-function keep_alive(tx, store_name) {
-  let pin = true;
-  function spin() {
-    if (!pin)
-      return;
-    tx.objectStore(store_name).get(0).onsuccess = spin;
-  }
-  spin();
-
-  return () => { pin = false; }
-}
 
 indexeddb_test(
   (t, db, tx) => {

--- a/IndexedDB/upgrade-transaction-deactivation-timing.html
+++ b/IndexedDB/upgrade-transaction-deactivation-timing.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Upgrade transaction deactivation timing</title>
+<link rel="help" href="http://localhost:4201/#upgrade-transaction-steps">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active in upgradeneeded callback');
+  },
+  (t, db) => { t.done(); },
+  'Upgrade transactions are active in upgradeneeded callback');
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+    assert_true(is_transaction_active(tx, 'store'),
+                'Transaction should be active in upgradeneeded callback');
+
+    Promise.resolve().then(t.step_func(() => {
+      assert_true(is_transaction_active(tx, 'store'),
+                  'Transaction should be active in microtask checkpoint');
+    }));
+  },
+  (t, db) => { t.done(); },
+  'Upgrade transactions are active in upgradeneeded callback and microtasks');
+
+
+indexeddb_test(
+  (t, db, tx) => {
+    db.createObjectStore('store');
+    const release_tx = keep_alive(tx, 'store');
+
+    setTimeout(t.step_func(() => {
+      assert_false(is_transaction_active(tx, 'store'),
+                   'Transaction should be inactive in next task');
+      release_tx();
+    }), 0);
+  },
+  (t, db) => { t.done(); },
+  'Upgrade transactions are deactivated before next task');
+
+</script>


### PR DESCRIPTION
The IDB spec implicitly "monkey patches" HTML with imprecise prose
when describing newly created transactions:

"When control is returned to the event loop, the implementation must
unset the active flag."

The plan is replace that with a proper hook. Adding tests first to ensure the
expected behavior is captured appropriately.

https://github.com/w3c/IndexedDB/issues/87