### PR TITLE
XMLHttpRequest: minor cleanup

### DIFF
--- a/XMLHttpRequest/open-url-redirected-worker-origin.htm
+++ b/XMLHttpRequest/open-url-redirected-worker-origin.htm
@@ -5,15 +5,14 @@
     <title>XMLHttpRequest: redirected worker scripts, origin and referrer</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::OL[1]/LI[3] following::OL[1]/LI[3]/ol[1]/li[1] following::OL[1]/LI[3]/ol[1]/li[2] following::OL[1]/LI[3]/ol[1]/li[3]" />
 </head>
 <body>
     <div id="log"></div>
     <script type="text/javascript">
         var test = async_test() // This "test" does not actually do any assertations. It's just there to have multiple, separate, asyncronous sub-tests.
         var expectations = {
-            'Referer header': 'referer: '+(location.href.replace(/[^/]*$/, ''))+"resources/workerxhr-origin-referrer.js\n",
-            'Origin header': 'origin: '+location.protocol+'//'+location.hostname+((location.port === "")?"":":"+location.port)+'\n',
+            'Referer header': 'Referer: '+(location.href.replace(/[^/]*$/, ''))+"resources/workerxhr-origin-referrer.js\n",
+            'Origin header': 'Origin: '+location.protocol+'//'+location.hostname+((location.port === "")?"":":"+location.port)+'\n',
             'Request URL test' : (location.href.replace(/[^/]*$/, ''))+'resources/requri.py?full'
         }
         // now start the worker

--- a/XMLHttpRequest/send-sync-blocks-async.htm
+++ b/XMLHttpRequest/send-sync-blocks-async.htm
@@ -1,9 +1,6 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-    <!-- This behaviour is not explicitly spelled out in the spec.
-    It does say "queue tasks" under the "if the synchronous flag is unset" header in point 10 of the "send" algorithm.. -->
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following-sibling::ol/li[10]/dl/dd/dl/dd[2]/p[3]" />
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <title>XMLHttpRequest: sync requests should block events on pending async requests</title>
@@ -22,7 +19,7 @@
         {
             var xhr_async = new XMLHttpRequest()
             xhr_async.open('GET', 'resources/delay.py?ms=1000', true) // first launch an async request, completes in 1 second
-            xhr_async.onreadystatechange = t.step_func(() => {
+            xhr_async.onreadystatechange = test.step_func(() => {
                 actual.push('async ' + xhr_async.readyState)
                 if(xhr_async.readyState === 4 && actual.indexOf('sync 4')>-1){
                     VerifyResult()
@@ -33,7 +30,7 @@
             test.step_timeout(() => {
                 var xhr_sync = new XMLHttpRequest();
                 xhr_sync.open('GET', 'resources/delay.py?ms=2000', false) // here's a sync request that will take 2 seconds to finish
-                xhr_sync.onreadystatechange = t.step_func(() => {
+                xhr_sync.onreadystatechange = test.step_func(() => {
                     actual.push('sync ' + xhr_sync.readyState)
                     if(xhr_sync.readyState === 4 && actual.indexOf('async 4')>-1){
                         VerifyResult()


### PR DESCRIPTION
* Header casing is now important
* The variable test was used, not t
* Event loop behavior is spelled out