### PR TITLE
Add tests for "Get Title" command

### DIFF
--- a/webdriver/conftest.py
+++ b/webdriver/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 from support.fixtures import (
-    configuration, create_frame, create_window, http, new_session, server_config, session,
-    url)
+    configuration, create_dialog, create_frame, create_window, http,
+    new_session, server_config, session, url)
 
 pytest.fixture(scope="session")(configuration)
+pytest.fixture()(create_dialog)
 pytest.fixture()(create_frame)
 pytest.fixture()(create_window)
 pytest.fixture()(http)

--- a/webdriver/get_title.py
+++ b/webdriver/get_title.py
@@ -1,0 +1,282 @@
+import pytest
+import time
+
+from support.asserts import assert_error, assert_success, assert_dialog_handled
+from support.fixtures import create_dialog
+from support.inline import inline
+
+def read_global(session, name):
+    return session.execute_script("return %s;" % name)
+
+# 1. If the current top-level browsing context is no longer open, return error
+#    with error code no such window.
+def test_title_from_closed_context(session, create_window):
+    new_window = create_window()
+    session.window_handle = new_window
+    session.close()
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_error(result, "no such window")
+
+# [...]
+# 2. Handle any user prompts and return its value if it is an error.
+# [...]
+# In order to handle any user prompts a remote end must take the following
+# steps:
+# 2. Run the substeps of the first matching user prompt handler:
+#
+#    [...]
+#    - dismiss state
+#      1. Dismiss the current user prompt.
+#    [...]
+#
+# 3. Return success.
+def test_title_handle_prompt_dismiss(new_session):
+    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}})
+    session.url = inline("<title>WD doc title</title>")
+
+    expected_title = read_global(session, "document.title")
+    create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "dismiss #1")
+    assert read_global(session, "dismiss1") == None
+
+    expected_title = read_global(session, "document.title")
+    create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "dismiss #2")
+    assert read_global(session, "dismiss2") == None
+
+    expected_title = read_global(session, "document.title")
+    create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "dismiss #3")
+    assert read_global(session, "dismiss3") == None
+
+# [...]
+# 2. Handle any user prompts and return its value if it is an error.
+# [...]
+# In order to handle any user prompts a remote end must take the following
+# steps:
+# 2. Run the substeps of the first matching user prompt handler:
+#
+#    [...]
+#    - accept state
+#      1. Accept the current user prompt.
+#    [...]
+#
+# 3. Return success.
+def test_title_handle_prompt_accept(new_session):
+    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    session.url = inline("<title>WD doc title</title>")
+    create_dialog(session)("alert", text="accept #1", result_var="accept1")
+
+    expected_title = read_global(session, "document.title")
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "accept #1")
+    assert read_global(session, "accept1") == None
+
+    expected_title = read_global(session, "document.title")
+    create_dialog(session)("confirm", text="accept #2", result_var="accept2")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "accept #2")
+    assert read_global(session, "accept2"), True
+
+    expected_title = read_global(session, "document.title")
+    create_dialog(session)("prompt", text="accept #3", result_var="accept3")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, expected_title)
+    assert_dialog_handled(session, "accept #3")
+    assert read_global(session, "accept3") == ""
+
+# [...]
+# 2. Handle any user prompts and return its value if it is an error.
+# [...]
+# In order to handle any user prompts a remote end must take the following
+# steps:
+# 2. Run the substeps of the first matching user prompt handler:
+#
+#    [...]
+#    - missing value default state
+#    - not in the table of simple dialogs
+#      1. Dismiss the current user prompt.
+#      2. Return error with error code unexpected alert open.
+def test_title_handle_prompt_missing_value(session, create_dialog):
+    session.url = inline("<title>WD doc title</title>")
+    create_dialog("alert", text="dismiss #1", result_var="dismiss1")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_error(result, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #1")
+    assert read_global(session, "accept1") == None
+
+    create_dialog("confirm", text="dismiss #2", result_var="dismiss2")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_error(result, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #2")
+    assert read_global(session, "dismiss2") == False
+
+    create_dialog("prompt", text="dismiss #3", result_var="dismiss3")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_error(result, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #3")
+    assert read_global(session, "dismiss3") == None
+
+# The behavior of the `window.print` function is platform-dependent and may not
+# trigger the creation of a dialog at all. Therefore, this test should only be
+# run in contexts that support the dialog (a condition that may not be
+# determined automatically).
+#def test_title_with_non_simple_dialog(session):
+#    document = "<title>With non-simple dialog</title><h2>Hello</h2>"
+#    spawn = """
+#        var done = arguments[0];
+#        setTimeout(function() {
+#            done();
+#        }, 0);
+#        setTimeout(function() {
+#            window.print();
+#        }, 0);
+#    """
+#    session.url = inline(document)
+#    session.execute_async_script(spawn)
+#
+#    result = session.transport.send("GET",
+#                                    "session/%s/title" % session.session_id)
+#    assert_error(result, "unexpected alert open")
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+# [...]
+# The title attribute must, on getting, run the following algorithm:
+# [...]
+# 2. Otherwise, let value be the child text content of the title element [...]
+# [...]
+# 4. Return value.
+def test_title_from_top_context(session):
+    session.url = inline("<title>Foobar</title><h2>Hello</h2>")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+    assert_success(result, read_global(session, "document.title"))
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+# [...]
+# The title attribute must, on getting, run the following algorithm:
+# [...]
+# 2. Otherwise, let value be the child text content of the title element [...]
+#
+#    The title element of a document is the first title element in the document
+#    (in tree order), if there is one, or null otherwise.
+#
+# [...]
+# 4. Return value.
+def test_title_with_duplicate_element(session):
+    session.url = inline("<title>First</title><title>Second</title>")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, read_global(session, "document.title"))
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+# [...]
+# The title attribute must, on getting, run the following algorithm:
+# [...]
+# 2. Otherwise, let value be the child text content of the title element, or
+#    the empty string if the title element is null.
+# [...]
+# 4. Return value.
+def test_title_without_element(session):
+    session.url = inline("<h2>Hello</h2>")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, read_global(session, "document.title"))
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+def test_title_after_modification(session):
+    session.url = inline("<title>Initial</title><h2>Hello</h2>")
+    session.execute_script("document.title = 'updated'")
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, read_global(session, "document.title"))
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+# [...]
+# The title attribute must, on getting, run the following algorithm:
+# [...]
+# 2. Otherwise, let value be the child text content of the title element [...]
+# 3. Strip and collapse ASCII whitespace in value.
+# 4. Return value.
+def test_title_strip_and_collapse(session):
+    document = "<title>   a b\tc\nd\t \n e\t\n </title><h2>Hello</h2>"
+    session.url = inline(document)
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, read_global(session, "document.title"))
+
+# [...]
+# 3. Let title be the initial value of the title IDL attribute of the current
+#    top-level browsing context's active document.
+# 4. Return success with data title.
+def test_title_from_frame(session, create_frame):
+    session.url = inline("<title>Parent</title>parent")
+
+    session.switch_frame(create_frame())
+    session.switch_frame(create_frame())
+
+    result = session.transport.send("GET",
+                                    "session/%s/title" % session.session_id)
+
+    assert_success(result, read_global(session, "document.title"))

--- a/webdriver/get_title.py
+++ b/webdriver/get_title.py
@@ -166,7 +166,7 @@ def test_title_handle_prompt_missing_value(session, create_dialog):
 #            done();
 #        }, 0);
 #        setTimeout(function() {
-#            window.print();
+#            window['print']();
 #        }, 0);
 #    """
 #    session.url = inline(document)

--- a/webdriver/support/asserts.py
+++ b/webdriver/support/asserts.py
@@ -75,3 +75,18 @@ def assert_success(response, value):
 
     assert response.status == 200
     assert response.body["value"] == value
+
+def assert_dialog_handled(session, expected_text):
+    result = session.transport.send("GET",
+                                    "session/%s/alert/text" % session.session_id)
+
+    # If there were any existing dialogs prior to the creation of this
+    # fixture's dialog, then the "Get Alert Text" command will return
+    # successfully. In that case, the text must be different than that
+    # of this fixture's dialog.
+    try:
+        assert_error(result, "no such alert")
+    except:
+        assert (result.status == 200 and
+                result.body["value"] != expected_text), (
+               "Dialog with text '%s' was not handled." % expected_text)

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -1,9 +1,11 @@
 import json
 import os
 import urlparse
+import re
 
 import webdriver
 
+from support.asserts import assert_error
 from support.http_request import HTTPRequest
 from support import merge_dictionaries
 
@@ -40,7 +42,7 @@ def _restore_windows(session):
 
     for window in _windows(session, exclude=[current_window]):
         session.window_handle = window
-        if len(session.window_handles) > 1:
+        if len(session.handles) > 1:
             session.close()
 
     session.window_handle = current_window
@@ -181,3 +183,40 @@ def url(server_config):
                                   fragment))
         return rv
     return inner
+
+def create_dialog(session):
+    """Create a dialog (one of "alert", "prompt", or "confirm") and provide a
+    function to validate that the dialog has been "handled" (either accepted or
+    dismissed) by returning some value."""
+
+    def create_dialog(dialog_type, text=None, result_var=None):
+        assert dialog_type in ("alert", "confirm", "prompt"), (
+               "Invalid dialog type: '%s'" % dialog_type)
+
+        if text is None:
+            text = ""
+
+        assert isinstance(text, basestring), "`text` parameter must be a string"
+
+        if result_var is None:
+            result_var = "__WEBDRIVER"
+
+        assert re.search(r"^[_$a-z$][_$a-z0-9]*$", result_var, re.IGNORECASE), (
+            'The `result_var` must be a valid JavaScript identifier')
+
+        # Script completion and modal summoning are scheduled on two separate
+        # turns of the event loop to ensure that both occur regardless of how
+        # the user agent manages script execution.
+        spawn = """
+            var done = arguments[0];
+            setTimeout(done, 0);
+            setTimeout(function() {{
+                window.{0} = window.{1}("{2}");
+            }}, 0);
+        """.format(result_var, dialog_type, text)
+
+        session.send_session_command("POST",
+                                     "execute/async",
+                                     {"script": spawn, "args": []})
+
+    return create_dialog


### PR DESCRIPTION
@andreastt this is not yet ready for `master` because it relies on behavior in
`wdclient` that is both undocumented and non-spec-compliant.  Specifically: the
setting of the `unhandledPromptBehavior` capability. Although I've been
validating my work using geckodriver and Firefox exclusively, support for the
new capabilities format has only just landed and is not yet released.  That
makes the tests concerning `unhandledPromptBehavior` especially prone to
programming error on my part.

Still, I thought it would be good to submit my work now that I have rebased it
on top of gh-4756. This will let us start talking about it earlier and
hopefully result in a smoother review process over all.

If I'm reading the `wdclient` source code and the specification correctly, the
current format is:

```json
{
  "requiredCapabilities": {},
  "desiredCapabilities": {}
}
```

Where the new format is:

```json
{
  "capabilities": {
    "alwaysMatch": {},
    "firstMatch": {}
  }
}
```

I'm not sure how you would like to handle this, but I have a suggestion. How
about we update the "create session" logic to use the new "capabilities" format
and then extend the `Session#start` method to accept capabilities as an
optional parameter?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
