### PR TITLE
Test that removed WebVTT APIs are not supported

### DIFF
--- a/webvtt/api/historical.html
+++ b/webvtt/api/historical.html
@@ -12,7 +12,7 @@
   ['TextTrack', 'addRegion'],
   ['TextTrack', 'removeRegion'],
   ['VTTRegion', 'track'],
-  ['VTTRegion', 'id'],
+  // id re-introduced in https://github.com/w3c/webvtt/pull/349/files
 
 ].forEach(function(feature) {
   var interf = feature[0];

--- a/webvtt/api/historical.html
+++ b/webvtt/api/historical.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<title>Historical WebVTT APIs must not be supported</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+// Also see /html/semantics/embedded-content/media-elements/historical.html
+
+[
+  // https://github.com/w3c/webvtt/pull/31
+  ['VTTCue', 'regionId'],
+  ['TextTrack', 'regions'],
+  ['TextTrack', 'addRegion'],
+  ['TextTrack', 'removeRegion'],
+  ['VTTRegion', 'track'],
+  ['VTTRegion', 'id'],
+
+].forEach(function(feature) {
+  var interf = feature[0];
+  var member = feature[1];
+  test(function() {
+    assert_true(interf in window, interf + ' is not supported');
+    assert_false(member in window[interf].prototype);
+  }, interf + ' ' + member + ' member must be nuked');
+});
+
+[
+  // https://github.com/w3c/webvtt/pull/31
+  'VTTRegionList',
+
+].forEach(function(interf) {
+  test(function() {
+    assert_false(interf in window);
+  }, interf + ' interface must be nuked');
+});
+</script>


### PR DESCRIPTION
Follows https://github.com/w3c/webvtt/pull/31

---

Actually `id` might be added back in https://github.com/w3c/webvtt/pull/201 ...

cc @BenjaminSchaaf

<!-- Reviewable:start -->

<!-- Reviewable:end -->
