### PR TITLE
Implement the same behavior for <object>-inside-<object> and <object>-inside-mediaelement as we do for <embed> already.

### DIFF
--- a/html/semantics/embedded-content/the-object-element/object-ignored-in-media-element.html
+++ b/html/semantics/embedded-content/the-object-element/object-ignored-in-media-element.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>HTML Test: The embed element represents a document</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta name="assert" content="Check if the object element is ignored when used inside a media element">
+<script type="application/javascript">
+  var nestingTest = async_test("Test <object> being ignored inside media element");
+  onload = nestingTest.step_func_done(function() {
+    assert_true(true, "We got to a load event without loading things we should not load");
+  });
+</script>
+<body>
+  <video>
+    <object type="text/html" data="../resources/should-not-load.html"
+            test-description="<object> in <video>"></object>
+  </video>
+  <audio>
+    <object type="text/html" data="../resources/should-not-load.html"
+            test-description="<object> in <audio>"></object>
+  </audio>
+</body>

--- a/html/semantics/embedded-content/the-object-element/object-in-object-fallback-2.html
+++ b/html/semantics/embedded-content/the-object-element/object-in-object-fallback-2.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <title></title>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script>
+      var loadedCount = 0;
+      var nestingTest = async_test("Test <object> nesting inside <object>");
+      onload = nestingTest.step_func_done(function() {
+        assert_equals(loadedCount, 12, "Should have loaded all should-load elements");
+      });
+    </script>
+    <style>
+      object { display: none }
+    </style>
+  </head>
+  <body>
+    <object data="../resources/should-load.html" style="width: 100px; height: 100px">
+      <object type="text/html" data="../resources/should-not-load.html"
+              test-description="<object> inside <object>"></object>
+    </object>
+    <object style="width: 100px; height: 100px" data="data:application/x-does-not-exist,test">
+      <object type="text/html" data="../resources/should-load.html"></object>
+    </object>
+    <object style="width: 100px; height: 100px" data="data:application/x-does-not-exist,test">
+      <div></div>
+      <object type="text/html" data="../resources/should-load.html"></object>
+    </object>
+    <object style="width: 100px; height: 100px" data="data:application/x-does-not-exist,test">
+      <div>
+        <object type="text/html" data="../resources/should-load.html"></object>
+      </div>
+    </object>
+    <object style="width: 100px; height: 100px" data="data:application/x-does-not-exist,test">
+      <object type="text/html" data="../resources/should-load.html"></object>
+      <object type="text/html" data="../resources/should-load.html"></object>
+      <object data="../resources/should-load.html">
+        <object type="text/html" data="../resources/should-not-load.html"
+                test-description="<object> inside loaded <object> inside non-loaded <object>"></object>
+      </object>
+      <object data="data:application/x-does-not-exist,test">
+        <object type="text/html" data="../resources/should-load.html"></object>
+      </object>
+    </object>
+    <div>
+      <object data="../resources/should-load.html" style="width: 100px; height: 100px"></object>
+      <object type="text/html" data="../resources/should-load.html"></object>
+    </div>
+    <div>
+      <object type="text/html" data="../resources/should-load.html"></object>
+      <object data="../resources/should-load.html" style="width: 100px; height: 100px"></object>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1332956