### PR TITLE
Revert "Remove the service-worker version of get-host-info.sub.js."

### DIFF
--- a/service-workers/service-worker/client-navigate.https.html
+++ b/service-workers/service-worker/client-navigate.https.html
@@ -3,7 +3,7 @@
 <title>Service Worker: WindowClient.navigate</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
   function wait_for_message(msg) {

--- a/service-workers/service-worker/clients-get-cross-origin.https.html
+++ b/service-workers/service-worker/clients-get-cross-origin.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: Clients.get across origins</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/clients-get.https.html
+++ b/service-workers/service-worker/clients-get.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: Clients.get</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/fetch-canvas-tainting-cache.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting-cache.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: canvas tainting of the fetched image using cached responses</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-canvas-tainting.https.html
+++ b/service-workers/service-worker/fetch-canvas-tainting.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: canvas tainting of the fetched image</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-cors-xhr.https.html
+++ b/service-workers/service-worker/fetch-cors-xhr.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: CORS XHR of fetch()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-csp.https.html
+++ b/service-workers/service-worker/fetch-csp.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: CSP control of fetch()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/fetch-event-redirect.https.html
+++ b/service-workers/service-worker/fetch-event-redirect.https.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="resources/testharness-helpers.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-frame-resource.https.html
+++ b/service-workers/service-worker/fetch-frame-resource.https.html
@@ -3,7 +3,7 @@
 <meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-header-visibility.https.html
+++ b/service-workers/service-worker/fetch-header-visibility.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: Visibility of headers during fetch.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/fetch-mixed-content-to-inscope.https.html
+++ b/service-workers/service-worker/fetch-mixed-content-to-inscope.https.html
@@ -3,7 +3,7 @@
 <meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body></body>
 <script>

--- a/service-workers/service-worker/fetch-mixed-content-to-outscope.https.html
+++ b/service-workers/service-worker/fetch-mixed-content-to-outscope.https.html
@@ -3,7 +3,7 @@
 <meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <body></body>
 <script>

--- a/service-workers/service-worker/fetch-request-css-base-url.https.html
+++ b/service-workers/service-worker/fetch-request-css-base-url.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: CSS's base URL must be the request URL even when fetched from other URL</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/fetch-request-css-images.https.html
+++ b/service-workers/service-worker/fetch-request-css-images.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: FetchEvent for css image</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 var SCOPE = 'resources/fetch-request-resources-iframe.https.html';

--- a/service-workers/service-worker/fetch-request-fallback.https.html
+++ b/service-workers/service-worker/fetch-request-fallback.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: the fallback behavior of FetchEvent</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 var expected_urls = [];

--- a/service-workers/service-worker/fetch-request-redirect.https.html
+++ b/service-workers/service-worker/fetch-request-redirect.https.html
@@ -3,7 +3,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 

--- a/service-workers/service-worker/fetch-request-resources.https.html
+++ b/service-workers/service-worker/fetch-request-resources.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: FetchEvent for resources</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 var url_count = 0;

--- a/service-workers/service-worker/fetch-request-xhr.https.html
+++ b/service-workers/service-worker/fetch-request-xhr.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: the body of FetchEvent using XMLHttpRequest</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/fetch-response-xhr.https.html
+++ b/service-workers/service-worker/fetch-response-xhr.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: the response of FetchEvent using XMLHttpRequest</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/fetch-waits-for-activate.https.html
+++ b/service-workers/service-worker/fetch-waits-for-activate.https.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="resources/testharness-helpers.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/getregistrations.https.html
+++ b/service-workers/service-worker/getregistrations.https.html
@@ -3,7 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="../fetch/resources/fetch-test-helpers.sub.js"></script>
 <script>
 // Purge the existing registrations for the origin.

--- a/service-workers/service-worker/invalid-blobtype.https.html
+++ b/service-workers/service-worker/invalid-blobtype.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: respondWith with header value containing a null byte</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/invalid-header.https.html
+++ b/service-workers/service-worker/invalid-header.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: respondWith with header value containing a null byte</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/navigate-window.https.html
+++ b/service-workers/service-worker/navigate-window.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: Navigate a Window</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/navigation-redirect.https.html
+++ b/service-workers/service-worker/navigation-redirect.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: Navigation redirection</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/postmessage-to-client.https.html
+++ b/service-workers/service-worker/postmessage-to-client.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: postMessage to Client</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 var frame;

--- a/service-workers/service-worker/referer.https.html
+++ b/service-workers/service-worker/referer.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: check referer of fetch()</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 async_test(function(t) {

--- a/service-workers/service-worker/register-closed-window.https.html
+++ b/service-workers/service-worker/register-closed-window.https.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="resources/testharness-helpers.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <body>
 <script>

--- a/service-workers/service-worker/resource-timing.https.html
+++ b/service-workers/service-worker/resource-timing.https.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
 <script>
 function resourceUrl(path) {

--- a/service-workers/service-worker/resources/client-navigate-worker.js
+++ b/service-workers/service-worker/resources/client-navigate-worker.js
@@ -1,6 +1,6 @@
 importScripts("worker-testharness.js");
 importScripts("test-helpers.sub.js");
-importScripts("/common/get-host-info.sub.js")
+importScripts("get-host-info.sub.js")
 importScripts("testharness-helpers.js")
 
 self.onfetch = function(e) {

--- a/service-workers/service-worker/resources/clients-get-other-origin.html
+++ b/service-workers/service-worker/resources/clients-get-other-origin.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/resources/dummy-worker-interceptor.js
+++ b/service-workers/service-worker/resources/dummy-worker-interceptor.js
@@ -1,4 +1,4 @@
-importScripts('/common/get-host-info.sub.js');
+importScripts('get-host-info.sub.js');
 
 var worker_text = 'postMessage("worker loading intercepted by service worker"); ';
 

--- a/service-workers/service-worker/resources/fetch-canvas-tainting-iframe.html
+++ b/service-workers/service-worker/resources/fetch-canvas-tainting-iframe.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var image_path = base_path() + 'fetch-access-control.py?PNGIMAGE';

--- a/service-workers/service-worker/resources/fetch-cors-xhr-iframe.html
+++ b/service-workers/service-worker/resources/fetch-cors-xhr-iframe.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var path = base_path() + 'fetch-access-control.py';

--- a/service-workers/service-worker/resources/fetch-csp-iframe.html
+++ b/service-workers/service-worker/resources/fetch-csp-iframe.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var image_path = base_path() + 'fetch-access-control.py?PNGIMAGE';

--- a/service-workers/service-worker/resources/fetch-header-visibility-iframe.html
+++ b/service-workers/service-worker/resources/fetch-header-visibility-iframe.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
   var host_info = get_host_info();

--- a/service-workers/service-worker/resources/fetch-mixed-content-iframe-inscope-to-inscope.html
+++ b/service-workers/service-worker/resources/fetch-mixed-content-iframe-inscope-to-inscope.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var image_path = base_path() + 'fetch-access-control.py?PNGIMAGE';

--- a/service-workers/service-worker/resources/fetch-mixed-content-iframe-inscope-to-outscope.html
+++ b/service-workers/service-worker/resources/fetch-mixed-content-iframe-inscope-to-outscope.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var image_path = base_path() + 'fetch-access-control.py?PNGIMAGE';

--- a/service-workers/service-worker/resources/fetch-mixed-content-iframe.html
+++ b/service-workers/service-worker/resources/fetch-mixed-content-iframe.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var params = get_query_params(location.href);

--- a/service-workers/service-worker/resources/fetch-request-css-base-url-worker.js
+++ b/service-workers/service-worker/resources/fetch-request-css-base-url-worker.js
@@ -1,4 +1,4 @@
-importScripts('/common/get-host-info.sub.js');
+importScripts('../resources/get-host-info.sub.js');
 importScripts('test-helpers.sub.js');
 
 var port = undefined;

--- a/service-workers/service-worker/resources/fetch-request-xhr-iframe.https.html
+++ b/service-workers/service-worker/resources/fetch-request-xhr-iframe.https.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var port;

--- a/service-workers/service-worker/resources/fetch-response-xhr-iframe.https.html
+++ b/service-workers/service-worker/resources/fetch-response-xhr-iframe.https.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/resources/get-host-info.sub.js
+++ b/service-workers/service-worker/resources/get-host-info.sub.js
@@ -1,0 +1,17 @@
+function get_host_info() {
+  const HTTP_PORT = '{{ports[http][0]}}';
+  const HTTPS_PORT = '{{ports[https][0]}}';
+  const ORIGINAL_HOST = '{{host}}';
+  const REMOTE_HOST = '{{domains[www1]}}';
+  const OTHER_HOST = '{{domains[www2]}}';
+  return {
+    HTTP_ORIGIN: 'http://' + ORIGINAL_HOST + ':' + HTTP_PORT,
+    HTTPS_ORIGIN: 'https://' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTPS_ORIGIN_WITH_CREDS: 'https://foo:bar@' + ORIGINAL_HOST + ':' + HTTPS_PORT,
+    HTTP_REMOTE_ORIGIN: 'http://' + REMOTE_HOST + ':' + HTTP_PORT,
+    HTTPS_REMOTE_ORIGIN: 'https://' + REMOTE_HOST + ':' + HTTPS_PORT,
+    HTTPS_REMOTE_ORIGIN_WITH_CREDS: 'https://foo:bar@' + REMOTE_HOST + ':' + HTTPS_PORT,
+    UNAUTHENTICATED_ORIGIN: 'http://' + OTHER_HOST + ':' + HTTP_PORT,
+    AUTHENTICATED_ORIGIN: 'https://' + OTHER_HOST + ':' + HTTPS_PORT
+  };
+}

--- a/service-workers/service-worker/resources/navigation-redirect-other-origin.html
+++ b/service-workers/service-worker/resources/navigation-redirect-other-origin.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/resources/referer-iframe.html
+++ b/service-workers/service-worker/resources/referer-iframe.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js"></script>
 <script>
 function check_referer(url, expected_referer) {

--- a/service-workers/service-worker/resources/service-worker-csp-worker.py
+++ b/service-workers/service-worker/resources/service-worker-csp-worker.py
@@ -1,7 +1,7 @@
 bodyDefault = '''
 importScripts('worker-testharness.js');
 importScripts('test-helpers.sub.js');
-importScripts('/common/get-host-info.sub.js');
+importScripts('../resources/get-host-info.sub.js');
 
 var host_info = get_host_info();
 
@@ -47,7 +47,7 @@ async_test(function(t) {
 bodyScript = '''
 importScripts('worker-testharness.js');
 importScripts('test-helpers.sub.js');
-importScripts('/common/get-host-info.sub.js');
+importScripts('../resources/get-host-info.sub.js');
 
 var host_info = get_host_info();
 
@@ -93,7 +93,7 @@ async_test(function(t) {
 bodyConnect = '''
 importScripts('worker-testharness.js');
 importScripts('test-helpers.sub.js');
-importScripts('/common/get-host-info.sub.js');
+importScripts('../resources/get-host-info.sub.js');
 
 var host_info = get_host_info();
 

--- a/service-workers/service-worker/resources/worker-interception-iframe.https.html
+++ b/service-workers/service-worker/resources/worker-interception-iframe.https.html
@@ -1,4 +1,4 @@
-<script src="/common/get-host-info.sub.js"></script>
+<script src="../resources/get-host-info.sub.js"></script>
 <script src="test-helpers.sub.js?pipe=sub"></script>
 <script>
 var host_info = get_host_info();

--- a/service-workers/service-worker/resources/worker-load-interceptor.js
+++ b/service-workers/service-worker/resources/worker-load-interceptor.js
@@ -1,4 +1,4 @@
-importScripts('/common/get-host-info.sub.js');
+importScripts('get-host-info.sub.js');
 
 var response_text = "This load was successfully intercepted.";
 var response_script = "postMessage(\"This load was successfully intercepted.\");";

--- a/service-workers/service-worker/websocket.https.html
+++ b/service-workers/service-worker/websocket.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: WebSocket handshake channel is not intercepted</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 

--- a/service-workers/service-worker/xhr.https.html
+++ b/service-workers/service-worker/xhr.https.html
@@ -2,7 +2,7 @@
 <title>Service Worker: XHR doesn't exist</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/common/get-host-info.sub.js"></script>
+<script src="resources/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
 <script>
 


### PR DESCRIPTION
Reverts w3c/web-platform-tests#4862

The two get-host-info.sub.js files should be sync-ed before the service worker version can be deleted.