### PR TITLE
webrtc: add setLocalDescription test for icegatheringstatechange

### DIFF
--- a/webrtc/rtcpeerconnection/iceGatheringState.html
+++ b/webrtc/rtcpeerconnection/iceGatheringState.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>RTCPeerConnection ICEGatheringState tests</title>
+</head>
+<body>
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script type="text/javascript">
+  async_test(function(test) {
+    var pc = new RTCPeerConnection(null);
+
+    pc.onicegatheringstatechange = test.step_func(function(event) {
+      if (pc.iceGatheringState === 'complete') {
+        test.done();
+      }
+    });
+    pc.createOffer({offerToReceiveAudio: 1})
+    .then(offer => pc.setLocalDescription(offer))
+    .catch(test.step_func(function(e) {
+      assert_unreached('Error ' + e.name + ': ' + e.message);
+    }));
+  }, 'Tests that the ICE gathering state ends up as "completed" after applying a local offer.');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
passes in Firefox 54 as least. Needs to wait for
    https://bugs.chromium.org/p/chromium/issues/detail?id=681083
to land in chrome-unstable.