### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=169851

### DIFF
--- a/fetch/api/cors/cors-preflight.js
+++ b/fetch/api/cors/cors-preflight.js
@@ -99,4 +99,6 @@ corsPreflight("CORS [GET] [several headers], server refuses", corsUrl, "GET", fa
 corsPreflight("CORS [PUT] [several headers], server allows", corsUrl, "PUT", true, headers, safeHeaders);
 corsPreflight("CORS [PUT] [several headers], server refuses", corsUrl, "PUT", false, headers, safeHeaders);
 
+corsPreflight("CORS [PUT] [only safe headers], server allows", corsUrl, "PUT", true, null, safeHeaders);
+
 done();


### PR DESCRIPTION
Safari sends empty "Access-Control-Request-Headers" in preflight request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5192)
<!-- Reviewable:end -->
