### PR TITLE
Stability script: strip backticks in markdown_adjust

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -584,7 +584,7 @@ def markdown_adjust(s):
     s = s.replace('\t', u'\\t')
     s = s.replace('\n', u'\\n')
     s = s.replace('\r', u'\\r')
-    s = s.replace('`',  u'\\`')
+    s = s.replace('`',  u'')
     return s
 
 


### PR DESCRIPTION
It doesn't work to escape backticks inside backticks, so instead
just remove them.

---

See e.g. https://github.com/w3c/web-platform-tests/pull/5131#issuecomment-286174998 (the `opener.html` test)