### PR TITLE
Remove stray reference

### DIFF
--- a/docs/_appendix/github-intro.md
+++ b/docs/_appendix/github-intro.md
@@ -364,9 +364,6 @@ This is how to import the Pull Request's branch
 into your existing local checkout of the repository.
 If you don't have one, go [fork](#fork), [clone](#clone), and [configure](#configure-remote--upstream) it.
 
-If you would rather keep the PR separate from your usual working copy,
-have a look at [The Easy Way](#the-easy-way).
-
 1. Move into your local clone: `cd wherever-you-put-your-repo`
 2. Add a remote for the PR author's repo: `git remote add <author-id> git://github.com/<author-id>/<repo-name>.git`
 3. Fetch the PR: `git fetch <author-id> <name-of-the-PR-branch>`


### PR DESCRIPTION
The sentence and link removed by this commit refers to a section of the documentation that previously existed but was deleted. We should no longer refer to it.

by @frivoal 