### PR TITLE
Remove interception case from service worker URL parsing tests

### DIFF
--- a/service-workers/service-worker/multi-globals/current/test-sw.js
+++ b/service-workers/service-worker/multi-globals/current/test-sw.js
@@ -1,15 +1,1 @@
-'use strict';
-
-this.addEventListener('install', event => {
-    this.skipWaiting();
-});
-
-this.addEventListener('activate', event => {
-    clients.claim();
-});
-
-this.addEventListener('fetch', event => {
-    if (event.request.url.includes('test.txt')) {
-        event.respondWith(new Response('current'));
-    }
-});
+// Service worker for current/

--- a/service-workers/service-worker/multi-globals/incumbent/test-sw.js
+++ b/service-workers/service-worker/multi-globals/incumbent/test-sw.js
@@ -1,15 +1,1 @@
-'use strict';
-
-this.addEventListener('install', event => {
-    this.skipWaiting();
-});
-
-this.addEventListener('activate', event => {
-    clients.claim();
-});
-
-this.addEventListener('fetch', event => {
-    if (event.request.url.includes('test.txt')) {
-        event.respondWith(new Response('incumbent'));
-    }
-});
+// Service worker for incumbent/

--- a/service-workers/service-worker/multi-globals/relevant/test-sw.js
+++ b/service-workers/service-worker/multi-globals/relevant/test-sw.js
@@ -1,15 +1,1 @@
-'use strict';
-
-this.addEventListener('install', event => {
-    this.skipWaiting();
-});
-
-this.addEventListener('activate', event => {
-    clients.claim();
-});
-
-this.addEventListener('fetch', event => {
-    if (event.request.url.includes('test.txt')) {
-        event.respondWith(new Response('relevant'));
-    }
-});
+// Service worker for relevant/

--- a/service-workers/service-worker/multi-globals/test-sw.js
+++ b/service-workers/service-worker/multi-globals/test-sw.js
@@ -1,15 +1,1 @@
-'use strict';
-
-this.addEventListener('install', event => {
-    this.skipWaiting();
-});
-
-this.addEventListener('activate', event => {
-    clients.claim();
-});
-
-this.addEventListener('fetch', event => {
-    if (event.request.url.includes('test.txt')) {
-        event.respondWith(new Response('entry'));
-    }
-});
+// Service worker for /

--- a/service-workers/service-worker/multi-globals/url-parsing.https.html
+++ b/service-workers/service-worker/multi-globals/url-parsing.https.html
@@ -20,20 +20,32 @@ const loadPromise = new Promise(resolve => {
 });
 
 promise_test(t => {
+    let registration;
+
     return loadPromise.then(() => {
         return frames[0].testRegister();
-    }).then(registration => {
-        assert_equals(registration.scope, normalizeURL('relevant/'), 'the scope URL should be relevant/');
+    }).then(r => {
+        registration = r;
+        return wait_for_state(t, registration.installing, 'activated');
+    }).then(_ => {
+        assert_equals(registration.active.scriptURL, normalizeURL('relevant/test-sw.js'), 'the script URL should be parsed against the relevant global');
+        assert_equals(registration.scope, normalizeURL('relevant/'), 'the default scope URL should be parsed against the parsed script URL');
 
         return registration.unregister();
     });
 }, 'register should use the relevant global of the object it was called on to resolve the script URL and the default scope URL');
 
 promise_test(t => {
+    let registration;
+
     return loadPromise.then(() => {
         return frames[0].testRegister({ scope: 'scope' });
-    }).then(registration => {
-        assert_equals(registration.scope, normalizeURL('relevant/scope'), 'the scope URL should be relevant/scope');
+    }).then(r => {
+        registration = r;
+        return wait_for_state(t, registration.installing, 'activated');
+    }).then(_ => {
+        assert_equals(registration.active.scriptURL, normalizeURL('relevant/test-sw.js'), 'the script URL should be parsed against the relevant global');
+        assert_equals(registration.scope, normalizeURL('relevant/scope'), 'the given scope URL should be parsed against the relevant global');
 
         return registration.unregister();
     });

--- a/service-workers/service-worker/multi-globals/url-parsing.https.html
+++ b/service-workers/service-worker/multi-globals/url-parsing.https.html
@@ -20,25 +20,14 @@ const loadPromise = new Promise(resolve => {
 });
 
 promise_test(t => {
-    let registration;
-
     return loadPromise.then(() => {
         return frames[0].testRegister();
-    }).then(r => {
-        registration = r;
-        const newestWorker = r.installing || r.waiting || r.active;
-        return wait_for_state(t, newestWorker, 'activated');
-    }).then(() => {
-        return fetch('relevant/test.txt');
-    })
-    .then(response => response.text())
-    .then(text => {
-        assert_equals(text, 'relevant',
-            'the service worker found at relevant/test-sw.js must have been the one to intercept the fetch');
+    }).then(registration => {
+        assert_equals(registration.scope, normalizeURL('relevant/'), 'the scope URL should be relevant/');
 
         return registration.unregister();
     });
-}, 'register should use the relevant global of the object it was called on to resolve the script URL');
+}, 'register should use the relevant global of the object it was called on to resolve the script URL and the default scope URL');
 
 promise_test(t => {
     return loadPromise.then(() => {
@@ -48,7 +37,7 @@ promise_test(t => {
 
         return registration.unregister();
     });
-}, 'register should use the relevant global of the object it was called on to resolve the scope URL');
+}, 'register should use the relevant global of the object it was called on to resolve the script URL and the given scope URL');
 
 promise_test(t => {
     let registration;


### PR DESCRIPTION
Multi-global tests for service worker URL parsing intend to test whether
the right global is used for parsing the script URL and scope URL. This
replaces the unnecessary interception scenario with just checking the
registration's scope.

Follow-up on https://github.com/w3c/web-platform-tests/commit/688f5f85cbfa5c56326551753ba86735dcf60393.