### PR TITLE
[check_stability] Improve "changed file" detection

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -394,8 +394,9 @@ def get_branch_point(user):
     git = get_git_cmd(wpt_root)
     if os.environ.get("TRAVIS_PULL_REQUEST", "false") != "false":
         # This is a PR, so the base branch is in TRAVIS_BRANCH
-        branch_point = os.environ.get("TRAVIS_COMMIT_RANGE").split(".", 1)[0]
-        branch_point = git("rev-parse", branch_point)
+        travis_branch = os.environ.get("TRAVIS_BRANCH")
+        assert travis_branch, "TRAVIS_BRANCH environment variable is defined"
+        branch_point = git("rev-parse", travis_branch)
     else:
         # Otherwise we aren't on a PR, so we try to find commits that are only in the
         # current branch c.f.
@@ -428,7 +429,7 @@ def get_files_changed(branch_point):
     """Get and return files changed since current branch diverged from master."""
     root = os.path.abspath(os.curdir)
     git = get_git_cmd(wpt_root)
-    files = git("diff", "--name-only", "-z", "%s.." % branch_point)
+    files = git("diff", "--name-only", "-z", "%s..." % branch_point)
     if not files:
         return []
     assert files[-1] == "\0"


### PR DESCRIPTION
@jgraham I'd like to call out the change from `..` to `...` in particular as
this has the potential to impact use cases beyond "TravisCI pull request."

The "check stability" script is intended to run only those tests that
have been effected by a given changeset. It calculates the relevant set
of test files by analyzing the git repository's history.

Previously, the script referenced an environment variable provided by
TravisCI named `TRAVIS_COMMIT_RANGE` when running for GitHub.com pull
requests. That variable is documented [1] as follows:

> - `TRAVIS_COMMIT_RANGE`: The range of commits that were included in the push
>   or pull request. (Note that this is empty for builds triggered by the
>   initial commit of a new branch.)

Beyond being somewhat imprecise, that value has been found to be
incorrect in some cases [2]. The definition leaves open the possibility
for race conditions resulting from changes to the target branch over the
course of the TravisCI build life cycle.

Update the "changed file" detection heuristic to instead use the
`TRAVIS_BRANCH` variable, whose definition is much more precise and less
susceptible to race conditions of the type described above. In addition,
update the operator used to specify git endpoints in the subsequent
invocation of `git diff` as this syntax is distinct from that used to
specify ranges [3].

[1] https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
[2] https://github.com/travis-ci/travis-ci/issues/7578
[3] https://git-scm.com/docs/git-diff#_description

>     git diff [--options] <commit>..<commit> [--] [<path>...]
>         This is synonymous to the previous form. If <commit> on one
>         side is omitted, it will have the same effect as using HEAD
>         instead.
>
>     git diff [--options] <commit>...<commit> [--] [<path>...]
>         This form is to view the changes on the branch containing and
>         up to the second <commit>, starting at a common ancestor of
>         both <commit>. "git diff A...B" is equivalent to "git diff
>         $(git-merge-base A B) B". You can omit any one of <commit>,
>         which has the same effect as using HEAD instead.
>
>     Just in case if you are doing something exotic, it should be noted
>     that all of the <commit> in the above description, except in the
>     last two forms that use ".." notations, can be any <tree>.
>
>     For a more complete list of ways to spell <commit>, see
>     "SPECIFYING REVISIONS" section in gitrevisions(7). However, "diff"
>     is about comparing two endpoints, not ranges, and the range
>     notations ("<commit>..<commit>" and "<commit>...<commit>") do not
>     mean a range as defined in the "SPECIFYING RANGES" section in
>     gitrevisions(7).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5416)
<!-- Reviewable:end -->
