### PR TITLE
Fix line-height-step-valign-001

### DIFF
--- a/css/css-rhythm-1/line-height-step-valign-001.html
+++ b/css/css-rhythm-1/line-height-step-valign-001.html
@@ -12,6 +12,7 @@ div {
 }
 .test {
   line-height-step: 80px;
+  line-height: 1;
 }
 .ref {
   line-height: 1;


### PR DESCRIPTION
This patch fixes line-height-step-valign-001 to be more interoperably
testable by not relying on the behavior of 'line-height: normal'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5251)
<!-- Reviewable:end -->
