### PR TITLE
[payment-request] constructor() and show() tests

### DIFF
--- a/payment-request/constructor/store-details-id.html
+++ b/payment-request/constructor/store-details-id.html
@@ -1,10 +1,8 @@
 <!DOCTYPE HTML>
 <meta charset='utf-8'>
-<title>PaymentRequest: when calling show() the acceptPromise should get created and returned.</title>
+<title>PaymentRequest: use id passed in details as payment request id.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-
-<p></p>
 
 <script>
 async_test((t) => {
@@ -12,10 +10,10 @@ async_test((t) => {
     let pr = new PaymentRequest([{
       supportedMethods: ['non-supported-payment-method']
     }], {
+      id: 'foobar',
       total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}
     });
-    let p = pr.show();
-    assert_true(p instanceof Promise);
+    assert_true(pr.id == 'foobar');
   });
 });
 </script>

--- a/payment-request/constructor/typeerror-on-empty-methoddata.html
+++ b/payment-request/constructor/typeerror-on-empty-methoddata.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<meta charset='utf-8'>
+<title>PaymentRequest: TypeError on empty methodData.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+async_test((t) => {
+  onload = t.step_func_done(() => {
+    assert_throws(new TypeError(), function() {
+      let pr = new PaymentRequest([], {
+        id: 'foobar',
+        total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}
+      });
+    })
+  });
+});
+</script>

--- a/payment-request/payment-request-show-accept-promise-returned.html
+++ b/payment-request/payment-request-show-accept-promise-returned.html
@@ -8,11 +8,14 @@
 
 <script>
 async_test((t) => {
-  const paymentArgs = [[{supportedMethods: ['non-supported-payment-method']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
-
   onload = t.step_func_done(() => {
-    let pr = new PaymentRequest(paymentArgs)
-    let p = pr.show()
+    let pr = new PaymentRequest([{
+      supportedMethods: ['non-supported-payment-method']
+    }], {
+      total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}
+    });
+    let p = pr.show();
     assert_true(p instanceof Promise);
   });
 });
+</script>

--- a/payment-request/payment-request-show-accept-promise-returned.html
+++ b/payment-request/payment-request-show-accept-promise-returned.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<meta charset='utf-8'>
+<title>PaymentRequest: when calling show() the acceptPromise should get created and returned.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<p></p>
+
+<script>
+async_test((t) => {
+  const paymentArgs = [[{supportedMethods: ['non-supported-payment-method']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
+
+  onload = t.step_func_done(() => {
+    let pr = new PaymentRequest(paymentArgs)
+    let p = pr.show()
+    assert_true(p instanceof Promise);
+  });
+});

--- a/payment-request/show/accept-promise-returned.html
+++ b/payment-request/show/accept-promise-returned.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<meta charset='utf-8'>
+<title>PaymentRequest: when calling show() the acceptPromise should get created and returned.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+async_test((t) => {
+  onload = t.step_func_done(() => {
+    let pr = new PaymentRequest([{
+      supportedMethods: ['non-supported-payment-method']
+    }], {
+      total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}
+    });
+    let p = pr.show();
+    assert_true(p instanceof Promise);
+  });
+});
+</script>


### PR DESCRIPTION
Add a test to the payment-request directory that tests that the acceptPromise is created and returned when show() is called on a PaymentRequest.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
