### PR TITLE
ReadableStream: Verify pipeThrough with real Promise / fake readable

### DIFF
--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -104,4 +104,18 @@ test(() => {
 
 }, 'pipeThrough can handle calling a pipeTo that returns a non-promise thenable object');
 
+promise_test(() => {
+  const dummy = {
+    pipeTo() {
+      return Promise.reject(new Error('this rejection should not be reported as unhandled'));
+    }
+  };
+
+  ReadableStream.prototype.pipeThrough.call(dummy, { });
+
+  // The test harness should complain about unhandled rejections by then.
+  return flushAsyncEvents();
+
+}, 'pipeThrough should correct mark a real promise from a fake readable as handled');
+
 done();


### PR DESCRIPTION
ReadableStream.prototype.pipeThrough accepts any object as *this* and will call
this.pipeTo(). It checks whether the object returned from pipeTo() is a Promise
and marks it as handled if it is.

While implementing pipeThrough() I was trying to think of a way to avoid
checking for a real Promise and thought instead of checking that *this* is a
real ReadableStream instead. But that would be wrong, so add a test to ensure
no-one else goes down that path.