### PR TITLE
Replace usage of setTimeout with step_timeout in html/rendering

### DIFF
--- a/html/rendering/replaced-elements/resources/svg-sizing.js
+++ b/html/rendering/replaced-elements/resources/svg-sizing.js
@@ -400,7 +400,7 @@ var SVGSizing = (function() {
                     var next = function() {func(config, id, cont)};
                     // Make sure we don't blow the stack, without too much slowness
                     if (id % 20 === 0) {
-                        setTimeout(next, 0);
+                        step_timeout(next, 0);
                     } else {
                         next();
                     }

--- a/html/rendering/replaced-elements/svg-embedded-sizing/svg-embedded-sizing.js
+++ b/html/rendering/replaced-elements/svg-embedded-sizing/svg-embedded-sizing.js
@@ -82,10 +82,10 @@ function testPlaceholderWithHeight(placeholder,
             } else {
                 t.step(function() {
                     placeholder.addEventListener('load', function() {
-                        // setTimeout is a work-around to let engines
+                        // step_timeout is a work-around to let engines
                         // finish layout of child browsing contexts even
                         // after the load event
-                        setTimeout(t.step_func(checkSize), 0);
+                        step_timeout(t.step_func(checkSize), 0);
                     });
                     testContainer.appendChild(container);
                 });


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.