### PR TITLE
Simplify the setup around the editor state's GetSelectionRange function.

### DIFF
--- a/html/semantics/forms/textfieldselection/selection.html
+++ b/html/semantics/forms/textfieldselection/selection.html
@@ -14,18 +14,24 @@
   var dirs = ['forward', 'backward', 'none'];
   var sampleText = "0123456789";
 
-  var createInputElement = function(value) {
+  var createInputElement = function(value, append = true) {
     var el = document.createElement("input");
     el.type = "text";
     el.value = value;
-    body.appendChild(el);
+    el.id = "input" + (append ? "-appended" : "-not-appended");
+    if (append) {
+      body.appendChild(el);
+    }
     return el;
   };
 
-  var createTextareaElement = function(value) {
+  var createTextareaElement = function(value, append = true) {
     var el = document.createElement("textarea");
     el.value = value;
-    body.appendChild(el);
+    el.id = "textarea" + (append ? "-appended" : "-not-appended");
+    if (append) {
+      body.appendChild(el);
+    }
     return el;
   };
 
@@ -82,49 +88,74 @@
   }, "test if non-ascii selection text is correct for textarea");
 
 
-  test(function() {
-    var el = createInputElement(sampleText);
-    // If there is no selection, then it must return the offset(in logical order)
-    // to the character that immediately follows the text entry cursor.
-    assert_equals(el.selectionStart, el.value.length, "SelectionStart offset without selection");
-    el.select();
-    assert_equals(el.selectionStart, 0, "SelectionStart offset");
-    el.parentNode.removeChild(el);
-  }, "test SelectionStart offset for input");
+  for (var append of [true, false]) {
+    test(function() {
+      var el = createInputElement(sampleText, append);
+      // If there is no selection, then it must return the offset(in logical order)
+      // to the character that immediately follows the text entry cursor.
+      assert_equals(el.selectionStart, el.value.length,
+                    "SelectionStart offset without selection in " + el.id);
+      if (!el.parentNode) {
+        return;
+      }
+      el.select();
+      assert_equals(el.selectionStart, 0, "SelectionStart offset");
+      el.parentNode.removeChild(el);
+    }, "test SelectionStart offset for input that is " +
+         (append ? "appended" : " not appended"));
+  }
+
+  for (var append of [true, false]) {
+    test(function() {
+      var el = createTextareaElement(sampleText, append);
+      // If there is no selection, then it must return the offset(in logical order)
+      // to the character that immediately follows the text entry cursor.
+      assert_equals(el.selectionStart, el.value.length,
+                    "SelectionStart offset without selection in " + el.id);
+      if (!el.parentNode) {
+        return;
+      }
+      el.select();
+      assert_equals(el.selectionStart, 0, "SelectionStart offset");
+      el.parentNode.removeChild(el);
+    }, "test SelectionStart offset for textarea that is " +
+         (append ? "appended" : " not appended"));
+  }
+
+  for (var append of [true, false]) {
+    test(function() {
+      var el = createInputElement(sampleText, append);
+      // If there is no selection, then it must return the offset(in logical order)
+      // to the character that immediately follows the text entry cursor.
+      assert_equals(el.selectionEnd, el.value.length,
+                    "SelectionEnd offset without selection in " + el.id);
+      if (!el.parentNode) {
+        return;
+      }
+      el.select();
+      assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset");
+      el.parentNode.removeChild(el);
+    }, "test SelectionEnd offset for input that is " +
+         (append ? "appended" : " not appended"));
+  }
 
 
-  test(function() {
-    var el = createTextareaElement(sampleText);
-    // If there is no selection, then it must return the offset(in logical order)
-    // to the character that immediately follows the text entry cursor.
-    assert_equals(el.selectionStart, el.value.length, "SelectionStart offset without selection");
-    el.select();
-    assert_equals(el.selectionStart, 0, "SelectionStart offset");
-    el.parentNode.removeChild(el);
-  }, "test SelectionStart offset for textarea");
-
-
-  test(function() {
-    var el = createInputElement(sampleText);
-    // If there is no selection, then it must return the offset(in logical order)
-    // to the character that immediately follows the text entry cursor.
-    assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset without selection");
-    el.select();
-    assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset");
-    el.parentNode.removeChild(el);
-  }, "test SelectionEnd offset for input");
-
-
-  test(function() {
-    var el = createTextareaElement(sampleText);
-    // If there is no selection, then it must return the offset(in logical order)
-    // to the character that immediately follows the text entry cursor.
-    assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset without selection");
-    el.select();
-    assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset");
-    el.parentNode.removeChild(el);
-  }, "test SelectionEnd offset for textarea");
-
+  for (var append of [true, false]) {
+    test(function() {
+      var el = createTextareaElement(sampleText, append);
+      // If there is no selection, then it must return the offset(in logical order)
+      // to the character that immediately follows the text entry cursor.
+      assert_equals(el.selectionEnd, el.value.length,
+                    "SelectionEnd offset without selection in " + el.id);
+      if (!el.parentNode) {
+        return;
+      }
+      el.select();
+      assert_equals(el.selectionEnd, el.value.length, "SelectionEnd offset");
+      el.parentNode.removeChild(el);
+    }, "test SelectionEnd offset for textarea that is " +
+         (append ? "appended" : " not appended"));
+  }
 
   test(function() {
     var el = createInputElement(sampleText);


### PR DESCRIPTION

Really, there are only two cases we need to worry about.  Either
IsSelectionCached(), and then our SelectionProperties has the data we want, or
not and then we have a non-null mSelCon which has the data we want.

Since we are now using cached selection state a lot more (instead of
initializing the editor whenever someone asks for selection state), we need to
actually update it more correctly when .value is set.

And since we now update the cached selection state for the case when .value has
been set (to point to the end of the text), we need to change
HTMLInputElement::HasCachedSelection to return false for that case.  Otherwise
we will always do eager editor init on value set.  We handle that by not doing
eager init if the cached selection is collapsed.

The web platform test changes test the "update on .value set" behavior.  They
fail without this patch, pass with it.

MozReview-Commit-ID: DDU8U4MGb23

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343037 [ci skip]