### PR TITLE
Fix PerformanceNavigationTiming accessor behavior after document detach.


### DIFF
--- a/navigation-timing/nav2_test_document_replaced.html
+++ b/navigation-timing/nav2_test_document_replaced.html
@@ -12,11 +12,11 @@
             var pnt1;
             var step = 1;
             function onload_test()
-            {   
+            {
                 navigation_frame = document.getElementById("frameContext").contentWindow;
                 setTimeout("nav_frame();", 0);
             }
-            
+
             function nav_frame()
             {
                 switch (step)

--- a/navigation-timing/nav2_test_document_replaced.html
+++ b/navigation-timing/nav2_test_document_replaced.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Navigation Timing 2 WPT</title>
+        <link rel="author" title="Google" href="http://www.google.com/" />
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script>
+            var navigation_frame;
+            var pnt1;
+            var step = 1;
+            function onload_test()
+            {   
+                navigation_frame = document.getElementById("frameContext").contentWindow;
+                setTimeout("nav_frame();", 0);
+            }
+            
+            function nav_frame()
+            {
+                switch (step)
+                {
+                    case 1:
+                    {
+                        pnt1 = navigation_frame.performance.getEntriesByType("navigation")[0];
+                        navigation_frame.location.href = '/navigation-timing/resources/blank_page_green_with_onunload.html';
+                        step++;
+                        break;
+                    }
+                    case 2:
+                    {
+                        navigation_frame.history.back();
+                        step++;
+                        break;
+                    }
+                    case 3:
+                    {
+                        var pnt2 = navigation_frame.performance.getEntriesByType("navigation")[0];
+                        assert_equals(pnt1.type, "navigate");
+                        assert_equals(pnt2.type, "back_forward");
+                        done();
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        </script>
+    </head>
+    <body>
+        <h1>
+            Description</h1>
+        <p>
+            This test validates that a PerformanceNavigatingTiming corresponding to a detached document can't access a different document's state. </p>
+        <iframe id="frameContext" onload="onload_test();" src="resources/blank_page_yellow_with_onunload.html" style="width: 250px; height: 250px;"></iframe>
+    </body>
+</html>

--- a/navigation-timing/nav2_test_frame_removed.html
+++ b/navigation-timing/nav2_test_frame_removed.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Navigation Timing 2 WPT</title>
+        <link rel="author" title="Google" href="http://www.google.com/" />
+        <link rel="help" href="http://www.w3.org/TR/navigation-timing/#sec-navigation-timing-interface"/>
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+        <script>
+            function onload_test()
+            {   test(function() {
+                    var pnt = window.frames[0].performance.getEntriesByType("navigation")[0];
+                    document.getElementById("frameContext").remove();
+                    assert_equals(pnt.type, "navigate");
+                });
+            }
+        </script>
+    </head>
+    <body>
+        <h1>
+            Description</h1>
+        <p>
+            This test validates that PerformanceNavigationTiming::type()'s defualt value is navigate </p>
+        <iframe id="frameContext" onload="onload_test();" src="resources/blank_page_yellow_with_onunload.html" style="width: 250px; height: 250px;"></iframe>
+    </body>
+</html>

--- a/navigation-timing/nav2_test_frame_removed.html
+++ b/navigation-timing/nav2_test_frame_removed.html
@@ -21,7 +21,7 @@
         <h1>
             Description</h1>
         <p>
-            This test validates that PerformanceNavigationTiming::type()'s defualt value is navigate </p>
+            This test validates that PerformanceNavigationTiming::type()'s default value is navigate </p>
         <iframe id="frameContext" onload="onload_test();" src="resources/blank_page_yellow_with_onunload.html" style="width: 250px; height: 250px;"></iframe>
     </body>
 </html>


### PR DESCRIPTION
Currently, PerformanceNavigationTiming holds on to a LocalFrame directly.
A DocumentLoader will be extracted at runtime from this LocalFrame. During the
lifetime of a LocalFrame, multiple documents can get loaded and get attached
to the same frame, which causes old PNT instance to reference DocumentLoader
that could be created for new cross-origin document. Therefore, instead of
holding on to a LocalFrame, PNT should hold on to a Document instead.

The change in this patch also fixes the crash reported by clusterfuzz, which
is dereferencing a null pointer when PerformanceNavigationTiming::type gets called
after a Document gets replaced which causes its associated DocumentLoader to be null.

BUG=704352, 703540

Review-Url: https://codereview.chromium.org/2774543003
Cr-Commit-Position: refs/heads/master@{#460198}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5254)
<!-- Reviewable:end -->
