### PR TITLE
Fix standalone tests using queryImage()

### DIFF
--- a/referrer-policy/generic/subresource-test/image-decoding.html
+++ b/referrer-policy/generic/subresource-test/image-decoding.html
@@ -31,7 +31,7 @@
           assert_own_property(headers, "connection")
         });
         messaging_test.done();
-      });
+      }, null, "always", messaging_test);
     </script>
 
     <div id="log"></div>

--- a/referrer-policy/generic/unsupported-csp-referrer-directive.html
+++ b/referrer-policy/generic/unsupported-csp-referrer-directive.html
@@ -22,7 +22,7 @@
       queryImage(url, test.step_func(function(message) {
         assert_equals(message.referrer, document.location.href);
         test.done();
-      }));
+      }), null, 'always', test);
     </script>
 
     <div id="log"></div>


### PR DESCRIPTION
They broke after changes to queryImage were upstreamed from mozilla, but
the standalone tests weren't touched