### PR TITLE
[custom-elements] Remove duplicated test

### DIFF
--- a/custom-elements/reactions/DOMTokenList.html
+++ b/custom-elements/reactions/DOMTokenList.html
@@ -126,15 +126,6 @@ test(function () {
 }, 'toggle on DOMTokenList must enqueue an attributeChanged reaction when removing a value from an attribute');
 
 test(function () {
-    var element = define_new_custom_element(['lang']);
-    var instance = document.createElement(element.name);
-    instance.setAttribute('class', 'hello world');
-    assert_array_equals(element.takeLog().types(), ['constructed']);
-    instance.classList.toggle('world');
-    assert_array_equals(element.takeLog().types(), []);
-}, 'remove on DOMTokenList must not enqueue an attributeChanged reaction when removing a value from an unobserved attribute');
-
-test(function () {
     var element = define_new_custom_element(['class']);
     var instance = document.createElement(element.name);
     instance.setAttribute('class', 'hello');


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and machines. In order to avoid this confusion, [an upcoming extension to the test harness](https://github.com/w3c/testharness.js/pull/240) will cause any test file with duplicate test names to be interpreted as an error.