### PR TITLE
Correct bug in stability script

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -541,9 +541,9 @@ def err_string(results_dict, iterations):
     for key, value in sorted(results_dict.items()):
         rv.append("%s%s" %
                   (key, ": %s/%s" % (value, iterations) if value != iterations else ""))
-    rv = ", ".join(rv)
     if total_results < iterations:
         rv.append("MISSING: %s/%s" % (iterations - total_results, iterations))
+    rv = ", ".join(rv)
     if is_inconsistent(results_dict, iterations):
         rv = "**%s**" % rv
     return rv


### PR DESCRIPTION
Defer the transformation from string to List until after all items have
been appended.

See https://travis-ci.org/w3c/web-platform-tests/jobs/208254823 for a demonstration of the error this addresses.