### PR TITLE
Make all parameters to initMessageEvent() optional except the first one

### DIFF
--- a/html/dom/resources/interfaces.idl
+++ b/html/dom/resources/interfaces.idl
@@ -1789,7 +1789,7 @@ interface MessageEvent : Event {
   readonly attribute (WindowProxy or MessagePort)? source;
   readonly attribute FrozenArray<MessagePort> ports;
 
-  void initMessageEvent(DOMString type, boolean bubbles, boolean cancelable, any data, DOMString origin, DOMString lastEventId, (WindowProxy or MessagePort) source, sequence<MessagePort> ports);
+  void initMessageEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any data = null, optional DOMString origin = "", optional DOMString lastEventId = "", optional (WindowProxy or MessagePort)? source = null, optional sequence<MessagePort> ports = []);
 };
 
 dictionary MessageEventInit : EventInit {

--- a/html/webappapis/scripting/events/messageevent-constructor.https.html
+++ b/html/webappapis/scripting/events/messageevent-constructor.https.html
@@ -70,11 +70,17 @@ test(function() {
 
 test(function() {
   var ev = document.createEvent("messageevent")
-  assert_equals(MessageEvent.prototype.initMessageEvent.length, 8, "MessageEvent.prototype.initMessageEvent.length should be 8")
-  assert_throws(new TypeError(), function() {
-    ev.initMessageEvent("test", true, false, "testData", "testOrigin", "testId", window)
-  }, "Calling initMessageEvent with only 7 parameters should throw a TypeError")
-}, "All parameters to initMessageEvent should be mandatory")
+  assert_equals(MessageEvent.prototype.initMessageEvent.length, 1, "MessageEvent.prototype.initMessageEvent.length should be 1")
+  ev.initMessageEvent("test")
+  assert_equals(ev.type, "test", "type attribute")
+  assert_equals(ev.bubbles, false, "bubbles attribute")
+  assert_equals(ev.cancelable, false, "bubbles attribute")
+  assert_equals(ev.data, null, "data attribute")
+  assert_equals(ev.origin, "", "origin attribute")
+  assert_equals(ev.lastEventId, "", "lastEventId attribute")
+  assert_equals(ev.source, null, "source attribute")
+  assert_array_equals(ev.ports, [], "ports attribute")
+}, "initMessageEvent operation default parameter values")
 
 promise_test(function(t) {
     var worker_url = "/service-workers/service-worker/resources/empty-worker.js";


### PR DESCRIPTION
Make all parameters to initMessageEvent() optional except the first one.

See corresponding HTML specification change at:
https://github.com/whatwg/html/pull/2410

and discussion at:
whatwg/dom#387