### PR TITLE
Rework tests for linear-equivalent cubic-bezier timing functions from effect-easing.html;

### DIFF
--- a/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Tests for calculation of the transformed distance when computing an effect value</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<script src="../../resources/effect-easing-tests.js"></script>
+<body>
+<div id="log"></div>
+<div id="target"></div>
+<script>
+'use strict';
+
+// Test that a linear-equivalent cubic-bezier easing applied to a keyframe does
+// not alter (including clamping) the result.
+
+gEffectEasingTests.forEach(params => {
+  const linearEquivalentEasings = [ 'cubic-bezier(0, 0, 0, 0)',
+                                    'cubic-bezier(1, 1, 1, 1)' ];
+  test(function(t) {
+    linearEquivalentEasings.forEach(linearEquivalentEasing => {
+      const timing = { duration: 1000,
+                       fill: 'forwards',
+                       easing: params.easing };
+
+      const linearTarget = createDiv(t);
+      const linearAnim = linearTarget.animate([ { width: '0px' },
+                                                { width: '100px' } ],
+                                              timing);
+
+      const equivalentTarget = createDiv(t);
+      const equivalentAnim =
+        equivalentTarget.animate([ { width: '0px',
+                                     easing: linearEquivalentEasing },
+                                   { width: '100px' } ],
+                                 timing);
+
+      [ 0, 250, 500, 750, 1000 ].forEach(sampleTime => {
+        linearAnim.currentTime = sampleTime;
+        equivalentAnim.currentTime = sampleTime;
+
+        assert_equals(getComputedStyle(linearTarget).width,
+                      getComputedStyle(equivalentTarget).width,
+                      `The 'width' of the animated elements should be equal ` +
+                      `at ${sampleTime}ms`);
+      });
+    });
+  }, 'Linear-equivalent cubic-bezier keyframe easing applied to an effect ' +
+     `with a ${params.desc} does not alter the result`);
+});
+
+</script>
+</body>

--- a/web-animations/interfaces/KeyframeEffect/effect-easing.html
+++ b/web-animations/interfaces/KeyframeEffect/effect-easing.html
@@ -23,59 +23,6 @@ function assert_style_left_at(animation, time, easingFunction) {
                        easingFunction(portion) * 100 + ' at ' + time + 'ms');
 }
 
-var gEffectEasingTestsWithKeyframeEasing = [
-  {
-    desc: 'effect easing produces values greater than 1 with keyframe ' +
-          'easing cubic-bezier(0, 0, 0, 0)',
-    easing: 'cubic-bezier(0, 1.5, 1, 1.5)',
-    keyframeEasing: 'cubic-bezier(0, 0, 0, 0)', // linear
-    easingFunction: cubicBezier(0, 1.5, 1, 1.5)
-  },
-  {
-    desc: 'effect easing produces values greater than 1 with keyframe ' +
-          'easing cubic-bezier(1, 1, 1, 1)',
-    easing: 'cubic-bezier(0, 1.5, 1, 1.5)',
-    keyframeEasing: 'cubic-bezier(1, 1, 1, 1)', // linear
-    easingFunction: cubicBezier(0, 1.5, 1, 1.5)
-  },
-  {
-    desc: 'effect easing produces negative values 1 with keyframe ' +
-          'easing cubic-bezier(0, 0, 0, 0)',
-    easing: 'cubic-bezier(0, -0.5, 1, -0.5)',
-    keyframeEasing: 'cubic-bezier(0, 0, 0, 0)', // linear
-    easingFunction: cubicBezier(0, -0.5, 1, -0.5)
-  },
-  {
-    desc: 'effect easing produces negative values 1 with keyframe ' +
-          'easing cubic-bezier(1, 1, 1, 1)',
-    easing: 'cubic-bezier(0, -0.5, 1, -0.5)',
-    keyframeEasing: 'cubic-bezier(1, 1, 1, 1)', // linear
-    easingFunction: cubicBezier(0, -0.5, 1, -0.5)
-  },
-];
-
-gEffectEasingTestsWithKeyframeEasing.forEach(function(options) {
-  test(function(t) {
-    var target = createDiv(t);
-    target.style.position = 'absolute';
-    var anim = target.animate(
-      [ { left: '0px', easing: options.keyframeEasing },
-        { left: '100px' } ],
-        { duration: 1000,
-          fill: 'forwards',
-          easing: options.easing });
-    var easing = options.easingFunction;
-
-    anim.pause();
-
-    assert_style_left_at(anim, 0, easing);
-    assert_style_left_at(anim, 250, easing);
-    assert_style_left_at(anim, 500, easing);
-    assert_style_left_at(anim, 750, easing);
-    assert_style_left_at(anim, 1000, easing);
-  }, options.desc);
-});
-
 // Other test cases that effect easing produces values outside of [0,1].
 test(function(t) {
   var target = createDiv(t);

--- a/web-animations/resources/effect-easing-tests.js
+++ b/web-animations/resources/effect-easing-tests.js
@@ -67,6 +67,11 @@ var gEffectEasingTests = [
     desc: 'easing function which produces values greater than 1',
     easing: 'cubic-bezier(0, 1.5, 1, 1.5)',
     easingFunction: cubicBezier(0, 1.5, 1, 1.5)
+  },
+  {
+    desc: 'easing function which produces values less than 1',
+    easing: 'cubic-bezier(0, -0.5, 1, -0.5)',
+    easingFunction: cubicBezier(0, -0.5, 1, -0.5)
   }
 ];
 


### PR DESCRIPTION

The purpose of these tests appears to be to check that a linear-equivalent
cubic-bezier timing function (e.g. 'cubic-bezier(0, 0, 0, 0)') does not affect
the result such as clamping values out of the [0, 1] range.

This test really is testing the calculation of the 'transformed distance' in
the "The effect value of a keyframe effect" so we move the test there and
rework it to more clearly test what it is intended to cover.

MozReview-Commit-ID: 9sEr7MlVZKL

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332206