### PR TITLE
[html] Specify unique names for tests

### DIFF
--- a/html/semantics/embedded-content/the-object-element/object-events.html
+++ b/html/semantics/embedded-content/the-object-element/object-events.html
@@ -23,7 +23,7 @@ async_test(function(t) {
 
   obj.data = "file:\\http://nonexistent.html";
   document.body.appendChild(obj);
-}, "error event");
+}, "error event (using 'file:' protocol)");
 
 async_test(function(t) {
   var obj = document.createElement("object");
@@ -37,7 +37,7 @@ async_test(function(t) {
 
   obj.data = "http://test:test";
   document.body.appendChild(obj);
-}, "error event");
+}, "error event (using 'http:' protocol)");
 
 
 async_test(function(t) {


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and machines. In order to avoid this confusion, [an upcoming extension to the test harness](https://github.com/w3c/testharness.js/pull/240) will cause any test file with duplicate test names to be interpreted as an error.