### PR TITLE
[selectors4] Add one more test for :focus-within and Shadow DOM

### DIFF
--- a/css/selectors4/focus-within-shadow-006.html
+++ b/css/selectors4/focus-within-shadow-006.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors Level 4: focus-within with shadow DOM</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
+<link rel="help" href="https://dom.spec.whatwg.org/#shadow-trees">
+<link rel="match" href="focus-within-shadow-001-ref.html">
+<meta name="flags" content="interact dom">
+<meta name="assert" content="Checks that ':focus-within' is propagated to the flat tree ancestors, even if it comes from a slotted element.">
+<style>
+  /* Suppress things that cannot be reproduced in the reference file */
+  :focus {
+    outline: none;
+  }
+  :focus-within {
+      border-color: green;
+  }
+</style>
+<p>Test passes if there is a green rectangle below.</p>
+
+<div id="log"></div>
+<script>
+  if (!document.body.attachShadow)
+    document.getElementById("log").innerHTML = "<strong>Skip this test, shadow DOM is not supported.</strong>";
+</script>
+
+<div id="shadow-host">
+  <div id="focusme" tabindex="1"></div>
+</div>
+
+<script>
+  var shadowHost = document.getElementById("shadow-host");
+  shadowHost.attachShadow({ mode: "open"}).innerHTML =
+    "<style>" +
+    "  #shadow-div:focus-within { border: solid 15px green; }" +
+    "</style>" +
+    "<div id='shadow-div'>" +
+    "  <slot></slot>" +
+    "</div>";
+  var focusme = document.getElementById("focusme");
+  focusme.focus();
+</script>

--- a/css/selectors4/focus-within-shadow-006.html
+++ b/css/selectors4/focus-within-shadow-006.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <title>Selectors Level 4: focus-within with shadow DOM</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
 <link rel="help" href="https://dom.spec.whatwg.org/#shadow-trees">
 <link rel="match" href="focus-within-shadow-001-ref.html">
-<meta name="flags" content="interact dom">
+<meta name="flags" content="dom">
 <meta name="assert" content="Checks that ':focus-within' is propagated to the flat tree ancestors, even if it comes from a slotted element.">
 <style>
   /* Suppress things that cannot be reproduced in the reference file */
@@ -39,4 +40,6 @@
     "</div>";
   var focusme = document.getElementById("focusme");
   focusme.focus();
+  document.documentElement.classList.remove("reftest-wait");
 </script>
+</html>


### PR DESCRIPTION
This test is similar to the example in w3c/csswg-drafts#1135.
It checks that when the slotted element is focused,
`:focus-within` pseudo-class affects to the ancestors in the flat tree.

Please @TakayoshiKochi could you take a look to this test? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5271)
<!-- Reviewable:end -->
