### PR TITLE
[service workers] Reduce reliance on global state

### DIFF
--- a/service-workers/service-worker/fetch-event-async-respond-with.https.html
+++ b/service-workers/service-worker/fetch-event-async-respond-with.https.html
@@ -2,6 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
+<script src="resources/service-worker-recorder.js"></script>
 <script>
 promise_test(function(t) {
     var script = 'resources/fetch-event-async-respond-with-worker.js';
@@ -9,24 +10,23 @@ promise_test(function(t) {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(function(registration) {
-          return wait_for_state(t, registration.installing, 'activated');
+          return wait_for_state(t, registration.installing, 'activated')
+            .then(function() {
+                return ServiceWorkerRecorder.client.clear(registration.active);
+              });
         })
       .then(function() {
           return with_iframe(scope);
         })
       .then(function(frame) {
-          add_completion_callback(function() { frame.remove(); });
-          var channel = new MessageChannel();
-          var saw_message = new Promise(function(resolve) {
-              channel.port1.onmessage = function(e) { resolve(e.data); }
-            });
-          var worker = frame.contentWindow.navigator.serviceWorker.controller;
+          t.add_cleanup(function() { frame.remove(); });
 
-          worker.postMessage({port: channel.port2}, [channel.port2]);
-          return saw_message;
+          return ServiceWorkerRecorder.client.read(
+              frame.contentWindow.navigator.serviceWorker.controller
+            );
         })
-      .then(function(message) {
-          assert_equals(message, 'PASS');
+      .then(function(results) {
+          assert_array_equals(results, ['PASS']);
           return service_worker_unregister_and_done(t, scope);
         })
   }, 'Calling respondWith asynchronously throws an exception');

--- a/service-workers/service-worker/fetch-event-respond-with-stops-propagation.https.html
+++ b/service-workers/service-worker/fetch-event-respond-with-stops-propagation.https.html
@@ -2,6 +2,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
+<script src="resources/service-worker-recorder.js"></script>
 <script>
 promise_test(function(t) {
     var script =
@@ -10,24 +11,23 @@ promise_test(function(t) {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(function(registration) {
-          return wait_for_state(t, registration.installing, 'activated');
+          return wait_for_state(t, registration.installing, 'activated')
+            .then(function() {
+                return ServiceWorkerRecorder.client.clear(registration.active);
+              });
         })
       .then(function() {
           return with_iframe(scope);
         })
       .then(function(frame) {
           t.add_cleanup(function() { frame.remove(); });
-          var channel = new MessageChannel();
-          var saw_message = new Promise(function(resolve) {
-              channel.port1.onmessage = function(e) { resolve(e.data); }
-            });
-          var worker = frame.contentWindow.navigator.serviceWorker.controller;
 
-          worker.postMessage({port: channel.port2}, [channel.port2]);
-          return saw_message;
+          return ServiceWorkerRecorder.client.read(
+              frame.contentWindow.navigator.serviceWorker.controller
+            );
         })
-      .then(function(message) {
-          assert_equals(message, 'PASS');
+      .then(function(result) {
+          assert_array_equals(result, ['first handler invoked']);
           return service_worker_unregister_and_done(t, scope);
         })
   }, 'respondWith() invokes stopImmediatePropagation()');

--- a/service-workers/service-worker/fetch-request-css-base-url.https.html
+++ b/service-workers/service-worker/fetch-request-css-base-url.https.html
@@ -4,7 +4,25 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
+<script src="resources/service-worker-recorder.js"></script>
 <script>
+// Continually execute the provided function until it returns the value `true`
+// or a Promise that resolves to `true`.
+function waitFor(condition) {
+  function go() {
+      return Promise.resolve(condition())
+        .then(function(result) {
+            if (result === true) {
+              return;
+            }
+            return new Promise(function(resolve) { step_timeout(resolve, 100); })
+                .then(go);
+          });
+    };
+
+  return go();
+};
+
 async_test(function(t) {
     var SCOPE = 'resources/fetch-request-css-base-url-iframe.html';
     var SCRIPT = 'resources/fetch-request-css-base-url-worker.js';
@@ -14,42 +32,43 @@ async_test(function(t) {
     return service_worker_unregister_and_register(t, SCRIPT, SCOPE)
       .then(function(registration) {
           worker = registration.installing;
-          return wait_for_state(t, worker, 'activated');
-        })
-      .then(function() {
-          return new Promise(function(resolve) {
-              var channel = new MessageChannel();
-              testDonePromise = new Promise(function(resolveTestDone) {
-                channel.port1.onmessage = t.step_func(function(msg) {
-                  if (msg.data.ready) {
-                    resolve();
-                    return;
-                  }
-                  var result = msg.data;
-                  var base = get_host_info()['HTTPS_ORIGIN'] + base_path();
-                  assert_equals(
-                    result.url,
-                    base + 'resources/dummy.png',
-                    'The base URL while loading the images referred from CSS ' +
-                    'must be the request URL of CSS.');
-                  assert_equals(
-                    result.referrer,
-                    base + 'resources/fetch-request-css-base-url-style.css',
-                    'While loading the image defined in CSS the referrer must ' +
-                    'be the request URL of CSS.');
-                  resolveTestDone();
-                });
+          return wait_for_state(t, worker, 'activated')
+            .then(function() {
+                return ServiceWorkerRecorder.client.clear(registration.active);
               });
-              worker.postMessage(
-                {port: channel.port2}, [channel.port2]);
-            });
         })
       .then(function() { return with_iframe(SCOPE); })
-      .then(function(f) {
-          return testDonePromise.then(function() {
-            f.remove();
-            return service_worker_unregister_and_done(t, SCOPE);
-          });
+      .then(function(iframe) {
+          var requestInfo;
+          // There is no event that signals when a stylesheet's sub-resources
+          // have been loaded, so a polling approach must be used to delay test
+          // execution until after the service worker has intercepted the
+          // request as expected.
+          return waitFor(function() {
+              return ServiceWorkerRecorder.client.read(worker)
+                .then(function(results) {
+                    requestInfo = results[0];
+                    return results.length > 0;
+                  });
+            })
+            .then(function() {
+                iframe.remove();
+                return requestInfo;
+              });
+        })
+      .then(function(result) {
+          var base = get_host_info()['HTTPS_ORIGIN'] + base_path();
+          assert_equals(
+            result.url,
+            base + 'resources/dummy.png',
+            'The base URL while loading the images referred from CSS ' +
+            'must be the request URL of CSS.');
+          assert_equals(
+            result.referrer,
+            base + 'resources/fetch-request-css-base-url-style.css',
+            'While loading the image defined in CSS the referrer must ' +
+            'be the request URL of CSS.');
+          return service_worker_unregister_and_done(t, SCOPE);
         })
       .catch(unreached_rejection(t));
   }, 'CSS\'s base URL must be the request URL even when fetched from other URL.');

--- a/service-workers/service-worker/resources/fetch-event-async-respond-with-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-async-respond-with-worker.js
@@ -1,19 +1,23 @@
-var result;
-
-self.addEventListener('message', function(event) {
-    event.data.port.postMessage(result);
-  });
+importScripts('./service-worker-recorder.js');
 
 self.addEventListener('fetch', function(event) {
+  var respondLater = new Promise(function(resolve) {
     setTimeout(function() {
         try {
           event.respondWith(new Response());
-          result = 'FAIL: did not throw';
+          resolve('FAIL: did not throw');
         } catch (error) {
-          if (error.name == 'InvalidStateError')
-            result = 'PASS';
-          else
-            result = 'FAIL: Unexpected exception: ' + error;
+          if (error.name == 'InvalidStateError') {
+            resolve('PASS');
+          } else {
+            resolve('FAIL: Unexpected exception: ' + error);
+          }
         }
       }, 0);
+    });
+
+    event.waitUntil(respondLater
+      .then(function(result) {
+          return ServiceWorkerRecorder.worker.save(result);
+        }));
   });

--- a/service-workers/service-worker/resources/fetch-event-respond-with-stops-propagation-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-respond-with-stops-propagation-worker.js
@@ -1,15 +1,12 @@
-var result = null;
-
-self.addEventListener('message', function(event) {
-    event.data.port.postMessage(result);
-  });
+importScripts('./service-worker-recorder.js');
 
 self.addEventListener('fetch', function(event) {
-    if (!result)
-      result = 'PASS';
+    ServiceWorkerRecorder.worker.save('first handler invoked');
     event.respondWith(new Response());
   });
 
 self.addEventListener('fetch', function(event) {
-    result = 'FAIL: fetch event propagated';
+    event.waitUntil(
+      ServiceWorkerRecorder.worker.save('second handler invoked')
+    );
   });

--- a/service-workers/service-worker/resources/fetch-recording-worker.js
+++ b/service-workers/service-worker/resources/fetch-recording-worker.js
@@ -1,0 +1,5 @@
+importScripts('./service-worker-recorder.js');
+
+self.addEventListener('fetch', function(event) {
+    event.waitUntil(ServiceWorkerRecorder.worker.save(event.request.url));
+  });

--- a/service-workers/service-worker/resources/fetch-request-css-base-url-worker.js
+++ b/service-workers/service-worker/resources/fetch-request-css-base-url-worker.js
@@ -1,15 +1,6 @@
 importScripts('/common/get-host-info.sub.js');
 importScripts('test-helpers.sub.js');
-
-var port = undefined;
-
-self.onmessage = function(e) {
-  var message = e.data;
-  if ('port' in message) {
-    port = message.port;
-    port.postMessage({ready: true});
-  }
-};
+importScripts('./service-worker-recorder.js');
 
 self.addEventListener('fetch', function(event) {
     var url = event.request.url;
@@ -19,9 +10,9 @@ self.addEventListener('fetch', function(event) {
         'fetch-request-css-base-url-style.css',
         {mode: 'no-cors'}));
     } else if (url.indexOf('dummy.png') != -1) {
-      port.postMessage({
+      event.waitUntil(ServiceWorkerRecorder.worker.save({
           url: event.request.url,
           referrer: event.request.referrer
-        });
+        }));
     }
   });

--- a/service-workers/service-worker/resources/service-worker-recorder.js
+++ b/service-workers/service-worker/resources/service-worker-recorder.js
@@ -1,0 +1,232 @@
+'use strict';
+// ServiceWorkerRecorder.js
+//
+// A set of utility functions for tracking arbitrary events during the lifetime
+// of a Service Worker. Although Service Workers may be written to store state
+// in the global scope and provide it to clients on demand, this practice is
+// volatile because the user agent may terminate workers at any moment. This
+// utility provides persistence across terminations by storing state in an
+// IndexedDB instance.
+//
+// The available methods, their signatures, and their expected usage are
+// defined below. The methods defined in the `ServieWorkerRecorder.worker`
+// namespace are intended for use within Service Worker contexts; the methods
+// defined in the `ServiceWorkerRecorder.client` namespace are intended for use
+// in client contexts. Note that this script must be included in both the
+// Service Worker context and the client's context in order for the provided
+// methods to function as intended.
+self.ServiceWorkerRecorder = (function() {
+  var dbName = 'service-worker-recorder.js';
+  var storeName = 'events';
+  var fileName = location.toString();
+  var start = new Date().getTime();
+  var ServiceWorkerRecorder = { client: {}, worker: {} };
+  var scope;
+
+  if (typeof registration !== 'undefined') {
+    scope = registration.scope;
+  }
+
+  function connect() {
+    return new Promise(function(resolve, reject) {
+        var request = indexedDB.open(dbName);
+        request.onerror = reject;
+        request.onblocked = function() {
+          reject(new Error('service-worker-recorder.js: database is blocked'));
+        };
+        request.onupgradeneeded = function(event) {
+          var db = event.target.result;
+          var events = db.createObjectStore(storeName, { autoIncrement: true });
+          events.createIndex(
+            'byNameScopeAndTime', ['fileName', 'scope', 'timeStamp']
+          );
+        };
+        request.onsuccess = function(event) {
+          resolve(event.target.result);
+        };
+      });
+  }
+
+  function clientSend(worker, topic, value) {
+    return new Promise(function(resolve, reject) {
+        function onMessage(event) {
+          resolve(event.data);
+        }
+        var channel = new MessageChannel();
+        var data = {port: channel.port2, topic: topic, value: value};
+        channel.port1.onmessage = onMessage;
+        worker.postMessage(data, [channel.port2]);
+      });
+  }
+
+  function onMessage(event) {
+    var topic = event.data && event.data.topic;
+    var operation = null;
+
+    if (topic === 'service-worker-recorder.js:clear') {
+      operation = ServiceWorkerRecorder.worker.clear;
+    } else if (topic === 'service-worker-recorder.js:save') {
+      operation = ServiceWorkerRecorder.worker.save;
+    } else if (topic === 'service-worker-recorder.js:read') {
+      operation = ServiceWorkerRecorder.worker.read;
+    }
+
+    if (operation) {
+      event.waitUntil(operation().then(function(result) {
+          event.data.port.postMessage(result);
+        }));
+    }
+  }
+
+  /**
+   * Remove all records that were inserted prior to the current moment.
+   *
+   * @returns {Promise}
+   */
+  ServiceWorkerRecorder.worker.clear = function() {
+    var timeStamp = start + performance.now();
+
+    return connect().then(function(db) {
+        var transaction = db.transaction([storeName], 'readwrite');
+        var store = transaction.objectStore(storeName)
+        var lowerBound = [fileName, scope, 0];
+        var upperBound = [fileName, scope, timeStamp];
+        var past = IDBKeyRange.bound(lowerBound, upperBound);
+        var get = store.index('byNameScopeAndTime').openKeyCursor(past);
+        var close = db.close.bind(db, db);
+        var del = new Promise(function(resolve, reject) {
+            var deleteRequests = [];
+            get.onerror = function() { reject(get.error); };
+            get.onsuccess = function() {
+              var cursor = get.result;
+              if (!cursor) {
+                Promise.all(deleteRequests)
+                  .then(resolve, reject);
+                return;
+              }
+
+              deleteRequests.push(new Promise(function(resolve, reject) {
+                  var request = store.delete(cursor.primaryKey);
+                  request.onsuccess = function() { resolve(); };
+                  request.onerror = reject;
+                }));
+
+              cursor.continue();
+            };
+          });
+
+        del.then(close, close);
+
+        return del;
+      });
+  };
+  /**
+   * Send a request to the provided worker to remove all records that were
+   * inserted prior to the current moment.
+   *
+   * @param {ServiceWorker} worker
+   *
+   * @returns {Promise}
+   */
+  ServiceWorkerRecorder.client.clear = function(worker) {
+    return clientSend(worker, 'service-worker-recorder.js:clear');
+  };
+
+  /**
+   * Create a new record with the provided value.
+   *
+   * @param {any} value
+   *
+   * @returns {Promise}
+   */
+  ServiceWorkerRecorder.worker.save = function(value) {
+    var timeStamp = start + performance.now();
+
+    return connect().then(function(db) {
+        var transaction = db.transaction([storeName], 'readwrite');
+        var close = db.close.bind(db);
+        var put = new Promise(function(resolve, reject) {
+            transaction.objectStore(storeName).put({
+                timeStamp: timeStamp,
+                fileName: fileName,
+                scope: scope,
+                value: value
+              });
+            transaction.onerror = reject;
+            transaction.oncomplete = resolve;
+          });
+
+        put.then(close, close);
+
+        return put;
+      });
+  };
+  /**
+   * Send a request to the provided worker to create a record with the provided
+   * value.
+   *
+   * @param {ServiceWorker} worker
+   * @param {any} value
+   *
+   * @returns {Promise}
+   */
+  ServiceWorkerRecorder.client.save = function(worker, value) {
+    return clientSend(worker, 'service-worker-recorder.js:save', value);
+  };
+
+  /**
+   * Read all records from the database.
+   *
+   * @returns {Promise<Array>}
+   */
+  ServiceWorkerRecorder.worker.read = function() {
+    return connect().then(function(db) {
+        var txn = db.transaction([storeName]);
+        var lowerBound = [fileName, scope, 0];
+        var upperBound = [fileName, scope, Infinity];
+        var past = IDBKeyRange.bound(lowerBound, upperBound);
+        var request = txn.objectStore(storeName).index('byNameScopeAndTime')
+          .openCursor(past);
+        var close = db.close.bind(db);
+        var readAll = new Promise(function(resolve, reject) {
+            var results = [];
+            txn.onerror = request.onerror = reject;
+
+            request.onsuccess = function(event) {
+              var cursor = event.target.result;
+              if (cursor) {
+                results.push(cursor.value);
+                cursor.continue();
+                return;
+              }
+              results.sort(function(a, b) {
+                  return a.timeStamp - b.timeStamp;
+                });
+              resolve(results.map(function(result) { return result.value; }));
+            };
+          });
+
+        readAll.then(close, close);
+
+        return readAll;
+      });
+  };
+  /**
+   * Send a request to the provided worker to read all records from the
+   * database.
+   *
+   * @param {ServiceWorker} worker
+   *
+   * @returns {Promise<Array>}
+   */
+  ServiceWorkerRecorder.client.read = function(worker) {
+    return clientSend(worker, 'service-worker-recorder.js:read');
+  };
+
+  if ('ServiceWorkerGlobalScope' in self &&
+    self instanceof ServiceWorkerGlobalScope) {
+    self.addEventListener('message', onMessage);
+  }
+
+  return ServiceWorkerRecorder;
+}());

--- a/service-workers/service-worker/resources/websocket.js
+++ b/service-workers/service-worker/resources/websocket.js
@@ -1,7 +1,0 @@
-self.urls = [];
-self.addEventListener('fetch', function(event) {
-    self.urls.push(event.request.url);
-  });
-self.addEventListener('message', function(event) {
-    event.data.port.postMessage({urls: self.urls});
-  });

--- a/service-workers/service-worker/websocket-traffic-no-fetch.https.html
+++ b/service-workers/service-worker/websocket-traffic-no-fetch.https.html
@@ -4,11 +4,12 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/common/get-host-info.sub.js"></script>
 <script src="resources/test-helpers.sub.js?pipe=sub"></script>
+<script src="resources/service-worker-recorder.js"></script>
 <script>
 
 async_test(function(t) {
     var path = new URL(".", window.location).pathname
-    var url = 'resources/websocket.js';
+    var url = 'resources/fetch-recording-worker.js';
     var scope = 'resources/blank.html?websocket';
     var host_info = get_host_info();
     var frameURL = host_info['HTTPS_ORIGIN'] + path + scope;
@@ -16,7 +17,10 @@ async_test(function(t) {
 
     service_worker_unregister_and_register(t, url, scope)
       .then(function(registration) {
-          return wait_for_state(t, registration.installing, 'activated');
+          return wait_for_state(t, registration.installing, 'activated')
+            .then(function() {
+                return ServiceWorkerRecorder.client.clear(registration.active);
+              });
         })
       .then(function() { return with_iframe(frameURL); })
       .then(function(f) {
@@ -24,18 +28,16 @@ async_test(function(t) {
           return websocket(t, frame);
         })
       .then(function() {
-          return new Promise(function(resolve, reject) {
-            function onMessage(e) {
-              for (var url in e.data.urls) {
-                assert_equals(url.indexOf(get_websocket_url()), -1,
-                              "Observed an unexpected FetchEvent for the WebSocket handshake");
-              }
-              t.done();
-            }
-            var channel = new MessageChannel();
-            channel.port1.onmessage = t.step_func(onMessage);
-            frame.contentWindow.navigator.serviceWorker.controller.postMessage({port: channel.port2}, [channel.port2]);
-          });
+          return ServiceWorkerRecorder.client.read(
+              frame.contentWindow.navigator.serviceWorker.controller
+            );
+        })
+      .then(function(data) {
+          for (var url in data) {
+            assert_equals(url.indexOf(get_websocket_url()), -1,
+                          "Observed an unexpected FetchEvent for the WebSocket handshake");
+          }
+          t.done();
         })
       .then(function() {
           frame.remove();


### PR DESCRIPTION
The Service Worker specification allows user agents to terminate workers
at any time. This makes global state highly volatile. Tests which rely
on persistence between invocations of service worker handlers are
therefore subject to sporadic failure according to the browser's
internal worker termination heuristic.

Update tests that previously relied on global service worker state to
instead store state in a persistent IndexedDB object store. Introduce a
set of utility functions to simplify interaction with this object store.

@ehsan @mkruisselbrink @mattto See
https://github.com/w3c/ServiceWorker/issues/1087 for an ongoing discussion
regarding worker termination and reliance on global state (and please feel free
to weigh in with your own perspective).

An alternative to using IndexedDB would be to send event data from the worker
to the client via [the `clients`
interface](https://w3c.github.io/ServiceWorker/#service-worker-global-scope-clients).
This might be simpler in some ways, but I'm reluctant to use the Service Worker
API to test the Service Worker API.

Finally, there are still more tests that rely on global state. I am submitting
this patch in order to solicit feedback on a viable workaround prior to fully
addressing the problem.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
