### PR TITLE
Refactor embed-ignored-in-media-element to make it simple to test the same thing with <object>.

### DIFF
--- a/html/semantics/embedded-content/the-embed-element/embed-ignored-in-media-element.html
+++ b/html/semantics/embedded-content/the-embed-element/embed-ignored-in-media-element.html
@@ -5,18 +5,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name="assert" content="Check if the embed element is ignored when used inside a media element">
 <script type="application/javascript">
- window.childLoaded = false;
- async_test(function() {
-   addEventListener("load", this.step_func_done(function() {
-     assert_false(window.childLoaded);
-   }));
- }, "Test embed being ignored inside media element");
+  var nestingTest = async_test("Test embed being ignored inside media element");
+  onload = nestingTest.step_func_done(function() {
+    assert_true(true, "We got to a load event without loading things we should not load");
+  });
 </script>
 <body>
   <video>
-    <embed type="text/html" src="embed-iframe.html" />
+    <embed type="text/html" src="../resources/should-not-load.html"
+           test-description="<embed> in <video>">
   </video>
   <audio>
-    <embed type="text/html" src="embed-iframe.html" />
+    <embed type="text/html" src="../resources/should-not-load.html"
+           test-description="<embed> in <audio>">
   </audio>
 </body>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332956