### PR TITLE
Truncate data written to logs in C.I. environment

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -10,11 +10,10 @@ import sys
 import tarfile
 import zipfile
 from abc import ABCMeta, abstractmethod
-from cStringIO import StringIO
+from cStringIO import StringIO as CStringIO
 from collections import defaultdict
 from ConfigParser import RawConfigParser
-from io import BytesIO
-from tools.manifest import manifest
+from io import BytesIO, StringIO
 
 import requests
 
@@ -24,14 +23,14 @@ LogHandler = None
 LogLevelFilter = None
 StreamHandler = None
 TbplFormatter = None
+manifest = None
 reader = None
 wptcommandline = None
 wptrunner = None
 wpt_root = None
 wptrunner_root = None
 
-logger = logging.getLogger(os.path.splitext(__file__)[0])
-
+logger = None
 
 def do_delayed_imports():
     """Import and set up modules only needed if execution gets to this point."""
@@ -39,12 +38,14 @@ def do_delayed_imports():
     global LogLevelFilter
     global StreamHandler
     global TbplFormatter
+    global manifest
     global reader
     global wptcommandline
     global wptrunner
     from mozlog import reader
     from mozlog.formatters import TbplFormatter
     from mozlog.handlers import BaseHandler, LogLevelFilter, StreamHandler
+    from tools.manifest import manifest
     from wptrunner import wptcommandline, wptrunner
     setup_log_handler()
     setup_action_filter()
@@ -57,8 +58,6 @@ def setup_logging():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
-
-setup_logging()
 
 
 def setup_action_filter():
@@ -105,6 +104,50 @@ class TravisFold(object):
     def __exit__(self, type, value, traceback):
         """Emit fold end syntax."""
         print("travis_fold:end:%s" % self.name, file=sys.stderr)
+
+
+class FilteredIO(object):
+    """Wrap a file object, invoking the provided callback for every call to
+    `write` and only proceeding with the operation when that callback returns
+    True."""
+    def __init__(self, original, on_write):
+        self.original = original
+        self.on_write = on_write
+
+    def __getattr__(self, name):
+        return getattr(self.original, name)
+
+    def disable(self):
+        self.write = lambda msg: None
+
+    def write(self, msg):
+        encoded = msg.encode("utf8", "backslashreplace").decode("utf8")
+        if self.on_write(self.original, encoded) is True:
+            self.original.write(encoded)
+
+
+def replace_streams(capacity, warning_msg):
+    # Value must be boxed to support modification from inner function scope
+    count = [0]
+    capacity -= 2 + len(warning_msg)
+    stderr = sys.stderr
+
+    def on_write(handle, msg):
+        length = len(msg)
+        count[0] += length
+
+        if count[0] > capacity:
+            sys.stdout.disable()
+            sys.stderr.disable()
+            handle.write(msg[0:capacity - count[0]])
+            handle.flush()
+            stderr.write("\n%s\n" % warning_msg)
+            return False
+
+        return True
+
+    sys.stdout = FilteredIO(sys.stdout, on_write)
+    sys.stderr = FilteredIO(sys.stderr, on_write)
 
 
 class Browser(object):
@@ -275,7 +318,7 @@ def seekable(fileobj):
     try:
         fileobj.seek(fileobj.tell())
     except Exception:
-        return StringIO(fileobj.read())
+        return CStringIO(fileobj.read())
     else:
         return fileobj
 
@@ -522,7 +565,6 @@ def table(headings, data, log):
         log("|%s|" % "|".join(" %s" % row[i].ljust(max_widths[i] - 1) for i in cols))
     log("")
 
-
 def write_inconsistent(inconsistent, iterations):
     """Output inconsistent tests to logger.error."""
     logger.error("## Unstable results ##\n")
@@ -582,6 +624,10 @@ def get_parser():
                         # This is a workaround to get what should be the same value
                         default=os.environ.get("TRAVIS_REPO_SLUG").split('/')[0],
                         help="Travis user name")
+    parser.add_argument("--output-bytes",
+                        action="store",
+                        type=int,
+                        help="Maximum number of bytes to write to standard output/error")
     parser.add_argument("product",
                         action="store",
                         help="Product to run against (`browser-name` or 'browser-name:channel')")
@@ -592,10 +638,18 @@ def main():
     """Perform check_stability functionality and return exit code."""
     global wpt_root
     global wptrunner_root
+    global logger
 
     retcode = 0
     parser = get_parser()
     args = parser.parse_args()
+
+    if args.output_bytes is not None:
+        replace_streams(args.output_bytes,
+                        "Log reached capacity (%s bytes); output disabled." % args.output_bytes)
+
+    logger = logging.getLogger(os.path.splitext(__file__)[0])
+    setup_logging()
 
     wpt_root = os.path.abspath(os.curdir)
     wptrunner_root = os.path.normpath(os.path.join(wpt_root, "..", "wptrunner"))

--- a/ci_stability.sh
+++ b/ci_stability.sh
@@ -44,7 +44,7 @@ install_chrome() {
 }
 
 test_stability() {
-    python check_stability.py $PRODUCT
+    python check_stability.py $PRODUCT --output-bytes $((1024 * 1024 * 3))
 }
 
 main() {


### PR DESCRIPTION
My choice of maximum row count is completely arbitrary. I'm happy to change it to any other value based on the experience of my reviewers. For context:

- the log generated for the patch that identified this issue (gh-4549) triggered tests for 15 "noisy" files and produced a log that exceeded Travis CI's 4 megabyte limit.
- the log generated for this pull request (which modifies the same 15 files) is 1.1 megabytes in size.

Please note that this solution (limiting overall log size by truncating per-file tables) does *not* scale for patches that effect a large number of tests that contain many subtests. In those cases, the overall log size may grow beyond TravisCI's 4MB limit despite the truncation of each individual test's table. Supporting this case gracefully would significantly increase the script's complexity (e.g.  log buffering techniques, row allocation heuristics, etc.). This is likely not warranted given the fact that such patches are equally onerous for reviewers to validate and are likely discouraged as a matter of policy.

Further truncate the log posted to GitHub.com. This is a hard clamp at GitHub's maximum length, minus the text necessary to notify the reader that the truncation occurred. This operation may invalidate part of the output (e.g. Markdown tables of open HTML tags), but again, I think we should prefer simplicity to completeness in guarding against this particular edge case. A link to the Travis "build job" page (containing a "less-abbreviated" version of the output) is included where available.

If all that seems reasonable, then this should resolve gh-4550.