### PR TITLE
Make all parameters to initEvent() / initCustomEvent() optional excep…

### DIFF
--- a/dom/events/CustomEvent.html
+++ b/dom/events/CustomEvent.html
@@ -15,5 +15,21 @@ test(function() {
   var fooEvent = document.createEvent("CustomEvent");
   fooEvent.initEvent(type, true, true);
   target.dispatchEvent(fooEvent);
-});
+}, "CustomEvent dispatching.");
+
+test(function() {
+    var e = document.createEvent("CustomEvent");
+    assert_throws(new TypeError(), function() {
+        e.initCustomEvent();
+    });
+}, "First parameter to initCustomEvent should be mandatory.");
+
+test(function() {
+    var e = document.createEvent("CustomEvent");
+    e.initCustomEvent("foo");
+    assert_equals(e.type, "foo", "type");
+    assert_false(e.bubbles, "bubbles");
+    assert_false(e.cancelable, "cancelable");
+    assert_equals(e.detail, null, "detail");
+}, "initCustomEvent's default parameter values.");
 </script>

--- a/dom/events/Event-initEvent.html
+++ b/dom/events/Event-initEvent.html
@@ -116,4 +116,19 @@ async_test(function() {
 
   this.done()
 }, "Calling initEvent during propagation.")
+
+test(function() {
+  var e = document.createEvent("Event")
+  assert_throws(new TypeError(), function() {
+    e.initEvent()
+  })
+}, "First parameter to initEvent should be mandatory.")
+
+test(function() {
+  var e = document.createEvent("Event")
+  e.initEvent("type")
+  assert_equals(e.type, "type", "type")
+  assert_false(e.bubbles, "bubbles")
+  assert_false(e.cancelable, "cancelable")
+}, "Tests initEvent's default parameter values.")
 </script>

--- a/dom/interfaces.html
+++ b/dom/interfaces.html
@@ -34,7 +34,7 @@ interface Event {
   [Unforgeable] readonly attribute boolean isTrusted;
   readonly attribute DOMTimeStamp timeStamp;
 
-  void initEvent(DOMString type, boolean bubbles, boolean cancelable);
+  void initEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false);
 };
 
 dictionary EventInit {
@@ -48,7 +48,7 @@ dictionary EventInit {
 interface CustomEvent : Event {
   readonly attribute any detail;
 
-  void initCustomEvent(DOMString type, boolean bubbles, boolean cancelable, any detail);
+  void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
 };
 
 dictionary CustomEventInit : EventInit {


### PR DESCRIPTION
…t the first one

Make all parameters to initEvent() / initCustomEvent() optional except the first one.
to match:
- https://github.com/whatwg/dom/pull/417
- https://github.com/whatwg/dom/issues/387