### PR TITLE
WritableStream: Add tests for re-entrant calls inside strategySize

### DIFF
--- a/streams/writable-streams/bad-strategies.js
+++ b/streams/writable-streams/bad-strategies.js
@@ -61,7 +61,7 @@ promise_test(t => {
 
   const writer = ws.getWriter();
 
-  const p1 = promise_rejects(t, error1, writer.write('a'), 'write should reject with the thrown error');
+  const p1 = promise_rejects(t, new TypeError(), writer.write('a'), 'write should reject with a TypeError');
 
   const p2 = promise_rejects(t, error1, writer.closed, 'closed should reject with the thrown error');
 

--- a/streams/writable-streams/reentrant-strategy.dedicatedworker.html
+++ b/streams/writable-streams/reentrant-strategy.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategy.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('reentrant-strategy.js'));
+</script>

--- a/streams/writable-streams/reentrant-strategy.html
+++ b/streams/writable-streams/reentrant-strategy.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategy.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+
+<script src="reentrant-strategy.js"></script>

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -1,11 +1,18 @@
 'use strict';
 
+// These tests exercise the pathological case of calling WritableStream* methods from within the strategy.size()
+// callback. This is not something any real code should ever do. Implementations are not expected to exhibit sane
+// behaviour in this case, but they should have the same behaviour. Failures here indicate subtle deviations from the
+// standard that may affect real, non-pathological code.
+
 if (self.importScripts) {
   self.importScripts('/resources/testharness.js');
   self.importScripts('../resources/test-utils.js');
   self.importScripts('../resources/recording-streams.js');
 }
 
+const error1 = { name: 'error1' };
+
 promise_test(() => {
   let writer;
   const strategy = {
@@ -20,35 +27,11 @@ promise_test(() => {
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
   return writer.write(2)
-      .then(() => Promise.resolve())
+      .then(() => Promise.resolve()) // See next test for why this is needed.
       .then(() => {
         assert_array_equals(ws.events, ['write', 0, 'write', 1, 'write', 2], 'writes should appear in order');
       });
 }, 'writes should be written in the standard order');
-
-promise_test(() => {
-  let writer;
-  const strategy = {
-    size(chunk) {
-      if (chunk > 0) {
-        writer.write(chunk - 1);
-      }
-      return chunk;
-    }
-  };
-
-  const ws = recordingWritableStream({}, strategy);
-  writer = ws.getWriter();
-  return writer.write(2)
-      .then(() => {
-        assert_array_equals(ws.events, ['write', 0, 'write', 1], 'promise should resolve early');
-        return writer.close();
-      })
-      .then(() => {
-        assert_array_equals(ws.events, ['write', 0, 'write', 1, 'write', 2, 'close'],
-                            'write should happen before close');
-      });
-}, 'writer.write() promise should resolve too early');
 
 promise_test(() => {
   let writer;
@@ -76,8 +59,57 @@ promise_test(() => {
         assert_array_equals(events, ['size', 2, 'size', 1, 'size', 0,
                                      'sink.write', 0, 'sink.write', 1, 'writer.write done', 2,
                                      'sink.write', 2, 'writer.write done', 1,
-                                     'writer.write done', 0]);
+                                     'writer.write done', 0],
+                            'events should happen in standard order');
       });
 }, 'writer.write() promises should resolve in the standard order');
+
+promise_test(t => {
+  let controller;
+  const strategy = {
+    size() {
+      controller.error(error1);
+      return 1;
+    }
+  };
+  const ws = recordingWritableStream({
+    start(c) {
+      controller = c;
+    }
+  }, strategy);
+  const resolved = [];
+  const writer = ws.getWriter();
+  const readyPromise1 = writer.ready.then(() => resolved.push('ready1'));
+  const writePromise = promise_rejects(t, error1, writer.write(),
+                                       'write() should reject with error1')
+                                           .then(() => resolved.push('write'));
+  const readyPromise2 = promise_rejects(t, error1, writer.ready, 'ready should reject with error1')
+      .then(() => resolved.push('ready2'));
+  const closedPromise = promise_rejects(t, error1, writer.closed, 'closed should reject with error1')
+      .then(() => resolved.push('closed'));
+  return Promise.all([readyPromise1, writePromise, readyPromise2, closedPromise])
+      .then(() => {
+        assert_array_equals(resolved, ['ready1', 'write', 'ready2', 'closed'],
+                            'promises should resolve in standard order');
+        assert_array_equals(ws.events, [], 'underlying sink write should not be called');
+      });
+}, 'controller.error() should work when called from within strategy.size()');
+
+promise_test(() => {
+  let writer;
+  const strategy = {
+    size() {
+      writer.close('C');
+      return 1;
+    }
+  };
+
+  const ws = recordingWritableStream({}, strategy);
+  writer = ws.getWriter();
+  return writer.write('W')
+      .then(() => {
+        assert_array_equals(ws.events, ['write', 'W', 'close', 'C'], 'close should happen after write');
+      });
+}, 'close() should be work when called from within strategy.size()');
 
 done();

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -1,8 +1,7 @@
 'use strict';
 
 // These tests exercise the pathological case of calling WritableStream* methods from within the strategy.size()
-// callback. This is not something any real code should ever do. Implementations are not expected to exhibit sane
-// behaviour in this case, but they should have the same behaviour. Failures here indicate subtle deviations from the
+// callback. This is not something any real code should ever do. Failures here indicate subtle deviations from the
 // standard that may affect real, non-pathological code.
 
 if (self.importScripts) {

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -116,6 +116,23 @@ promise_test(t => {
   let writer;
   const strategy = {
     size() {
+      writer.abort('nice');
+      return 1;
+    }
+  };
+
+  const ws = recordingWritableStream({}, strategy);
+  writer = ws.getWriter();
+  return promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject')
+      .then(() => {
+        assert_array_equals(ws.events, ['abort', 'nice'], 'sink.write() should not be called');
+      });
+}, 'abort() should work when called from within strategy.size()');
+
+promise_test(t => {
+  let writer;
+  const strategy = {
+    size() {
       writer.releaseLock();
       return 1;
     }

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -1,0 +1,83 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+  self.importScripts('../resources/recording-streams.js');
+}
+
+promise_test(() => {
+  let writer;
+  const strategy = {
+    size(chunk) {
+      if (chunk > 0) {
+        writer.write(chunk - 1);
+      }
+      return chunk;
+    }
+  };
+
+  const ws = recordingWritableStream({}, strategy);
+  writer = ws.getWriter();
+  return writer.write(2)
+      .then(() => Promise.resolve())
+      .then(() => {
+        assert_array_equals(ws.events, ['write', 0, 'write', 1, 'write', 2], 'writes should appear in order');
+      });
+}, 'writes should be written in the standard order');
+
+promise_test(() => {
+  let writer;
+  const strategy = {
+    size(chunk) {
+      if (chunk > 0) {
+        writer.write(chunk - 1);
+      }
+      return chunk;
+    }
+  };
+
+  const ws = recordingWritableStream({}, strategy);
+  writer = ws.getWriter();
+  return writer.write(2)
+      .then(() => {
+        assert_array_equals(ws.events, ['write', 0, 'write', 1], 'promise should resolve early');
+        return writer.close();
+      })
+      .then(() => {
+        assert_array_equals(ws.events, ['write', 0, 'write', 1, 'write', 2, 'close'],
+                            'write should happen before close');
+      });
+}, 'writer.write() promise should resolve too early');
+
+promise_test(() => {
+  let writer;
+  const events = [];
+  const strategy = {
+    size(chunk) {
+      events.push('size', chunk);
+      if (chunk > 0) {
+        writer.write(chunk - 1)
+            .then(() => events.push('writer.write done', chunk - 1));
+      }
+      return chunk;
+    }
+  };
+  const ws = new WritableStream({
+    write(chunk) {
+      events.push('sink.write', chunk);
+    }
+  }, strategy);
+  writer = ws.getWriter();
+  return writer.write(2)
+      .then(() => events.push('writer.write done', 2))
+      .then(() => flushAsyncEvents())
+      .then(() => {
+        assert_array_equals(events, ['size', 2, 'size', 1, 'size', 0,
+                                     'sink.write', 0, 'sink.write', 1, 'writer.write done', 2,
+                                     'sink.write', 2, 'writer.write done', 1,
+                                     'writer.write done', 0]);
+      });
+}, 'writer.write() promises should resolve in the standard order');
+
+done();

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -26,7 +26,6 @@ promise_test(() => {
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
   return writer.write(2)
-      .then(() => Promise.resolve()) // See next test for why this is needed.
       .then(() => {
         assert_array_equals(ws.events, ['write', 0, 'write', 1, 'write', 2], 'writes should appear in order');
       });

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -57,9 +57,9 @@ promise_test(() => {
       .then(() => flushAsyncEvents())
       .then(() => {
         assert_array_equals(events, ['size', 2, 'size', 1, 'size', 0,
-                                     'sink.write', 0, 'sink.write', 1, 'writer.write done', 2,
+                                     'sink.write', 0, 'sink.write', 1, 'writer.write done', 0,
                                      'sink.write', 2, 'writer.write done', 1,
-                                     'writer.write done', 0],
+                                     'writer.write done', 2],
                             'events should happen in standard order');
       });
 }, 'writer.write() promises should resolve in the standard order');
@@ -80,8 +80,8 @@ promise_test(t => {
   const resolved = [];
   const writer = ws.getWriter();
   const readyPromise1 = writer.ready.then(() => resolved.push('ready1'));
-  const writePromise = promise_rejects(t, error1, writer.write(),
-                                       'write() should reject with error1')
+  const writePromise = promise_rejects(t, new TypeError(), writer.write(),
+                                       'write() should reject with a TypeError')
                                            .then(() => resolved.push('write'));
   const readyPromise2 = promise_rejects(t, error1, writer.ready, 'ready should reject with error1')
       .then(() => resolved.push('ready2'));
@@ -95,21 +95,70 @@ promise_test(t => {
       });
 }, 'controller.error() should work when called from within strategy.size()');
 
-promise_test(() => {
+promise_test(t => {
   let writer;
   const strategy = {
     size() {
-      writer.close('C');
+      writer.close();
       return 1;
     }
   };
 
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
-  return writer.write('W')
+  return promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject')
       .then(() => {
-        assert_array_equals(ws.events, ['write', 'W', 'close', 'C'], 'close should happen after write');
+        assert_array_equals(ws.events, ['close'], 'sink.write() should not be called');
       });
-}, 'close() should be work when called from within strategy.size()');
+}, 'close() should work when called from within strategy.size()');
+
+promise_test(t => {
+  let writer;
+  const strategy = {
+    size() {
+      writer.releaseLock();
+      return 1;
+    }
+  };
+
+  const ws = recordingWritableStream({}, strategy);
+  writer = ws.getWriter();
+  const writePromise = promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject');
+  const readyPromise = promise_rejects(t, new TypeError(), writer.ready, 'ready promise should reject');
+  const closedPromise = promise_rejects(t, new TypeError(), writer.closed, 'closed promise should reject');
+  return Promise.all([writePromise, readyPromise, closedPromise])
+      .then(() => {
+        assert_array_equals(ws.events, [], 'sink.write() should not be called');
+      });
+}, 'releaseLock() should abort the write() when called within strategy.size()');
+
+promise_test(t => {
+  let writer1;
+  let ws;
+  let writePromise2;
+  let closePromise;
+  let closedPromise2;
+  const strategy = {
+    size(chunk) {
+      if (chunk > 0) {
+        writer1.releaseLock();
+        const writer2 = ws.getWriter();
+        writePromise2 = writer2.write(0);
+        closePromise = writer2.close();
+        closedPromise2 = writer2.closed;
+      }
+      return 1;
+    }
+  };
+  ws = recordingWritableStream({}, strategy);
+  writer1 = ws.getWriter();
+  const writePromise1 = promise_rejects(t, new TypeError(), writer1.write(1), 'write() promise should reject');
+  const readyPromise = promise_rejects(t, new TypeError(), writer1.ready, 'ready promise should reject');
+  const closedPromise1 = promise_rejects(t, new TypeError(), writer1.closed, 'closed promise should reject');
+  return Promise.all([writePromise1, readyPromise, closedPromise1, writePromise2, closePromise, closedPromise2])
+      .then(() => {
+        assert_array_equals(ws.events, ['write', 0, 'close'], 'sink.write() should only be called once');
+      });
+}, 'original reader should error when new reader is created within strategy.size()');
 
 done();

--- a/streams/writable-streams/reentrant-strategy.serviceworker.https.html
+++ b/streams/writable-streams/reentrant-strategy.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategy.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('reentrant-strategy.js', 'Service worker test setup');
+</script>

--- a/streams/writable-streams/reentrant-strategy.sharedworker.html
+++ b/streams/writable-streams/reentrant-strategy.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategy.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('reentrant-strategy.js'));
+</script>


### PR DESCRIPTION
A pathological implementation of strategy.size() can make re-entrant calls to WritableStream* methods. Implementations need to have standard behaviour in this case, so add tests to verify it.