### PR TITLE
Add console timeline timelineEnd historical tests

### DIFF
--- a/console/console-timeline-timelineEnd-historical.any.js
+++ b/console/console-timeline-timelineEnd-historical.any.js
@@ -1,0 +1,9 @@
+"use strict";
+
+test(() => {
+  assert_equals(console.timeline, undefined, "console.timeline should be undefined");
+}, "'timeline' function should not exist on the console object");
+
+test(() => {
+  assert_equals(console.timelineEnd, undefined, "console.timelineEnd should be undefined");
+}, "'timelineEnd' function should not exist on the console object");


### PR DESCRIPTION
These tests ensure the non-existence of the console functions `timeline` and `timelineEnd`. They only exist in Firefox (no-op) and Chrome (committed to the removal of these functions).

Filed bug for FF removal: https://bugzilla.mozilla.org/show_bug.cgi?id=1351795