### PR TITLE
Replace usage of setTimeout with step_timeout in html/infrastructure

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -35,7 +35,7 @@ onload = function() {
                       // page and the test timing out
                       test_obj.force_timeout();
                   }
-                  setTimeout(poll, 200);
+                  step_timeout(poll, 200);
               } else {
                   assert_equals(xhr.response, expected);
                   test_obj.done();
@@ -43,7 +43,7 @@ onload = function() {
           });
           xhr.send();
       })
-      setTimeout(poll, 200);
+      step_timeout(poll, 200);
   }
 
   // background attribute, check with getComputedStyle


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/4974)
<!-- Reviewable:end -->
