### PR TITLE
Introduce `create_session` "fixture"

### DIFF
--- a/webdriver/conftest.py
+++ b/webdriver/conftest.py
@@ -1,12 +1,12 @@
 import pytest
 from support.fixtures import (
-    create_frame, create_window, http, server_config, session, create_session,
+    create_frame, create_session, create_window, http, server_config, session,
     url)
 
 pytest.fixture()(create_frame)
+pytest.fixture()(create_session)
 pytest.fixture()(create_window)
 pytest.fixture()(http)
 pytest.fixture()(server_config)
 pytest.fixture(scope="function")(session)
-pytest.fixture()(create_session)
 pytest.fixture()(url)

--- a/webdriver/conftest.py
+++ b/webdriver/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from support.fixtures import (
-    create_frame, create_window, http, server_config, session, session_session,
+    create_frame, create_window, http, server_config, session, create_session,
     url)
 
 pytest.fixture()(create_frame)
@@ -8,5 +8,5 @@ pytest.fixture()(create_window)
 pytest.fixture()(http)
 pytest.fixture()(server_config)
 pytest.fixture(scope="function")(session)
-pytest.fixture()(session_session)
+pytest.fixture()(create_session)
 pytest.fixture()(url)

--- a/webdriver/support/__init__.py
+++ b/webdriver/support/__init__.py
@@ -1,0 +1,1 @@
+from merge_dictionaries import merge_dictionaries

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -106,10 +106,10 @@ def create_session(request):
             test_capabilities = {}
         env_capabilities = json.loads(os.environ.get("WD_CAPABILITIES", "{}"))
 
-        always_match = merge_dictionaries(env_capabilities.get("always_match", {}),
-                                          test_capabilities.get("always_match", {}))
-        first_match = merge_dictionaries(env_capabilities.get("first_match", {}),
-                                         test_capabilities.get("first_match", {}))
+        always_match = merge_dictionaries(env_capabilities.get("alwaysMatch", {}),
+                                          test_capabilities.get("alwaysMatch", {}))
+        first_match = merge_dictionaries(env_capabilities.get("firstMatch", {}),
+                                         test_capabilities.get("firstMatch", {}))
         session = webdriver.Session(host, port, required_capabilities=always_match,
                                     desired_capabilities=first_match)
 

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -106,12 +106,8 @@ def create_session(request):
             test_capabilities = {}
         env_capabilities = json.loads(os.environ.get("WD_CAPABILITIES", "{}"))
 
-        always_match = merge_dictionaries(env_capabilities.get("alwaysMatch", {}),
-                                          test_capabilities.get("alwaysMatch", {}))
-        first_match = merge_dictionaries(env_capabilities.get("firstMatch", {}),
-                                         test_capabilities.get("firstMatch", {}))
-        session = webdriver.Session(host, port, required_capabilities=always_match,
-                                    desired_capabilities=first_match)
+        capabilities = merge_dictionaries(env_capabilities, test_capabilities)
+        session = webdriver.Session(host, port, capabilities=capabilities)
 
         def destroy():
             if session.session_id is not None:

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -5,6 +5,7 @@ import urlparse
 import webdriver
 
 from support.http_request import HTTPRequest
+from support.merge_dictionaries import merge_dictionaries
 
 default_host = "http://127.0.0.1"
 default_port = "4444"
@@ -88,31 +89,50 @@ def http(session):
 def server_config():
     return json.loads(os.environ.get("WD_SERVER_CONFIG"))
 
-def session(session_session, request):
-    # finalisers are popped off a stack,
-    # making their ordering reverse
-    request.addfinalizer(lambda: _switch_to_top_level_browsing_context(session_session))
-    request.addfinalizer(lambda: _restore_windows(session_session))
-    request.addfinalizer(lambda: _dismiss_user_prompts(session_session))
-    request.addfinalizer(lambda: _ensure_valid_window(session_session))
+# Provide a factory function that produces wdclient `Session` instances. If the
+# `WD_CAPABILITIES` environment variable is set, it will be parsed as JSON and
+# the resulting object will be included in the WebDriver "Create Session"
+# command. Additional capabilities may be specified as an optional argument to
+# this function, but the operation will fail if any values conflict with those
+# specified via the environment. If the session is still active at the
+# completion of the test, it will be destroyed automatically.
+def create_session(request):
+    def create_session(test_capabilities=None):
+        host = os.environ.get("WD_HOST", default_host)
+        port = int(os.environ.get("WD_PORT", default_port))
+        if test_capabilities is None:
+            test_capabilities = {}
+        env_capabilities = json.loads(os.environ.get("WD_CAPABILITIES", "{}"))
 
-    return session_session
+        always_match = merge_dictionaries(env_capabilities.get("always_match", {}),
+                                          test_capabilities.get("always_match", {}))
+        first_match = merge_dictionaries(env_capabilities.get("first_match", {}),
+                                         test_capabilities.get("first_match", {}))
+        session = webdriver.Session(host, port, required_capabilities=always_match,
+                                    desired_capabilities=first_match)
 
-# Create a wdclient `Session` object for each Pytest "session"
-def session_session(request):
-    host = os.environ.get("WD_HOST", default_host)
-    port = int(os.environ.get("WD_PORT", default_port))
-    capabilities = json.loads(os.environ.get("WD_CAPABILITIES", "{}"))
+        def destroy():
+            if session.session_id is not None:
+                session.end()
 
-    session = webdriver.Session(host, port, desired_capabilities=capabilities)
+        # finalisers are popped off a stack, making their ordering reverse
+        request.addfinalizer(destroy)
+        request.addfinalizer(lambda: _switch_to_top_level_browsing_context(session))
+        request.addfinalizer(lambda: _restore_windows(session))
+        request.addfinalizer(lambda: _dismiss_user_prompts(session))
+        request.addfinalizer(lambda: _ensure_valid_window(session))
 
-    def destroy():
-        if session.session_id is not None:
-            session.end()
+        return session
 
-    request.addfinalizer(destroy)
+    return create_session
 
-    return session
+# Create a wdclient `Session` object for each Pytest "session". If the
+# `WD_CAPABILITIES` environment variable is set, it will be parsed as JSON and
+# the resulting object will be included in the WebDriver "Create Session"
+# command. If the session is still active at the completion of the test, it
+# will be destroyed automatically.
+def session(create_session):
+    return create_session()
 
 def url(server_config):
     def inner(path, query="", fragment=""):

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -5,7 +5,7 @@ import urlparse
 import webdriver
 
 from support.http_request import HTTPRequest
-from support.merge_dictionaries import merge_dictionaries
+from support import merge_dictionaries
 
 default_host = "http://127.0.0.1"
 default_port = "4444"
@@ -89,14 +89,16 @@ def http(session):
 def server_config():
     return json.loads(os.environ.get("WD_SERVER_CONFIG"))
 
-# Provide a factory function that produces wdclient `Session` instances. If the
-# `WD_CAPABILITIES` environment variable is set, it will be parsed as JSON and
-# the resulting object will be included in the WebDriver "Create Session"
-# command. Additional capabilities may be specified as an optional argument to
-# this function, but the operation will fail if any values conflict with those
-# specified via the environment. If the session is still active at the
-# completion of the test, it will be destroyed automatically.
 def create_session(request):
+    """Provide a factory function that produces wdclient `Session` instances.
+    If the `WD_CAPABILITIES` environment variable is set, it will be parsed as
+    JSON and the resulting object will be included in the WebDriver "Create
+    Session" command. Additional capabilities may be specified as an optional
+    argument to this function, but the operation will fail if any values
+    conflict with those specified via the environment. If the session is still
+    active at the completion of the test, it will be destroyed
+    automatically."""
+
     def create_session(test_capabilities=None):
         host = os.environ.get("WD_HOST", default_host)
         port = int(os.environ.get("WD_PORT", default_port))

--- a/webdriver/support/merge_dictionaries.py
+++ b/webdriver/support/merge_dictionaries.py
@@ -1,3 +1,10 @@
+def iteritems(d):
+    """Create a key-value iterator for the given dict in both Python 2.x and
+    Python 3.x environments"""
+    if hasattr(d, "iteritems"):
+        return d.iteritems()
+    return d.items()
+
 def merge_dictionaries(first, second):
     """Given two dictionaries, create a third that defines all specified
     key/value pairs. This merge_dictionaries is performed "deeply" on any nested
@@ -5,12 +12,12 @@ def merge_dictionaries(first, second):
     an exception will be raised."""
     result = dict(first)
 
-    for key, value in second.iteritems():
+    for key, value in iteritems(second):
         if key in result and result[key] != value:
             if isinstance(result[key], dict) and isinstance(value, dict):
                 result[key] = merge_dictionaries(result[key], value)
             elif result[key] != value:
-                raise Exception("merge_dictionaries: refusing to overwrite " +
+                raise TypeError("merge_dictionaries: refusing to overwrite " +
                                   "attribute: `%s`" % key)
         else:
             result[key] = value
@@ -25,9 +32,9 @@ if __name__ == "__main__":
     e = None
     try:
         merge_dictionaries({"a": 23}, {"a": 45})
-    except Exception as e:
-        pass
-    assert isinstance(e, Exception)
+    except Exception as _e:
+        e = _e
+    assert isinstance(e, TypeError)
 
     assert merge_dictionaries({"a": 23}, {"a": 23}) == {"a": 23}
 
@@ -37,6 +44,6 @@ if __name__ == "__main__":
     e = None
     try:
         merge_dictionaries({"a": {"b": 23}}, {"a": {"b": 45}})
-    except Exception as e:
-        pass
-    assert isinstance(e, Exception)
+    except Exception as _e:
+        e = _e
+    assert isinstance(e, TypeError)

--- a/webdriver/support/merge_dictionaries.py
+++ b/webdriver/support/merge_dictionaries.py
@@ -1,0 +1,42 @@
+def merge_dictionaries(first, second):
+    """Given two dictionaries, create a third that defines all specified
+    key/value pairs. This merge_dictionaries is performed "deeply" on any nested
+    dictionaries. If a value is defined for the same key by both dictionaries,
+    an exception will be raised."""
+    result = dict(first)
+
+    for key, value in second.iteritems():
+        if key in result and result[key] != value:
+            if isinstance(result[key], dict) and isinstance(value, dict):
+                result[key] = merge_dictionaries(result[key], value)
+            elif result[key] != value:
+                raise Exception("merge_dictionaries: refusing to overwrite " +
+                                  "attribute: `%s`" % key)
+        else:
+            result[key] = value
+
+    return result
+
+if __name__ == "__main__":
+    assert merge_dictionaries({}, {}) == {}
+    assert merge_dictionaries({}, {"a": 23}) == {"a": 23}
+    assert merge_dictionaries({"a": 23}, {"b": 45}) == {"a": 23, "b": 45}
+
+    e = None
+    try:
+        merge_dictionaries({"a": 23}, {"a": 45})
+    except Exception as e:
+        pass
+    assert isinstance(e, Exception)
+
+    assert merge_dictionaries({"a": 23}, {"a": 23}) == {"a": 23}
+
+    assert merge_dictionaries({"a": {"b": 23}}, {"a": {"c": 45}}) == {"a": {"b": 23, "c": 45}}
+    assert merge_dictionaries({"a": {"b": 23}}, {"a": {"b": 23}}) == {"a": {"b": 23}}
+
+    e = None
+    try:
+        merge_dictionaries({"a": {"b": 23}}, {"a": {"b": 45}})
+    except Exception as e:
+        pass
+    assert isinstance(e, Exception)


### PR DESCRIPTION
Some details of the WebDriver specification require modifications to the
way the session is created. In particular, this includes behavior around
the parsing and enabling of various WebDriver "capabilities." However,
due to various infrastructural needs, the test harness must be made
aware of each WebDriver session created for a given test. This
requirement prevents tests from instantiating Sessions directly.

Define a factory function as a Pytest "fixture" in order to give tests
control over object construction while maintaining integration with the
testing infrastructure.