### PR TITLE
Reduce assert_throws(null, ...) usage in cors/ and selectors/

### DIFF
--- a/cors/allow-headers.htm
+++ b/cors/allow-headers.htm
@@ -44,7 +44,7 @@ function shouldFail(origin) {
                             + '/resources/cors-makeheader.py?origin='
                             + encodeURIComponent(origin),
                     false)
-        assert_throws(null, function() { client.send() }, 'send')
+        assert_throws("NetworkError", function() { client.send() }, 'send')
     }, 'Disallow origin: ' + origin.replace('\0', '\\0'));
 }
 

--- a/cors/origin.htm
+++ b/cors/origin.htm
@@ -47,7 +47,7 @@ function shouldFail(origin) {
                             + '/resources/cors-makeheader.py?origin='
                             + encodeURIComponent(origin),
                     false)
-        assert_throws(null, function() { client.send() }, 'send')
+        assert_throws("NetworkError", function() { client.send() }, 'send')
     }, 'Disallow origin: ' + origin.replace(/\0/g, "\\0"));
 }
 
@@ -105,7 +105,7 @@ function doubleOrigin(origin, origin2) {
                             + encodeURIComponent(origin)
                             + '&origin2=' + encodeURIComponent(origin2),
                     false)
-        assert_throws(null, function() { client.send() }, 'send')
+        assert_throws("NetworkError", function() { client.send() }, 'send')
     }, 'Disallow multiple headers (' + origin + ', ' + origin2 + ')');
 }
 

--- a/cors/request-headers.htm
+++ b/cors/request-headers.htm
@@ -48,7 +48,7 @@ test(function() {
     client.open('GET', CROSSDOMAIN + 'resources/cors-makeheader.py?headers=x-print', false)
     client.setRequestHeader('x-print', 'unicorn')
     client.setRequestHeader('y-print', 'unicorn')
-    assert_throws(null, function() { client.send(null) })
+    assert_throws("NetworkError", function() { client.send(null) })
 }, 'Unspecified request headers are disallowed')
 
 test(function() {

--- a/selectors/attribute-selectors/attribute-case/syntax.html
+++ b/selectors/attribute-selectors/attribute-case/syntax.html
@@ -106,9 +106,7 @@ onload = function() {
         assert_equals(global.getComputedStyle(elm).visibility, 'visible', 'invalid selector matched');
       }, s + ' in ' + global.mode);
       test(function() {
-        // Should be TypeError but this is not widely implemented yet
-        // and this isn't intended to be a querySelector API conformance test.
-        assert_throws(null, function() {
+        assert_throws("SyntaxError", function() {
           global.document.querySelector(s);
         }, 'invalid selector');
       }, s + ' with querySelector in ' + global.mode);


### PR DESCRIPTION
Addresses part of #5317.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5389)
<!-- Reviewable:end -->
