### PR TITLE
P4 Test fetch referer header in worker and redirected worker scripts.

### DIFF
--- a/fetch/api/basic/request-referrer-redirected-worker.html
+++ b/fetch/api/basic/request-referrer-redirected-worker.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch in worker: referrer header</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      let finalURL = "/fetch/api/basic/request-referrer.js";
+      let url = "/fetch/api/resources/redirect.py?location=" +
+                encodeURIComponent(finalURL);
+      fetch_tests_from_worker(new Worker(url));
+    </script>
+  </body>
+</html>

--- a/fetch/api/basic/request-referrer-worker.html
+++ b/fetch/api/basic/request-referrer-worker.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Fetch in worker: referrer header</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      fetch_tests_from_worker(new Worker("request-referrer.js"));
+    </script>
+  </body>
+</html>

--- a/fetch/api/basic/request-referrer.js
+++ b/fetch/api/basic/request-referrer.js
@@ -3,7 +3,7 @@ if (this.document === undefined) {
   importScripts("../resources/utils.js");
 }
 
-function testReferrer(referrer, expected) {
+function testReferrer(referrer, expected, desc) {
   promise_test(function(test) {
     var url = RESOURCES_DIR + "inspect-headers.py?headers=referer"
     var req = new Request(url, { referrer: referrer });
@@ -17,12 +17,12 @@ function testReferrer(referrer, expected) {
         assert_equals(actual, "", "request's referer should be empty");
       }
     });
-  });
+  }, desc);
 }
 
-testReferrer("about:client", window.location.href);
+testReferrer("about:client", self.location.href, 'about:client referrer');
 
-var fooURL = new URL("./foo", window.location).href;
-testReferrer(fooURL, fooURL);
+var fooURL = new URL("./foo", self.location).href;
+testReferrer(fooURL, fooURL, 'url referrer');
 
 done();


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1340652