### PR TITLE
[hr-time] Fix IDL to get correct testing of Global property

### DIFF
--- a/hr-time/idlharness.html
+++ b/hr-time/idlharness.html
@@ -15,6 +15,7 @@
 <div id="log"></div>
 
 <pre id='untested_idl' style='display:none'>
+[PrimaryGlobal]
 interface Window {
 };
 


### PR DESCRIPTION
This was an adventure in learning WebIDL. Ultimately this comes down to:

[Web IDL spec](https://heycam.github.io/webidl/#es-attributes) for location of attributes has:

> * ...
> * Otherwise, if the interface is a consequential interface of a [Global]- or [PrimaryGlobal]-annotated interface, then the property exists on the single object that implements the [Global]- or [PrimaryGlobal]-annotated interface as well as on the consequential interface’s interface prototype object.
> * Otherwise, the property exists solely on the interface’s interface prototype object.

The test was missing the `[PrimaryGlobal]` annotation and so we were testing incorrectly.

---

Fixing this causes the test to pass as expected in all browsers I could test (WebKit, Chrome, Firefox).