### PR TITLE
XMLHttpRequest: make various header tests much more strict

### DIFF
--- a/XMLHttpRequest/anonymous-mode-unsupported.htm
+++ b/XMLHttpRequest/anonymous-mode-unsupported.htm
@@ -29,7 +29,7 @@
         client.open("GET", "resources/inspect-headers.py?filter_name=cookie")
         client.onreadystatechange = test.step_func(function(){
           if(client.readyState === 4){
-            assert_equals(client.responseText, 'cookie: test=anonymous-mode-unsupported\n', 'The deprecated anonymous:true should be ignored, cookie sent anyway')
+            assert_equals(client.responseText, 'Cookie: test=anonymous-mode-unsupported\n', 'The deprecated anonymous:true should be ignored, cookie sent anyway')
             test.done();
           }
         });

--- a/XMLHttpRequest/open-after-setrequestheader.htm
+++ b/XMLHttpRequest/open-after-setrequestheader.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: open() after setRequestHeader()</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::ol/li[14]/ul/li[4]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method">
 
   </head>
   <body>

--- a/XMLHttpRequest/open-referer.htm
+++ b/XMLHttpRequest/open-referer.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: open() - value of Referer header</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="/following::ol[1]/li[2]/ol[1]/li[4]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method">
   </head>
   <body>
     <div id="log"></div>
@@ -13,7 +13,7 @@
         var client = new XMLHttpRequest()
         client.open("POST", "resources/inspect-headers.py?filter_name=referer", false)
         client.send(null)
-        assert_equals(client.responseText, "referer: "+location.href+'\n')
+        assert_equals(client.responseText, "Referer: "+location.href+'\n')
       })
     </script>
   </body>

--- a/XMLHttpRequest/preserve-ua-header-on-redirect.htm
+++ b/XMLHttpRequest/preserve-ua-header-on-redirect.htm
@@ -14,7 +14,7 @@
           client.onreadystatechange = function() {
             test.step(function() {
               if(client.readyState == 4) {
-                assert_equals(client.responseText, 'user-agent: '+navigator.userAgent+'\n')
+                assert_equals(client.responseText, 'User-Agent: '+navigator.userAgent+'\n')
                 test.done()
               }
             })
@@ -29,7 +29,7 @@
           client.onreadystatechange = function() {
             test2.step(function() {
               if(client.readyState == 4) {
-                assert_equals(client.responseText, 'user-agent: TEST\n')
+                assert_equals(client.responseText, 'User-Agent: TEST\n')
                 test2.done()
               }
             })

--- a/XMLHttpRequest/resources/inspect-headers.py
+++ b/XMLHttpRequest/resources/inspect-headers.py
@@ -1,3 +1,21 @@
+def get_response(raw_headers, filter_value, filter_name):
+    result = ""
+    for line in raw_headers.headers:
+        if line[-2:] != '\r\n':
+            return "Syntax error: missing CRLF: " + line
+        line = line[:-2]
+
+        if ': ' not in line:
+            return "Syntax error: no colon and space: " + line
+
+        name, value = line.split(': ', 1)
+        if filter_value:
+            if value == filter_value:
+                result += name + ","
+        elif name.lower() == filter_name:
+            result += name + ": " + value + "\n";
+    return result
+
 def main(request, response):
     headers = []
     if "cors" in request.GET:
@@ -6,17 +24,10 @@ def main(request, response):
         headers.append(("Access-Control-Allow-Methods", "GET, POST, PUT, FOO"))
         headers.append(("Access-Control-Allow-Headers", "x-test, x-foo"))
         headers.append(("Access-Control-Expose-Headers", "x-request-method, x-request-content-type, x-request-query, x-request-content-length"))
+    headers.append(("content-type", "text/plain"))
 
     filter_value = request.GET.first("filter_value", "")
     filter_name = request.GET.first("filter_name", "").lower()
+    result = get_response(request.raw_headers, filter_value, filter_name)
 
-    result = ""
-    for name, value in request.headers.iteritems():
-        if filter_value:
-            if value == filter_value:
-                result += name.lower() + ","
-        elif name.lower() == filter_name:
-            result += name.lower() + ": " + value + "\n";
-
-    headers.append(("content-type", "text/plain"))
     return headers, result

--- a/XMLHttpRequest/send-accept-language.htm
+++ b/XMLHttpRequest/send-accept-language.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: send() - Accept-Language</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(text(),'Accept-Language')]/.. following::code[contains(text(),'Accept-Language')]/../following::ul[1]/li[1] following::code[contains(text(),'Accept-Language')]/../following::ul[1]/li[2]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method">
   </head>
   <body>
     <div id="log"></div>
@@ -13,14 +13,14 @@
         var client = new XMLHttpRequest()
         client.open('GET', 'resources/inspect-headers.py?filter_name=accept-language', false)
         client.send(null)
-        assert_regexp_match(client.responseText, /accept-language:\s.+/)
+        assert_regexp_match(client.responseText, /Accept-Language:\s.+/)
       }, 'Send "sensible" default value, whatever that means')
       test(function() {
         var client = new XMLHttpRequest()
         client.open("GET", "resources/inspect-headers.py?filter_name=accept-language", false)
         client.setRequestHeader("Accept-Language", "x-GameSpeak")
         client.send(null)
-        assert_equals(client.responseText, "accept-language: x-GameSpeak\n")
+        assert_equals(client.responseText, "Accept-Language: x-GameSpeak\n")
       })
     </script>
   </body>

--- a/XMLHttpRequest/setrequestheader-allow-empty-value.htm
+++ b/XMLHttpRequest/setrequestheader-allow-empty-value.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: setRequestHeader() - empty header</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]/p[contains(@class,'note')] /following::ol/li[6]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
   </head>
   <body>
     <div id="log"></div>
@@ -15,7 +15,7 @@
           client.open("POST", "resources/inspect-headers.py?filter_name=X-Empty", false)
           client.setRequestHeader('X-Empty', value)
           client.send(null)
-          assert_equals(client.responseText, 'x-empty: '+ String(value).toLowerCase()+'\n' )
+          assert_equals(client.responseText, 'X-Empty: ' + value + '\n' )
         }, document.title + " (" + value + ")")
       }
       request("")

--- a/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
+++ b/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: setRequestHeader() - header value with whitespace</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]/p[contains(@class,'note')] /following::ol/li[6]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
   </head>
   <body>
     <div id="log"></div>
@@ -15,7 +15,7 @@
           client.open("POST", "resources/inspect-headers.py?filter_name=X-Empty", false)
           client.setRequestHeader('X-Empty', value)
           client.send(null)
-          assert_equals(client.responseText, 'x-empty: '+ String(value.trim()).toLowerCase()+'\n' )
+          assert_equals(client.responseText, 'X-Empty: ' + String(value.trim()) + '\n' )
         }, document.title + " (" + value + ")")
       }
       request(" ")

--- a/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
+++ b/XMLHttpRequest/setrequestheader-allow-whitespace-in-value.htm
@@ -15,7 +15,7 @@
           client.open("POST", "resources/inspect-headers.py?filter_name=X-Empty", false)
           client.setRequestHeader('X-Empty', value)
           client.send(null)
-          assert_equals(client.responseText, 'X-Empty: ' + String(value.trim()) + '\n' )
+          assert_equals(client.responseText, 'X-Empty: ' + value.trim() + '\n' )
         }, document.title + " (" + value + ")")
       }
       request(" ")

--- a/XMLHttpRequest/setrequestheader-case-insensitive.htm
+++ b/XMLHttpRequest/setrequestheader-case-insensitive.htm
@@ -4,14 +4,14 @@
     <title>XMLHttpRequest: setRequestHeader() - headers that differ in case</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[6] /following::ol/li[7]" />  
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
   </head>
   <body>
     <div id="log"></div>
     <script>
       test(function() {
         var client = new XMLHttpRequest()
-        client.open("POST", "resources/inspect-headers.py?filter_value=t1,t2,t3", false)
+        client.open("POST", "resources/inspect-headers.py?filter_value=t1, t2, t3", false)
         client.setRequestHeader("x-test", "t1")
         client.setRequestHeader("X-TEST", "t2")
         client.setRequestHeader("X-teST", "t3")

--- a/XMLHttpRequest/setrequestheader-content-type.htm
+++ b/XMLHttpRequest/setrequestheader-content-type.htm
@@ -4,19 +4,15 @@
     <title>XMLHttpRequest: setRequestHeader() - Content-Type header</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]/p[contains(@class,'note')] /following::ol/li[6]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
   </head>
   <body>
     <div id="log"></div>
     <script>
       function request(inputGenerator, headersToSend, expectedType, title) {
         test(function() {
-          try {
-            var toSend = inputGenerator();
-          } catch(e) {
-            assert_unreached("Skipping test as could not create a " + inputGenerator.name.replace("_", "") + "; ");
-          }
-          var client = new XMLHttpRequest()
+          const toSend = inputGenerator(),
+                client = new XMLHttpRequest()
           client.open("POST", "resources/inspect-headers.py?filter_name=Content-Type", false)
           for(header in headersToSend) {
             if (headersToSend.hasOwnProperty(header)) {
@@ -25,15 +21,13 @@
           }
           client.send(toSend)
 
-          var responseType = client.responseText.replace("\n", "").replace("; ", ";").toLowerCase(); // don't care about case or space after semicolon for charset
+          const responseType = client.responseText
           if (expectedType === undefined || expectedType === null) {
             assert_equals(responseType, "");
           } else if (expectedType instanceof RegExp) {
-            if (!expectedType.ignoreCase) expectedType = new RegExp(expectedType, "i"); // always ignore case; the regex itself will have to remember to handle the optional space after the semicolon for charset
             assert_regexp_match(responseType, expectedType);
           } else {
-            expectedType = "content-type: " + String(expectedType ? expectedType.trim().replace("; ", ";") : expectedType).toLowerCase()
-            assert_equals(responseType, expectedType);
+            assert_equals(responseType, "Content-Type: " + expectedType + "\n");
           }
         }, title)
       }
@@ -46,7 +40,7 @@
       request(
         function _String() { return ""; },
         {"Content-Type": " "},
-        " ",
+        "",
         'setRequestHeader(" ") sends the string " "'
       )
       request(
@@ -130,7 +124,7 @@
       request(
         function _Blob() { return new Blob(["<xml/>"], {type : "application/xml;charset=ASCII"}); },
         {},
-        "application/xml;charset=ASCII",
+        "application/xml;charset=ascii", // new Blob lowercases the type argument
         "Blob request with set type uses that it for Content-Type unless setRequestHeader()"
       )
       request(
@@ -184,8 +178,8 @@
       request(
         function _FormData() { return new FormData(); },
         {},
-        /multipart\/form-data;boundary=(.*)/,
-        'FormData request has correct default Content-Type of "multipart\/form-data;boundary=_"'
+        /multipart\/form-data; boundary=(.*)/,
+        'FormData request has correct default Content-Type of "multipart\/form-data; boundary=_"'
       )
       request(
         function _FormData() { return new FormData(); },

--- a/XMLHttpRequest/setrequestheader-header-allowed.htm
+++ b/XMLHttpRequest/setrequestheader-header-allowed.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: setRequestHeader() - headers that are allowed</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[6] /following::ol/li[7]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
   </head>
   <body>
     <div id="log"></div>
@@ -12,11 +12,11 @@
       function request(header) {
         test(function() {
           var client = new XMLHttpRequest()
-          client.open("POST", "resources/inspect-headers.py?filter_value=t1,t2", false)
+          client.open("POST", "resources/inspect-headers.py?filter_value=t1, t2", false)
           client.setRequestHeader(header, "t1")
           client.setRequestHeader(header, "t2")
           client.send(null)
-          assert_equals(client.responseText, header.toLowerCase() + ",")
+          assert_equals(client.responseText, header + ",")
         }, document.title + " (" + header + ")")
       }
       request("Authorization")

--- a/XMLHttpRequest/setrequestheader-header-forbidden.htm
+++ b/XMLHttpRequest/setrequestheader-header-forbidden.htm
@@ -4,7 +4,7 @@
     <title>XMLHttpRequest: setRequestHeader() - headers that are forbidden</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[5]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
 
   </head>
   <body>
@@ -31,6 +31,7 @@
         client.setRequestHeader("Upgrade", "TEST")
         client.setRequestHeader("Via", "TEST")
         client.setRequestHeader("Proxy-", "TEST")
+        client.setRequestHeader("Proxy-LIES", "TEST")
         client.setRequestHeader("Proxy-Authorization", "TEST")
         client.setRequestHeader("Sec-", "TEST")
         client.setRequestHeader("Sec-X", "TEST")

--- a/XMLHttpRequest/setrequestheader-open-setrequestheader.htm
+++ b/XMLHttpRequest/setrequestheader-open-setrequestheader.htm
@@ -6,13 +6,13 @@ Test from https://bugzilla.mozilla.org/show_bug.cgi?id=819051
   <title>XMLHttpRequest: setRequestHeader() and open()</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::OL[1]/LI[14]/ul[1]/li[4]" />
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::OL[1]/LI[6] following::ol[1]/li[7]" />
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method">
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method">
 </head>
 <body>
     <p id="log"></p>
 <script type="text/javascript">
-var test = async_test();
+async_test(test => {
 
 var url = "resources/inspect-headers.py";
 
@@ -22,14 +22,12 @@ xhr.setRequestHeader("X-appended-to-this", "False");
 xhr.open("GET", url + "?filter_name=x-appended-to-this");
 xhr.setRequestHeader("X-appended-to-this", "True");
 
-xhr.onreadystatechange = function() {
-    if (this.readyState == 4) {
-        test.step(function (){
-            assert_equals(xhr.responseText, "x-appended-to-this: True\n", "Set headers record should have been cleared by open.");
-            test_standard_header();
-        });
+xhr.onreadystatechange = test.step_func(() => {
+    if (xhr.readyState == 4) {
+        assert_equals(xhr.responseText, "X-appended-to-this: True\n", "Set headers record should have been cleared by open.");
+        test_standard_header();
     }
-}
+})
 
 xhr.send();
 
@@ -41,20 +39,15 @@ function test_standard_header () {
     xhr.open("GET", url + "?filter_name=accept");
     xhr.setRequestHeader("Accept", "bar/foo");
 
-    xhr.onreadystatechange = function() {
-        if (this.readyState == 4) {
-            test.step(function (){
-                assert_equals(xhr.responseText, "accept: bar/foo\n", "Set headers record should have been cleared by open.");
-                test.done();
-            });
+    xhr.onreadystatechange = test.step_func(() => {
+        if (xhr.readyState == 4) {
+            assert_equals(xhr.responseText, "Accept: bar/foo\n", "Set headers record should have been cleared by open.");
+            test.done();
         }
-    }
+    })
 
     xhr.send();
 }
 
-
+})
 </script>
-</pre>
-</body>
-</html>


### PR DESCRIPTION
Fixes #2612 and fixes #4377.

Also fixes part of #4641.