### PR TITLE
[css-logical-properties-1] Add test case margin{-block,-inline}

### DIFF
--- a/css/css-logical/logicalprops-margin-block.html
+++ b/css/css-logical/logicalprops-margin-block.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Logical Properties: margin-block{-start,end}</title>
+<link rel="author" title="Xu Xing" href="mailto:openxu@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-logical-props-1/#logical-prop">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#logical-to-physical">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/style-check.js"></script>
+
+<style>
+div {
+  border: 1px solid #000;
+}
+
+/*Horizontal-tb mode*/
+#div_htb {
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_htb {
+  margin-top: 100px;
+  margin-bottom: 80px;
+}
+
+#div_htb_override {
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+  margin-top: 110px;
+  margin-bottom: 90px;
+}
+#ref_div_htb_override {
+  margin-top: 110px;
+  margin-bottom: 90px;
+}
+
+#div_htb_override2 {
+  margin-top: 110px;
+  margin-bottom: 90px;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_htb_override2 {
+  margin-top: 100px;
+  margin-bottom: 80px;
+}
+
+/*Vertical-lr mode.*/
+#div_vlr {
+  writing-mode: vertical-lr;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_vlr {
+  writing-mode: vertical-lr;
+  margin-left: 100px;
+  margin-right: 80px;
+}
+
+#div_vlr_override {
+  writing-mode: vertical-lr;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+  margin-left: 110px;
+  margin-right: 90px;
+}
+#ref_div_vlr_override {
+  writing-mode: vertical-lr;
+  margin-left: 110px;
+  margin-right: 90px;
+}
+
+#div_vlr_override2 {
+  writing-mode: vertical-lr;
+  margin-left: 110px;
+  margin-right: 90px;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_vlr_override2 {
+  writing-mode: vertical-lr;
+  margin-left: 100px;
+  margin-right: 80px;
+}
+
+/*Vertical-rl mode.*/
+#div_vrl {
+  writing-mode: vertical-rl;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_vrl {
+  writing-mode: vertical-rl;
+  margin-right: 100px;
+  margin-left: 80px;
+}
+
+#div_vrl_override {
+  writing-mode: vertical-rl;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+  margin-right: 110px;
+  margin-left: 90px;
+
+}
+#ref_div_vrl_override {
+  writing-mode: vertical-rl;
+  margin-right: 110px;
+  margin-left: 90px;
+}
+
+#div_vrl_override2 {
+  writing-mode: vertical-rl;
+  margin-right: 110px;
+  margin-left: 90px;
+  margin-block-start: 100px;
+  margin-block-end: 80px;
+}
+#ref_div_vrl_override2 {
+  writing-mode: vertical-rl;
+  margin-right: 100px;
+  margin-left: 80px;
+}
+</style>
+
+<div id="div_htb"></div>
+<div id="ref_div_htb"></div>
+<div id="div_htb_override"></div>
+<div id="ref_div_htb_override"></div>
+<div id="div_htb_override2"></div>
+<div id="ref_div_htb_override2"></div>
+
+<div id="div_vlr"></div>
+<div id="ref_div_vlr"></div>
+<div id="div_vlr_override"></div>
+<div id="ref_div_vlr_override"></div>
+<div id="div_vlr_override2"></div>
+<div id="ref_div_vlr_override2"></div>
+
+<div id="div_vrl"></div>
+<div id="ref_div_vrl"></div>
+<div id="div_vrl_override"></div>
+<div id="ref_div_vrl_override"></div>
+<div id="div_vrl_override2"></div>
+<div id="ref_div_vrl_override2"></div>
+
+<script>
+test(function () {
+  assert_true(compareBlockMargin_htb("div_htb", "ref_div_htb"));
+  assert_true(compareBlockMargin_htb("div_htb_override", "ref_div_htb_override"));
+  assert_true(compareBlockMargin_htb("div_htb_override2", "ref_div_htb_override2"));
+
+  assert_true(compareBlockMargin_vertical("div_vlr", "ref_div_vlr"));
+  assert_true(compareBlockMargin_vertical("div_vlr_override", "ref_div_vlr_override"));
+  assert_true(compareBlockMargin_vertical("div_vlr_override2", "ref_div_vlr_override2"));
+
+  assert_true(compareBlockMargin_vertical("div_vrl", "ref_div_vrl"));
+  assert_true(compareBlockMargin_vertical("div_vrl_override", "ref_div_vrl_override"));
+  assert_true(compareBlockMargin_vertical("div_vrl_override2", "ref_div_vrl_override2"));
+}, "Check that margin-block{-start,end} in different writing mode");
+
+
+</script>

--- a/css/css-logical/logicalprops-margin-inline.html
+++ b/css/css-logical/logicalprops-margin-inline.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Logical Properties: margin-inline{-start,end}</title>
+<link rel="author" title="Xu Xing" href="mailto:openxu@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-logical-props-1/#logical-prop">
+<link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#logical-to-physical">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/style-check.js"></script>
+
+<style>
+div {
+  border: 1px solid #000;
+}
+
+/*Horizontal-tb mode*/
+#div_htb_ltr {
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_htb_ltr {
+  margin-left: 100px;
+  margin-right: 80px;
+}
+
+#div_htb_rtl {
+  direction: rtl;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_htb_rtl {
+  direction: rtl;
+  margin-right: 100px;
+  margin-left: 80px;
+}
+
+#div_htb_override {
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+  margin-left: 110px;
+  margin-right: 90px;
+}
+#ref_div_htb_override {
+  margin-left: 110px;
+  margin-right: 90px;
+}
+
+#div_htb_override2 {
+  margin-left: 110px;
+  margin-right: 90px;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_htb_override2 {
+  margin-left: 100px;
+  margin-right: 80px;
+}
+
+/*Vertical-lr mode, the same as vertical-rl mode. Direction is ltr*/
+#div_vlr_ltr {
+  writing-mode: vertical-lr;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_vlr_ltr {
+  writing-mode: vertical-lr;
+  margin-top: 100px;
+  margin-bottom: 80px;
+}
+
+#div_vlr_ltr_override {
+  writing-mode: vertical-lr;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+  margin-top: 110px;
+  margin-bottom: 90px;
+}
+#ref_div_vlr_ltr_override {
+  writing-mode: vertical-lr;
+  margin-top: 110px;
+  margin-bottom: 90px;
+}
+
+#div_vlr_ltr_override2 {
+  writing-mode: vertical-lr;
+  margin-top: 110px;
+  margin-bottom: 90px;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_vlr_ltr_override2 {
+  writing-mode: vertical-lr;
+  margin-top: 100px;
+  margin-bottom: 80px;
+}
+
+/*Vertical-lr mode, the same as vertical-rl mode. Direction is rtl*/
+#div_vlr_rtl {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_vlr_rtl {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-bottom: 100px;
+  margin-top: 80px;
+}
+
+#div_vlr_rtl_override {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+  margin-bottom: 110px;
+  margin-top: 90px;
+}
+#ref_div_vlr_rtl_override {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-bottom: 110px;
+  margin-top: 90px;
+}
+
+#div_vlr_rtl_override2 {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-bottom: 110px;
+  margin-top: 90px;
+  margin-inline-start: 100px;
+  margin-inline-end: 80px;
+}
+#ref_div_vlr_rtl_override2 {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  margin-bottom: 100px;
+  margin-top: 80px;
+}
+</style>
+
+<div id="div_htb_ltr"></div>
+<div id="ref_div_htb_ltr"></div>
+<div id="div_htb_rtl"></div>
+<div id="ref_div_htb_rtl"></div>
+<div id="div_htb_override"></div>
+<div id="ref_div_htb_override"></div>
+<div id="div_htb_override2"></div>
+<div id="ref_div_htb_override2"></div>
+
+<div id="div_vlr_ltr"></div>
+<div id="ref_div_vlr_ltr"></div>
+<div id="div_vlr_ltr_override">1</div>
+<div id="ref_div_vlr_ltr_override">1</div>
+<div id="div_vlr_ltr_override2"></div>
+<div id="ref_div_vlr_ltr_override2"></div>
+
+<div id="div_vlr_rtl"></div>
+<div id="ref_div_vlr_rtl"></div>
+<div id="div_vlr_rtl_override"></div>
+<div id="ref_div_vlr_rtl_override"></div>
+<div id="div_vlr_rtl_override2"></div>
+<div id="ref_div_vlr_rtl_override2"></div>
+
+<script>
+test(function () {
+  assert_true(compareInlineMargin_htb("div_htb_ltr", "ref_div_htb_ltr"));
+  assert_true(compareInlineMargin_htb("div_htb_rtl", "ref_div_htb_rtl"));
+  assert_true(compareInlineMargin_htb("div_htb_override", "ref_div_htb_override"));
+  assert_true(compareInlineMargin_htb("div_htb_override2", "ref_div_htb_override2"));
+
+  assert_true(compareInlineMargin_vertical("div_vlr_ltr", "ref_div_vlr_ltr"));
+  assert_true(compareInlineMargin_vertical("div_vlr_ltr_override", "ref_div_vlr_ltr_override"));
+  assert_true(compareInlineMargin_vertical("div_vlr_ltr_override2", "ref_div_vlr_ltr_override2"));
+
+  assert_true(compareInlineMargin_vertical("div_vlr_rtl", "ref_div_vlr_rtl"));
+  assert_true(compareInlineMargin_vertical("div_vlr_rtl_override", "ref_div_vlr_rtl_override"));
+  assert_true(compareInlineMargin_vertical("div_vlr_rtl_override2", "ref_div_vlr_rtl_override2"));
+}, "Check that margin-inline{-start,end} in different writing mode");
+</script>

--- a/css/css-logical/logicalprops-quirklength.html
+++ b/css/css-logical/logicalprops-quirklength.html
@@ -1,7 +1,8 @@
 <meta charset="utf-8">
-<title>CSS Logical Properties: {max-,min-}block-size</title>
+<title>CSS Logical Properties</title>
 <link rel="author" title="Xu Xing" href="mailto:openxu@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/css-logical-props-1/#logical-dimension-properties">
+<link rel="help" href="https://drafts.csswg.org/css-logical-props-1/#logical-prop">
 <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#logical-to-physical">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -23,7 +24,12 @@ var tests = [
   {cssText:"inline-size: 1"},
   {cssText:"min-inline-size: 1"},
   {cssText:"max-inline-size: 1"},
+  {cssText:"margin-block-start: 1"},
+  {cssText:"margin-block-end: 1"},
+  {cssText:"margin-inline-start: 1"},
+  {cssText:"margin-inline-end: 1"},
 ];
+
 tests.forEach(function(t) {
   test(() => assert_false(isValidDeclaration(t.cssText)), 'Check that "' + t.cssText + '" is not valid in quirks mode');
 });


### PR DESCRIPTION
Originally posted as https://github.com/w3c/csswg-test/pull/1170 by @axinging on 10 Jan 2017, 07:59 UTC:

> Spec is here: https://drafts.csswg.org/css-logical-props-1/#logical-prop.
> This depends on https://github.com/w3c/csswg-test/pull/1165.
> 
> <!-- Reviewable:start -->

<!-- Reviewable:end -->

