### PR TITLE
webrtc: add setRemoteDescription / onaddstream test

### DIFF
--- a/webrtc/rtcpeerconnection/setRemoteDescription.html
+++ b/webrtc/rtcpeerconnection/setRemoteDescription.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>RTCPeerConnection setRemoteDescription tests</title>
+</head>
+<body>
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script type="text/javascript">
+  // tests that onaddstream is called and parses the msid information from the SDP and creates
+  // the streams and tracks with matching identifiers.
+  // TODO: onaddstream is no longer part of the spec but is more widely implemented than ontrack
+  //       as of Feb. 2017. This test should be deprecated once ontrack is more widely implemented.
+  async_test(function(test) {
+    const sdp = 'v=0\r\n' +
+        'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+        's=-\r\n' +
+        't=0 0\r\n' +
+        'a=msid-semantic:WMS *\r\n' +
+        'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+        'c=IN IP4 0.0.0.0\r\n' +
+        'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
+        'a=ice-ufrag:someufrag\r\n' +
+        'a=ice-pwd:somelongpwdwithenoughrandomness\r\n' +
+        'a=fingerprint:sha-256 8C:71:B3:8D:A5:38:FD:8F:A4:2E:A2:65:6C:86:52:BC:E0:6E:94:F2:9F:7C:4D:B5:DF:AF:AA:6F:44:90:8D:F4\r\n' +
+        'a=setup:actpass\r\n' +
+        'a=rtcp-mux\r\n' +
+        'a=mid:mid1\r\n' +
+        'a=sendonly\r\n' +
+        'a=rtpmap:111 opus/48000/2\r\n' +
+        'a=msid:stream1 track1\r\n' +
+        'a=ssrc:1001 cname:some\r\n';
+
+    var pc = new RTCPeerConnection(null);
+
+    pc.onaddstream = test.step_func(function(event) {
+      assert_equals(event.stream.getTracks().length, 1, 'the stream contains one track');
+      assert_equals(event.stream.getAudioTracks().length, 1, 'the stream contains one audio track');
+      assert_equals(event.stream.getVideoTracks().length, 0, 'the stream contains no video tracks');
+
+      assert_equals(event.stream.id, 'stream1', 'the stream name is parsed from the MSID line');
+      assert_equals(event.stream.getTracks()[0].id, 'track1', 'the track name is parsed from the MSID line');
+      test.done();
+    });
+
+    pc.setRemoteDescription(new RTCSessionDescription({type: 'offer', sdp: sdp}))
+    .catch(test.step_func(function(e) {
+      assert_unreached('Error ' + e.name + ': ' + e.message);
+    }));
+  }, 'Triggers onaddstream when called with a remote description and the MSID is parsed.');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
adds a setRemoteDescription / onaddstream test that ensures
that the MSID is set right on the stream and track in the
onaddstream event.

@alvestrand wdyt? onaddstream is deprecated but this is fairly trivial to change to ontrack at some point. Or should I just do a similar ontrack test (which will fail in Chrome)