### PR TITLE
[html/offline] Avoid race condition in tests

### DIFF
--- a/html/browsers/offline/application-cache-api/api_update.html
+++ b/html/browsers/offline/application-cache-api/api_update.html
@@ -15,12 +15,7 @@
         var next = t.step_func(function() {
           cache.onnoupdate = cache.oncached = null;
 
-          try {
-            cache.update()
-            assert_true(true, "update method test")
-          } catch (e) {
-            assert_unreached("update method failed.");
-          }
+          cache.update()
 
           t.done();
         });

--- a/html/browsers/offline/application-cache-api/api_update.html
+++ b/html/browsers/offline/application-cache-api/api_update.html
@@ -11,12 +11,24 @@
     <script>
       var cache = window.applicationCache;
 
-      test(function() {
-        try {
-          cache.update()
-          assert_true(true, "update method test")
-        } catch (e) {
-          assert_unreached("update method failed.");
+      async_test(function(t) {
+        var next = t.step_func(function() {
+          cache.onnoupdate = cache.oncached = null;
+
+          try {
+            cache.update()
+            assert_true(true, "update method test")
+          } catch (e) {
+            assert_unreached("update method failed.");
+          }
+
+          t.done();
+        });
+
+        if (cache.status === cache.IDLE) {
+          next();
+        } else {
+          cache.onnoupdate = cache.oncached = next;
         }
       });
     </script>

--- a/html/browsers/offline/application-cache-api/api_update_error.html
+++ b/html/browsers/offline/application-cache-api/api_update_error.html
@@ -1,16 +1,11 @@
 <!DOCTYPE HTML>
-<html manifest="../resources/manifest/clock.manifest">
+<html manifest="./non-existent-file.manifest">
   <head>
     <title>Offline Application Cache - API_update_error</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
   </head>
   <body>
-    <ol>
-      <li>Remove the manifest file (manifest/clock.manifest) from the server.</li>
-      <li>Refresh the page, then calling update() will throw InvalidStateError exception.</li>
-    </ol>
-
     <div id="log"></div>
 
     <script>


### PR DESCRIPTION
The change I'm proposing to `api_update_error.html` seems too obvious to have been overlooked. I wanted to call that out in case here and explicitly ask: is there something I'm missing about the best way to assert that behavior?

Commit message:

> At the onset of a given test, the shared application manifest may or may
> not already be available in the user agent's cache. Because this
> variability is controlled by external factors (specifically: the
> previous tests executed in the session), the status of the application
> cache may not be consistent. Tests whose semantics are effected by this
> status must therefore explicitly control for the variability in order to
> exercise the same behavior in all circumstances.
>
> Update the test for successful invocation by accounting for both
> "manifest ready" and "manifest not ready" states. Update the test for
> unsuccessful invocation by specifying a URL to a non-existent resource.