### PR TITLE
[presentation-api] fix the "Creating a receiving browsing context" test

### DIFF
--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html
@@ -91,16 +91,19 @@
             const openIndexedDB = () => {
                 if ('indexedDB' in window) {
                     const dbReq = indexedDB.open(dbName, 1);
-                    const eventWatcher = new EventWatcher(t, dbReq, ['upgradeneeded', 'success']);
-                    return eventWatcher.wait_for('upgradeneeded').then(() => {
-                        db = dbReq.result;
-                        const store = db.createObjectStore(storeName, { keyPath: 'id' });
-                        store.add(storeData);
-                        return eventWatcher.wait_for('success');
-                    }).then(() => {
-                        db = dbReq.result;
-                        db.close();
-                        db = null;
+                    return new Promise((resolve, reject) => {
+                        dbReq.onupgradeneeded = () => {
+                            db = dbReq.result;
+                            const store = db.createObjectStore(storeName, { keyPath: 'id' });
+                            store.add(storeData);
+                        };
+                        dbReq.onsuccess = () => {
+                            db = dbReq.result;
+                            db.close();
+                            db = null;
+                            resolve();
+                        };
+                        dbReq.onerror = reject;
                     });
                 }
                 else


### PR DESCRIPTION
While the current implementation of the "Creating a receiving browsing context" test uses `EventWatcher` to handle `upgradeneeded` and `success` events fired by IndexedDB, it was found that Firefox throws an exception like `InvalidStateError: A mutation operation was attempted on a database that did not allow mutations.` when these events are fired.

This PR replaces `EventWatcher` for IndexedDB with `new Promise` so that such an exception can be avoided, although I don't think it might be a better way.