### PR TITLE
Cleanup resource-timing tests

### DIFF
--- a/resource-timing/SyntheticResponse.py
+++ b/resource-timing/SyntheticResponse.py
@@ -20,7 +20,7 @@ def main(request, response):
                 response.write_status_headers()
                 headersSent = 1
 
-            response.writer.write(text)
+            response.writer.write_content(text)
 #        else:
 #            error "  INVALID ARGUMENT %s" % arg
 

--- a/resource-timing/resource-timing.js
+++ b/resource-timing/resource-timing.js
@@ -131,7 +131,7 @@ window.onload =
 
         // Create responseStart/responseEnd tests from the following array of templates.  In this test, the server delays before
         // responding with responsePart1, then delays again before completing with responsePart2.  The test looks for the expected
-        // pauses before responeStart and responseEnd.
+        // pauses before responseStart and responseEnd.
         [
             { initiator: "iframe",         responsePart1: serverStepDelay + "ms;", responsePart2: (serverStepDelay * 2) + "ms;(done)",                                                      mime: mimeHtml },
             { initiator: "xmlhttprequest", responsePart1: serverStepDelay + "ms;", responsePart2: (serverStepDelay * 2) + "ms;(done)",                                                      mime: mimeText },
@@ -142,7 +142,7 @@ window.onload =
         ]
         .forEach(function (template) {
             testCases.push({
-                description: "'" + template.initiator + ": 1 second delay before 'responseStart', another 1 second delay before 'responseEnd'.",
+                description: "'" + template.initiator + ": " + serverStepDelay + "ms delay before 'responseStart', another " + serverStepDelay + "ms delay before 'responseEnd'.",
                 test: function (test) {
                     initiateFetch(
                         test,
@@ -190,7 +190,7 @@ window.onload =
         ]
         .forEach(function (template) {
             testCases.push({
-                description: "'" + template.initiator + " (Redirected): 1 second delay before 'redirectEnd', another 1 second delay before 'responseStart'.",
+                description: "'" + template.initiator + " (Redirected): " + serverStepDelay + "ms delay before 'redirectEnd', another " + serverStepDelay + "ms delay before 'responseStart'.",
                 test: function (test) {
                     initiateFetch(
                         test,

--- a/resource-timing/resource_connection_reuse.html
+++ b/resource-timing/resource_connection_reuse.html
@@ -36,11 +36,12 @@ function onload_test() {
     // when a persistent connection is used, follow-on resources should be included as PerformanceResourceTiming objects
     test_equals(entries.length, 2, 'There should be 2 PerformanceEntries');
 
-    // when a persistent connection is used, for the resource that reuses the socket, connectStart and connectEnd should have the same value as fetchStart
-    var entry = entries[1];
-    test_equals(entry.fetchStart, entry.connectStart, "connectStart and fetchStart should be the same");
-
-    test_equals(entry.fetchStart, entry.connectEnd, "connectEnd and fetchStart should be the same");
+    if (entries.length >= 2) {
+        // when a persistent connection is used, for the resource that reuses the socket, connectStart and connectEnd should have the same value as fetchStart
+        var entry = entries[1];
+        test_equals(entry.fetchStart, entry.connectStart, "connectStart and fetchStart should be the same");
+        test_equals(entry.fetchStart, entry.connectEnd, "connectEnd and fetchStart should be the same");
+    }
 
     done();
 }


### PR DESCRIPTION
- Fix SyntheticResponse.py to write content in chunks as intended
  - This fixes http://w3c-test.org/resource-timing/resource-timing.html in Chrome and WebKit
  - I'm not how Firefox was passing this, but it continues to pass after these changes.
- Fix resource-timing.js description claiming 1s when it was really 250ms
- Fix resource_connection_reuse.html to fail immediately on failure like other tests
- Fix typos