### PR TITLE
WebVTT: Check for support of the API up front

### DIFF
--- a/webvtt/api/VTTCue/align.html
+++ b/webvtt/api/VTTCue/align.html
@@ -10,6 +10,7 @@ test(function(){
     document.body.appendChild(video);
 
     var cue = new VTTCue(0, 1, 'text');
+    assert_true('align' in cue, 'align is not supported');
     assert_equals(cue.align, 'center');
 
     var track = document.createElement('track');

--- a/webvtt/api/VTTCue/line.html
+++ b/webvtt/api/VTTCue/line.html
@@ -9,6 +9,7 @@ test(function(){
     var video = document.createElement('video');
     document.body.appendChild(video);
     var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('line' in c1, 'line is not supported');
     assert_equals(c1.line, "auto");
     var track = document.createElement('track');
     var t = track.track;

--- a/webvtt/api/VTTCue/lineAlign.html
+++ b/webvtt/api/VTTCue/lineAlign.html
@@ -10,6 +10,7 @@ test(function(){
     document.body.appendChild(video);
 
     var cue = new VTTCue(0, 1, 'text');
+    assert_true('lineAlign' in cue, 'lineAlign is not supported');
     assert_equals(cue.lineAlign, 'start');
 
     var track = document.createElement('track');

--- a/webvtt/api/VTTCue/position.html
+++ b/webvtt/api/VTTCue/position.html
@@ -7,6 +7,7 @@
 <script>
 test(function(){
     var cue = new VTTCue(0, 1, 'text');
+    assert_true('position' in cue, 'position is not supported');
 
     cue.position = 'auto';
     assert_equals(cue.position, 'auto');
@@ -24,5 +25,8 @@ test(function(){
 
     cue.position = 1.5;
     assert_equals(cue.position, 1.5);
+
+    cue.position = 'auto';
+    assert_equals(cue.position, 'auto');
 }, document.title+', script-created cue');
 </script>

--- a/webvtt/api/VTTCue/positionAlign.html
+++ b/webvtt/api/VTTCue/positionAlign.html
@@ -7,6 +7,7 @@
 <script>
 test(function(){
     var cue = new VTTCue(0, 1, 'text');
+    assert_true('positionAlign' in cue, 'positionAlign is not supported');
 
     ['line-left', 'center', 'line-right', 'auto'].forEach(function(valid) {
         cue.positionAlign = valid;

--- a/webvtt/api/VTTCue/region.html
+++ b/webvtt/api/VTTCue/region.html
@@ -10,7 +10,7 @@ test(function(){
     document.body.appendChild(video);
 
     var cue = new VTTCue(0, 1, 'text');
-    assert_equals(cue.region, null);
+    assert_true('region' in cue, 'region is not supported');
 
     var track = document.createElement('track');
     var t = track.track;

--- a/webvtt/api/VTTCue/region.html
+++ b/webvtt/api/VTTCue/region.html
@@ -11,6 +11,7 @@ test(function(){
 
     var cue = new VTTCue(0, 1, 'text');
     assert_true('region' in cue, 'region is not supported');
+    assert_equals(cue.region, null);
 
     var track = document.createElement('track');
     var t = track.track;

--- a/webvtt/api/VTTCue/size.html
+++ b/webvtt/api/VTTCue/size.html
@@ -7,6 +7,7 @@
 <script>
 test(function(){
     var cue = new VTTCue(0, 1, 'text');
+    assert_true('size' in cue, 'size is not supported');
 
     for (i = 0; i <= 100; i++) {
         cue.size = i;

--- a/webvtt/api/VTTCue/snapToLines.html
+++ b/webvtt/api/VTTCue/snapToLines.html
@@ -12,6 +12,7 @@ setup(function(){
 });
 test(function(){
     var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('snapToLines' in c1, 'snapToLines is not supported');
     assert_true(c1.snapToLines);
     c1.line = 101;
     c1.snapToLines = false;

--- a/webvtt/api/VTTCue/text.html
+++ b/webvtt/api/VTTCue/text.html
@@ -12,6 +12,7 @@ setup(function(){
 });
 test(function(){
     var c1 = new VTTCue(0, 1, 'text1\r\n\n\u0000');
+    assert_true('text' in cue, 'text is not supported');
     assert_equals(c1.text, 'text1\r\n\n\u0000');
     c1.text = c1.text;
     assert_equals(c1.text, 'text1\r\n\n\u0000');

--- a/webvtt/api/VTTCue/vertical.html
+++ b/webvtt/api/VTTCue/vertical.html
@@ -14,6 +14,7 @@ test(function(){
     var video = document.createElement('video');
     document.body.appendChild(video);
     var c1 = new VTTCue(0, 1, 'text1');
+    assert_true('vertical' in c1, 'vertical is not supported');
     assert_equals(c1.vertical, '');
     var track = document.createElement('track');
     var t = track.track;

--- a/webvtt/api/VTTRegion/lines.html
+++ b/webvtt/api/VTTRegion/lines.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('lines' in region, 'lines is not supported');
 
     for (var i = 1; i <= 100; i++) {
         region.lines = i;

--- a/webvtt/api/VTTRegion/regionAnchorX.html
+++ b/webvtt/api/VTTRegion/regionAnchorX.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('regionAnchorX' in region, 'regionAnchorX is not supported');
 
     for (var i = 0; i <= 100; i++) {
         region.regionAnchorX = i;

--- a/webvtt/api/VTTRegion/regionAnchorY.html
+++ b/webvtt/api/VTTRegion/regionAnchorY.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('regionAnchorY' in region, 'regionAnchorY is not supported');
 
     for (var i = 0; i <= 100; i++) {
         region.regionAnchorY = i;

--- a/webvtt/api/VTTRegion/scroll.html
+++ b/webvtt/api/VTTRegion/scroll.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('scroll' in region, 'scroll is not supported');
 
     region.scroll = '';
     assert_equals(region.scroll, '');

--- a/webvtt/api/VTTRegion/viewportAnchorX.html
+++ b/webvtt/api/VTTRegion/viewportAnchorX.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('viewportAnchorX' in region, 'viewportAnchorX is not supported');
 
     for (var i = 0; i <= 100; i++) {
         region.viewportAnchorX = i;

--- a/webvtt/api/VTTRegion/viewportAnchorY.html
+++ b/webvtt/api/VTTRegion/viewportAnchorY.html
@@ -7,6 +7,7 @@
 <script>
 test(function() {
     var region = new VTTRegion();
+    assert_true('viewportAnchorY' in region, 'viewportAnchorY is not supported');
 
     for (var i = 0; i <= 100; i++) {
         region.viewportAnchorY = i;

--- a/webvtt/api/VTTRegion/width.html
+++ b/webvtt/api/VTTRegion/width.html
@@ -7,6 +7,7 @@
 <script>
 test(function(){
     var region = new VTTRegion();
+    assert_true('width' in region, 'width is not supported');
 
     for (var i = 0; i <= 100; i++) {
         region.width = i;


### PR DESCRIPTION
This gives much clearer message and makes sure tests fail if
the tested API is not supported.

---

For example, in Safari, /webvtt/api/VTTRegion/lines.html now fails with

> assert_true: lines is not supported expected true got false

instead of

> assert_equals: expected 0 but got -0