### PR TITLE
HTML: Test that the timeout argument wraps around at 2**32

### DIFF
--- a/html/webappapis/timers/type-long-setinterval.html
+++ b/html/webappapis/timers/type-long-setinterval.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Type long timeout for setInterval</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+var interval;
+function next() {
+  clearInterval(interval);
+  done();
+}
+interval = setInterval(next, Math.pow(2, 32));
+setTimeout(assert_unreached, 100);
+</script>

--- a/html/webappapis/timers/type-long-settimeout.html
+++ b/html/webappapis/timers/type-long-settimeout.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Type long timeout for setTimeout</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setTimeout(done, Math.pow(2, 32));
+setTimeout(assert_unreached, 100);
+</script>


### PR DESCRIPTION
This test comes from a comment in the HTML spec's source; see
https://github.com/whatwg/html/pull/2506