### PR TITLE
HTML: Expand test coverage: default, `_blank` browsing context names

### DIFF
--- a/html/browsers/windows/browsing-context-names/browsing-context-_blank.html
+++ b/html/browsers/windows/browsing-context-names/browsing-context-_blank.html
@@ -14,9 +14,9 @@ test(t => {
     window2.close();
     window3.close();
   });
-  assert_false(window1 === window2);
-  assert_false(window2 === window3);
-  assert_false(window1 === window3);
+  assert_not_equals(window1, window2);
+  assert_not_equals(window2, window3);
+  assert_not_equals(window1, window3);
 }, 'window.open into `_blank` should create a new browsing context each time');
 
 test(t => {
@@ -28,8 +28,8 @@ test(t => {
     window2.close();
     window3.close();
   });
-  assert_false(window1 === window2);
-  assert_false(window2 === window3);
-  assert_false(window1 === window3);
+  assert_not_equals(window1, window2);
+  assert_not_equals(window2, window3);
+  assert_not_equals(window1, window3);
 }, '`_blank` should be ASCII case-insensitive');
 </script>

--- a/html/browsers/windows/browsing-context-names/browsing-context-_blank.html
+++ b/html/browsers/windows/browsing-context-names/browsing-context-_blank.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: Browsing context - `_blank` name keyword</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(t => {
+  var window1 = window.open('about:blank', '_blank');
+  var window2 = window.open('about:blank', '_blank');
+  var window3 = window.open('about:blank', '_blank');
+  t.add_cleanup(() => {
+    window1.close();
+    window2.close();
+    window3.close();
+  });
+  assert_false(window1 === window2);
+  assert_false(window2 === window3);
+  assert_false(window1 === window3);
+}, 'window.open into `_blank` should create a new browsing context each time');
+
+test(t => {
+  var window1 = window.open('about:blank', '_bLAnk');
+  var window2 = window.open('about:blank', '_bLAnk');
+  var window3 = window.open('about:blank', '_bLAnk');
+  t.add_cleanup(() => {
+    window1.close();
+    window2.close();
+    window3.close();
+  });
+  assert_false(window1 === window2);
+  assert_false(window2 === window3);
+  assert_false(window1 === window3);
+}, '`_blank` should be ASCII case-insensitive');
+</script>

--- a/html/browsers/windows/browsing-context-names/browsing-context-default-name.html
+++ b/html/browsers/windows/browsing-context-names/browsing-context-default-name.html
@@ -5,22 +5,25 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
-<iframe src="message.html" style="display:none"></iframe>
+<iframe src="/common/blank.html" style="display:none"></iframe>
+<object id="obj" type="text/html" data="about:blank"></object>
+<embed id="embedded" type="image/svg+xml" src="/images/green.svg" width="0" height="0" />
 <script>
+test(t => {
+  assert_equals(window.frames[0].name, "");
+  assert_equals(document.getElementById("embedded").name, "");
+  assert_equals(window["obj"].name, "");
+}, "A embedded browsing context has empty-string default name");
 
-test(function () {
-  assert_equals(window.frames[0].name, "", "The browsing context should not have a default name.");
-}, "A embedded browsing context has no default name");
-
-test(function () {
+test(t => {
   var win = window.open("about:blank", "_blank");
-  assert_equals(win.name, "", "The browsing context should not have a name.");
+  assert_equals(win.name, "");
   win.close();
-}, "A browsing context which is opened by window.open() method with '_blank' parameter has no default name");
+}, "A browsing context which is opened by window.open() method with '_blank' parameter has empty-string default name");
 
 //This test must be run when the current browsing context's name is not set
-test(function () {
-  assert_equals(window.name, "", "The browsing context should not have a name.");
-}, "A browsing context has no default name");
+test(t => {
+  assert_equals(window.name, "");
+}, "A browsing context has an empty-string default name");
 
 </script>


### PR DESCRIPTION
In this PR:

- Extend test coverage for default browsing context names
- Add test coverage for `_blank` browsing context keyword

I am breaking down some test coverage work within [HTML 7.1.5 Browsing Context Names](https://html.spec.whatwg.org/#browsing-context-names) into multiple chunks because there's a bunch here and I'm running into some interesting stuff. 

