### PR TITLE
[Reland #1] Don't create layout objects for children of display-none iframes.


### DIFF
--- a/html/resources/common.js
+++ b/html/resources/common.js
@@ -61,7 +61,6 @@ function newIFrame(context, src) {
     }
 
     var iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
 
     if (typeof (src) != 'undefined') {
         iframe.src = src;


### PR DESCRIPTION
The initial CL leaked DOM objects by calling
documentElement()->lazyReattachIfAttached() during Document::shutdown(). This
reland advances m_lifecycle to DocumentLifecycle::Stopping slightly earlier in
Document::shutdown(), and then only triggers
documentElement()->lazyReattachIfAttached() if the state is earlier than
DocumentLifecycle::Stopping.

Partial stack of the DOM leak:
  ...
  documentElement()->lazyReattachIfAttached();
  blink::Document::willChangeFrameOwnerProperties()\n
  blink::HTMLFrameOwnerElement::setWidget()\n
  blink::FrameView::dispose()\n
  blink::Document::shutdown()\n
  blink::FrameLoader::prepareForCommit()\n
  blink::FrameLoader::commitProvisionalLoad()\n
  blink::DocumentLoader::commitIfReady()\n
  blink::DocumentLoader::processData()

> Most of this CL is plumbing for FrameOwnerProperties. Interesting changes:
>   * LayoutView can no longer have children if its FrameOwner is "DisplayNone".
>   * A local frame is "DisplayNone" if and only if it has no widget [which should
>     correspond to the actual display:none style].
>   * The DisplayNone property is propagated to remote frames via
>     FrameOwnerProperties.
>
> Spec discussion: https://github.com/whatwg/html/issues/1813

BUG=650433

Review-Url: https://codereview.chromium.org/2743053003
Cr-Commit-Position: refs/heads/master@{#460646}

