### PR TITLE
Update dom/lists/DOMTokenList-iteration.html so it no longer expects duplicates

### DIFF
--- a/dom/lists/DOMTokenList-iteration.html
+++ b/dom/lists/DOMTokenList-iteration.html
@@ -7,17 +7,17 @@
 <script>
   test(function() {
     var list = document.querySelector("span").classList;
-    assert_array_equals([...list], ["a", "a", "b"]);
+    assert_array_equals([...list], ["a", "b"]);
 
     var keys = list.keys();
     assert_false(keys instanceof Array);
     keys = [...keys];
-    assert_array_equals(keys, [0, 1, 2]);
+    assert_array_equals(keys, [0, 1]);
 
     var values = list.values();
     assert_false(values instanceof Array);
     values = [...values];
-    assert_array_equals(values, ["a", "a", "b"]);
+    assert_array_equals(values, ["a", "b"]);
 
     var entries = list.entries();
     assert_false(entries instanceof Array);


### PR DESCRIPTION
As per the latest DOM specification [1], when a DOMTokenList gets created, we
end up running the "attribute change steps" for element, localName, value, value,
and null. The attribute changed steps for DOMTokenList say "set tokens to value,
parsed." "parsed" links to [2] which says to run the ordered set parser, which
should get rid of duplicates. WebKit, for example, does get rid of duplicates.

[1] https://dom.spec.whatwg.org/#interface-domtokenlist
[2] https://dom.spec.whatwg.org/#concept-ordered-set-parser