### PR TITLE
URL test fix: "failure" value must be literal true

### DIFF
--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -5206,12 +5206,12 @@
   {
     "input": "http://?",
     "base": "about:blank",
-    "failure": "true"
+    "failure": true
   },
   {
     "input": "http://#",
     "base": "about:blank",
-    "failure": "true"
+    "failure": true
   },
   "# Non-special-URL path tests",
   {


### PR DESCRIPTION
Fixes two test cases where "failure" value is "true" (string). Must be literal true.