### PR TITLE
[selectors4] Fix reference to avoid glitches on :focus-within tests

### DIFF
--- a/css/selectors4/focus-within-001-ref.html
+++ b/css/selectors4/focus-within-001-ref.html
@@ -9,6 +9,8 @@ div {
   border: solid 15px green;
 }
 </style>
-<p>Test passes if, when the element below is focused, it is surrounded by a thick green border. There must be no red or blue once it is focused.</p>
+<p>Test passes if, when the element below is focused,
+it is surrounded by a thick green border.
+There must be no red or blue once it is focused.</p>
 <div>Focus this element</div>
 </html>

--- a/css/selectors4/focus-within-001.html
+++ b/css/selectors4/focus-within-001.html
@@ -26,7 +26,9 @@ div:focus-within {
 border-color: green;
 }
 </style>
-<p>Test passes if, when the element below is focused, it is surrounded by a thick green border. There must be no red or blue once it is focused.</p>
+<p>Test passes if, when the element below is focused,
+it is surrounded by a thick green border.
+There must be no red or blue once it is focused.</p>
 <div id="focusme" class="reftest-wait" onfocus="this.classList.toggle('reftest-wait');" tabindex="1">Focus this element</div>
 <script>
 /* This script is an optional convenience,


### PR DESCRIPTION
Some tests were using 3 lines and other 1 line for the same text.
When comparing 3 (test) vs 1 line (reference) this was causing
very small differences and considering the test as failure in Chrome.

This text is not relevant at all for `:focus-within` tests,
so it's better to use 3 lines in all the files (tests and reference).

This is a very simple change, please @gsnedders or @frivoal 
could you take a look? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5316)
<!-- Reviewable:end -->
