### PR TITLE
streams/: Fix issues found by eslint

### DIFF
--- a/streams/piping/general.js
+++ b/streams/piping/general.js
@@ -155,7 +155,7 @@ promise_test(() => {
 }, 'Piping from a ReadableStream for which a chunk becomes asynchronously readable after the pipeTo');
 
 for (const preventAbort of [true, false]) {
-  promise_test(t => {
+  promise_test(() => {
 
     const rs = new ReadableStream({
       pull() {
@@ -171,7 +171,7 @@ for (const preventAbort of [true, false]) {
 }
 
 for (const preventCancel of [true, false]) {
-  promise_test(t => {
+  promise_test(() => {
 
     const rs = new ReadableStream({
       pull(controller) {

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -37,7 +37,7 @@ promise_test(() => {
     assert_array_equals(chunks, [1, 2, 3, 4, 5]), 'chunks should match');
 }, 'Piping through a duck-typed pass-through transform stream should work');
 
-promise_test(t => {
+promise_test(() => {
   const transform = {
     writable: new WritableStream({
       start(c) {
@@ -77,7 +77,7 @@ test(() => {
 
 test(() => {
   const dummy = {
-    pipeTo(args) {
+    pipeTo() {
       return { not: 'a promise' };
     }
   };
@@ -90,7 +90,7 @@ test(() => {
 
 test(() => {
   const dummy = {
-    pipeTo(args) {
+    pipeTo() {
       return {
         then() {},
         this: 'is not a real promise'

--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -101,7 +101,7 @@ promise_test(t => {
 }, 'ReadableStream with byte source: Construct with highWaterMark of 0');
 
 test(() => {
-  const rs = new ReadableStream({
+  new ReadableStream({
     start(c) {
       assert_equals(c.desiredSize, 10, 'desiredSize must start at the highWaterMark');
       c.close();
@@ -114,7 +114,7 @@ test(() => {
 }, 'ReadableStream with byte source: desiredSize when closed');
 
 test(() => {
-  const rs = new ReadableStream({
+  new ReadableStream({
     start(c) {
       assert_equals(c.desiredSize, 10, 'desiredSize must start at the highWaterMark');
       c.error();

--- a/streams/readable-streams/bad-underlying-sources.js
+++ b/streams/readable-streams/bad-underlying-sources.js
@@ -153,7 +153,7 @@ promise_test(() => {
   });
 
   rs.cancel();
-  assert_throws(new TypeError, () => controller.enqueue('a'), 'Calling enqueue after canceling should throw');
+  assert_throws(new TypeError(), () => controller.enqueue('a'), 'Calling enqueue after canceling should throw');
 
   return rs.getReader().closed;
 
@@ -171,7 +171,7 @@ promise_test(() => {
   });
 
   rs.cancel();
-  assert_throws(new TypeError, () => controller.enqueue('c'), 'Calling enqueue after canceling should throw');
+  assert_throws(new TypeError(), () => controller.enqueue('c'), 'Calling enqueue after canceling should throw');
 
   return rs.getReader().closed;
 

--- a/streams/readable-streams/cancel.js
+++ b/streams/readable-streams/cancel.js
@@ -39,10 +39,10 @@ promise_test(() => {
   // We call delay multiple times to avoid cancelling too early for the
   // source to enqueue at least one chunk.
   const cancel = delay(5).then(() => delay(5)).then(() => delay(5)).then(() => {
-    let cancelPromise = reader.cancel();
+    const cancelPromise = reader.cancel();
     assert_false(cancellationFinished, 'cancellation in source should happen later');
     return cancelPromise;
-  })
+  });
 
   return readableStreamToArray(rs, reader).then(chunks => {
     assert_greater_than(chunks.length, 0, 'at least one chunk should be read');

--- a/streams/readable-streams/default-reader.js
+++ b/streams/readable-streams/default-reader.js
@@ -350,8 +350,8 @@ promise_test(t => {
     }
   );
 
-}, 'ReadableStreamDefaultReader: if start rejects with no parameter, it should error the stream with an undefined '
-    + 'error');
+}, 'ReadableStreamDefaultReader: if start rejects with no parameter, it should error the stream with an undefined ' +
+    'error');
 
 promise_test(t => {
 

--- a/streams/readable-streams/general.js
+++ b/streams/readable-streams/general.js
@@ -195,7 +195,9 @@ promise_test(() => {
   const theError = new Error('rejected!');
   const rs = new ReadableStream({
     start() {
-      return delay(1).then(() => { throw theError; });
+      return delay(1).then(() => {
+        throw theError;
+      });
     }
   });
 
@@ -733,7 +735,7 @@ promise_test(() => {
 }, 'ReadableStream: should call underlying source methods as methods');
 
 test(() => {
-  const rs = new ReadableStream({
+  new ReadableStream({
     start(c) {
       assert_equals(c.desiredSize, 10, 'desiredSize must start at highWaterMark');
       c.close();
@@ -745,7 +747,7 @@ test(() => {
 }, 'ReadableStream: desiredSize when closed');
 
 test(() => {
-  const rs = new ReadableStream({
+  new ReadableStream({
     start(c) {
       assert_equals(c.desiredSize, 10, 'desiredSize must start at highWaterMark');
       c.error();

--- a/streams/readable-streams/pipe-through.js
+++ b/streams/readable-streams/pipe-through.js
@@ -9,8 +9,8 @@ test(() => {
 
   let pipeToArguments;
   const thisValue = {
-    pipeTo() {
-      pipeToArguments = arguments;
+    pipeTo(...args) {
+      pipeToArguments = args;
     }
   };
 

--- a/streams/writable-streams/aborting.js
+++ b/streams/writable-streams/aborting.js
@@ -677,8 +677,8 @@ promise_test(t => {
   }).then(() => {
     assert_array_equals(
         events, [],
-        'writePromise, abortPromise and writer.closed must not be fulfilled/rejected yet even after '
-            + 'controller.error() call');
+        'writePromise, abortPromise and writer.closed must not be fulfilled/rejected yet even after ' +
+            'controller.error() call');
 
     resolveWrite();
 

--- a/streams/writable-streams/close.js
+++ b/streams/writable-streams/close.js
@@ -60,7 +60,7 @@ promise_test(t => {
   return writer.close().then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'));
 }, 'when sink calls error synchronously while closing, the stream should become errored');
 
-promise_test(t => {
+promise_test(() => {
   const ws = new WritableStream({
     write(chunk, controller) {
       controller.error(error1);
@@ -76,7 +76,7 @@ promise_test(t => {
   });
 }, 'releaseLock on a stream with a pending write in which the stream has been errored');
 
-promise_test(t => {
+promise_test(() => {
   const ws = new WritableStream({
     close(controller) {
       controller.error(error1);

--- a/streams/writable-streams/write.js
+++ b/streams/writable-streams/write.js
@@ -191,8 +191,8 @@ promise_test(t => {
                       'writer.closed must reject with the error passed to the controller')
     ]);
   });
-}, 'writer.write(), ready and closed reject with the error passed to controller.error() made before sink.write'
-    + ' rejection');
+}, 'writer.write(), ready and closed reject with the error passed to controller.error() made before sink.write' +
+    ' rejection');
 
 promise_test(() => {
   const numberOfWrites = 1000;


### PR DESCRIPTION
There is no requirement for tests to pass eslint, but I find it a useful tool
for debugging so I cleaned up a few non-controversial issues in the streams/
test directory.

Fixed:

- Unused variables
- Missing '()' invoking a constructor
- 'cancelPromise' is never reassigned. Use 'const' instead
- Missing semicolon
- '+' should be placed at the end of the line (subjective, but probably nobody
  cares enough to object)
- This line has 2 statements. Maximum allowed is 1
- Use the rest parameters instead of 'arguments'

Not changed:

- Variable 'ignoredReadPromise' is unused on purpose
- Lines > 120 (no universal agreement on this)
- Arrow function should not return assignment (no universal agreement)
- A space is required after '{' / before '}' (no universal agreement)