### PR TITLE
Replace usage of setTimeout with step_timeout in old-tests/Microsoft

### DIFF
--- a/old-tests/submission/Microsoft/history/history_000.htm
+++ b/old-tests/submission/Microsoft/history/history_000.htm
@@ -318,7 +318,7 @@
         }
         function queue(func) {
             //50 allows adequate time for .back and .forward navigations to queue first
-            setTimeout(func, 50);
+            step_timeout(func, 50);
         }
         
         add_result_callback(testFinished);

--- a/old-tests/submission/Microsoft/sandbox/sandbox_001.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_001.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 8000);
+        var timer = step_timeout(callback, 8000);
         window.addEventListener("message", callback, false);
     </script>
     <iframe src="iframe_sandbox_001.htm" sandbox="allow-scripts" style="display: none"></iframe>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_005.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_005.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <iframe src="iframe_sandbox_001.htm" sandbox style="display: none"></iframe>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_012.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_012.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_013.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_013.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_014.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_014.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_015.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_015.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_017.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_017.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_018.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_018.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_019.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_019.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_023.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_023.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <iframe src="iframe_sandbox_023.htm" sandbox="allow-scripts allow-same-origin" style="display:none"></iframe>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_024.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_024.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_026.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_026.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_027.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_027.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_028.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_028.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <iframe src="iframe_sandbox_028.htm" sandbox="allow-scripts" style="display:none"></iframe>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_029.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_029.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_031.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_031.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/sandbox/sandbox_032.htm
+++ b/old-tests/submission/Microsoft/sandbox/sandbox_032.htm
@@ -24,7 +24,7 @@
             t.done();
         }
 
-        var timer = setTimeout(callback, 4000);
+        var timer = step_timeout(callback, 4000);
         window.addEventListener("message", callback, false);
     </script>
     <div id=log></div>

--- a/old-tests/submission/Microsoft/structuredclone/structuredclone_0.html
+++ b/old-tests/submission/Microsoft/structuredclone/structuredclone_0.html
@@ -385,7 +385,7 @@
         }
     }
     function queue(func) {
-        setTimeout(func, 10);
+        step_timeout(func, 10);
     }
     
     add_result_callback(testFinished);


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
