### PR TITLE
Upstream service worker `controller` tests to WPT


### DIFF
--- a/service-workers/service-worker/controller-on-load.https.html
+++ b/service-workers/service-worker/controller-on-load.https.html
@@ -18,7 +18,7 @@ t.step(function() {
           return wait_for_state(t, registration.installing, 'activated');
         }))
       .then(t.step_func(function() {
-          return with_iframe(scope)
+          return with_iframe(scope);
         }))
       .then(t.step_func(function(f) {
           frame = f;


### PR DESCRIPTION
The Web Platform Tests project includes equivalent versions of these
tests. Those copies have since been extended with additional assertions,
rendering the Chromium versions obsolve.

Remove the Chromium tests in favor of the more rigorous WPT versions.
Correct a small formatting error introduced by the extension to the WPT
tests.

BUG=688116
R=falken@chromium.org

Review-Url: https://codereview.chromium.org/2778223003
Cr-Commit-Position: refs/heads/master@{#460405}

