### PR TITLE
Revert of Remove |remote| and |readonly| members of MediaStreamTrack. (patchset #5 id:80001 of https://codereview.chromium.org/2723433002/ )


### DIFF
--- a/mediacapture-streams/MediaStreamTrack-init.https.html
+++ b/mediacapture-streams/MediaStreamTrack-init.https.html
@@ -40,6 +40,8 @@ idl_array.add_idls("interface MediaStreamTrack : EventTarget {\
     readonly    attribute boolean               muted;\
                 attribute EventHandler          onmute;\
                 attribute EventHandler          onunmute;\
+    readonly    attribute boolean               _readonly;\
+    readonly    attribute boolean               remote;\
     readonly    attribute MediaStreamTrackState readyState;\
                 attribute EventHandler          onended;\
                 attribute EventHandler          onoverconstrained;\


### PR DESCRIPTION
Reason for revert:
Temporarily reverting this CL because it causes a perf regression. See http://crbug.com/703605.

Will reland once we understand why the regression occurred.

Original issue's description:
> Remove |remote| and |readonly| members of MediaStreamTrack.
>
> Spec reference:
> http://w3c.github.io/mediacapture-main/getusermedia.html#attributes-1
>
> removal was in the February 22, 2016'.
> [#321] Remove track attributes "remote" and "readonly" :
> https://github.com/w3c/mediacapture-main/pull/321
>
> Intent to Deprecate and Remove :
> https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/d20ECb2sWzI
>
> BUG=598704
>
> Review-Url: https://codereview.chromium.org/2723433002
> Cr-Commit-Position: refs/heads/master@{#456639}
> Committed: https://chromium.googlesource.com/chromium/src/+/27c39dbef0b07b7cd62fb2476d0f0836115fe672

TBR=tkent@chromium.org,aelias@chromium.org,alexmos@chromium.org,bbudge@chromium.org,dpranke@chromium.org,drott@chromium.org,esprehn@chromium.org,haraken@chromium.org,hongchan@chromium.org,hta@chromium.org,mcasas@chromium.org,mkwst@chromium.org,peter@chromium.org,rdevlin.cronin@chromium.org,sergeyu@chromium.org,peary2@gmail.com
# Not skipping CQ checks because original CL landed more than 1 days ago.
BUG=598704

Review-Url: https://codereview.chromium.org/2767963002
Cr-Commit-Position: refs/heads/master@{#459096}

