### PR TITLE
Update NT2 name to be the requested URL instead of 'document' There's a strong request to merge this in M57, see spec bug: https://github.com/w3c/navigation-timing/issues/59


### DIFF
--- a/navigation-timing/nav2_test_attributes_values.html
+++ b/navigation-timing/nav2_test_attributes_values.html
@@ -63,8 +63,7 @@
                     var entries = entryList.getEntries();
                     assert_equals(entries[0].entryType, "navigation",
                         "Expected entryType to be: navigation.");
-                    assert_equals(entries[0].name, "document",
-                        "Expected name to be: document.");
+                    assert_equals(entries[0].name, "http://web-platform.test:8001/navigation-timing/nav2_test_attributes_values.html");
                     assert_equals(entries[0].startTime, 0,
                         "Expected startTime to be: 0.");
                     assert_equals(entries[0].duration, entries[0].loadEventEnd,
@@ -75,8 +74,8 @@
                     // running this test.
                     assert_true(entries[0].transferSize > entries[0].encodedBodySize,
                         "Expected transferSize to be greater than encodedBodySize in uncached navigation.");
-                    assert_equals(entries[0].encodedBodySize, 4140);
-                    assert_equals(entries[0].decodedBodySize, 4140);
+                    assert_equals(entries[0].encodedBodySize, 4154);
+                    assert_equals(entries[0].decodedBodySize, 4154);
                     verifyTimingEventOrder(entries[0], navTiming2EventOrder1);
                     // When unloadEvent happens
                     if (entries[0]["unloadEventStart"] != 0) {

--- a/navigation-timing/nav2_test_instance_accessors.html
+++ b/navigation-timing/nav2_test_instance_accessors.html
@@ -50,10 +50,10 @@
                 t.step_func(function (entryList) {
                     var instance1 = performance.getEntries()[0];
                     var instance2 = performance.getEntriesByType("navigation")[0];
-                    var instance3 = performance.getEntriesByName("document")[0];
+                    var instance3 = performance.getEntriesByName("http://web-platform.test:8001/navigation-timing/nav2_test_instance_accessors.html")[0];
 
                     assert_equals(performance.getEntriesByType("navigation").length, 1, "Expected there is only one navigation timing instance.");
-                    assert_equals(performance.getEntriesByName("document").length, 1, "Expected there is only one navigation timing instance.");
+                    assert_equals(performance.getEntriesByName("http://web-platform.test:8001/navigation-timing/nav2_test_instance_accessors.html").length, 1, "Expected there is only one navigation timing instance.");
 
                     for (var i = 0; i < navTiming2Attributes.length; i++) {
                         assert_equals(instance1[navTiming2Attributes[i]], instance2[navTiming2Attributes[i]]);


### PR DESCRIPTION
BUG=675039

Review-Url: https://codereview.chromium.org/2675973004
Cr-Commit-Position: refs/heads/master@{#448517}

