### PR TITLE
Add a missing PerformanceTiming readonly attribute name

### DIFF
--- a/user-timing/resources/webperftestharness.js
+++ b/user-timing/resources/webperftestharness.js
@@ -32,6 +32,7 @@ var timingAttributes = [
     'requestStart',
     'responseEnd',
     'responseStart',
+    'secureConnectionStart',
     'unloadEventEnd',
     'unloadEventStart'
 ];


### PR DESCRIPTION
Any PerformanceTiming interface readonly attribute name should cause a SyntaxError when used by performance.mark in Window. Although this attribute is specially optional, it is a readonly attribute in the interface, so it should be tested.

---

[Spec](https://w3c.github.io/user-timing/#dom-performance-mark) for `performance.mark`:

> 1. If the global object is a Window object and markName uses the same name as a read only attribute in the PerformanceTiming interface [NAVIGATION-TIMING-2], throw a SyntaxError.

[Spec](https://w3c.github.io/navigation-timing/#the-performancetiming-interface) for `PerformanceTiming`:

>     interface PerformanceTiming {
>         ...
>         readonly attribute unsigned long long secureConnectionStart;
>     }

[Spec](https://w3c.github.io/navigation-timing/#dom-performancetiming-secureconnectionstart) for `secureConnectionStart`:

> **secureConnectionStart**
> This attribute is optional. User agents that don't have this attribute available must set it as undefined. [...]

---

Firefox does not appear to support `secureConnectionStart` yet. So adding this attributes causes Firefox to fail a few tests.

An alternative solution would be to only add "secureConnectionStart" to this list if it is supported by the browser, but I'm not sure that matters given the spec text above. Any read only attribute should throw a SyntaxError. I don't think supported or not matters.