### PR TITLE
Remove test for SVGZoomEvent

### DIFF
--- a/svg/interfaces.html
+++ b/svg/interfaces.html
@@ -983,14 +983,6 @@ interface SVGScriptElement : SVGElement {
 
 SVGScriptElement implements SVGURIReference;
 
-interface SVGZoomEvent : UIEvent {
-  [SameObject] readonly attribute DOMRectReadOnly zoomRectScreen;
-  readonly attribute float previousScale;
-  [SameObject] readonly attribute DOMPointReadOnly previousTranslate;
-  readonly attribute float newScale;
-  [SameObject] readonly attribute DOMPointReadOnly newTranslate;
-};
-
 interface SVGAElement : SVGGraphicsElement {
   [SameObject] readonly attribute SVGAnimatedString target;
 };


### PR DESCRIPTION
It isn't in SVG 2, I don't think any engine other than Gecko supports
it, and Gecko is removing it:

https://bugzilla.mozilla.org/show_bug.cgi?id=1314388

Chrome already removed it last year:

https://bugs.chromium.org/p/chromium/issues/detail?id=367890

And in svg/historical.html we already test that it's removed.