### PR TITLE
Make the icons black again

### DIFF
--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -82,6 +82,7 @@ nav.home {
     }
 
     svg {
+        color: black;
         width: auto;
         height: $spacing-unit * 2;
     }


### PR DESCRIPTION
They became link-colored in https://github.com/w3c/web-platform-tests/pull/4891; this fixes that, but keeps them as links.