### PR TITLE
SVGStringList update tests.


### DIFF
--- a/svg/interfaces.html
+++ b/svg/interfaces.html
@@ -1432,7 +1432,7 @@ idlArray.add_idls(idls);
 idlArray.add_objects({
   SVGAnimatedBoolean: ['feConvolveMatrix.preserveAlpha'],
   SVGAnimatedString: ['a.target'],
-  SVGStringList: ['a.requiredFeatures'],
+  SVGStringList: ['a.requiredExtensions'],
   SVGAnimatedEnumeration: ['text.lengthAdjust'],
   SVGAnimatedInteger: ['feConvolveMatrix.orderX'],
   SVGNumber: ['svg.createSVGNumber()'],


### PR DESCRIPTION
Update the SVGStringList tests to use a SVGStringList other than requiredFeatures,
as we need to remove requiredFeatures.
Fix SVGStringList-basics.
Make SVGStringList.js use requiredExtensions instead of requiredFeatures.

BUG=635420

Review-Url: https://codereview.chromium.org/2780443002
Cr-Commit-Position: refs/heads/master@{#460120}

