### PR TITLE
mute commit log in travis build - fixes #4635

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -399,7 +399,6 @@ def get_files_changed():
     git = get_git_cmd(wpt_root)
     branch_point = git("merge-base", "HEAD", "master").strip()
     logger.debug("Branch point from master: %s" % branch_point)
-    logger.debug(git("log", "--oneline", "%s.." % branch_point))
     files = git("diff", "--name-only", "-z", "%s.." % branch_point)
     if not files:
         return []


### PR DESCRIPTION
This removes the list of commits in the build from the check_stability.py script. That list can sometimes be so long as to make the log exceed Travis's UI maximum of 10000 lines as described in https://github.com/w3c/web-platform-tests/issues/4635.