### PR TITLE
Update select event tests for spec change and completeness

### DIFF
--- a/html/semantics/forms/textfieldselection/select-event.html
+++ b/html/semantics/forms/textfieldselection/select-event.html
@@ -1,45 +1,83 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
 <title>text field selection: select()</title>
-<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <link rel=help href="https://html.spec.whatwg.org/multipage/#textFieldSelection">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
+
 <textarea>foobar</textarea>
+<input type="text" value="foobar">
+<input type="search" value="foobar">
+<input type="tel" value="1234">
+<input type="url" value="https://example.com/">
+<input type="password" value="hunter2">
+
 <script>
-  var input_types = ["text", "search", "tel", "url", "password"],
-      t1 = async_test("select() on textarea queues select event"),
-      q1 = false;
+"use strict";
 
-  input_types.forEach(function(type) {
-    var input = document.createElement("input"),
-        t = async_test("select() on input type " + type + " queues select event"),
-        q = false;
-    t.step(function() {
-      input.type = type;
-      input.value = "foobar";
-      document.body.appendChild(input);
-      input.onselect = t.step_func_done(function(e) {
-        assert_true(q, "event should be queued");
-        assert_true(e.isTrusted, "event is trusted");
-        assert_true(e.bubbles, "event bubbles");
-        assert_false(e.cancelable, "event is not cancelable");
+const els = [document.querySelector("textarea"), ...document.querySelectorAll("input")];
+
+const actions = [
+  {
+    label: "select()",
+    action: el => el.select()
+  },
+  {
+    label: "selectionStart",
+    action: el => el.selectionStart = 1
+  },
+  {
+    label: "selectionEnd",
+    action: el => el.selectionEnd = el.value.length - 1
+  },
+  {
+    label: "selectionDirection",
+    action: el => el.selectionDirection = "right"
+  },
+  {
+    label: "setSelectionRange()",
+    action: el => el.setSelectionRange(1, el.value.length - 1) // changes direction implicitly to none/forward
+  },
+  {
+    label: "setRangeText()",
+    action: el => el.setRangeText("newmiddle")
+  }
+];
+
+for (const el of els) {
+  const elLabel = el.localName === "textarea" ? "textarea" : "input type " + el.type;
+
+  for (const action of actions) {
+    // promise_test instead of async_test is important because these need to happen in sequence (to test that events
+    // fire if and only if the selection changes).
+    promise_test(t => {
+      const watcher = new EventWatcher(t, el, "select");
+
+      const promise = watcher.wait_for("select").then(e => {
+        assert_true(e.isTrusted, "isTrusted must be true");
+        assert_true(e.bubbles, "bubbles must be true");
+        assert_false(e.cancelable, "cancelable must be false");
       });
-      input.select();
-      q=true;
-    });
-  });
 
-  document.querySelector("textarea").onselect = t1.step_func_done(function(e) {
-    assert_true(q1, "event should be queued");
-    assert_true(e.isTrusted, "event is trusted");
-    assert_true(e.bubbles, "event bubbles");
-    assert_false(e.cancelable, "event is not cancelable");
-  });
+      action.action(el);
 
-  t1.step(function() {
-    document.querySelector("textarea").select();
-    q1=true;
-  });
+      return promise;
+    }, `${elLabel}: ${action.label}`);
+
+    promise_test(t => {
+      el.onselect = t.unreached_func("the select event must not fire the second time");
+
+      action.action(el);
+
+      return new Promise(resolve => {
+        t.step_timeout(() => {
+          el.onselect = null;
+          resolve();
+        }, 300);
+      });
+    }, `${elLabel}: ${action.label} a second time (must not fire select)`);
+  }
+}
 </script>

--- a/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
@@ -104,17 +104,5 @@
         element.setRangeText();
       });
     }, element.id + " setRangeText without argument throws a type error");
-
-    async_test(function() {
-      var q = false;
-      element.onselect = this.step_func_done(function(e) {
-        assert_true(q, "event should be queued");
-        assert_true(e.isTrusted, "event is trusted");
-        assert_true(e.bubbles, "event bubbles");
-        assert_false(e.cancelable, "event is not cancelable");
-      });
-      element.setRangeText("foobar2", 0, 6);
-      q = true;
-    }, element.id + " setRangeText fires a select event");
   })
 </script>

--- a/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setSelectionRange.html
@@ -258,17 +258,4 @@ test(function() {
     assert_equals(textarea.selectionEnd, 1, "element.selectionStart should be 1");
   },'textarea setSelectionRange(undefined,1)');
 },"test of textarea.setSelectionRange");
-
-async_test(function() {
-  var q = false;
-  var textarea = document.getElementById("b");
-  textarea.addEventListener("select", this.step_func_done(function(e) {
-    assert_true(q, "event should be queued");
-    assert_true(e.isTrusted, "event is trusted");
-    assert_true(e.bubbles, "event bubbles");
-    assert_false(e.cancelable, "event is not cancelable");
-  }));
-  textarea.setSelectionRange(0, 1);
-  q = true;
-}, "textarea setSelectionRange fires a select event");
 </script>


### PR DESCRIPTION
This updates the tests for the select event on inputs and textareas in a few ways:

- It adds tests that they do not fire for a non-changing selection, per the spec change in https://github.com/whatwg/html/pull/2352.
- It tests them more exhaustively, for all selection APIs including the setters
- It consolidates them inside the single select-event.html file instead of having some in the files for their respective methods.

/cc @tkent-google @smaug----. Both fail the various tests that for the new requirement about no event for non-changing selection. Gecko has some additional failures around isTrusted and cancelable.