### PR TITLE
Replace usage of setTimeout with step_timeout in page-visibility

### DIFF
--- a/page-visibility/resources/pagevistestharness.js
+++ b/page-visibility/resources/pagevistestharness.js
@@ -117,5 +117,5 @@ function TabSwitch()
 {
     //var open_link = window.open("http://www.bing.com");
     open_link = window.open('', '_blank');
-    setTimeout(function() { open_link.close(); }, 2000);
+    step_timeout(function() { open_link.close(); }, 2000);
 }


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
