### PR TITLE
URL: test port overflow for non-special URLs

### DIFF
--- a/url/setters_tests.json
+++ b/url/setters_tests.json
@@ -1383,6 +1383,17 @@
             }
         },
         {
+            "comment": "Port numbers are 16 bit integers, overflowing is an error",
+            "href": "non-special://example.net:8080/path",
+            "new_value": "65536",
+            "expected": {
+                "href": "non-special://example.net:8080/path",
+                "host": "example.net:8080",
+                "hostname": "example.net",
+                "port": "8080"
+            }
+        },
+        {
             "href": "file://test/",
             "new_value": "12",
             "expected": {

--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -275,6 +275,11 @@
     "failure": true
   },
   {
+    "input": "non-special://f:999999/c",
+    "base": "http://example.org/foo/bar",
+    "failure": true
+  },
+  {
     "input": "http://f: 21 / b ? d # e ",
     "base": "http://example.org/foo/bar",
     "failure": true


### PR DESCRIPTION
Fixes https://github.com/whatwg/url/issues/257.