### PR TITLE
Implement nsTextEditorState::SetSelectionEnd.

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-start-end.html
+++ b/html/semantics/forms/textfieldselection/selection-start-end.html
@@ -55,6 +55,19 @@
 
   test(function() {
     for (let el of createTestElements(testValue)) {
+      assert_equals(el.selectionEnd, testValue.length,
+                    `Initial .value set on ${el.id} should set selectionEnd to end of value`);
+      var t = async_test(`onselect should fire when selectionEnd is changed on ${el.id}`);
+      el.onselect = t.step_func_done(function(e) {
+        assert_equals(e.type, "select");
+        el.remove();
+      });
+      el.selectionEnd = 2;
+    }
+  }, "onselect should fire when selectionEnd is changed");
+
+  test(function() {
+    for (let el of createTestElements(testValue)) {
       assert_equals(el.selectionStart, testValue.length,
                     `Initial .value set on ${el.id} should set selectionStart to end of value`);
       el.selectionStart = 0;
@@ -65,4 +78,18 @@
       el.remove();
     }
   }, "Setting selectionStart to a value larger than selectionEnd should increase selectionEnd");
+
+  test(function() {
+    for (let el of createTestElements(testValue)) {
+      assert_equals(el.selectionStart, testValue.length,
+                    `Initial .value set on ${el.id} should set selectionStart to end of value`);
+      assert_equals(el.selectionEnd, testValue.length,
+                    `Initial .value set on ${el.id} should set selectionEnd to end of value`);
+      el.selectionStart = 8;
+      el.selectionEnd = 5;
+      assert_equals(el.selectionStart, 5, `selectionStart on ${el.id}`);
+      assert_equals(el.selectionEnd, 5, `selectionEnd on ${el.id}`);
+      el.remove();
+    }
+  }, "Setting selectionEnd to a value smaller than selectionStart should decrease selectionStart");
 </script>


### PR DESCRIPTION

This introduces three behavior changes:

1)  Before this change, in cached mode, we did not enforce the "start <= end"
    invariant.
2)  Before this change, in cached mode, we did not fire "select" events on
    selectionEnd changes.
3)  Changes the IDL type of HTMLInputElement's selectionEnd attribute to
    "unsigned long" to match the spec and HTMLTextareaElement.

MozReview-Commit-ID: J3Gkhr8VnbS

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343037 [ci skip]