### PR TITLE
Rename nsContentUtils::NameChanged to QNameChanged and use null prefix.

### DIFF
--- a/html/semantics/forms/the-select-element/common-HTMLOptionsCollection.html
+++ b/html/semantics/forms/the-select-element/common-HTMLOptionsCollection.html
@@ -96,4 +96,22 @@ test(function () {
 
 }, "Setting element by index should correctly append and replace elements");
 
+test(function () {
+    var selection = document.createElementNS("http://www.w3.org/1999/xhtml", "foo:select");
+
+    selection.length = 5;
+    assert_equals(selection.length, 5,
+                  "Number of nodes in collection should have changed");
+    for (var i = 0; i < 5; ++i) {
+        var child = selection.children[i];
+        assert_equals(child.localName, "option",
+                      "new child should be an option");
+        assert_equals(child.namespaceURI, "http://www.w3.org/1999/xhtml",
+                      "new child should be an HTML element");
+        assert_equals(child.prefix, null,
+                      "new child should not copy select's prefix");
+    }
+
+}, "Changing the length adds new nodes; The new nodes will not copy select's prefix");
+
 </script>

--- a/html/semantics/tabular-data/the-table-element/tFoot.html
+++ b/html/semantics/tabular-data/the-table-element/tFoot.html
@@ -54,4 +54,12 @@ test(function() {
         t.tFoot = document.createElement("thead");
     });
 })
+
+test(function () {
+    var table = document.createElementNS("http://www.w3.org/1999/xhtml", "foo:table")
+    var tfoot = table.createTFoot();
+
+    assert_equals(table.tFoot, tfoot);
+    assert_equals(tfoot.prefix, null);
+});
 </script>

--- a/html/semantics/tabular-data/the-table-element/tHead.html
+++ b/html/semantics/tabular-data/the-table-element/tHead.html
@@ -63,4 +63,12 @@ test(function() {
         t2.tHead = t2thead;
     });
 });
+
+test(function () {
+    var table = document.createElementNS("http://www.w3.org/1999/xhtml", "foo:table")
+    var thead = table.createTHead();
+
+    assert_equals(table.tHead, thead);
+    assert_equals(thead.prefix, null);
+});
 </script>

--- a/html/semantics/tabular-data/the-tr-element/insertCell.html
+++ b/html/semantics/tabular-data/the-tr-element/insertCell.html
@@ -52,4 +52,13 @@ test(function () {
   });
 }, "HTMLTableRowElement insertCell(cells.length + 1)");
 
+test(function () {
+  var table = document.createElementNS("http://www.w3.org/1999/xhtml", "foo:table")
+  var row = table.insertRow(0);
+  var cell = row.insertCell(0);
+
+  assert_equals(row.cells[0], cell);
+  assert_equals(cell.prefix, null);
+}, "HTMLTableRowElement insertCell will not copy table's prefix");
+
 </script>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1335356