### PR TITLE
Additional key generator tests for Indexed DB

### DIFF
--- a/IndexedDB/keygenerator-explicit.html
+++ b/IndexedDB/keygenerator-explicit.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Key Generator behavior with explicit keys generator overflow</title>
+<link rel=help href="https://w3c.github.io/IndexedDB/#key-generator-construct">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+function big_key_test(key, description) {
+  indexeddb_test(
+    (t, db) => {
+      assert_equals(indexedDB.cmp(key, key), 0, 'Key is valid');
+
+      db.createObjectStore('store', {autoIncrement: true});
+    },
+    (t, db) => {
+      const tx = db.transaction('store', 'readwrite');
+      const store = tx.objectStore('store');
+      const value = 0;
+
+      store.put(value).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 1,
+                      'Key generator should initially be 1');
+      });
+
+      store.put(value).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 2,
+                      'Key generator should increment');
+      });
+
+      store.put(value, 1000).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 1000,
+                      'Explicit key should be used');
+      });
+
+      store.put(value).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 1001,
+                      'Key generator should have updated');
+      });
+
+      store.put(value, key).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, key,
+                      'Explicit key should be used');
+      });
+
+      store.put(value).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 1002,
+                      'Key generator should have ignored');
+      });
+
+      store.put(value).onsuccess = t.step_func(e => {
+        assert_equals(e.target.result, 1003,
+                      'Key generator should continue incrementing');
+      });
+
+      tx.onabort = t.step_func(() => {
+        assert_unreached(`Transaction aborted: ${tx.error.message}`);
+      });
+      tx.oncomplete = t.step_func(() => { t.done(); });
+    },
+    description);
+}
+
+[
+  {
+    key: Math.pow(2, 60),
+    description: 'greater than 53 bits, less than 64 bits'
+  },
+  {
+    key: -Math.pow(2, 60),
+    description: 'greater than 53 bits, less than 64 bits (negative)'
+  },
+  {
+    key: Math.pow(2, 70),
+    description: 'greater than 64 bits, but still finite'
+  },
+  {
+    key: -Math.pow(2, 70),
+    description: 'greater than 64 bits, but still finite (negative)'
+  },
+  {
+    key: Infinity,
+    description: 'equal to Infinity'
+  },
+  {
+    key: -Infinity,
+    description: 'equal to -Infinity'
+  }
+].forEach(function(testCase) {
+  big_key_test(testCase.key,
+               `Key generator vs. explicit key ${testCase.description}`);
+});
+
+
+
+</script>

--- a/IndexedDB/keygenerator-explicit.html
+++ b/IndexedDB/keygenerator-explicit.html
@@ -72,6 +72,22 @@ function big_key_test(key, description) {
     description: 'greater than 53 bits, less than 64 bits (negative)'
   },
   {
+    key: Math.pow(2, 63),
+    description: '63 bits'
+  },
+  {
+    key: -Math.pow(2, 63),
+    description: '63 bits (negative)'
+  },
+  {
+    key: Math.pow(2, 64),
+    description: '64 bits'
+  },
+  {
+    key: -Math.pow(2, 64),
+    description: '64 bits (negative)'
+  },
+  {
     key: Math.pow(2, 70),
     description: 'greater than 64 bits, but still finite'
   },

--- a/IndexedDB/keygenerator-inject.html
+++ b/IndexedDB/keygenerator-inject.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Key Generator behavior with explicit keys and value injection</title>
+<link rel=help href="https://w3c.github.io/IndexedDB/#inject-key-into-value">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true, keyPath: 'id'});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    t.onabort = t.unreached_func('transaction should not abort');
+
+    const store = tx.objectStore('store');
+
+    store.put({name: 'a'}).onsuccess = t.step_func(e => {
+      const key = e.target.result;
+      assert_equals(key, 1, 'Key generator initial value should be 1');
+      store.get(key).onsuccess = t.step_func(e => {
+        const value = e.target.result;
+        assert_equals(typeof value, 'object', 'Result should be object');
+        assert_equals(value.name, 'a', 'Result should have name property');
+        assert_equals(value.id, key, 'Key should be injected');
+        t.done();
+      });
+    });
+  },
+  'Key is injected into value - simple path');
+
+indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true, keyPath: 'a.b.id'});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    t.onabort = t.unreached_func('transaction should not abort');
+
+    const store = tx.objectStore('store');
+
+    store.put({name: 'a'}).onsuccess = t.step_func(e => {
+      const key = e.target.result;
+      assert_equals(key, 1, 'Key generator initial value should be 1');
+      store.get(key).onsuccess = t.step_func(e => {
+        const value = e.target.result;
+        assert_equals(typeof value, 'object', 'Result should be object');
+        assert_equals(value.name, 'a', 'Result should have name property');
+        assert_equals(value.a.b.id, key, 'Key should be injected');
+        t.done();
+      });
+    });
+  },
+  'Key is injected into value - complex path');
+
+indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true, keyPath: 'id'});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const store = tx.objectStore('store');
+
+    assert_throws('DataError', () => {
+      store.put(123);
+    }, 'Key path should be checked against value');
+
+    t.done();
+  },
+  'put() throws if key cannot be injected - simple path');
+
+indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true, keyPath: 'a.b.id'});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const store = tx.objectStore('store');
+
+    assert_throws('DataError', () => {
+      store.put({a: 123});
+    }, 'Key path should be checked against value');
+
+    assert_throws('DataError', () => {
+      store.put({a: {b: 123} });
+    }, 'Key path should be checked against value');
+
+    t.done();
+  },
+  'put() throws if key cannot be injected - complex path');
+
+</script>


### PR DESCRIPTION
This covers two cases with key generators:

* With in-line keys where the key cannot be injected
* Generator behavior explicit keys above 2^53