### PR TITLE
Change onreadystatechange assertion to a minimum of 2 rather than 10,

### DIFF
--- a/XMLHttpRequest/event-readystatechange-loaded.htm
+++ b/XMLHttpRequest/event-readystatechange-loaded.htm
@@ -24,7 +24,7 @@ test.step(function() {
         }
 
         if (client.readyState === 4) {
-            assert_equals(countedLoading, 10, "LOADING state change may be emitted multiple times");
+            assert_greater_than(countedLoading, 1, "LOADING state change may be emitted multiple times");
 
             test.done();
         }


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1319306 [ci skip]