### PR TITLE
Set font when testing font relative units to make sure test is portable.

### DIFF
--- a/css/css-shapes-1/shape-outside/values/shape-image-threshold-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-image-threshold-000.html
@@ -7,7 +7,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-image-threshold-property">
         <meta name="assert" content="shape-image-threshold is any valid number and computed the
                                      clipped value between 0 and 1.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-image-threshold-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-image-threshold-001.html
@@ -7,7 +7,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-image-threshold-property">
         <meta name="assert" content="shape-image-threshold may take calc values and computed the
                                      clipped value between 0 and 1.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-image-threshold-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-image-threshold-002.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-image-threshold-property">
         <meta name="assert" content="shape-image-threshold is set to 0 when an invalid value is specified.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-image-threshold-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-image-threshold-003.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-image-threshold-property">
         <meta name="assert" content="shape-outside can be assigned the 'inherit' value and does not inherit by default.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-000.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="shape-margin values may be either a length or percentage">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-001.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="shape-margin values may be in any length unit">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-002.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="shape-margin values may be either a length or percentage">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-003.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="shape-margin values may be calc() values">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-004.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-004.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="shape-margin values may only be positive length units.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-margin-005.html
+++ b/css/css-shapes-1/shape-outside/values/shape-margin-005.html
@@ -6,7 +6,7 @@
         <link rel="author" title="Rebecca Hauck" href="mailto:rhauck@adobe.com">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-margin-property">
         <meta name="assert" content="The shape-margin value is not inherited and can be assigned the 'inherit' value.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-box-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-box-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#typedef-shape-box">
         <meta name="assert" content="Shape-outside may be one of the box model box values">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-circle">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A circular basic shape has an optional radius and position component">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-001.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-circle">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A circle's radius may be a length, percentage, or keyword.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-002.html
@@ -15,7 +15,7 @@
                                 or   [ left|center|right ]
                                 or   [ left|center|right top|center|bottom ]
                                 or   [ top|center|bottom ]. ">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-003.html
@@ -14,7 +14,7 @@
                                 or   [ left|center|right top|center|bottom ]
                                 or   [ top|center|bottom ].
                                 All position arguments not in this form are invalid.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-004.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-004.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#lengths">
         <meta name="assert" content="A circle's position arguments may in any valid <length> unit allowed by a <position> value.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-005.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-005.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-circle">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A circle's radius may be in any valid length unit.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-006.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-006.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A circle's radius may be in signed positive or decimal/non-decimal format. Negative
                                      radii are invalid.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-007.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-007.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-circle">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="This test verifies that invalid shape-radius arguments on circle() don't parse.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-008.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-008.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-circle">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="This test verifies that invalid position arguments on circle() don't parse">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-009.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-009.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A circle's position arguments may be in signed positive/negative or
                                      decimal/non-decimal format.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-010.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-010.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="A circle's arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-circle-011.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-circle-011.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="A circle's <position> arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css-cascade-3/#computed">
         <meta name="assert" content="The basic shape can contain relative length formats, which resolve to the computed (absolute) length value">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-000.html
@@ -18,15 +18,17 @@
         <script type="text/javascript">
             // font relative units: em, ex, ch, rem
             var units = ['em', 'ex', 'ch', 'rem'];
-            var div = document.createElement('div');
-            document.body.appendChild(div);
             var resolveds = {};
-            units.forEach(function(unit) {
-                div.style.width = '10' + unit;
-                var s = getComputedStyle(div);
-                resolveds[unit] = parseFloat(s.width);
-            });
-            document.body.removeChild(div);
+            ParsingUtils.setupFonts(function () {
+                var div = document.createElement('div');
+                document.body.appendChild(div);
+                units.forEach(function(unit) {
+                    div.style.width = '10' + unit;
+                    var s = getComputedStyle(div);
+                    resolveds[unit] = parseFloat(s.width);
+                });
+                document.body.removeChild(div);
+            })();
 
             function fillArray(string, length) {
                 return Array.apply(null, new Array(length)).map(String.prototype.valueOf, string);

--- a/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-computed-shape-001.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css-cascade-3/#computed">
         <meta name="assert" content="The basic shape can contain percentages, which remain unchanged when computed">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-ellipse">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An elliptical basic shape has two optional components, radii (2) and a position.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-001.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-ellipse">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An elliptical basic shape's radii may be keywords, lengths or percentages">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-002.html
@@ -15,7 +15,7 @@
                                 or   [ left|center|right ]
                                 or   [ left|center|right top|center|bottom ]
                                 or   [ top|center|bottom ]. ">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-003.html
@@ -14,7 +14,7 @@
                                 or   [ left|center|right top|center|bottom ]
                                 or   [ top|center|bottom ].
                                 All position arguments not in this form are invalid.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-004.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-004.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#lengths">
         <meta name="assert" content="An ellipse's position arguments may in any valid <length> unit allowed by a <position> value.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-005.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-005.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-ellipse">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An ellipse's radii may be in any valid length unit.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-006.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-006.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An ellipse's radii may be in signed positive or decimal/non-decimal format. Negative
                                      radii are invalid.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-007.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-007.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-ellipse">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="This test verifies that invalid shape-radius arguments on ellipse() don't parse.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-008.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-008.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-ellipse">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="This test verifies that invalid position arguments on ellipse() don't parse">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-009.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-009.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An ellipse's position arguments may be in signed positive/negative or
                                      decimal/non-decimal format.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-010.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-010.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="An ellipse's arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-011.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-ellipse-011.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="An ellipse's <position> arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-inset">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An inset has 1 to 4 insets, and optional border radii that follow the border-radius format">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-001.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-inset">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An inset has 1 to 4 insets as percentages or length in any unit">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-002.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="An inset's radial component has 1 to 4 length/percentages, optionally followed by a '/'
                                      and an additional 1 to 4 length/percentages and lengths can be in any unit.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-003.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#lengths">
         <meta name="assert" content="An inset's radial component's values can be in any length unit">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-004.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-004.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="These tests verify that shape-outside inset() arguments can be numbers that are signed in
                                      positive and negative and/or decimal/non-decimal form.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-005.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-005.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-inset">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="These tests verifies that invalid inset() arguments don't parse.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-006.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-006.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="These tests verify that shape-outside inset() radial component can be numbers that are in
                                      signed positive and/or decimal/non-decimal form. Negative values are not allowed">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-007.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-007.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-inset">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="These tests verify invalid radial component arguments don't parse.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-008.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-008.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="An inset's arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-inset-009.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-inset-009.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="An inset's radial component arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-polygon">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A polygonal basic shape has an optional fill-rule and one or more pairs of coordinates">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-001.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-polygon">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A polygonal basic shape's optional fill-rule may be either 'nonzero' or 'evenodd'">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-002.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-002.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-polygon">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A polygonal basic shape's points may be either lengths or percentages">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-003.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-003.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-polygon">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A polygonal basic shape's points may be either lengths or percentages">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-004.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-004.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#lengths">
         <meta name="assert" content="A polygon's veritices may in percentage or any valid <length> units.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-005.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-005.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#funcdef-polygon">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="A polygon's vertices can be in signed positive/negative or decimal/non-decimal format">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-polygon-006.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-polygon-006.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
         <meta name="assert" content="A polygon's arguments may be in calc() values.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-arguments-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-arguments-000.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/cssom-1/#serializing-css-values">
         <meta name="assert" content="A basic basic shape can contain any length unit type, or percentage">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-arguments-001.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-arguments-001.html
@@ -9,7 +9,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/cssom-1/#serializing-css-values">
         <meta name="assert" content="The basic shape can contain all valid number formats">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-box-pair-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-box-pair-000.html
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#typedef-shape-box">
         <meta name="assert" content="Shape-outside may be a pair of shape and box values">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-inherit-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-inherit-000.html
@@ -7,7 +7,7 @@
         <link rel="reviewer" title="Alan Stearns" href="mailto:stearns@adobe.com"> <!-- 2014-03-04 -->
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="Shape-outside takes can be assigned the 'inherit' value.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-initial-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-initial-000.html
@@ -7,7 +7,7 @@
         <link rel="reviewer" title="Alan Stearns" href="mailto:stearns@adobe.com"> <!-- 2014-03-04 -->
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="Shape-outside takes its default value of none when assigned the 'initial' value">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-none-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-none-000.html
@@ -7,7 +7,7 @@
         <link rel="reviewer" title="Alan Stearns" href="mailto:stearns@adobe.com"> <!-- 2014-03-04 -->
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <meta name="assert" content="shape-outside can be explictly assigned the default value of none.">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/shape-outside-shape-notation-000.html
+++ b/css/css-shapes-1/shape-outside/values/shape-outside-shape-notation-000.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+                    <!DOCTYPE html>
 <html>
     <head>
         <title>Shape Outside Valid Basic Shape Functional Notation</title>
@@ -8,7 +8,7 @@
         <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property">
         <link rel="help" href="http://www.w3.org/TR/cssom-1/#serializing-css-values">
         <meta name="assert" content="Basic shapes use functional notation, and may contain optional whitespace inside the parentheses">
-        <meta name="flags" content="dom">
+        <meta name="flags" content="ahem dom">
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
         <script src="support/parsing-utils.js"></script>

--- a/css/css-shapes-1/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes-1/shape-outside/values/support/parsing-utils.js
@@ -350,9 +350,9 @@ function convertToPx(origValue) {
              } else if (unit == 'em') {
                  number = (16 * number);
              } else if (unit == 'ex') {
-                 number = (7.1796875 * number);
+                 number = (12.8 * number);
              } else if (unit == 'ch') {
-                 number = (8 * number);
+                 number = (16 * number);
              } else if (unit == 'rem') {
                  number = (16 * number);
              } else if (unit == 'vw') {
@@ -436,6 +436,38 @@ function generateInsetRoundCases(units, testType) {
         }
     }
     return results;
+}
+
+function each(object, func) {
+    for (var prop in object) {
+        if (object.hasOwnProperty(prop)) {
+            func(prop, object[prop]);
+        }
+    }
+}
+
+function setupFonts(func) {
+    return function () {
+        var fontProperties = {
+            'font-family': 'Ahem',
+            'font-size': '16px',
+            'line-height': '1'
+        };
+        var savedValues = { };
+        each(fontProperties, function (key, value) {
+            savedValues[key] = document.body.style.getPropertyValue(key);
+            document.body.style.setProperty(key, value);
+        });
+        func.apply(this, arguments);
+        each(fontProperties, function (key, value) {
+            if (value) {
+                document.body.style.setProperty(key, value);
+            }
+            else {
+                document.body.style.removeProperty(key);
+            }
+        });
+    };
 }
 
 var validUnits = [
@@ -847,11 +879,11 @@ var calcTestValues = [
 
 return {
     testInlineStyle: testInlineStyle,
-    testComputedStyle: testComputedStyle,
+    testComputedStyle: setupFonts(testComputedStyle),
     testShapeMarginInlineStyle: testShapeMarginInlineStyle,
-    testShapeMarginComputedStyle: testShapeMarginComputedStyle,
+    testShapeMarginComputedStyle: setupFonts(testShapeMarginComputedStyle),
     testShapeThresholdInlineStyle: testShapeThresholdInlineStyle,
-    testShapeThresholdComputedStyle: testShapeThresholdComputedStyle,
+    testShapeThresholdComputedStyle: setupFonts(testShapeThresholdComputedStyle),
     buildTestCases: buildTestCases,
     buildRadiiTests: buildRadiiTests,
     buildPositionTests: buildPositionTests,
@@ -861,6 +893,7 @@ return {
     buildCalcTests: buildCalcTests,
     validUnits: validUnits,
     calcTestValues: calcTestValues,
-    roundResultStr: roundResultStr
+    roundResultStr: roundResultStr,
+    setupFonts: setupFonts
 }
 })();


### PR DESCRIPTION
From https://github.com/w3c/csswg-test/pull/687

---

Originally posted as https://github.com/w3c/csswg-test/pull/687 by @bemjb on 02 Dec 2014, 20:52 UTC:

> ... is portable.
> 
> <!-- Reviewable:start -->

<!-- Reviewable:end -->

