### PR TITLE
[eventsource] Do not send invalid HTTP response

### DIFF
--- a/eventsource/resources/status-error.py
+++ b/eventsource/resources/status-error.py
@@ -1,4 +1,15 @@
 def main(request, response):
   status = (request.GET.first("status", "404"), "HAHAHAHA")
   headers = [("Content-Type", "text/event-stream")]
-  return status, headers, "data: data\n\n"
+
+  # According to RFC7231, HTTP responses bearing status code 204 or 205 must
+  # not specify a body. The expected browser behavior for this condition is not
+  # currently defined--see the following for further discussion:
+  #
+  # https://github.com/w3c/web-platform-tests/pull/5227
+  if status[0] in ["204", "205"]:
+      body = ""
+  else:
+      body = "data: data\n\n"
+
+  return status, headers, body


### PR DESCRIPTION
HTTP responses bearing status codes 204 and 205 MUST NOT include a body
[1] [2]. In violating this restriction, the previous implementation of
this test triggered unspecified behavior, which led to instability in
the Chromium web browser.

Update the test's request handler to omit a body for such responses.

[1] https://tools.ietf.org/html/rfc7231#section-6.3.5 reads:

> A 204 response is terminated by the first empty line after the header
> fields because it cannot contain a message body.

[2] https://tools.ietf.org/html/rfc7231#section-6.3.6 reads

> Since the 205 status code implies that no additional content will be
> provided, a server MUST NOT generate a payload in a 205 response.