### PR TITLE
Replace usage of setTimeout with step_timeout in navigation-timing

### DIFF
--- a/navigation-timing/test_document_open.html
+++ b/navigation-timing/test_document_open.html
@@ -19,7 +19,7 @@ var didOpen = false;
 
 function onload_test() {
   if (!didOpen) {
-    setTimeout(testTimingWithDocumentOpen, 0);
+    step_timeout(testTimingWithDocumentOpen, 0);
     didOpen = true;
   }
 }
@@ -52,7 +52,7 @@ function testTimingWithDocumentOpen() {
   subdocument.write('</html>');
   subdocument.close();
 
-  setTimeout(function() {
+  step_timeout(function() {
     var timing = subcontentWindow.performance.timing;
     for (var i in timingAttributes) {
       test_equals(timing[timingAttributes[i]],

--- a/navigation-timing/test_navigate_within_document.html
+++ b/navigation-timing/test_navigate_within_document.html
@@ -42,7 +42,7 @@
                     initial_timing[property] = timing[property];
                 }
                 window.location.href = "#1";
-                setTimeout("check_timing_not_changed()", 0);
+                step_timeout(check_timing_not_changed, 0);
             }
 
             function load_handler()
@@ -57,7 +57,7 @@
                 timing = performanceNamespace.timing;
 
                 window.removeEventListener("load", load_handler);
-                setTimeout("save_timing_after_load()", 0);
+                step_timeout(save_timing_after_load, 0);
             }
 
             window.addEventListener("load", load_handler, false);

--- a/navigation-timing/test_navigation_type_backforward.html
+++ b/navigation-timing/test_navigation_type_backforward.html
@@ -24,7 +24,7 @@
                 }
 
                 // do this with a timeout to see the visuals of the navigations.
-                setTimeout("nav_frame();", 100);
+                step_timeout(nav_frame, 100);
             }
 
             var step = 1;

--- a/navigation-timing/test_navigation_type_reload.html
+++ b/navigation-timing/test_navigation_type_reload.html
@@ -37,9 +37,9 @@
                 reload_frame.onload = function() {
                     /* Need to make sure we don't examine loadEventEnd
                      until after the load event has finished firing */
-                    setTimeout(do_test, 0);
+                    step_timeout(do_test, 0);
                 }
-                setTimeout("reload_the_frame();", 100);
+                step_timeout(reload_the_frame, 100);
             }
 
             function reload_the_frame()

--- a/navigation-timing/test_timing_attributes_order.html
+++ b/navigation-timing/test_timing_attributes_order.html
@@ -102,7 +102,7 @@
         <iframe id="frameContext"
                 onload="/* Need to make sure we don't examine loadEventEnd
                            until after the load event has finished firing */
-                        setTimeout(onload_test, 0);"
+                        step_timeout(onload_test, 0);"
                 src="resources/blank_page_unload.html"
                 style="width: 250px; height: 250px;"></iframe>
     </body>

--- a/navigation-timing/test_timing_reload.html
+++ b/navigation-timing/test_timing_reload.html
@@ -40,7 +40,7 @@
                     initial_timing[property] = timing[property];
                 }
 
-                setTimeout("reload_the_frame();", 100);
+                step_timeout(reload_the_frame, 100);
             }
 
             function reload_the_frame()


### PR DESCRIPTION
This is expected to help test stability on slow configurations, as the
timeouts will be multiplied by the timeout multiplier.

Split out from #1816.