### PR TITLE
service workers: test FetchEvent.clientId is never null

### DIFF
--- a/service-workers/service-worker/resources/client-navigate-worker.js
+++ b/service-workers/service-worker/resources/client-navigate-worker.js
@@ -5,7 +5,7 @@ importScripts("testharness-helpers.js")
 
 self.onfetch = function(e) {
   if (e.request.url.indexOf("client-navigate-frame.html") >= 0) {
-    if (e.clientId === null) {
+    if (e.clientId === "") {
       e.respondWith(fetch(e.request));
     } else {
       e.respondWith(Response.error());

--- a/service-workers/service-worker/resources/clients-get-worker.js
+++ b/service-workers/service-worker/resources/clients-get-worker.js
@@ -1,6 +1,6 @@
 self.onfetch = function(e) {
   if (e.request.url.indexOf("clients-get-frame.html") >= 0) {
-    if (e.clientId === null) {
+    if (e.clientId === "") {
       e.respondWith(fetch(e.request));
     } else {
       e.respondWith(Response.error());

--- a/service-workers/service-worker/resources/fetch-event-test-worker.js
+++ b/service-workers/service-worker/resources/fetch-event-test-worker.js
@@ -24,7 +24,7 @@ function handleReferrerFull(event) {
 
 function handleClientId(event) {
   var body;
-  if (event.clientId !== null) {
+  if (event.clientId !== "") {
     body = 'Client ID Found: ' + event.clientId;
   } else {
     body = 'Client ID Not Found';

--- a/service-workers/service-worker/resources/interfaces-worker.sub.js
+++ b/service-workers/service-worker/resources/interfaces-worker.sub.js
@@ -87,7 +87,7 @@ test(function() {
       false, 'Default FetchEvent.bubbles should be false');
     assert_equals(
       new FetchEvent('FetchEvent', {request: req}).clientId,
-      null, 'Default FetchEvent.clientId should be null');
+      "", 'Default FetchEvent.clientId should be the empty string');
     assert_equals(
       new FetchEvent('FetchEvent', {request: req}).isReload,
       false, 'Default FetchEvent.isReload should be false');


### PR DESCRIPTION
In the cases where clientId was null before, it's now supposed to be the empty string.

https://github.com/w3c/ServiceWorker/commit/8b483b091e0f0bae6b698cf05d915c2029748ae0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5372)
<!-- Reviewable:end -->
