### PR TITLE
[presentation-api] minor bug fix for startNewPresentation_displaynotallowed-manual.html

### DIFF
--- a/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
+++ b/presentation-api/controlling-ua/startNewPresentation_displaynotallowed-manual.html
@@ -10,7 +10,7 @@
 <p>Before starting this test, confirm that there are one or more available presentation display on your local network.</p>
 <p>Click the button below to start the manual test. If prompted to select a device, please dismiss the dialog box. The test passes if a "PASS" result appears.
 </p>
-<button id="presentBtn" onclick="startPresentation()">Start Presentation Test</button>
+<button id="presentBtn">Start Presentation Test</button>
 
 <script>
     // disable the timeout function for the tests


### PR DESCRIPTION
This PR removes a redundant `onclick` attribute of `<button>` in startNewPresentation_displaynotallowed-manual.html.