### PR TITLE
Fetch: make referrer-origin test work on w3c-test.org

### DIFF
--- a/fetch/api/policies/referrer-origin.js
+++ b/fetch/api/policies/referrer-origin.js
@@ -3,7 +3,7 @@ if (this.document === undefined) {
   importScripts("../resources/utils.js");
 }
 
-var referrerOrigin = "http://{{host}}:{{ports[http][0]}}/";
+var referrerOrigin = (new URL("/", location.href)).href;
 var fetchedUrl = RESOURCES_DIR + "inspect-headers.py?headers=referer";
 
 promise_test(function(test) {


### PR DESCRIPTION
In particular, this makes it no longer depend on the port being a
non-default-port for the scheme.

Closes #2618.