### PR TITLE
Replace usage of setTimeout with step_timeout in html/syntax

### DIFF
--- a/html/syntax/parsing/test.js
+++ b/html/syntax/parsing/test.js
@@ -320,7 +320,7 @@ function init_tests(test_type) {
     var x = tests[test_id];
     var t = x[0];
     iframe_map[t.name] = iframe.id;
-    setTimeout(function() {
+    step_timeout(function() {
                  t.step(function() {
                    var string_uri_encoded_input = x[1];
                    var string_escaped_expected = x[2];


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.