### PR TITLE
Add test for StorageManager API vs. opaque origins

### DIFF
--- a/storage/opaque-origin.https.html
+++ b/storage/opaque-origin.https.html
@@ -41,6 +41,7 @@ function make_script(snippet) {
          '            window.parent.postMessage({result: error.name}, "*");' +
          '          });' +
          '    } catch (ex) {' +
+         // Report if not implemented/exposed, rather than time out.
          '      window.parent.postMessage({result: ex.message}, "*");' +
          '    }' +
          '  };' +
@@ -70,9 +71,9 @@ function make_script(snippet) {
         return wait_for_message(iframe);
       })
       .then(message => {
-        assert_equals(message.result, 'SecurityError',
-                      `${snippet} should reject with SecurityError`);
+        assert_equals(message.result, 'TypeError',
+                      `${snippet} should reject with TypeError`);
       });
-  }, `${snippet} in sandboxed iframe should reject with SecurityError`);
+  }, `${snippet} in sandboxed iframe should reject with TypeError`);
 });
 </script>

--- a/storage/opaque-origin.https.html
+++ b/storage/opaque-origin.https.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>StorageManager API and opaque origins</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+function load_iframe(src, sandbox) {
+  return new Promise(resolve => {
+    const iframe = document.createElement('iframe');
+    iframe.onload = () => { resolve(iframe); };
+    if (sandbox)
+      iframe.sandbox = sandbox;
+    iframe.srcdoc = src;
+    iframe.style.display = 'none';
+    document.documentElement.appendChild(iframe);
+  });
+}
+
+function wait_for_message(iframe) {
+  return new Promise(resolve => {
+    self.addEventListener('message', function listener(e) {
+      if (e.source === iframe.contentWindow) {
+        resolve(e.data);
+        self.removeEventListener('message', listener);
+      }
+    });
+  });
+}
+
+function make_script(snippet) {
+  return '<script>' +
+         '  window.onmessage = () => {' +
+         '    try {' +
+         '      (' + snippet + ')' +
+         '        .then(' +
+         '          result => {' +
+         '            window.parent.postMessage({result: "no rejection"}, "*");' +
+         '          }, ' +
+         '          error => {' +
+         '            window.parent.postMessage({result: error.name}, "*");' +
+         '          });' +
+         '    } catch (ex) {' +
+         '      window.parent.postMessage({result: ex.message}, "*");' +
+         '    }' +
+         '  };' +
+         '<\/script>';
+}
+
+['navigator.storage.persist()',
+ 'navigator.storage.persisted()',
+ 'navigator.storage.estimate()'
+].forEach(snippet => {
+  promise_test(t => {
+    return load_iframe(make_script(snippet))
+      .then(iframe => {
+        iframe.contentWindow.postMessage({}, '*');
+        return wait_for_message(iframe);
+      })
+      .then(message => {
+        assert_equals(message.result, 'no rejection',
+                      `${snippet} should not reject`);
+      });
+  }, `${snippet} in non-sandboxed iframe should not reject`);
+
+  promise_test(t => {
+    return load_iframe(make_script(snippet), 'allow-scripts')
+      .then(iframe => {
+        iframe.contentWindow.postMessage({}, '*');
+        return wait_for_message(iframe);
+      })
+      .then(message => {
+        assert_equals(message.result, 'SecurityError',
+                      `${snippet} should reject with SecurityError`);
+      });
+  }, `${snippet} in sandboxed iframe should reject with SecurityError`);
+});
+</script>


### PR DESCRIPTION
Entry points (persist(), persisted(), estimate()) should reject
in opaque origins (e.g. sandboxed iframes).

https://github.com/whatwg/storage/issues/41