### PR TITLE
Pointerevent test cleanup


### DIFF
--- a/pointerevents/pointerevent_releasepointercapture_events_to_original_target-manual.html
+++ b/pointerevents/pointerevent_releasepointercapture_events_to_original_target-manual.html
@@ -120,12 +120,12 @@
         <h1>Pointer Event: releasePointerCapture() - subsequent events follow normal hitting testing mechanisms</h1>
         <h4>
             Test Description:
+            Use your pointer and press down in the black box. Then move around in the box and release your pointer.
             After invoking the releasePointerCapture method on an element, subsequent events for the specified
-            pointer must follow normal hit testing mechanisms for determining the event target
+            pointer must follow normal hit testing mechanisms for determining the event target.
         </h4>
         <br />
         <div id="target0">
-            Use mouse, touch or pen to contact here and move around.
         </div>
         <div id="complete-notice">
             <p>Test complete:  Scroll to Summary to view Pass/Fail Results.</p>


### PR DESCRIPTION
This CL adds the rest of the pointerevent tests
automations in Chrome as well as cleaning up the
text for a test.
Note that Chrome fails the two finger pan test.

BUG=689669

Review-Url: https://codereview.chromium.org/2681923002
Cr-Commit-Position: refs/heads/master@{#449045}

