### PR TITLE
Ensure that finalizers for webdriver tests always work on a valid window.

### DIFF
--- a/webdriver/conftest.py
+++ b/webdriver/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-
 from support.fixtures import (
     create_frame, create_window, http, server_config, session, session_session,
     url)

--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -9,6 +9,14 @@ from support.http_request import HTTPRequest
 default_host = "http://127.0.0.1"
 default_port = "4444"
 
+def _ensure_valid_window(session):
+    """If current window is not open anymore, ensure to have a valid one selected."""
+    try:
+        session.window_handle
+    except webdriver.NoSuchWindowException:
+        session.window_handle = session.handles[0]
+
+
 def _dismiss_user_prompts(session):
     """Dismisses any open user prompts in windows."""
     current_window = session.window_handle
@@ -86,6 +94,7 @@ def session(session_session, request):
     request.addfinalizer(lambda: _switch_to_top_level_browsing_context(session_session))
     request.addfinalizer(lambda: _restore_windows(session_session))
     request.addfinalizer(lambda: _dismiss_user_prompts(session_session))
+    request.addfinalizer(lambda: _ensure_valid_window(session_session))
 
     return session_session
 


### PR DESCRIPTION

In case of tests are closing the current window, and do not switch back to
a valid window, the finalizers will fail because the window to operate on
doesn't exist anymore.

MozReview-Commit-ID: 8tX6oK45530

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1322383 [ci skip]