### PR TITLE
Report: Inconsistency in HTTP 204 response body parsing

### DIFF
--- a/http-demo/index.html
+++ b/http-demo/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8" />
+  <title>Inconsistency in response parsing</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function script(src) {
+  var s = document.createElement('script');
+  s.setAttribute('src', src + '&time=' + new Date().getTime());
+  document.body.appendChild(s);
+  return new Promise(function(resolve, reject) {
+      s.onload = resolve;
+	  s.onerror = reject;
+    });
+}
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=0');
+      });
+}, 'zero leading characters in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=1');
+      });
+}, 'one leading character in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=2');
+      });
+}, 'two leading characters in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=3');
+      });
+}, 'three leading characters in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=4');
+      });
+}, 'four leading characters in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=5');
+      });
+}, 'five leading characters in second response');
+
+promise_test(function(t) {
+  return Promise.resolve()
+    .then(function() {
+        return script('index.py?seq=1');
+      })
+    .then(function() {
+        return script('index.py?seq=2&leading=6');
+      });
+}, 'six leading characters in second response');
+</script>

--- a/http-demo/index.py
+++ b/http-demo/index.py
@@ -1,0 +1,28 @@
+import time
+
+second = '''HTTP/1.1 200 OK
+Content-Type: application/javascript
+Content-Length: 1
+
+0'''
+
+first = '''HTTP/1.1 204 No Content
+Content-Type: application/javascript
+Content-Length: %s
+
+''' % len(second)
+
+def main(request, response):
+    payload = ''
+    leading_characters = int(request.GET.first('leading', '0'))
+
+    if leading_characters > 0:
+        payload += 'x' * leading_characters
+
+    if request.GET.first('seq') == '1':
+        payload += first
+    else:
+        payload += second
+
+    response.writer.write(payload)
+    response.writer.flush()


### PR DESCRIPTION
When a 204 response specifies as `Content-Length` header, different browsers exhibit different behaviors on different platforms. Although [the HTTP specification explicitly disallows this situation](https://tools.ietf.org/html/rfc7230#section-3.3.2), @annevk suggested that this might be behavior that should be accounted for in relevant W3C/WhatWG specifications.

I've opened this pull request to demonstrate the inconsistency. Please note that although the demo takes the form of a WPT test, it is *not* suitable for a number of reasons.

After checking out this branch, navigate to http://localhost:8000/http-demo/index.html . The tests perform the following actions:

1. Browser: perform a GET request for `demo.py?seq=1` by injecting a `<script>`
   tag into the document
2. Server: respond with `HTTP/1.1 204 No Content`, specifying a non-zero value
   for the `Content-Length` header, but omitting a body
3. Browser: in the `onload` event handler for the script created in step 1,
   perform a second GET request for `demo.py?seq=2` (again, by injecting a
   `<script>` tag into the document)
4. Server: write between zero and six bytes to the response stream that do
   *not* conform to HTTP
5. Server: respond with `HTTP/1.1 200 OK`, specifying a non-zero
   `Content-Length` and a complete body.

There are six sub-tests here: the first writes 0 non-HTTP (or "garbage") bytes in step 4; the following sub-tests write successively more bytes.

Results:

Browser               | Platform   | Behavior for request 1 | Behavior for request 2 (no "garbage)" | Behavior for request 2 (1-4 "garbage" bytes) | Behavior for request 2 (5 "garbage" bytes)
----------------------|------------|------------------------|---------------------------------------|----------------------------------------------|-------------------------------------------
Chromium 56           | GNU/Linux  | resolves successfully  | resolves successfully                 | resolves successfully                        | does not resolve
Chrome 59             | GNU/Linux  | resolves successfully  | resolves successfully                 | resolves successfully                        | reports network error `net::ERR_INVALID_HTTP_RESPONSE`
~~Chrome 57~~             | ~~Windows 10~~ | ~~resolves successfully~~  | ~~resolves successfully~~                 | ~~resolves with HTTP 502 error~~                 | ~~resolves with HTTP 502 error~~
Firefox 52            | GNU/Linux  | resolves successfully  | resolves successfully                 | resolves successfully                        | resolves successfully
~~Firefox 52~~            | ~~Windows 10~~ | ~~resolves successfully~~  | ~~resolves successfully~~                 | ~~resolves with HTTP 502 error~~                 | ~~resolves with HTTP 502 error~~
~~Safari (all versions)~~ | ~~all~~        | ~~does not resolve~~       | ~~n/a~~                                   | ~~n/a~~                                          | ~~n/a~~
~~Edge 13 & 14~~          | ~~Windows 10~~ | ~~does not resolve~~       | ~~n/a~~                                   | ~~n/a~~                                          | ~~n/a~~

In all cases, the WPT server instance was running on a GNU/Linux system. Results for the GNU/Linux platform were collected using locally-running browsers. Results for Non-GNU/Linux platforms were collected using browsers running remotely (as provided by the BrowserStack service). It seems possible that this discrepancy contributed to the variation reported above.

*Note on determinism* These behaviors are only observable when requests 1 and 2 share the same connection. As far as I know, the user agent is free to distribute requests across connections in any manner. While the demonstration seems fairly reliable, I don't think it is technically stable.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
