### PR TITLE
XMLHttpRequest: overrideMimeType cannot throw for invalid MIME types

### DIFF
--- a/XMLHttpRequest/overridemimetype-invalid-mime-type.htm
+++ b/XMLHttpRequest/overridemimetype-invalid-mime-type.htm
@@ -1,25 +1,41 @@
 <!doctype html>
-<html>
-  <head>
-    <title>XMLHttpRequest: overrideMimeType() in unsent state, invalid MIME types</title>
-    <meta charset="utf-8">
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-overridemimetype()-method" data-tested-assertations="/following::ol/li[2]" />
-  </head>
-  <body>
-    <div id="log"></div>
-    <script>
-      test(function() {
-        var client = new XMLHttpRequest();
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text\\plain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text plain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('text\nplain;charset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType('cahrset=Shift-JIS'); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType(null); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType(50212); });
-        assert_throws("SyntaxError", function() { client.overrideMimeType( (new Array(1000)).join('a/b/c/') ); });
-      });
-    </script>
-  </body>
-</html>
+<title>XMLHttpRequest: overrideMimeType() and invalid MIME types</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://xhr.spec.whatwg.org/#the-overridemimetype()-method">
+<div id="log"></div>
+<script>
+async_test(t => {
+  const client = new XMLHttpRequest()
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseText, "ÿ")
+    assert_equals(client.getResponseHeader("Content-Type"), "text/html;charset=windows-1252")
+  })
+  client.open("GET", "resources/status.py?type=" + encodeURIComponent("text/html;charset=windows-1252") + "&content=%FF")
+  client.overrideMimeType("bogus")
+  client.send()
+}, "Bogus MIME type does not override encoding")
+
+async_test(t => {
+  const client = new XMLHttpRequest()
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseText, "ÿ")
+    assert_equals(client.getResponseHeader("Content-Type"), "text/html;charset=windows-1252")
+  })
+  client.open("GET", "resources/status.py?type=" + encodeURIComponent("text/html;charset=windows-1252") + "&content=%FF")
+  client.overrideMimeType("bogus;charset=Shift_JIS")
+  client.send()
+}, "Bogus MIME type does not override encoding, 2")
+
+async_test(t => {
+  const client = new XMLHttpRequest()
+  client.onload = t.step_func_done(() => {
+    assert_equals(client.responseXML, null)
+    assert_equals(client.getResponseHeader("Content-Type"), "text/xml")
+  })
+  client.open("GET", "resources/status.py?type=" + encodeURIComponent("text/xml") + "&content=" + encodeURIComponent("<x/>"))
+  client.overrideMimeType("bogus")
+  client.send()
+}, "Bogus MIME type does override MIME type")
+</script>


### PR DESCRIPTION
See https://github.com/whatwg/xhr/issues/82.