### PR TITLE
Replace usage of setTimeout with step_timeout in html/browsers

### DIFF
--- a/html/browsers/browsing-the-web/unloading-documents/support/001-1.html
+++ b/html/browsers/browsing-the-web/unloading-documents/support/001-1.html
@@ -13,7 +13,7 @@
  })
 onload = t.step_func(function() {
   localStorage.test6564729 = '0';
-  setTimeout(t.step_func(function() {document.links[0].click()}));
+  step_timeout(t.step_func(function() {document.links[0].click()}));
 });
 </script>
 <body onbeforeunload="localStorage.test6564729 += '1'"

--- a/html/browsers/browsing-the-web/unloading-documents/support/002-1.html
+++ b/html/browsers/browsing-the-web/unloading-documents/support/002-1.html
@@ -18,7 +18,7 @@
 
 onload = t.step_func(function() {
   localStorage.test6564729 = '0';
-  setTimeout(function() {document.getElementsByTagName("input")[0].click()}, 100);
+  step_timeout(function() {document.getElementsByTagName("input")[0].click()}, 100);
 });
 </script>
 <body onbeforeunload="localStorage.test6564729 += '2'"

--- a/html/browsers/browsing-the-web/unloading-documents/support/003-1.html
+++ b/html/browsers/browsing-the-web/unloading-documents/support/003-1.html
@@ -12,7 +12,7 @@
    localStorage.test6564729 += '4';
  })
 
- onload=t.step_func(function() {localStorage.test6564729 = '0'; setTimeout(t.step_func(function() {document.links[0].click()}), 100)})
+ onload=t.step_func(function() {localStorage.test6564729 = '0'; step_timeout(t.step_func(function() {document.links[0].click()}), 100)})
 
 </script>
 <body

--- a/html/browsers/browsing-the-web/unloading-documents/support/004-1.html
+++ b/html/browsers/browsing-the-web/unloading-documents/support/004-1.html
@@ -15,7 +15,7 @@
  })
 onload = t.step_func(function() {
   localStorage.test6564729 = 'A';
-  setTimeout(t.step_func(function() {document.getElementsByTagName("input")[0].click()}), 100);
+  step_timeout(t.step_func(function() {document.getElementsByTagName("input")[0].click()}), 100);
 })
 </script>
 <body onbeforeunload="localStorage.test6564729 += 'C'"

--- a/html/browsers/browsing-the-web/unloading-documents/support/005-1.html
+++ b/html/browsers/browsing-the-web/unloading-documents/support/005-1.html
@@ -2,7 +2,7 @@
 <script>
 onload = opener.t.step_func(function() {
   localStorage.test6564729 = '0'
-  setTimeout(opener.t.step_func(function() {document.links[0].click()}), 100);
+  opener.t.step_timeout(function() {document.links[0].click()}, 100);
 });
 </script>
 <body

--- a/html/browsers/history/the-history-interface/001.html
+++ b/html/browsers/history/the-history-interface/001.html
@@ -24,7 +24,7 @@ window.onload = function () {
         document.getElementsByTagName('p')[0].innerHTML += '<br>WARNING: Browsers may intentionally fail to update history.length when pages are loaded over HTTPS, as a privacy restriction. If possible, load this page over HTTP.';
     }
     //use a timeout, because some browsers intentionally do not add history entries for URL changes in the onload thread
-    setTimeout(testinit,100);
+    step_timeout(testinit,100);
 };
 function testinit() {
     atstep = 1;
@@ -59,7 +59,7 @@ function reportload() {
         }, 'history.state should update after a state is pushed');
         histlength = history.length;
         history.back();
-        setTimeout(tests2,50); //.back is queued to end of thread
+        step_timeout(tests2,50); //.back is queued to end of thread
     }
     function tests2() {
         test(function () {
@@ -69,7 +69,7 @@ function reportload() {
             assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test' );
         }, 'traversing history must traverse pushed states');
         history.go(-1);
-        setTimeout(tests3,50); //.go is queued to end of thread
+        step_timeout(tests3,50); //.go is queued to end of thread
     }
     function tests3() {
         test(function () {
@@ -77,7 +77,7 @@ function reportload() {
         }, 'traversing history must also traverse hash changes');
         //Safari 5.0.3 fails here - it navigates *this* document to the *iframe's* location, instead of just navigating the iframe
         history.go(2);
-        setTimeout(tests4,50); //.go is queued to end of thread
+        step_timeout(tests4,50); //.go is queued to end of thread
     }
     function tests4() {
         test(function () {
@@ -101,7 +101,7 @@ function reportload() {
             assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test2', 'location.hash did not change when told to' );
         }, 'location.hash must be allowed to change (part 1)');
         history.go(-1);
-        setTimeout(tests5,50); //.go is queued to end of thread
+        step_timeout(tests5,50); //.go is queued to end of thread
     }
     function tests5() {
         test(function () {
@@ -112,7 +112,7 @@ function reportload() {
             assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test', 'location.hash changed when an unrelated state was pushed' );
         }, 'pushState must not alter location.hash when no URL is provided');
         history.go(1); //should do nothing, since the pushState should have removed the forward history
-        setTimeout(tests6,50); //.go is queued to end of thread
+        step_timeout(tests6,50); //.go is queued to end of thread
     }
     function tests6() {
         test(function () {
@@ -132,11 +132,11 @@ function reportload() {
         //allow the browser to mistakenly run the .go if it is going to
         //do not put two .go commands in the same thread, in case the browser mistakenly calculates the history position when
         //calling .go instead of when executing the traversal task - that could give a false PASS in the next test otherwise
-        setTimeout(tests7,50);
+        step_timeout(tests7,50);
     }
     function tests7() {
         iframe.contentWindow.history.go(-1); //must be queued, but should not be removed this time
-        setTimeout(tests8,50); //.go is queued to end of thread
+        step_timeout(tests8,50); //.go is queued to end of thread
     }
     function tests8() {
         test(function () {
@@ -148,7 +148,7 @@ function reportload() {
             //push a state that changes the hash
             iframe.contentWindow.history.pushState('','',iframe.contentWindow.location.pathname+'#test5');
         } catch(unsuperr) {}
-        setTimeout(tests9,50); //allow the hashchange event to process, if the browser has mistakenly fired it
+        step_timeout(tests9,50); //allow the hashchange event to process, if the browser has mistakenly fired it
     }
     function tests9() {
         test(function () {
@@ -230,10 +230,10 @@ function reportload() {
         }, 'pushState MIGHT set the document title');
         */
         history.go(-1);
-        setTimeout(tests10,50); //.go is queued to end of thread
+        step_timeout(tests10,50); //.go is queued to end of thread
     }
     function tests10() {
-        var eventtime = setTimeout(function () { tests11(false); },500); //should be cleared by the event handler long before it has a chance to fire
+        var eventtime = step_timeout(function () { tests11(false); },500); //should be cleared by the event handler long before it has a chance to fire
         iframe.contentWindow.addEventListener('popstate',function (e) { clearTimeout(eventtime); tests11(true,e); },false);
         history.forward();
     }
@@ -283,7 +283,7 @@ function reportload() {
         } catch(unsuperr) {}
         //it's already cached, so this should be very fast if the browser mistakenly loads it
         //it should not need to load at all, since it's just a pushed state
-        setTimeout(tests12,1000);
+        step_timeout(tests12,1000);
     }
     function tests12() {
         test(function () {
@@ -291,7 +291,7 @@ function reportload() {
         }, 'pushState should not actually load the new URL');
         atstep = 3;
         iframe.contentWindow.location.reload(); //load the real URL
-        lasttimer = setTimeout(function () { tests13(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
+        lasttimer = step_timeout(function () { tests13(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
     }
     function tests13(passed) {
         test(function () {
@@ -306,7 +306,7 @@ function reportload() {
         //blank2 has loaded
         atstep = 2;
         //use a timeout, because some browsers intentionally do not add history entries for URL changes in an onload thread
-        setTimeout(tests1,100);
+        step_timeout(tests1,100);
     } else if( atstep == 3 ) {
         //blank3 should now have loaded after the .reload() command
         atstep = 4;

--- a/html/browsers/history/the-history-interface/002.html
+++ b/html/browsers/history/the-history-interface/002.html
@@ -24,7 +24,7 @@ window.onload = function () {
         document.getElementsByTagName('p')[0].innerHTML += '<br>WARNING: Browsers may intentionally fail to update history.length when pages are loaded over HTTPS, as a privacy restriction. If possible, load this page over HTTP.';
     }
     //use a timeout, because some browsers intentionally do not add history entries for URL changes in the onload thread
-    setTimeout(testinit,100);
+    step_timeout(testinit,100);
 };
 function testinit() {
     atstep = 1;
@@ -50,7 +50,7 @@ function reportload() {
         }, 'initial history.state should be null');
         iframe.contentWindow.location.hash = 'test2';
         history.back();
-        setTimeout(tests2,50); //.go is queued to end of thread
+        step_timeout(tests2,50); //.go is queued to end of thread
     }
     function tests2() {
         test(function () {
@@ -73,14 +73,14 @@ function reportload() {
             assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), 'test3' );
         }, 'hash should change when replaceState is called with a URL');
         history.go(-1);
-        setTimeout(tests3,50); //.go is queued to end of thread
+        step_timeout(tests3,50); //.go is queued to end of thread
     }
     function tests3() {
         test(function () {
             assert_equals( iframe.contentWindow.location.hash.replace(/^#/,''), '' );
         }, 'replaceState must replace the existing state and not add an extra one');
         history.go(2);
-        setTimeout(tests4,50); //.go is queued to end of thread
+        step_timeout(tests4,50); //.go is queued to end of thread
     }
     function tests4() {
         test(function () {
@@ -118,7 +118,7 @@ function reportload() {
             iframe.contentWindow.history.replaceState('','',iframe.contentWindow.location.pathname+'#test5');
         } catch(unsuperr2) {}
         //allow the browser to run the .go
-        setTimeout(tests5,50);
+        step_timeout(tests5,50);
     }
     function tests5() {
         test(function () {
@@ -126,7 +126,7 @@ function reportload() {
         }, 'replaceState must not remove any tasks queued by the history traversal task source');
         //Safari 5.0.3 fails here - it navigates *this* document to the *iframe's* location, instead of just navigating the iframe
         history.go(1);
-        setTimeout(tests6,50); //.go is queued to end of thread
+        step_timeout(tests6,50); //.go is queued to end of thread
     }
     function tests6() {
         test(function () {
@@ -138,7 +138,7 @@ function reportload() {
             //push a state that changes the hash
             iframe.contentWindow.history.replaceState('','',iframe.contentWindow.location.pathname+'#test6');
         } catch(unsuperr) {}
-        setTimeout(tests7,50); //allow the hashchange event to process, if the browser has mistakenly fired it
+        step_timeout(tests7,50); //allow the hashchange event to process, if the browser has mistakenly fired it
     }
     function tests7() {
         test(function () {
@@ -205,10 +205,10 @@ function reportload() {
             assert_false( cloneobj === iframe.contentWindow.history.state );
         }, 'history.state should be a clone of the original object, not a reference to it');
         history.go(-1);
-        setTimeout(tests8,50); //.go is queued to end of thread
+        step_timeout(tests8,50); //.go is queued to end of thread
     }
     function tests8() {
-        var eventtime = setTimeout(function () { tests9(false); },500); //should be cleared by the event handler long before it has a chance to fire
+        var eventtime = step_timeout(function () { tests9(false); },500); //should be cleared by the event handler long before it has a chance to fire
         iframe.contentWindow.addEventListener('popstate',function (e) { clearTimeout(eventtime); tests9(true,e); },false);
         history.forward();
     }
@@ -258,7 +258,7 @@ function reportload() {
         } catch(unsuperr) {}
         //it's already cached, so this should be very fast if the browser mistakenly loads it
         //it should not need to load at all, since it's just a pushed state
-        setTimeout(tests10,1000);
+        step_timeout(tests10,1000);
     }
     function tests10() {
         test(function () {
@@ -266,7 +266,7 @@ function reportload() {
         }, 'replaceState should not actually load the new URL');
         atstep = 3;
         iframe.contentWindow.location.reload(); //load the real URL
-        lasttimer = setTimeout(function () { tests11(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
+        lasttimer = step_timeout(function () { tests11(false); },3000); //should be cleared by the onload handler long before it has a chance to fire
     }
     function tests11(passed) {
         test(function () {
@@ -281,7 +281,7 @@ function reportload() {
         //blank2 has loaded
         atstep = 2;
         //use a timeout, because some browsers intentionally do not add history entries for URL changes in an onload thread
-        setTimeout(tests1,100);
+        step_timeout(tests1,100);
     } else if( atstep == 3 ) {
         //blank3 should now have loaded after the .reload() command
         atstep = 4;

--- a/html/browsers/history/the-history-interface/004.html
+++ b/html/browsers/history/the-history-interface/004.html
@@ -12,18 +12,18 @@ window.onload = function () {
     location.href = location.href.replace(/#.*$/,'');
     return;
   }
-  setTimeout(add1,100);
+  step_timeout(add1,100);
   function add1() {
     location.hash = '#foo';
-    setTimeout(add2,100);
+    step_timeout(add2,100);
   }
   function add2() {
     location.hash = '#bar';
-    setTimeout(add3,100);
+    step_timeout(add3,100);
   }
   function add3() {
     location.hash = '#baz';
-    setTimeout(dojumps,100);
+    step_timeout(dojumps,100);
   }
   function dojumps() {
     window.onhashchange = function () {
@@ -36,7 +36,7 @@ window.onload = function () {
       assert_equals( location.hash.replace(/^#/,''), 'baz', 'the browser navigated synchronously' );
     }, '.go commands should be queued until the thread has ended');
     history.go(-1);
-    setTimeout(checkjumps,100);
+    step_timeout(checkjumps,100);
   }
   function checkjumps() {
     test(function () {

--- a/html/browsers/history/the-history-interface/005.html
+++ b/html/browsers/history/the-history-interface/005.html
@@ -12,7 +12,7 @@ var readyForPop = false, bodypop = false, inlinepop = false;
 setup({explicit_done:true});
 
 //use a timeout to avoid "popstate fires onload" from setting the variables too early
-setTimeout(step1,1000);
+step_timeout(step1,1000);
 function step1() {
   readyForPop = true;
   test(function () {
@@ -20,7 +20,7 @@ function step1() {
     history.pushState('','');
   }, 'history.pushState support is needed for this testcase');
   history.go(-1);
-  setTimeout(step2,50); //.go is queued to end of thread
+  step_timeout(step2,50); //.go is queued to end of thread
 }
 function step2() {
   test(function () {
@@ -28,7 +28,7 @@ function step2() {
   }, '<body onpopstate="..."> should register a listener for the popstate event');
   window.onpopstate = function () { inlinepop = true; };
   history.go(-1);
-  setTimeout(step3,50); //.go is queued to end of thread
+  step_timeout(step3,50); //.go is queued to end of thread
 }
 function step3() {
   test(function () {

--- a/html/browsers/history/the-history-interface/006.html
+++ b/html/browsers/history/the-history-interface/006.html
@@ -21,7 +21,7 @@ window.onload = function () {
     assert_equals( history.state, null );
   }, 'history.state should still be null onload');
   popfired = false;
-  setTimeout(function () {
+  step_timeout(function () {
     test(function () {
       assert_false( popfired );
     }, 'popstate event should not fire after onload fires');

--- a/html/browsers/history/the-history-interface/007.html
+++ b/html/browsers/history/the-history-interface/007.html
@@ -38,7 +38,7 @@ window.onload = function () {
     assert_equals( history.state, 'state1' );
   }, 'history.state should reflect the navigated state onload');
   popfired = false;
-  setTimeout(function () {
+  step_timeout(function () {
     test(function () {
       assert_false( !!popfired );
     }, 'popstate event should not fire after onload fires');

--- a/html/browsers/history/the-history-interface/009-1.html
+++ b/html/browsers/history/the-history-interface/009-1.html
@@ -9,7 +9,7 @@
     <div id="log"></div>
     <script type="text/javascript">
 window.onload = function () {
-  setTimeout(function () {
+  parent.step_timeout(function () {
     try { history.pushState('','','009-2.html?1234'); } catch(e) {}
     location.href = '009-3.html?pipe=sub';
   },10);

--- a/html/browsers/history/the-history-interface/009-3.html
+++ b/html/browsers/history/the-history-interface/009-3.html
@@ -17,7 +17,7 @@ parent.test(function () {
         parent.assert_equals( document.referrer, lastUrl );
 }, 'document.referrer should use the pushed state');
 window.onload = function () {
-        setTimeout(function () {
+        parent.step_timeout(function () {
                 try { history.pushState('','','009-4.html?2345'); } catch(e) {}
                 location.href = '009-5.html?pipe=sub';
         },10);

--- a/html/browsers/history/the-history-interface/011.html
+++ b/html/browsers/history/the-history-interface/011.html
@@ -19,7 +19,7 @@ test(function () {
   assert_equals( location.href, newUrl );
 }, 'pushed location should be reflected immediately');
 window.onload = function () {
-  setTimeout(function () {
+  step_timeout(function () {
     test(function () {
       assert_equals( location.href, newUrl );
     }, 'pushed location should be retained after the page has loaded');

--- a/html/browsers/history/the-history-interface/012.html
+++ b/html/browsers/history/the-history-interface/012.html
@@ -19,7 +19,7 @@ test(function () {
   assert_equals( location.href, newUrl );
 }, 'replaced location should be reflected immediately');
 window.onload = function () {
-  setTimeout(function () {
+  step_timeout(function () {
     test(function () {
       assert_equals( location.href, newUrl );
     }, 'replaced location should be retained after the page has loaded');

--- a/html/browsers/offline/application-cache-api/api_status_idle.html
+++ b/html/browsers/offline/application-cache-api/api_status_idle.html
@@ -11,7 +11,7 @@
       var t = async_test("idle status test"),
           cache = window.applicationCache;
 
-      setTimeout(function(){
+      step_timeout(function(){
         t.step(function() {
           assert_equals(cache.status, cache.IDLE, "cache.status should equals cache.IDLE");
         });

--- a/html/browsers/offline/resources/js/clock.js
+++ b/html/browsers/offline/resources/js/clock.js
@@ -1,3 +1,3 @@
-setTimeout(function () {
+step_timeout(function () {
     document.getElementById('clock').value = new Date();
 }, 1000);

--- a/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-02.html
+++ b/html/browsers/the-window-object/accessing-other-browsing-contexts/indexed-browsing-contexts-02.html
@@ -42,7 +42,7 @@
       document.getElementById("obj").removeAttribute("data");
       assert_equals(window.length, 3, "The top browsing context should have 3 child browsing contexts.");
 
-      setTimeout(function () {
+      step_timeout(function () {
         assert_equals(window.length, 2, "The top browsing context should have 2 child browsing contexts.");
       }, 1);
     });


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
