### PR TITLE
Remove dropzone from DOM tests.

### DIFF
--- a/dom/lists/DOMTokenList-coverage-for-attributes.html
+++ b/dom/lists/DOMTokenList-coverage-for-attributes.html
@@ -11,7 +11,6 @@ var pairs = [
   // Defined in DOM
   {attr: "classList", sup: ["anyElement"]},
   // Defined in HTML
-  {attr: "dropzone", sup: ["anyHTMLElement"]},
   {attr: "htmlFor", sup: ["output"]},
   {attr: "relList", sup: ["a", "area", "link"]},
   {attr: "sandbox", sup: ["iframe"]},
@@ -27,7 +26,7 @@ var namespaces = [
 
 var elements = ["a", "area", "link", "iframe", "output", "td", "th"];
 function testAttr(pair, new_el){
-  return (pair.attr === "classList" || (new_el.namespaceURI === "http://www.w3.org/1999/xhtml" && (pair.attr === "dropzone" || pair.sup.indexOf(new_el.localName) != -1)));
+  return (pair.attr === "classList" || (new_el.namespaceURI === "http://www.w3.org/1999/xhtml" && pair.sup.indexOf(new_el.localName) != -1));
 }
 
 pairs.forEach(function(pair) {

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -789,8 +789,7 @@ for (var element in elements) {
     // Don't try to test the defaultVal -- it should be either 0 or -1, but the
     // rules are complicated, and a lot of them are SHOULDs.
     ReflectionTests.reflects({type: "long", defaultVal: null}, "tabIndex", element);
-    // TODO: classList, contextMenu, itemProp, itemRef, dropzone (require
-    // tokenlist support)
+    // TODO: classList, contextMenu, itemProp, itemRef
 
     for (var idlAttrName in elements[element]) {
         var type = elements[element][idlAttrName];

--- a/html/dom/resources/interfaces.idl
+++ b/html/dom/resources/interfaces.idl
@@ -136,7 +136,6 @@ interface HTMLElement : Element {
   [CEReactions] attribute DOMString accessKey;
   readonly attribute DOMString accessKeyLabel;
   [CEReactions] attribute boolean draggable;
-  [CEReactions, SameObject, PutForwards=value] readonly attribute DOMTokenList dropzone;
   [CEReactions] attribute HTMLMenuElement? contextMenu;
   [CEReactions] attribute boolean spellcheck;
   void forceSpellCheck();


### PR DESCRIPTION
The dropzone attribute is being removed from the HTML specification, per https://github.com/whatwg/html/issues/2331. This is part of a series of PRs that aim to remove the attribute from web-platform-tests.