### PR TITLE
[service-workers] Correct test cleanup logic

### DIFF
--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -48,7 +48,8 @@ t.step(function() {
         // The only purpose of the iframe created here is to generate an HTTP
         // request, so the element may be removed as soon as the frame has
         // completed loading.
-        with_iframe(scope).then(function(f) { f.remove(); });
+        with_iframe(scope).then(function(f) { f.remove(); })
+          .catch(unreached_rejection(t));
     }
 
     function onResult(event) {

--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -8,7 +8,6 @@ var t = async_test('Request: end-to-end');
 t.step(function() {
     var url = 'resources/request-end-to-end-worker.js';
     var scope = 'resources/blank.html';
-    var frames = [];
 
     service_worker_unregister_and_register(t, url, scope)
       .then(onRegister)
@@ -46,7 +45,10 @@ t.step(function() {
     }
 
     function onPortReady() {
-        with_iframe(scope).then(function(f) { frames.push(f); });
+        // The only purpose of the iframe created here is to generate an HTTP
+        // request, so the element may be removed as soon as the frame has
+        // completed loading.
+        with_iframe(scope).then(function(f) { f.remove(); });
     }
 
     function onResult(event) {
@@ -66,7 +68,6 @@ t.step(function() {
         assert_equals(event.data.errorNameWhileAppendingHeader, 'TypeError',
                       'Appending a new header to the request must throw a ' +
                       'TypeError.')
-        frames.forEach(function(f) { f.remove(); });
         service_worker_unregister_and_done(t, scope);
     }
 });


### PR DESCRIPTION
@mkruisselbrink In gh-4879, we discussed the need to introduce another call to this test's `onResult` function in `t.step`/`t.step_func`. I haven't made that change here because I don't think it's necessary, after all.

After a closer reading of the test, I found that [the Service Worker's `statechange` event handler is wrapped](https://github.com/w3c/web-platform-tests/blob/18a3faa22764659eb9c39185b3a89df64ab88c0c/service-workers/service-worker/request-end-to-end.https.html#L25), and all subsequent function calls (including `onResult`) are synchronous.

This patch is for an unrelated bug in that test's cleanup logic.

Commit message:

> Because the test may complete before the generated frame's `load` event
> is triggered, the frame element may not necessarily be available to the
> calling script once the assertions have been executed. Account for this
> detail by deferring removal until the element is known to be available.