### PR TITLE
WritableStream: Add tests for changes in whatwg/streams#672

### DIFF
--- a/streams/writable-streams/aborting.js
+++ b/streams/writable-streams/aborting.js
@@ -872,4 +872,52 @@ promise_test(t => {
   });
 }, 'releaseLock() during delayed async abort() should create a new rejected closed promise');
 
+promise_test(t => {
+  let writeReject;
+  let controller;
+  const ws = new WritableStream({
+    write(chunk, c) {
+      controller = c;
+      return new Promise((resolve, reject) => {
+        writeReject = reject;
+      });
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const writePromise = writer.write('a');
+    const abortPromise = writer.abort();
+    controller.error(error1);
+    writeReject(error2);
+    return Promise.all([
+      promise_rejects(t, error2, writePromise, 'write() should reject with error2'),
+      promise_rejects(t, error1, abortPromise, 'abort() should reject with error1')
+    ]);
+  });
+}, 'abort() should be rejected with the error passed to controller.error() during pending write()');
+
+promise_test(t => {
+  let closeReject;
+  let controller;
+  const ws = new WritableStream({
+    close(c) {
+      controller = c;
+      return new Promise((resolve, reject) => {
+        closeReject = reject;
+      });
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const closePromise = writer.close();
+    const abortPromise = writer.abort();
+    controller.error(error1);
+    closeReject(error2);
+    return Promise.all([
+      promise_rejects(t, error2, closePromise, 'close() should reject with error2'),
+      promise_rejects(t, error1, abortPromise, 'abort() should reject with error1')
+    ]);
+  });
+}, 'abort() should be rejected with the error passed to controller.error() during pending close()');
+
 done();

--- a/streams/writable-streams/general.js
+++ b/streams/writable-streams/general.js
@@ -226,4 +226,25 @@ promise_test(() => {
   return writer2.ready;
 }, 'redundant releaseLock() is no-op');
 
+promise_test(t => {
+  const events = [];
+  const ws = new WritableStream();
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    // Force the ready promise back to a pending state.
+    const writerPromise = writer.write('dummy');
+    const readyPromise = writer.ready.catch(() => events.push('ready'));
+    const closedPromise = writer.closed.catch(() => events.push('closed'));
+    writer.releaseLock();
+    return Promise.all([readyPromise, closedPromise]).then(() => {
+      assert_array_equals(events, ['ready', 'closed'], 'ready promise should fire before closed promise');
+      // Stop the writer promise hanging around after the test has finished.
+      return Promise.all([
+        writerPromise,
+        ws.abort()
+      ]);
+    });
+  });
+}, 'ready promise should fire before closed on releaseLock');
+
 done();


### PR DESCRIPTION
Test the following changes:
- abort() should be rejected with the error passed to controller.error() called
during a pending write()/close(). Not the rejection reason of the
write()/close() (fix in WritableStreamFinishInFlightCloseWithError()) Promise
resolution order change:
- Moved [[readyPromise]] resolution in WritableStreamDefaultWriterRelease() to
be consistent with the other places

These were introduced in https://github.com/whatwg/streams/pull/672

Other changes from that commit were tested in
https://github.com/w3c/web-platform-tests/pull/5101.