### PR TITLE
Add sauce labs capability

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -888,6 +888,10 @@ def main():
     os.chdir(args.root)
     browser_name = args.product.split(":")[0]
 
+    if browser_name == "sauce" and not args.sauce_key:
+        logger.warning("Cannot run tests on Sauce Labs. No access key.")
+        return retcode
+
     with TravisFold("browser_setup"):
         logger.info(format_comment_title(args.product))
 

--- a/check_stability.py
+++ b/check_stability.py
@@ -189,7 +189,7 @@ class Firefox(Browser):
     binary = "%s/firefox/firefox"
     platform_ini = "%s/firefox/platform.ini"
 
-    def __init__(self, kwargs):
+    def __init__(self, **kwargs):
         pass
 
     def install(self):
@@ -262,7 +262,7 @@ class Chrome(Browser):
     product = "chrome"
     binary = "/usr/bin/google-chrome"
 
-    def __init__(self, kwargs):
+    def __init__(self, **kwargs):
         pass
 
     def install(self):
@@ -324,7 +324,7 @@ class Sauce(Browser):
 
     product = "sauce"
 
-    def __init__(self, kwargs):
+    def __init__(self, **kwargs):
         browser = kwargs["product"].split(":")
         self.browser_name = browser[1]
         self.browser_version = browser[2]
@@ -348,7 +348,7 @@ class Sauce(Browser):
         return self.browser_version
 
     def wptrunner_args(self, root):
-        """Return Sauce-specific wpt-runner arguments."""
+        """Return Sauce-specific wptrunner arguments."""
         return {
             "product": "sauce",
             "sauce_browser": self.browser_name,
@@ -925,7 +925,7 @@ def main():
         install_wptrunner()
         do_delayed_imports()
 
-        browser = browser_cls(vars(args))
+        browser = browser_cls(**vars(args))
         browser.install()
         browser.install_webdriver()
 

--- a/check_stability.py
+++ b/check_stability.py
@@ -189,6 +189,9 @@ class Firefox(Browser):
     binary = "%s/firefox/firefox"
     platform_ini = "%s/firefox/platform.ini"
 
+    def __init__(self, kwargs):
+        pass
+
     def install(self):
         """Install Firefox."""
         call("pip", "install", "-r", os.path.join(wptrunner_root, "requirements_firefox.txt"))
@@ -259,6 +262,9 @@ class Chrome(Browser):
     product = "chrome"
     binary = "/usr/bin/google-chrome"
 
+    def __init__(self, kwargs):
+        pass
+
     def install(self):
         """Install Chrome."""
 
@@ -308,6 +314,53 @@ class Chrome(Browser):
             else:
                 logger.critical("dbus not running and can't be started")
                 sys.exit(1)
+
+
+class Sauce(Browser):
+    """Sauce-specific interface.
+
+    Includes installation and wptrunner setup methods.
+    """
+
+    product = "sauce"
+
+    def __init__(self, kwargs):
+        browser = kwargs["product"].split(":")
+        self.browser_name = browser[1]
+        self.browser_version = browser[2]
+        self.sauce_platform = kwargs["sauce_platform"]
+        self.sauce_build = kwargs["sauce_build_number"]
+        self.sauce_key = kwargs["sauce_key"]
+        self.sauce_user = kwargs["sauce_user"]
+        self.sauce_build_tags = kwargs["sauce_build_tags"]
+        self.sauce_tunnel_id = kwargs["sauce_tunnel_identifier"]
+
+    def install(self):
+        """Install sauce selenium python deps."""
+        call("pip", "install", "-r", os.path.join(wptrunner_root, "requirements_sauce.txt"))
+
+    def install_webdriver(self):
+        """No need to install webdriver locally."""
+        pass
+
+    def version(self, root):
+        """Retrieve the release version of the browser under test."""
+        return self.browser_version
+
+    def wptrunner_args(self, root):
+        """Return Sauce-specific wpt-runner arguments."""
+        return {
+            "product": "sauce",
+            "sauce_browser": self.browser_name,
+            "sauce_build": self.sauce_build,
+            "sauce_key": self.sauce_key,
+            "sauce_platform": self.sauce_platform,
+            "sauce_tags": self.sauce_build_tags,
+            "sauce_tunnel_id": self.sauce_tunnel_id,
+            "sauce_user": self.sauce_user,
+            "sauce_version": self.browser_version,
+            "test_types": ["testharness", "reftest"]
+        }
 
 
 def get(url):
@@ -655,7 +708,7 @@ def format_comment_title(product):
     title = parts[0].title()
 
     if len(parts) > 1:
-       title += " (%s channel)" % parts[1]
+       title += " (%s)" % parts[1]
 
     return "# %s #" % title
 
@@ -772,6 +825,30 @@ def get_parser():
                         type=str,
                         help="Location of ini-formatted configuration file",
                         default="check_stability.ini")
+    parser.add_argument("--sauce-platform",
+                        action="store",
+                        default=os.environ.get("PLATFORM"),
+                        help="Sauce Labs OS")
+    parser.add_argument("--sauce-build-number",
+                        action="store",
+                        default=os.environ.get("TRAVIS_BUILD_NUMBER"),
+                        help="Sauce Labs build identifier")
+    parser.add_argument("--sauce-build-tags",
+                        action="store", nargs="*",
+                        default=[os.environ.get("TRAVIS_PYTHON_VERSION")],
+                        help="Sauce Labs build tag")
+    parser.add_argument("--sauce-tunnel-identifier",
+                        action="store",
+                        default=os.environ.get("TRAVIS_JOB_NUMBER"),
+                        help="Sauce Connect tunnel identifier")
+    parser.add_argument("--sauce-user",
+                        action="store",
+                        default=os.environ.get("SAUCE_USERNAME"),
+                        help="Sauce Labs user name")
+    parser.add_argument("--sauce-key",
+                        action="store",
+                        default=os.environ.get("SAUCE_ACCESS_KEY"),
+                        help="Sauce Labs access key")
     parser.add_argument("product",
                         action="store",
                         help="Product to run against (`browser-name` or 'browser-name:channel')")
@@ -809,14 +886,14 @@ def main():
         return 1
 
     os.chdir(args.root)
-
     browser_name = args.product.split(":")[0]
 
     with TravisFold("browser_setup"):
         logger.info(format_comment_title(args.product))
 
         browser_cls = {"firefox": Firefox,
-                       "chrome": Chrome}.get(browser_name)
+                       "chrome": Chrome,
+                       "sauce": Sauce}.get(browser_name)
         if browser_cls is None:
             logger.critical("Unrecognised browser %s" % browser_name)
             return 1
@@ -844,7 +921,7 @@ def main():
         install_wptrunner()
         do_delayed_imports()
 
-        browser = browser_cls()
+        browser = browser_cls(vars(args))
         browser.install()
         browser.install_webdriver()
 


### PR DESCRIPTION
This adds Sauce Labs as a browser target for running web platform tests on Microsoft Edge and Apple Safari. This is dependent on adding the support to wptrunner as done in this PR: https://github.com/w3c/wptrunner/pull/243

You can see the expected output from the Sauce jobs here: https://github.com/bobholt/web-platform-tests/pull/10, matching the existing output from Firefox and Chrome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5231)
<!-- Reviewable:end -->
