### PR TITLE
Test a few more cases in the event handler processing algorithm

### DIFF
--- a/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
+++ b/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
@@ -11,43 +11,89 @@
 <script>
 "use strict";
 
-async_test(t => {
+promise_test(t => {
   let onbeforeunloadHappened = false;
   window.onbeforeunload = t.step_func(() => {
     onbeforeunloadHappened = true;
     return "cancel me";
   });
 
-  const listener = t.step_func(e => {
+  const eventWatcher = new EventWatcher(t, window, "beforeunload");
+  const promise = eventWatcher.wait_for("beforeunload").then(e => {
     assert_true(onbeforeunloadHappened, "CustomEvent must be able to trigger the event handler");
     assert_false(e.defaultPrevented, "The event must not have been canceled");
     window.onbeforeunload = null;
-    t.done();
   });
-
-  window.addEventListener("beforeunload", listener);
 
   window.dispatchEvent(new CustomEvent("beforeunload"));
+
+  return promise;
 }, "Returning a string must not cancel the event: CustomEvent, non-cancelable");
 
-async_test(t => {
+promise_test(t => {
   let onbeforeunloadHappened = false;
   window.onbeforeunload = t.step_func(() => {
     onbeforeunloadHappened = true;
     return "cancel me";
   });
 
-  const listener = t.step_func(e => {
+  const eventWatcher = new EventWatcher(t, window, "beforeunload");
+  const promise = eventWatcher.wait_for("beforeunload").then(e => {
     assert_true(onbeforeunloadHappened, "CustomEvent must be able to trigger the event handler");
     assert_false(e.defaultPrevented, "The event must not have been canceled");
     window.onbeforeunload = null;
     t.done();
   });
 
-  window.addEventListener("beforeunload", listener);
+  window.dispatchEvent(new CustomEvent("beforeunload", { cancelable: true }));
+
+  return promise;
+}, "Returning a string must not cancel the event: CustomEvent, cancelable");
+
+promise_test(t => {
+  let onbeforeunloadHappened = false;
+  window.onbeforeunload = t.step_func(() => {
+    onbeforeunloadHappened = true;
+    return false;
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "beforeunload");
+  const promise = eventWatcher.wait_for("beforeunload").then(e => {
+    assert_true(onbeforeunloadHappened, "CustomEvent must be able to trigger the event handler");
+    assert_false(e.defaultPrevented, "The event must not have been canceled");
+    window.onbeforeunload = null;
+    t.done();
+  });
 
   window.dispatchEvent(new CustomEvent("beforeunload", { cancelable: true }));
-}, "Returning a string must not cancel the event: CustomEvent, cancelable");
+
+  return promise;
+}, "Returning false must cancel the event, because it's coerced to the DOMString \"false\" which does not cancel " +
+   "CustomEvents: CustomEvent, cancelable");
+
+// This test can be removed if we update the DOM Standard to disallow createEvent("beforeunload"). Most browsers do not
+// implement that. https://github.com/whatwg/dom/issues/362
+promise_test(t => {
+  let onbeforeunloadHappened = false;
+  window.onbeforeunload = t.step_func(() => {
+    onbeforeunloadHappened = true;
+    return "cancel me";
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "beforeunload");
+  const promise = eventWatcher.wait_for("beforeunload").then(e => {
+    assert_true(onbeforeunloadHappened, "The event handler must have been triggered");
+    assert_false(e.defaultPrevented, "The event must not have been canceled");
+    window.onbeforeunload = null;
+    t.done();
+  });
+
+  const ev = document.createEvent("beforeunload");
+  ev.initEvent("beforeunload", false, true);
+  window.dispatchEvent(ev);
+
+  return promise;
+}, "Returning a string must not cancel the event: BeforeUnloadEvent with type \"click\", cancelable");
 
 const testCases = [
   {

--- a/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
+++ b/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
@@ -71,25 +71,18 @@ promise_test(t => {
 }, "Returning false must cancel the event, because it's coerced to the DOMString \"false\" which does not cancel " +
    "CustomEvents: CustomEvent, cancelable");
 
-// This test can be removed if we update the DOM Standard to disallow createEvent("beforeunload"). Most browsers do not
-// implement that. https://github.com/whatwg/dom/issues/362
+// This test can be removed if we update the DOM Standard to disallow createEvent("beforeunloadevent"). Most browsers do
+// not implement that. https://github.com/whatwg/dom/issues/362
 promise_test(t => {
-  let onbeforeunloadHappened = false;
-  window.onbeforeunload = t.step_func(() => {
-    onbeforeunloadHappened = true;
-    return "cancel me";
-  });
-
-  const eventWatcher = new EventWatcher(t, window, "beforeunload");
-  const promise = eventWatcher.wait_for("beforeunload").then(e => {
-    assert_true(onbeforeunloadHappened, "The event handler must have been triggered");
+  const eventWatcher = new EventWatcher(t, window, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
     assert_false(e.defaultPrevented, "The event must not have been canceled");
     window.onbeforeunload = null;
     t.done();
   });
 
-  const ev = document.createEvent("beforeunload");
-  ev.initEvent("beforeunload", false, true);
+  const ev = document.createEvent("BeforeUnloadEvent");
+  ev.initEvent("click", false, true);
   window.dispatchEvent(ev);
 
   return promise;

--- a/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
+++ b/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html
@@ -71,8 +71,8 @@ promise_test(t => {
 }, "Returning false must cancel the event, because it's coerced to the DOMString \"false\" which does not cancel " +
    "CustomEvents: CustomEvent, cancelable");
 
-// This test can be removed if we update the DOM Standard to disallow createEvent("beforeunloadevent"). Most browsers do
-// not implement that. https://github.com/whatwg/dom/issues/362
+// This test can be removed if we update the DOM Standard to disallow createEvent("BeforeUnloadEvent"). Browser support
+// is inconsistent. https://github.com/whatwg/dom/issues/362
 promise_test(t => {
   const eventWatcher = new EventWatcher(t, window, "click");
   const promise = eventWatcher.wait_for("click").then(e => {

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/synthetic-errorevent-click.html
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/synthetic-errorevent-click.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Event handlers processing algorithm: click events using ErrorEvent</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-event-handler-processing-algorithm">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<div id="log"></div>
+
+<script>
+"use strict";
+promise_test(t => {
+  document.onclick = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, document, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  document.dispatchEvent(new ErrorEvent("click", { cancelable: true }));
+
+  return promise;
+}, "click event is normal (return true does not cancel; one arg) on Document, with a synthetic ErrorEvent");
+
+promise_test(t => {
+  window.onclick = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, window, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  window.dispatchEvent(new ErrorEvent("click", { cancelable: true }));
+
+  return promise;
+}, "click event is normal (return true does not cancel; one arg) on Window, with a synthetic ErrorEvent");
+
+promise_test(t => {
+  const el = document.createElement("script");
+  el.onclick = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, el, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  el.dispatchEvent(new ErrorEvent("click", { cancelable: true }));
+
+  return promise;
+}, "click event is normal (return true does not cancel; one arg) on a script element, with a synthetic ErrorEvent");
+
+promise_test(t => {
+  const worker = new Worker("resources/no-op-worker.js");
+  worker.onerror = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, worker, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  worker.dispatchEvent(new ErrorEvent("click", { cancelable: true }));
+
+  return promise;
+}, "click event is normal (return true does not cancel; one arg) on Worker, with a synthetic ErrorEvent");
+</script>

--- a/html/webappapis/scripting/events/event-handler-processing-algorithm-error/synthetic-errorevent-click.worker.js
+++ b/html/webappapis/scripting/events/event-handler-processing-algorithm-error/synthetic-errorevent-click.worker.js
@@ -1,0 +1,22 @@
+"use strict";
+importScripts("/resources/testharness.js");
+
+setup({ allow_uncaught_exception: true });
+
+promise_test(t => {
+  self.onerror = t.step_func((...args) => {
+    assert_equals(args.length, 1);
+    return true;
+  });
+
+  const eventWatcher = new EventWatcher(t, self, "click");
+  const promise = eventWatcher.wait_for("click").then(e => {
+    assert_equals(e.defaultPrevented, false);
+  });
+
+  self.dispatchEvent(new ErrorEvent("click", { cancelable: true }));
+
+  return promise;
+}, "error event is normal (return true does not cancel; one arg) on WorkerGlobalScope, with a synthetic ErrorEvent");
+
+done();


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2428. This also fixes beforeunload-canceling.html to use promise_test instead of async_test to avoid running two tests concurrently.