### PR TITLE
Add dropzone to the list of obsoleted HTML elements.

### DIFF
--- a/html/dom/elements/elements-in-the-dom/historical.html
+++ b/html/dom/elements/elements-in-the-dom/historical.html
@@ -13,6 +13,8 @@
   "commandDisabled",
   "commandChecked",
   "commandTriggers",
+  // https://github.com/whatwg/html/pull/2402
+  "dropzone",
   // https://github.com/whatwg/html/commit/5ddfc78b1f82e86cc202d72ccc752a0e15f1e4ad
   "inert",
 ].forEach(function(member) {


### PR DESCRIPTION
dropzone is getting removed from the HTML standard in https://github.com/whatwg/html/pull/2402

I am following the advice in https://github.com/whatwg/html/pull/2402#issuecomment-283771544 and will submit PRs that gradually remove dropzone from WPT.