### PR TITLE
Replace usage of setTimeout with step_timeout in IndexedDB

### DIFF
--- a/IndexedDB/idbfactory_deleteDatabase4.htm
+++ b/IndexedDB/idbfactory_deleteDatabase4.htm
@@ -26,7 +26,7 @@
             db.onerror = fail(t, "db.error");
             db.abort = fail(t, "db.abort");
 
-            setTimeout(t.step_func(Second), 4);
+            step_timeout(t.step_func(Second), 4);
             db.close();
         });
 

--- a/IndexedDB/idbindex_get4.htm
+++ b/IndexedDB/idbindex_get4.htm
@@ -31,7 +31,7 @@
             assert_equals(e.target.result.key, 4);
             assert_equals(e.target.result.indexedProperty, 'data4');
 
-            setTimeout(function() { t.done(); }, 4)
+            step_timeout(function() { t.done(); }, 4)
         });
     }
 </script>

--- a/IndexedDB/idbindex_getKey4.htm
+++ b/IndexedDB/idbindex_getKey4.htm
@@ -30,7 +30,7 @@
         rq.onsuccess = t.step_func(function(e) {
             assert_equals(e.target.result, 4);
 
-            setTimeout(function() { t.done(); }, 4)
+            step_timeout(function() { t.done(); }, 4)
         });
     }
 </script>

--- a/IndexedDB/idbobjectstore_get4.htm
+++ b/IndexedDB/idbobjectstore_get4.htm
@@ -17,7 +17,7 @@
                    .get(1);
         rq.onsuccess = t.step_func(function(e) {
             assert_equals(e.target.results, undefined);
-            setTimeout(function() { t.done(); }, 10);
+            step_timeout(function() { t.done(); }, 10);
         });
     };
 

--- a/IndexedDB/transaction-lifetime-blocked.htm
+++ b/IndexedDB/transaction-lifetime-blocked.htm
@@ -41,7 +41,7 @@
             db.onerror = fail(t, "db.error");
             db.abort = fail(t, "db.abort");
 
-            setTimeout(t.step_func(OpenSecond), 10);
+            step_timeout(t.step_func(OpenSecond), 10);
         });
 
         // Errors
@@ -91,7 +91,7 @@
                   "open2.success",
                 ]);
 
-            setTimeout(function() { t.done(); }, 10);
+            step_timeout(function() { t.done(); }, 10);
         });
 
         // Errors

--- a/IndexedDB/transaction-lifetime.htm
+++ b/IndexedDB/transaction-lifetime.htm
@@ -41,7 +41,7 @@
             db.onerror = fail(t, "db.error");
             db.abort = fail(t, "db.abort");
 
-            setTimeout(t.step_func(OpenSecond), 10);
+            step_timeout(t.step_func(OpenSecond), 10);
         });
 
         // Errors
@@ -83,7 +83,7 @@
                   "open2.success",
                 ]);
 
-            setTimeout(function() { t.done(); }, 10);
+            step_timeout(function() { t.done(); }, 10);
         });
 
         // Errors

--- a/IndexedDB/writer-starvation.htm
+++ b/IndexedDB/writer-starvation.htm
@@ -81,7 +81,7 @@
             });
 
             if (read_success_count < RQ_COUNT + 5)
-                setTimeout(this.step_func(loop), write_request_count ? 1000 : 100);
+                step_timeout(this.step_func(loop), write_request_count ? 1000 : 100);
             else
                 // This is merely a "nice" hack to run finish after the last request is done
                 db.transaction("s")
@@ -89,7 +89,7 @@
                   .count()
                   .onsuccess = this.step_func(function()
                 {
-                    setTimeout(this.step_func(finish), 100);
+                    step_timeout(this.step_func(finish), 100);
                 });
         }
     }


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.