### PR TITLE
Add tests for which global is used in blob URL origins

### DIFF
--- a/FileAPI/support/document-domain-setter.sub.html
+++ b/FileAPI/support/document-domain-setter.sub.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Relevant/current/blob source page used as a test helper</title>
+
+<script>
+"use strict";
+document.domain = "{{host}}";
+</script>

--- a/FileAPI/support/incumbent.sub.html
+++ b/FileAPI/support/incumbent.sub.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>Incumbent page used as a test helper</title>
+
+<iframe src="//{{domains[www1]}}:{{location[port]}}/FileAPI/support/document-domain-setter.sub.html" id="c"></iframe>
+<iframe src="//{{domains[www2]}}:{{location[port]}}/FileAPI/support/document-domain-setter.sub.html" id="r"></iframe>
+<iframe src="//{{domains[élève]}}:{{location[port]}}/FileAPI/support/document-domain-setter.sub.html" id="bs"></iframe>
+
+<script>
+"use strict";
+document.domain = "{{host}}";
+
+window.createBlobURL = () => {
+    const current = document.querySelector("#c").contentWindow;
+    const relevant = document.querySelector("#r").contentWindow;
+    const blobSource = document.querySelector("#bs").contentWindow;
+
+    const blob = new blobSource.Blob(["Test Blob"]);
+
+    return current.URL.createObjectURL.call(relevant, blob);
+};
+
+</script>

--- a/FileAPI/url/multi-global-origin-serialization.sub.html
+++ b/FileAPI/url/multi-global-origin-serialization.sub.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Blob URL serialization (specifically the origin) in multi-global situations</title>
+<link rel="help" href="https://w3c.github.io/FileAPI/#unicodeBlobURL">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<!-- this page is the entry global -->
+
+<iframe src="//{{domains[www]}}:{{location[port]}}/FileAPI/support/incumbent.sub.html"></iframe>
+
+<script>
+"use strict";
+document.domain = "{{host}}";
+
+window.onload = () => {
+  const url = frames[0].createBlobURL();
+  const desired = "blob:{{location[scheme]}}://www1";
+  assert_equals(url.substring(0, desired.length), desired,
+    "Origin should contain www1, from the current settings object");
+  done();
+};
+</script>


### PR DESCRIPTION
Helps with https://github.com/w3c/FileAPI/issues/60.

This checks that it's the current, since that's what we want to change the spec to, not the incumbent, what the spec currently says. It passes in Gecko and Blink; Edge fails as it seems to use an entirely different blob URL format. Haven't tested Safari.