### PR TITLE
[shadow-dom] Specify unique names for tests

### DIFF
--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -139,7 +139,7 @@ function testMutatingSlotName(options)
         slotElement.removeAttribute('name');
         assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes must be empty when there are no matching elements for the slot name');
 
-    }, 'assignedNodes must update when a default slot is introduced dynamically by a slot rename');
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
 }
 
 testMutatingSlotName(null);
@@ -193,7 +193,7 @@ function testInsertingAndRemovingSlots(options)
         assert_array_equals(secondSlotElement.assignedNodes(options), [],
             'assignedNodes on formerly-first but now second unnamed slot element must return an empty array');
 
-    }, 'assignedNodes must update when slot elements are inserted or removed');
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
 }
 
 testInsertingAndRemovingSlots(null);

--- a/shadow-dom/event-inside-slotted-node.html
+++ b/shadow-dom/event-inside-slotted-node.html
@@ -240,8 +240,8 @@
                 assert_array_equals(log[10], [shadow.upperShadow, shadow.lowerShadow.host], 'EventPath[10] must be the upper shadow root');
                 assert_array_equals(log[11], [shadow.upperShadow.host, shadow.lowerShadow.host], 'EventPath[11] must be the host');
 
-            }, 'Firing an event on a node with two ancestors with a detached ' + outerUpperMode + ' and ' + outerLowerMode
-                + ' shadow trees with an inner ' + innerMode + ' shadow tree');
+            }, 'Firing an event on a node within a ' + innerMode + ' shadow tree that is itself a ' + outerLowerMode
+                + ' shadow tree (the latter being the descendent of a host for a separate ' + outerUpperMode + ' shadow tree)');
         }
 
         testEventInsideNestedShadowsUnderAnotherShadow('open', 'open', 'open');

--- a/shadow-dom/event-with-related-target.html
+++ b/shadow-dom/event-with-related-target.html
@@ -189,7 +189,7 @@
                 assert_array_equals(log.relatedTargets,
                     ['B', 'B', 'B', 'B', 'B'], 'The related targets must be correct.');
 
-            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+            }, 'Firing an event at A1a with relatedNode at B1a with ' + mode + ' mode shadow trees');
         }
 
         testEventAtA1aWithB1a('open');
@@ -218,7 +218,7 @@
                 assert_array_equals(log.relatedTargets,
                     ['A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1', 'A1'], 'The related targets must be correct.');
 
-            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+            }, 'Firing an event at B1a with relatedNode at A1a (detached) with ' + mode + ' mode shadow trees');
         }
 
         testEventAtB1aWithDetachedA1a('open');
@@ -245,7 +245,7 @@
                 assert_array_equals(log.eventPath,      ['A1a', 'A1-SR', 'A1'], 'The event path must be correct.');
                 assert_array_equals(log.relatedTargets, ['B',   'B',     'B' ], 'The related targets must be correct.');
 
-            }, 'Firing an event at B1a with relatedNode at A1a with ' + mode + ' mode shadow trees');
+            }, 'Firing an event at A1a with relatedNode at B1a (detached) with ' + mode + ' mode shadow trees');
         }
 
         testEventAtA1aWithDetachedB1a('open');


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and machines. In order to avoid this confusion, [an upcoming extension to the test harness](https://github.com/w3c/testharness.js/pull/240) will cause any test file with duplicate test names to be interpreted as an error.