### PR TITLE
add test for pv prerender

### DIFF
--- a/page-visibility/prerender_call.html
+++ b/page-visibility/prerender_call.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<title>Prerender test for Page Visibility API</title>
+<link rel="prerender" href="resources/prerender_target.html" pr="1.0">
+<script>
+var t = async_test('VisibilityState of the target page was set to "prerender" when it has been prerendered');
+window.onload = t.step_func(function() {
+    window.setTimeout(function() {
+        assert_equals(localStorage.getItem("visibilityState:prerender"), "hit", "visibilityState of the target page was set to 'prerender'");
+        t.done();
+        localStorage.clear();
+    }, 1000);
+});
+</script>
+</head>
+<body>
+    <h1>Description</h1>
+    <p>This document validate that VisibilityState of the target page was set to "prerender" when it has been prerendered.</p>
+</body>
+</html>

--- a/page-visibility/prerender_call.html
+++ b/page-visibility/prerender_call.html
@@ -3,11 +3,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <title>Prerender test for Page Visibility API</title>
-<link rel="prerender" href="resources/prerender_target.html" pr="1.0">
+<link rel="prerender" href="resources/prerender_target.html">
 <script>
 var t = async_test('VisibilityState of the target page was set to "prerender" when it has been prerendered');
 window.onload = t.step_func(function() {
-    window.setTimeout(function() {
+    t.step_timeout(function() {
         assert_equals(localStorage.getItem("visibilityState:prerender"), "hit", "visibilityState of the target page was set to 'prerender'");
         t.done();
         localStorage.clear();
@@ -17,6 +17,6 @@ window.onload = t.step_func(function() {
 </head>
 <body>
     <h1>Description</h1>
-    <p>This document validate that VisibilityState of the target page was set to "prerender" when it has been prerendered.</p>
+    <p>This document validate that visibilityState of a target page was set to "prerender" when it has been prerendered.</p>
 </body>
 </html>

--- a/page-visibility/resources/prerender_target.html
+++ b/page-visibility/resources/prerender_target.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Document has been prerendered</title>
+    </head>
+    <body>
+        <script type="text/javascript">
+        if(document.visibilityState) {
+            window.localStorage.setItem("visibilityState:" + document.visibilityState, "hit"); 
+        }
+        </script>
+    </body>
+</html>

--- a/page-visibility/resources/prerender_target.html
+++ b/page-visibility/resources/prerender_target.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Document has been prerendered</title>
-    </head>
-    <body>
-        <script type="text/javascript">
-        if(document.visibilityState) {
-            window.localStorage.setItem("visibilityState:" + document.visibilityState, "hit"); 
-        }
-        </script>
-    </body>
+<head>
+    <title>Document has been prerendered</title>
+</head>
+<body>
+    <script type="text/javascript">
+    if(document.visibilityState) {
+        window.localStorage.setItem("visibilityState:" + document.visibilityState, "hit");
+    }
+</script>
+</body>
 </html>


### PR DESCRIPTION
If a page has been prerendered, and its `visibilityState` has not previously transitioned to "`visible`", then its `visibilityState` should be set to "`prerender`".

This test is to fix [page-visibility issue #28](https://github.com/w3c/page-visibility/issues/28).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5185)
<!-- Reviewable:end -->
