### PR TITLE
Fix tests for error type of __proto__ on cross-domain objects

### DIFF
--- a/common/test-setting-immutable-prototype.js
+++ b/common/test-setting-immutable-prototype.js
@@ -6,13 +6,18 @@ self.testSettingImmutablePrototypeToNewValueOnly =
     });
   }, `${prefix}: setting the prototype to ${newValueString} via Object.setPrototypeOf should throw a TypeError`);
 
-  const dunderProtoError = isSameOriginDomain ? { name: "TypeError" } : { name: "SecurityError" };
+  let dunderProtoError = "SecurityError";
+  let dunderProtoErrorName = "\"SecurityError\" DOMException";
+  if (isSameOriginDomain) {
+    dunderProtoError = new TypeError();
+    dunderProtoErrorName = "TypeError";
+  }
 
   test(() => {
     assert_throws(dunderProtoError, function() {
       target.__proto__ = newValue;
     });
-  }, `${prefix}: setting the prototype to ${newValueString} via __proto__ should throw a ${dunderProtoError.name}`);
+  }, `${prefix}: setting the prototype to ${newValueString} via __proto__ should throw a ${dunderProtoErrorName}`);
 
   test(() => {
     assert_false(Reflect.setPrototypeOf(target, newValue));

--- a/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin-domain.sub.html
+++ b/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin-domain.sub.html
@@ -23,7 +23,8 @@ window.onload = () => {
     assert_equals(Object.getPrototypeOf(targetLocation), null);
   }, "Cross-origin via document.domain: the prototype is null");
 
-  testSettingImmutablePrototype("Cross-origin via document.domain", targetLocation, origProto);
+  testSettingImmutablePrototype("Cross-origin via document.domain", targetLocation, origProto,
+    { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin.sub.html
+++ b/html/browsers/history/the-location-interface/location-prototype-setting-cross-origin.sub.html
@@ -21,7 +21,7 @@ window.onload = () => {
     assert_equals(Object.getPrototypeOf(targetLocation), null);
   }, "Cross-origin: the prototype is null");
 
-  testSettingImmutablePrototype("Cross-origin", targetLocation, null);
+  testSettingImmutablePrototype("Cross-origin", targetLocation, null, { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/history/the-location-interface/location-prototype-setting-goes-cross-origin-domain.sub.html
+++ b/html/browsers/history/the-location-interface/location-prototype-setting-goes-cross-origin-domain.sub.html
@@ -28,11 +28,11 @@ window.onload = () => {
     assert_equals(Object.getPrototypeOf(targetLocation), null);
   }, "Became cross-origin via document.domain: the prototype is now null");
 
-  testSettingImmutablePrototype("Became cross-origin via document.domain", targetLocation, null);
+  testSettingImmutablePrototype("Became cross-origin via document.domain", targetLocation, null, { isSameOriginDomain: false });
 
   testSettingImmutablePrototypeToNewValueOnly(
     "Became cross-origin via document.domain", targetLocation, origProto,
-    "the original value from before going cross-origin");
+    "the original value from before going cross-origin", { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/history/the-location-interface/location-prototype-setting-same-origin-domain.sub.html
+++ b/html/browsers/history/the-location-interface/location-prototype-setting-same-origin-domain.sub.html
@@ -23,7 +23,7 @@ window.onload = () => {
     assert_not_equals(origProto, null);
   }, "Same-origin-domain prerequisite check: the original prototype is accessible");
 
-  testSettingImmutablePrototype("Same-origin-domain", targetLocation, origProto);
+  testSettingImmutablePrototype("Same-origin-domain", targetLocation, origProto, { isSameOriginDomain: true });
 
   done();
 };

--- a/html/browsers/history/the-location-interface/location-prototype-setting-same-origin.html
+++ b/html/browsers/history/the-location-interface/location-prototype-setting-same-origin.html
@@ -17,5 +17,5 @@ test(() => {
   assert_not_equals(origProto, null);
 }, "Same-origin prerequisite check: the original prototype is accessible");
 
-testSettingImmutablePrototype("Same-origin", location, origProto);
+testSettingImmutablePrototype("Same-origin", location, origProto, { isSameOriginDomain: true });
 </script>

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin-domain.sub.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin-domain.sub.html
@@ -20,9 +20,9 @@ window.onload = () => {
 
   test(() => {
     assert_equals(Object.getPrototypeOf(target), null);
-  }, "Cross-origin: the prototype is null");
+  }, "Cross-origin via document.domain: the prototype is null");
 
-  testSettingImmutablePrototype("Cross-origin", target, null);
+  testSettingImmutablePrototype("Cross-origin via document.domain", target, null, { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin.sub.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-cross-origin.sub.html
@@ -21,7 +21,7 @@ window.onload = () => {
     assert_equals(Object.getPrototypeOf(target), null);
   }, "Cross-origin: the prototype is null");
 
-  testSettingImmutablePrototype("Cross-origin", target, null);
+  testSettingImmutablePrototype("Cross-origin", target, null, { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-goes-cross-origin-domain.sub.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-goes-cross-origin-domain.sub.html
@@ -28,11 +28,11 @@ window.onload = () => {
     assert_equals(Object.getPrototypeOf(target), null);
   }, "Became cross-origin via document.domain: the prototype is now null");
 
-  testSettingImmutablePrototype("Became cross-origin via document.domain", target, null);
+  testSettingImmutablePrototype("Became cross-origin via document.domain", target, null, { isSameOriginDomain: false });
 
   testSettingImmutablePrototypeToNewValueOnly(
     "Became cross-origin via document.domain", target, origProto,
-    "the original value from before going cross-origin");
+    "the original value from before going cross-origin", { isSameOriginDomain: false });
 
   done();
 };

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-same-origin-domain.sub.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-same-origin-domain.sub.html
@@ -23,7 +23,7 @@ window.onload = () => {
     assert_not_equals(origProto, null);
   }, "Same-origin-domain prerequisite check: the original prototype is accessible");
 
-  testSettingImmutablePrototype("Same-origin-domain", target, origProto);
+  testSettingImmutablePrototype("Same-origin-domain", target, origProto, { isSameOriginDomain: true });
 
   done();
 };

--- a/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-same-origin.html
+++ b/html/browsers/the-windowproxy-exotic-object/windowproxy-prototype-setting-same-origin.html
@@ -17,5 +17,5 @@ test(() => {
   assert_not_equals(origProto, null);
 }, "Same-origin prerequisite check: the original prototype is accessible");
 
-testSettingImmutablePrototype("Same-origin", window, origProto);
+testSettingImmutablePrototype("Same-origin", window, origProto, { isSameOriginDomain: true });
 </script>


### PR DESCRIPTION
This is a follow-up to #5015 which corrects a problem noted by Boris in https://bugzilla.mozilla.org/show_bug.cgi?id=1347706#c2.