### PR TITLE
Move tests for effect easing to timing-model;

### DIFF
--- a/service-workers/service-worker/performance-timeline.https.html
+++ b/service-workers/service-worker/performance-timeline.https.html
@@ -21,16 +21,10 @@ promise_test(t => {
     .then(_ => with_iframe(scope))
     .then(f => {
       frame = f;
-      return Promise.all([
-        // This will get effectively an empty service worker FetchEvent
-        // handler.  It should have no additional delay.  Note that the
-        // text() call is necessary to complete the response and have the
-        // timings show up in the performance entries.
-        frame.contentWindow.fetch(url).then(r => r && r.text()),
-        // This will cause the service worker to spin for two seconds
-        // in its FetchEvent handler.
-        frame.contentWindow.fetch(slowURL).then(r => r && r.text())
-      ]);
+      return frame.contentWindow.fetch(url).then(r => r && r.text());
+    })
+    .then(_ => {
+      return frame.contentWindow.fetch(slowURL).then(r => r && r.text());
     })
     .then(_ => {
       function elapsed(u) {
@@ -42,7 +36,7 @@ promise_test(t => {
       // Verify the request slowed by the service worker is indeed measured
       // to be slower.  Note, we compare to smaller delay instead of the exact
       // delay amount to avoid making the test racy under automation.
-      assert_true(slowURLTime >= urlTime + 1500,
+      assert_greater_than(slowURLTime, urlTime + 1000,
                   'Slow service worker request should measure increased delay.');
       frame.remove();
       return service_worker_unregister_and_done(t, scope);

--- a/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Keyframe handling tests</title>
+<title>Effect value computation tests when keyframes overlap</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -69,46 +69,5 @@ test(function(t) {
 }, 'Overlapping keyframes between 0 and 1 use the appropriate value on each'
    + ' side of the overlap point');
 
-test(function(t) {
-  var div = createDiv(t);
-  var anim = div.animate({ visibility: ['hidden','visible'] },
-                         { duration: 100 * MS_PER_SEC, fill: 'both' });
-
-  anim.currentTime = 0;
-  assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress = 0.');
-
-  anim.currentTime = 10 * MS_PER_SEC + 1;
-  assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress > 0 due to linear easing.');
-
-  anim.finish();
-  assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress = 1.');
-
-}, "Test visibility clamping behavior.");
-
-test(function(t) {
-  var div = createDiv(t);
-  var anim = div.animate({ visibility: ['hidden', 'visible'] },
-                         { duration: 100 * MS_PER_SEC, fill: 'both',
-                           easing: 'cubic-bezier(0.25, -0.6, 0, 0.5)' });
-
-  anim.currentTime = 0;
-  assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress = 0.');
-
-  // Timing function is below zero. So we expected visibility is hidden.
-  anim.currentTime = 10 * MS_PER_SEC + 1;
-  assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress < 0 due to cubic-bezier easing.');
-
-  anim.currentTime = 60 * MS_PER_SEC;
-  assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress > 0 due to cubic-bezier easing.');
-
-}, "Test visibility clamping behavior with an easing that has a negative component");
-
-done();
 </script>
 </body>

--- a/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Effect value computation tests for 'visibility' property</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<body>
+<div id="log"></div>
+<div id="target"></div>
+<script>
+'use strict';
+
+test(function(t) {
+  var div = createDiv(t);
+  var anim = div.animate({ visibility: ['hidden','visible'] },
+                         { duration: 100 * MS_PER_SEC, fill: 'both' });
+
+  anim.currentTime = 0;
+  assert_equals(getComputedStyle(div).visibility, 'hidden',
+                'Visibility when progress = 0.');
+
+  anim.currentTime = 10 * MS_PER_SEC + 1;
+  assert_equals(getComputedStyle(div).visibility, 'visible',
+                'Visibility when progress > 0 due to linear easing.');
+
+  anim.finish();
+  assert_equals(getComputedStyle(div).visibility, 'visible',
+                'Visibility when progress = 1.');
+
+}, "Test visibility clamping behavior.");
+
+test(function(t) {
+  var div = createDiv(t);
+  var anim = div.animate({ visibility: ['hidden', 'visible'] },
+                         { duration: 100 * MS_PER_SEC, fill: 'both',
+                           easing: 'cubic-bezier(0.25, -0.6, 0, 0.5)' });
+
+  anim.currentTime = 0;
+  assert_equals(getComputedStyle(div).visibility, 'hidden',
+                'Visibility when progress = 0.');
+
+  // Timing function is below zero. So we expected visibility is hidden.
+  anim.currentTime = 10 * MS_PER_SEC + 1;
+  assert_equals(getComputedStyle(div).visibility, 'hidden',
+                'Visibility when progress < 0 due to cubic-bezier easing.');
+
+  anim.currentTime = 60 * MS_PER_SEC;
+  assert_equals(getComputedStyle(div).visibility, 'visible',
+                'Visibility when progress > 0 due to cubic-bezier easing.');
+
+}, "Test visibility clamping behavior with an easing that has a negative component");
+
+</script>
+</body>

--- a/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
@@ -18,17 +18,17 @@ test(function(t) {
 
   anim.currentTime = 0;
   assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress = 0.');
+                'Visibility when progress = 0');
 
   anim.currentTime = 10 * MS_PER_SEC + 1;
   assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress > 0 due to linear easing.');
+                'Visibility when progress > 0 due to linear easing');
 
   anim.finish();
   assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress = 1.');
+                'Visibility when progress = 1');
 
-}, "Test visibility clamping behavior.");
+}, 'Visibility clamping behavior');
 
 test(function(t) {
   var div = createDiv(t);
@@ -38,18 +38,18 @@ test(function(t) {
 
   anim.currentTime = 0;
   assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress = 0.');
+                'Visibility when progress = 0');
 
   // Timing function is below zero. So we expected visibility is hidden.
   anim.currentTime = 10 * MS_PER_SEC + 1;
   assert_equals(getComputedStyle(div).visibility, 'hidden',
-                'Visibility when progress < 0 due to cubic-bezier easing.');
+                'Visibility when progress < 0 due to cubic-bezier easing');
 
   anim.currentTime = 60 * MS_PER_SEC;
   assert_equals(getComputedStyle(div).visibility, 'visible',
-                'Visibility when progress > 0 due to cubic-bezier easing.');
+                'Visibility when progress > 0 due to cubic-bezier easing');
 
-}, "Test visibility clamping behavior with an easing that has a negative component");
+}, 'Visibility clamping behavior with an easing that has a negative component');
 
 </script>
 </body>

--- a/web-animations/interfaces/KeyframeEffect/effect-easing.html
+++ b/web-animations/interfaces/KeyframeEffect/effect-easing.html
@@ -23,26 +23,6 @@ function assert_style_left_at(animation, time, easingFunction) {
                        easingFunction(portion) * 100 + ' at ' + time + 'ms');
 }
 
-gEffectEasingTests.forEach(function(options) {
-  test(function(t) {
-    var target = createDiv(t);
-    target.style.position = 'absolute';
-    var anim = target.animate([ { left: '0px' }, { left: '100px' } ],
-                              { duration: 1000,
-                                fill: 'forwards',
-                                easing: options.easing });
-    var easing = options.easingFunction;
-
-    anim.pause();
-
-    assert_style_left_at(anim, 0, easing);
-    assert_style_left_at(anim, 250, easing);
-    assert_style_left_at(anim, 500, easing);
-    assert_style_left_at(anim, 750, easing);
-    assert_style_left_at(anim, 1000, easing);
-  }, options.desc);
-});
-
 var gEffectEasingTestsWithKeyframeEasing = [
   {
     desc: 'effect easing produces values greater than 1 with keyframe ' +

--- a/web-animations/timing-model/time-transformations/transformed-progress.html
+++ b/web-animations/timing-model/time-transformations/transformed-progress.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Tests for the transformed progress</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#calculating-the-transformed-progress">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<script src="../../resources/effect-easing-tests.js"></script>
+<body>
+<div id="log"></div>
+<div id="target"></div>
+<script>
+'use strict';
+
+gEffectEasingTests.forEach(params => {
+  test(function(t) {
+    const target = createDiv(t);
+    const anim   = target.animate(null, { duration: 1000,
+                                          fill: 'forwards',
+                                          easing: params.easing });
+
+    [ 0, 250, 500, 750, 1000 ].forEach(sampleTime => {
+      anim.currentTime = sampleTime;
+      const portion = sampleTime / anim.effect.getComputedTiming().duration;
+      const expectedProgress = params.easingFunction(portion);
+      assert_approx_equals(anim.effect.getComputedTiming().progress,
+                           expectedProgress,
+                           0.01,
+                           'The progress should be approximately ' +
+                           expectedProgress + ` at ${sampleTime}ms`);
+    });
+  }, 'Transformed progress for ' + params.desc);
+});
+
+</script>
+</body>

--- a/workers/Worker_cross_origin_security_err.htm
+++ b/workers/Worker_cross_origin_security_err.htm
@@ -8,7 +8,7 @@ async_test(function(t) {
   try {
     var w = new Worker("ftp://example.org/support/WorkerBasic.js");
     w.onerror = t.step_func_done(function(e) {
-      assert_true(e instanceof ErrorEvent);
+      assert_true(e instanceof Event);
     });
   } catch (e) {
     t.step_func_done(function(e) { assert_true(true); });

--- a/workers/constructors/SharedWorker/same-origin.html
+++ b/workers/constructors/SharedWorker/same-origin.html
@@ -16,7 +16,7 @@ function testSharedWorkerHelper(t, script) {
   try {
     var worker = new SharedWorker(script, '');
     worker.onerror = t.step_func_done(function(e) {
-      assert_true(e instanceof ErrorEvent);
+      assert_true(e instanceof Event);
     });
   } catch (e) {
     t.step_func_done(function(e) { assert_true(true); });

--- a/workers/constructors/Worker/same-origin.html
+++ b/workers/constructors/Worker/same-origin.html
@@ -14,7 +14,7 @@ function testSharedWorkerHelper(t, script) {
   try {
     var worker = new SharedWorker(script, '');
     worker.onerror = t.step_func_done(function(e) {
-      assert_true(e instanceof ErrorEvent);
+      assert_true(e instanceof Event);
     });
   } catch (e) {
     t.step_func_done(function(e) { assert_true(true); });

--- a/workers/interfaces.idl
+++ b/workers/interfaces.idl
@@ -27,9 +27,12 @@ typedef OnErrorEventHandlerNonNull? OnErrorEventHandler;
 interface WorkerGlobalScope : EventTarget {
   readonly attribute WorkerGlobalScope self;
   readonly attribute WorkerLocation location;
+  readonly attribute WorkerNavigator navigator;
+
+  void importScripts(DOMString... urls);
 
   attribute OnErrorEventHandler onerror;
-  attribute EventHandler onlanguagechange;
+
   attribute EventHandler onoffline;
   attribute EventHandler ononline;
 };
@@ -41,11 +44,6 @@ interface WorkerGlobalScope : EventTarget {
   attribute EventHandler onmessage;
 };
 
-//[Exposed=Worker]
-partial interface WorkerGlobalScope { // not obsolete
-  void importScripts(DOMString... urls);
-  readonly attribute WorkerNavigator navigator;
-};
 WorkerGlobalScope implements WindowTimers;
 WorkerGlobalScope implements WindowBase64;
 

--- a/workers/interfaces.idl
+++ b/workers/interfaces.idl
@@ -28,7 +28,6 @@ interface WorkerGlobalScope : EventTarget {
   readonly attribute WorkerGlobalScope self;
   readonly attribute WorkerLocation location;
 
-  void close();
   attribute OnErrorEventHandler onerror;
   attribute EventHandler onlanguagechange;
   attribute EventHandler onoffline;
@@ -38,6 +37,7 @@ interface WorkerGlobalScope : EventTarget {
 [Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
 /*sealed*/ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
   void postMessage(any message, optional sequence<Transferable> transfer);
+  void close();
   attribute EventHandler onmessage;
 };
 


### PR DESCRIPTION

This set of tests are really just testing that we apply the timing function to
the animation effect so they belong in the appropriate part of the timing model
tests (and should check getComputedTiming not getComputedStyle).

I've also started to update tests to ES6 where appropriate since it seems
arrow functions, template literals, etc. are all supported on all UAs that
are implementing or likely to implement Web Animations.

MozReview-Commit-ID: 3kXao0Xi0BA

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332206