### PR TITLE
IndexedDB: Add tests for event properties

### DIFF
--- a/IndexedDB/idbfactory-open-error-properties.html
+++ b/IndexedDB/idbfactory-open-error-properties.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Test IDBFactory open() error event properties</title>
+<meta name=help href="https://w3c.github.io/IndexedDB/#dom-idbfactory-open">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+async_test(t => {
+  const dbname = document.location + '-' + t.name;
+  indexedDB.deleteDatabase(dbname);
+  const open = indexedDB.open(dbname);
+  open.onsuccess = t.unreached_func('open should not succeed');
+  open.onupgradeneeded = t.step_func(() => {
+    const tx = open.transaction;
+    tx.abort();
+  });
+  open.onerror = t.step_func(e => {
+    assert_equals(e.target, open, 'event target was request');
+    assert_equals(e.type, 'error', 'Event type should be error');
+    assert_true(e.bubbles, 'Event should bubble');
+    assert_true(e.cancelable, 'Event should be cancelable');
+    t.done();
+  });
+}, 'Properties of error event from failed open()');
+
+</script>

--- a/IndexedDB/idbfactory-open-error-properties.html
+++ b/IndexedDB/idbfactory-open-error-properties.html
@@ -17,7 +17,7 @@ async_test(t => {
     tx.abort();
   });
   open.onerror = t.step_func(e => {
-    assert_equals(e.target, open, 'event target was request');
+    assert_equals(e.target, open, 'event target should be request');
     assert_equals(e.type, 'error', 'Event type should be error');
     assert_true(e.bubbles, 'Event should bubble');
     assert_true(e.cancelable, 'Event should be cancelable');

--- a/IndexedDB/transaction-abort-request-error.html
+++ b/IndexedDB/transaction-abort-request-error.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Test error events fired at requests from aborted transaction</title>
+<meta name=help href="https://w3c.github.io/IndexedDB/#abort-a-transaction">
+<meta name=help href="https://w3c.github.io/IndexedDB/#request-construct">
+<meta name=help href="https://w3c.github.io/IndexedDB/#transaction-construct">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const request = tx.objectStore('store').get(0);
+    tx.abort();
+    request.onsuccess = t.unreached_func('request should not succeed');
+
+    let connection_saw_error = false;
+    let transaction_saw_error = false;
+
+    request.onerror = t.step_func(e => {
+      assert_equals(request.readyState, 'done',
+                    'Request\'s done flag should be set');
+      assert_equals(request.result, undefined,
+                    'Request\'s result should be undefined');
+      assert_equals(request.error.name, 'AbortError',
+                    'Request\'s error should be AbortError');
+
+      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.type, 'error', 'Event type should be error');
+      assert_true(e.bubbles, 'Event should bubble');
+      assert_true(e.cancelable, 'Event should cancelable');
+
+      assert_true(connection_saw_error,
+                  'Event propagated through connection');
+      assert_true(transaction_saw_error,
+                  'Event propagated through transaction');
+      t.done();
+    });
+
+    // Event propagates via "get the parent" on request and transaction.
+
+    db.addEventListener('error', t.step_func(e => {
+      connection_saw_error = true;
+      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.type, 'error', 'Event type should be error');
+      assert_true(e.bubbles, 'Event should bubble');
+      assert_true(e.cancelable, 'Event should cancelable');
+    }), true);
+
+    tx.addEventListener('error', t.step_func(e => {
+      transaction_saw_error = true;
+      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.type, 'error', 'Event type should be error');
+      assert_true(e.bubbles, 'Event should bubble');
+      assert_true(e.cancelable, 'Event should cancelable');
+
+      assert_true(connection_saw_error,
+                  'Event propagated through connection');
+    }), true);
+  },
+  'Properties of error events fired at requests when aborting a transaction');
+
+</script>

--- a/IndexedDB/transaction-abort-request-error.html
+++ b/IndexedDB/transaction-abort-request-error.html
@@ -30,7 +30,7 @@ indexeddb_test(
       assert_equals(request.error.name, 'AbortError',
                     'Request\'s error should be AbortError');
 
-      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.target, request, 'event target should be request');
       assert_equals(e.type, 'error', 'Event type should be error');
       assert_true(e.bubbles, 'Event should bubble');
       assert_true(e.cancelable, 'Event should cancelable');
@@ -46,7 +46,7 @@ indexeddb_test(
 
     db.addEventListener('error', t.step_func(e => {
       connection_saw_error = true;
-      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.target, request, 'event target should be request');
       assert_equals(e.type, 'error', 'Event type should be error');
       assert_true(e.bubbles, 'Event should bubble');
       assert_true(e.cancelable, 'Event should cancelable');
@@ -54,7 +54,7 @@ indexeddb_test(
 
     tx.addEventListener('error', t.step_func(e => {
       transaction_saw_error = true;
-      assert_equals(e.target, request, 'event target was request');
+      assert_equals(e.target, request, 'event target should be request');
       assert_equals(e.type, 'error', 'Event type should be error');
       assert_true(e.bubbles, 'Event should bubble');
       assert_true(e.cancelable, 'Event should cancelable');


### PR DESCRIPTION
Add tests that verify the bubbles and cancelable properties of events fired during open and transaction abort.