### PR TITLE
Allow for redirects after a CORS-preflight

### DIFF
--- a/cors/preflight-failure.htm
+++ b/cors/preflight-failure.htm
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>CORS - Preflight responds with non-2XX status code</title>
+<meta name=author title="Fernando Jiménez Moreno" href="mailto:ferjmoreno@gmail.com">
+
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js?pipe=sub></script>
+
+<h1>Preflight responds with non-2XX status code</h1>
+
+<div id=log></div>
+<script>
+
+// Request count for cache busting and easy identifying of request in traffic
+// analyzer.
+var req_c = 0;
+
+var CROSSDOMAIN_URL = CROSSDOMAIN + 'resources/cors-makeheader.py?';
+
+/*
+ * Redirection with preflights.
+ */
+function preflight_failure(code) {
+  var desc = 'Should throw error if preflight respond with ' + code;
+  async_test(desc).step(function() {
+    var client = new XMLHttpRequest();
+    var redirect =
+      encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
+
+    client.open('GET',
+        CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
+        + '&code=' + code + '&preflight=' + code
+        + '&' + req_c++,
+        true /* async */);
+    client.setRequestHeader('x-test', 'test');
+    client.onerror = this.step_func(function() {
+      this.done();
+    });
+    client.onreadystatechange = this.step_func(function() {
+      assert_equals(client.status, 0);
+    });
+    client.onload = this.step_func(function() {
+      assert_unreached('Unexpected onload');
+    });
+    client.send(null);
+  });
+}
+[100, 101,
+ 300, 301, 302, 303, 304, 305, 306, 307, 308,
+ 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417,
+ 500, 501, 502, 503, 504, 505].forEach(preflight_failure);
+
+</script>

--- a/cors/redirect-preflight.htm
+++ b/cors/redirect-preflight.htm
@@ -2,6 +2,7 @@
 <meta charset=utf-8>
 <title>CORS - redirect with preflight</title>
 <meta name=author title="Odin Hørthe Omdal" href="mailto:odiho@opera.com">
+<meta name=author title="Fernando Jiménez Moreno" href="mailto:ferjmoreno@gmail.com">
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -12,54 +13,62 @@
 <div id=log></div>
 <script>
 
-var req_c = 0 // Request count for cache busting and easy identifying of request in traffic analyzer
+// Request count for cache busting and easy identifying of request in traffic
+// analyzer.
+var req_c = 0;
+
+var CROSSDOMAIN_URL = CROSSDOMAIN + 'resources/cors-makeheader.py?';
 
 /*
- * Redirection with preflights
+ * Redirection with preflights.
  */
-
 function redir_preflight(code) {
     test(function() {
-        var client = new XMLHttpRequest(),
-            redirect = CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-test&' + req_c++
+        var client = new XMLHttpRequest();
+        var redirect =
+          encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
 
-        client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?'
-                           + 'headers=x-test&location=' + encodeURIComponent(redirect)
-                           + '&code=' + code + '&preflight=' + code + '&' + req_c++,
-                    false)
-        client.setRequestHeader('x-test', 'test')
+        client.open('GET',
+                    CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
+                                    + '&code=' + code + '&preflight=' + code
+                                    + '&' + req_c++,
+                    false);
+        client.setRequestHeader('x-test', 'test');
         assert_throws(null, function() { client.send(null) });
 
-    },
-    'Redirect ' + code + ' on preflight')
+    }, 'Redirect ' + code + ' on preflight');
 }
-redir_preflight(301)
-redir_preflight(302)
-redir_preflight(303)
-redir_preflight(307)
-redir_preflight(308)
+redir_preflight(301);
+redir_preflight(302);
+redir_preflight(303);
+redir_preflight(307);
+redir_preflight(308);
 
-/* Even thought the preflight was allowed (200), CORS should not follow
-   a subsequent redirect */
+/*
+ * Redirection after successfull (200) preflight.
+ */
 function redir_after_preflight(code) {
     test(function() {
-        var client = new XMLHttpRequest(),
-            redirect = CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-test&' + req_c++
+        var client = new XMLHttpRequest();
+        var redirect = encodeURIComponent(
+            CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-test&' + req_c++
+        );
 
         client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?'
                            + 'preflight=200&headers=x-test&location='
-                           + encodeURIComponent(redirect) + '&code=' + code + '&' + req_c++,
-                    false)
-        client.setRequestHeader('x-test', 'test')
-        assert_throws(null, function() { client.send(null) });
+                           + redirect + '&code=' + code + '&' + req_c++,
+                    false);
+        client.setRequestHeader('x-test', 'test');
+        client.send(null);
+        assert_equals(client.status, 200, "Successfull redirect");
 
     },
-    'Disallow redirect ' + code + ' after succesful (200) preflight')
+    'Allow redirect ' + code + ' after succesful (200) preflight');
 }
-redir_after_preflight(301)
-redir_after_preflight(302)
-redir_after_preflight(303)
-redir_after_preflight(307)
-redir_after_preflight(308)
+redir_after_preflight(301);
+redir_after_preflight(302);
+redir_after_preflight(303);
+redir_after_preflight(307);
+redir_after_preflight(308);
 
 </script>

--- a/cors/redirect-preflight.htm
+++ b/cors/redirect-preflight.htm
@@ -20,55 +20,28 @@ var req_c = 0;
 var CROSSDOMAIN_URL = CROSSDOMAIN + 'resources/cors-makeheader.py?';
 
 /*
- * Redirection with preflights.
- */
-function redir_preflight(code) {
-    test(function() {
-        var client = new XMLHttpRequest();
-        var redirect =
-          encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
-
-        client.open('GET',
-                    CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
-                                    + '&code=' + code + '&preflight=' + code
-                                    + '&' + req_c++,
-                    false);
-        client.setRequestHeader('x-test', 'test');
-        assert_throws(null, function() { client.send(null) });
-
-    }, 'Redirect ' + code + ' on preflight');
-}
-redir_preflight(301);
-redir_preflight(302);
-redir_preflight(303);
-redir_preflight(307);
-redir_preflight(308);
-
-/*
  * Redirection after successfull (200) preflight.
  */
-function redir_after_preflight(code) {
-    test(function() {
-        var client = new XMLHttpRequest();
-        var redirect = encodeURIComponent(
-            CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-test&' + req_c++
-        );
+function redir_after_successfull_preflight(code) {
+  var desc = 'Should allow redirect ' + code + ' after succesful (200) preflight';
+  async_test(desc).step(function() {
+    var client = new XMLHttpRequest();
+    var redirect = encodeURIComponent(
+      CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-test&' + req_c++
+    );
 
-        client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?'
-                           + 'preflight=200&headers=x-test&location='
-                           + redirect + '&code=' + code + '&' + req_c++,
-                    false);
-        client.setRequestHeader('x-test', 'test');
-        client.send(null);
-        assert_equals(client.status, 200, "Successfull redirect");
-
-    },
-    'Allow redirect ' + code + ' after succesful (200) preflight');
+    client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?'
+        + 'preflight=200&headers=x-test&location='
+        + redirect + '&code=' + code + '&' + req_c++,
+        true /* async */);
+    client.setRequestHeader('x-test', 'test');
+    client.onreadystatechange = this.step_func(function() {
+      assert_equals(client.status, 200, 'Successfull redirect');
+      this.done();
+    });
+    client.send(null);
+  });
 }
-redir_after_preflight(301);
-redir_after_preflight(302);
-redir_after_preflight(303);
-redir_after_preflight(307);
-redir_after_preflight(308);
+[301, 302, 303, 307, 308].forEach(redir_after_successfull_preflight);
 
 </script>


### PR DESCRIPTION
This PR tries to address the [changes](https://github.com/whatwg/fetch/commit/0d9a4db8bc02251cc9e391543bb3c1322fb882f2) on the Fetch spec introduced to allow redirects after CORS-preflitghts.

I took the opportunity to do some code clean up as well.