### PR TITLE
Replace usage of setTimeout with step_timeout in pointerevents

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -157,14 +157,14 @@ function updateDescriptionComplete() {
 }
 
 function updateDescriptionSecondStepTouchActionElement(target, scrollReturnInterval) {
-    window.setTimeout(function() {
+    window.step_timeout(function() {
     objectScroller(target, 'up', 0);}
     , scrollReturnInterval);
     document.getElementById('desc').innerHTML = "Test Description: Try to scroll element RIGHT moving your outside of the red border";
 }
 
 function updateDescriptionThirdStepTouchActionElement(target, scrollReturnInterval) {
-    window.setTimeout(function() {
+    window.step_timeout(function() {
     objectScroller(target, 'left', 0);}
     , scrollReturnInterval);
     document.getElementById('desc').innerHTML = "Test Description: Try to scroll element DOWN then RIGHT starting your touch inside of the element. Then tap complete button";


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4970)
<!-- Reviewable:end -->
