### PR TITLE
[dom] Correct duplicated test names

### DIFF
--- a/dom/nodes/DOMImplementation-createDocument.html
+++ b/dom/nodes/DOMImplementation-createDocument.html
@@ -37,7 +37,6 @@ test(function() {
      *   the expected exception, or null if none
      */
     [null, null, false, new TypeError()],
-    [null, null, null, null],
     [null, "", null, null],
     [undefined, null, undefined, null],
     [undefined, undefined, undefined, null],

--- a/dom/nodes/Document-createElementNS.html
+++ b/dom/nodes/Document-createElementNS.html
@@ -16,9 +16,7 @@ var tests = createElementNS_tests.concat([
    *   the expected exception, or null if none
    */
   ["", "", "INVALID_CHARACTER_ERR"],
-  [null, null, null],
   [null, "", "INVALID_CHARACTER_ERR"],
-  [undefined, null, null],
   [undefined, "", "INVALID_CHARACTER_ERR"],
   ["http://example.com/", null, null],
   ["http://example.com/", "", "INVALID_CHARACTER_ERR"],

--- a/dom/nodes/Document-createElementNS.js
+++ b/dom/nodes/Document-createElementNS.js
@@ -91,7 +91,6 @@ var createElementNS_tests = [
   ["http://example.com/", "a.b:c", null],
   ["http://example.com/", "a-b:c", null],
   ["http://example.com/", "xml", null],
-  ["http://example.com/", "xmlns", "NAMESPACE_ERR"],
   ["http://example.com/", "XMLNS", null],
   ["http://example.com/", "xmlfoo", null],
   ["http://example.com/", "xml:foo", "NAMESPACE_ERR"],

--- a/dom/ranges/Range-selectNode.html
+++ b/dom/ranges/Range-selectNode.html
@@ -73,24 +73,24 @@ function testTree(root, marker) {
         // This is being modified during the tests, so let's not test it.
         return;
     }
-    tests.push([marker + root.nodeName.toLowerCase() + " node, current doc's range, type " + root.nodeType, range, root]);
-    tests.push([marker + root.nodeName.toLowerCase() + " node, foreign doc's range, type " + root.nodeType, foreignRange, root]);
-    tests.push([marker + root.nodeName.toLowerCase() + " node, XML doc's range, type " + root.nodeType, xmlRange, root]);
-    tests.push([marker + root.nodeName.toLowerCase() + " node, detached range, type " + root.nodeType, detachedRange, root]);
+    tests.push([marker + ": " + root.nodeName.toLowerCase() + " node, current doc's range, type " + root.nodeType, range, root]);
+    tests.push([marker + ": " + root.nodeName.toLowerCase() + " node, foreign doc's range, type " + root.nodeType, foreignRange, root]);
+    tests.push([marker + ": " + root.nodeName.toLowerCase() + " node, XML doc's range, type " + root.nodeType, xmlRange, root]);
+    tests.push([marker + ": " + root.nodeName.toLowerCase() + " node, detached range, type " + root.nodeType, detachedRange, root]);
     for (var i = 0; i < root.childNodes.length; i++) {
-        testTree(root.childNodes[i], "**" + marker);
+        testTree(root.childNodes[i], marker + "[" + i + "]");
     }
 }
-testTree(document, " current doc: ");
-testTree(foreignDoc, " foreign doc: ");
-testTree(detachedDiv, " detached div in current doc: ");
+testTree(document, "current doc");
+testTree(foreignDoc, "foreign doc");
+testTree(detachedDiv, "detached div in current doc");
 
-var otherTests = [xmlDoc, xmlElement, detachedTextNode, foreignTextNode,
-xmlTextNode, processingInstruction, comment, foreignComment, xmlComment,
-docfrag, foreignDocfrag, xmlDocfrag];
+var otherTests = ["xmlDoc", "xmlElement", "detachedTextNode",
+"foreignTextNode", "xmlTextNode", "processingInstruction", "comment",
+"foreignComment", "xmlComment", "docfrag", "foreignDocfrag", "xmlDocfrag"];
 
 for (var i = 0; i < otherTests.length; i++) {
-    testTree(otherTests[i], " ");
+    testTree(window[otherTests[i]], otherTests[i]);
 }
 
 generate_tests(testSelectNode, tests);


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and
machines. In order to avoid this confusion, [an upcoming extension to the test
harness](https://github.com/w3c/testharness.js/pull/240) will cause any test
file with duplicate test names to be interpreted as an error.

This situation occurs in a few of the "dom" tests. In most cases, this is
likely an unintentional repetition. The resolution is to simply remove one of
the two tests.

It is possible, however, that the duplication is actually the result of a
transcription error--that one of the two tests was intended to assert a
slightly different condition. In this case, the duplication actually highlights
an area of missing coverage and is best resolved by modifying the input values
to make the tests distinct.

I lack the domain knowledge to definitively differentiate between these two
possibilities. I have assumed that the former is always the case, but I request
that my reviewers take care to verify this assumption.

This change set also includes an extension to the logic for generating
tests--that code was previously generating duplicate strings for distinct
steps.