### PR TITLE
[html] Account for bug that causes instability

### DIFF
--- a/html/semantics/document-metadata/styling/LinkStyle.html
+++ b/html/semantics/document-metadata/styling/LinkStyle.html
@@ -31,7 +31,7 @@
     <script>
       function waitForLinks(done) {
         function poll() {
-          if (getComputedStyle(target).textDecoration === "underline") {
+          if (getComputedStyle(target).zIndex === "1234") {
             setTimeout(done, 0);
             document.body.removeChild(beacon);
           } else {

--- a/html/semantics/document-metadata/styling/LinkStyle.html
+++ b/html/semantics/document-metadata/styling/LinkStyle.html
@@ -29,14 +29,46 @@
     <div id="test" style="display:none">STYLING TEST</div>
 
     <script>
-      test(function() {
-        var style = null,
-            i;
-        for (i = 1; i < 5; i++) {
-          style = document.getElementById("style" + i);
-          assert_equals(style.sheet, null, "The sheet attribute of style" + i + " should be null.");
-          assert_false(style.disabled, "The disabled attribute of style" + i + " should be false.");
+      function waitForLinks(done) {
+        function poll() {
+          if (getComputedStyle(target).textDecoration === "underline") {
+            setTimeout(done, 0);
+            document.body.removeChild(beacon);
+          } else {
+            setTimeout(poll, 50);
+          }
         }
+
+        var beacon = document.createElement("link");
+        var target = document.getElementById("test");
+        beacon.setAttribute("rel", "stylesheet");
+        beacon.setAttribute("href", "./support/beacon.css");
+
+        document.body.appendChild(beacon);
+        poll();
+      }
+
+      /**
+       * Browsers may incorrectly issue requests for these resources and defer
+       * definition of the `sheet` attribute until after loading is complete.
+       * In such cases, synchronous assertions regarding the absence of
+       * attributes will spuriously pass.
+       *
+       * In order to account for this incorrect behavior (exhibited at the time
+       * of this writing most notably by the Chromium browser), defer the
+       * assertions until a later-specified stylesheet has been loaded.
+       */
+      async_test(function(t) {
+        waitForLinks(t.step_func(function() {
+          var style = null,
+              i;
+          for (i = 1; i < 5; i++) {
+            style = document.getElementById("style" + i);
+            assert_equals(style.sheet, null, "The sheet attribute of style" + i + " should be null.");
+            assert_false(style.disabled, "The disabled attribute of style" + i + " should be false.");
+          }
+          t.done();
+        }));
       }, "The LinkStyle interface's sheet attribute must return null; the disabled attribute must be false");
 
       test(function() {

--- a/html/semantics/document-metadata/styling/LinkStyle.html
+++ b/html/semantics/document-metadata/styling/LinkStyle.html
@@ -29,25 +29,6 @@
     <div id="test" style="display:none">STYLING TEST</div>
 
     <script>
-      function waitForLinks(done) {
-        function poll() {
-          if (getComputedStyle(target).zIndex === "1234") {
-            setTimeout(done, 0);
-            document.body.removeChild(beacon);
-          } else {
-            setTimeout(poll, 50);
-          }
-        }
-
-        var beacon = document.createElement("link");
-        var target = document.getElementById("test");
-        beacon.setAttribute("rel", "stylesheet");
-        beacon.setAttribute("href", "./support/beacon.css");
-
-        document.body.appendChild(beacon);
-        poll();
-      }
-
       /**
        * Browsers may incorrectly issue requests for these resources and defer
        * definition of the `sheet` attribute until after loading is complete.
@@ -56,10 +37,10 @@
        *
        * In order to account for this incorrect behavior (exhibited at the time
        * of this writing most notably by the Chromium browser), defer the
-       * assertions until a later-specified stylesheet has been loaded.
+       * assertions until the "load" event has been triggered.
        */
       async_test(function(t) {
-        waitForLinks(t.step_func(function() {
+        window.addEventListener("load", t.step_func(function() {
           var style = null,
               i;
           for (i = 1; i < 5; i++) {
@@ -78,14 +59,17 @@
         assert_equals(link.sheet, null, "The sheet attribute of the link element not in a document should be null.");
       }, "The LinkStyle interface's sheet attribute must return null if the corresponding element is not in a Document");
 
-      test(function() {
-        var style = null,
-            i;
-        for (i = 5; i < 8; i++) {
-          style = document.getElementById("style" + i);
-          assert_true(style.sheet instanceof StyleSheet, "The sheet attribute of style" + i + " should be a StyleSheet object.");
-          assert_equals(style.disabled, style.sheet.disabled, "The disabled attribute of style" + i + " should equal to the same attribute of StyleSheet.");
-        }
+      async_test(function(t) {
+        window.addEventListener("load", t.step_func(function() {
+          var style = null,
+              i;
+          for (i = 5; i < 8; i++) {
+            style = document.getElementById("style" + i);
+            assert_true(style.sheet instanceof StyleSheet, "The sheet attribute of style" + i + " should be a StyleSheet object.");
+            assert_equals(style.disabled, style.sheet.disabled, "The disabled attribute of style" + i + " should equal to the same attribute of StyleSheet.");
+          }
+          t.done();
+        }));
       }, "The LinkStyle interface's sheet attribute must return StyleSheet object; the disabled attribute must be same as the StyleSheet's disabled attribute");
 
       test(function() {

--- a/html/semantics/document-metadata/styling/support/beacon.css
+++ b/html/semantics/document-metadata/styling/support/beacon.css
@@ -1,0 +1,3 @@
+#test {
+  text-decoration: underline;
+}

--- a/html/semantics/document-metadata/styling/support/beacon.css
+++ b/html/semantics/document-metadata/styling/support/beacon.css
@@ -1,3 +1,4 @@
 #test {
-  text-decoration: underline;
+  z-index: 1234;
+  position: relative;
 }

--- a/html/semantics/document-metadata/styling/support/beacon.css
+++ b/html/semantics/document-metadata/styling/support/beacon.css
@@ -1,4 +1,0 @@
-#test {
-  z-index: 1234;
-  position: relative;
-}


### PR DESCRIPTION
The Chromium browser currently implements incorrect semantics regarding
the `sheet` property of the `link` element. Defer assertions until such
time as incorrect behavior is known to be observable.