### PR TITLE
Verify <img ismap> server coordinate origin interop

### DIFF
--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-after.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-after.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <title>img ismap attribute coordinate origin</title>
+    <style>
+    #bg { background-color: lightgray; position: relative; }
+    #target { position: absolute; width: 48px; height: 48px; border: 2px dashed green; pointer-events: none; }
+    .after { top: 246px; left: 246px; }
+    img { margin: 50px; border: 50px solid white; padding: 50px; }
+    </style>
+  </head>
+  <body>
+    <div id="bg">
+      <div id="target" class="after"></div>
+      <a href="/somewhere/">
+        <img src="/images/blue96x96.png" ismap>
+      </a>
+    </div>
+    <h1>Click inside the dashed rectangle</h1>
+  </body>
+</html>

--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-before.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-before.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <title>img ismap attribute coordinate origin</title>
+    <style>
+    #bg { background-color: lightgray; position: relative; }
+    #target { position: absolute; width: 96px; height: 96px; border: 2px dashed green; pointer-events: none; }
+    .before { top: 50px; left: 50px; }
+    img { margin: 50px; border: 50px solid white; padding: 50px; }
+    </style>
+  </head>
+  <body>
+    <div id="bg">
+      <div id="target" class="before"></div>
+      <a href="/somewhere/">
+        <img src="/images/blue96x96.png" ismap>
+      </a>
+    </div>
+    <h1>Click inside the dashed rectangle</h1>
+  </body>
+</html>

--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-inside.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-iframe-inside.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <title>img ismap attribute coordinate origin</title>
+    <style>
+    #bg { background-color: lightgray; position: relative; }
+    #target { position: absolute; width: 96px; height: 96px; border: 2px dashed green; pointer-events: none; }
+    .in { top: 148px; left: 148px; }
+    img { margin: 50px; border: 50px solid white; padding: 50px; }
+    </style>
+  </head>
+  <body>
+    <div id="bg">
+      <div id="target" class="in"></div>
+      <a href="/common/blank.html">
+        <img src="/images/blue96x96.png" ismap>
+      </a>
+    </div>
+    <h1>Click inside the dashed rectangle</h1>
+  </body>
+</html>

--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
@@ -63,10 +63,10 @@
         assert_not_equals(i, -1);
         var x = parseFloat(coordsStr.substring(0, i));
         var y = parseFloat(coordsStr.substring(i+1));
-        assert_greater_than_equal(x, minXY, "The x coordinate ["+x+"] must be greater-than (or equal-to) " + minXY);
-        assert_less_than_equal(x, maxXY, "The x coordinate ["+x+"] must be less-than (or equal-to) " + maxXY);
-        assert_greater_than_equal(y, minXY, "The y coordinate ["+y+"] must be greater-than (or equal-to) " + minXY);
-        assert_less_than_equal(y, maxXY, "The y coordinate ["+y+"] must be less-than (or equal-to) " + maxXY);
+        assert_greater_than_equal(x, minXY);
+        assert_less_than_equal(x, maxXY);
+        assert_greater_than_equal(y, minXY);
+        assert_less_than_equal(y, maxXY);
         test.done();
       });
       if (testIndex >= tests.length)

--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
@@ -63,8 +63,10 @@
         assert_not_equals(i, -1);
         var x = parseFloat(coordsStr.substring(0, i));
         var y = parseFloat(coordsStr.substring(i+1));
-        assert_true((x >= minXY) && (x <= maxXY), "The x coordinate ["+x+"] must be greater-than (or equal-to) " + minXY + " and less-than (or equal-to) " + maxXY);
-        assert_true((y >= minXY) && (y <= maxXY), "The y coordinate ["+y+"] must be greater-than (or equal-to) " + minXY + " and less-than (or equal-to) " + maxXY);
+        assert_greater_than_equal(x, minXY, "The x coordinate ["+x+"] must be greater-than (or equal-to) " + minXY);
+        assert_less_than_equal(x, maxXY, "The x coordinate ["+x+"] must be less-than (or equal-to) " + maxXY);
+        assert_greater_than_equal(y, minXY, "The y coordinate ["+y+"] must be greater-than (or equal-to) " + minXY);
+        assert_less_than_equal(y, maxXY, "The y coordinate ["+y+"] must be less-than (or equal-to) " + maxXY);
         test.done();
       });
       if (testIndex >= tests.length)

--- a/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
+++ b/html/semantics/embedded-content/the-img-element/ismap/img-ismap-coordinates-manual.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html>
+  <head>
+    <title>img ismap attribute coordinate origin</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <style>
+    iframe { width: 500px; height: 500px; }
+    </style>
+  </head>
+  <body>
+    <iframe></iframe>
+    <div id="log"></div>
+    <script type="text/javascript">
+    tests = [
+      {
+        file: "img-ismap-coordinates-iframe-inside.html",
+      },
+      {
+        test: async_test("Coordinates within the content box of an image map have origin of the context box"),
+        resultMinXY: 0,
+        resultMaxXY: 96,
+      },
+      {
+        file: "img-ismap-coordinates-iframe-before.html",
+      },
+      {
+        test: async_test("Coordinates within the margin/padding (top-left) of the image map are clamped to zero"),
+        resultMinXY: 0,
+        resultMaxXY: 0,
+      },
+      {
+        file: "img-ismap-coordinates-iframe-after.html",
+      },
+      {
+        test: async_test("Coordinates within the margin/padding (bottom-right) of the image map have origin in the content box"),
+        resultMinXY: 97,
+        resultMaxXY: 146,
+      }
+    ];
+    testIndex = 0;
+
+    var iframe = document.querySelector('iframe');
+    iframe.onload = function testInit() {
+      if (testIndex % 2 == 0) {
+        testIndex++;
+        return;
+      }
+      // User clicked on a results...
+      var url = iframe.contentWindow.location.toString();
+      var test = tests[testIndex].test;
+      var minXY = tests[testIndex].resultMinXY;
+      var maxXY = tests[testIndex].resultMaxXY;
+      testIndex++;
+      if (testIndex < tests.length)
+        iframe.src = tests[testIndex].file; // Advance the test...
+      // Validate the last test's results...
+      test.step(function () {
+        var i = url.indexOf("?");
+        assert_not_equals(i, -1);
+        var coordsStr = url.substr(i+1);
+        var i = coordsStr.indexOf(',');
+        assert_not_equals(i, -1);
+        var x = parseFloat(coordsStr.substring(0, i));
+        var y = parseFloat(coordsStr.substring(i+1));
+        assert_true((x >= minXY) && (x <= maxXY), "The x coordinate ["+x+"] must be greater-than (or equal-to) " + minXY + " and less-than (or equal-to) " + maxXY);
+        assert_true((y >= minXY) && (y <= maxXY), "The y coordinate ["+y+"] must be greater-than (or equal-to) " + minXY + " and less-than (or equal-to) " + maxXY);
+        test.done();
+      });
+      if (testIndex >= tests.length)
+        iframe.style.display = "none";
+    }
+    iframe.src = tests[0].file;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
In relation to: https://github.com/w3c/html/issues/492

Firefox/Chrome follow the spec. Edge is a little wonky... I hear webkit is also not quite aligned... perhaps someone can run these tests and let me know?

Tests:
> If the click event was a real pointing-device-triggered click event on the img element, then let x be the distance in CSS pixels from the left edge of the image’s left border, if it has one, or the left edge of the image otherwise, to the location of the click, and let y be the distance in CSS pixels from the top edge of the image’s top border, if it has one, or the top edge of the image otherwise, to the location of the click. Otherwise, let x and y be zero.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
