### PR TITLE
Test that source closing doesn't shut down the pipe too early

### DIFF
--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -424,4 +424,37 @@ promise_test(() => {
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes');
 
+promise_test(() => {
+
+  const rs = recordingReadableStream();
+
+  let resolveWritePromise;
+  const ws = recordingWritableStream({
+    write() {
+      return new Promise(resolve => {
+        resolveWritePromise = resolve;
+      });
+    }
+  });
+
+  let pipeComplete = false;
+  const pipePromise = rs.pipeTo(ws, { preventClose: true }).then(() => {
+    pipeComplete = true;
+  });
+
+  rs.controller.enqueue('a');
+  rs.controller.close();
+
+  // Flush async events and verify that no shutdown occurs.
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(ws.events, ['write', 'a']); // no 'close'
+    assert_equals(pipeComplete, false, 'the pipe must not be complete');
+
+    resolveWritePromise();
+
+    return pipePromise;
+  });
+
+}, 'Closing must be propagated forward: shutdown must not occur until the final write completes; preventClose = true');
+
 done();

--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -447,7 +447,8 @@ promise_test(() => {
 
   // Flush async events and verify that no shutdown occurs.
   return flushAsyncEvents().then(() => {
-    assert_array_equals(ws.events, ['write', 'a']); // no 'close'
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the chunk must have been written, but close must not have happened yet');
     assert_equals(pipeComplete, false, 'the pipe must not be complete');
 
     resolveWritePromise();

--- a/streams/piping/multiple-propagation.js
+++ b/streams/piping/multiple-propagation.js
@@ -71,20 +71,23 @@ promise_test(t => {
   });
   const ws = recordingWritableStream();
   const writer = ws.getWriter();
-  writer.close();
+  const closePromise = writer.close();
   writer.releaseLock();
 
   return promise_rejects(t, error1, rs.pipeTo(ws), 'pipeTo must reject with the readable stream\'s error').then(() => {
     assert_array_equals(rs.events, []);
-    assert_array_equals(ws.events, ['close']);
+    assert_array_equals(ws.events, ['abort', error1]);
 
     return Promise.all([
       promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1'),
-      ws.getWriter().closed
+      promise_rejects(t, new TypeError(), ws.getWriter().closed,
+        'closed must reject with a TypeError indicating the writable stream was aborted'),
+      promise_rejects(t, new TypeError(), closePromise,
+        'close() must reject with a TypeError indicating the writable stream was aborted'),
     ]);
   });
 
-}, 'Piping from an errored readable stream to a closed writable stream');
+}, 'Piping from an errored readable stream to a closing writable stream');
 
 promise_test(t => {
   const rs = recordingReadableStream({


### PR DESCRIPTION
In particular, data that was read should not be thrown away, but instead should be written. See https://github.com/whatwg/streams/issues/644.

<del>Spec is not yet aligned. Uploading this for reference for now.</del> <ins>Spec PR: https://github.com/whatwg/streams/pull/726</ins>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5270)
<!-- Reviewable:end -->
