### PR TITLE
[DO NOT MERGE] Add a new test in IndexedDB to try to diagnose Travis CI problem

### DIFF
--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -128,3 +128,5 @@ function indexeddb_test(upgrade_func, open_func, description, options) {
     });
   }, description);
 }
+
+// modification to support.js

--- a/IndexedDB/test-new-test.html
+++ b/IndexedDB/test-new-test.html
@@ -6,7 +6,7 @@
 <script src="support.js"></script>
 <script>
 
-async_test(t => {
+test(t => {
 
   t.assert_true(true);
 

--- a/IndexedDB/test-new-test.html
+++ b/IndexedDB/test-new-test.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB test, not meant to be committed</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+async_test(t => {
+
+  t.assert_true(true);
+
+}, 'test a new test in IndexedDB, not meant to be committed');
+
+</script>


### PR DESCRIPTION
The Chrome timeout problem on Travis CI looks like it's happening again on a new commit:
build: https://travis-ci.org/w3c/web-platform-tests/jobs/196800670
PR: https://github.com/w3c/web-platform-tests/pull/4659

One idea I have is that maybe modifications in IndexedDB have something to do with causing the issue, since that seems to be the only thing unique the 2 failing PRs have as opposed to the other ones that have passed recently. Creating this PR to test out that hypothesis.