### PR TITLE
[stability] Report duplicate tests as "excess"

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -575,6 +575,8 @@ def err_string(results_dict, iterations):
                   (key, ": %s/%s" % (value, iterations) if value != iterations else ""))
     if total_results < iterations:
         rv.append("MISSING: %s/%s" % (iterations - total_results, iterations))
+    elif total_results > iterations:
+        rv.append("EXCESS: %s" % (total_results - iterations))
     rv = ", ".join(rv)
     if is_inconsistent(results_dict, iterations):
         rv = "**%s**" % rv

--- a/check_stability.py
+++ b/check_stability.py
@@ -640,7 +640,21 @@ def table(headings, data, log):
 
 def write_inconsistent(inconsistent, iterations):
     """Output inconsistent tests to logger.error."""
-    logger.error("## Unstable results ##\n")
+    s = '' if iterations == 1 else 's'
+    logger.error("## Unstable results ##")
+    logger.error("")
+
+    logger.error(("The following table lists tests that exhibited " +
+        "inconsistent results after {total} iteration{s}. The label " +
+        "`MISSING` indicates that the referenced test ran fewer than " +
+        "{total} time{s}. This can occur if tests are generated via logic " +
+        "that is non-deterministic. The label `EXCESS` indicates that the " +
+        "referenced test ran more than {total} time{s}. This may also be " +
+        "due to non-determinism in test generation logic, but it is more " +
+        "likely the result of duplicated test names."
+        ).format(total=iterations, s=s))
+    logger.error("")
+
     strings = [(
         "`%s`" % markdown_adjust(test),
         ("`%s`" % markdown_adjust(subtest)) if subtest else "",

--- a/infra/demo.html
+++ b/infra/demo.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset=utf-8>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+test(function() {}, 'duplicate');
+test(function() {}, 'duplicate');
+Math.random() > 0.5 && test(function() {}, 'ghost');
+test(function() {
+  assert_true(Math.random() > 0.5);
+}, 'flakey');
+test(function() {}, 'always pass');
+test(function() { assert_true(false); }, 'always fail');
+</script>


### PR DESCRIPTION
Previously, the "stability checker" script would report results for
duplicate test names in the same format as results for non-duplicate test
names, without any additional commentary. For example, a test run for a
test that included two stable subtests with the same name ("`test #1`") and
one unstable subtest ("`test #2`") might produce the following output:

    |       Test         |   Subtest |         Results            |                Messages                |
    |--------------------|-----------|----------------------------|----------------------------------------|
    | `/infra/demo.html` | `test #1` | **PASS: 20/10**            |                                        |
    | `/infra/demo.html` | `test #2` | **FAIL: 5/10, PASS: 5/10** | `assert_true: expected true got false` |

Without proper context, these results caused confusion for contributors.

Extend the rendered output to communicate the reason for failure more
directly by including the count of tests in excess, e.g.:

    |       Test         |   Subtest |         Results            |                Messages                |
    |--------------------|-----------|----------------------------|----------------------------------------|
    | `/infra/demo.html` | `test #1` | **PASS: 20/10**, EXCESS:10 |                                        |
    | `/infra/demo.html` | `test #2` | **FAIL: 5/10, PASS: 5/10** | `assert_true: expected true got false` |