### PR TITLE
Restore use of setTimeout in reftest-wait test

### DIFF
--- a/infrastructure/reftest-wait.html
+++ b/infrastructure/reftest-wait.html
@@ -11,7 +11,7 @@
 }
 </style>
 <script>
-step_timeout(function() {
+setTimeout(function() {
     document.querySelector(".marker").style.background = 'green';
     document.documentElement.classList.remove("reftest-wait");
 }, 1000);

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -152,6 +152,7 @@ SET TIMEOUT: eventsource/eventsource-request-cancellation.htm
 SET TIMEOUT: html/*
 SET TIMEOUT: IndexedDB/*
 SET TIMEOUT: longtask-timing/longtask-in-parentiframe.html
+SET TIMEOUT: infrastructure/*
 SET TIMEOUT: media-source/mediasource-util.js
 SET TIMEOUT: media-source/URL-createObjectURL-revoke.html
 SET TIMEOUT: mixed-content/generic/sanity-checker.js


### PR DESCRIPTION
As this is a reference test, it does not have access to testharness.js
for step_timeout. Normally reference tests should not need to sleep for
time periods anyway, however this is an infrastructure test and so just
whitelist the usage.