### PR TITLE
[css-variables-1] Test border-* shorthand serialization with variable reference in border

### DIFF
--- a/css/css-variables-1/vars-border-shorthand-serialize.html
+++ b/css/css-variables-1/vars-border-shorthand-serialize.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS Variables Test: Set border shorthand and serialize border-color</title>
+  <link rel="author" title="Kevin Babbitt" href="kbabbitt@microsoft.com">
+  <link rel="help" href="http://www.w3.org/TR/css-variables-1/#variables-in-shorthands">
+  <meta name="assert" content="Pending-substitution values must be serialized as the empty string, if an API allows them to be observed.">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="test" style="border: var(--borderwidth) solid black"></div>
+
+    <script type="text/javascript">
+        "use strict";
+
+        test(function() {
+            assert_equals(document.getElementById("test").style.getPropertyValue("border-color"), "");
+        }, "border-color should serialize to the empty string when border references a variable");
+    </script>
+</body>
+</html>
+

--- a/css/css-variables-1/vars-border-shorthand-serialize.html
+++ b/css/css-variables-1/vars-border-shorthand-serialize.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>CSS Variables Test: Set border shorthand and serialize border-color</title>
+    <title>CSS Variables Test: Set border shorthand and serialize border-*</title>
   <link rel="author" title="Kevin Babbitt" href="kbabbitt@microsoft.com">
   <link rel="help" href="http://www.w3.org/TR/css-variables-1/#variables-in-shorthands">
   <meta name="assert" content="Pending-substitution values must be serialized as the empty string, if an API allows them to be observed.">
@@ -9,7 +9,7 @@
   <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
-    <div id="test" style="border: var(--borderwidth) solid black"></div>
+    <div id="test" style="border: var(--border)"></div>
 
     <script type="text/javascript">
         "use strict";
@@ -17,6 +17,12 @@
         test(function() {
             assert_equals(document.getElementById("test").style.getPropertyValue("border-color"), "");
         }, "border-color should serialize to the empty string when border references a variable");
+        test(function() {
+            assert_equals(document.getElementById("test").style.getPropertyValue("border-style"), "");
+        }, "border-style should serialize to the empty string when border references a variable");
+        test(function() {
+            assert_equals(document.getElementById("test").style.getPropertyValue("border-width"), "");
+        }, "border-width should serialize to the empty string when border references a variable");
     </script>
 </body>
 </html>


### PR DESCRIPTION
Originally posted as https://github.com/w3c/csswg-test/pull/1197 by @kbabbitt on 01 Feb 2017, 22:44 UTC:

> Test for correct serialization of border-* shorthands when the border shorthand is set and has a variable reference.
> 
> <!-- Reviewable:start -->
> ---
> This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/csswg-test/1197)
> <!-- Reviewable:end -->

