### PR TITLE
Fix 128.html

### DIFF
--- a/old-tests/submission/Opera/script_scheduling/128.html
+++ b/old-tests/submission/Opera/script_scheduling/128.html
@@ -28,7 +28,7 @@ t.step(function() {
 });
 
 onload = t.step_func(function() {
-  assert_array_equals(eventOrder, ["inline script #1", "inline script #2", "inline script #3", "end inline script #2", "end inline script #1"]);
+  assert_array_equals(eventOrder, ["inline script #1", "inline script #3", "inline script #2", "end inline script #2", "end inline script #1"]);
   t.done();
 });
 </script>


### PR DESCRIPTION

The spec says that a script must be immediately prepared whenever "the script element
is connected and a node or document fragment is inserted into the script element,
after any script elements inserted at that time."