### PR TITLE
test that LF is allowed in the title attribute and the textarea element

### DIFF
--- a/html/dom/elements/global-attributes/the-title-attribute-lf.html
+++ b/html/dom/elements/global-attributes/the-title-attribute-lf.html
@@ -6,13 +6,18 @@
 <script src="/resources/testharnessreport.js"></script>
 <body>
   <h1>the title attribute allows "LF" characters</h1>
-  <div id="title_lf" title='Blah, blah blah etc. &#x000A;title breaks for LF'>Blah, blah blah etc. <br>title breaks for LF.</div>
+  
+  <div id="title_lf" title='Blah, blah blah etc. &#x000A;title splits into 2 lines for LF'>Blah, blah blah etc. <br>title splits into 2 lines for LF.</div>
+  <div id="title_lf_twice" title='Blah, blah blah etc. &#x000A;&#x000A;title splits into 3 lines for LFLF.'>Blah, blah blah etc. <br><br>title splits into 3 lines for LFLF.</div>
 
   <script type="text/javascript">
     var elementLF = document.getElementById('title_lf');
+    var elementLFTwice = document.getElementById('title_lf_twice');
+
     test(function() {
       assert_equals(elementLF.title, 'Blah, blah blah etc. \ntitle breaks for LF', 'title allows "LF" characters');
+
+      assert_equals(elementLFTwice.title, 'Blah, blah blah etc. \n\ntitle breaks for LF', 'title allows "LF" characters and split into multiple lines.');
     }, 'the title attribute allows "LF" characters, please manually check if the tooltip is properly rendered');
   </script>
 </body>
-

--- a/html/dom/elements/global-attributes/the-title-attribute-lf.html
+++ b/html/dom/elements/global-attributes/the-title-attribute-lf.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>the title attribute - allows "LF"</title>
+<link rel="help" href="http://w3c.github.io/html/dom.html#the-title-attribute">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <h1>the title attribute allows "LF" characters</h1>
+  <div id="title_lf" title='Blah, blah blah etc. &#x000A;title breaks for LF'>Blah, blah blah etc. <br>title breaks for LF.</div>
+
+  <script type="text/javascript">
+    var elementLF = document.getElementById('title_lf');
+    test(function() {
+      assert_equals(elementLF.title, 'Blah, blah blah etc. \ntitle breaks for LF', 'title allows "LF" characters');
+    }, 'the title attribute of textarea allows "LF" characters, please manually check if the tooltip is properly rendered');
+  </script>
+</body>
+

--- a/html/dom/elements/global-attributes/the-title-attribute-lf.html
+++ b/html/dom/elements/global-attributes/the-title-attribute-lf.html
@@ -12,7 +12,7 @@
     var elementLF = document.getElementById('title_lf');
     test(function() {
       assert_equals(elementLF.title, 'Blah, blah blah etc. \ntitle breaks for LF', 'title allows "LF" characters');
-    }, 'the title attribute of textarea allows "LF" characters, please manually check if the tooltip is properly rendered');
+    }, 'the title attribute allows "LF" characters, please manually check if the tooltip is properly rendered');
   </script>
 </body>
 

--- a/html/semantics/forms/the-textarea-element/textarea-lf.html
+++ b/html/semantics/forms/the-textarea-element/textarea-lf.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>the textarea element - allow "LF" or "CR"</title>
+<link rel="help" href="http://w3c.github.io/html/sec-forms.html#the-textarea-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+  <h1>the textarea element allows "LF" or "CR" characters</h1>
+  <textarea placeholder='Blah, blah blah etc. &#x000A;placeholder breaks for LF' cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_lf_placeholder"></textarea>
+  <textarea placeholder='Blah, blah blah etc. &#x000D;placeholder breaks for CR' cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_cr_placeholder"></textarea>
+  <textarea placeholder='Blah, blah blah etc. &#x000D;&#x000A;placeholder breaks for CRLF' cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_crlf_placeholder"></textarea>
+  
+  <textarea cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_lf_value"></textarea>
+  <textarea cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_cr_value"></textarea>
+  <textarea cols='80' name='lf_test' maxlength='200' rows=5 id="textarea_crlf_value"></textarea>
+
+  <script type="text/javascript">
+    var elementLFPlaceholder = document.getElementById('textarea_lf_placeholder');
+    var elementCRPlaceholder = document.getElementById('textarea_cr_placeholder');
+    var elementCRLFPlaceholder = document.getElementById('textarea_crlf_placeholder');
+
+    var elementLFValue = document.getElementById('textarea_lf_value');
+    var elementCRValue = document.getElementById('textarea_cr_value');
+    var elementCRLFValue = document.getElementById('textarea_crlf_value');
+
+    elementLFValue.value = 'Blah, blah blah etc. \nplaceholder breaks for LF';
+    elementCRValue.value = 'Blah, blah blah etc. \rplaceholder breaks for CR';
+    elementCRLFValue.value = 'Blah, blah blah etc. \r\nplaceholder breaks for CRLF';
+    
+    test(function() {
+      assert_equals(elementLFPlaceholder.placeholder, 'Blah, blah blah etc. \nplaceholder breaks for LF', 'placeholder allows "LF" characters');
+
+      assert_equals(elementCRPlaceholder.placeholder, 'Blah, blah blah etc. \rplaceholder breaks for CR', 'placeholder allows "CR" characters');
+
+      assert_equals(elementCRLFPlaceholder.placeholder, 'Blah, blah blah etc. \r\nplaceholder breaks for CRLF', 'placeholder allows "CRLF" characters');
+    }, 'the placeholder attribute of textarea allows "CR" "LF" characters, please manually check if they are properly rendered');
+    test(function() {
+      assert_equals(elementLFValue.value, 'Blah, blah blah etc. \nplaceholder breaks for LF', 'placeholder allows "LF" characters');
+
+      assert_equals(elementCRValue.value, 'Blah, blah blah etc. \nplaceholder breaks for CR', 'placeholder allows "CR" characters');
+
+      assert_equals(elementCRLFValue.value, 'Blah, blah blah etc. \nplaceholder breaks for CRLF', 'placeholder allows "CRLF" characters');
+    }, 'the value attribute of textarea allows "CR" "LF" characters, please manually check if they are properly rendered');
+  </script>
+</body>
+

--- a/html/semantics/forms/the-textarea-element/textarea-lf.html
+++ b/html/semantics/forms/the-textarea-element/textarea-lf.html
@@ -43,4 +43,3 @@
     }, 'the value attribute of textarea allows "CR" "LF" characters, please manually check if they are properly rendered');
   </script>
 </body>
-


### PR DESCRIPTION
These tests validate that:

> If the title attribute’s value contains LF characters, the content is split into multiple lines.

-- LF is allowed, properly rendered in Blink, Webkit and Gecko;

> LF, CR in the API value attribute of the textarea element should be converted to LF and break the line.

-- LF CR is allowed, properly rendered in Blink, Webkit and Gecko;

> in the placeholder attribute value of the textarea element, CR LF character pairs (CRLF) in the hint, as well as all other CR and LF characters in the hint, must be treated as line breaks;

-- LF CR is allowed, properly rendered in Blink,  no line breaks in Webkit and Gecko;

<!-- Reviewable:start -->

<!-- Reviewable:end -->
