### PR TITLE
[service-workers] Avoid race condition in test

### DIFF
--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -22,22 +22,34 @@ t.step(function() {
 
     function onRegister(registration) {
         var sw = registration.installing;
+        sw.addEventListener('statechange', t.step_func(function(event) {
+            if (event.target.state == 'activated') {
+                onActive(sw);
+            }
+        }));
+    }
+
+    function onActive(sw) {
         var port = sendMessagePort(sw);
         port.addEventListener('message', t.step_func(function(event) {
             onMessage(event);
         }), false);
         port.start();
-        sw.addEventListener('statechange', t.step_func(function(event) {
-            if (event.target.state == 'activated')
-                onActive();
-        }));
-    }
-
-    function onActive() {
-        with_iframe(scope).then(function(f) { frames.push(f); });
     }
 
     function onMessage(event) {
+        if (event.data === 'received port') {
+            onPortReady();
+        } else {
+            onResult(event);
+        }
+    }
+
+    function onPortReady() {
+        with_iframe(scope).then(function(f) { frames.push(f); });
+    }
+
+    function onResult(event) {
         assert_equals(
             event.data.url,
             location.href.substring(0, location.href.lastIndexOf('/') + 1) +

--- a/service-workers/service-worker/resources/request-end-to-end-worker.js
+++ b/service-workers/service-worker/resources/request-end-to-end-worker.js
@@ -1,4 +1,8 @@
 var port = undefined;
+// Create a then-able object that is never resolved.
+function createPending() {
+  return { then: createPending };
+}
 
 onmessage = function(e) {
   var message = e.data;
@@ -6,6 +10,11 @@ onmessage = function(e) {
     port = message.port;
 
     port.postMessage('received port');
+    // The ServiceWorker which handles the "message" event must persist long
+    // enough to handle the subsequent "fetch" event. To promote test
+    // simplicity, the worker prevents its own termination indefinitely via a
+    // then-able that is never resolved.
+    e.waitUntil(createPending());
   }
 };
 

--- a/service-workers/service-worker/resources/request-end-to-end-worker.js
+++ b/service-workers/service-worker/resources/request-end-to-end-worker.js
@@ -4,6 +4,8 @@ onmessage = function(e) {
   var message = e.data;
   if (typeof message === 'object' && 'port' in message) {
     port = message.port;
+
+    port.postMessage('received port');
   }
 };
 


### PR DESCRIPTION
The parent document in this test first sends a message to the
ServiceWorker and later triggers a `fetch` event. Prior to this commit,
the test initiated these two operations independently but required that
the Service Worker's `onmessage` handler was invoked prior to its
`onfetch` handler. However, because user agents may define independent
task queues for `fetch` and `postMessage` [1], there the sequence in
which the tasks are handled is not guaranteed. By incorrectly assuming
the determinacy of event order, the test created a race condition in
user agents that maintain two queues.

Re-factor the test to force a consistent execution order.

[1] From https://html.spec.whatwg.org/multipage/webappapis.html#task-queue

> Each task is defined as coming from a specific task source. All the
> tasks from one particular task source and destined to a particular
> event loop (e.g. the callbacks generated by timers of a Document, the
> events fired for mouse movements over that Document, the tasks queued
> for the parser of that Document) must always be added to the same task
> queue, but tasks from different task sources may be placed in
> different task queues.