### PR TITLE
Fetch: header names are exposed in lowercase and values separated by 0x2C 0x20

### DIFF
--- a/XMLHttpRequest/getallresponseheaders-cl.htm
+++ b/XMLHttpRequest/getallresponseheaders-cl.htm
@@ -7,7 +7,7 @@ test(() => {
   const client = new XMLHttpRequest
   client.open("GET", "resources/header-content-length.asis", false)
   client.send()
-  assert_equals(client.getAllResponseHeaders(), "CONTENT-LENGTH: 0\r\n")
+  assert_equals(client.getAllResponseHeaders(), "content-length: 0\r\n")
 })
 test(() => {
   const client = new XMLHttpRequest
@@ -17,11 +17,11 @@ test(() => {
   client.setRequestHeader("content-TYPE", "x/x")
   client.send()
   assert_regexp_match(client.responseText, /content-TYPE/)
-  assert_regexp_match(client.responseText, /THIS-IS-A-TEST: 1,/)
+  assert_regexp_match(client.responseText, /THIS-IS-A-TEST: 1, 2/)
 })
 promise_test(() => {
   return fetch("resources/echo-headers.py", {headers: [["THIS-is-A-test", 1], ["THIS-IS-A-TEST", 2]] }).then(res => res.text()).then(body => {
-    assert_regexp_match(body, /THIS-is-A-test: 1/)
+    assert_regexp_match(body, /THIS-is-A-test: 1, 2/)
   })
 })
 </script>

--- a/fetch/api/headers/headers-combine.html
+++ b/fetch/api/headers/headers-combine.html
@@ -18,15 +18,14 @@
                               ["triple", "tripleValue3"]
       ];
       var expectedDict = {"single": "singleValue",
-                          "double": "doubleValue1,doubleValue2",
-                          "triple": "tripleValue1,tripleValue2,tripleValue3"
+                          "double": "doubleValue1, doubleValue2",
+                          "triple": "tripleValue1, tripleValue2, tripleValue3"
       };
 
       test(function() {
         var headers = new Headers(headerSeqCombine);
         for (name in expectedDict)
-          assert_equals(headers.get(name), expectedDict[name],
-              "name: " + name + " has value: " + expectedDict[name]);
+          assert_equals(headers.get(name), expectedDict[name]);
       }, "Create headers using same name for different values");
 
       test(function() {
@@ -51,8 +50,7 @@
         for (name in expectedDict) {
           var value = headers.get(name);
           headers.append(name,"newSingleValue");
-          assert_equals(headers.get(name), (value + "," + "newSingleValue"),
-            "name: " + name + " has value: " + headers.get(name));
+          assert_equals(headers.get(name), (value + ", " + "newSingleValue"));
         }
       }, "Check append methods when called with already used name");
     </script>


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/504 and
https://github.com/whatwg/xhr/pull/130.