### PR TITLE
Replace usage of setTimeout with step_timeout in old-tests/Opera

### DIFF
--- a/old-tests/submission/Opera/script_scheduling/013.html
+++ b/old-tests/submission/Opera/script_scheduling/013.html
@@ -22,7 +22,7 @@
 		assert_array_equals(eventOrder, ['inline script #1',  'head script #1','end script #1', 'inline script #2']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 100); })
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 100); })
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/015.html
+++ b/old-tests/submission/Opera/script_scheduling/015.html
@@ -22,7 +22,7 @@
 
         ///XXX I think the spec allows this case to race
 	onload = function(){
-          setTimeout(t.step_func(
+          step_timeout(t.step_func(
             function() {
               assert_any(assert_array_equals, eventOrder, [['inline script #1', 'head script #1', 'head script #2', 'end script #1', 'external script #1', 'inline script #2'],
                                                            ['inline script #1', 'head script #1', 'head script #2', 'end script #1', 'inline script #2', 'external script #1']]);

--- a/old-tests/submission/Opera/script_scheduling/015a.html
+++ b/old-tests/submission/Opera/script_scheduling/015a.html
@@ -24,7 +24,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'head script #1', 'head script #2', 'end script #1', 'inline script #2', 'external script #1']);
 		t.done();
         }
-	onload = function(){setTimeout(t.step_func(function() {test.apply(t)}), 2000); }
+	onload = function(){step_timeout(t.step_func(function() {test.apply(t)}), 2000); }
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/016.html
+++ b/old-tests/submission/Opera/script_scheduling/016.html
@@ -22,7 +22,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'body script #1', 'end script #1', 'inline script #2']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 100); })
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 100); })
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/017.html
+++ b/old-tests/submission/Opera/script_scheduling/017.html
@@ -22,7 +22,7 @@
 
         //The order of the external script vs the second inline script is undefined because the added script is async by default
         //But we expect most UAs to have the second order
-	onload = function() {setTimeout(t.step_func(function() {
+	onload = function() {step_timeout(t.step_func(function() {
           assert_any(assert_array_equals, eventOrder, [
                     ['inline script #1', 'body script #1', 'body script #2', 'end script #1', 'external script #1', 'inline script #2'],
                     ['inline script #1', 'body script #1', 'body script #2', 'end script #1', 'inline script #2', 'external script #1']]);

--- a/old-tests/submission/Opera/script_scheduling/018.html
+++ b/old-tests/submission/Opera/script_scheduling/018.html
@@ -29,7 +29,7 @@
                 ]);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(test.apply(t), 100); })
+	onload = t.step_func(function(){step_timeout(test.apply(t), 100); })
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/019.html
+++ b/old-tests/submission/Opera/script_scheduling/019.html
@@ -25,7 +25,7 @@
                                                             ]);
 		t.done();
 }
-	onload = function(){setTimeout(t.step_func(test), 100); }
+	onload = function(){step_timeout(t.step_func(test), 100); }
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/020.html
+++ b/old-tests/submission/Opera/script_scheduling/020.html
@@ -22,7 +22,7 @@
                                                              ['inline script #1', 'end script #1', 'inline script #2', 'data URL script']]);
 		t.done();
         }
-	onload = function() {setTimeout( t.step_func(test), 100); }
+	onload = function() {step_timeout( t.step_func(test), 100); }
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/021.html
+++ b/old-tests/submission/Opera/script_scheduling/021.html
@@ -23,7 +23,7 @@
 /* pass condition changed 2010-12-01 due to CT-198 */
 		
 	}
-	onload = t.step_func(function(){setTimeout( test, 100); })
+	onload = t.step_func(function(){step_timeout( test, 100); })
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/022.html
+++ b/old-tests/submission/Opera/script_scheduling/022.html
@@ -18,7 +18,7 @@
 	log( 'inline script #2' );
 	var t = async_test()
 
-	onload = function() {setTimeout(t.step_func(
+	onload = function() {step_timeout(t.step_func(
           function() {
             assert_any(assert_array_equals, eventOrder, [['inline script #1', 'end script #1', 'external script #1', 'inline script #2'],
                                                          ['inline script #1', 'end script #1', 'inline script #2', 'external script #1']]);

--- a/old-tests/submission/Opera/script_scheduling/024.html
+++ b/old-tests/submission/Opera/script_scheduling/024.html
@@ -25,7 +25,7 @@
         }
 	onload = t.step_func(function(){
 		script.src='scripts/include-2.js'; // needs to be ignored, script already "is executed"
-		setTimeout(t.step_func(test), 100);
+		step_timeout(t.step_func(test), 100);
 	})
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/025.html
+++ b/old-tests/submission/Opera/script_scheduling/025.html
@@ -23,7 +23,7 @@
 		t.done();
 }
 	onload = t.step_func(function(){
-		setTimeout(t.step_func(test), 100);
+		step_timeout(t.step_func(test), 100);
 	})
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/026.html
+++ b/old-tests/submission/Opera/script_scheduling/026.html
@@ -20,7 +20,7 @@
 	log( 'inline script #2' );
 
 	onload = function() {
-          setTimeout(
+          step_timeout(
             t.step_func(function() {
               assert_any(assert_array_equals, eventOrder, [['inline script #1', 'end script #1', 'external script #1', 'inline script #2'],
                                                            ['inline script #1', 'end script #1', 'inline script #2', 'external script #1']]);

--- a/old-tests/submission/Opera/script_scheduling/027.html
+++ b/old-tests/submission/Opera/script_scheduling/027.html
@@ -23,7 +23,7 @@
 		t.done();
 }
 	onload = t.step_func(function(){
-		setTimeout(t.step_func(test), 100);
+		step_timeout(t.step_func(test), 100);
 	})
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/030.html
+++ b/old-tests/submission/Opera/script_scheduling/030.html
@@ -26,7 +26,7 @@
 	var t = async_test()
 
         var w = window;
-	onload = function() {setTimeout(
+	onload = function() {step_timeout(
           t.step_func(function() {
             w.assert_any(w.assert_array_equals, w.eventOrder,
                       [['inline script #1', 'click event', 'end script #1', 'JS URL', 'inline script #2'],

--- a/old-tests/submission/Opera/script_scheduling/031.html
+++ b/old-tests/submission/Opera/script_scheduling/031.html
@@ -24,7 +24,7 @@
 	    assert_array_equals(eventOrder, ['inline script #1', 'focus event', 'blur event', 'focus el 2 event', 'end script #1', 'inline script #2']);
 	    t.done();
         }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 200);})
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 200);})
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/032.html
+++ b/old-tests/submission/Opera/script_scheduling/032.html
@@ -23,7 +23,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 200);})
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 200);})
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/033.html
+++ b/old-tests/submission/Opera/script_scheduling/033.html
@@ -29,7 +29,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 200);})
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 200);})
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/034.html
+++ b/old-tests/submission/Opera/script_scheduling/034.html
@@ -22,7 +22,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2', 'frame/popup script']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 200);})
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 200);})
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/035.html
+++ b/old-tests/submission/Opera/script_scheduling/035.html
@@ -28,7 +28,7 @@
 		try{
 			document.body.appendChild(document.importNode( top.frames[0].document.getElementsByTagName('script')[0], true ));
 		}catch(e){ log('ERROR - tested functionality not supported'); }
-		setTimeout(t.step_func(test), 200);
+		step_timeout(t.step_func(test), 200);
 	});
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/036.html
+++ b/old-tests/submission/Opera/script_scheduling/036.html
@@ -27,7 +27,7 @@
 		t.done();
 }
 	onload = t.step_func(function(){
-		setTimeout(t.step_func(test), 200);
+		step_timeout(t.step_func(test), 200);
 	});
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/037.html
+++ b/old-tests/submission/Opera/script_scheduling/037.html
@@ -26,7 +26,7 @@
 		t.done();
 }
 	onload = t.step_func(function(){
-		setTimeout(t.step_func(test), 200);
+		step_timeout(t.step_func(test), 200);
 	});
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/038.html
+++ b/old-tests/submission/Opera/script_scheduling/038.html
@@ -27,7 +27,7 @@
 		t.done();
 }
 	onload = function() {
-		setTimeout(t.step_func(test), 200);
+		step_timeout(t.step_func(test), 200);
 	};
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/039.html
+++ b/old-tests/submission/Opera/script_scheduling/039.html
@@ -29,7 +29,7 @@
                 t.done();
         }
         onload = t.step_func(function() {
-                setTimeout(t.step_func(test), 200);
+                step_timeout(t.step_func(test), 200);
         });
         </script>
 

--- a/old-tests/submission/Opera/script_scheduling/040.html
+++ b/old-tests/submission/Opera/script_scheduling/040.html
@@ -27,7 +27,7 @@
 		t.done();
 }
 	onload = t.step_func(function(){
-		setTimeout(t.step_func(test), 200);
+		step_timeout(t.step_func(test), 200);
 	});
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/051.html
+++ b/old-tests/submission/Opera/script_scheduling/051.html
@@ -23,7 +23,7 @@
                                                              ['inline script #1', 'end script #1', 'inline script #2', 'script tags in DOM: 6']]);
 		t.done();
         }
-	onload = function(){setTimeout(t.step_func(test), 100); }
+	onload = function(){step_timeout(t.step_func(test), 100); }
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/052.html
+++ b/old-tests/submission/Opera/script_scheduling/052.html
@@ -19,7 +19,7 @@
 		assert_array_equals(eventOrder, ['script tags in DOM: 4', 'inline script #2']);
 		t.done();
 }
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 100); })
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 100); })
 	</script>
 
 </body>

--- a/old-tests/submission/Opera/script_scheduling/068.html
+++ b/old-tests/submission/Opera/script_scheduling/068.html
@@ -20,7 +20,7 @@
 
            function test() {
               if(!window.findFooLoaded) {
-                  return setTimeout(t.step_func(test),200);
+                  return step_timeout(t.step_func(test),200);
               }
               assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'found #foo element: NO']);
               t.done();

--- a/old-tests/submission/Opera/script_scheduling/069.html
+++ b/old-tests/submission/Opera/script_scheduling/069.html
@@ -20,7 +20,7 @@
 
         function test() {
                 if(!(window.findFooLoaded && window.findBodyLoaded)) {
-                    return setTimeout(t.step_func(test), 200);
+                    return step_timeout(t.step_func(test), 200);
                 }
                 assert_any(assert_array_equals, eventOrder,
                            [['document.body: <BODY>', 'found #foo element: YES'],

--- a/old-tests/submission/Opera/script_scheduling/070.html
+++ b/old-tests/submission/Opera/script_scheduling/070.html
@@ -34,7 +34,7 @@
 
     function test() {
       if(!window.include6Loaded) {
-            return setTimeout(t.step_func(test),200);
+            return step_timeout(t.step_func(test),200);
       }
       assert_array_equals(eventOrder, ['calling document.write', 'inline script #1', 'inline script #2', 'calling document.close', 'external script (#foo found? YES)']);
       t.done();

--- a/old-tests/submission/Opera/script_scheduling/071.html
+++ b/old-tests/submission/Opera/script_scheduling/071.html
@@ -37,7 +37,7 @@
 
 
     function test() {
-      if( !window.include6Loaded )return setTimeout(t.step_func(test),200); //  try checking again if external script didn't run yet
+      if( !window.include6Loaded )return step_timeout(t.step_func(test),200); //  try checking again if external script didn't run yet
       assert_array_equals(eventOrder, ['calling document.write',
           'inline script #1',
           'calling document.close',

--- a/old-tests/submission/Opera/script_scheduling/075.html
+++ b/old-tests/submission/Opera/script_scheduling/075.html
@@ -36,7 +36,7 @@
 
     onload = t.step_func(test)
     /* onload doesn't fire in this test, a fallback.. */
-    setTimeout(t.step_func(test), 800 );
+    step_timeout(t.step_func(test), 800 );
 </script>
   </body>
 </html>

--- a/old-tests/submission/Opera/script_scheduling/077.html
+++ b/old-tests/submission/Opera/script_scheduling/077.html
@@ -26,7 +26,7 @@
                                 if(script3) {
                                     head.removeChild(script3);
                                 }
-                                setTimeout(t.step_func(function(){
+                                step_timeout(t.step_func(function(){
                                                assert_array_equals(eventOrder, ['Script #2 ran', 'Script #1 ran', 'Script #3 ran','Script #4 ran']);
                                                t.done();
                                            }), 400);

--- a/old-tests/submission/Opera/script_scheduling/079.html
+++ b/old-tests/submission/Opera/script_scheduling/079.html
@@ -13,7 +13,7 @@ onload = t.step_func(function() {
   log('onload handler');
   document.getElementById("log").textContent = 'please wait...';
   window.location='javascript:log("javascript: URL")';
-  setTimeout(t.step_func(function(){
+  step_timeout(t.step_func(function(){
     log('timeout');
     assert_array_equals(eventOrder, ['inline script #1', 'onload handler', 'onload ends', 'javascript: URL', 'timeout']);
     t.done();

--- a/old-tests/submission/Opera/script_scheduling/080.html
+++ b/old-tests/submission/Opera/script_scheduling/080.html
@@ -24,7 +24,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2', 'JS URL', 'frame script']);
 		t.done();
 	}
-	onload = t.step_func(function(){setTimeout(t.step_func(test), 400);})
+	onload = t.step_func(function(){step_timeout(t.step_func(test), 400);})
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/081.html
+++ b/old-tests/submission/Opera/script_scheduling/081.html
@@ -24,7 +24,7 @@
 		t.done();
         }
 	onload = t.step_func(function() {
-		setTimeout(t.step_func(test), 12);
+		step_timeout(t.step_func(test), 12);
 	});
 	</script>
 

--- a/old-tests/submission/Opera/script_scheduling/082.html
+++ b/old-tests/submission/Opera/script_scheduling/082.html
@@ -28,7 +28,7 @@
 		assert_array_equals(eventOrder, ['inline script #1', 'end script #1', 'inline script #2', 'external script #1', 'load on include-1.js', 'external script #7', 'load on include-7.js', 'external script #2', 'load on include-2.js']);
 		t.done();
         }
-	onload = function() {setTimeout(t.step_func(test), 12)};
+	onload = function() {step_timeout(t.step_func(test), 12)};
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/083.html
+++ b/old-tests/submission/Opera/script_scheduling/083.html
@@ -42,7 +42,7 @@
 		]);
 		t.done();
 }
-	onload = function() {setTimeout(t.step_func(function() {fireFooEvent(); test()}), 80)};
+	onload = function() {step_timeout(t.step_func(function() {fireFooEvent(); test()}), 80)};
 	</script>
 
 </body></html>

--- a/old-tests/submission/Opera/script_scheduling/102.html
+++ b/old-tests/submission/Opera/script_scheduling/102.html
@@ -10,7 +10,7 @@
               document.open();
               document.write("<title> scheduler: defer script after initial onload event</title><script src='/resources/testharness.js'><\/script><script src='/resources/testharnessreport.js'><\/script><script src='testlib/testlib.js'><\/script><div id='log'>document.written content</div><script>var t = async_test(); log('inline script #1')<\/script><script src='scripts/include-1.js'><\/script><script async src='scripts/include-2.js'><\/script>");
               document.close();
-              window.setTimeout(function() {
+              window.step_timeout(function() {
                 window.t.step(function() {
                   window.assert_any(window.assert_array_equals, window.eventOrder, 
                                     [['inline script #1', 'external script #1', 'external script #2'],

--- a/old-tests/submission/Opera/script_scheduling/116.html
+++ b/old-tests/submission/Opera/script_scheduling/116.html
@@ -12,7 +12,7 @@
                 var t = async_test();
 	        function test() {
 			if(!(window.findBodyLoaded)) {
-        	            return setTimeout(t.step_func(test),200);
+        	            return step_timeout(t.step_func(test),200);
                 	}
                         document.body.appendChild(div);
 			assert_array_equals(eventOrder, ['document.body: <FRAMESET>']);

--- a/old-tests/submission/Opera/script_scheduling/121.html
+++ b/old-tests/submission/Opera/script_scheduling/121.html
@@ -12,6 +12,6 @@
 <script>
 t.step(function() {
   document.getElementById("test").removeAttribute("type");
-  setTimeout(t.step_func(function() {t.done()}), 100);
+  step_timeout(t.step_func(function() {t.done()}), 100);
 });
 </script>


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
