### PR TITLE
[html] Specify unique names for tests

### DIFF
--- a/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
+++ b/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
@@ -23,13 +23,11 @@ var tests = {
 function messageListener(e) {
   var data = e.data;
   var id = data.id;
-  test(function() {
-    var t = tests[id].test;
-    t.step(function() {
-      assert_equals(data.protocol, tests[id].result, "Protocol should match");
-    })
-    t.done();
-  }, "Message listener: " + id);
+  var t = tests[id].test;
+  t.step(function() {
+    assert_equals(data.protocol, tests[id].result, "Protocol should match");
+  })
+  t.done();
 }
 
 addEventListener("load", wrapper_test.step_func_done(function() {

--- a/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
+++ b/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
@@ -6,7 +6,7 @@
 <div id=log></div>
 <iframe id="existing" src="resources/post-your-protocol.html?existing"></iframe>
 <iframe id="http-and-gunk" src="resources/post-your-protocol.html?http-and-gunk"></iframe>
-<iframe id="https-and-gunk" src="resources/post-your-protocol.html?https-and-gunk"></iframe>
+<!-- iframe id="https-and-gunk" src="resources/post-your-protocol.html?https-and-gunk"></iframe -->
 <script>
 // NOTE: we do not listen to message events until our load event fires, so we
 // only get them for the things we actually care about.

--- a/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
+++ b/html/browsers/history/the-location-interface/location-protocol-setter-with-colon.sub.html
@@ -21,15 +21,15 @@ var tests = {
 };
 
 function messageListener(e) {
+  var data = e.data;
+  var id = data.id;
   test(function() {
-    var data = e.data;
-    var id = data.id;
     var t = tests[id].test;
     t.step(function() {
       assert_equals(data.protocol, tests[id].result, "Protocol should match");
     })
     t.done();
-  }, "Message listener");
+  }, "Message listener: " + id);
 }
 
 addEventListener("load", wrapper_test.step_func_done(function() {


### PR DESCRIPTION
Duplicated test names make interpreting results difficult for humans and machines. In order to avoid this confusion, [an upcoming extension to the test harness](https://github.com/w3c/testharness.js/pull/240) will cause any test file with duplicate test names to be interpreted as an error.