### PR TITLE
[presentation-api] update IDL tests for a receiving user agent

### DIFF
--- a/presentation-api/receiving-ua/common.js
+++ b/presentation-api/receiving-ua/common.js
@@ -1,0 +1,10 @@
+(window => {
+  // Both a controlling side and a receiving one must share the same Stash ID to
+  // transmit data from one to the other. On the other hand, due to polling mechanism
+  // which cleans up a stash, stashes in both controller-to-receiver direction
+  // and one for receiver-to-controller are necessary.
+  window.stashIds = {
+    toController: '0c382524-5738-4df0-837d-4f53ea8addc2',
+    toReceiver: 'a9618cd1-ca2b-4155-b7f6-630dce953c44'
+  }
+})(window);

--- a/presentation-api/receiving-ua/idlharness-manual.html
+++ b/presentation-api/receiving-ua/idlharness-manual.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Presentation API IDL tests for Receiving User Agent</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
+<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-receiving-user-agent">
+<link rel="stylesheet" href="/resources/testharness.css">
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p>Click the button below and select the available presentation display, to start the manual test.</p>
+<button id="presentBtn">Start Presentation Test</button>
+
+<script>
+    const presentBtn = document.getElementById('presentBtn');
+    presentBtn.onclick = () => {
+        presentBtn.disabled = true;
+        const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+        const request = new PresentationRequest('support/idlharness_receiving-ua.html');
+
+        return request.start().then(c => {
+            connection = c;
+            return stash.init();
+        }).then(() => {
+            return stash.receive();
+        }).then(result => {
+            const json = JSON.parse(result);
+            // notify receiver's results of a parent window (e.g. test runner)
+            if (window.opener && 'completion_callback' in window.opener) {
+                window.opener.completion_callback(json.tests, json.status);
+            }
+            // display receiver's results as HTML
+            const log = document.createElement('div');
+            log.id = 'log';
+            log.innerHTML = json.log;
+            document.body.appendChild(log);
+
+            connection.terminate();
+        });
+    };
+</script>

--- a/presentation-api/receiving-ua/idlharness-manual.html
+++ b/presentation-api/receiving-ua/idlharness-manual.html
@@ -34,7 +34,18 @@
             log.innerHTML = json.log;
             document.body.appendChild(log);
 
-            connection.terminate();
+            if (connection.state === 'connecting') {
+                connection.onconnect = () => {
+                    connection.terminate();
+                }
+            }
+            else if (connection.state === 'closed') {
+                request.reconnect(connection.id).then(c => {
+                    c.terminate();
+                });
+            }
+            else
+                connection.terminate();
         });
     };
 </script>

--- a/presentation-api/receiving-ua/idlharness-manual.html
+++ b/presentation-api/receiving-ua/idlharness-manual.html
@@ -11,6 +11,7 @@
 <button id="presentBtn">Start Presentation Test</button>
 
 <script>
+    let connection;
     const presentBtn = document.getElementById('presentBtn');
     presentBtn.onclick = () => {
         presentBtn.disabled = true;

--- a/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
@@ -26,10 +26,12 @@ dictionary EventInit {
 
 <script id='idl' type="text/plain">
 partial interface Navigator {
-    [SameObject]
+    [SecureContext,
+     SameObject]
     readonly attribute Presentation presentation;
 };
 
+[SecureContext]
 interface Presentation {
 };
 
@@ -37,7 +39,8 @@ partial interface Presentation {
     readonly attribute PresentationReceiver? receiver;
 };
 
-[Constructor(DOMString type, PresentationConnectionAvailableEventInit eventInitDict)]
+[SecureContext,
+ Constructor(DOMString type, PresentationConnectionAvailableEventInit eventInitDict)]
 interface PresentationConnectionAvailableEvent : Event {
     [SameObject]
     readonly attribute PresentationConnection connection;
@@ -59,46 +62,50 @@ enum BinaryType {
     "arraybuffer"
 };
 
+[SecureContext]
 interface PresentationConnection : EventTarget {
-    readonly attribute USVString?                  id;
-    readonly attribute USVString?                  url;
+    readonly attribute USVString                   id;
+    readonly attribute USVString                   url;
     readonly attribute PresentationConnectionState state;
     void close();
     void terminate();
-    attribute EventHandler                onconnect;
-    attribute EventHandler                onclose;
-    attribute EventHandler                onterminate;
+             attribute EventHandler                onconnect;
+             attribute EventHandler                onclose;
+             attribute EventHandler                onterminate;
 
     // Communication
-    attribute BinaryType                  binaryType;
-    attribute EventHandler                onmessage;
+             attribute BinaryType                  binaryType;
+             attribute EventHandler                onmessage;
     void send(DOMString message);
     void send(Blob data);
     void send(ArrayBuffer data);
     void send(ArrayBufferView data);
 };
 
-enum PresentationConnectionClosedReason {
+enum PresentationConnectionCloseReason {
     "error",
     "closed",
     "wentaway"
 };
 
-[Constructor(DOMString type, PresentationConnectionCloseEventInit eventInitDict)]
+[SecureContext,
+ Constructor(DOMString type, PresentationConnectionCloseEventInit eventInitDict)]
 interface PresentationConnectionCloseEvent : Event {
-    readonly attribute PresentationConnectionClosedReason reason;
-    readonly attribute DOMString                          message;
+    readonly attribute PresentationConnectionCloseReason reason;
+    readonly attribute DOMString                         message;
 };
 
 dictionary PresentationConnectionCloseEventInit : EventInit {
-    required PresentationConnectionClosedReason reason;
-    		 DOMString                          message = "";
+    required PresentationConnectionCloseReason reason;
+             DOMString                         message = "";
 };
 
+[SecureContext]
 interface PresentationReceiver {
     readonly attribute Promise<PresentationConnectionList> connectionList;
 };
 
+[SecureContext]
 interface PresentationConnectionList : EventTarget {
     readonly attribute FrozenArray<PresentationConnection> connections;
              attribute EventHandler                        onconnectionavailable;

--- a/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/idlharness_receiving-ua.html
@@ -2,11 +2,14 @@
 <meta charset="utf-8">
 <title>Presentation API IDL tests for Receiving User Agent</title>
 <link rel="author" title="Louay Bassbouss" href="http://www.fokus.fraunhofer.de">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dfn-receiving-user-agent">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
+<script src="../common.js"></script>
+<script src="stash.js"></script>
 
 <script id="untested_idl" type="text/plain">
 interface Navigator {
@@ -24,14 +27,13 @@ dictionary EventInit {
 <script id='idl' type="text/plain">
 partial interface Navigator {
     [SameObject]
-    readonly attribute Presentation? presentation;
+    readonly attribute Presentation presentation;
 };
 
 interface Presentation {
 };
 
 partial interface Presentation {
-    [SameObject]
     readonly attribute PresentationReceiver? receiver;
 };
 
@@ -58,7 +60,8 @@ enum BinaryType {
 };
 
 interface PresentationConnection : EventTarget {
-    readonly attribute DOMString?                  id;
+    readonly attribute USVString?                  id;
+    readonly attribute USVString?                  url;
     readonly attribute PresentationConnectionState state;
     void close();
     void terminate();
@@ -93,7 +96,6 @@ dictionary PresentationConnectionCloseEventInit : EventInit {
 };
 
 interface PresentationReceiver {
-    [SameObject]
     readonly attribute Promise<PresentationConnectionList> connectionList;
 };
 
@@ -104,17 +106,21 @@ interface PresentationConnectionList : EventTarget {
 </script>
 
 <script>
-    (function() {
-        "use strict";
-        var idl_array = new IdlArray();
-        var idls = document.getElementById('idl').textContent;
+    (() => {
+        'use strict';
+        const idl_array = new IdlArray();
+        const idls = document.getElementById('idl').textContent;
         idl_array.add_untested_idls(document.getElementById('untested_idl').textContent);
         idl_array.add_idls(idls);
         idl_array.add_objects({
             Presentation: ['navigator.presentation'],
             PresentationReceiver: ['navigator.presentation.receiver']
         });
+        add_completion_callback((tests, status) => {
+            const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+            const log = document.getElementById('log');
+            stash.send(JSON.stringify({ tests: tests, status: status, log: log.innerHTML }));
+        });
         idl_array.test();
     })();
 </script>
-

--- a/presentation-api/receiving-ua/support/stash.js
+++ b/presentation-api/receiving-ua/support/stash.js
@@ -1,0 +1,83 @@
+var Stash = function(inbound, outbound) {
+  this.stashPath = '/presentation-api/controlling-ua/support/stash.py?id=';
+  this.inbound = inbound;
+  this.outbound = outbound;
+}
+
+// initialize a stash on wptserve
+Stash.prototype.init = function() {
+  return Promise.all([
+    fetch(this.stashPath + this.inbound).then(response => {
+      return response.text();
+    }),
+    fetch(this.stashPath + this.outbound).then(response => {
+      return response.text();
+    })
+  ]);
+}
+
+// upload a test result to a stash on wptserve
+Stash.prototype.send = function(result) {
+  return fetch(this.stashPath + this.outbound, {
+    method: 'POST',
+    body: JSON.stringify({ type: 'data', data: result })
+  }).then(response => {
+    return response.text();
+  }).then(text => {
+    return text === 'ok' ? null : Promise.reject();
+  })
+};
+
+// wait until a test result is uploaded to a stash on wptserve
+Stash.prototype.receive = function() {
+  return new Promise((resolve, reject) => {
+    let intervalId;
+    const interval = 500; // msec
+    const polling = () => {
+      return fetch(this.stashPath + this.inbound).then(response => {
+        return response.text();
+      }).then(text => {
+        if (text) {
+          try {
+            const json = JSON.parse(text);
+            if (json.type === 'data')
+              resolve(json.data);
+            else
+              reject();
+          } catch(e) {
+            resolve(text);
+          }
+          clearInterval(intervalId);
+        }
+      });
+    };
+    intervalId = setInterval(polling, interval);
+  });
+};
+
+// reset a stash on wptserve
+Stash.prototype.stop = function() {
+  return Promise.all([
+    fetch(this.stashPath + this.inbound).then(response => {
+      return response.text();
+    }),
+    fetch(this.stashPath + this.outbound).then(response => {
+      return response.text();
+    })
+  ]).then(() => {
+    return Promise.all([
+      fetch(this.stashPath + this.inbound, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'stop' })
+      }).then(response => {
+        return response.text();
+      }),
+      fetch(this.stashPath + this.outbound, {
+        method: 'POST',
+        body: JSON.stringify({ type: 'stop' })
+      }).then(response => {
+        return response.text();
+      })
+    ]);
+  });
+}

--- a/presentation-api/receiving-ua/support/stash.py
+++ b/presentation-api/receiving-ua/support/stash.py
@@ -1,0 +1,10 @@
+def main(request, response):
+    key = request.GET.first("id")
+
+    if request.method == "POST":
+        request.server.stash.put(key, request.body)
+        return "ok"
+    else:
+        value = request.server.stash.take(key)
+        assert request.server.stash.take(key) is None
+        return value


### PR DESCRIPTION
This PR modifies `receiving-ua/idlharness.html`.

* All IDL tests declared in `idlharness.html` are moved to `support/idlharness_receiving-ua.html`.
* The IDL tests for a receiving side can be invoked via `idlharness-manual.html` for a controlling side.
* As mentioned in https://github.com/w3c/web-platform-tests/issues/4991#issuecomment-282183770, the receiving side sends the test results to the controlling side via a stash. If the controlling side is opened by test runner, the test results are passed to the test runner, as well.