### PR TITLE
Remove tests for URL.createFor.

### DIFF
--- a/FileAPI/historical.html
+++ b/FileAPI/historical.html
@@ -36,6 +36,10 @@
             assert_false(prefixes[i]+'BlobBuilder' in window, prefixes[i]+'BlobBuilder');
         }
     }, 'BlobBuilder should not be supported.');
+
+    test(function() {
+        assert_false('createFor' in URL);
+    }, 'createFor method should not be supported');
   </script>
  </body>
 </html>

--- a/FileAPI/idlharness-manual.html
+++ b/FileAPI/idlharness-manual.html
@@ -136,7 +136,6 @@ interface FileReaderSync {
 partial interface URL {
 
   static DOMString createObjectURL(Blob blob);
-  static DOMString createFor(Blob blob);
   static void revokeObjectURL(DOMString url);
 
 };

--- a/FileAPI/idlharness.idl
+++ b/FileAPI/idlharness.idl
@@ -89,6 +89,5 @@ interface FileReaderSync {
 [Exposed=(Window,DedicatedWorker,SharedWorker)]
 partial interface URL {
   static DOMString createObjectURL(Blob blob);
-  static DOMString createFor(Blob blob);
   static void revokeObjectURL(DOMString url);
 };

--- a/FileAPI/url/url_createobjecturl_blob.html
+++ b/FileAPI/url/url_createobjecturl_blob.html
@@ -16,11 +16,5 @@
     assert_equals(typeof testBlob, "string", "Blob URI is typeof string");
     assert_equals(testBlob.indexOf("blob"), 0, "Blob URI starts with 'blob'");
   }, "Check if the Blob URI starts with 'blob' using createObjectURL()");
-
-  test(function() {
-    var testBlob = window.URL.createFor(blob);
-    assert_equals(typeof testBlob, "string", "Blob URI is typeof string");
-    assert_equals(testBlob.indexOf("blob"), 0, "Blob URI starts with 'blob'");
-  }, "Check if the Blob URI starts with 'blob' using createFor()");
 </script>
 

--- a/FileAPI/url/url_createobjecturl_file-manual.html
+++ b/FileAPI/url/url_createobjecturl_file-manual.html
@@ -38,12 +38,6 @@
         assert_equals(blobURL.indexOf("blob"), 0, "Blob URL's scheme is blob");
       }, "Check if URL.createObjectURL(File) returns a Blob URL");
 
-      test(function() {
-        blobURL = window.URL.createFor(file);
-        assert_equals(typeof blobURL, "string", "Blob URL is type of string");
-        assert_equals(blobURL.indexOf("blob"), 0, "Blob URL's scheme is blob");
-      }, "Check if URL.createFor(File) returns a Blob URL");
-
       t.done();
     });
   });


### PR DESCRIPTION
https://github.com/w3c/FileAPI/pull/62 will remove the URL.createFor method,
this removes the corresponding tests.