### PR TITLE
XMLHttpRequest: about:blank and bogus blob URLs are cross-origin

### DIFF
--- a/XMLHttpRequest/send-non-same-origin.htm
+++ b/XMLHttpRequest/send-non-same-origin.htm
@@ -5,8 +5,6 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <base>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#cross-origin-request-steps" data-tested-assertations="/following::DL[2]/DT[1] /following::DL[2]/DD[1]" />
-    <link rel="help" href="https://xhr.spec.whatwg.org/#cross-origin-request-event-rules" data-tested-assertations="/following::DL[1]/DT[2] /following::DL[1]/DD[2]" />
   </head>
   <body>
     <div id="log"></div>

--- a/XMLHttpRequest/send-non-same-origin.htm
+++ b/XMLHttpRequest/send-non-same-origin.htm
@@ -28,6 +28,8 @@
       url(host_info.HTTP_REMOTE_ORIGIN)
       url("javascript:alert('FAIL')")
       url("folder.txt")
+      url("about:blank")
+      url("blob:bogusidentifier")
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #3124.