### PR TITLE
Replace usage of setTimeout with step_timeout in shadow-dom

### DIFF
--- a/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
+++ b/shadow-dom/untriaged/html-elements-in-shadow-trees/inert-html-elements/test-001.html
@@ -72,7 +72,7 @@ A_08_01_01_T01.step(function () {
     // should be reloaded, so iframe context shouldn't be affected
 
     // set timeout to give the iframe time to load content
-    setTimeout('A_08_01_01_T01.checkIframeContent()', 2000);
+    step_timeout(A_08_01_01_T01.checkIframeContent, 2000);
 });
 </script>
 </body>


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.