### PR TITLE
URL: Correct expected result for non-empty search attribute

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -4622,7 +4622,7 @@
     "port": "",
     "pathname": "/baz",
     "search": "?qux",
-    "searchParams": "",
+    "searchParams": "qux=",
     "hash": "#foo%08bar"
   },
   "# IPv4 parsing (via https://github.com/nodejs/node/pull/10317)",


### PR DESCRIPTION
This fixes test data to expect the `searchParams` idl attribute to be
"qux=" since its `search` idl attribtue expects "?qux". This was causing
a test failure in url-constructor.html. The test data was first added in 65eb641.

cc @annevk