### PR TITLE
Fix <input type="checkbox/radio"> assertions

### DIFF
--- a/html/semantics/forms/the-input-element/valueMode.html
+++ b/html/semantics/forms/the-input-element/valueMode.html
@@ -82,28 +82,28 @@ test(function () {
   var input = document.createElement("input");
   input.type = "checkbox";
   input.value = "foo";
-  assert_equals(input.value, "on");
+  assert_equals(input.value, "foo");
 }, "value IDL attribute of input type checkbox without value attribute");
 test(function() {
   var input = document.createElement("input");
   input.type = "checkbox";
   input.setAttribute("value", "bar");
   input.value = "foo";
-  assert_equals(input.value, "bar");
+  assert_equals(input.value, "foo");
 }, "value IDL attribute of input type checkbox with value attribute");
 
 test(function () {
   var input = document.createElement("input");
   input.type = "radio";
   input.value = "foo";
-  assert_equals(input.value, "on");
+  assert_equals(input.value, "foo");
 }, "value IDL attribute of input type radio without value attribute");
 test(function() {
   var input = document.createElement("input");
   input.type = "radio";
   input.setAttribute("value", "bar");
   input.value = "foo";
-  assert_equals(input.value, "bar");
+  assert_equals(input.value, "foo");
 }, "value IDL attribute of input type radio with value attribute");
 
 // MODE VALUE


### PR DESCRIPTION
Per https://html.spec.whatwg.org/multipage/#checkbox-state-(type=checkbox):dom-input-value-default-on
and https://html.spec.whatwg.org/multipage/#radio-button-state-(type=radio):dom-input-value-default-on ,
for `<input>`s of type `checkbox` or `radio`:
> The **`value` IDL attribute** is in mode **default/on**.

Per https://html.spec.whatwg.org/multipage/#dom-input-value-default-on
> The **`value` IDL attribute** [...] is in one of the following modes, which define its behavior:
>   [...]
>   **default/on**
>     On getting, if the element has a **`value` [content] attribute**, it must return that attribute's value; otherwise, it must return the string "on".
>     On setting, it must set the element's **`value` [content] attribute** to the new value.

The tests in question set `HTMLInputElement.value` and then immediately get `HTMLInputElement.value`
So the IDL attribute sets the content attribute. So there is always a content attribute.
So the getter never hits the "lacks a content attribute" case and always hits the "just return the content attribute's value" case.
So we should expect to get back the same value that we just set.