### PR TITLE
Replace usage of setTimeout with step_timeout in websockets

### DIFF
--- a/websockets/closing-handshake/004.html
+++ b/websockets/closing-handshake/004.html
@@ -18,7 +18,7 @@ async_test(function(t) {
   ws.onclose = t.step_func(function(e) {
     assert_equals(e.wasClean, true);
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(t.step_func(function() {t.done()}), 50);
+    step_timeout(t.step_func(function() {t.done()}), 50);
   })
 });
 </script>

--- a/websockets/constructor/006.html
+++ b/websockets/constructor/006.html
@@ -19,7 +19,7 @@ async_test(function(t) {
     assert_equals(e.data, 'test');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done()}), 50);
+      step_timeout(t.step_func(function() {t.done()}), 50);
     });
     ws.close();
   });

--- a/websockets/constructor/009.html
+++ b/websockets/constructor/009.html
@@ -14,7 +14,7 @@ async_test(function(t) {
     assert_equals(ws.protocol, 'foobar');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done()}), 50);
+      step_timeout(t.step_func(function() {t.done()}), 50);
     })
     ws.close();
   })

--- a/websockets/constructor/010.html
+++ b/websockets/constructor/010.html
@@ -13,7 +13,7 @@ async_test(function(t) {
   ws.onopen = t.step_func(function(e) {
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});
-      setTimeout(t.step_func(function() {t.done();}), 50);
+      step_timeout(t.step_func(function() {t.done();}), 50);
     })
     ws.close();
   })

--- a/websockets/constructor/011.html
+++ b/websockets/constructor/011.html
@@ -21,7 +21,7 @@ async_test(function(t) {
     assert_true(gotOpen, 'got open');
     assert_true(gotError, 'got error');
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(t.step_func(function() {t.done();}), 50);
+    step_timeout(t.step_func(function() {t.done();}), 50);
   })
 });
 </script>

--- a/websockets/constructor/012.html
+++ b/websockets/constructor/012.html
@@ -11,7 +11,7 @@ async_test(function(t) {
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/handshake_no_protocol', 'foobar');
   ws.onclose = t.step_func(function(e) {
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(t.step_func(function() {t.done();}), 50)
+    step_timeout(t.step_func(function() {t.done();}), 50)
   })
   ws.onmessage = t.step_func(function() {assert_unreached()});
 });

--- a/websockets/constructor/022.html
+++ b/websockets/constructor/022.html
@@ -13,7 +13,7 @@ async_test(function(t) {
     assert_equals(ws.protocol, 'foobar');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done();}), 50)
+      step_timeout(t.step_func(function() {t.done();}), 50)
     });
     ws.close();
   });

--- a/websockets/interfaces/WebSocket/close/close-connecting.html
+++ b/websockets/interfaces/WebSocket/close/close-connecting.html
@@ -10,7 +10,7 @@
 <script>
 async_test(function(t) {
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/sleep_10_v13');
-  setTimeout(t.step_func(function() {
+  step_timeout(t.step_func(function() {
     assert_equals(ws.readyState, ws.CONNECTING);
     ws.close();
     assert_equals(ws.readyState, ws.CLOSING);

--- a/websockets/interfaces/WebSocket/close/close-nested.html
+++ b/websockets/interfaces/WebSocket/close/close-nested.html
@@ -17,7 +17,7 @@ async_test(function(t) {
       ws.close();
       assert_equals(ws.readyState, ws.CLOSED);
     }
-    setTimeout(t.step_func(function() {
+    step_timeout(t.step_func(function() {
       assert_equals(i, 1);
       t.done();
     }), 50);

--- a/websockets/interfaces/WebSocket/send/006.html
+++ b/websockets/interfaces/WebSocket/send/006.html
@@ -17,7 +17,7 @@ async_test(function(t) {
     assert_equals(e.data, 'a\uFFFDxb\uFFFDxc\uFFFD\uFFFDx');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(function() {t.done();}, 50);
+      step_timeout(function() {t.done();}, 50);
     });
     ws.close();
   })

--- a/websockets/interfaces/WebSocket/send/007.html
+++ b/websockets/interfaces/WebSocket/send/007.html
@@ -19,7 +19,7 @@ async_test(function(t) {
   });
   ws.onclose = t.step_func(function(e) {
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(function() {t.done()}, 50);
+    step_timeout(function() {t.done()}, 50);
   });
   ws.onerror = ws.onmessage = t.step_func(function() {assert_unreached()});
 });

--- a/websockets/interfaces/WebSocket/send/008.html
+++ b/websockets/interfaces/WebSocket/send/008.html
@@ -18,7 +18,7 @@ async_test(function(t) {
     var sent = ws.send('test');
     assert_equals(sent, undefined);
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(function() {t.done()}, 50);
+    step_timeout(function() {t.done()}, 50);
   })
   ws.onerror = t.step_func(function() {assert_unreached()});
 });

--- a/websockets/interfaces/WebSocket/send/009.html
+++ b/websockets/interfaces/WebSocket/send/009.html
@@ -19,7 +19,7 @@ async_test(function(t){
   });
   ws.onclose = t.step_func(function(e) {
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(function() {t.done()}, 50);
+    step_timeout(function() {t.done()}, 50);
   });
   ws.onerror = t.step_func(function() {assert_unreached()});
 });

--- a/websockets/interfaces/WebSocket/send/011.html
+++ b/websockets/interfaces/WebSocket/send/011.html
@@ -18,7 +18,7 @@ async_test(function(t) {
     assert_equals(e.data, '\u00E5 a\u030A \uD801\uDC7E');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(function() {t.done()}, 50);
+      step_timeout(function() {t.done()}, 50);
     })
     ws.close();
   })

--- a/websockets/interfaces/WebSocket/send/012.html
+++ b/websockets/interfaces/WebSocket/send/012.html
@@ -18,7 +18,7 @@ async_test(function(t){
     assert_equals(e.data, 'null');
     ws.onclose = t.step_func(function(e) {
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(function() {t.done()}, 50);
+      step_timeout(function() {t.done()}, 50);
     })
     ws.close();
   });

--- a/websockets/keeping-connection-open/001.html
+++ b/websockets/keeping-connection-open/001.html
@@ -13,12 +13,12 @@ async_test(function(t) {
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
   ws.onclose = ws.onerror = ws.onmessage = t.step_func(function() {assert_unreached()});
   ws.onopen = t.step_func(function(e) {
-    setTimeout(t.step_func(function() {
+    step_timeout(t.step_func(function() {
       ws.send('test');
       ws.onmessage = t.step_func(function(e) {
         assert_equals(e.data, 'test');
         ws.onclose = t.step_func(function(e) {
-          setTimeout(t.step_func(function() {t.done();}), 50)
+          step_timeout(t.step_func(function() {t.done();}), 50)
         });
         ws.close();
       });

--- a/websockets/opening-handshake/001.html
+++ b/websockets/opening-handshake/001.html
@@ -12,7 +12,7 @@ async_test(function(t) {
   ws.onclose = t.step_func(function(e) {
     assert_false(e.wasClean);
     ws.onclose = t.step_func(function() {assert_unreached()});
-    setTimeout(t.step_func(function() {t.done();}), 50)
+    step_timeout(t.step_func(function() {t.done();}), 50)
   });
    ws.onmessage = ws.onopen = t.step_func(function() {assert_unreached()});
 }, null, {timeout:9900});

--- a/websockets/opening-handshake/002.html
+++ b/websockets/opening-handshake/002.html
@@ -14,7 +14,7 @@ async_test(function(t) {
     ws.onclose = t.step_func(function(e) {
       assert_equals(e.wasClean, true);
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done();}), 50)
+      step_timeout(t.step_func(function() {t.done();}), 50)
     })
     ws.close();
   });

--- a/websockets/opening-handshake/003.html
+++ b/websockets/opening-handshake/003.html
@@ -14,7 +14,7 @@ async_test(function(t) {
     ws.onclose = t.step_func(function(e) {
       assert_equals(e.wasClean, true);
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done();}), 50)
+      step_timeout(t.step_func(function() {t.done();}), 50)
     })
     ws.close();
   })

--- a/websockets/opening-handshake/005.html
+++ b/websockets/opening-handshake/005.html
@@ -14,7 +14,7 @@ async_test(function(t) {
     ws.onclose = t.step_func(function(e) {
       assert_equals(e.wasClean, true);
       ws.onclose = t.step_func(function() {assert_unreached()});
-      setTimeout(t.step_func(function() {t.done();}), 50)
+      step_timeout(t.step_func(function() {t.done();}), 50)
     })
     ws.close();
   })

--- a/websockets/unload-a-document/002-1.html
+++ b/websockets/unload-a-document/002-1.html
@@ -19,7 +19,7 @@ t.step(function() {
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
     ws.onopen = t.step_func(function(e) {
 
-      setTimeout(t.step_func(function() {
+      step_timeout(t.step_func(function() {
         assert_equals(ws.readyState, ws.CLOSED, 'ws.readyState');
         t.done();
       }), 4000);

--- a/websockets/unload-a-document/005-1.html
+++ b/websockets/unload-a-document/005-1.html
@@ -10,9 +10,9 @@ var hasRun = false;
 function run(){
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo');
   ws.onopen = t.step_func(function(e) {
-    setTimeout(t.step_func(function() {
+    t.step_timeout(function() {
       ws.send('test');
-    }), 1000);
+    }, 1000);
     window[0].location = 'data:text/html,<body onload="history.back()">';
     ws.onmessage = t.step_func(function(e) {
       ws.close();

--- a/websockets/unload-a-document/005.html
+++ b/websockets/unload-a-document/005.html
@@ -10,7 +10,7 @@
 <p>Test requires popup blocker disabled</p>
 <div id=log></div>
 <script>
-var t = async_test(null, {timeout:15000});
+var t = async_test();
 t.step(function() {
   var w = window.open("005-1.html");
   add_result_callback(function() {


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
