### PR TITLE
XMLHttpRequest should reset timers when send() is executed again,

### DIFF
--- a/XMLHttpRequest/xmlhttprequest-timeout-reused.html
+++ b/XMLHttpRequest/xmlhttprequest-timeout-reused.html
@@ -1,0 +1,48 @@
+ <!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>XHR2 Timeout Property Tests</title>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#timeout-error" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-timeout-attribute" data-tested-assertations="following::ol[1]/li[2]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#handler-xhr-ontimeout" data-tested-assertations="../.."/>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#timeout-error" data-tested-assertations=".."/>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#request-error" data-tested-assertations="following::ol[1]/li[9]"/>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#infrastructure-for-the-send()-method" data-tested-assertations="following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/.. following-sibling::dl//code[contains(@title,'dom-XMLHttpRequest-timeout')]/../following-sibling::dd following::dt[1] following::dd[1]" />
+    <meta name=timeout content=long>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="log"></div>
+    <script type="text/javascript">
+
+function startRequest() {
+    xhr.open("GET", "./resources/content.py?content=Hi", true);
+    xhr.timeout = 2000;
+    setTimeout(function () {
+      xhr.send();
+    }, 1000);
+}
+
+var test = async_test();
+test.step(function()
+{
+    var count = 0;
+    xhr = new XMLHttpRequest();
+    xhr.onload = function () {
+        assert_equals(xhr.response, "Hi");
+        if (++count == 2) {
+            test.done();
+        }
+    }
+    xhr.ontimeout = function () {
+      assert_unreached("HTTP error should not timeout");
+    }
+    startRequest();
+    setTimeout(startRequest, 3500);
+});
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1328470