### PR TITLE
URL: per the standard a leading ? is removed for the search attribute setter

### DIFF
--- a/url/setters_tests.json
+++ b/url/setters_tests.json
@@ -1671,8 +1671,8 @@
             "href": "https://example.net?lang=en-US#nav",
             "new_value": "??lang=fr",
             "expected": {
-                "href": "https://example.net/??lang=fr#nav",
-                "search": "??lang=fr"
+                "href": "https://example.net/?lang=fr#nav",
+                "search": "?lang=fr"
             }
         },
         {


### PR DESCRIPTION
See also https://bugs.webkit.org/show_bug.cgi?id=170452.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5387)
<!-- Reviewable:end -->
