### PR TITLE
Replace usage of setTimeout with step_timeout in user-timing

### DIFF
--- a/user-timing/test_user_timing_clear_marks.html
+++ b/user-timing/test_user_timing_clear_marks.html
@@ -37,7 +37,7 @@
             {
                 // create a mark using the test delay; the mark's value should be equivalent to the loadEventStart
                 // navigation timing attribute plus the test delay
-                setTimeout(mark_test_cb, markTestDelay);
+                step_timeout(mark_test_cb, markTestDelay);
             }
         }
 

--- a/user-timing/test_user_timing_clear_measures.html
+++ b/user-timing/test_user_timing_clear_measures.html
@@ -36,7 +36,7 @@
             else
             {
                 // create measures using the test delay
-                setTimeout(measure_test_cb, measureTestDelay);
+                step_timeout(measure_test_cb, measureTestDelay);
             }
         }
 

--- a/user-timing/test_user_timing_mark.html
+++ b/user-timing/test_user_timing_mark.html
@@ -54,7 +54,7 @@
 
                 // create the duplicate mark using the test delay; the duplicate mark's value should be equivalent to
                 // the loadEventStart navigation timing attribute plus the test delay
-                setTimeout(mark_test_cb, markTestDelay);
+                step_timeout(mark_test_cb, markTestDelay);
             }
         }
 

--- a/user-timing/test_user_timing_measure.html
+++ b/user-timing/test_user_timing_measure.html
@@ -93,7 +93,7 @@
 
                 // create the test end mark using the test delay; this will allow for a significant difference between
                 // the mark values that should be represented in the duration of measures using these marks
-                setTimeout(measure_test_cb, measureTestDelay);
+                step_timeout(measure_test_cb, measureTestDelay);
             }
         }
 

--- a/user-timing/test_user_timing_measure_navigation_timing.html
+++ b/user-timing/test_user_timing_measure_navigation_timing.html
@@ -90,7 +90,7 @@
 
                 // create the test end mark using the test delay; this will allow for a significant difference between
                 // the mark values that should be represented in the duration of measures using these marks
-                setTimeout(measure_test_cb, measureTestDelay);
+                step_timeout(measure_test_cb, measureTestDelay);
             }
         }
 


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
