### PR TITLE
wpt: Update the getCueAsHTML testcase for testing leading zero of webvtt timestamp object.

### DIFF
--- a/webvtt/api/VTTCue/getCueAsHTML.html
+++ b/webvtt/api/VTTCue/getCueAsHTML.html
@@ -9,7 +9,7 @@ test(function(){
     var video = document.createElement('video');
     var t1 = video.addTextTrack('subtitles');
     document.body.appendChild(video);
-    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><00:00:00.500>x\0');
+    var c1 = new VTTCue(0, 1, '<c></c><c.a.b></c><i></i><b></b><u></u><ruby><rt></rt></ruby><v></v><v a b></v><1:00:00.500>x\0');
     t1.addCue(c1);
     window.frag = c1.getCueAsHTML();
     assert_equals(frag.childNodes.length, 10, 'childNodes.length');
@@ -83,9 +83,9 @@ test(function(){
 }, document.title+', <v a b>');
 test(function(){
     assert_equals(frag.childNodes[8].target, 'timestamp', 'target');
-    assert_equals(frag.childNodes[8].data, '00:00:00.500', 'data');
+    assert_equals(frag.childNodes[8].data, '01:00:00.500', 'data');
     assert_true(frag.childNodes[8] instanceof ProcessingInstruction, 'instanceof');
-}, document.title+', <00:00:00.500>');
+}, document.title+', <1:00:00.500>');
 test(function(){
     assert_equals(frag.childNodes[9].data, 'x\0', 'data');
     assert_true(frag.childNodes[9] instanceof Text, 'instanceof');


### PR DESCRIPTION

MozReview-Commit-ID: BQPugEkRCP0

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1307710