### PR TITLE
[css-text-3] White space pre wrap end of line

### DIFF
--- a/css/css-text-3/white-space/pre-wrap-001.html
+++ b/css/css-text-3/white-space/pre-wrap-001.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap is not wrapped</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-002.html
+++ b/css/css-text-3/white-space/pre-wrap-002.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:break-all</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is break-all">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-break: break-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-003.html
+++ b/css/css-text-3/white-space/pre-wrap-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:keep-all</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is keep-all.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-break: keep-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-004.html
+++ b/css/css-text-3/white-space/pre-wrap-004.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:loose</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is loose.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: loose;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-005.html
+++ b/css/css-text-3/white-space/pre-wrap-005.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:normal</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is normal.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: normal;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-006.html
+++ b/css/css-text-3/white-space/pre-wrap-006.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:strict</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is strict.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: strict;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-007.html
+++ b/css/css-text-3/white-space/pre-wrap-007.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on overflow-wrap:break-word</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if overflow-wrap is break-word.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-wrap: break-word; /* deprecated alias */
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX    XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-008.html
+++ b/css/css-text-3/white-space/pre-wrap-008.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap is wrapped when overflow-wrap is break-spaces</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  overflow-wrap: break-spaces;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div> XX  XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-009.html
+++ b/css/css-text-3/white-space/pre-wrap-009.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: single preserved white space at the end of with white-space:pre-wrap overflow-wrap:break-spaces</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="a single preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 2ch;
+  overflow-wrap: break-spaces;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-010.html
+++ b/css/css-text-3/white-space/pre-wrap-010.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: single preserved white space at the end of with white-space:pre-wrap overflow-wrap:break-spaces break-word</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="a single preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces break-word.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  overflow-wrap: break-spaces break-word;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div> XX XX</div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-011.html
+++ b/css/css-text-3/white-space/pre-wrap-011.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not cause wrapping</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="When the hite-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div> XX <!-- the space to the left of this comment is intentional-->
+ XX </div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-011.html
+++ b/css/css-text-3/white-space/pre-wrap-011.html
@@ -22,6 +22,6 @@ div {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div> XX <!-- the space to the left of this comment is intentional-->
+  <div> XX&#x20;
  XX </div>
 </body>

--- a/css/css-text-3/white-space/pre-wrap-011.html
+++ b/css/css-text-3/white-space/pre-wrap-011.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
 <link rel="match" href="reference/pre-wrap-001-ref.html">
-<meta name="assert" content="When the hite-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped.">
+<meta name="assert" content="When the white-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped.">
 <style>
 div {
   font-size: 20px;

--- a/css/css-text-3/white-space/pre-wrap-012.html
+++ b/css/css-text-3/white-space/pre-wrap-012.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with right alignement</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when right-aligning.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: right;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX <!--the space to the left of this comment is intentional-->
+XX </div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-012.html
+++ b/css/css-text-3/white-space/pre-wrap-012.html
@@ -21,6 +21,6 @@ div {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div>XX <!--the space to the left of this comment is intentional-->
+  <div>XX&#x20;
 XX </div>
 </body>

--- a/css/css-text-3/white-space/pre-wrap-013.html
+++ b/css/css-text-3/white-space/pre-wrap-013.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with center alignement</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when centering.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: center;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX <!--the space to the left of this comment is intentional-->
+XX </div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-013.html
+++ b/css/css-text-3/white-space/pre-wrap-013.html
@@ -21,6 +21,6 @@ div {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div>XX <!--the space to the left of this comment is intentional-->
+  <div>XX&#x20;
 XX </div>
 </body>

--- a/css/css-text-3/white-space/pre-wrap-014.html
+++ b/css/css-text-3/white-space/pre-wrap-014.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with justification</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/pre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when justifying.">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: justify;
+  text-justify: inter-character;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>X&#8203;X <!--the space to the left of this comment is intentional-->
+X&#8203;X </div>
+</body>

--- a/css/css-text-3/white-space/pre-wrap-014.html
+++ b/css/css-text-3/white-space/pre-wrap-014.html
@@ -22,6 +22,6 @@ div {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <div>X&#8203;X <!--the space to the left of this comment is intentional-->
+  <div>X&#8203;X&#x20;
 X&#8203;X </div>
 </body>

--- a/css/css-text-3/white-space/reference/pre-wrap-001-ref.html
+++ b/css/css-text-3/white-space/reference/pre-wrap-001-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test reference file</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  color: green;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <div>XX<br>XX</div>
+</body>

--- a/css/css-text-3/white-space/reference/textarea-pre-wrap-001-ref.html
+++ b/css/css-text-3/white-space/reference/textarea-pre-wrap-001-ref.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test reference file</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<!-- pre-wrap-001-ref.html could probably be used instead,
+but since textarea is a form control that's not fully specified,
+using a separate reference just in case something is indeed different
+is safer. -->
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  color: green;
+  white-space: pre;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX
+XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-001.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-001.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap is not wrapped in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap in a textarea">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-001.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-001.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap is not wrapped in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap in a textarea">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-002.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-002.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:break-all in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is break-all in a textarea">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-002.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-002.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:break-all in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is break-all in a textarea">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-break: break-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-003.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-003.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:keep-all in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is keep-all in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-003.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-003.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on word-break:keep-all in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if word-break is keep-all in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-break: keep-all;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-004.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-004.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:loose in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is loose in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: loose;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-004.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-004.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:loose in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is loose in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-005.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-005.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:normal in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is normal in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-005.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-005.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:normal in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is normal in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: normal;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-006.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-006.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:strict in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is strict in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  line-break: strict;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-006.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-006.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on line-break:strict in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if line-break is strict in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-007.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-007.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on overflow-wrap:break-word in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if overflow-wrap is break-word in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-007.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-007.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not change based on overflow-wrap:break-word in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap, even if overflow-wrap is break-word in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  word-wrap: break-word; /* deprecated alias */
+  overflow-wrap: break-word;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX    XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-008.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-008.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-008.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap is wrapped when overflow-wrap is break-spaces in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 4ch;
+  overflow-wrap: break-spaces;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea> XX  XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-009.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-009.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="a single preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-009.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-009.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: single preserved white space at the end of with white-space:pre-wrap overflow-wrap:break-spaces in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="a single preserved white space at the end of the line is not wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 2ch;
+  overflow-wrap: break-spaces;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-010.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-010.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="a single preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces break-word in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-010.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-010.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: single preserved white space at the end of with white-space:pre-wrap overflow-wrap:break-spaces break-word in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="a single preserved white space at the end of the line is wrapped when the white-space property is set to pre-wrap and overflow-wrap is break-spaces break-word in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  overflow-wrap: break-spaces break-word;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea> XX XX</textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-011.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-011.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="When the hite-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-011.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-011.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap does not cause wrapping in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="When the hite-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 1ch 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  margin-left: -1ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea> XX 
+ XX </textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-011.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-011.html
@@ -5,7 +5,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#overflow-wrap-property">
 <link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
-<meta name="assert" content="When the hite-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped in a textarea.">
+<meta name="assert" content="When the white-space property is set to pre-wrap, preserved white space at the end of the line must hang or be collapsed, and must not cause preceeding content to be wrapped in a textarea.">
 <style>
 textarea {
   word-wrap: initial; /*deprecated alias*/

--- a/css/css-text-3/white-space/textarea-pre-wrap-011.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-011.html
@@ -33,6 +33,6 @@ textarea {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <textarea> XX 
+  <textarea> XX&#x20;
  XX </textarea>
 </body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-012.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-012.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with right alignement in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when right-aligning in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: right;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX 
+XX </textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-012.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-012.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with right alignement in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when right-aligning in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-012.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-012.html
@@ -32,6 +32,6 @@ textarea {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <textarea>XX 
+  <textarea>XX&#x20;
 XX </textarea>
 </body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-013.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-013.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with center alignement in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when centering in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: center;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>XX 
+XX </textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-013.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-013.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with center alignement in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when centering in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-013.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-013.html
@@ -32,6 +32,6 @@ textarea {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <textarea>XX 
+  <textarea>XX&#x20;
 XX </textarea>
 </body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-014.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-014.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with justification in a textarea</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
+<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when justifying in a textarea.">
+<style>
+textarea {
+  word-wrap: initial; /*deprecated alias*/
+  overflow-wrap: initial;
+  line-break: initial;
+  word-break: initial;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  resize: none;
+  overflow: hidden; /* I don't want scrollbars, and overflow:visible isn't typically supported on textarea */
+
+  font-size: 20px;
+  font-family: ahem;
+  line-height: 1em;
+  white-space: pre-wrap;
+  color: green;
+
+  background: linear-gradient(red, red) 0 0/2ch 2ch no-repeat;
+
+  width: 3ch;
+  text-align: justify;
+  text-justify: inter-character;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
+  <textarea>X&#8203;X 
+X&#8203;X </textarea>
+</body>

--- a/css/css-text-3/white-space/textarea-pre-wrap-014.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-014.html
@@ -3,7 +3,7 @@
 <title>CSS Text level 3 Test: preserved white space at the end of and white-space:pre-wrap with justification in a textarea</title>
 <link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
 <link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-phase-2">
-<link rel="match" href="reference/textareapre-wrap-001-ref.html">
+<link rel="match" href="reference/textarea-pre-wrap-001-ref.html">
 <meta name="assert" content="When white-space is pre-wrap, only spaces that overflow the line get collapsed or hanged, the ones that fit have an effect when justifying in a textarea.">
 <style>
 textarea {

--- a/css/css-text-3/white-space/textarea-pre-wrap-014.html
+++ b/css/css-text-3/white-space/textarea-pre-wrap-014.html
@@ -33,6 +33,6 @@ textarea {
 </style>
 <body>
   <p>Test passes if there is a <strong>filled green square</strong> and <strong>no red</strong>.</p>
-  <textarea>X&#8203;X 
+  <textarea>X&#8203;X&#x20;
 X&#8203;X </textarea>
 </body>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -483,10 +483,6 @@ TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/css21/p
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-001-rtl-reverse.xhtml
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/moz-multicol3-column-balancing-break-inside-avoid-1.html
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/moz-multicol3-column-balancing-break-inside-avoid-1-ref.html
-TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-011.html
-TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-012.html
-TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-013.html
-TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-014.html
 
 SET TIMEOUT: css/compositing-1/mix-blend-mode/mix-blend-mode-parent-with-3D-transform-and-transition.html
 SET TIMEOUT: css/compositing-1/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform-and-transition.html

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -483,6 +483,10 @@ TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/css21/p
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-mbp-horiz-001-rtl-reverse.xhtml
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/moz-multicol3-column-balancing-break-inside-avoid-1.html
 TRAILING WHITESPACE: css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/moz-multicol3-column-balancing-break-inside-avoid-1-ref.html
+TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-011.html
+TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-012.html
+TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-013.html
+TRAILING WHITESPACE: css/css-text-3/white-space/textarea-pre-wrap-014.html
 
 SET TIMEOUT: css/compositing-1/mix-blend-mode/mix-blend-mode-parent-with-3D-transform-and-transition.html
 SET TIMEOUT: css/compositing-1/mix-blend-mode/mix-blend-mode-sibling-with-3D-transform-and-transition.html


### PR DESCRIPTION
Originally posted as https://github.com/w3c/csswg-test/pull/1137 by @frivoal on 17 Oct 2016, 13:14 UTC:

> Adding some tests to check preserved spaces at the end of the line when the white-space property is pre-wrap.
> 
> Checking that the property which is supposed to influence that properly does (overflow-wrap), as well as checking that those that shouldn't don't (since in some browsers, they currently do).
> 
> Also including the same tests based on a regular div and on a textarea, since by spec there should be no difference, but in some implementations there is.
> 
> <!-- Reviewable:start -->

<!-- Reviewable:end -->

