### PR TITLE
Fix hr-time IDL test - Missing EventTarget definition

### DIFF
--- a/hr-time/idlharness.html
+++ b/hr-time/idlharness.html
@@ -15,7 +15,6 @@
 <div id="log"></div>
 
 <pre id='untested_idl' style='display:none'>
-
 interface Window {
 };
 
@@ -23,6 +22,9 @@ interface Window {
 interface WorkerGlobalScope {
 };
 
+[Exposed=(Window,Worker)]
+interface EventTarget {
+};
 </pre>
 
 <pre id='idl'>


### PR DESCRIPTION
Tests are unexpectedly failing because EventTarget interface parent of the
Performance interface is not defined. Add it.

--

This is a progression in Safari, Firefox, and Chrome.