### PR TITLE
Add missing tests for steps-end in delay phase;

### DIFF
--- a/web-animations/timing-model/time-transformations/transformed-progress.html
+++ b/web-animations/timing-model/time-transformations/transformed-progress.html
@@ -194,6 +194,23 @@ var gStepTimingFunctionTests = [
                 ]
   },
   {
+    description: 'Test bounds point of step-end easing',
+    effect:     {
+                  delay: 1000,
+                  duration: 1000,
+                  fill: 'both',
+                  easing: 'steps(2, end)'
+                },
+    conditions: [
+                  { currentTime: 0,    progress: 0 },
+                  { currentTime: 999,  progress: 0 },
+                  { currentTime: 1000, progress: 0 },
+                  { currentTime: 1499, progress: 0 },
+                  { currentTime: 1500, progress: 0.5 },
+                  { currentTime: 2000, progress: 1 }
+                ]
+  },
+  {
     description: 'Test bounds point of step-end easing ' +
                  'with iterationStart and delay',
     effect:     {


### PR DESCRIPTION

(Once we remove the special clamping behvaior later in this patch series, the
added test here will fail if we don't add special handling for the case
when the progress is zero and we are in the delay phase.)

MozReview-Commit-ID: Dnon2soE1Se

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332206