### PR TITLE
Raise stability errors to be visible in PR comments

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -11,7 +11,6 @@ import tarfile
 import zipfile
 from abc import ABCMeta, abstractmethod
 from cStringIO import StringIO as CStringIO
-from collections import defaultdict
 from ConfigParser import RawConfigParser
 from io import BytesIO, StringIO
 
@@ -483,18 +482,43 @@ def setup_log_handler():
         Subclasses reader.LogHandler.
         """
         def __init__(self):
-            self.results = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+            self.results = []
+
+        def find_or_create_test(self, data):
+            for test in self.results:
+                if test["name"] == data["test"]:
+                    return test
+
+            test = {"name": data["test"], "subtests": [], "status": {"OK": 0, "FAIL": 0}}
+            self.results.append(test)
+            return test
+
+        def find_or_create_subtest(self, data):
+            test = self.find_or_create_test(data)
+
+            for subtest in test["subtests"]:
+                if subtest["name"] == data["subtest"]:
+                    return subtest
+
+            subtest = {"name": data["subtest"], "status": { "PASS": 0, "FAIL": 0 }}
+            test["subtests"].append(subtest)
+
+            return subtest
 
         def test_status(self, data):
-            self.results[data["test"]][data.get("subtest")][data["status"]] += 1
+            subtest = self.find_or_create_subtest(data)
+            subtest["status"][data["status"]] += 1
 
         def test_end(self, data):
-            self.results[data["test"]][None][data["status"]] += 1
+            test = self.find_or_create_test(data)
+            test["status"][data["status"]] += 1
 
 
 def is_inconsistent(results_dict, iterations):
     """Return whether or not a single test is inconsistent."""
-    return len(results_dict) > 1 or sum(results_dict.values()) != iterations
+    values = results_dict.values()
+    nonzero_results = filter(lambda count: count > 0, values)
+    return len(nonzero_results) > 1 or sum(values) != iterations
 
 
 def err_string(results_dict, iterations):
@@ -502,12 +526,15 @@ def err_string(results_dict, iterations):
     rv = []
     total_results = sum(results_dict.values())
     for key, value in sorted(results_dict.items()):
+        if value == 0:
+            continue
+
         rv.append("%s%s" %
                   (key, ": %s/%s" % (value, iterations) if value != iterations else ""))
     rv = ", ".join(rv)
     if total_results < iterations:
         rv.append("MISSING: %s/%s" % (iterations - total_results, iterations))
-    if len(results_dict) > 1 or total_results != iterations:
+    if is_inconsistent(results_dict, iterations):
         rv = "**%s**" % rv
     return rv
 
@@ -518,10 +545,10 @@ def process_results(log, iterations):
     handler = LogHandler()
     reader.handle_log(reader.read(log), handler)
     results = handler.results
-    for test, test_results in results.iteritems():
-        for subtest, result in test_results.iteritems():
-            if is_inconsistent(result, iterations):
-                inconsistent.append((test, subtest, result))
+    for test in results:
+        for subtest in test["subtests"]:
+            if is_inconsistent(subtest["status"], iterations):
+                inconsistent.append((test["name"], subtest["name"], subtest["status"]))
     return results, inconsistent
 
 
@@ -588,21 +615,21 @@ def write_results(results, iterations, comment_pr):
                                                           "tests" if len(results) > 1
                                                           else "test"))
 
-    for test, test_results in results.iteritems():
+    for test in results:
         baseurl = "http://w3c-test.org/submissions"
-        if "https" in os.path.splitext(test)[0].split(".")[1:]:
+        name = test["name"]
+        if "https" in os.path.splitext(name)[0].split(".")[1:]:
             baseurl = "https://w3c-test.org/submissions"
         if pr_number:
             logger.info("<details>\n")
             logger.info('<summary><a href="%s/%s%s">%s</a></summary>\n\n' %
-                        (baseurl, pr_number, test, test))
+                        (baseurl, pr_number, name, name))
         else:
-            logger.info("### %s ###" % test)
-        parent = test_results.pop(None)
-        strings = [("", err_string(parent, iterations))]
-        strings.extend(((("`%s`" % markdown_adjust(subtest)) if subtest
-                         else "", err_string(results, iterations))
-                        for subtest, results in test_results.iteritems()))
+            logger.info("### %s ###" % name)
+        strings = [("", err_string(test["status"], iterations))]
+        strings.extend(((("`%s`" % markdown_adjust(subtest["name"])) if subtest
+                         else "", err_string(subtest["status"], iterations))
+                        for subtest in test["subtests"]))
         table(["Subtest", "Results"], strings, logger.info)
         if pr_number:
             logger.info("</details>\n")


### PR DESCRIPTION
This raises the failing test messages into the results tables in the PR comment (see screenshot below, and presumably the w3c-bots comments on this PR). (cc @RByers - is this what you're looking for?)

Note: this includes @jugglinmike's commits from https://github.com/w3c/web-platform-tests/pull/4745 (including one that causes an instability for demonstration purposes, and which should be removed). His work on that PR is required by this one.

- Closes #4745 
- Fixes #4515