### PR TITLE
Add wisniewskit as an owner for XMLHttpRequest

### DIFF
--- a/XMLHttpRequest/OWNERS
+++ b/XMLHttpRequest/OWNERS
@@ -10,3 +10,4 @@
 @jdm
 @Ms2ger
 @annevk
+@wisniewskit


### PR DESCRIPTION
I now work for Mozilla, and have been involved with XHR spec-work for a number of months. @annevk suggested that I add myself as an owner in issue #3738.