### PR TITLE
Upstream service worker message event tests to WPT


### DIFF
--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event-constructor.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event-constructor.https.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>ServiceWorkerGlobalScope: ExtendableMessageEvent Constructor</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../resources/test-helpers.sub.js'></script>
+<script>
+service_worker_test(
+    'resources/extendable-message-event-constructor-worker.js', document.title
+  );
+</script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/extendable-message-event.https.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<title>ServiceWorkerGlobalScope: ExtendableMessageEvent</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<script src='../resources/test-helpers.sub.js'></script>
+<script src='./resources/extendable-message-event-utils.js'></script>
+<script>
+promise_test(function(t) {
+    var script = 'resources/extendable-message-event-worker.js';
+    var scope = 'resources/scope/extendable-message-event-from-toplevel';
+    var registration;
+
+    return service_worker_unregister_and_register(t, script, scope)
+      .then(function(r) {
+          registration = r;
+          add_completion_callback(function() { registration.unregister(); });
+          return wait_for_state(t, registration.installing, 'activated');
+        })
+      .then(function() {
+          var saw_message = new Promise(function(resolve) {
+              navigator.serviceWorker.onmessage =
+                  function(event) { resolve(event.data); }
+            });
+          var channel = new MessageChannel;
+          registration.active.postMessage('', [channel.port1]);
+          return saw_message;
+        })
+      .then(function(results) {
+          var expected = {
+            constructor: { name: 'ExtendableMessageEvent' },
+            origin: location.origin,
+            lastEventId: '',
+            source: {
+                constructor: { name: 'WindowClient' },
+                frameType: 'top-level',
+                url: location.href,
+                visibilityState: 'visible',
+                focused: true
+            },
+            ports: [ { constructor: { name: 'MessagePort' } } ]
+          };
+          ExtendableMessageEventUtils.assert_equals(results, expected);
+        });
+  }, 'Post an extendable message from a top-level client');
+
+promise_test(function(t) {
+    var script = 'resources/extendable-message-event-worker.js';
+    var scope = 'resources/scope/extendable-message-event-from-nested';
+    var frame;
+
+    return service_worker_unregister_and_register(t, script, scope)
+      .then(function(registration) {
+          add_completion_callback(function() { registration.unregister(); });
+          return wait_for_state(t, registration.installing, 'activated');
+        })
+      .then(function() { return with_iframe(scope); })
+      .then(function(f) {
+          frame = f;
+          add_completion_callback(function() { frame.remove(); });
+          var saw_message = new Promise(function(resolve) {
+              frame.contentWindow.navigator.serviceWorker.onmessage =
+                  function(event) { resolve(event.data); }
+            });
+          f.contentWindow.navigator.serviceWorker.controller.postMessage('');
+          return saw_message;
+        })
+      .then(function(results) {
+          var expected = {
+              constructor: { name: 'ExtendableMessageEvent' },
+              origin: location.origin,
+              lastEventId: '',
+              source: {
+                  constructor: { name: 'WindowClient' },
+                  url: frame.contentWindow.location.href,
+                  frameType: 'nested',
+                  visibilityState: 'visible',
+                  focused: false
+              },
+              ports: []
+            };
+          ExtendableMessageEventUtils.assert_equals(results, expected);
+        });
+  }, 'Post an extendable message from a nested client');
+
+promise_test(function(t) {
+    var script = 'resources/extendable-message-event-loopback-worker.js';
+    var scope = 'resources/scope/extendable-message-event-loopback';
+    var registration;
+
+    return service_worker_unregister_and_register(t, script, scope)
+      .then(function(r) {
+          registration = r;
+          add_completion_callback(function() { registration.unregister(); });
+          return wait_for_state(t, registration.installing, 'activated');
+        })
+      .then(function() {
+          var results = [];
+          var saw_message = new Promise(function(resolve) {
+              navigator.serviceWorker.onmessage = function(event) {
+                switch (event.data.type) {
+                  case 'record':
+                    results.push(event.data.results);
+                    break;
+                  case 'finish':
+                    resolve(results);
+                    break;
+                }
+              };
+            });
+          registration.active.postMessage({type: 'start'});
+          return saw_message;
+        })
+      .then(function(results) {
+          assert_equals(results.length, 2);
+
+          var expected_trial_1 = {
+              constructor: { name: 'ExtendableMessageEvent' },
+              origin: location.origin,
+              lastEventId: '',
+              source: {
+                  constructor: { name: 'ServiceWorker' },
+                  scriptURL: normalizeURL(script),
+                  state: 'activated'
+              },
+              ports: []
+          };
+          assert_equals(results[0].trial, 1);
+          ExtendableMessageEventUtils.assert_equals(
+              results[0].event, expected_trial_1
+          );
+
+          var expected_trial_2 = {
+              constructor: { name: 'ExtendableMessageEvent' },
+              origin: location.origin,
+              lastEventId: '',
+              source: {
+                  constructor: { name: 'ServiceWorker' },
+                  scriptURL: normalizeURL(script),
+                  state: 'activated'
+              },
+              ports: [],
+          };
+          assert_equals(results[1].trial, 2);
+          ExtendableMessageEventUtils.assert_equals(
+              results[1].event, expected_trial_2
+          );
+        });
+  }, 'Post loopback extendable messages');
+
+promise_test(function(t) {
+    var script1 = 'resources/extendable-message-event-ping-worker.js';
+    var script2 = 'resources/extendable-message-event-pong-worker.js';
+    var scope = 'resources/scope/extendable-message-event-pingpong';
+    var registration;
+
+    return service_worker_unregister_and_register(t, script1, scope)
+      .then(function(r) {
+          registration = r;
+          add_completion_callback(function() { registration.unregister(); });
+          return wait_for_state(t, registration.installing, 'activated');
+        })
+      .then(function() {
+          // A controlled frame is necessary for keeping a waiting worker.
+          return with_iframe(scope);
+        })
+      .then(function(frame) {
+          add_completion_callback(function() { frame.remove(); });
+          return navigator.serviceWorker.register(script2, {scope: scope});
+        })
+      .then(function(r) {
+          return wait_for_state(t, r.installing, 'installed');
+        })
+      .then(function() {
+          var results = [];
+          var saw_message = new Promise(function(resolve) {
+              navigator.serviceWorker.onmessage = function(event) {
+                switch (event.data.type) {
+                  case 'record':
+                    results.push(event.data.results);
+                    break;
+                  case 'finish':
+                    resolve(results);
+                    break;
+                }
+              };
+            });
+          registration.active.postMessage({type: 'start'});
+          return saw_message;
+        })
+      .then(function(results) {
+          assert_equals(results.length, 2);
+
+          var expected_ping = {
+              constructor: { name: 'ExtendableMessageEvent' },
+              origin: location.origin,
+              lastEventId: '',
+              source: {
+                  constructor: { name: 'ServiceWorker' },
+                  scriptURL: normalizeURL(script1),
+                  state: 'activated'
+              },
+              ports: []
+          };
+          assert_equals(results[0].pingOrPong, 'ping');
+          ExtendableMessageEventUtils.assert_equals(
+              results[0].event, expected_ping
+          );
+
+          var expected_pong = {
+              constructor: { name: 'ExtendableMessageEvent' },
+              origin: location.origin,
+              lastEventId: '',
+              source: {
+                  constructor: { name: 'ServiceWorker' },
+                  scriptURL: normalizeURL(script2),
+                  state: 'installed'
+              },
+              ports: []
+          };
+          assert_equals(results[1].pingOrPong, 'pong');
+          ExtendableMessageEventUtils.assert_equals(
+              results[1].event, expected_pong
+          );
+        });
+  }, 'Post extendable messages among service workers');
+</script>

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-constructor-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-constructor-worker.js
@@ -1,0 +1,193 @@
+importScripts('/resources/testharness.js');
+
+const TEST_OBJECT = { wanwan: 123 };
+const CHANNEL1 = new MessageChannel();
+const CHANNEL2 = new MessageChannel();
+const PORTS = [CHANNEL1.port1, CHANNEL1.port2, CHANNEL2.port1];
+function createEvent(initializer) {
+  if (initializer === undefined)
+    return new ExtendableMessageEvent('type');
+  return new ExtendableMessageEvent('type', initializer);
+}
+
+// These test cases are mostly copied from the following file in the Chromium
+// project (as of commit 848ad70823991e0f12b437d789943a4ab24d65bb):
+// third_party/WebKit/LayoutTests/fast/events/constructors/message-event-constructor.html
+
+test(function() {
+  assert_false(createEvent().bubbles);
+  assert_false(createEvent().cancelable);
+  assert_equals(createEvent().data, null);
+  assert_equals(createEvent().origin, '');
+  assert_equals(createEvent().lastEventId, '');
+  assert_equals(createEvent().source, null);
+  assert_array_equals(createEvent().ports, []);
+}, 'no initializer specified');
+
+test(function() {
+  assert_false(createEvent({ bubbles: false }).bubbles);
+  assert_true(createEvent({ bubbles: true }).bubbles);
+}, '`bubbles` is specified');
+
+test(function() {
+  assert_false(createEvent({ cancelable: false }).cancelable);
+  assert_true(createEvent({ cancelable: true }).cancelable);
+}, '`cancelable` is specified');
+
+test(function() {
+  assert_equals(createEvent({ data: TEST_OBJECT }).data, TEST_OBJECT);
+  assert_equals(createEvent({ data: undefined }).data, null);
+  assert_equals(createEvent({ data: null }).data, null);
+  assert_equals(createEvent({ data: false }).data, false);
+  assert_equals(createEvent({ data: true }).data, true);
+  assert_equals(createEvent({ data: '' }).data, '');
+  assert_equals(createEvent({ data: 'chocolate' }).data, 'chocolate');
+  assert_equals(createEvent({ data: 12345 }).data, 12345);
+  assert_equals(createEvent({ data: 18446744073709551615 }).data,
+                            18446744073709552000);
+  assert_equals(createEvent({ data: NaN }).data, NaN);
+  // Note that valueOf() is not called, when the left hand side is
+  // evaluated.
+  assert_false(
+      createEvent({ data: {
+          valueOf: function() { return TEST_OBJECT; } } }).data ==
+      TEST_OBJECT);
+  assert_equals(createEvent({ get data(){ return 123; } }).data, 123);
+  assert_throws({ name: 'Error' }, function() {
+      createEvent({ get data() { throw { name: 'Error' }; } }); });
+}, '`data` is specified');
+
+test(function() {
+  assert_equals(createEvent({ origin: 'melancholy' }).origin, 'melancholy');
+  assert_equals(createEvent({ origin: '' }).origin, '');
+  assert_equals(createEvent({ origin: null }).origin, 'null');
+  assert_equals(createEvent({ origin: false }).origin, 'false');
+  assert_equals(createEvent({ origin: true }).origin, 'true');
+  assert_equals(createEvent({ origin: 12345 }).origin, '12345');
+  assert_equals(
+      createEvent({ origin: 18446744073709551615 }).origin,
+      '18446744073709552000');
+  assert_equals(createEvent({ origin: NaN }).origin, 'NaN');
+  assert_equals(createEvent({ origin: [] }).origin, '');
+  assert_equals(createEvent({ origin: [1, 2, 3] }).origin, '1,2,3');
+  assert_equals(
+      createEvent({ origin: { melancholy: 12345 } }).origin,
+      '[object Object]');
+  // Note that valueOf() is not called, when the left hand side is
+  // evaluated.
+  assert_equals(
+      createEvent({ origin: {
+          valueOf: function() { return 'melancholy'; } } }).origin,
+      '[object Object]');
+  assert_equals(
+      createEvent({ get origin() { return 123; } }).origin, '123');
+  assert_throws({ name: 'Error' }, function() {
+      createEvent({ get origin() { throw { name: 'Error' }; } }); });
+}, '`origin` is specified');
+
+test(function() {
+  assert_equals(
+      createEvent({ lastEventId: 'melancholy' }).lastEventId, 'melancholy');
+  assert_equals(createEvent({ lastEventId: '' }).lastEventId, '');
+  assert_equals(createEvent({ lastEventId: null }).lastEventId, 'null');
+  assert_equals(createEvent({ lastEventId: false }).lastEventId, 'false');
+  assert_equals(createEvent({ lastEventId: true }).lastEventId, 'true');
+  assert_equals(createEvent({ lastEventId: 12345 }).lastEventId, '12345');
+  assert_equals(
+      createEvent({ lastEventId: 18446744073709551615 }).lastEventId,
+      '18446744073709552000');
+  assert_equals(createEvent({ lastEventId: NaN }).lastEventId, 'NaN');
+  assert_equals(createEvent({ lastEventId: [] }).lastEventId, '');
+  assert_equals(
+      createEvent({ lastEventId: [1, 2, 3] }).lastEventId, '1,2,3');
+  assert_equals(
+      createEvent({ lastEventId: { melancholy: 12345 } }).lastEventId,
+      '[object Object]');
+  // Note that valueOf() is not called, when the left hand side is
+  // evaluated.
+  assert_equals(
+      createEvent({ lastEventId: {
+          valueOf: function() { return 'melancholy'; } } }).lastEventId,
+      '[object Object]');
+  assert_equals(
+      createEvent({ get lastEventId() { return 123; } }).lastEventId,
+      '123');
+  assert_throws({ name: 'Error' }, function() {
+      createEvent({ get lastEventId() { throw { name: 'Error' }; } }); });
+}, '`lastEventId` is specified');
+
+test(function() {
+  assert_equals(createEvent({ source: CHANNEL1.port1 }).source, CHANNEL1.port1);
+  assert_equals(
+      createEvent({ source: self.registration.active }).source,
+      self.registration.active);
+  assert_equals(
+      createEvent({ source: CHANNEL1.port1 }).source, CHANNEL1.port1);
+  assert_throws(
+      { name: 'TypeError' }, function() { createEvent({ source: this }); },
+      'source should be Client or ServiceWorker or MessagePort');
+}, '`source` is specified');
+
+test(function() {
+  // Valid message ports.
+  var passed_ports = createEvent({ ports: PORTS}).ports;
+  assert_equals(passed_ports[0], CHANNEL1.port1);
+  assert_equals(passed_ports[1], CHANNEL1.port2);
+  assert_equals(passed_ports[2], CHANNEL2.port1);
+  assert_array_equals(createEvent({ ports: [] }).ports, []);
+  assert_array_equals(createEvent({ ports: undefined }).ports, []);
+
+  // Invalid message ports.
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: [1, 2, 3] }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: TEST_OBJECT }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: null }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: this }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: false }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: true }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: '' }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: 'chocolate' }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: 12345 }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: 18446744073709551615 }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ ports: NaN }); });
+  assert_throws({ name: 'TypeError' },
+      function() { createEvent({ get ports() { return 123; } }); });
+  assert_throws({ name: 'Error' }, function() {
+      createEvent({ get ports() { throw { name: 'Error' }; } }); });
+  // Note that valueOf() is not called, when the left hand side is
+  // evaluated.
+  var valueOf = function() { return PORTS; };
+  assert_throws({ name: 'TypeError' }, function() {
+      createEvent({ ports: { valueOf: valueOf } }); });
+}, '`ports` is specified');
+
+test(function() {
+  var initializers = {
+      bubbles: true,
+      cancelable: true,
+      data: TEST_OBJECT,
+      origin: 'wonderful',
+      lastEventId: 'excellent',
+      source: CHANNEL1.port1,
+      ports: PORTS
+  };
+  assert_equals(createEvent(initializers).bubbles, true);
+  assert_equals(createEvent(initializers).cancelable, true);
+  assert_equals(createEvent(initializers).data, TEST_OBJECT);
+  assert_equals(createEvent(initializers).origin, 'wonderful');
+  assert_equals(createEvent(initializers).lastEventId, 'excellent');
+  assert_equals(createEvent(initializers).source, CHANNEL1.port1);
+  assert_equals(createEvent(initializers).ports[0], PORTS[0]);
+  assert_equals(createEvent(initializers).ports[1], PORTS[1]);
+  assert_equals(createEvent(initializers).ports[2], PORTS[2]);
+}, 'all initial values are specified');

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-loopback-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-loopback-worker.js
@@ -1,0 +1,36 @@
+importScripts('./extendable-message-event-utils.js');
+
+self.addEventListener('message', function(event) {
+    switch (event.data.type) {
+      case 'start':
+        self.registration.active.postMessage(
+            {type: '1st', client_id: event.source.id});
+        break;
+      case '1st':
+        // 1st loopback message via ServiceWorkerRegistration.active.
+        var results = {
+            trial: 1,
+            event: ExtendableMessageEventUtils.serialize(event)
+        };
+        var client_id = event.data.client_id;
+        event.source.postMessage({type: '2nd', client_id: client_id});
+        event.waitUntil(clients.get(client_id)
+            .then(function(client) {
+                client.postMessage({type: 'record', results: results});
+              }));
+        break;
+      case '2nd':
+        // 2nd loopback message via ExtendableMessageEvent.source.
+        var results = {
+            trial: 2,
+            event: ExtendableMessageEventUtils.serialize(event)
+        };
+        var client_id = event.data.client_id;
+        event.waitUntil(clients.get(client_id)
+            .then(function(client) {
+                client.postMessage({type: 'record', results: results});
+                client.postMessage({type: 'finish'});
+              }));
+        break;
+      }
+  });

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-ping-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-ping-worker.js
@@ -1,0 +1,23 @@
+importScripts('./extendable-message-event-utils.js');
+
+self.addEventListener('message', function(event) {
+    switch (event.data.type) {
+      case 'start':
+        // Send a ping message to another service worker.
+        self.registration.waiting.postMessage(
+            {type: 'ping', client_id: event.source.id});
+        break;
+      case 'pong':
+        var results = {
+            pingOrPong: 'pong',
+            event: ExtendableMessageEventUtils.serialize(event)
+        };
+        var client_id = event.data.client_id;
+        event.waitUntil(clients.get(client_id)
+            .then(function(client) {
+                client.postMessage({type: 'record', results: results});
+                client.postMessage({type: 'finish'});
+              }));
+        break;
+    }
+  });

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-pong-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-pong-worker.js
@@ -1,0 +1,18 @@
+importScripts('./extendable-message-event-utils.js');
+
+self.addEventListener('message', function(event) {
+    switch (event.data.type) {
+      case 'ping':
+        var results = {
+            pingOrPong: 'ping',
+            event: ExtendableMessageEventUtils.serialize(event)
+        };
+        var client_id = event.data.client_id;
+        event.waitUntil(clients.get(client_id)
+            .then(function(client) {
+                client.postMessage({type: 'record', results: results});
+                event.source.postMessage({type: 'pong', client_id: client_id});
+              }));
+        break;
+    }
+  });

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-utils.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-utils.js
@@ -1,0 +1,78 @@
+var ExtendableMessageEventUtils = {};
+
+// Create a representation of a given ExtendableMessageEvent that is suitable
+// for transmission via the `postMessage` API.
+ExtendableMessageEventUtils.serialize = function(event) {
+  var ports = event.ports.map(function(port) {
+        return { constructor: { name: port.constructor.name } };
+    });
+  return {
+    constructor: {
+      name: event.constructor.name
+    },
+    origin: event.origin,
+    lastEventId: event.lastEventId,
+    source: {
+      constructor: {
+        name: event.source.constructor.name
+      },
+      url: event.source.url,
+      frameType: event.source.frameType,
+      visibilityState: event.source.visibilityState,
+      focused: event.source.focused
+    },
+    ports: ports
+  };
+};
+
+// Compare the actual and expected values of an ExtendableMessageEvent that has
+// been transformed using the `serialize` function defined in this file.
+ExtendableMessageEventUtils.assert_equals = function(actual, expected) {
+  assert_equals(
+    actual.constructor.name, expected.constructor.name, 'event constructor'
+  );
+  assert_equals(actual.origin, expected.origin, 'event `origin` property');
+  assert_equals(
+    actual.lastEventId,
+    expected.lastEventId,
+    'event `lastEventId` property'
+  );
+
+  assert_equals(
+    actual.source.constructor.name,
+    expected.source.constructor.name,
+    'event `source` property constructor'
+  );
+  assert_equals(
+    actual.source.url, expected.source.url, 'event `source` property `url`'
+  );
+  assert_equals(
+    actual.source.frameType,
+    expected.source.frameType,
+    'event `source` property `frameType`'
+  );
+  assert_equals(
+    actual.source.visibilityState,
+    expected.source.visibilityState,
+    'event `source` property `visibilityState`'
+  );
+  assert_equals(
+    actual.source.focused,
+    expected.source.focused,
+    'event `source` property `focused`'
+  );
+
+  assert_equals(
+    actual.ports.length,
+    expected.ports.length,
+    'event `ports` property length'
+  );
+
+  for (var idx = 0; idx < expected.ports.length; ++idx) {
+    assert_equals(
+      actual.ports[idx].constructor.name,
+      expected.ports[idx].constructor.name,
+      'MessagePort #' + idx + ' constructor'
+    );
+  }
+};

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/extendable-message-event-worker.js
@@ -1,0 +1,5 @@
+importScripts('./extendable-message-event-utils.js');
+
+self.addEventListener('message', function(event) {
+    event.source.postMessage(ExtendableMessageEventUtils.serialize(event));
+  });


### PR DESCRIPTION
This patch corrects invalid assertions relating to the `ports` property
described by the ExtendableMessageEvent API (see crbug.com/702352 and
crbug.com/702361). It also re-formats the tests to improve test precision (by
reducing reliance on the `toString` operation) and more closely align with the
patterns used within the Web Platform Tests project.

BUG=688116,702352,702361
R=falken@chromium.org

Review-Url: https://codereview.chromium.org/2751113005
Cr-Commit-Position: refs/heads/master@{#459099}

