### PR TITLE
Stability checker: recognize "multi-global" tests

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -435,6 +435,20 @@ def get_affected_testfiles(files_changed):
         repo_path = "/" + os.path.relpath(full_path, wpt_root).replace(os.path.sep, "/")
         nontest_changed_paths.add((full_path, repo_path))
 
+    # JavaScript files named with a `.any.js` suffix are interpreted in a
+    # number of different contexts, but they are all interpreted using a
+    # document that does not have without a corresponding file on disk. Changes
+    # to these test files should trigger stability checking using those
+    # "virtual" documents.
+    multiglobal_re = re.compile(r'^(.*)\.any\.js$')
+    multiglobal_suffixes = [".any.html", ".any.worker.html"]
+    for changed in files_changed:
+        match = multiglobal_re.match(changed)
+        if match is None:
+            continue
+        for suffix in multiglobal_suffixes:
+            affected_testfiles.add(os.path.relpath(match.expand("\\1" + suffix), wpt_root))
+
     for root, dirs, fnames in os.walk(wpt_root):
         # Walk top_level_subdir looking for test files containing either the
         # relative filepath or absolute filepatch to the changed files.

--- a/foo/OWNERS
+++ b/foo/OWNERS
@@ -1,0 +1,2 @@
+@jugglinmike
+@richardmstallman

--- a/foo/multi-global.any.js
+++ b/foo/multi-global.any.js
@@ -1,0 +1,3 @@
+test(function() {
+  assert_true(Math.random() > 0.5);
+}, 'intentionally flaky');

--- a/foo/traditional.html
+++ b/foo/traditional.html
@@ -1,0 +1,7 @@
+<!DOCTYPE HTML>
+<script src="/resources/testharness.js"></script>
+<script>
+test(function() {
+  assert_true(Math.random() > 0.5);
+}, 'intentionally flaky');
+</script>


### PR DESCRIPTION
According to the `testharness.js` documentation [1], files ending in `.any.js` will be used to run tests in both "window scope and a worker scope." Extend the stability checker to recognize this convention such that changes to these "multi-global" files trigger stability validation for the corresponding tests.
    
[1] http://web-platform-tests.org/writing-tests/testharness.html

This should resolve gh-5130.

@jgraham Do you think any part of this belongs in `wptrunner` instead?