### PR TITLE
HTML: Add tests for tokenization of noopener window.open feature

### DIFF
--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001.html
@@ -21,7 +21,6 @@ test (t => {
     '\n=noopener=',
     '\tnoopener',
     '\r,,,=noopener',
-    '\u0000noopener',
     '\u000Cnoopener'
   ];
   featureVariants.forEach(feature => {
@@ -63,7 +62,6 @@ test (t => {
     ', noopener   =',
     'noopener,=',
     'noopener foo', // => ('noopener', ''), ('foo', '')
-    'noopener\u0000foo', // => ('noopener', ''), ('foo', '')
     'foo noopener=1', // => ('foo', ''), ('noopener', '1')
     'foo=\u000Cnoopener' // => ('foo', ''), ('noopener', '')
   ];
@@ -86,8 +84,7 @@ test (t => {
     'noopener\n=\r noopener,', // => ('noopener', 'noopener')
     'noopener=,yes', // => ('noopener'), ('yes')
     'noopener= foo=,', // => ('noopener', 'foo')
-    'noopener = \u000Cyes', // => ('noopener', 'yes')
-    'noopener =\u0000 yes' // => ('noopener', 'yes')
+    'noopener = \u000Cyes' // => ('noopener', 'yes')
   ];
   featureVariants.forEach(feature => {
     var win = window.open(windowURL, '', feature);
@@ -133,13 +130,15 @@ test (t => {
 
 test (t => {
   var invalidFeatureVariants = [
-    '-noopener',
-    'NOOPENERRRR',
-    'noOpenErR',
-    'no_opener',
-    ' no opener',
-    'no\nopener',
-    'no,opener'
+    '-noopener', //     => ('-noopener', '')
+    'NOOPENERRRR', //   => ('noopenerrr', '')
+    'noOpenErR', //     => ('noopenerr', '')
+    'no_opener', //     => ('no_opener', '')
+    ' no opener', //    => ('no', ''), ('opener', '')
+    'no\nopener', //    => ('no', ''), ('opener', '')
+    'no,opener', //     => ('no', ''), ('opener', '')
+    '\0noopener', //    => ('\0noopener', '')
+    'noopener\u0000=yes' // => ('noopener\0', 'yes')
   ];
   invalidFeatureVariants.forEach(feature => {
     var win = window.open(windowURL, '', feature);

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/open-features-tokenization-001.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML: window.open `features`: tokenization -- `noopener`</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#apis-for-creating-and-navigating-browsing-contexts-by-name">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+var windowURL = 'resources/close-self.html';
+
+// Tests for how windows features are tokenized into 'name', 'value'
+// window features separators are ASCII whitespace, '=' and  ','
+
+test (t => {
+  // Tokenizing `name`: initial window features separators are ignored
+  // Each of these variants should tokenize to ('noopener', '')
+  var featureVariants = [
+    ' noopener',
+    '=noopener',
+    ',,noopener',
+    ',=, noopener',
+    '\n=noopener=',
+    '\tnoopener',
+    '\r,,,=noopener',
+    '\u0000noopener',
+    '\u000Cnoopener'
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should activate feature "noopener"`);
+  });
+}, 'tokenization should skip window features separators before `name`');
+
+test (t => {
+  // Tokenizing `name`: lowercase conversion
+  // Each of these variants should tokenize as feature ('noopener', '')
+  // except where indicated
+  // Note also that `value` is lowercased during tokenization
+  var featureVariants = [
+    'NOOPENER',
+    'noOpenER',
+    '  NOopener',
+    '=NOOPENER',
+    'noopener=NOOPENER', // => ('noopener', 'noopener')
+    'NOOPENER=noopener' // => ('noopener', 'noopener')
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should activate feature "noopener"`);
+  });
+}, 'feature `name` should be converted to ASCII lowercase');
+
+test (t => {
+  // After `name` has been collected, ignore any window features separators until '='
+  // except ',' OR a non-window-features-separator — break in those cases
+  // i.e. ignore whitespace until '=' unless a ',' is encountered first
+  // Each of these variants should tokenize as feature ('noopener', '')
+  var featureVariants = [
+    'noopener',
+    ' noopener\r',
+    'noopener\n =',
+    'noopener,',
+    'noopener  =,',
+    ', noopener   =',
+    'noopener,=',
+    'noopener foo', // => ('noopener', ''), ('foo', '')
+    'noopener\u0000foo', // => ('noopener', ''), ('foo', '')
+    'foo noopener=1', // => ('foo', ''), ('noopener', '1')
+    'foo=\u000Cnoopener' // => ('foo', ''), ('noopener', '')
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should activate feature "noopener"`);
+  });
+}, 'after `name`, tokenization should skip window features separators that are not "=" or ","');
+
+test (t => {
+  // After initial '=', tokenizing should ignore all separators except ','
+  // before collecting `value`
+  // Each of these variants should tokenize as feature ('noopener', '')
+  // Except where indicated
+  var featureVariants = [
+    'noopener=  yes', // => ('noopener', 'yes')
+    'noopener==,',
+    'noopener=\n ,',
+    'noopener = \t ,',
+    'noopener\n=\r noopener,', // => ('noopener', 'noopener')
+    'noopener=,yes', // => ('noopener'), ('yes')
+    'noopener= foo=,', // => ('noopener', 'foo')
+    'noopener = \u000Cyes', // => ('noopener', 'yes')
+    'noopener =\u0000 yes' // => ('noopener', 'yes')
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should activate feature "noopener"`);
+  });
+}, 'Tokenizing should ignore window feature separators except "," after initial "=" and before value');
+
+test (t => {
+  // Tokenizing `value` should collect any non-separator code points until first separator
+  var featureVariants = [
+    'noopener=noopener', // => ('noopener', 'noopener')
+    'noopener=yes', // => ('noopener', 'yes')
+    'noopener = yes ,', // => ('noopener', 'yes')
+    'noopener=\nyes  ,', // => ('noopener', 'yes')
+    'noopener=yes yes', // => ('noopener', 'yes'), ('yes', '')
+    'noopener=yes\ts', // => ('noopener', 'yes'), ('s', '')
+    'noopener==', // => ('noopener', '')
+    'noopener=0\n,', // => ('noopener', '0')
+    '==noopener===', // => ('noopener', '')
+    'noopener==\u000C' // => ('noopener', '')
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should set "noopener"`);
+  });
+}, 'Tokenizing should read characters until first window feature separator as `value`');
+
+test (t => {
+  // If tokenizedFeatures contains an entry with the key "noopener"...disown opener
+  // i.e. `value` should be irrelevant
+  var featureVariants = [
+    'noopener=false',
+    ',noopener=0, ',
+    'foo=bar,noopener=noopener,',
+    'noopener=true',
+    'noopener=foo\nbar\t'
+  ];
+  featureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_equals(win, null, `"${feature}" should activate feature "noopener"`);
+  });
+}, '"noopener" should be based on name (key), not value');
+
+test (t => {
+  var invalidFeatureVariants = [
+    '-noopener',
+    'NOOPENERRRR',
+    'noOpenErR',
+    'no_opener',
+    ' no opener',
+    'no\nopener',
+    'no,opener'
+  ];
+  invalidFeatureVariants.forEach(feature => {
+    var win = window.open(windowURL, '', feature);
+    assert_not_equals(win, null, `"${feature}" should NOT activate feature "noopener"`);
+  });
+}, 'invalid feature names should not tokenize as "noopener"');
+</script>

--- a/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/resources/close-self.html
+++ b/html/browsers/the-window-object/apis-for-creating-and-navigating-browsing-contexts-by-name/resources/close-self.html
@@ -1,0 +1,3 @@
+<script>
+  window.close();
+</script>


### PR DESCRIPTION
Attn @zcorpan on this one. Apologies in advance that the summary here is long-ish.

There's still a bunch of work to be done in this area (testing `window.open` features overall) but I wanted to open a smallish PR here as there are more wrinkles than usual. This series of tests chucks differently-formatted variants of the `noopener` feature at `window.open`.

First, note that this PR is for spec stuff that hasn't landed as of time of writing, but is looking like it is getting there: https://github.com/whatwg/html/pull/2476 ... bit of a chicken and egg situation: I don't know whether tests need to land first here or whether that spec change needs to be merged first.

While Firefox has implemented the `noopener` support (disowning `opener` and returning `null` as expected in those cases), it has some not-to-spec behavior around `window.close`. To wit: a newly-created browser context with no `opener` _cannot close itself_. `window.close` in those situations will log a warning (`"Scripts may not close windows that were not opened by script."`) and the `close` will be unsuccessful. This behavior is [alluded to in this bug thread](https://bugzilla.mozilla.org/show_bug.cgi?id=1316857) but does not appear to have a bug opened specifically against it. [Current spec language](
https://html.spec.whatwg.org/#apis-for-creating-and-navigating-browsing-contexts-by-name:dom-open
) suggests the `window` in this case _should_ be closable:

> A browsing context is script-closable if it is an auxiliary browsing context that was created by a script (as opposed to by an action of the user), or if it is a top-level browsing context whose session history contains only one Document.

The current FF behavior means that for any time a `window` is opened and successfully disowns its `opener`, that window gets left behind at the end of the tests because it cannot be closed by any method I know of (automatically). Now, FF is currently failing to tokenize most variants of `noopener` so there aren't many windows left behind (just one for now), but, ick.

Which leads to another question: does this open too many windows for one test file? Are there performance/timeout concerns?

And also: are my assumptions for feature names that should be tokenized to `noopener` ultimately accurate? I tried to step through the tokenization steps and think of various valid and invalid variants.

Anyway, like I said, I wanted to get this out there before continuing on to other pieces of this in case I'm way off base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5306)
<!-- Reviewable:end -->
