### PR TITLE
[css-ui-3] Fixes incorrect test instructions

### DIFF
--- a/css/css-ui-3/nav-down-012.html
+++ b/css/css-ui-3/nav-down-012.html
@@ -9,7 +9,7 @@
     <p>First, use directional navigation to navigate the focus to the "START" link below.</p>
     <!-- In Opera 12.16, directional navigation may be done using Shift+<arrow key>.
          In the SmartTV emulator, use the keypad in the GUI. -->
-    <p>Test passes if navigating up once moves the focus to the "FINISH" link.</p>
+    <p>Test passes if navigating down once moves the focus to the "FINISH" link.</p>
 
     <p><a href="" id="finish">ignore</a></p>
 

--- a/css/css-ui-3/support/nav-down-012-frame.html
+++ b/css/css-ui-3/support/nav-down-012-frame.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Daniel Glazman" href="mailto:d.glazman@partner.samsung.com">
 <style>
     #start {
-        nav-down: #finish frame;
+        nav-down: #finish "frame";
     }
 </style>
 <body>


### PR DESCRIPTION
Whether a typo or an hasty copy&pate, this made the test instructions
wrong.

See https://lists.w3.org/Archives/Public/public-css-testsuite/2017Apr/0003.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5377)
<!-- Reviewable:end -->
