### PR TITLE
fix check_stability script to work without TRAVIS_REPO_SLUG env var

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -622,7 +622,7 @@ def get_parser():
                         action="store",
                         # Travis docs say do not depend on USER env variable.
                         # This is a workaround to get what should be the same value
-                        default=os.environ.get("TRAVIS_REPO_SLUG").split('/')[0],
+                        default=os.environ.get("TRAVIS_REPO_SLUG", "w3c").split('/')[0],
                         help="Travis user name")
     parser.add_argument("--output-bytes",
                         action="store",


### PR DESCRIPTION
allows local running of check_stability.py for testing

I considered moving the `split` out of the default declaration and into the body of the script, because it's kind of a bear, but that would require passing `--user w3c/` instead of the more sensible `--user w3c` when running from the command line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4809)
<!-- Reviewable:end -->
