### PR TITLE
Fix bogus expectations in webvtt test media_404_omit_subtitles.html

### DIFF
--- a/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html
+++ b/webvtt/rendering/cues-with-video/processing-model/evil/media_404_omit_subtitles.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<!-- no reftest-wait -->
 <title>WebVTT rendering, when media cannot be played (404 error), subtitles are not displayed</title>
 <link rel="match" href="media_404_omit_subtitles-ref.html">
 <style>
@@ -10,10 +10,12 @@ body { margin:0 }
     color: green
 }
 </style>
-<script src="/common/reftest-wait.js"></script>
-<video width="320" height="180" autoplay onplaying="this.onplaying = null; this.pause(); takeScreenshot();">
-    <source src="videonotfound.webm" type="video/webm">
-    <source src="videonotfound.mp4" type="video/mp4">
+<!--
+The subtitles are not expected to render because the "show poster flag"
+is set, so when the track loads it will *not* run "time marches on".
+-->
+<video width="320" height="180" autoplay>
+    <source src="/common/text-plain.txt?pipe=status(404)">
     <track src="support/test.vtt">
     <script>
     document.getElementsByTagName('track')[0].track.mode = 'showing';


### PR DESCRIPTION
The test expected autoplay to happen but readyState will never reach
HAVE_ENOUGH_DATA.

Found in https://github.com/w3c/web-platform-tests/pull/4385#issuecomment-280165630
by @gsnedders.