### PR TITLE
Fix idlharness to properly handle FrozenArray return types.

### DIFF
--- a/html/dom/interfaces.html
+++ b/html/dom/interfaces.html
@@ -201,7 +201,7 @@ function doTest([untested, tested]) {
     AbstractWorker: [],
     Worker: [],
     SharedWorker: [],
-    MessageEvent: [],
+    MessageEvent: ['new MessageEvent("message", { data: 5 })'],
     MessageChannel: [],
     MessagePort: [],
     HTMLAppletElement: ['document.createElement("applet")'],


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1306170