### PR TITLE
Fix duplicate test names in beacon tests, a=testonly

### DIFF
--- a/beacon/headers/header-referrer.js
+++ b/beacon/headers/header-referrer.js
@@ -12,7 +12,7 @@ function testReferrerHeader(testBase, expectedReferrer) {
     return pollResult(expectedReferrer, id) .then(result => {
       assert_equals(result, expectedReferrer, "Correct referrer header result");
     });
-  }, "Successful test ");
+  }, "Test referer header " + testBase);
 }
 
 // SendBeacon is an asynchronous and non-blocking request to a web server.


### PR DESCRIPTION

MozReview-Commit-ID: 54IfPksgDOU

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1345490 [ci skip]