### PR TITLE
Rewrite preload test.

### DIFF
--- a/preload/single_download_late_used_preload.html
+++ b/preload/single_download_late_used_preload.html
@@ -2,14 +2,14 @@
 <title>Ensure preloaded resources are not downloaded again when used</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<link rel=preload href="resources/square.png" as=image>
+<link rel=preload href="resources/square.png?pipe=trickle(d1)" as=image>
 <script>
     var link = document.getElementsByTagName("link")[0]
     assert_equals(link.as, "image");
     link.addEventListener("load", () => {
         assert_equals(performance.getEntriesByType("resource").length, 3)
         var img = document.createElement("img");
-        img.src = "resources/square.png";
+        img.src = "resources/square.png?pipe=trickle(d1)";
         img.onload = () => {
             assert_equals(performance.getEntriesByType("resource").length, 3);
             done();

--- a/preload/single_download_late_used_preload.html
+++ b/preload/single_download_late_used_preload.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
+<title>Ensure preloaded resources are not downloaded again when used</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script>
-    var t = async_test('Makes sure that preloaded resources are not downloaded again when used');
-</script>
-<div id=result></div>
 <link rel=preload href="resources/square.png" as=image>
 <script>
-    window.addEventListener("load", t.step_func(function() {
-        t.step_timeout(function() {
-            document.getElementById("result").innerHTML = "<image src='resources/square.png'>";
-            t.step_timeout(function() {
-                assert_equals(performance.getEntriesByType("resource").length, 3);
-                t.done();
-            }, 1000);
-        }, 1000);
-    }));
+    var link = document.getElementsByTagName("link")[0]
+    assert_equals(link.as, "image");
+    link.addEventListener("load", () => {
+        assert_equals(performance.getEntriesByType("resource").length, 3)
+        var img = document.createElement("img");
+        img.src = "resources/square.png";
+        img.onload = () => {
+            assert_equals(performance.getEntriesByType("resource").length, 3);
+            done();
+        };
+        document.body.appendChild(img);
+    });
 </script>
+<body>


### PR DESCRIPTION
This test was broken as the number of resources loaded was 3 independent of
support for preload. In addition the use of setTimeout managed to make it
untable in gecko. Rewrite the test to depend on the load events rather than
on timers, and to fail early in browsers with no preload support.