### PR TITLE
Replace usage of setTimeout with step_timeout in webaudio

### DIFF
--- a/webaudio/js/lodash.js
+++ b/webaudio/js/lodash.js
@@ -3355,7 +3355,7 @@
       thisArg = this;
 
       clearTimeout(timeoutId);
-      timeoutId = setTimeout(delayed, wait);
+      timeoutId = step_timeout(delayed, wait);
 
       if (isImmediate) {
         result = func.apply(thisArg, args);
@@ -3374,7 +3374,7 @@
    * @param {Function} func The function to delay.
    * @param {Number} wait The number of milliseconds to delay execution.
    * @param {Mixed} [arg1, arg2, ...] Arguments to invoke the function with.
-   * @returns {Number} Returns the `setTimeout` timeout id.
+   * @returns {Number} Returns the `step_timeout` timeout id.
    * @example
    *
    * var log = _.bind(console.log, console);
@@ -3383,7 +3383,7 @@
    */
   function delay(func, wait) {
     var args = slice.call(arguments, 2);
-    return setTimeout(function() { func.apply(undefined, args); }, wait);
+    return step_timeout(function() { func.apply(undefined, args); }, wait);
   }
 
   /**
@@ -3395,7 +3395,7 @@
    * @category Functions
    * @param {Function} func The function to defer.
    * @param {Mixed} [arg1, arg2, ...] Arguments to invoke the function with.
-   * @returns {Number} Returns the `setTimeout` timeout id.
+   * @returns {Number} Returns the `step_timeout` timeout id.
    * @example
    *
    * _.defer(function() { alert('deferred'); });
@@ -3403,7 +3403,7 @@
    */
   function defer(func) {
     var args = slice.call(arguments, 1);
-    return setTimeout(function() { func.apply(undefined, args); }, 1);
+    return step_timeout(function() { func.apply(undefined, args); }, 1);
   }
 
   /**
@@ -3534,7 +3534,7 @@
         result = func.apply(thisArg, args);
       }
       else if (!timeoutId) {
-        timeoutId = setTimeout(trailingCall, remaining);
+        timeoutId = step_timeout(trailingCall, remaining);
       }
       return result;
     };

--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
@@ -75,7 +75,7 @@ function processListener (e) {
  // When media playback ended, save the begin to compare with expected buffer
  audio.addEventListener("ended", function(e) {
    // Setting a timeout since we need audioProcess event to run for all samples
-   window.setTimeout(loadExpectedBuffer, 50);
+   window.step_timeout(loadExpectedBuffer, 50);
  });
 
  audio.play();


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
