### PR TITLE
CORS: stop testing 1xx for CORS preflights

### DIFF
--- a/cors/preflight-failure.htm
+++ b/cors/preflight-failure.htm
@@ -22,13 +22,13 @@ var CROSSDOMAIN_URL = get_host_info().HTTP_REMOTE_ORIGIN + '/cors/resources/cors
  * Redirection with preflights.
  */
 function preflight_failure(code) {
-  var desc = 'Should throw error if preflight respond with ' + code;
+  var isCodeOK = code >= 200 && code <= 299,
+      descOK = isCodeOK ? 'succeed' : 'throw error',
+      desc = 'Should ' + descOK + ' if preflight has status ' + code;
   async_test(desc).step(function() {
     var client = new XMLHttpRequest();
     var redirect =
       encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
-
-    var isCodeOK = code >= 200 && code <= 299;
 
     client.open('GET',
         CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
@@ -51,11 +51,12 @@ function preflight_failure(code) {
     client.send(null);
   });
 }
-[100, 101,
- 200,
+[200, 299,
  300, 301, 302, 303, 304, 305, 306, 307, 308,
  400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417,
- 500, 501, 502, 503, 504, 505
+ 500, 501, 502, 503, 504, 505,
+ 680,
+ 790
 ].forEach(preflight_failure);
 
 </script>


### PR DESCRIPTION
Those status codes are not reliable, see
https://github.com/w3c/wptserve/issues/117 for follow up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5378)
<!-- Reviewable:end -->
