### PR TITLE
[web-animations] Specify unique names for tests

### DIFF
--- a/web-animations/animation-model/animation-types/addition-per-property.html
+++ b/web-animations/animation-model/animation-types/addition-per-property.html
@@ -44,7 +44,8 @@ for (var property in gCSSProperties) {
                           ' should have testAddition property');
       assert_equals(typeof typeObject.testAddition, 'function',
                     'testAddition method should be a function');
-    }, animationTypeString + ' has testAddition function');
+    }, property + ' (type: ' + animationTypeString +
+       ') has testAddition function');
 
     if (typeObject.testAddition &&
         typeof typeObject.testAddition === 'function') {

--- a/web-animations/animation-model/animation-types/interpolation-per-property.html
+++ b/web-animations/animation-model/animation-types/interpolation-per-property.html
@@ -44,7 +44,8 @@ for (var property in gCSSProperties) {
                           ' should have testInterpolation property');
       assert_equals(typeof typeObject.testInterpolation, 'function',
                     'testInterpolation method should be a function');
-    }, animationTypeString + ' has testInterpolation function');
+    }, property + ' (type: ' + animationTypeString +
+       ' has testInterpolation function');
 
     if (typeObject.testInterpolation &&
         typeof typeObject.testInterpolation === 'function') {

--- a/web-animations/animation-model/animation-types/interpolation-per-property.html
+++ b/web-animations/animation-model/animation-types/interpolation-per-property.html
@@ -45,7 +45,7 @@ for (var property in gCSSProperties) {
       assert_equals(typeof typeObject.testInterpolation, 'function',
                     'testInterpolation method should be a function');
     }, property + ' (type: ' + animationTypeString +
-       ' has testInterpolation function');
+       ') has testInterpolation function');
 
     if (typeObject.testInterpolation &&
         typeof typeObject.testInterpolation === 'function') {

--- a/web-animations/animation-model/animation-types/spacing-keyframes-filters.html
+++ b/web-animations/animation-model/animation-types/spacing-keyframes-filters.html
@@ -189,7 +189,7 @@ test(function(t) {
                Math.sqrt(1 * 1 + 0.5 * 0.5 + 1 * 1),
                Math.sqrt(0.25 * 0.25 + 1 * 1) ];
   assert_animation_offsets(anim, dist);
-}, 'Test spacing on filter function lists' );
+}, 'Test spacing on filter function lists with consistent sequence' );
 
 test(function(t) {
   var anim =
@@ -204,7 +204,7 @@ test(function(t) {
                0,
                Math.sqrt(0.25 * 0.25 + 1 * 1) ];
   assert_animation_offsets(anim, dist);
-}, 'Test spacing on filter function lists' );
+}, 'Test spacing on filter function lists with inconsistent sequence' );
 
 </script>
 </body>

--- a/web-animations/interfaces/Animation/ready.html
+++ b/web-animations/interfaces/Animation/ready.html
@@ -71,7 +71,7 @@ promise_test(function(t) {
   animation.cancel();
 
   return retPromise;
-}, 'ready promise is rejected when a pause-pending animation is cancelled by'
+}, 'ready promise is rejected when a play-pending animation is cancelled by'
    + ' calling cancel()');
 
 promise_test(function(t) {

--- a/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
+++ b/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
@@ -166,7 +166,7 @@ test(function(t) {
   assert_equals(getComputedStyle(div).opacity, '1',
                 'change direction from "normal" to "reverse" ' +
                 'at the starting point');
-}, 'change direction from "normal" to "reverse"');
+}, 'change direction from "normal" to "reverse" when currentTime is 0');
 
 </script>
 </body>

--- a/web-animations/interfaces/KeyframeEffectReadOnly/spacing.html
+++ b/web-animations/interfaces/KeyframeEffectReadOnly/spacing.html
@@ -59,13 +59,15 @@ test(function(t) {
   assert_throws(new TypeError, function() {
     createDiv(t).animate(null, { spacing: 'paced(.margin)' });
   });
-}, 'Test throwing TypeError if using a non-ident started string');
+}, 'Test throwing TypeError if using a non-ident started string with ' +
+   'a period');
 
 test(function(t) {
   assert_throws(new TypeError, function() {
     createDiv(t).animate(null, { spacing: 'paced(1margin)' });
   });
-}, 'Test throwing TypeError if using a non-ident started string');
+}, 'Test throwing TypeError if using a non-ident started string with ' +
+   'a number');
 
 test(function(t) {
   assert_throws(new TypeError, function() {


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and machines. In order to avoid this confusion, [an upcoming extension to the test harness](https://github.com/w3c/testharness.js/pull/240) will cause any test file with duplicate test names to be interpreted as an error.