### PR TITLE
Remove jQuery import in windowless elements' event handler behaviour test

### DIFF
--- a/html/webappapis/scripting/events/body-exposed-window-event-handlers.html
+++ b/html/webappapis/scripting/events/body-exposed-window-event-handlers.html
@@ -2,7 +2,6 @@
 <meta charset="utf-8">
 <title></title>
 <body></body>
-<script src="https://code.jquery.com/jquery-1.10.2.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>


### PR DESCRIPTION
It's been [discovered](https://github.com/servo/servo/pull/15359#issuecomment-280324767) post-merge that I have accidentally included a jQuery import in the test. This PR removes the erroneous import.