### PR TITLE
Stability script: normalize results format

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -589,7 +589,7 @@ def process_results(log, iterations):
     results = handler.results
     for test_name, test in results.iteritems():
         if is_inconsistent(test["status"], iterations):
-            inconsistent.append((test_name, None, test["status"], None))
+            inconsistent.append((test_name, None, test["status"], []))
         for subtest_name, subtest in test["subtests"].iteritems():
             if is_inconsistent(subtest["status"], iterations):
                 inconsistent.append((test_name, subtest_name, subtest["status"], subtest["messages"]))


### PR DESCRIPTION
The "check stability" script parses test results into a List of tuples.
Later operations expect the fourth element to be a (possibly empty) List
of "messages". While this expectation is satisfied when the instability
is the result of a subtest's behavior, the parsing operation previously
violated the contract when interpreting test failures.

Update the parsing logic to provide an empty List in cases where a test
(rather than a subtest) is the source of instability.