### PR TITLE
Add the background-fetch directory with an IDL Harness test

### DIFF
--- a/background-fetch/OWNERS
+++ b/background-fetch/OWNERS
@@ -1,0 +1,2 @@
+@beverloo
+@jakearchibald

--- a/background-fetch/interfaces-worker.https.html
+++ b/background-fetch/interfaces-worker.https.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Background Fetch API IDL tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<h1>idlharness test</h1>
+<p>This test validates the WebIDL included in the Background Fetch API (Service Workers).</p>
+
+<script>
+'use strict';
+
+service_worker_test('interfaces.worker.js', 'Service Worker-scoped tests.');
+</script>

--- a/background-fetch/interfaces.html
+++ b/background-fetch/interfaces.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Background Fetch API IDL tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<h1>idlharness test</h1>
+<p>This test validates the WebIDL included in the Background Fetch API (Documents).</p>
+
+<script>
+'use strict';
+
+promise_test(function() {
+  return fetch('interfaces.idl')
+    .then(response => response.text())
+    .then(idls => {
+      var idlArray = new IdlArray();
+      idlArray.add_untested_idls('interface ServiceWorkerRegistration {};');
+      idlArray.add_untested_idls('[Exposed=ServiceWorker] interface ServiceWorkerGlobalScope {};');
+      idlArray.add_idls(idls);
+      idlArray.test();
+    });
+}, 'Exposed interfaces in a Document.');
+</script>

--- a/background-fetch/interfaces.idl
+++ b/background-fetch/interfaces.idl
@@ -1,0 +1,115 @@
+// 3.1. Extensions to ServiceWorkerRegistration
+
+partial interface ServiceWorkerRegistration {
+  readonly attribute BackgroundFetchManager backgroundFetch;
+};
+
+// 3.2. BackgroundFetchManager
+
+[Exposed=(Window,Worker)]
+interface BackgroundFetchManager {
+  Promise<BackgroundFetchRegistration> fetch(DOMString tag, (RequestInfo or sequence<RequestInfo>) requests, optional BackgroundFetchOptions options);
+  Promise<BackgroundFetchRegistration?> get(DOMString tag);
+  Promise<FrozenArray<DOMString>> getTags();
+  // TODO: in future this should become an async iterator for BackgroundFetchRegistration objects
+};
+
+dictionary BackgroundFetchOptions {
+  sequence<IconDefinition> icons;
+  DOMString title;
+  long totalDownloadSize;
+};
+
+// This is taken from https://w3c.github.io/manifest/#icons-member.
+// This definition should probably be moved somewhere more general.
+dictionary IconDefinition {
+  DOMString src;
+  DOMString sizes;
+  DOMString type;
+};
+
+// 3.3. BackgroundFetchRegistration
+
+[Exposed=(Window,Worker)]
+interface BackgroundFetchRegistration {
+  readonly attribute DOMString tag;
+  readonly attribute FrozenArray<IconDefinition> icons;
+  readonly attribute long totalDownloadSize;
+  readonly attribute DOMString title;
+  readonly attribute FrozenArray<BackgroundFetchActiveFetches> fetches;
+
+  void abort();
+};
+
+[Exposed=(Window,Worker)]
+interface BackgroundFetchFetches {
+  readonly attribute Request request;
+};
+
+[Exposed=(Window,Worker)]
+interface BackgroundFetchActiveFetches : BackgroundFetchFetches {
+  readonly attribute Promise<Response> responseReady;
+  // TODO: this will include fetch controller/observer objects
+};
+
+// 3.4. Events
+
+partial interface ServiceWorkerGlobalScope {
+  attribute EventHandler onbackgroundfetched;
+  attribute EventHandler onbackgroundfetchfail;
+  attribute EventHandler onbackgroundfetchabort;
+  attribute EventHandler onbackgroundfetchclick;
+};
+
+// 3.4.1. BackgroundFetchEvent
+
+[Constructor(DOMString type, BackgroundFetchEventInit init), Exposed=ServiceWorker]
+interface BackgroundFetchEvent : ExtendableEvent {
+  readonly attribute DOMString tag;
+};
+
+dictionary BackgroundFetchEventInit : ExtendableEventInit {
+  required DOMString tag;
+};
+
+// 3.4.2. BackgroundFetchEndEvent
+
+[Constructor(DOMString type, BackgroundFetchEndEventInit init), Exposed=ServiceWorker]
+interface BackgroundFetchEndEvent : BackgroundFetchEvent {
+  readonly attribute FrozenArray<BackgroundFetchSettledFetches> completeFetches;
+
+  Promise<void> updateUI(DOMString title);
+};
+
+dictionary BackgroundFetchEndEventInit : BackgroundFetchEventInit {
+  required BackgroundFetchSettledFetches completeFetches;
+};
+
+[Exposed=ServiceWorker]
+interface BackgroundFetchSettledFetches : BackgroundFetchFetches {
+  readonly attribute Response? response;
+};
+
+// 3.4.3. BackgroundFetchFailEvent
+
+[Constructor(DOMString type, BackgroundFetchEndEventInit init), Exposed=ServiceWorker]
+interface BackgroundFetchFailEvent : BackgroundFetchEndEvent {
+  readonly attribute FrozenArray<BackgroundFetchSettledFetches> failedFetches;
+};
+
+dictionary BackgroundFetchFailEventInit : BackgroundFetchEndEventInit {
+  required BackgroundFetchSettledFetches failedFetches;
+};
+
+// 3.4.4. BackgroundFetchClickEvent
+
+[Constructor(DOMString type, BackgroundFetchEndEventInit init), Exposed=ServiceWorker]
+interface BackgroundFetchClickEvent : BackgroundFetchEvent {
+  readonly attribute BackgroundFetchState state;
+};
+
+dictionary BackgroundFetchClickEventInit : BackgroundFetchEventInit {
+  required BackgroundFetchState state;
+};
+
+enum BackgroundFetchState { "pending", "succeeded", "failed" };

--- a/background-fetch/interfaces.worker.js
+++ b/background-fetch/interfaces.worker.js
@@ -1,0 +1,16 @@
+'use strict';
+
+importScripts('/resources/testharness.js');
+importScripts('/resources/WebIDLParser.js', '/resources/idlharness.js');
+
+promise_test(function() {
+  return fetch('interfaces.idl')
+    .then(response => response.text())
+    .then(idls => {
+      var idlArray = new IdlArray();
+      idlArray.add_untested_idls('interface ServiceWorkerRegistration {};');
+      idlArray.add_untested_idls('[Exposed=ServiceWorker] interface ServiceWorkerGlobalScope {};');
+      idlArray.add_idls(idls);
+      idlArray.test();
+    });
+}, 'Exposed interfaces in a Service Worker.');


### PR DESCRIPTION
This is based on the Background Fetch API that @jakearchibald has proposed in the WICG:
http://wicg.github.io/background-fetch/

The tests are ran both in a document and in a Service Worker.