### PR TITLE
Fix a copy/paste error in webvtt/api/VTTCue/text.html

### DIFF
--- a/webvtt/api/VTTCue/text.html
+++ b/webvtt/api/VTTCue/text.html
@@ -12,7 +12,7 @@ setup(function(){
 });
 test(function(){
     var c1 = new VTTCue(0, 1, 'text1\r\n\n\u0000');
-    assert_true('text' in cue, 'text is not supported');
+    assert_true('text' in c1, 'text is not supported');
     assert_equals(c1.text, 'text1\r\n\n\u0000');
     c1.text = c1.text;
     assert_equals(c1.text, 'text1\r\n\n\u0000');


### PR DESCRIPTION
Found by @fsoder in https://bugs.chromium.org/p/chromium/issues/detail?id=698659#c2

This bug was introduced in #4994.