### PR TITLE
Implement script MIME restrictions for X-Content-Type-Options: nosniff for Workers


### DIFF
--- a/workers/WorkerGlobalScope_importScripts_NosniffErr.htm
+++ b/workers/WorkerGlobalScope_importScripts_NosniffErr.htm
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title> importScripts() with nosniff X-Content-Type-Options </title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new Worker('./support/ImportScriptsNosniffErr.js'));
+</script>

--- a/workers/Worker_NosniffErr.htm
+++ b/workers/Worker_NosniffErr.htm
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title> Worker with nosniff X-Content-Type-Options header </title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+async_test(function(t) {
+  var worker = new Worker("./support/nosiniff-error-worker.py");
+  worker.onerror = t.step_func_done(function(e) {
+    assert_equals(e.type, 'error');
+  });
+});
+</script>

--- a/workers/support/ImportScriptsNosniffErr.js
+++ b/workers/support/ImportScriptsNosniffErr.js
@@ -1,0 +1,9 @@
+importScripts('/resources/testharness.js');
+
+test(t => {
+  assert_throws('NetworkError', () => {
+    importScripts("nosiniff-error-worker.py");
+  });
+}, "importScripts throws on 'nosniff' violation");
+
+done();

--- a/workers/support/nosiniff-error-worker.py
+++ b/workers/support/nosiniff-error-worker.py
@@ -1,0 +1,3 @@
+def main(request, response):
+    return [('Content-Type', 'text/html'),
+            ('X-Content-Type-Options', 'nosniff')], ""


### PR DESCRIPTION
The restrictions for ScriptResources were introduced 4 years ago.
https://chromium.googlesource.com/chromium/src/+/54acddd3e95047b46c0afd4482313a078378680f
But the restrictions for worker scripts were not introduced.

BUG=689003

Review-Url: https://codereview.chromium.org/2689173002
Cr-Commit-Position: refs/heads/master@{#449937}

