### PR TITLE
 Rename ReadableStreamReader to ReadableStreamDefaultReader

### DIFF
--- a/streams/readable-streams/brand-checks.js
+++ b/streams/readable-streams/brand-checks.js
@@ -5,15 +5,15 @@ if (self.importScripts) {
   self.importScripts('/resources/testharness.js');
 }
 
-let ReadableStreamReader;
+let ReadableStreamDefaultReader;
 let ReadableStreamController;
 
 test(() => {
 
   // It's not exposed globally, but we test a few of its properties here.
-  ReadableStreamReader = (new ReadableStream()).getReader().constructor;
+  ReadableStreamDefaultReader = (new ReadableStream()).getReader().constructor;
 
-}, 'Can get the ReadableStreamReader constructor indirectly');
+}, 'Can get the ReadableStreamDefaultReader constructor indirectly');
 
 test(() => {
 
@@ -29,7 +29,7 @@ test(() => {
 function fakeReadableStream() {
   return {
     cancel() { return Promise.resolve(); },
-    getReader() { return new ReadableStreamReader(new ReadableStream()); },
+    getReader() { return new ReadableStreamDefaultReader(new ReadableStream()); },
     pipeThrough(obj) { return obj.readable; },
     pipeTo() { return Promise.resolve(); },
     tee() { return [realReadableStream(), realReadableStream()]; }
@@ -40,7 +40,7 @@ function realReadableStream() {
   return new ReadableStream();
 }
 
-function fakeReadableStreamReader() {
+function fakeReadableStreamDefaultReader() {
   return {
     get closed() { return Promise.resolve(); },
     cancel() { return Promise.resolve(); },
@@ -77,44 +77,44 @@ test(() => {
 
 test(() => {
 
-  assert_throws(new TypeError(), () => new ReadableStreamReader(fakeReadableStream()),
-                'Constructing a ReadableStreamReader should throw');
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader(fakeReadableStream()),
+                'Constructing a ReadableStreamDefaultReader should throw');
 
-}, 'ReadableStreamReader enforces a brand check on its argument');
-
-promise_test(t => {
-
-  return Promise.all([
-    getterRejects(t, ReadableStreamReader.prototype, 'closed', fakeReadableStreamReader()),
-    getterRejects(t, ReadableStreamReader.prototype, 'closed', realReadableStream())
-  ]);
-
-}, 'ReadableStreamReader.prototype.closed enforces a brand check');
+}, 'ReadableStreamDefaultReader enforces a brand check on its argument');
 
 promise_test(t => {
 
   return Promise.all([
-    methodRejects(t, ReadableStreamReader.prototype, 'cancel', fakeReadableStreamReader()),
-    methodRejects(t, ReadableStreamReader.prototype, 'cancel', realReadableStream())
+    getterRejects(t, ReadableStreamDefaultReader.prototype, 'closed', fakeReadableStreamDefaultReader()),
+    getterRejects(t, ReadableStreamDefaultReader.prototype, 'closed', realReadableStream())
   ]);
 
-}, 'ReadableStreamReader.prototype.cancel enforces a brand check');
+}, 'ReadableStreamDefaultReader.prototype.closed enforces a brand check');
 
 promise_test(t => {
 
   return Promise.all([
-    methodRejects(t, ReadableStreamReader.prototype, 'read', fakeReadableStreamReader()),
-    methodRejects(t, ReadableStreamReader.prototype, 'read', realReadableStream())
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'cancel', fakeReadableStreamDefaultReader()),
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'cancel', realReadableStream())
   ]);
 
-}, 'ReadableStreamReader.prototype.read enforces a brand check');
+}, 'ReadableStreamDefaultReader.prototype.cancel enforces a brand check');
+
+promise_test(t => {
+
+  return Promise.all([
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'read', fakeReadableStreamDefaultReader()),
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'read', realReadableStream())
+  ]);
+
+}, 'ReadableStreamDefaultReader.prototype.read enforces a brand check');
 
 test(() => {
 
-  methodThrows(ReadableStreamReader.prototype, 'releaseLock', fakeReadableStreamReader());
-  methodThrows(ReadableStreamReader.prototype, 'releaseLock', realReadableStream());
+  methodThrows(ReadableStreamDefaultReader.prototype, 'releaseLock', fakeReadableStreamDefaultReader());
+  methodThrows(ReadableStreamDefaultReader.prototype, 'releaseLock', realReadableStream());
 
-}, 'ReadableStreamReader.prototype.releaseLock enforces a brand check');
+}, 'ReadableStreamDefaultReader.prototype.releaseLock enforces a brand check');
 
 test(() => {
 

--- a/streams/readable-streams/default-reader.dedicatedworker.html
+++ b/streams/readable-streams/default-reader.dedicatedworker.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>readable-stream-reader.js shared worker wrapper file</title>
+<title>default-reader.js dedicated worker wrapper file</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
 'use strict';
-fetch_tests_from_worker(new SharedWorker('readable-stream-reader.js'));
+fetch_tests_from_worker(new Worker('default-reader.js'));
 </script>

--- a/streams/readable-streams/default-reader.html
+++ b/streams/readable-streams/default-reader.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>readable-stream-reader.js browser context wrapper file</title>
+<title>default-reader.js browser context wrapper file</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <script src="../resources/rs-utils.js"></script>
 
-<script src="readable-stream-reader.js"></script>
+<script src="default-reader.js"></script>

--- a/streams/readable-streams/default-reader.js
+++ b/streams/readable-streams/default-reader.js
@@ -5,29 +5,29 @@ if (self.importScripts) {
   self.importScripts('/resources/testharness.js');
 }
 
-let ReadableStreamReader;
+let ReadableStreamDefaultReader;
 
 test(() => {
 
   // It's not exposed globally, but we test a few of its properties here.
-  ReadableStreamReader = (new ReadableStream()).getReader().constructor;
+  ReadableStreamDefaultReader = (new ReadableStream()).getReader().constructor;
 
-}, 'Can get the ReadableStreamReader constructor indirectly');
+}, 'Can get the ReadableStreamDefaultReader constructor indirectly');
 
 test(() => {
 
-  assert_throws(new TypeError(), () => new ReadableStreamReader('potato'));
-  assert_throws(new TypeError(), () => new ReadableStreamReader({}));
-  assert_throws(new TypeError(), () => new ReadableStreamReader());
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader('potato'));
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader({}));
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader());
 
-}, 'ReadableStreamReader constructor should get a ReadableStream object as argument');
+}, 'ReadableStreamDefaultReader constructor should get a ReadableStream object as argument');
 
 test(() => {
 
   const methods = ['cancel', 'constructor', 'read', 'releaseLock'];
   const properties = methods.concat(['closed']).sort();
 
-  const rsReader = new ReadableStreamReader(new ReadableStream());
+  const rsReader = new ReadableStreamDefaultReader(new ReadableStream());
   const proto = Object.getPrototypeOf(rsReader);
 
   assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties);
@@ -56,41 +56,41 @@ test(() => {
   assert_equals(typeof rsReader.releaseLock, 'function', 'has a releaseLock method');
   assert_equals(rsReader.releaseLock.length, 0, 'releaseLock has no parameters');
 
-}, 'ReadableStreamReader instances should have the correct list of properties');
+}, 'ReadableStreamDefaultReader instances should have the correct list of properties');
 
 test(() => {
 
-  const rsReader = new ReadableStreamReader(new ReadableStream());
+  const rsReader = new ReadableStreamDefaultReader(new ReadableStream());
   assert_equals(rsReader.closed, rsReader.closed, 'closed should return the same promise');
 
-}, 'ReadableStreamReader closed should always return the same promise object');
+}, 'ReadableStreamDefaultReader closed should always return the same promise object');
 
 test(() => {
 
   const rs = new ReadableStream();
-  new ReadableStreamReader(rs); // Constructing directly the first time should be fine.
-  assert_throws(new TypeError(), () => new ReadableStreamReader(rs),
+  new ReadableStreamDefaultReader(rs); // Constructing directly the first time should be fine.
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader(rs),
                 'constructing directly the second time should fail');
 
-}, 'Constructing a ReadableStreamReader directly should fail if the stream is already locked (via direct ' +
+}, 'Constructing a ReadableStreamDefaultReader directly should fail if the stream is already locked (via direct ' +
    'construction)');
 
 test(() => {
 
   const rs = new ReadableStream();
-  new ReadableStreamReader(rs); // Constructing directly should be fine.
+  new ReadableStreamDefaultReader(rs); // Constructing directly should be fine.
   assert_throws(new TypeError(), () => rs.getReader(), 'getReader() should fail');
 
-}, 'Getting a ReadableStreamReader via getReader should fail if the stream is already locked (via direct ' +
+}, 'Getting a ReadableStreamDefaultReader via getReader should fail if the stream is already locked (via direct ' +
    'construction)');
 
 test(() => {
 
   const rs = new ReadableStream();
   rs.getReader(); // getReader() should be fine.
-  assert_throws(new TypeError(), () => new ReadableStreamReader(rs), 'constructing directly should fail');
+  assert_throws(new TypeError(), () => new ReadableStreamDefaultReader(rs), 'constructing directly should fail');
 
-}, 'Constructing a ReadableStreamReader directly should fail if the stream is already locked (via getReader)');
+}, 'Constructing a ReadableStreamDefaultReader directly should fail if the stream is already locked (via getReader)');
 
 test(() => {
 
@@ -98,7 +98,7 @@ test(() => {
   rs.getReader(); // getReader() should be fine.
   assert_throws(new TypeError(), () => rs.getReader(), 'getReader() should fail');
 
-}, 'Getting a ReadableStreamReader via getReader should fail if the stream is already locked (via getReader)');
+}, 'Getting a ReadableStreamDefaultReader via getReader should fail if the stream is already locked (via getReader)');
 
 test(() => {
 
@@ -108,9 +108,9 @@ test(() => {
     }
   });
 
-  new ReadableStreamReader(rs); // Constructing directly should not throw.
+  new ReadableStreamDefaultReader(rs); // Constructing directly should not throw.
 
-}, 'Constructing a ReadableStreamReader directly should be OK if the stream is closed');
+}, 'Constructing a ReadableStreamDefaultReader directly should be OK if the stream is closed');
 
 test(() => {
 
@@ -121,9 +121,9 @@ test(() => {
     }
   });
 
-  new ReadableStreamReader(rs); // Constructing directly should not throw.
+  new ReadableStreamDefaultReader(rs); // Constructing directly should not throw.
 
-}, 'Constructing a ReadableStreamReader directly should be OK if the stream is errored');
+}, 'Constructing a ReadableStreamDefaultReader directly should be OK if the stream is errored');
 
 promise_test(() => {
 
@@ -332,7 +332,7 @@ promise_test(t => {
   controller.error();
   return promise;
 
-}, 'ReadableStreamReader closed promise should be rejected with undefined if that is the error');
+}, 'ReadableStreamDefaultReader closed promise should be rejected with undefined if that is the error');
 
 
 promise_test(t => {
@@ -350,7 +350,8 @@ promise_test(t => {
     }
   );
 
-}, 'ReadableStreamReader: if start rejects with no parameter, it should error the stream with an undefined error');
+}, 'ReadableStreamDefaultReader: if start rejects with no parameter, it should error the stream with an undefined '
+    + 'error');
 
 promise_test(t => {
 
@@ -367,7 +368,7 @@ promise_test(t => {
   controller.error(theError);
   return promise;
 
-}, 'Erroring a ReadableStream after checking closed should reject ReadableStreamReader closed promise');
+}, 'Erroring a ReadableStream after checking closed should reject ReadableStreamDefaultReader closed promise');
 
 promise_test(t => {
 
@@ -386,7 +387,7 @@ promise_test(t => {
 
   return promise_rejects(t, theError, rs.getReader().closed);
 
-}, 'Erroring a ReadableStream before checking closed should reject ReadableStreamReader closed promise');
+}, 'Erroring a ReadableStream before checking closed should reject ReadableStreamDefaultReader closed promise');
 
 promise_test(() => {
 

--- a/streams/readable-streams/default-reader.serviceworker.https.html
+++ b/streams/readable-streams/default-reader.serviceworker.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>readable-stream-reader.js service worker wrapper file</title>
+<title>default-reader.js service worker wrapper file</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,5 +8,5 @@
 
 <script>
 'use strict';
-service_worker_test('readable-stream-reader.js', 'Service worker test setup');
+service_worker_test('default-reader.js', 'Service worker test setup');
 </script>

--- a/streams/readable-streams/default-reader.sharedworker.html
+++ b/streams/readable-streams/default-reader.sharedworker.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>readable-stream-reader.js dedicated worker wrapper file</title>
+<title>default-reader.js shared worker wrapper file</title>
 
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
 'use strict';
-fetch_tests_from_worker(new Worker('readable-stream-reader.js'));
+fetch_tests_from_worker(new SharedWorker('default-reader.js'));
 </script>

--- a/streams/readable-streams/garbage-collection.js
+++ b/streams/readable-streams/garbage-collection.js
@@ -70,6 +70,6 @@ promise_test(() => {
   return delay(50).then(() => assert_throws(new TypeError(), () => rs.getReader(),
     'old reader should still be locking the stream even after garbage collection'));
 
-}, 'Garbage-collecting a ReadableStreamReader should not unlock its stream');
+}, 'Garbage-collecting a ReadableStreamDefaultReader should not unlock its stream');
 
 done();


### PR DESCRIPTION
Use the name "ReadableStreamDefaultReader" for the default reader in tests to
match the standard. Also change the test filenames from readable-stream-reader.*
to default-reader.*.
