### PR TITLE
Revert "Revert of Remove |remote| and |readonly| members of MediaStreamTrack. (patchset #5 id:80001 of https://codereview.chromium.org/2723433002/ )"

### DIFF
--- a/mediacapture-streams/MediaStreamTrack-init.https.html
+++ b/mediacapture-streams/MediaStreamTrack-init.https.html
@@ -40,8 +40,6 @@ idl_array.add_idls("interface MediaStreamTrack : EventTarget {\
     readonly    attribute boolean               muted;\
                 attribute EventHandler          onmute;\
                 attribute EventHandler          onunmute;\
-    readonly    attribute boolean               _readonly;\
-    readonly    attribute boolean               remote;\
     readonly    attribute MediaStreamTrackState readyState;\
                 attribute EventHandler          onended;\
                 attribute EventHandler          onoverconstrained;\


### PR DESCRIPTION
Reverts w3c/web-platform-tests#5214