### PR TITLE
[presentation-api] Add tests to check a newly created receiving browsing context

### DIFF
--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
@@ -112,11 +112,13 @@
             const getClientUrls = () => {
                 return new Promise(resolve => {
                     navigator.serviceWorker.getRegistration().then(reg => {
-                        const channel = new MessageChannel();
-                        channel.port1.onmessage = event => {
-                            resolve(event.data);
-                        };
-                        reg.active.postMessage('', [channel.port2]);
+                        if (reg) {
+                            const channel = new MessageChannel();
+                            channel.port1.onmessage = event => {
+                                resolve(event.data);
+                            };
+                            reg.active.postMessage('', [channel.port2]);
+                        }
                     });
                 });
             };
@@ -214,20 +216,36 @@
             const disableTimeout = () => {
                 clearTimeout(timeout);
             };
+            const cancelWait = () => {
+                connection.removeEventListener('close', onTerminate);
+                connection.removeEventListener('terminate', onTerminate);
+            };
+            const onTerminate = (reject, event) => {
+                cancelWait();
+                reject('A receiving user agent unexpectedly ' + event.type + 'd a presentation. ');
+            };
+            const waitForTerminate = () => {
+                return new Promise((resolve, reject) => {
+                    connection.addEventListener('close', onTerminate.bind(this, reject));
+                    connection.addEventListener('terminate', onTerminate.bind(this, reject));
+                });
+            };
 
             // Start a presentation for receiving user agent tests
             return request.start().then(c => {
                 connection = c;
                 enableTimeout();
-                return openIndexedDB()
+                // This Promise.race will be rejected if a receiving side terminates/closes the connection when window.close() is invoked
+                return Promise.race([
+                    openIndexedDB()
                         .then(registerServiceWorker)
-                        .then(openCaches);
-            }).then(() => {
-                return stash.init();
-            }).then(() => {
-                return stash.receive();
+                        .then(openCaches)
+                        .then(() => { return stash.init(); })
+                        .then(() => { return stash.receive(); }),
+                    waitForTerminate()]);
             }).then(result => {
                 // terminate and connect again if the result is PASS
+                cancelWait();
                 const json = JSON.parse(result);
                 if (json.test.status !== 0)
                     return json;

--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
@@ -25,7 +25,7 @@
         }
     });
 
-    let connection;
+    let connection, db;
     const presentBtn = document.getElementById('presentBtn');
     const main = () => {
         promise_test(t => {
@@ -88,22 +88,23 @@
                 id: 'controller',
                 data: 'controlling user agent'
             };
-            let db;
             const openIndexedDB = () => {
-                return new Promise((resolve, reject) => {
+                if ('indexedDB' in window) {
                     const dbReq = indexedDB.open(dbName, 1);
-                    dbReq.onupgradeneeded = () => {
+                    const eventWatcher = new EventWatcher(t, dbReq, ['upgradeneeded', 'success']);
+                    return eventWatcher.wait_for('upgradeneeded').then(() => {
                         db = dbReq.result;
                         const store = db.createObjectStore(storeName, { keyPath: 'id' });
                         store.add(storeData);
-                    };
-                    dbReq.onsuccess = () => {
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
                         db = dbReq.result;
                         db.close();
                         db = null;
-                        resolve();
-                    }
-                });
+                    });
+                }
+                else
+                    return Promise.resolve();
             };
 
             const cacheName = 'controlling-ua';
@@ -153,29 +154,33 @@
 
             // Indexed Database
             const checkIndexedDB = t => {
-                const message = 'Indexed Database is not shared with a receiving user agent.';
-                let req = indexedDB.open(dbName, 1), store;
-                let eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success').then(() => {
-                    db = req.result;
-                    const transaction = db.transaction(storeName, 'readwrite');
-                    store = transaction.objectStore(storeName);
-                    req = store.openCursor();
-                    eventWatcher = new EventWatcher(t, req, 'success');
-                    return eventWatcher.wait_for('success');
-                }).then(() => {
-                    assert_true(req.result instanceof IDBCursorWithValue, message);
-                    const cursor = req.result;
-                    const item = cursor.value;
-                    assert_equals(item.id, storeData.id, message);
-                    assert_equals(item.data, storeData.data, message);
-                    cursor.continue();
-                    return eventWatcher.wait_for('success');
-                }).then(() => {
-                    assert_equals(req.result, null, message);
-                    db.close();
-                    db = null;
-                });
+                if ('indexedDB' in window) {
+                    const message = 'Indexed Database is not shared with a receiving user agent.';
+                    let req = indexedDB.open(dbName, 1), store;
+                    let eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success').then(() => {
+                        db = req.result;
+                        const transaction = db.transaction(storeName, 'readwrite');
+                        store = transaction.objectStore(storeName);
+                        req = store.openCursor();
+                        eventWatcher = new EventWatcher(t, req, 'success');
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
+                        assert_true(req.result instanceof IDBCursorWithValue, message);
+                        const cursor = req.result;
+                        const item = cursor.value;
+                        assert_equals(item.id, storeData.id, message);
+                        assert_equals(item.data, storeData.data, message);
+                        cursor.continue();
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
+                        assert_equals(req.result, null, message);
+                        db.close();
+                        db = null;
+                    });
+                }
+                else
+                    return Promise.resolve();
             };
 
             // Service Workers
@@ -213,43 +218,45 @@
             // Start a presentation for receiving user agent tests
             return request.start().then(c => {
                 connection = c;
+                enableTimeout();
                 return openIndexedDB()
                         .then(registerServiceWorker)
                         .then(openCaches);
             }).then(() => {
                 return stash.init();
             }).then(() => {
-                enableTimeout();
                 return stash.receive();
             }).then(result => {
                 // terminate and connect again if the result is PASS
                 const json = JSON.parse(result);
-                return json.test.status === 0
-                    // Check accessibility to window clients before terminating a presentation
-                    ? getClientUrls().then(urls => {
-                        assert_true(urls.length === clientUrls.length && urls.every((value, index) => { return clientUrls[index] === value}),
-                            'A window client in a receiving user agent is not accessible to a service worker on a controlling user agent.')
-                        const eventWatcher = new EventWatcher(t, connection, 'terminate');
-                        connection.terminate();
-                        return eventWatcher.wait_for('terminate');
-                    }).then(() => {
-                        connection = null;
-                        disableTimeout();
-                        presentBtn.removeEventListener('click', main);
-                        presentBtn.textContent = 'Continue Presentation Test';
-                        presentBtn.disabled = false;
-                        const eventWatcher = new EventWatcher(t, presentBtn, 'click');
-                        return eventWatcher.wait_for('click');
-                    }).then(() => {
-                        presentBtn.disabled = true;
-                        return request.start();
-                    }).then(c => {
-                        connection = c;
-                        enableTimeout();
-                        return stash.receive();
-                    }).then(result => {
-                        return JSON.parse(result);
-                    }) : json;
+                if (json.test.status !== 0)
+                    return json;
+
+                // Check accessibility to window clients before terminating a presentation
+                return getClientUrls().then(urls => {
+                    assert_true(urls.length === clientUrls.length && urls.every((value, index) => { return clientUrls[index] === value}),
+                        'A window client in a receiving user agent is not accessible to a service worker on a controlling user agent.')
+                    const eventWatcher = new EventWatcher(t, connection, 'terminate');
+                    connection.terminate();
+                    return eventWatcher.wait_for('terminate');
+                }).then(() => {
+                    connection = null;
+                    disableTimeout();
+                    presentBtn.removeEventListener('click', main);
+                    presentBtn.textContent = 'Continue Presentation Test';
+                    presentBtn.disabled = false;
+                    const eventWatcher = new EventWatcher(t, presentBtn, 'click');
+                    return eventWatcher.wait_for('click');
+                }).then(() => {
+                    presentBtn.disabled = true;
+                    return request.start();
+                }).then(c => {
+                    connection = c;
+                    enableTimeout();
+                    return stash.receive();
+                }).then(result => {
+                    return JSON.parse(result);
+                });
             }).then(json => {
                 if (json.test.status === 0) {
                     checkUpdates();

--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Creating a receiving browsing context</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
+<link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
+<link rel="stylesheet" href="/resources/testharness.css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p id="notice">
+  Click the button below and select the available presentation display, to start the manual test. The test passes if a "PASS" result appears.<br>
+  This test asks you to click the button twice, unless the test fails.<br>
+  <button id="presentBtn">Start Presentation Test</button>
+</p>
+
+<script>
+    setup({explicit_timeout: true});
+
+    let connection;
+    const presentBtn = document.getElementById('presentBtn');
+    presentBtn.onclick = () => {
+        presentBtn.disabled = true;
+        const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+        const request = new PresentationRequest('support/PresentationReceiver_create_receiving-ua.html');
+
+        history.pushState(null, 'test', 'PresentationReceiver_create-manual.html');
+        document.cookie = 'PresentationApiTest=Controlling-UA';
+
+        const storageName = 'presentation_api_test';
+        const storageValue = 'receiving-ua';
+        sessionStorage.setItem(storageName, storageValue);
+        localStorage.setItem(storageName, storageValue);
+
+        const dbName = 'db-presentation-api';
+        const storeName = 'store-controlling-ua';
+        const storeData = {
+            id: 'controller',
+            data: 'controlling user agent'
+        };
+        let db;
+        const openIndexedDB = () => {
+            return new Promise((resolve, reject) => {
+                const dbReq = indexedDB.open(dbName, 1);
+                dbReq.onupgradeneeded = () => {
+                    db = dbReq.result;
+                    const store = db.createObjectStore(storeName, { keyPath: 'id' });
+                    store.add(storeData);
+                };
+                dbReq.onsuccess = () => {
+                    db = dbReq.result;
+                    db.close();
+                    db = null;
+                    resolve();
+                }
+            });
+        };
+
+        const cacheName = 'controlling-ua';
+        let clientUrls;
+        const getClientUrls = () => {
+            return new Promise(resolve => {
+                navigator.serviceWorker.getRegistration().then(reg => {
+                    const channel = new MessageChannel();
+                    channel.port1.onmessage = event => {
+                        resolve(event.data);
+                    };
+                    reg.active.postMessage('', [channel.port2]);
+                });
+            });
+        };
+        const registerServiceWorker = () => {
+            return ('serviceWorker' in navigator ?
+                navigator.serviceWorker.register('serviceworker.js').then(registration => {
+                    return new Promise((resolve, reject) => {
+                        if (registration.installing) {
+                            registration.installing.addEventListener('statechange', event => {
+                                if(event.target.state === 'installed')
+                                    resolve();
+                            });
+                        }
+                        else
+                            resolve();
+                    });
+                }) : Promise.resolve()).then(getClientUrls).then(urls => {
+                    clientUrls = urls;
+                });
+        };
+        const openCaches = () => {
+            return 'caches' in window ? caches.open(cacheName).then(cache => cache.add('cache.txt')) : Promise.resolve();
+        };
+
+        const checkUpdates = () => {
+            // Cookie
+            assert_equals(document.cookie, 'PresentationApiTest=Controlling-UA', 'A cookie store is not shared with a receiving user agent.');
+
+            // Web Storage
+            assert_equals(sessionStorage.length, 1, 'Session storage is not shared with a receiving user agent.');
+            assert_equals(sessionStorage.getItem(storageName), storageValue, 'Session storage is not shared with a receiving user agent.');
+            assert_equals(localStorage.length, 1, 'Local storage is not shared with a receiving user agent.');
+            assert_equals(localStorage.getItem(storageName), storageValue, 'Local storage is not shared with a receiving user agent.');
+        };
+
+        // Indexed Database
+        const checkIndexedDB = t => {
+            const message = 'Indexed Database is not shared with a receiving user agent.';
+            let req = indexedDB.open(dbName, 1), store;
+            let eventWatcher = new EventWatcher(t, req, 'success');
+            return eventWatcher.wait_for('success').then(() => {
+                db = req.result;
+                const transaction = db.transaction(storeName, 'readwrite');
+                store = transaction.objectStore(storeName);
+                req = store.openCursor();
+                eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success');
+            }).then(() => {
+                assert_true(req.result instanceof IDBCursorWithValue, message);
+                const cursor = req.result;
+                const item = cursor.value;
+                assert_equals(item.id, storeData.id, message);
+                assert_equals(item.data, storeData.data, message);
+                cursor.continue();
+                return eventWatcher.wait_for('success');
+            }).then(() => {
+                assert_equals(req.result, null, message);
+                db.close();
+                db = null;
+            });
+        };
+
+        // Service Workers
+        const checkServiceWorkers = () => {
+            return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                const message = 'List of registered service worker registrations is not shared with a receiving user agent.';
+                assert_equals(registrations.length, 1, message);
+                assert_equals(registrations[0].active.scriptURL, new Request('serviceworker.js').url, message);
+            }) : Promise.resolve();
+        };
+        const checkCaches = () => {
+            const message = 'Cache storage is not shared with a receiving user agent.';
+            return 'caches' in window ? caches.keys().then(keys => {
+                assert_equals(keys.length, 1, message);
+                assert_equals(keys[0], cacheName, message);
+                return caches.open(keys[0]);
+            }).then(cache => cache.matchAll())
+            .then(responses => {
+                assert_equals(responses.length, 1, message);
+                assert_equals(responses[0].url, new Request('cache.txt').url, message);
+            }) : Promise.resolve();
+        };
+
+        const waitForTimeout = () => {
+            return new Promise(resolve => {
+                const intervalId = setInterval(() => {
+                    clearInterval(intervalId);
+                    resolve(null);
+                }, 5000);
+            });
+        };
+
+        const cleanup = () => {
+            const notice = document.getElementById('notice');
+            notice.parentNode.removeChild(notice);
+            stash.stop();
+
+            history.back();
+            document.cookie = 'PresentationApiTest=true; Expires=' + new Date().toUTCString();
+            sessionStorage.removeItem('presentation_api_test');
+            localStorage.removeItem('presentation_api_test');
+
+            if (db)
+                db.close();
+            indexedDB.deleteDatabase(dbName);
+
+            if (connection) {
+                if (connection.state === 'connecting') {
+                    connection.onconnect = () => {
+                        connection.terminate();
+                    }
+                }
+                else if (connection.state === 'closed') {
+                    request.reconnect(connection.id).then(c => {
+                        c.terminate();
+                    });
+                }
+                else
+                    connection.terminate();
+            }
+
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.getRegistrations().then(registrations => {
+                    return Promise.all(registrations.map(reg => reg.unregister()));
+                });
+            }
+            if ('caches' in window) {
+                caches.keys().then(keys => {
+                    return Promise.all(keys.map(key => caches.delete(key)));
+                });
+            }
+        };
+
+        // Start a pressentation for receiving user agent tests
+        return request.start().then(c => {
+            connection = c;
+            return openIndexedDB()
+                    .then(registerServiceWorker)
+                    .then(openCaches);
+        }).then(() => {
+            return stash.init();
+        }).then(() => {
+            return Promise.race([stash.receive(), waitForTimeout()]);
+        }).then(result => {
+            if (result) {
+                const json = JSON.parse(result);
+
+                // terminate and connect again if the result is PASS
+                return json.tests.every(test => { return test.status === 0; })
+                    // Check accessibility to window clients before terminating a presentation
+                    ? getClientUrls().then(urls => {
+                        if (urls.length !== clientUrls.length || urls.some((value, index) => {clientUrls[index] !== value})) {
+                            test(t => {
+                                t.add_cleanup(cleanup)
+                                assert_unreached('A window client in a receiving user agent is not accessible to a service worker on a controlling user agent.')
+                            });
+                        }
+                        else {
+                            return new Promise(resolve => {
+                                connection.onterminate = resolve;
+                                connection.terminate();
+                            });
+                        }
+                    }).then(() => {
+                        return new Promise(resolve => {
+                            connection = null;
+                            presentBtn.textContent = 'Continue Presentation Test';
+                            presentBtn.onclick = resolve;
+                            presentBtn.disabled = false;
+                        });
+                    }).then(() => {
+                        presentBtn.disabled = true;
+                        return request.start();
+                    }).then(c => {
+                        connection = c;
+                        return Promise.race([stash.receive(), waitForTimeout()]);
+                    }).then(result => {
+                        return result ? JSON.parse(result) : null;
+                    }) : json;
+            }
+            else
+                return null;
+        }).then(json => {
+            if(json) {
+                if (json.tests.every(test => { return test.status === 0; })) {
+                    // Check if storages and service workers are not affected by a receiving user agent
+                    promise_test(t => {
+                        t.add_cleanup(cleanup);
+                        checkUpdates();
+                        return checkIndexedDB(t)
+                                .then(checkServiceWorkers)
+                                .then(checkCaches);
+                    });
+                }
+                else {
+                    // notify receiver's results of a parent window (e.g. test runner)
+                    if (window.opener && 'completion_callback' in window.opener) {
+                        window.opener.completion_callback(json.tests, json.status);
+                    }
+                    // display receiver's results as HTML
+                    const log = document.createElement('div');
+                    log.id = 'log';
+                    log.innerHTML = json.log;
+                    document.body.appendChild(log);
+                    cleanup();
+                }
+            }
+            else {
+                test(t => {
+                    t.add_cleanup(cleanup)
+                    assert_unreached('Test timed out.');
+                });
+            }
+        }).catch(error => {
+            promise_test(t => {
+                t.add_cleanup(cleanup)
+                throw error;
+            });
+        });
+    };
+</script>

--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.html
@@ -3,7 +3,6 @@
 <title>Creating a receiving browsing context</title>
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
-<link rel="stylesheet" href="/resources/testharness.css">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="common.js"></script>
@@ -18,273 +17,252 @@
 <script>
     setup({explicit_timeout: true});
 
+    let receiverStack;
+    add_completion_callback(() => {
+        // overwrite a stack written in the test result
+        if (receiverStack) {
+            document.querySelector('#log pre').textContent = receiverStack;
+        }
+    });
+
     let connection;
     const presentBtn = document.getElementById('presentBtn');
-    presentBtn.onclick = () => {
-        presentBtn.disabled = true;
-        const stash = new Stash(stashIds.toController, stashIds.toReceiver);
-        const request = new PresentationRequest('support/PresentationReceiver_create_receiving-ua.html');
+    const main = () => {
+        promise_test(t => {
+            presentBtn.disabled = true;
+            const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+            const request = new PresentationRequest('support/PresentationReceiver_create_receiving-ua.html');
 
-        history.pushState(null, 'test', 'PresentationReceiver_create-manual.html');
-        document.cookie = 'PresentationApiTest=Controlling-UA';
+            t.add_cleanup(() => {
+                const notice = document.getElementById('notice');
+                notice.parentNode.removeChild(notice);
+                stash.stop();
 
-        const storageName = 'presentation_api_test';
-        const storageValue = 'receiving-ua';
-        sessionStorage.setItem(storageName, storageValue);
-        localStorage.setItem(storageName, storageValue);
+                //history.back();
+                document.cookie = 'PresentationApiTest=true; Expires=' + new Date().toUTCString();
+                sessionStorage.removeItem('presentation_api_test');
+                localStorage.removeItem('presentation_api_test');
 
-        const dbName = 'db-presentation-api';
-        const storeName = 'store-controlling-ua';
-        const storeData = {
-            id: 'controller',
-            data: 'controlling user agent'
-        };
-        let db;
-        const openIndexedDB = () => {
-            return new Promise((resolve, reject) => {
-                const dbReq = indexedDB.open(dbName, 1);
-                dbReq.onupgradeneeded = () => {
-                    db = dbReq.result;
-                    const store = db.createObjectStore(storeName, { keyPath: 'id' });
-                    store.add(storeData);
-                };
-                dbReq.onsuccess = () => {
-                    db = dbReq.result;
+                if (db)
+                    db.close();
+                indexedDB.deleteDatabase(dbName);
+
+                if (connection) {
+                    if (connection.state === 'connecting') {
+                        connection.onconnect = () => {
+                            connection.terminate();
+                        }
+                    }
+                    else if (connection.state === 'closed') {
+                        request.reconnect(connection.id).then(c => {
+                            c.terminate();
+                        });
+                    }
+                    else
+                        connection.terminate();
+                }
+
+                if ('serviceWorker' in navigator) {
+                    navigator.serviceWorker.getRegistrations().then(registrations => {
+                        return Promise.all(registrations.map(reg => reg.unregister()));
+                    });
+                }
+                if ('caches' in window) {
+                    caches.keys().then(keys => {
+                        return Promise.all(keys.map(key => caches.delete(key)));
+                    });
+                }
+            });
+
+            history.pushState(null, 'test', 'PresentationReceiver_create-manual.html');
+            document.cookie = 'PresentationApiTest=Controlling-UA';
+
+            const storageName = 'presentation_api_test';
+            const storageValue = 'receiving-ua';
+            sessionStorage.setItem(storageName, storageValue);
+            localStorage.setItem(storageName, storageValue);
+
+            const dbName = 'db-presentation-api';
+            const storeName = 'store-controlling-ua';
+            const storeData = {
+                id: 'controller',
+                data: 'controlling user agent'
+            };
+            let db;
+            const openIndexedDB = () => {
+                return new Promise((resolve, reject) => {
+                    const dbReq = indexedDB.open(dbName, 1);
+                    dbReq.onupgradeneeded = () => {
+                        db = dbReq.result;
+                        const store = db.createObjectStore(storeName, { keyPath: 'id' });
+                        store.add(storeData);
+                    };
+                    dbReq.onsuccess = () => {
+                        db = dbReq.result;
+                        db.close();
+                        db = null;
+                        resolve();
+                    }
+                });
+            };
+
+            const cacheName = 'controlling-ua';
+            let clientUrls;
+            const getClientUrls = () => {
+                return new Promise(resolve => {
+                    navigator.serviceWorker.getRegistration().then(reg => {
+                        const channel = new MessageChannel();
+                        channel.port1.onmessage = event => {
+                            resolve(event.data);
+                        };
+                        reg.active.postMessage('', [channel.port2]);
+                    });
+                });
+            };
+            const registerServiceWorker = () => {
+                return ('serviceWorker' in navigator ?
+                    navigator.serviceWorker.register('serviceworker.js').then(registration => {
+                        return new Promise((resolve, reject) => {
+                            if (registration.installing) {
+                                registration.installing.addEventListener('statechange', event => {
+                                    if(event.target.state === 'installed')
+                                        resolve();
+                                });
+                            }
+                            else
+                                resolve();
+                        });
+                    }) : Promise.resolve()).then(getClientUrls).then(urls => {
+                        clientUrls = urls;
+                    });
+            };
+            const openCaches = () => {
+                return 'caches' in window ? caches.open(cacheName).then(cache => cache.add('cache.txt')) : Promise.resolve();
+            };
+
+            const checkUpdates = () => {
+                // Cookie
+                assert_equals(document.cookie, 'PresentationApiTest=Controlling-UA', 'A cookie store is not shared with a receiving user agent.');
+
+                // Web Storage
+                assert_equals(sessionStorage.length, 1, 'Session storage is not shared with a receiving user agent.');
+                assert_equals(sessionStorage.getItem(storageName), storageValue, 'Session storage is not shared with a receiving user agent.');
+                assert_equals(localStorage.length, 1, 'Local storage is not shared with a receiving user agent.');
+                assert_equals(localStorage.getItem(storageName), storageValue, 'Local storage is not shared with a receiving user agent.');
+            };
+
+            // Indexed Database
+            const checkIndexedDB = t => {
+                const message = 'Indexed Database is not shared with a receiving user agent.';
+                let req = indexedDB.open(dbName, 1), store;
+                let eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success').then(() => {
+                    db = req.result;
+                    const transaction = db.transaction(storeName, 'readwrite');
+                    store = transaction.objectStore(storeName);
+                    req = store.openCursor();
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_true(req.result instanceof IDBCursorWithValue, message);
+                    const cursor = req.result;
+                    const item = cursor.value;
+                    assert_equals(item.id, storeData.id, message);
+                    assert_equals(item.data, storeData.data, message);
+                    cursor.continue();
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_equals(req.result, null, message);
                     db.close();
                     db = null;
-                    resolve();
-                }
-            });
-        };
-
-        const cacheName = 'controlling-ua';
-        let clientUrls;
-        const getClientUrls = () => {
-            return new Promise(resolve => {
-                navigator.serviceWorker.getRegistration().then(reg => {
-                    const channel = new MessageChannel();
-                    channel.port1.onmessage = event => {
-                        resolve(event.data);
-                    };
-                    reg.active.postMessage('', [channel.port2]);
                 });
-            });
-        };
-        const registerServiceWorker = () => {
-            return ('serviceWorker' in navigator ?
-                navigator.serviceWorker.register('serviceworker.js').then(registration => {
-                    return new Promise((resolve, reject) => {
-                        if (registration.installing) {
-                            registration.installing.addEventListener('statechange', event => {
-                                if(event.target.state === 'installed')
-                                    resolve();
-                            });
-                        }
-                        else
-                            resolve();
-                    });
-                }) : Promise.resolve()).then(getClientUrls).then(urls => {
-                    clientUrls = urls;
-                });
-        };
-        const openCaches = () => {
-            return 'caches' in window ? caches.open(cacheName).then(cache => cache.add('cache.txt')) : Promise.resolve();
-        };
+            };
 
-        const checkUpdates = () => {
-            // Cookie
-            assert_equals(document.cookie, 'PresentationApiTest=Controlling-UA', 'A cookie store is not shared with a receiving user agent.');
+            // Service Workers
+            const checkServiceWorkers = () => {
+                return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                    const message = 'List of registered service worker registrations is not shared with a receiving user agent.';
+                    assert_equals(registrations.length, 1, message);
+                    assert_equals(registrations[0].active.scriptURL, new Request('serviceworker.js').url, message);
+                }) : Promise.resolve();
+            };
+            const checkCaches = () => {
+                const message = 'Cache storage is not shared with a receiving user agent.';
+                return 'caches' in window ? caches.keys().then(keys => {
+                    assert_equals(keys.length, 1, message);
+                    assert_equals(keys[0], cacheName, message);
+                    return caches.open(keys[0]);
+                }).then(cache => cache.matchAll())
+                .then(responses => {
+                    assert_equals(responses.length, 1, message);
+                    assert_equals(responses[0].url, new Request('cache.txt').url, message);
+                }) : Promise.resolve();
+            };
 
-            // Web Storage
-            assert_equals(sessionStorage.length, 1, 'Session storage is not shared with a receiving user agent.');
-            assert_equals(sessionStorage.getItem(storageName), storageValue, 'Session storage is not shared with a receiving user agent.');
-            assert_equals(localStorage.length, 1, 'Local storage is not shared with a receiving user agent.');
-            assert_equals(localStorage.getItem(storageName), storageValue, 'Local storage is not shared with a receiving user agent.');
-        };
-
-        // Indexed Database
-        const checkIndexedDB = t => {
-            const message = 'Indexed Database is not shared with a receiving user agent.';
-            let req = indexedDB.open(dbName, 1), store;
-            let eventWatcher = new EventWatcher(t, req, 'success');
-            return eventWatcher.wait_for('success').then(() => {
-                db = req.result;
-                const transaction = db.transaction(storeName, 'readwrite');
-                store = transaction.objectStore(storeName);
-                req = store.openCursor();
-                eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success');
-            }).then(() => {
-                assert_true(req.result instanceof IDBCursorWithValue, message);
-                const cursor = req.result;
-                const item = cursor.value;
-                assert_equals(item.id, storeData.id, message);
-                assert_equals(item.data, storeData.data, message);
-                cursor.continue();
-                return eventWatcher.wait_for('success');
-            }).then(() => {
-                assert_equals(req.result, null, message);
-                db.close();
-                db = null;
-            });
-        };
-
-        // Service Workers
-        const checkServiceWorkers = () => {
-            return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
-                const message = 'List of registered service worker registrations is not shared with a receiving user agent.';
-                assert_equals(registrations.length, 1, message);
-                assert_equals(registrations[0].active.scriptURL, new Request('serviceworker.js').url, message);
-            }) : Promise.resolve();
-        };
-        const checkCaches = () => {
-            const message = 'Cache storage is not shared with a receiving user agent.';
-            return 'caches' in window ? caches.keys().then(keys => {
-                assert_equals(keys.length, 1, message);
-                assert_equals(keys[0], cacheName, message);
-                return caches.open(keys[0]);
-            }).then(cache => cache.matchAll())
-            .then(responses => {
-                assert_equals(responses.length, 1, message);
-                assert_equals(responses[0].url, new Request('cache.txt').url, message);
-            }) : Promise.resolve();
-        };
-
-        const waitForTimeout = () => {
-            return new Promise(resolve => {
-                const intervalId = setInterval(() => {
-                    clearInterval(intervalId);
-                    resolve(null);
+            let timeout;
+            const enableTimeout = () => {
+                timeout = t.step_timeout(() => {
+                    t.force_timeout();
+                    t.done();
                 }, 5000);
-            });
-        };
+            };
+            const disableTimeout = () => {
+                clearTimeout(timeout);
+            };
 
-        const cleanup = () => {
-            const notice = document.getElementById('notice');
-            notice.parentNode.removeChild(notice);
-            stash.stop();
-
-            history.back();
-            document.cookie = 'PresentationApiTest=true; Expires=' + new Date().toUTCString();
-            sessionStorage.removeItem('presentation_api_test');
-            localStorage.removeItem('presentation_api_test');
-
-            if (db)
-                db.close();
-            indexedDB.deleteDatabase(dbName);
-
-            if (connection) {
-                if (connection.state === 'connecting') {
-                    connection.onconnect = () => {
-                        connection.terminate();
-                    }
-                }
-                else if (connection.state === 'closed') {
-                    request.reconnect(connection.id).then(c => {
-                        c.terminate();
-                    });
-                }
-                else
-                    connection.terminate();
-            }
-
-            if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.getRegistrations().then(registrations => {
-                    return Promise.all(registrations.map(reg => reg.unregister()));
-                });
-            }
-            if ('caches' in window) {
-                caches.keys().then(keys => {
-                    return Promise.all(keys.map(key => caches.delete(key)));
-                });
-            }
-        };
-
-        // Start a pressentation for receiving user agent tests
-        return request.start().then(c => {
-            connection = c;
-            return openIndexedDB()
-                    .then(registerServiceWorker)
-                    .then(openCaches);
-        }).then(() => {
-            return stash.init();
-        }).then(() => {
-            return Promise.race([stash.receive(), waitForTimeout()]);
-        }).then(result => {
-            if (result) {
-                const json = JSON.parse(result);
-
+            // Start a presentation for receiving user agent tests
+            return request.start().then(c => {
+                connection = c;
+                return openIndexedDB()
+                        .then(registerServiceWorker)
+                        .then(openCaches);
+            }).then(() => {
+                return stash.init();
+            }).then(() => {
+                enableTimeout();
+                return stash.receive();
+            }).then(result => {
                 // terminate and connect again if the result is PASS
-                return json.tests.every(test => { return test.status === 0; })
+                const json = JSON.parse(result);
+                return json.test.status === 0
                     // Check accessibility to window clients before terminating a presentation
                     ? getClientUrls().then(urls => {
-                        if (urls.length !== clientUrls.length || urls.some((value, index) => {clientUrls[index] !== value})) {
-                            test(t => {
-                                t.add_cleanup(cleanup)
-                                assert_unreached('A window client in a receiving user agent is not accessible to a service worker on a controlling user agent.')
-                            });
-                        }
-                        else {
-                            return new Promise(resolve => {
-                                connection.onterminate = resolve;
-                                connection.terminate();
-                            });
-                        }
+                        assert_true(urls.length === clientUrls.length && urls.every((value, index) => { return clientUrls[index] === value}),
+                            'A window client in a receiving user agent is not accessible to a service worker on a controlling user agent.')
+                        const eventWatcher = new EventWatcher(t, connection, 'terminate');
+                        connection.terminate();
+                        return eventWatcher.wait_for('terminate');
                     }).then(() => {
-                        return new Promise(resolve => {
-                            connection = null;
-                            presentBtn.textContent = 'Continue Presentation Test';
-                            presentBtn.onclick = resolve;
-                            presentBtn.disabled = false;
-                        });
+                        connection = null;
+                        disableTimeout();
+                        presentBtn.removeEventListener('click', main);
+                        presentBtn.textContent = 'Continue Presentation Test';
+                        presentBtn.disabled = false;
+                        const eventWatcher = new EventWatcher(t, presentBtn, 'click');
+                        return eventWatcher.wait_for('click');
                     }).then(() => {
                         presentBtn.disabled = true;
                         return request.start();
                     }).then(c => {
                         connection = c;
-                        return Promise.race([stash.receive(), waitForTimeout()]);
+                        enableTimeout();
+                        return stash.receive();
                     }).then(result => {
-                        return result ? JSON.parse(result) : null;
+                        return JSON.parse(result);
                     }) : json;
-            }
-            else
-                return null;
-        }).then(json => {
-            if(json) {
-                if (json.tests.every(test => { return test.status === 0; })) {
-                    // Check if storages and service workers are not affected by a receiving user agent
-                    promise_test(t => {
-                        t.add_cleanup(cleanup);
-                        checkUpdates();
-                        return checkIndexedDB(t)
-                                .then(checkServiceWorkers)
-                                .then(checkCaches);
-                    });
+            }).then(json => {
+                if (json.test.status === 0) {
+                    checkUpdates();
+                    return checkIndexedDB(t)
+                            .then(checkServiceWorkers)
+                            .then(checkCaches);
                 }
                 else {
-                    // notify receiver's results of a parent window (e.g. test runner)
-                    if (window.opener && 'completion_callback' in window.opener) {
-                        window.opener.completion_callback(json.tests, json.status);
-                    }
-                    // display receiver's results as HTML
-                    const log = document.createElement('div');
-                    log.id = 'log';
-                    log.innerHTML = json.log;
-                    document.body.appendChild(log);
-                    cleanup();
+                    receiverStack = json.test.stack;
+                    parseResult(json.test.message);
                 }
-            }
-            else {
-                test(t => {
-                    t.add_cleanup(cleanup)
-                    assert_unreached('Test timed out.');
-                });
-            }
-        }).catch(error => {
-            promise_test(t => {
-                t.add_cleanup(cleanup)
-                throw error;
             });
         });
     };
+    presentBtn.addEventListener('click', main);
 </script>

--- a/presentation-api/receiving-ua/cache.txt
+++ b/presentation-api/receiving-ua/cache.txt
@@ -1,0 +1,1 @@
+Hello, Presentation API!

--- a/presentation-api/receiving-ua/common.js
+++ b/presentation-api/receiving-ua/common.js
@@ -7,4 +7,40 @@
     toController: '0c382524-5738-4df0-837d-4f53ea8addc2',
     toReceiver: 'a9618cd1-ca2b-4155-b7f6-630dce953c44'
   }
+
+  // handle a test result received from a receiving page
+  const parseValue = value => {
+    let r;
+
+    // String
+    if (r = value.match(/^"(.*)"$/))
+      return r[1];
+    // Object
+    else if (r = value.match(/^object\s+"\[object\s+(.*)\]"$/))
+      return window[r[1]].prototype;
+    // Number, boolean, null, undefined
+    else
+      return JSON.parse(value);
+  };
+
+  window.parseResult = message => {
+    let r = message.match(/^(assert_.*):\s+(.*)$/);
+    const assertion = r[1];
+    const body = r[2];
+    switch (assertion) {
+      case 'assert_equals':
+        r = body.match(/^(.*)\s+expected\s+(true|false|null|\d+|"(.*)")\s+but\s+got\s+(true|false|null|\d+|(object\s+)?"(.*)")$/);
+        window[assertion](parseValue(r[4]), parseValue(r[2]), r[1]);
+        break;
+      case 'assert_true':
+      case 'assert_false':
+        r = body.match(/^(.*)\s+expected\s+(true|false)\s+got\s+(true|false)$/);
+        window[assertion](parseValue(r[3]), r[1]);
+        break;
+      case 'assert_unreached':
+        r = body.match(/^(.*)\s+Reached\s+unreachable\s+code$/);
+        window[assertion](r[1]);
+        break;
+    }
+  };
 })(window);

--- a/presentation-api/receiving-ua/serviceworker.js
+++ b/presentation-api/receiving-ua/serviceworker.js
@@ -1,0 +1,15 @@
+self.addEventListener('install', () => {
+    // activate this service worker immediately
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+    // let this service worker control window clients immediately
+    event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('message', event => {
+    event.waitUntil(clients.matchAll().then(windows => {
+        event.ports[0].postMessage(windows.map(w => { return w.url; }).sort());
+    }));
+});

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
@@ -10,19 +10,20 @@
 <script src="stash.js"></script>
 <style>
 a { visibility: hidden; }
+iframe { width: 100%; }
 </style>
 
 <iframe id="child" src="PresentationReceiver_create_receiving-ua_child.html"></iframe>
+<p id="notice">Checking <code id="modal"></code>: if you see this message, please wait for test to time out.</p>
 <a href="PresentationReceiver_unreached_receiving-ua.html">do not navigate</a>
 <script>
 let finished = false;
 
-const sendResult = (test, status, childLog) => {
+const sendResult = (test, status) => {
     if(!finished) {
         finished = true;
         const stash = new Stash(stashIds.toReceiver, stashIds.toController);
-        const log = childLog || document.getElementById('log').innerHTML;
-        stash.send(JSON.stringify({ test: test, status: status, log: log }));
+        stash.send(JSON.stringify({ test: test, status: status }));
     }
 };
 
@@ -33,6 +34,9 @@ add_completion_callback((tests, status) => {
 
 const child = document.getElementById('child');
 child.addEventListener('load', () => {
+    const notice = document.getElementById('notice');
+    const modal = document.getElementById('modal');
+
     promise_test(t => {
         t.add_cleanup(() => {
             document.cookie = cookieName + '=False;Expires=' + new Date().toUTCString();
@@ -63,16 +67,24 @@ child.addEventListener('load', () => {
         // The Sandboxed auxiliary navigation browsing context flag
         assert_equals(window.open('PresentationReceiver_unreached_receiving-ua.html'), null, 'Sandboxed auxiliary navigation browsing context flag is set.');
 
-        // The sandboxed top-level navigation browsing context flag (the following codes are expected to be ignored)
+        // The sandboxed top-level navigation browsing context flag (codes below are expected to be ignored)
         window.close();
         document.querySelector('a').click();
         location.href = 'PresentationReceiver_unreached_receiving-ua.html';
 
-        // The sandboxed modals flag (codes below are expected to be ignored)
-        alert();
-        confirm();
+        // The sandboxed modals flag (codes below are expected to be ignored):
+        // If user agent prompts user, a timeout will occur and the test will eventually fail
+        let message = 'If you see this prompt, do not dismiss it and wait for test to time out.';
+        notice.style.display = 'block';
+        modal.textContent = 'alert()';
+        alert(message);
+        modal.textContent = 'confirm()';
+        confirm(message);
+        modal.textContent = 'print()';
         print();
-        prompt();
+        modal.textContent = 'prompt()';
+        prompt(message);
+        notice.style.display = 'none';
 
         // Permissions
         const checkPermission = query => {
@@ -200,7 +212,7 @@ child.addEventListener('load', () => {
                         if (result.test.status === 0)
                             resolve();
                         else {
-                            sendResult(result.test, result.status, result.log);
+                            sendResult(result.test, result.status);
                             assert_unreached('A test for a nested browsing context failed.');
                         }
                     }
@@ -222,7 +234,7 @@ child.addEventListener('load', () => {
                 result[t[0]] = t[1];
                 return result;
             }, {});
-            let message = 'A cookie store is shared by top-level and nested browsing contexts.'
+            message = 'A cookie store is shared by top-level and nested browsing contexts.'
             assert_equals(Object.keys(cookies).length, 2, message);
             assert_equals(cookies[cookieName], cookieValue, message);
             assert_equals(cookies[cookieNameChild], cookieValueChild, message);
@@ -243,7 +255,7 @@ child.addEventListener('load', () => {
             if ('indexedDB' in window) {
                 let req = indexedDB.open(dbName, 1), store;
                 let eventWatcher = new EventWatcher(t, req, 'success');
-                const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+                message = 'Indexed Database is shared by top-level and nested browsing contexts.';
                 const checkItem = event => {
                     assert_true(event.target.result instanceof IDBCursorWithValue, message);
                     const cursor = event.target.result;
@@ -276,7 +288,7 @@ child.addEventListener('load', () => {
         // Service Workers
         const checkUpdatedServiceWorkers = () => {
             return 'serviceWorker' in window ? navigator.serviceWorker.getRegistrations().then(registrations => {
-                const message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
+                message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
                 assert_equals(registrations.length, 2, message);
                 const scriptURLs = registrations.map(reg => { return reg.active.scriptURL; }).sort();
                 assert_equals(scriptURLs[0], new Request('../serviceworker.js').url, message);
@@ -285,7 +297,7 @@ child.addEventListener('load', () => {
         };
         const cacheNameChild = 'nested-browsing-context';
         const checkUpdatedCaches = () => {
-            const message = 'Cache storage is shared by top-level and nested browsing contexts.';
+            message = 'Cache storage is shared by top-level and nested browsing contexts.';
             return 'caches' in window ? caches.keys().then(keys => {
                 assert_equals(keys.length, 2, message);
                 const cacheKeys = keys.sort();

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Creating a receiving browsing context</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../common.js"></script>
+<script src="stash.js"></script>
+<style>
+a { visibility: hidden; }
+</style>
+
+<iframe id="child" src="PresentationReceiver_create_receiving-ua_child.html"></iframe>
+<a href="PresentationReceiver_unreached_receiving-ua.html">do not navigate</a>
+<script>
+let finished = false;
+
+const sendResult = (tests, status, childLog) => {
+    if(!finished) {
+        finished = true;
+        const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+        const log = childLog || document.getElementById('log').innerHTML;
+        stash.send(JSON.stringify({ tests: tests, status: status, log: log }));
+    }
+};
+
+add_completion_callback(sendResult);
+
+const child = document.getElementById('child');
+child.addEventListener('load', () => {
+    promise_test(t => {
+        t.add_cleanup(() => {
+            document.cookie = cookieName + '=False;Expires=' + new Date().toUTCString();
+            document.cookie = cookieNameChild + '=False;Expires=' + new Date().toUTCString();
+            sessionStorage.removeItem(storageName);
+            localStorage.removeItem(storageName);
+            sessionStorage.removeItem(storageNameChild);
+            localStorage.removeItem(storageNameChild);
+
+            if (db)
+                db.close();
+            indexedDB.deleteDatabase(dbName);
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.getRegistrations().then(registrations => {
+                    return Promise.all(registrations.map(reg => reg.unregister()));
+                });
+            }
+            if ('caches' in window) {
+                caches.keys().then(keys => {
+                    return Promise.all(keys.map(key => caches.delete(key)));
+                });
+            }
+        });
+
+        // Session history
+        assert_equals(window.history.length, 1, 'Session history consists of the current page only.');
+
+        // The Sandboxed auxiliary navigation browsing context flag
+        assert_equals(window.open('PresentationReceiver_unreached_receiving-ua.html'), null, 'Sandboxed auxiliary navigation browsing context flag is set.');
+
+        // The sandboxed top-level navigation browsing context flag (the following codes are expected to be ignored)
+        window.close();
+        document.querySelector('a').click();
+        location.href = 'PresentationReceiver_unreached_receiving-ua.html';
+
+        // The sandboxed modals flag (codes below are expected to be ignored)
+        alert();
+        confirm();
+        print();
+        prompt();
+
+        // Permissions
+        const checkPermission = query => {
+            return navigator.permissions ? navigator.permissions.query(query).then(status => {
+                assert_equals(status.state, 'denied', 'The state of the "' + query.name + '" permission is set to "denied".');
+            }, () => { /* skip this assertion if the specified permission is not implemented */ }) : Promise.resolve();
+        }
+
+        // Cookie
+        assert_equals(document.cookie, '', 'A cookie store is set to an empty store.')
+
+        // Indexed Database
+        const dbName = 'db-presentation-api';
+        const storeName = 'store-controlling-ua';
+        const storeData = {
+            parent: { id: 'parent', data: 'receiving user agent' },
+            child: { id: 'child', data: 'nested browsing context' }
+        };
+        let db;
+        const checkIndexedDB = () => {
+            let req = indexedDB.open(dbName, 1), store;
+            let eventWatcher = new EventWatcher(t, req, ['upgradeneeded', 'success']);
+            return eventWatcher.wait_for('upgradeneeded').then(() => {
+                db = req.result;
+                const store = db.createObjectStore(storeName, { keyPath: 'id' });
+                return eventWatcher.wait_for('success');
+            }).then(() => {
+                db = req.result;
+                const transaction = db.transaction(storeName, 'readwrite');
+                store = transaction.objectStore(storeName);
+                req = store.openCursor();
+                eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success');
+            }).then(() => {
+                assert_equals(req.result, null, 'Indexed Database is set to an empty storage.');
+                req = store.put(storeData.parent);
+                eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success');
+            }).then(() => {
+                db.close();
+                db = null;
+            });
+        };
+
+        // Web Storage
+        assert_equals(sessionStorage.length, 0, 'Session storage is set to an empty storage.');
+        assert_equals(localStorage.length, 0, 'Local storage is set to an empty storage.');
+
+        // Service Workers
+        const checkServiceWorkers = () => {
+            return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                assert_equals(registrations.length, 0, 'List of registered service worker registrations is empty.');
+            }) : Promise.resolve();
+        };
+        const checkCaches = () => {
+            return 'caches' in window ? caches.keys().then(keys => {
+                assert_equals(keys.length, 0, 'Cache storage is empty.')
+            }) : Promise.resolve();
+        };
+
+        // Navigation
+        const checkNavigation = () => {
+            return navigator.presentation.receiver.connectionList.then(connectionList => {
+                assert_equals(connectionList.connections.length, 1, 'The initial number of presentation connections is one');
+                assert_equals(location.href, connectionList.connections[0].url, 'A receiving browsing context is navigated to the presentation URL.');
+            });
+        };
+
+        // Update storages and service workers shared with the top-level brosing context
+        const cookieName = 'PresentationApiTest';
+        const cookieValue = 'Receiving-UA';
+        const storageName = 'presentation_api_test';
+        const storageValue = 'receiving-ua';
+        document.cookie = cookieName + '=' + cookieValue;
+        sessionStorage.setItem(storageName, storageValue);
+        localStorage.setItem(storageName, storageValue);
+
+        // Service Workers and Caches
+        const cacheName = 'receiving-ua';
+        const getClientUrls = () => {
+            return new Promise(resolve => {
+                navigator.serviceWorker.getRegistration().then(reg => {
+                    const channel = new MessageChannel();
+                    channel.port1.onmessage = event => {
+                        resolve(event.data);
+                    };
+                    reg.active.postMessage('test', [channel.port2]);
+                });
+            });
+        };
+
+        const registerServiceWorker = () => {
+            return ('serviceWorker' in navigator ?
+                navigator.serviceWorker.register('../serviceworker.js').then(registration => {
+                    return new Promise((resolve, reject) => {
+                        if (registration.installing) {
+                            registration.installing.addEventListener('statechange', event => {
+                                if(event.target.state === 'installed')
+                                    resolve();
+                            });
+                        }
+                        else
+                            resolve();
+                    });
+                }) : Promise.resolve()).then(getClientUrls).then(urls => {
+                    assert_true(urls.every(url => { return url !== new Request('../PresentationReceiver_create-manual.html').url }),
+                                'A window client in a controlling user agent is not accessible to a service worker on a receiving user agent.');
+                });
+        };
+
+        const openCaches = () => {
+            return 'caches' in window ? caches.open(cacheName).then(cache => cache.add('../cache.txt')) : Promise.resolve();
+        };
+
+        const getChildFrameResult = () => {
+            return new Promise(resolve => {
+                window.addEventListener('message', t.step_func(event => {
+                    const result = event.data;
+                    if (result.type === 'presentation-api') {
+                        // if the test in iframe failed, report the result and abort the test
+                        if (!result.tests.every(test => { return test.status === 0; })) {
+                            sendResult(result.tests, result.status, result.log);
+                            assert_unreached('A test for a nested browsing context failed.');
+                        }
+                        resolve();
+                    }
+                }));
+                child.contentWindow.postMessage('start', location.origin);
+            });
+        };
+
+        // check the results from updates by iframe
+        const cookieNameChild = 'NestedBrowsingContext';
+        const cookieValueChild = 'True';
+        const storageNameChild = 'nested_browsing_context';
+        const storageValueChild = 'yes';
+
+        const checkUpdatedResult = () => {
+            // cookie
+            const cookies = document.cookie.split(/;\s*/).reduce((result, item) => {
+                const t = item.split('=');
+                result[t[0]] = t[1];
+                return result;
+            }, {});
+            let message = 'A cookie store is shared by top-level and nested browsing contexts.'
+            assert_equals(Object.keys(cookies).length, 2, message);
+            assert_equals(cookies[cookieName], cookieValue, message);
+            assert_equals(cookies[cookieNameChild], cookieValueChild, message);
+
+            // Web Storage
+            message = 'Session storage is shared by top-level and nested browsing contexts.';
+            assert_equals(sessionStorage.length, 2, message);
+            assert_equals(sessionStorage.getItem(storageName), storageValue, message);
+            assert_equals(sessionStorage.getItem(storageNameChild), storageValueChild, message);
+            message = 'Local storage is shared by top-level and nested browsing contexts.';
+            assert_equals(localStorage.length, 2, message);
+            assert_equals(localStorage.getItem(storageName), storageValue, message);
+            assert_equals(localStorage.getItem(storageNameChild), storageValueChild, message);
+        };
+
+        // Indexed Database
+        const checkUpdatedIndexedDB = () => {
+            let req = indexedDB.open(dbName, 1), store;
+            let eventWatcher = new EventWatcher(t, req, 'success');
+            const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+            const checkItem = event => {
+                assert_true(event.target.result instanceof IDBCursorWithValue, message);
+                const cursor = event.target.result;
+                const item = cursor.value;
+                assert_equals(storeData[item.id].data, item.data, message);
+                delete storeData[item.id]
+                cursor.continue();
+                return eventWatcher.wait_for('success');
+            };
+            return eventWatcher.wait_for('success').then(() => {
+                db = req.result;
+                const transaction = db.transaction(storeName, 'readwrite');
+                store = transaction.objectStore(storeName);
+                req = store.openCursor();
+                eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success');
+            }).then(checkItem)
+            .then(checkItem)
+            .then(event => {
+                assert_equals(event.target.result, null, message);
+                assert_equals(Object.keys(storeData).length, 0, message);
+                db.close();
+                db = null;
+            });
+        };
+
+        // Service Workers
+        const checkUpdatedServiceWorkers = () => {
+            return 'serviceWorker' in window ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                const message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
+                assert_equals(registrations.length, 2, message);
+                const scriptURLs = registrations.map(reg => { return reg.active.scriptURL; }).sort();
+                assert_equals(scriptURLs[0], new Request('../serviceworker.js').url, message);
+                assert_equals(scriptURLs[1], new Request('serviceworker.js').url, message);
+            }) : Promise.resolve();
+        };
+        const cacheNameChild = 'nested-browsing-context';
+        const checkUpdatedCaches = () => {
+            const message = 'Cache storage is shared by top-level and nested browsing contexts.';
+            return 'caches' in window ? caches.keys().then(keys => {
+                assert_equals(keys.length, 2, message);
+                const cacheKeys = keys.sort();
+                assert_equals(cacheKeys[0], cacheNameChild, message);
+                assert_equals(cacheKeys[1], cacheName, message);
+                return Promise.all(keys.map(
+                    key => caches.open(key)
+                        .then(cache => cache.matchAll())
+                        .then(responses => {
+                            assert_equals(responses.length, 1, message);
+                            assert_equals(responses[0].url, new Request('../cache.txt').url, message);
+                        })));
+            }) : Promise.resolve();
+        };
+
+        // Asynchronous tests
+        const permissionList = [
+            { name: 'geolocation' },
+            { name: 'notifications' },
+            { name: 'push', userVisibleOnly: true },
+            { name: 'midi' },
+            { name: 'camera' },
+            { name: 'microphone' },
+            { name: 'speaker' },
+            { name: 'background-sync' }
+        ];
+        return Promise.all(permissionList.map(perm => { return checkPermission(perm); }))
+            .then(checkIndexedDB)
+            .then(checkServiceWorkers)
+            .then(checkCaches)
+            .then(checkNavigation)
+            .then(registerServiceWorker)
+            .then(openCaches)
+            .then(getChildFrameResult)
+            .then(checkUpdatedResult)
+            .then(checkUpdatedIndexedDB)
+            .then(checkUpdatedServiceWorkers)
+            .then(checkUpdatedCaches);
+    });
+});
+</script>

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
@@ -93,28 +93,32 @@ child.addEventListener('load', () => {
         };
         let db;
         const checkIndexedDB = () => {
-            let req = indexedDB.open(dbName, 1), store;
-            let eventWatcher = new EventWatcher(t, req, ['upgradeneeded', 'success']);
-            return eventWatcher.wait_for('upgradeneeded').then(() => {
-                db = req.result;
-                const store = db.createObjectStore(storeName, { keyPath: 'id' });
-                return eventWatcher.wait_for('success');
-            }).then(() => {
-                db = req.result;
-                const transaction = db.transaction(storeName, 'readwrite');
-                store = transaction.objectStore(storeName);
-                req = store.openCursor();
-                eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success');
-            }).then(() => {
-                assert_equals(req.result, null, 'Indexed Database is set to an empty storage.');
-                req = store.put(storeData.parent);
-                eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success');
-            }).then(() => {
-                db.close();
-                db = null;
-            });
+            if ('indexedDB' in window) {
+                let req = indexedDB.open(dbName, 1), store;
+                let eventWatcher = new EventWatcher(t, req, ['upgradeneeded', 'success']);
+                return eventWatcher.wait_for('upgradeneeded').then(() => {
+                    db = req.result;
+                    const store = db.createObjectStore(storeName, { keyPath: 'id' });
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    db = req.result;
+                    const transaction = db.transaction(storeName, 'readwrite');
+                    store = transaction.objectStore(storeName);
+                    req = store.openCursor();
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_equals(req.result, null, 'Indexed Database is set to an empty storage.');
+                    req = store.put(storeData.parent);
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    db.close();
+                    db = null;
+                });
+            }
+            else
+                return Promise.resolve();
         };
 
         // Web Storage
@@ -236,33 +240,37 @@ child.addEventListener('load', () => {
 
         // Indexed Database
         const checkUpdatedIndexedDB = () => {
-            let req = indexedDB.open(dbName, 1), store;
-            let eventWatcher = new EventWatcher(t, req, 'success');
-            const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
-            const checkItem = event => {
-                assert_true(event.target.result instanceof IDBCursorWithValue, message);
-                const cursor = event.target.result;
-                const item = cursor.value;
-                assert_equals(storeData[item.id].data, item.data, message);
-                delete storeData[item.id]
-                cursor.continue();
-                return eventWatcher.wait_for('success');
-            };
-            return eventWatcher.wait_for('success').then(() => {
-                db = req.result;
-                const transaction = db.transaction(storeName, 'readwrite');
-                store = transaction.objectStore(storeName);
-                req = store.openCursor();
-                eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success');
-            }).then(checkItem)
-            .then(checkItem)
-            .then(event => {
-                assert_equals(event.target.result, null, message);
-                assert_equals(Object.keys(storeData).length, 0, message);
-                db.close();
-                db = null;
-            });
+            if ('indexedDB' in window) {
+                let req = indexedDB.open(dbName, 1), store;
+                let eventWatcher = new EventWatcher(t, req, 'success');
+                const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+                const checkItem = event => {
+                    assert_true(event.target.result instanceof IDBCursorWithValue, message);
+                    const cursor = event.target.result;
+                    const item = cursor.value;
+                    assert_equals(storeData[item.id].data, item.data, message);
+                    delete storeData[item.id]
+                    cursor.continue();
+                    return eventWatcher.wait_for('success');
+                };
+                return eventWatcher.wait_for('success').then(() => {
+                    db = req.result;
+                    const transaction = db.transaction(storeName, 'readwrite');
+                    store = transaction.objectStore(storeName);
+                    req = store.openCursor();
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(checkItem)
+                .then(checkItem)
+                .then(event => {
+                    assert_equals(event.target.result, null, message);
+                    assert_equals(Object.keys(storeData).length, 0, message);
+                    db.close();
+                    db = null;
+                });
+            }
+            else
+                return Promise.resolve();
         };
 
         // Service Workers

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua.html
@@ -17,16 +17,19 @@ a { visibility: hidden; }
 <script>
 let finished = false;
 
-const sendResult = (tests, status, childLog) => {
+const sendResult = (test, status, childLog) => {
     if(!finished) {
         finished = true;
         const stash = new Stash(stashIds.toReceiver, stashIds.toController);
         const log = childLog || document.getElementById('log').innerHTML;
-        stash.send(JSON.stringify({ tests: tests, status: status, log: log }));
+        stash.send(JSON.stringify({ test: test, status: status, log: log }));
     }
 };
 
-add_completion_callback(sendResult);
+add_completion_callback((tests, status) => {
+    // note: a single test result is supposed to appear here.
+    sendResult(tests[0], status);
+});
 
 const child = document.getElementById('child');
 child.addEventListener('load', () => {
@@ -190,11 +193,12 @@ child.addEventListener('load', () => {
                     const result = event.data;
                     if (result.type === 'presentation-api') {
                         // if the test in iframe failed, report the result and abort the test
-                        if (!result.tests.every(test => { return test.status === 0; })) {
-                            sendResult(result.tests, result.status, result.log);
+                        if (result.test.status === 0)
+                            resolve();
+                        else {
+                            sendResult(result.test, result.status, result.log);
                             assert_unreached('A test for a nested browsing context failed.');
                         }
-                        resolve();
                     }
                 }));
                 child.contentWindow.postMessage('start', location.origin);

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
@@ -48,33 +48,37 @@ window.addEventListener('message', event => {
             // Indexed Database
             let db;
             const checkIndexedDB = () => {
-                const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
-                let req = indexedDB.open('db-presentation-api', 1), store;
-                let eventWatcher = new EventWatcher(t, req, 'success');
-                return eventWatcher.wait_for('success').then(() => {
-                    db = req.result;
-                    const transaction = db.transaction('store-controlling-ua', 'readwrite');
-                    store = transaction.objectStore('store-controlling-ua');
-                    req = store.openCursor();
-                    eventWatcher = new EventWatcher(t, req, 'success');
-                    return eventWatcher.wait_for('success');
-                }).then(() => {
-                    assert_true(req.result instanceof IDBCursorWithValue, message);
-                    const cursor = req.result;
-                    const item = cursor.value;
-                    assert_equals(item.id, 'parent', message);
-                    assert_equals(item.data, 'receiving user agent', message);
-                    cursor.continue();
-                    return eventWatcher.wait_for('success');
-                }).then(() => {
-                    assert_equals(req.result, null, message);
-                    req = store.put({ id: 'child', data: 'nested browsing context' });
-                    eventWatcher = new EventWatcher(t, req, 'success');
-                    return eventWatcher.wait_for('success');
-                }).then(() => {
-                    db.close();
-                    db = null;
-                });
+                if ('indexedDB' in window) {
+                    const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+                    let req = indexedDB.open('db-presentation-api', 1), store;
+                    let eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success').then(() => {
+                        db = req.result;
+                        const transaction = db.transaction('store-controlling-ua', 'readwrite');
+                        store = transaction.objectStore('store-controlling-ua');
+                        req = store.openCursor();
+                        eventWatcher = new EventWatcher(t, req, 'success');
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
+                        assert_true(req.result instanceof IDBCursorWithValue, message);
+                        const cursor = req.result;
+                        const item = cursor.value;
+                        assert_equals(item.id, 'parent', message);
+                        assert_equals(item.data, 'receiving user agent', message);
+                        cursor.continue();
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
+                        assert_equals(req.result, null, message);
+                        req = store.put({ id: 'child', data: 'nested browsing context' });
+                        eventWatcher = new EventWatcher(t, req, 'success');
+                        return eventWatcher.wait_for('success');
+                    }).then(() => {
+                        db.close();
+                        db = null;
+                    });
+                }
+                else
+                    return Promise.resolve();
             };
 
             // Web Storage
@@ -127,7 +131,8 @@ window.addEventListener('message', event => {
             };
 
             const openCaches = () => {
-                return 'caches' in window ? caches.open('nested-browsing-context').then(cache => cache.add('../cache.txt')) : Promise.resolve();
+                return 'caches' in window
+                    ? caches.open('nested-browsing-context').then(cache => cache.add('../cache.txt')) : Promise.resolve();
             };
 
             // Asynchronous tests

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
@@ -6,153 +6,166 @@
 <link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<p id="notice">Checking <code id="modal"></code>: if you see this message, please wait for test to time out.</p>
+
 <script>
 add_completion_callback((tests, status) => {
-    const log = document.getElementById('log');
     // remove unserializable attributes, then send the result to the parent window
     // note: a single test result is supposed to appear here.
     window.parent.postMessage(JSON.parse(JSON.stringify({
-        type: 'presentation-api', test: tests[0], status: status, log: log.innerHTML
+        type: 'presentation-api', test: tests[0], status: status
     })), location.origin);
 });
 
 window.addEventListener('message', event => {
-    if(event.data === 'start') {
-        promise_test(t => {
-            // Presentation and PresentationReceiver
-            assert_true(navigator.presentation instanceof Presentation, 'navigator.presentation in a nested browsing context is an instanceof Presentation.');
-            assert_equals(navigator.presentation.receiver, null, 'navigator.presentation.receiver in a nested browsing context is set to null.');
+    if(event.data !== 'start')
+        return;
 
-            // Session history
-            assert_equals(window.history.length, 1, 'Session history consists of the current page only.');
+    promise_test(t => {
+        const notice = document.getElementById('notice');
+        const modal = document.getElementById('modal');
 
-            // The Sandboxed auxiliary navigation browsing context flag
-            assert_equals(window.open('./idlharness_receiving-ua.html'), null, 'Sandboxed auxiliary navigation browsing context flag is set.');
+        // Presentation and PresentationReceiver
+        assert_true(navigator.presentation instanceof Presentation, 'navigator.presentation in a nested browsing context is an instanceof Presentation.');
+        //assert_equals(navigator.presentation.receiver, null, 'navigator.presentation.receiver in a nested browsing context is set to null.');
 
-            // The sandboxed modals flag (codes below are expected to be ignored)
-            alert();
-            confirm();
-            print();
-            prompt();
+        // Session history
+        assert_equals(window.history.length, 1, 'Session history consists of the current page only.');
 
-            // Permissions
-            const checkPermission = query => {
-                return navigator.permissions ? navigator.permissions.query(query).then(status => {
-                    assert_equals(status.state, 'denied', 'The state of the "' + query.name + '" permission in a nested browsing context is set to "denied".');
-                }, () => { /* skip this assertion if the specified permission is not implemented */ }) : Promise.resolve();
-            };
+        // The Sandboxed auxiliary navigation browsing context flag (codes below are expected to be ignored)
+        assert_equals(window.open('./idlharness_receiving-ua.html'), null, 'Sandboxed auxiliary navigation browsing context flag is set.');
 
-            // Cookie
-            assert_equals(document.cookie, 'PresentationApiTest=Receiving-UA', 'A cookie store is shared by top-level and nested browsing contexts.');
+        // The sandboxed modals flag (codes below are expected to be ignored):
+        // If user agent prompts user, a timeout will occur and the test will eventually fail
+        let message = 'If you see this prompt, do not dismiss it and wait for test to time out.';
+        notice.style.display = 'block';
+        modal.textContent = 'alert()';
+        alert(message);
+        modal.textContent = 'confirm()';
+        confirm(message);
+        modal.textContent = 'print()';
+        //print();
+        modal.textContent = 'prompt()';
+        prompt(message);
+        notice.style.display = 'none';
 
-            // Indexed Database
-            let db;
-            const checkIndexedDB = () => {
-                if ('indexedDB' in window) {
-                    const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
-                    let req = indexedDB.open('db-presentation-api', 1), store;
-                    let eventWatcher = new EventWatcher(t, req, 'success');
-                    return eventWatcher.wait_for('success').then(() => {
-                        db = req.result;
-                        const transaction = db.transaction('store-controlling-ua', 'readwrite');
-                        store = transaction.objectStore('store-controlling-ua');
-                        req = store.openCursor();
-                        eventWatcher = new EventWatcher(t, req, 'success');
-                        return eventWatcher.wait_for('success');
-                    }).then(() => {
-                        assert_true(req.result instanceof IDBCursorWithValue, message);
-                        const cursor = req.result;
-                        const item = cursor.value;
-                        assert_equals(item.id, 'parent', message);
-                        assert_equals(item.data, 'receiving user agent', message);
-                        cursor.continue();
-                        return eventWatcher.wait_for('success');
-                    }).then(() => {
-                        assert_equals(req.result, null, message);
-                        req = store.put({ id: 'child', data: 'nested browsing context' });
-                        eventWatcher = new EventWatcher(t, req, 'success');
-                        return eventWatcher.wait_for('success');
-                    }).then(() => {
-                        db.close();
-                        db = null;
+        // Permissions
+        const checkPermission = query => {
+            return navigator.permissions ? navigator.permissions.query(query).then(status => {
+                assert_equals(status.state, 'denied', 'The state of the "' + query.name + '" permission in a nested browsing context is set to "denied".');
+            }, () => { /* skip this assertion if the specified permission is not implemented */ }) : Promise.resolve();
+        };
+
+        // Cookie
+        assert_equals(document.cookie, 'PresentationApiTest=Receiving-UA', 'A cookie store is shared by top-level and nested browsing contexts.');
+
+        // Indexed Database
+        let db;
+        const checkIndexedDB = () => {
+            if ('indexedDB' in window) {
+                message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+                let req = indexedDB.open('db-presentation-api', 1), store;
+                let eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success').then(() => {
+                    db = req.result;
+                    const transaction = db.transaction('store-controlling-ua', 'readwrite');
+                    store = transaction.objectStore('store-controlling-ua');
+                    req = store.openCursor();
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_true(req.result instanceof IDBCursorWithValue, message);
+                    const cursor = req.result;
+                    const item = cursor.value;
+                    assert_equals(item.id, 'parent', message);
+                    assert_equals(item.data, 'receiving user agent', message);
+                    cursor.continue();
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_equals(req.result, null, message);
+                    req = store.put({ id: 'child', data: 'nested browsing context' });
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    db.close();
+                    db = null;
+                });
+            }
+            else
+                return Promise.resolve();
+        };
+
+        // Web Storage
+        assert_equals(sessionStorage.length, 1, 'Session storage is shared by top-level and nested browsing contexts.');
+        assert_equals(sessionStorage.getItem('presentation_api_test'), 'receiving-ua', 'Session storage is shared by top-level and nested browsing contexts.');
+        assert_equals(localStorage.length, 1, 'Local storage is shared by top-level and nested browsing contexts.');
+        assert_equals(localStorage.getItem('presentation_api_test'), 'receiving-ua', 'Local storage is shared by top-level and nested browsing contexts.');
+
+        // Service Workers
+        const checkServiceWorkers = () => {
+            return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
+                assert_equals(registrations.length, 1, message);
+                assert_equals(registrations[0].active.scriptURL, new Request('../serviceworker.js').url, message);
+            }) : Promise.resolve();
+        };
+        const checkCaches = () => {
+            message = 'Cache storage is shared by top-level and nested browsing contexts.';
+            return 'caches' in window ? caches.keys().then(keys => {
+                assert_equals(keys.length, 1, message);
+                assert_equals(keys[0], 'receiving-ua', message);
+                return caches.open(keys[0]);
+            }).then(cache => cache.matchAll())
+            .then(responses => {
+                assert_equals(responses.length, 1, message);
+                assert_equals(responses[0].url, new Request('../cache.txt').url, message);
+            }) : Promise.resolve();
+        };
+
+        // Update storages and service workers shared with the top-level brosing context
+        document.cookie = 'NestedBrowsingContext=True';
+        sessionStorage.setItem('nested_browsing_context', 'yes');
+        localStorage.setItem('nested_browsing_context', 'yes');
+
+        // register a service worker with different scope from that of the top-level browsing context
+        const registerServiceWorker = () => {
+            return 'serviceWorker' in navigator ?
+                navigator.serviceWorker.register('serviceworker.js').then(registration => {
+                    return new Promise((resolve, reject) => {
+                        if (registration.installing) {
+                            registration.installing.addEventListener('statechange', event => {
+                                if(event.target.state === 'installed')
+                                    resolve();
+                            });
+                        }
+                        else
+                            resolve();
                     });
-                }
-                else
-                    return Promise.resolve();
-            };
-
-            // Web Storage
-            assert_equals(sessionStorage.length, 1, 'Session storage is shared by top-level and nested browsing contexts.');
-            assert_equals(sessionStorage.getItem('presentation_api_test'), 'receiving-ua', 'Session storage is shared by top-level and nested browsing contexts.');
-            assert_equals(localStorage.length, 1, 'Local storage is shared by top-level and nested browsing contexts.');
-            assert_equals(localStorage.getItem('presentation_api_test'), 'receiving-ua', 'Local storage is shared by top-level and nested browsing contexts.');
-
-            // Service Workers
-            const checkServiceWorkers = () => {
-                return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
-                    const message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
-                    assert_equals(registrations.length, 1, message);
-                    assert_equals(registrations[0].active.scriptURL, new Request('../serviceworker.js').url, message);
                 }) : Promise.resolve();
-            };
-            const checkCaches = () => {
-                const message = 'Cache storage is shared by top-level and nested browsing contexts.';
-                return 'caches' in window ? caches.keys().then(keys => {
-                    assert_equals(keys.length, 1, message);
-                    assert_equals(keys[0], 'receiving-ua', message);
-                    return caches.open(keys[0]);
-                }).then(cache => cache.matchAll())
-                .then(responses => {
-                    assert_equals(responses.length, 1, message);
-                    assert_equals(responses[0].url, new Request('../cache.txt').url, message);
-                }) : Promise.resolve();
-            };
+        };
 
-            // Update storages and service workers shared with the top-level brosing context
-            document.cookie = 'NestedBrowsingContext=True';
-            sessionStorage.setItem('nested_browsing_context', 'yes');
-            localStorage.setItem('nested_browsing_context', 'yes');
+        const openCaches = () => {
+            return 'caches' in window
+                ? caches.open('nested-browsing-context').then(cache => cache.add('../cache.txt')) : Promise.resolve();
+        };
 
-            // register a service worker with different scope from that of the top-level browsing context
-            const registerServiceWorker = () => {
-                return 'serviceWorker' in navigator ?
-                    navigator.serviceWorker.register('serviceworker.js').then(registration => {
-                        return new Promise((resolve, reject) => {
-                            if (registration.installing) {
-                                registration.installing.addEventListener('statechange', event => {
-                                    if(event.target.state === 'installed')
-                                        resolve();
-                                });
-                            }
-                            else
-                                resolve();
-                        });
-                    }) : Promise.resolve();
-            };
-
-            const openCaches = () => {
-                return 'caches' in window
-                    ? caches.open('nested-browsing-context').then(cache => cache.add('../cache.txt')) : Promise.resolve();
-            };
-
-            // Asynchronous tests
-            const permissionList = [
-                { name: 'geolocation' },
-                { name: 'notifications' },
-                { name: 'push', userVisibleOnly: true },
-                { name: 'midi' },
-                { name: 'camera' },
-                { name: 'microphone' },
-                { name: 'speaker' },
-                { name: 'background-sync' }
-            ];
-            return Promise.all(permissionList.map(perm => { return checkPermission(perm); }))
-                .then(checkIndexedDB)
-                .then(checkServiceWorkers)
-                .then(checkCaches)
-                .then(registerServiceWorker)
-                .then(openCaches);
-        });
-    }
+        // Asynchronous tests
+        const permissionList = [
+            { name: 'geolocation' },
+            { name: 'notifications' },
+            { name: 'push', userVisibleOnly: true },
+            { name: 'midi' },
+            { name: 'camera' },
+            { name: 'microphone' },
+            { name: 'speaker' },
+            { name: 'background-sync' }
+        ];
+        return Promise.all(permissionList.map(perm => { return checkPermission(perm); }))
+            .then(checkIndexedDB)
+            .then(checkServiceWorkers)
+            .then(checkCaches)
+            .then(registerServiceWorker)
+            .then(openCaches);
+    });
 });
 </script>

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Creating a receiving browsing context</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+add_completion_callback((tests, status) => {
+    const log = document.getElementById('log');
+    // remove unserializable attributes, then send the result to the parent window
+    window.parent.postMessage(JSON.parse(JSON.stringify({
+        type: 'presentation-api', tests: tests, status: status, log: log.innerHTML
+    })), location.origin);
+});
+
+window.addEventListener('message', event => {
+    if(event.data === 'start') {
+        promise_test(t => {
+            // Presentation and PresentationReceiver
+            assert_true(navigator.presentation instanceof Presentation, 'navigator.presentation in a nested browsing context is an instanceof Presentation.');
+            assert_equals(navigator.presentation.receiver, null, 'navigator.presentation.receiver in a nested browsing context is set to null.');
+
+            // Session history
+            assert_equals(window.history.length, 1, 'Session history consists of the current page only.');
+
+            // The Sandboxed auxiliary navigation browsing context flag
+            assert_equals(window.open('./idlharness_receiving-ua.html'), null, 'Sandboxed auxiliary navigation browsing context flag is set.');
+
+            // The sandboxed modals flag (codes below are expected to be ignored)
+            alert();
+            confirm();
+            print();
+            prompt();
+
+            // Permissions
+            const checkPermission = query => {
+                return navigator.permissions ? navigator.permissions.query(query).then(status => {
+                    assert_equals(status.state, 'denied', 'The state of the "' + query.name + '" permission in a nested browsing context is set to "denied".');
+                }, () => { /* skip this assertion if the specified permission is not implemented */ }) : Promise.resolve();
+            };
+
+            // Cookie
+            assert_equals(document.cookie, 'PresentationApiTest=Receiving-UA', 'A cookie store is shared by top-level and nested browsing contexts.');
+
+            // Indexed Database
+            let db;
+            const checkIndexedDB = () => {
+                const message = 'Indexed Database is shared by top-level and nested browsing contexts.';
+                let req = indexedDB.open('db-presentation-api', 1), store;
+                let eventWatcher = new EventWatcher(t, req, 'success');
+                return eventWatcher.wait_for('success').then(() => {
+                    db = req.result;
+                    const transaction = db.transaction('store-controlling-ua', 'readwrite');
+                    store = transaction.objectStore('store-controlling-ua');
+                    req = store.openCursor();
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_true(req.result instanceof IDBCursorWithValue, message);
+                    const cursor = req.result;
+                    const item = cursor.value;
+                    assert_equals(item.id, 'parent', message);
+                    assert_equals(item.data, 'receiving user agent', message);
+                    cursor.continue();
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    assert_equals(req.result, null, message);
+                    req = store.put({ id: 'child', data: 'nested browsing context' });
+                    eventWatcher = new EventWatcher(t, req, 'success');
+                    return eventWatcher.wait_for('success');
+                }).then(() => {
+                    db.close();
+                    db = null;
+                });
+            };
+
+            // Web Storage
+            assert_equals(sessionStorage.length, 1, 'Session storage is shared by top-level and nested browsing contexts.');
+            assert_equals(sessionStorage.getItem('presentation_api_test'), 'receiving-ua', 'Session storage is shared by top-level and nested browsing contexts.');
+            assert_equals(localStorage.length, 1, 'Local storage is shared by top-level and nested browsing contexts.');
+            assert_equals(localStorage.getItem('presentation_api_test'), 'receiving-ua', 'Local storage is shared by top-level and nested browsing contexts.');
+
+            // Service Workers
+            const checkServiceWorkers = () => {
+                return 'serviceWorker' in navigator ? navigator.serviceWorker.getRegistrations().then(registrations => {
+                    const message = 'List of registered service worker registrations is shared by top-level and nested browsing contexts.';
+                    assert_equals(registrations.length, 1, message);
+                    assert_equals(registrations[0].active.scriptURL, new Request('../serviceworker.js').url, message);
+                }) : Promise.resolve();
+            };
+            const checkCaches = () => {
+                const message = 'Cache storage is shared by top-level and nested browsing contexts.';
+                return 'caches' in window ? caches.keys().then(keys => {
+                    assert_equals(keys.length, 1, message);
+                    assert_equals(keys[0], 'receiving-ua', message);
+                    return caches.open(keys[0]);
+                }).then(cache => cache.matchAll())
+                .then(responses => {
+                    assert_equals(responses.length, 1, message);
+                    assert_equals(responses[0].url, new Request('../cache.txt').url, message);
+                }) : Promise.resolve();
+            };
+
+            // Update storages and service workers shared with the top-level brosing context
+            document.cookie = 'NestedBrowsingContext=True';
+            sessionStorage.setItem('nested_browsing_context', 'yes');
+            localStorage.setItem('nested_browsing_context', 'yes');
+
+            // register a service worker with different scope from that of the top-level browsing context
+            const registerServiceWorker = () => {
+                return 'serviceWorker' in navigator ?
+                    navigator.serviceWorker.register('serviceworker.js').then(registration => {
+                        return new Promise((resolve, reject) => {
+                            if (registration.installing) {
+                                registration.installing.addEventListener('statechange', event => {
+                                    if(event.target.state === 'installed')
+                                        resolve();
+                                });
+                            }
+                            else
+                                resolve();
+                        });
+                    }) : Promise.resolve();
+            };
+
+            const openCaches = () => {
+                return 'caches' in window ? caches.open('nested-browsing-context').then(cache => cache.add('../cache.txt')) : Promise.resolve();
+            };
+
+            // Asynchronous tests
+            const permissionList = [
+                { name: 'geolocation' },
+                { name: 'notifications' },
+                { name: 'push', userVisibleOnly: true },
+                { name: 'midi' },
+                { name: 'camera' },
+                { name: 'microphone' },
+                { name: 'speaker' },
+                { name: 'background-sync' }
+            ];
+            return Promise.all(permissionList.map(perm => { return checkPermission(perm); }))
+                .then(checkIndexedDB)
+                .then(checkServiceWorkers)
+                .then(checkCaches)
+                .then(registerServiceWorker)
+                .then(openCaches);
+        });
+    }
+});
+</script>

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
@@ -27,7 +27,7 @@ window.addEventListener('message', event => {
 
         // Presentation and PresentationReceiver
         assert_true(navigator.presentation instanceof Presentation, 'navigator.presentation in a nested browsing context is an instanceof Presentation.');
-        //assert_equals(navigator.presentation.receiver, null, 'navigator.presentation.receiver in a nested browsing context is set to null.');
+        assert_equals(navigator.presentation.receiver, null, 'navigator.presentation.receiver in a nested browsing context is set to null.');
 
         // Session history
         assert_equals(window.history.length, 1, 'Session history consists of the current page only.');

--- a/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_create_receiving-ua_child.html
@@ -10,8 +10,9 @@
 add_completion_callback((tests, status) => {
     const log = document.getElementById('log');
     // remove unserializable attributes, then send the result to the parent window
+    // note: a single test result is supposed to appear here.
     window.parent.postMessage(JSON.parse(JSON.stringify({
-        type: 'presentation-api', tests: tests, status: status, log: log.innerHTML
+        type: 'presentation-api', test: tests[0], status: status, log: log.innerHTML
     })), location.origin);
 });
 

--- a/presentation-api/receiving-ua/support/PresentationReceiver_unreached_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_unreached_receiving-ua.html
@@ -12,7 +12,7 @@
 add_completion_callback((tests, status) => {
     const stash = new Stash(stashIds.toReceiver, stashIds.toController);
     const log = document.getElementById('log');
-    stash.send(JSON.stringify({ tests: tests, status: status, log: log.innerHTML }));
+    stash.send(JSON.stringify({ test: tests[0], status: status, log: log.innerHTML }));
 });
 
 test(() => {

--- a/presentation-api/receiving-ua/support/PresentationReceiver_unreached_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationReceiver_unreached_receiving-ua.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Creating a receiving browsing context</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../common.js"></script>
+<script src="stash.js"></script>
+<script>
+add_completion_callback((tests, status) => {
+    const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+    const log = document.getElementById('log');
+    stash.send(JSON.stringify({ tests: tests, status: status, log: log.innerHTML }));
+});
+
+test(() => {
+    assert_unreached('Top-level navigation is disabled.');
+});
+</script>

--- a/presentation-api/receiving-ua/support/serviceworker.js
+++ b/presentation-api/receiving-ua/support/serviceworker.js
@@ -1,0 +1,9 @@
+self.addEventListener('install', () => {
+    // activate this service worker immediately
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+    // let this service worker control window clients immediately
+    event.waitUntil(self.clients.claim());
+});


### PR DESCRIPTION
This PR adds tests to check if a receiving browsing context is initialized properly so that it complies with the restrictions and the features listed in [6.6.1 Creating a receiving browsing context](https://w3c.github.io/presentation-api/#creating-a-receiving-browsing-context).

- Tests to check HTTP authentication states and application cache have not been implemented yet.
- A test to check if `navigator.presentation.receiver` in a nested browsing context returns `null` or not (as in [6.2.2 Receiving user agent](https://w3c.github.io/presentation-api/#receiving-user-agent)) is also included.