### PR TITLE
Drop step timing function for compositor animations;

### DIFF
--- a/web-animations/timing-model/time-transformations/transformed-progress.html
+++ b/web-animations/timing-model/time-transformations/transformed-progress.html
@@ -55,25 +55,6 @@ var gStepTimingFunctionTests = [
                 ]
   },
   {
-    description: 'Test bounds point of step-start easing with compositor',
-    keyframe:   [ { opacity: 0 },
-                  { opacity: 1 } ],
-    effect:     {
-                  delay: 1000,
-                  duration: 1000,
-                  fill: 'both',
-                  easing: 'steps(2, start)'
-                },
-    conditions: [
-                  { currentTime: 0,    progress: 0 },
-                  { currentTime: 999,  progress: 0 },
-                  { currentTime: 1000, progress: 0.5 },
-                  { currentTime: 1499, progress: 0.5 },
-                  { currentTime: 1500, progress: 1 },
-                  { currentTime: 2000, progress: 1 }
-                ]
-  },
-  {
     description: 'Test bounds point of step-start easing with reverse direction',
     keyframe:   [ { width: '0px' },
                   { width: '100px' } ],


### PR DESCRIPTION

This seems like a Gecko-specific test and even then it's not clear why we
expect the result could be different in this case.

MozReview-Commit-ID: Ix8jZLobwcA

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332206