### PR TITLE
Make running order of test cases deterministic in html/browsers/brows…

### DIFF
--- a/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
+++ b/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
@@ -118,7 +118,10 @@ const testCases = [
   }
 ];
 
-for (const testCase of testCases) {
+var testCaseIndex = 0;
+function runNextTest() {
+  const testCase = testCases[testCaseIndex];
+
   const labelAboutReturnValue = testCase.setReturnValue === undefined ? "" :
     `; setting returnValue to ${testCase.setReturnValue}`;
 
@@ -126,10 +129,14 @@ for (const testCase of testCases) {
     const iframe = document.createElement("iframe");
     iframe.onload = t.step_func(() => {
       iframe.contentWindow.runTest(t, testCase);
+      if (++testCaseIndex < testCases.length)
+        runNextTest();
     });
 
     iframe.src = "beforeunload-canceling-1.html";
     document.body.appendChild(iframe);
   }, `Returning ${testCase.valueToReturn} with a real iframe unloading${labelAboutReturnValue}`);
 }
+
+runNextTest();
 </script>


### PR DESCRIPTION
…ing-the-web/unloading-documents/beforeunload-canceling.html

WebKit's testharness prints out the returnValue of the BeforeUnloadEvent and
those are printed in a non-deterministic order given that the order of the
tests relies on the order of the load events firing for each frame. Make the
order deterministic to address flakiness issues in harnesses like the one
used by WebKit.