### PR TITLE
Add tests for the removal of <button type=menu>

### DIFF
--- a/html/dom/elements-forms.js
+++ b/html/dom/elements-forms.js
@@ -79,8 +79,7 @@ var formElements = {
     formTarget: "string",
     name: "string",
     type: {type: "enum", keywords: ["submit", "reset", "button"], defaultVal: "submit"},
-    value: "string",
-    // TODO: menu
+    value: "string"
   },
   select: {
     autofocus: "boolean",

--- a/html/dom/elements-misc.js
+++ b/html/dom/elements-misc.js
@@ -41,8 +41,8 @@ var miscElements = {
   summary: {},
   menu: {
     // Conforming
-    //TODO: check that missing value default is popup if parent's type is popup
-    type: {type: "enum", keywords:["popup", "toolbar"], defaultVal: "toolbar"},
+    //TODO: check that missing value default is context if parent's type is context
+    type: {type: "enum", keywords:["context", "toolbar"], defaultVal: "toolbar"},
     label: "string",
 
     // Obsolete

--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -1605,7 +1605,6 @@ interface HTMLButtonElement : HTMLElement {
            attribute DOMString name;
            attribute DOMString type;
            attribute DOMString value;
-           attribute HTMLMenuElement? menu;
 
   readonly attribute boolean willValidate;
   readonly attribute ValidityState validity;

--- a/html/rendering/bindings/the-button-element/button-type-menu-historical-ref.html
+++ b/html/rendering/bindings/the-button-element/button-type-menu-historical-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML>
+<title>Test that button with type="menu" renders the same as button with type="submit"</title>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://github.com/whatwg/html/pull/2342">
+
+<button type="submit">button</button>

--- a/html/rendering/bindings/the-button-element/button-type-menu-historical.html
+++ b/html/rendering/bindings/the-button-element/button-type-menu-historical.html
@@ -1,0 +1,8 @@
+<!DOCTYPE HTML>
+<title>Test that button with type="menu" renders the same as button with type="submit"</title>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://github.com/whatwg/html/pull/2342">
+<link rel="match" href="button-type-menu-historical-ref.html">
+
+<button type="menu">button</button>

--- a/html/semantics/forms/the-button-element/button-menu-historical.html
+++ b/html/semantics/forms/the-button-element/button-menu-historical.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<title>Test that nobody implemented the now-removed menu type and attribute on button</title>
+<meta charset="utf-8">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://github.com/whatwg/html/pull/2342">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="b" type="menu" menu="m">button</button>
+<menu id="m"></menu>
+
+<script>
+"use strict";
+
+const button = document.querySelector("button");
+
+test(() => {
+  assert_false('menu' in button, 'The menu property must not exist on the button');
+  assert_equals(button.menu, undefined, 'The value of the menu property on the button must be undefined');
+}, 'button.menu, the potentially-reflecting IDL attribute, does not exist');
+
+test(() => {
+  assert_equals(button.type, 'submit', 'The type property must reflect as its invalid value default of submit');
+}, 'button.type reflects properly');
+</script>


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2342

I am told Firefox on Mac OS will fail the reftest per https://github.com/whatwg/html/issues/237#issuecomment-275724486