### PR TITLE
[presentation-api] add test cases for sending/receiving messages by a controlling user agent

### DIFF
--- a/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Receiving a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#receiving-a-message-through-presentationconnection">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p id="notice">
+  Click the button below and select the available presentation display, to start the manual test. The test passes if a "PASS" result appears.<br>
+  <button id="presentBtn">Start Presentation Test</button>
+</p>
+
+<script>
+    setup({explicit_timeout: true});
+
+    const presentBtn = document.getElementById('presentBtn');
+
+    presentBtn.onclick = () => {
+        presentBtn.disabled = true;
+
+        promise_test(t => {
+            let connection, watcher, timeout, eventWatcher;
+            const request = new PresentationRequest(presentationUrls);
+
+            const checkEvent = event => {
+                assert_true(event.isTrusted, 'a trusted event is fired');
+                assert_true(event instanceof MessageEvent, 'The event uses the MessageEvent interface');
+                assert_false(event.bubbles, 'the event does not bubble');
+                assert_false(event.cancelable, 'the event is not cancelable');
+            };
+
+            t.add_cleanup(() => {
+                if (connection) {
+                    if (connection.state === 'connected')
+                        connection.terminate();
+                    else if (connection.state === 'closed') {
+                        request.reconnect(connection.id).then(c => {
+                            c.terminate();
+                        });
+                    }
+                }
+                const notice = document.getElementById('notice');
+                notice.parentNode.removeChild(notice);
+                stopWaitingStash();
+            });
+
+            return request.start().then(c => {
+                return initStash().then(() => {
+                    return uploadStash('onmessage');
+                }).then(() => {
+                    return c;
+                });
+            }).then(c => {
+                connection = c;
+                assert_equals(connection.state, 'connecting', 'the initial state of the presentation connection is "connecting"');
+                assert_equals(connection.binaryType, 'arraybuffer', 'the default value of binaryType is "arraybuffer"');
+
+                // enable timeout again, cause no user action is needed from here.
+                t.step_timeout(() => {
+                    t.force_timeout();
+                    t.done();
+                }, 5000);
+
+                eventWatcher = new EventWatcher(t, connection, 'message');
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                checkEvent(event);
+                assert_equals(event.data, message1, 'receive a string correctly');
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                checkEvent(event);
+                assert_equals(event.data, message2, 'receive a string correctly');
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                checkEvent(event);
+                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+                assert_true(event.data.equals(message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                checkEvent(event);
+                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+                assert_true(event.data.equals(message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                checkEvent(event);
+                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+                assert_true(event.data.equals(message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
+
+                connection.binaryType = 'blob';
+                return uploadStash('blob');
+            }).then(() => {
+                return eventWatcher.wait_for('message');
+            }).then(event => {
+                assert_true(event.data instanceof Blob, 'receive binary data as Blob');
+                return new Promise((resolve, reject) => {
+                    const reader = new FileReader();
+                    reader.onload = resolve;
+                    reader.onerror = reject;
+                    reader.readAsArrayBuffer(event.data);
+                });
+            }).then(event => {
+                assert_true(event.target.result.equals(message5), 'receive a Blob correctly');
+                connection.terminate();
+            });
+        });
+    };
+</script>

--- a/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
@@ -19,11 +19,28 @@
 
     const presentBtn = document.getElementById('presentBtn');
 
+    const message1 = '1st';
+    const message2 = '2nd';
+    const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+    const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+    const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+    const toUint8Array = buf => {
+        return buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+    }
+
+    // compare two ArrayBuffer or Uint8Array
+    const compare = (a, b) => {
+        const p = toUint8Array(a);
+        const q = toUint8Array(b);
+        return !!p && !!q && p.every((item, index) => { return item === q[index]; });
+    };
+
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
 
         promise_test(t => {
-            let connection, watcher, timeout, eventWatcher;
+            let connection, watcher, eventWatcher;
             const request = new PresentationRequest(presentationUrls);
 
             const checkEvent = event => {
@@ -49,12 +66,6 @@
             });
 
             return request.start().then(c => {
-                return initStash().then(() => {
-                    return uploadStash('onmessage');
-                }).then(() => {
-                    return c;
-                });
-            }).then(c => {
                 connection = c;
                 assert_equals(connection.state, 'connecting', 'the initial state of the presentation connection is "connecting"');
                 assert_equals(connection.binaryType, 'arraybuffer', 'the default value of binaryType is "arraybuffer"');
@@ -65,8 +76,14 @@
                     t.done();
                 }, 5000);
 
+                return initStash();
+            }).then(() => {
                 eventWatcher = new EventWatcher(t, connection, 'message');
-                return eventWatcher.wait_for('message');
+                // Tell receiving page to start sending messages, and wait for first message
+                return Promise.all([
+                    uploadStash('onmessage'),
+                    eventWatcher.wait_for('message')
+                ]).then(results => results[1]);
             }).then(event => {
                 checkEvent(event);
                 assert_equals(event.data, message1, 'receive a string correctly');
@@ -78,22 +95,23 @@
             }).then(event => {
                 checkEvent(event);
                 assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(event.data.equals(message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
+                assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
                 return eventWatcher.wait_for('message');
             }).then(event => {
                 checkEvent(event);
                 assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(event.data.equals(message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
+                assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
                 return eventWatcher.wait_for('message');
             }).then(event => {
                 checkEvent(event);
                 assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(event.data.equals(message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
+                assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
 
                 connection.binaryType = 'blob';
-                return uploadStash('blob');
-            }).then(() => {
-                return eventWatcher.wait_for('message');
+                return new Promise([
+                    uploadStash('blob'),
+                    eventWatcher.wait_for('message')
+                ]).then(results => results[1]);
             }).then(event => {
                 assert_true(event.data instanceof Blob, 'receive binary data as Blob');
                 return new Promise((resolve, reject) => {
@@ -103,7 +121,7 @@
                     reader.readAsArrayBuffer(event.data);
                 });
             }).then(event => {
-                assert_true(event.target.result.equals(message5), 'receive a Blob correctly');
+                assert_true(compare(event.target.result, message5), 'receive a Blob correctly');
                 connection.terminate();
             });
         });

--- a/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
@@ -38,6 +38,7 @@
 
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
+        const stash = new Stash('9bf08fea-a71a-42f9-b3c4-fa19499e4d12', 'f1fdfd10-b606-4748-a644-0a8e9df3bdd6');
 
         promise_test(t => {
             let connection, watcher, eventWatcher;
@@ -52,7 +53,12 @@
 
             t.add_cleanup(() => {
                 if (connection) {
-                    if (connection.state === 'connected')
+                    if (connection.state === 'connecting') {
+                        connection.onconnect = event => {
+                            connection.terminate();
+                        };
+                    }
+                    else if (connection.state === 'connected')
                         connection.terminate();
                     else if (connection.state === 'closed') {
                         request.reconnect(connection.id).then(c => {
@@ -62,7 +68,7 @@
                 }
                 const notice = document.getElementById('notice');
                 notice.parentNode.removeChild(notice);
-                stopWaitingStash();
+                stash.stop();
             });
 
             return request.start().then(c => {
@@ -76,12 +82,15 @@
                     t.done();
                 }, 5000);
 
-                return initStash();
+                watcher = new EventWatcher(t, connection, 'connect');
+                return watcher.wait_for('connect');
+            }).then(() => {
+                return stash.init();
             }).then(() => {
                 eventWatcher = new EventWatcher(t, connection, 'message');
                 // Tell receiving page to start sending messages, and wait for first message
                 return Promise.all([
-                    uploadStash('onmessage'),
+                    stash.send('onmessage'),
                     eventWatcher.wait_for('message')
                 ]).then(results => results[1]);
             }).then(event => {
@@ -108,8 +117,8 @@
                 assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
 
                 connection.binaryType = 'blob';
-                return new Promise([
-                    uploadStash('blob'),
+                return Promise.all([
+                    stash.send('blob'),
                     eventWatcher.wait_for('message')
                 ]).then(results => results[1]);
             }).then(event => {

--- a/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.html
@@ -38,7 +38,7 @@
 
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
-        const stash = new Stash('9bf08fea-a71a-42f9-b3c4-fa19499e4d12', 'f1fdfd10-b606-4748-a644-0a8e9df3bdd6');
+        const stash = new Stash(stashIds.toController, stashIds.toReceiver);
 
         promise_test(t => {
             let connection, watcher, eventWatcher;

--- a/presentation-api/controlling-ua/PresentationConnection_send-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_send-manual.html
@@ -39,7 +39,7 @@
 
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
-        const stash = new Stash('9bf08fea-a71a-42f9-b3c4-fa19499e4d12', 'f1fdfd10-b606-4748-a644-0a8e9df3bdd6');
+        const stash = new Stash(stashIds.toController, stashIds.toReceiver);
 
         promise_test(t => {
             let connection, watcher;

--- a/presentation-api/controlling-ua/PresentationConnection_send-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_send-manual.html
@@ -19,11 +19,29 @@
 
     const presentBtn = document.getElementById('presentBtn');
 
+    const message1 = '1st';
+    const message2 = '2nd';
+    const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+    const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+    const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+    const toUint8Array = buf => {
+        return buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+    }
+
+    // convert ArrayBuffer or Uint8Array into string
+    const toText = buf => {
+        const arr = toUint8Array(buf);
+        return !buf ? null : arr.reduce((result, item) => {
+            return result + String.fromCharCode(item);
+        }, '');
+    }
+
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
 
         promise_test(t => {
-            let connection, watcher, timeout, wait;
+            let connection, watcher;
             const request = new PresentationRequest(presentationUrls);
 
             t.add_cleanup(() => {
@@ -41,13 +59,6 @@
                 stopWaitingStash();
             });
 
-            const setStepTimeout = delay => {
-                timeout = t.step_timeout(() => {
-                    t.force_timeout();
-                    t.done();
-                }, delay);
-            };
-
             return request.start().then(c => {
                 return initStash().then(() => {
                     return uploadStash('send');
@@ -64,7 +75,10 @@
                 }, 'an InvalidStateError is thrown if the state is "connecting"');
 
                 // enable timeout again, cause no user action is needed from here.
-                setStepTimeout(10000);
+                t.step_timeout(() => {
+                    t.force_timeout();
+                    t.done();
+                }, 10000);
 
                 watcher = new EventWatcher(t, connection, ['connect', 'close']);
                 return watcher.wait_for('connect');
@@ -85,9 +99,9 @@
                 const results = JSON.parse(stash);
                 assert_true(!!results[0] && results[0].type === 'text'   && results[0].data === message1,          'send a string correctly');
                 assert_true(!!results[1] && results[1].type === 'text'   && results[1].data === message2,          'send a string correctly');
-                assert_true(!!results[2] && results[2].type === 'binary' && results[2].data === message3.toText(), 'send a Blob correctly');
-                assert_true(!!results[3] && results[3].type === 'binary' && results[3].data === message4.toText(), 'send a ArrayBuffer correctly');
-                assert_true(!!results[4] && results[4].type === 'binary' && results[4].data === message5.toText(), 'send a ArrayBufferView correctly');
+                assert_true(!!results[2] && results[2].type === 'binary' && results[2].data === toText(message3), 'send a Blob correctly');
+                assert_true(!!results[3] && results[3].type === 'binary' && results[3].data === toText(message4), 'send a ArrayBuffer correctly');
+                assert_true(!!results[4] && results[4].type === 'binary' && results[4].data === toText(message5), 'send a ArrayBufferView correctly');
 
                 // send data in "closed" state (throws an exception)
                 connection.close();

--- a/presentation-api/controlling-ua/PresentationConnection_send-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_send-manual.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Sending a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#sending-a-message-through-presentationconnection">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p id="notice">
+  Click the button below and select the available presentation display, to start the manual test. The test passes if a "PASS" result appears.<br>
+  <button id="presentBtn">Start Presentation Test</button>
+</p>
+
+<script>
+    setup({explicit_timeout: true});
+
+    const presentBtn = document.getElementById('presentBtn');
+
+    presentBtn.onclick = () => {
+        presentBtn.disabled = true;
+
+        promise_test(t => {
+            let connection, watcher, timeout, wait;
+            const request = new PresentationRequest(presentationUrls);
+
+            t.add_cleanup(() => {
+                if (connection) {
+                    if (connection.state === 'connected')
+                        connection.terminate();
+                    else if (connection.state === 'closed') {
+                        request.reconnect(connection.id).then(c => {
+                            c.terminate();
+                        });
+                    }
+                }
+                const notice = document.getElementById('notice');
+                notice.parentNode.removeChild(notice);
+                stopWaitingStash();
+            });
+
+            const setStepTimeout = delay => {
+                timeout = t.step_timeout(() => {
+                    t.force_timeout();
+                    t.done();
+                }, delay);
+            };
+
+            return request.start().then(c => {
+                return initStash().then(() => {
+                    return uploadStash('send');
+                }).then(waitForStash).then(() => {
+                    return c;
+                });
+            }).then(c => {
+                connection = c;
+
+                // send data in "connecting" state (throws an exception)
+                assert_equals(connection.state, 'connecting', 'the initial state of the presentation connection is "connecting"');
+                assert_throws('InvalidStateError', () => {
+                    connection.send('');
+                }, 'an InvalidStateError is thrown if the state is "connecting"');
+
+                // enable timeout again, cause no user action is needed from here.
+                setStepTimeout(10000);
+
+                watcher = new EventWatcher(t, connection, ['connect', 'close']);
+                return watcher.wait_for('connect');
+            }).then(() => {
+                return uploadStash('send');
+            }).then(() => {
+                return waitForStash();
+            }).then(() => {
+                // send messages
+                connection.send(message1);              // string
+                connection.send(message2);              // string
+                connection.send(new Blob([message3]));  // Blob
+                connection.send(message4.buffer);       // ArrayBuffer
+                connection.send(message5);              // ArrayBufferView
+                return waitForStash();
+            }).then(stash => {
+                // verify messages
+                const results = JSON.parse(stash);
+                assert_true(!!results[0] && results[0].type === 'text'   && results[0].data === message1,          'send a string correctly');
+                assert_true(!!results[1] && results[1].type === 'text'   && results[1].data === message2,          'send a string correctly');
+                assert_true(!!results[2] && results[2].type === 'binary' && results[2].data === message3.toText(), 'send a Blob correctly');
+                assert_true(!!results[3] && results[3].type === 'binary' && results[3].data === message4.toText(), 'send a ArrayBuffer correctly');
+                assert_true(!!results[4] && results[4].type === 'binary' && results[4].data === message5.toText(), 'send a ArrayBufferView correctly');
+
+                // send data in "closed" state (throws an exception)
+                connection.close();
+                return watcher.wait_for('close');
+            }).then(() => {
+                assert_equals(connection.state, 'closed', 'the state is set to "closed" when the presentation connection is closed');
+                assert_throws('InvalidStateError', () => {
+                    connection.send('');
+                }, 'an InvalidStateError is thrown if the state is "closed"');
+
+                // reconnect and terminate the connection
+                return request.reconnect(connection.id);
+            }).then(c => {
+                connection = c;
+                watcher = new EventWatcher(t, connection, ['connect', 'terminate']);
+                return watcher.wait_for('connect');
+            }).then(() => {
+                // send data in "terminated" state (throws an exception)
+                connection.terminate();
+                return watcher.wait_for('terminate');
+            }).then(() => {
+                assert_equals(connection.state, 'terminated', 'the state is set to "terminated" when the presentation connection is terminated');
+                assert_throws('InvalidStateError', () => {
+                    connection.send('');
+                }, 'an InvalidStateError is thrown if the state is "terminated"');
+            });
+        });
+    };
+</script>

--- a/presentation-api/controlling-ua/PresentationConnection_send-manual.html
+++ b/presentation-api/controlling-ua/PresentationConnection_send-manual.html
@@ -39,6 +39,7 @@
 
     presentBtn.onclick = () => {
         presentBtn.disabled = true;
+        const stash = new Stash('9bf08fea-a71a-42f9-b3c4-fa19499e4d12', 'f1fdfd10-b606-4748-a644-0a8e9df3bdd6');
 
         promise_test(t => {
             let connection, watcher;
@@ -56,16 +57,10 @@
                 }
                 const notice = document.getElementById('notice');
                 notice.parentNode.removeChild(notice);
-                stopWaitingStash();
+                stash.stop();
             });
 
             return request.start().then(c => {
-                return initStash().then(() => {
-                    return uploadStash('send');
-                }).then(waitForStash).then(() => {
-                    return c;
-                });
-            }).then(c => {
                 connection = c;
 
                 // send data in "connecting" state (throws an exception)
@@ -83,17 +78,17 @@
                 watcher = new EventWatcher(t, connection, ['connect', 'close']);
                 return watcher.wait_for('connect');
             }).then(() => {
-                return uploadStash('send');
+                return stash.init();
             }).then(() => {
-                return waitForStash();
-            }).then(() => {
+                return Promise.all([ stash.send('send'), stash.receive() ]);
+            }).then(results => {
                 // send messages
                 connection.send(message1);              // string
                 connection.send(message2);              // string
                 connection.send(new Blob([message3]));  // Blob
                 connection.send(message4.buffer);       // ArrayBuffer
                 connection.send(message5);              // ArrayBufferView
-                return waitForStash();
+                return stash.receive();
             }).then(stash => {
                 // verify messages
                 const results = JSON.parse(stash);

--- a/presentation-api/controlling-ua/common.js
+++ b/presentation-api/controlling-ua/common.js
@@ -13,4 +13,13 @@
     'support/presentation.html',
     castUrl
   ];
+
+  // Both a controlling side and a receiving one must share the same Stash ID to
+  // transmit data from one to the other. On the other hand, due to polling mechanism
+  // which cleans up a stash, stashes in both controller-to-receiver direction
+  // and one for receiver-to-controller are necessary.
+  window.stashIds = {
+    toController: '9bf08fea-a71a-42f9-b3c4-fa19499e4d12',
+    toReceiver: 'f1fdfd10-b606-4748-a644-0a8e9df3bdd6'
+  }
 })(window);

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -7,11 +7,25 @@
 <link rel="help" href="http://w3c.github.io/presentation-api/#interface-presentationconnectionlist">
 <script src="stash.js"></script>
 <script>
+  const message1 = '1st';
+  const message2 = '2nd';
+  const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+  const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+  const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+  // compare two ArrayBuffer or Uint8Array
+  const compare = (a, b) => {
+    const p = toUint8Array(a);
+    const q = toUint8Array(b);
+    return !!p && !!q && p.every((item, index) => { return item === q[index]; });
+  };
+
   const addConnection = connection => {
     connection.onconnect = function() {
-      let result = [], timeout, testCase;
+      let result = [], testCase;
 
       this.onmessage = event => {
+        document.body.innerHTML += event.data + '<br>';
         // PresentationConnection_send-manual.html
         if (testCase === 'send') {
           if (typeof event.data === 'string') {
@@ -20,8 +34,7 @@
           // default value of connection.binaryType is "arraybuffer"
           else if(event.data instanceof ArrayBuffer) {
             result.push({ type: 'binary', data: event.data});
-            if (event.data.equals(message5)) {
-              clearTimeout(timeout);
+            if (compare(event.data, message5)) {
               window.uploadStash(JSON.stringify(result));
             }
           }

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -16,9 +16,6 @@
         if (testCase === 'send') {
           if (typeof event.data === 'string') {
             result.push({ type: 'text', data: event.data });
-            timeout = setTimeout(() => {
-              window.uploadStash(JSON.stringify(result));
-            }, 5000);
           }
           // default value of connection.binaryType is "arraybuffer"
           else if(event.data instanceof ArrayBuffer) {

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -32,7 +32,7 @@
     return !!p && !!q && p.every((item, index) => { return item === q[index]; });
   };
 
-  const stash = new Stash('f1fdfd10-b606-4748-a644-0a8e9df3bdd6', '9bf08fea-a71a-42f9-b3c4-fa19499e4d12');
+  const stash = new Stash(stashIds.toReceiver, stashIds.toController);
 
   const addConnection = connection => {
     connection.onconnect = function() {

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -13,12 +13,26 @@
   const message4 = new Uint8Array([52, 116, 104]);      // "4th"
   const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
 
+  const toUint8Array = buf => {
+    return buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+  }
+
+  // convert ArrayBuffer or Uint8Array into string
+  const toText = buf => {
+    const arr = toUint8Array(buf);
+    return !buf ? null : arr.reduce((result, item) => {
+      return result + String.fromCharCode(item);
+    }, '');
+  }
+
   // compare two ArrayBuffer or Uint8Array
   const compare = (a, b) => {
     const p = toUint8Array(a);
     const q = toUint8Array(b);
     return !!p && !!q && p.every((item, index) => { return item === q[index]; });
   };
+
+  const stash = new Stash('f1fdfd10-b606-4748-a644-0a8e9df3bdd6', '9bf08fea-a71a-42f9-b3c4-fa19499e4d12');
 
   const addConnection = connection => {
     connection.onconnect = function() {
@@ -32,9 +46,9 @@
           }
           // default value of connection.binaryType is "arraybuffer"
           else if(event.data instanceof ArrayBuffer) {
-            result.push({ type: 'binary', data: event.data});
+            result.push({ type: 'binary', data: toText(event.data) });
             if (compare(event.data, message5)) {
-              window.uploadStash(JSON.stringify(result));
+              stash.send(JSON.stringify(result));
             }
           }
           else {
@@ -43,12 +57,12 @@
         }
       };
 
-      waitForStash().then(data => {
+      stash.receive().then(data => {
         testCase = data;
 
         // PresentationConnection_send-manual.html
         if (testCase === 'send') {
-          uploadStash('ok');
+          stash.send('ok');
         }
         // PresentationConnection_onmessage-manual.html
         else if (testCase === 'onmessage') {
@@ -57,7 +71,7 @@
           connection.send(new Blob([message3]));  // Blob
           connection.send(message4.buffer);       // ArrayBuffer
           connection.send(message5);              // ArrayBufferView
-          waitForStash().then(data => {
+          stash.receive().then(data => {
             connection.send(message5);
           });
         }

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -22,7 +22,6 @@
           }
           // default value of connection.binaryType is "arraybuffer"
           else if(event.data instanceof ArrayBuffer) {
-            document.body.innerHTML += event.data.toText() + '<br>';
             result.push({ type: 'binary', data: event.data});
             if (event.data.equals(message5)) {
               clearTimeout(timeout);

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -25,7 +25,6 @@
       let result = [], testCase;
 
       this.onmessage = event => {
-        document.body.innerHTML += event.data + '<br>';
         // PresentationConnection_send-manual.html
         if (testCase === 'send') {
           if (typeof event.data === 'string') {

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -3,22 +3,66 @@
 <meta charset="utf-8">
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="He Yue" href="mailto:yue.he@intel.com">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
 <link rel="help" href="http://w3c.github.io/presentation-api/#interface-presentationconnectionlist">
+<script src="stash.js"></script>
 <script>
-  var addConnection = function(connection) {
-    connection.onconnected = function () {
-      this.onmessage = function (evt) {
-        this.send(evt.data);
+  const addConnection = connection => {
+    connection.onconnect = function() {
+      let result = [], timeout, testCase;
+
+      this.onmessage = event => {
+        // PresentationConnection_send-manual.html
+        if (testCase === 'send') {
+          if (typeof event.data === 'string') {
+            result.push({ type: 'text', data: event.data });
+            timeout = setTimeout(() => {
+              window.uploadStash(JSON.stringify(result));
+            }, 5000);
+          }
+          // default value of connection.binaryType is "arraybuffer"
+          else if(event.data instanceof ArrayBuffer) {
+            document.body.innerHTML += event.data.toText() + '<br>';
+            result.push({ type: 'binary', data: event.data});
+            if (event.data.equals(message5)) {
+              clearTimeout(timeout);
+              window.uploadStash(JSON.stringify(result));
+            }
+          }
+          else {
+            result.push({ type: 'error' });
+          }
+        }
       };
+
+      waitForStash().then(data => {
+        testCase = data;
+
+        // PresentationConnection_send-manual.html
+        if (testCase === 'send') {
+          uploadStash('ok');
+        }
+        // PresentationConnection_onmessage-manual.html
+        else if (testCase === 'onmessage') {
+          connection.send(message1);              // string
+          connection.send(message2);              // string
+          connection.send(new Blob([message3]));  // Blob
+          connection.send(message4.buffer);       // ArrayBuffer
+          connection.send(message5);              // ArrayBufferView
+          waitForStash().then(data => {
+            connection.send(message5);
+          });
+        }
+      });
     };
   };
 
   navigator.presentation.receiver.connectionList
-    .then(function(list) {
-      list.onconnectionavailable = function(evt) {
+    .then(list => {
+      list.onconnectionavailable = evt => {
         addConnection(evt.connection);
       };
-      list.connections.map(function(connection) {
+      list.connections.map(connection => {
         addConnection(connection);
       });
     });

--- a/presentation-api/controlling-ua/support/presentation.html
+++ b/presentation-api/controlling-ua/support/presentation.html
@@ -5,6 +5,7 @@
 <link rel="author" title="He Yue" href="mailto:yue.he@intel.com">
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
 <link rel="help" href="http://w3c.github.io/presentation-api/#interface-presentationconnectionlist">
+<script src="../common.js"></script>
 <script src="stash.js"></script>
 <script>
   const message1 = '1st';

--- a/presentation-api/controlling-ua/support/stash.js
+++ b/presentation-api/controlling-ua/support/stash.js
@@ -1,32 +1,4 @@
 (window => {
-  //
-  // Common Parameters and Functions for test cases which use a stash
-  //
-  window.message1 = '1st';
-  window.message2 = '2nd';
-  window.message3 = new Uint8Array([51, 114, 100]);      // "3rd"
-  window.message4 = new Uint8Array([52, 116, 104]);      // "4th"
-  window.message5 = new Uint8Array([108, 97, 115, 116]); // "last"
-
-  Uint8Array.prototype.toText = function() {
-      return this.reduce(function(result, item) {
-          return result + String.fromCharCode(item);
-      }, '');
-  };
-
-  Uint8Array.prototype.equals = function(a) {
-      let array = a instanceof Uint8Array ? a : (a instanceof ArrayBuffer ? new Uint8Array(a) : null);
-      return !!array && this.every((item, index) => { return item === a[index]; });
-  };
-
-  ArrayBuffer.prototype.toText = function() {
-      return new Uint8Array(this).toText();
-  };
-
-  ArrayBuffer.prototype.equals = function(a) {
-      return new Uint8Array(this).equals(a);
-  };
-
   // Note: Tentatively, Only one stash ID is defined, due to a single presentationUrls
   // common to any test cases
   const stashPath = '/presentation-api/controlling-ua/support/stash.py?id=';

--- a/presentation-api/controlling-ua/support/stash.js
+++ b/presentation-api/controlling-ua/support/stash.js
@@ -64,7 +64,6 @@
           else
             setTimeout(polling, interval);
         });
-        xhr.send(null);
       };
       setTimeout(polling, interval);
     });

--- a/presentation-api/controlling-ua/support/stash.js
+++ b/presentation-api/controlling-ua/support/stash.js
@@ -1,54 +1,83 @@
-(window => {
-  // Note: Tentatively, Only one stash ID is defined, due to a single presentationUrls
-  // common to any test cases
-  const stashPath = '/presentation-api/controlling-ua/support/stash.py?id=';
-  const stashId = '59d947f0-31ba-4bc3-8b28-691e6bbb05a9';
+var Stash = function(inbound, outbound) {
+  this.stashPath = '/presentation-api/controlling-ua/support/stash.py?id=';
+  this.inbound = inbound;
+  this.outbound = outbound;
+}
 
-  // clean up a stash on wptserve
-  window.initStash = () => {
-    return fetch(stashPath + stashId).then(response => {
+// initialize a stash on wptserve
+Stash.prototype.init = function() {
+  return Promise.all([
+    fetch(this.stashPath + this.inbound).then(response => {
       return response.text();
-    });
-  };
-
-  // upload a test result to a stash on wptserve
-  window.uploadStash = result => {
-    return fetch(stashPath + stashId, {
-      method: 'POST',
-      body: result
-    }).then(response => {
+    }),
+    fetch(this.stashPath + this.outbound).then(response => {
       return response.text();
-    }).then(text => {
-      return text === 'ok' ? null : Promise.reject();
     })
-  };
+  ]);
+}
 
-  // wait until a test result is uploaded to a stash on wptserve
-  window.waitForStash = () => {
-    return new Promise((resolve, reject) => {
-      let intervalId;
-      const interval = 500; // msec
-      const polling = () => {
-        return fetch(stashPath + stashId).then(response => {
-          return response.text();
-        }).then(text => {
-          if(text) {
+// upload a test result to a stash on wptserve
+Stash.prototype.send = function(result) {
+  return fetch(this.stashPath + this.outbound, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'data', data: result })
+  }).then(response => {
+    return response.text();
+  }).then(text => {
+    return text === 'ok' ? null : Promise.reject();
+  })
+};
+
+// wait until a test result is uploaded to a stash on wptserve
+Stash.prototype.receive = function() {
+  return new Promise((resolve, reject) => {
+    let intervalId;
+    const interval = 500; // msec
+    const polling = () => {
+      return fetch(this.stashPath + this.inbound).then(response => {
+        return response.text();
+      }).then(text => {
+        if (text) {
+          try {
+            const json = JSON.parse(text);
+            if (json.type === 'data')
+              resolve(json.data);
+            else
+              reject();
+          } catch(e) {
             resolve(text);
-            clearInterval(intervalId);
           }
-        });
-      };
-      intervalId = setInterval(polling, interval);
-    });
-  };
+          clearInterval(intervalId);
+        }
+      });
+    };
+    intervalId = setInterval(polling, interval);
+  });
+};
 
-  // stop waiting for a stash on wptserve
-  window.stopWaitingStash = () => {
-    return fetch(stashPath + stashId, {
-      method: 'POST',
-      body: 'stopped'
-    }).then(response => {
+// reset a stash on wptserve
+Stash.prototype.stop = function() {
+  return Promise.all([
+    fetch(this.stashPath + this.inbound).then(response => {
       return response.text();
-    });
-  }
-})(window);
+    }),
+    fetch(this.stashPath + this.outbound).then(response => {
+      return response.text();
+    })
+  ]).then(() => {
+    return Promise.all([
+      fetch(this.stashPath + this.inbound, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'stop' })
+      }).then(response => {
+        return response.text();
+      }),
+      fetch(this.stashPath + this.outbound, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'stop' })
+      }).then(response => {
+        return response.text();
+      })
+    ]);
+  });
+}

--- a/presentation-api/controlling-ua/support/stash.js
+++ b/presentation-api/controlling-ua/support/stash.js
@@ -54,18 +54,19 @@
   // wait until a test result is uploaded to a stash on wptserve
   window.waitForStash = () => {
     return new Promise((resolve, reject) => {
+      let intervalId;
       const interval = 500; // msec
       const polling = () => {
         return fetch(stashPath + stashId).then(response => {
           return response.text();
         }).then(text => {
-          if(text)
+          if(text) {
             resolve(text);
-          else
-            setTimeout(polling, interval);
+            clearInterval(intervalId);
+          }
         });
       };
-      setTimeout(polling, interval);
+      intervalId = setInterval(polling, interval);
     });
   };
 

--- a/presentation-api/controlling-ua/support/stash.js
+++ b/presentation-api/controlling-ua/support/stash.js
@@ -1,0 +1,82 @@
+(window => {
+  //
+  // Common Parameters and Functions for test cases which use a stash
+  //
+  window.message1 = '1st';
+  window.message2 = '2nd';
+  window.message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+  window.message4 = new Uint8Array([52, 116, 104]);      // "4th"
+  window.message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+  Uint8Array.prototype.toText = function() {
+      return this.reduce(function(result, item) {
+          return result + String.fromCharCode(item);
+      }, '');
+  };
+
+  Uint8Array.prototype.equals = function(a) {
+      let array = a instanceof Uint8Array ? a : (a instanceof ArrayBuffer ? new Uint8Array(a) : null);
+      return !!array && this.every((item, index) => { return item === a[index]; });
+  };
+
+  ArrayBuffer.prototype.toText = function() {
+      return new Uint8Array(this).toText();
+  };
+
+  ArrayBuffer.prototype.equals = function(a) {
+      return new Uint8Array(this).equals(a);
+  };
+
+  // Note: Tentatively, Only one stash ID is defined, due to a single presentationUrls
+  // common to any test cases
+  const stashPath = '/presentation-api/controlling-ua/support/stash.py?id=';
+  const stashId = '59d947f0-31ba-4bc3-8b28-691e6bbb05a9';
+
+  // clean up a stash on wptserve
+  window.initStash = () => {
+    return fetch(stashPath + stashId).then(response => {
+      return response.text();
+    });
+  };
+
+  // upload a test result to a stash on wptserve
+  window.uploadStash = result => {
+    return fetch(stashPath + stashId, {
+      method: 'POST',
+      body: result
+    }).then(response => {
+      return response.text();
+    }).then(text => {
+      return text === 'ok' ? null : Promise.reject();
+    })
+  };
+
+  // wait until a test result is uploaded to a stash on wptserve
+  window.waitForStash = () => {
+    return new Promise((resolve, reject) => {
+      const interval = 500; // msec
+      const polling = () => {
+        return fetch(stashPath + stashId).then(response => {
+          return response.text();
+        }).then(text => {
+          if(text)
+            resolve(text);
+          else
+            setTimeout(polling, interval);
+        });
+        xhr.send(null);
+      };
+      setTimeout(polling, interval);
+    });
+  };
+
+  // stop waiting for a stash on wptserve
+  window.stopWaitingStash = () => {
+    return fetch(stashPath + stashId, {
+      method: 'POST',
+      body: 'stopped'
+    }).then(response => {
+      return response.text();
+    });
+  }
+})(window);

--- a/presentation-api/controlling-ua/support/stash.py
+++ b/presentation-api/controlling-ua/support/stash.py
@@ -1,0 +1,10 @@
+def main(request, response):
+    key = request.GET.first("id")
+
+    if request.method == "POST":
+        request.server.stash.put(key, request.body)
+        return "ok"
+    else:
+        value = request.server.stash.take(key)
+        assert request.server.stash.take(key) is None
+        return value


### PR DESCRIPTION
This PR adds two test cases where a controlling user agent sends and receives text and binary messages through PresentationConnection.

These test cases use a stash of wptserve to communicate with a receiving user agent without PresentationConnection.