### PR TITLE
Tests for scaled content with masks and mask-type property

### DIFF
--- a/css/css-masking/mask-svg-content/mask-negative-scale.svg
+++ b/css/css-masking/mask-svg-content/mask-negative-scale.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+	 xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="testmeta">
+	<title>CSS Masking: &lt;mask> with negative scale target</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
+	<html:link rel="match" href="reference/mask-negative-scale-001-ref.svg"/>
+	<metadata class="flags">svg</metadata>
+	<desc class="assert">The masked target elements get scaled with negative
+	factors. Check if that influences masking. You should see 4 green
+	rectangles with smaller blue rectangles in it in various rotations.</desc>
+</g>
+<defs>
+<g id="img" transform="translate(10,10)">
+	<rect width="200" height="200" fill="red"/>
+	<rect width="100" height="100" fill="green"/>
+	<rect width="50" height="50" fill="blue"/>
+</g>
+</defs>
+
+<mask id="mask">
+	<rect x="10" y="10" width="90" height="90" fill="white"/>
+</mask>
+
+<g transform="translate(200, 200)">
+<g transform="matrix(1 0 0 1 -100 -100)" mask="url(#mask)">
+	<use xlink:href="#img"/>
+</g>
+<g transform="matrix(-1 0 0 -1 -100 -100)" mask="url(#mask)">
+	<use xlink:href="#img"/>
+</g>
+<g transform="matrix(-1 0 0 1 -100 -100)" mask="url(#mask)">
+	<use xlink:href="#img"/>
+</g>
+<g transform="matrix(1 0 0 -1 -100 -100)" mask="url(#mask)">
+	<use xlink:href="#img"/>
+</g>
+</g>
+</svg>

--- a/css/css-masking/mask-svg-content/mask-negative-scale.svg
+++ b/css/css-masking/mask-svg-content/mask-negative-scale.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
 	 xmlns:xlink="http://www.w3.org/1999/xlink">
 <g id="testmeta">
-	<title>CSS Masking: &lt;mask> with negative scale target</title>
+	<title>CSS Masking: mask with negative scale target</title>
 	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>

--- a/css/css-masking/mask-svg-content/mask-text-001.svg
+++ b/css/css-masking/mask-svg-content/mask-text-001.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+	 xmlns:xlink="http://www.w3.org/1999/xlink" width="100px" height="100px">
+<g id="testmeta">
+	<title>CSS Masking: mask with transformed text content</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
+	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<metadata class="flags">svg</metadata>
+	<desc class="assert">The masked target elements get scaled with negative
+	factors. Check if that influences masking. You should see 4 green
+	rectangles with smaller blue rectangles in it in various rotations.</desc>
+</g>
+<mask id="mask">
+	<text fill="#fff" font-family="Ahem" font-size="12px" transform="rotate(90 50 50)" x="50%" y="50%">foobar</text>
+</mask>
+<rect width="100%" height="100%" x="0" y="0" mask="url(#mask)"/>
+</svg>

--- a/css/css-masking/mask-svg-content/mask-type-001.svg
+++ b/css/css-masking/mask-svg-content/mask-type-001.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: mask without mask-type alpha</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
+	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<metadata class="flags">svg</metadata>
+	<desc class="assert">The mask type "alpha" is applied to the mask element.
+	The mask should take the alpha channel of the content to mask. You should
+	see a green square.</desc>
+</g>
+<mask id="mask" mask-type="alpha">
+	<rect width="200" height="200" fill="black" opacity="0"/>
+	<rect x="50" y="50" width="100" height="100" fill="black"/>
+</mask>
+<rect width="200" height="200" fill="green" mask="url(#mask)"/>
+</svg>

--- a/css/css-masking/mask-svg-content/mask-type-001.svg
+++ b/css/css-masking/mask-svg-content/mask-type-001.svg
@@ -5,7 +5,7 @@
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
-	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<html:link rel="match" href="reference/mask-green-square-001-ref.svg"/>
 	<metadata class="flags">svg</metadata>
 	<desc class="assert">The mask type "alpha" is applied to the mask element.
 	The mask should take the alpha channel of the content to mask. You should

--- a/css/css-masking/mask-svg-content/mask-type-002.svg
+++ b/css/css-masking/mask-svg-content/mask-type-002.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: mask without mask-type luminance</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
+	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<metadata class="flags">svg</metadata>
+	<desc class="assert">The mask type "alpha" is applied to the mask element.
+	The mask should take the luminocity of the content to mask. You should
+	see a green square.</desc>
+</g>
+<mask id="mask" mask-type="luminance">
+	<rect width="200" height="200" fill="black"/>
+	<rect x="50" y="50" width="100" height="100" fill="white"/>
+</mask>
+<rect width="200" height="200" fill="green" mask="url(#mask)"/>
+</svg>

--- a/css/css-masking/mask-svg-content/mask-type-002.svg
+++ b/css/css-masking/mask-svg-content/mask-type-002.svg
@@ -5,7 +5,7 @@
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
-	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<html:link rel="match" href="reference/mask-green-square-001-ref.svg"/>
 	<metadata class="flags">svg</metadata>
 	<desc class="assert">The mask type "alpha" is applied to the mask element.
 	The mask should take the luminocity of the content to mask. You should

--- a/css/css-masking/mask-svg-content/mask-type-003.svg
+++ b/css/css-masking/mask-svg-content/mask-type-003.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: mask without specified mask-type</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
+	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
+	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<metadata class="flags">svg</metadata>
+	<desc class="assert">No mask type was specified the mask element should
+	take the luminocity of the content to mask. You should see a green square.
+	</desc>
+</g>
+<mask id="mask">
+	<rect width="200" height="200" fill="black"/>
+	<rect x="50" y="50" width="100" height="100" fill="white"/>
+</mask>
+<rect width="200" height="200" fill="green" mask="url(#mask)"/>
+</svg>

--- a/css/css-masking/mask-svg-content/mask-type-003.svg
+++ b/css/css-masking/mask-svg-content/mask-type-003.svg
@@ -5,7 +5,7 @@
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#svg-masks"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#MaskElement"/>
 	<html:link rel="help" href="http://www.w3.org/TR/css-masking-1/#the-mask-type"/>
-	<html:link rel="match" href="reference/mask-text-001-ref.svg"/>
+	<html:link rel="match" href="reference/mask-green-square-001-ref.svg"/>
 	<metadata class="flags">svg</metadata>
 	<desc class="assert">No mask type was specified the mask element should
 	take the luminocity of the content to mask. You should see a green square.

--- a/css/css-masking/mask-svg-content/reference/mask-green-square-001-ref.svg
+++ b/css/css-masking/mask-svg-content/reference/mask-green-square-001-ref.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: Reftest reference</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<metadata class="flags">svg</metadata>
+</g>
+<rect x="50" y="50" width="100" height="100" fill="green"/>
+</svg>

--- a/css/css-masking/mask-svg-content/reference/mask-negative-scale-001-ref.svg
+++ b/css/css-masking/mask-svg-content/reference/mask-negative-scale-001-ref.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: Reftest reference</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<metadata class="flags">svg</metadata>
+</g>
+<rect width="90" height="90" fill="green"/>
+<rect x="40" y="40" width="50" height="50" fill="blue"/>
+<rect x="110" width="90" height="90" fill="green"/>
+<rect x="110" y="40" width="50" height="50" fill="blue"/>
+<rect y="110" width="90" height="90" fill="green"/>
+<rect x="40" y="110" width="50" height="50" fill="blue"/>
+<rect x="110" y="110" width="90" height="90" fill="green"/>
+<rect x="110" y="110" width="50" height="50" fill="blue"/>
+</svg>

--- a/css/css-masking/mask-svg-content/reference/mask-text-001-ref.svg
+++ b/css/css-masking/mask-svg-content/reference/mask-text-001-ref.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+<g id="testmeta">
+	<title>CSS Masking: Reftest reference</title>
+	<html:link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com"/>
+	<metadata class="flags">svg</metadata>
+</g>
+<text fill="#000" font-family="Ahem" font-size="12px" transform="rotate(90 50 50)" x="50" y="50">foobar</text>
+</svg>


### PR DESCRIPTION


---

Originally posted as https://github.com/w3c/csswg-test/pull/619 by @dirkschulze on 22 Oct 2014, 07:13 UTC:

> <!-- Reviewable:start -->

<!-- Reviewable:end -->

