### PR TITLE
Replace usage of setTimeout with step_timeout in old-tests/webdriver

### DIFF
--- a/old-tests/webdriver/timeouts/res/implicit_waits_tests.html
+++ b/old-tests/webdriver/timeouts/res/implicit_waits_tests.html
@@ -15,14 +15,14 @@
         box.style.border = '1px solid black';
         box.style.margin = '5px';
 
-        window.setTimeout(function() {
+        window.step_timeout(function() {
           document.body.appendChild(box);
         }, 1000);
       }
 
       function reveal() {
         var elem = document.getElementById('revealed');
-        window.setTimeout(function() {
+        window.step_timeout(function() {
           elem.style.display = '';
         }, 1000);
       }


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.