### PR TITLE
Fetch: getAll() was removed from Headers

### DIFF
--- a/fetch/api/headers/historical.any.js
+++ b/fetch/api/headers/historical.any.js
@@ -1,0 +1,4 @@
+test(() => {
+  assert_false("getAll" in new Headers)
+  assert_false("getAll" in Headers.prototype)
+}, "Headers object no longer has a getAll() method")


### PR DESCRIPTION
See https://github.com/whatwg/fetch/issues/506.