### PR TITLE
Replace usage of setTimeout with step_timeout in eventsource

### DIFF
--- a/eventsource/eventsource-close.htm
+++ b/eventsource/eventsource-close.htm
@@ -46,7 +46,7 @@
               assert_equals(source.readyState, source.CLOSED, "closed readyState");
 
               // give some time for errors to hit us
-              setTimeout(this.step_func(function() { this.done(); }), 100);
+              step_timeout(this.step_func(function() { this.done(); }), 100);
               break;
 
             default:


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.