### PR TITLE
[css-align] Adds a simple TC for space-evenly & flexbox

### DIFF
--- a/css/css-align-3/distribution-values/space-evenly-001.html
+++ b/css/css-align-3/distribution-values/space-evenly-001.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang=en>
+  <meta charset=utf-8>
+  <title>CSS Box Alignment: space-evenly & flexbox with single item</title>
+  <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+  <meta name=flags content="">
+  <meta name=assert content="content-justify: space-evenly with flexbox and a single item must center it">
+  <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+  <link rel=help href="https://drafts.csswg.org/css-align/#distribution-values">
+  <link rel=help href="https://drafts.csswg.org/css-align/#fallback-alignment">
+  <link rel=help href="https://drafts.csswg.org/css-flexbox-1/#justify-content-property">
+<style>
+.red {
+	position: absolute;
+	z-index: -1;
+	width: 100px;
+	height: 100px;
+	background: red;
+}
+.container {
+	margin-left: -100px;
+	width: 300px;
+	display: flex;
+	justify-content: space-evenly;
+}
+.container div {
+	width: 100px;
+	height: 100px;
+	background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div class=red></div>
+<div class=container><div></div></div>
+

--- a/css/css-align-3/distribution-values/space-evenly-001.html
+++ b/css/css-align-3/distribution-values/space-evenly-001.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang=en>
   <meta charset=utf-8>
-  <title>CSS Box Alignment: space-evenly & flexbox with single item</title>
+  <title>CSS Box Alignment: space-evenly &amp; flexbox with single item</title>
   <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
   <meta name=flags content="">
-  <meta name=assert content="content-justify: space-evenly with flexbox and a single item must center it">
+  <meta name=assert content="justify-content: space-evenly with flexbox and a single item must center it">
   <link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
   <link rel=help href="https://drafts.csswg.org/css-align/#distribution-values">
   <link rel=help href="https://drafts.csswg.org/css-align/#fallback-alignment">


### PR DESCRIPTION
More tests would be better, but here's a start, with a test that actually catches a bug in Chrome and Safari (but passes in Firefox).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5336)
<!-- Reviewable:end -->
