### PR TITLE
Writable stream unified error behaviour tests

### DIFF
--- a/streams/resources/recording-streams.js
+++ b/streams/resources/recording-streams.js
@@ -52,18 +52,16 @@ self.recordingWritableStream = (extras = {}, strategy) => {
 
       return undefined;
     },
-    write(chunk) {
+    write(chunk, controller) {
       stream.events.push('write', chunk);
 
       if (extras.write) {
-        return extras.write(chunk);
+        return extras.write(chunk, controller);
       }
 
       return undefined;
     },
-    close(...args) {
-      assert_array_equals(args, [controllerToCopyOver], 'close must always be called with the controller');
-
+    close() {
       stream.events.push('close');
 
       if (extras.close) {

--- a/streams/writable-streams/aborting.js
+++ b/streams/writable-streams/aborting.js
@@ -14,9 +14,7 @@ error2.name = 'error2';
 
 promise_test(t => {
   const ws = new WritableStream({
-    write() {
-      return new Promise(() => { }); // forever-pending, so normally .ready would not fulfill.
-    }
+    write: t.unreached_func('write() should not be called')
   });
 
   const writer = ws.getWriter();
@@ -66,11 +64,12 @@ promise_test(t => {
     .then(() => {
       const writer = ws.getWriter();
 
-      writer.abort();
+      const abortPromise = writer.abort();
 
       return Promise.all([
         promise_rejects(t, new TypeError(), writer.write(1), 'write(1) must reject with a TypeError'),
-        promise_rejects(t, new TypeError(), writer.write(2), 'write(2) must reject with a TypeError')
+        promise_rejects(t, new TypeError(), writer.write(2), 'write(2) must reject with a TypeError'),
+        abortPromise
       ]);
     })
     .then(() => {
@@ -182,7 +181,7 @@ promise_test(t => {
   const ws = new WritableStream();
   const writer = ws.getWriter();
 
-  writer.abort(error1);
+  const abortPromise = writer.abort(error1);
 
   const events = [];
   writer.ready.catch(() => {
@@ -193,6 +192,7 @@ promise_test(t => {
   });
 
   return Promise.all([
+    abortPromise,
     promise_rejects(t, new TypeError(), writer.write(), 'writing should reject with a TypeError'),
     promise_rejects(t, new TypeError(), writer.close(), 'closing should reject with a TypeError'),
     promise_rejects(t, new TypeError(), writer.abort(), 'aborting should reject with a TypeError'),
@@ -231,7 +231,7 @@ promise_test(t => {
   });
 }, 'Closing but then immediately aborting a WritableStream causes the stream to error');
 
-promise_test(t => {
+promise_test(() => {
   let resolveClose;
   const ws = new WritableStream({
     close() {
@@ -335,13 +335,14 @@ promise_test(t => {
     return Promise.all([
       promise_rejects(t, error1, writePromise, 'write() should reject')
           .then(() => assert_false(closedResolved, '.closed should not resolve before write()')),
-      promise_rejects(t, error1, writer.closed, '.closed should reject')
+      promise_rejects(t, new TypeError(), writer.closed, '.closed should reject')
           .then(() => {
             closedResolved = true;
           }),
-      promise_rejects(t, error1, abortPromise, 'abort() should reject')]);
+      abortPromise
+    ]);
   });
-}, '.closed should not resolve before rejected write(); write() error should overwrite abort() error');
+}, '.closed should not resolve before rejected write(); write() error should not overwrite abort() error');
 
 promise_test(t => {
   const ws = new WritableStream({
@@ -375,11 +376,11 @@ promise_test(t => {
     return Promise.all([
       promise_rejects(t, error1, writer.write('1'), 'in-flight write should be rejected')
           .then(() => settlementOrder.push(1)),
-      promise_rejects(t, error1, writer.write('2'), 'first queued write should be rejected')
+      promise_rejects(t, new TypeError(), writer.write('2'), 'first queued write should be rejected')
           .then(() => settlementOrder.push(2)),
-      promise_rejects(t, error1, writer.write('3'), 'second queued write should be rejected')
+      promise_rejects(t, new TypeError(), writer.write('3'), 'second queued write should be rejected')
           .then(() => settlementOrder.push(3)),
-      promise_rejects(t, error1, writer.abort(error1), 'abort should be rejected')
+      writer.abort(error1)
     ]).then(() => assert_array_equals([1, 2, 3], settlementOrder, 'writes should be satisfied in order'));
   });
 }, 'writes should be satisfied in order after rejected write when aborting');
@@ -394,11 +395,12 @@ promise_test(t => {
   return writer.ready.then(() => {
     return Promise.all([
       promise_rejects(t, error1, writer.write('a'), 'writer.write() should reject with error from underlying write()'),
-      promise_rejects(t, error1, writer.close(), 'writer.close() should reject with error from underlying write()'),
-      promise_rejects(t, error1, writer.abort(), 'writer.abort() should reject with error from underlying write()')
+      promise_rejects(t, new TypeError(), writer.close(),
+                      'writer.close() should reject with error from underlying write()'),
+      writer.abort()
     ]);
   });
-}, 'close() should use error from underlying write() on abort');
+}, 'close() should reject with TypeError when abort() is first error');
 
 promise_test(() => {
   let resolveWrite;
@@ -583,7 +585,7 @@ promise_test(t => {
     });
 
     abortPromise = writer.abort(error1);
-    abortPromise.catch(() => {
+    abortPromise.then(() => {
       events.push('abortPromise');
     });
 
@@ -602,21 +604,20 @@ promise_test(t => {
     return Promise.all([
       promise_rejects(t, error2, writePromise,
                       'writePromise must reject with the error returned from the sink\'s write method'),
-      promise_rejects(t, error2, abortPromise,
-                      'abortPromise must reject with the error returned from the sink\'s write method'),
-      promise_rejects(t, error2, writer.closed,
-                      'writer.closed must reject with the error returned from the sink\'s write method'),
+      abortPromise,
+      promise_rejects(t, new TypeError(), writer.closed,
+                      'writer.closed must reject with an error indicating abort'),
       flushAsyncEvents()
     ]);
   }).then(() => {
-    assert_array_equals(events, ['writePromise', 'closed', 'abortPromise'],
-                        'writePromise, abortPromise and writer.closed must reject');
+    assert_array_equals(events, ['writePromise', 'abortPromise', 'closed'],
+                        'writePromise, abortPromise and writer.closed must fulfill');
 
     const writePromise3 = writer.write('a');
 
     return Promise.all([
-      promise_rejects(t, error2, writePromise3,
-                      'writePromise3 must reject with the error returned from the sink\'s write method'),
+      promise_rejects(t, new TypeError(), writePromise3,
+                      'writePromise3 must reject with an error indicating abort'),
       promise_rejects(t, new TypeError(), writer.ready,
                       'writer.ready must be still rejected with the error indicating abort')
     ]);
@@ -663,7 +664,7 @@ promise_test(t => {
     });
 
     abortPromise = writer.abort(error1);
-    abortPromise.catch(() => {
+    abortPromise.then(() => {
       events.push('abortPromise');
     });
 
@@ -677,13 +678,14 @@ promise_test(t => {
   }).then(() => {
     assert_array_equals(events, [], 'writePromise, abortPromise and writer.closed must not be fulfilled/rejected yet');
 
+    // This error is too late to change anything. abort() has already changed the stream state to 'erroring'.
     controller.error(error2);
 
     const writePromise3 = writer.write('a');
 
     return Promise.all([
-      promise_rejects(t, error2, writePromise3,
-                      'writePromise3 must reject with the error passed to the controller\'s error method'),
+      promise_rejects(t, new TypeError(), writePromise3,
+                      'writePromise3 must reject with an error indicating abort'),
       promise_rejects(t, new TypeError(), writer.ready,
                       'writer.ready must be still rejected with the error indicating abort'),
       flushAsyncEvents()
@@ -698,10 +700,9 @@ promise_test(t => {
 
     return Promise.all([
       writePromise,
-      promise_rejects(t, error2, abortPromise,
-                      'abortPromise must reject with the error passed to the controller\'s error method'),
-      promise_rejects(t, error2, writer.closed,
-                      'writer.closed must reject with the error passed to the controller\'s error method'),
+      abortPromise,
+      promise_rejects(t, new TypeError(), writer.closed,
+                      'writer.closed must reject with an error indicating abort'),
       flushAsyncEvents()
     ]);
   }).then(() => {
@@ -712,8 +713,8 @@ promise_test(t => {
 
     return Promise.all([
       writePromise,
-      promise_rejects(t, error2, writePromise4,
-                      'writePromise4 must reject with the error passed to the controller\'s error method'),
+      promise_rejects(t, new TypeError(), writePromise4,
+                      'writePromise4 must reject with an error indicating abort'),
       promise_rejects(t, new TypeError(), writer.ready,
                       'writer.ready must be still rejected with the error indicating abort')
     ]);
@@ -750,7 +751,7 @@ promise_test(t => {
 
   const writer = ws.getWriter();
 
-  writer.closed.catch(() => {
+  writer.closed.then(() => {
     events.push('closed');
   });
 
@@ -762,7 +763,7 @@ promise_test(t => {
     });
 
     abortPromise = writer.abort(error1);
-    abortPromise.catch(() => {
+    abortPromise.then(() => {
       events.push('abortPromise');
     });
 
@@ -794,15 +795,13 @@ promise_test(t => {
 
     return Promise.all([
       closePromise,
-      promise_rejects(t, error2, abortPromise,
-        'abortPromise must reject with the error passed to the controller\'s error method'),
-      promise_rejects(t, error2, writer.closed,
-        'writer.closed must reject with the error passed to the controller\'s error method'),
+      abortPromise,
+      writer.closed,
       flushAsyncEvents()
     ]);
   }).then(() => {
     assert_array_equals(events, ['closePromise', 'abortPromise', 'closed'],
-                        'closedPromise, abortPromise and writer.closed must reject');
+                        'closedPromise, abortPromise and writer.closed must fulfill');
 
     return Promise.all([
       promise_rejects(t, new TypeError(), writer.close(),
@@ -827,7 +826,7 @@ promise_test(t => {
 promise_test(t => {
   let resolveWrite;
   let controller;
-  const ws = new WritableStream({
+  const ws = recordingWritableStream({
     write(chunk, c) {
       controller = c;
       return new Promise(resolve => {
@@ -876,27 +875,28 @@ promise_test(t => {
     const writePromise3 = writer.write('a');
 
     return Promise.all([
-      promise_rejects(t, error2, abortPromise,
-                      'abortPromise must reject with the error passed to the controller\'s error method'),
       promise_rejects(t, error2, writePromise3,
                       'writePromise3 must reject with the error passed to the controller\'s error method'),
       flushAsyncEvents()
     ]);
   }).then(() => {
     assert_array_equals(
-        events, ['abortPromise'],
+        events, [],
         'writePromise and writer.closed must not be fulfilled/rejected yet even after writer.abort()');
 
     resolveWrite();
 
     return Promise.all([
+      promise_rejects(t, error2, abortPromise,
+                      'abort() must reject with the error passed to the controller\'s error method'),
       promise_rejects(t, error2, writer.closed,
                       'writer.closed must reject with the error passed to the controller\'s error method'),
       flushAsyncEvents()
     ]);
   }).then(() => {
-    assert_array_equals(events, ['abortPromise', 'writePromise', 'closed'],
+    assert_array_equals(events, ['writePromise', 'abortPromise', 'closed'],
                         'writePromise, abortPromise and writer.closed must fulfill/reject');
+    assert_array_equals(ws.events, ['write', 'a'], 'sink abort() should not be called');
 
     const writePromise4 = writer.write('a');
 
@@ -940,7 +940,7 @@ promise_test(t => {
 
   const writer = ws.getWriter();
 
-  writer.closed.catch(() => {
+  writer.closed.then(() => {
     events.push('closed');
   });
 
@@ -958,7 +958,7 @@ promise_test(t => {
     assert_array_equals(events, [], 'closePromise must not be fulfilled/rejected yet');
 
     abortPromise = writer.abort(error1);
-    abortPromise.catch(() => {
+    abortPromise.then(() => {
       events.push('abortPromise');
     });
 
@@ -969,7 +969,7 @@ promise_test(t => {
     ]);
   }).then(() => {
     assert_array_equals(
-        events, ['abortPromise'],
+        events, [],
         'closePromise and writer.closed must not be fulfilled/rejected yet even after writer.abort()');
 
     resolveClose();
@@ -978,12 +978,11 @@ promise_test(t => {
       closePromise,
       promise_rejects(t, error2, writer.ready,
                       'writer.ready must be still rejected with the error passed to the controller\'s error method'),
-      promise_rejects(t, error2, writer.closed,
-                      'writer.closed must reject with the error passed to the controller\'s error method'),
+      writer.closed,
       flushAsyncEvents()
     ]);
   }).then(() => {
-    assert_array_equals(events, ['abortPromise', 'closePromise', 'closed'],
+    assert_array_equals(events, ['closePromise', 'abortPromise', 'closed'],
                         'abortPromise, closePromise and writer.closed must fulfill/reject');
   }).then(() => {
     writer.releaseLock();
@@ -1020,6 +1019,7 @@ promise_test(t => {
   });
 }, 'releaseLock() while aborting should reject the original closed promise');
 
+// TODO(ricea): Consider removing this test if it is no longer useful.
 promise_test(t => {
   let resolveWrite;
   let resolveAbort;
@@ -1048,16 +1048,15 @@ promise_test(t => {
     resolveWrite();
     return abortStarted.then(() => {
       writer.releaseLock();
-      assert_not_equals(writer.closed, closed, 'closed promise should have changed');
+      assert_equals(writer.closed, closed, 'closed promise should not have changed');
       resolveAbort();
       return Promise.all([
         writePromise,
         abortPromise,
-        promise_rejects(t, new TypeError(), closed, 'original closed should reject'),
-        promise_rejects(t, new TypeError(), writer.closed, 'new closed should reject')]);
+        promise_rejects(t, new TypeError(), closed, 'closed should reject')]);
     });
   });
-}, 'releaseLock() during delayed async abort() should create a new rejected closed promise');
+}, 'releaseLock() during delayed async abort() should reject the writer.closed promise');
 
 promise_test(() => {
   let resolveStart;
@@ -1078,7 +1077,7 @@ promise_test(() => {
   });
 }, 'sink abort() should not be called until sink start() is done');
 
-promise_test(t => {
+promise_test(() => {
   let resolveStart;
   let controller;
   const ws = recordingWritableStream({
@@ -1092,21 +1091,20 @@ promise_test(t => {
   const abortPromise = ws.abort('done');
   controller.error(error1);
   resolveStart();
-  return promise_rejects(t, error1, abortPromise, 'abort() should reject if start() errors the controller')
-      .then(() =>
-      assert_array_equals(ws.events, [], 'abort() should be not be called if start() errors the controller'));
-}, 'abort() promise should reject if start() errors the controller');
+  return abortPromise.then(() =>
+      assert_array_equals(ws.events, ['abort', 'done'],
+                          'abort() should still be called if start() errors the controller'));
+}, 'if start attempts to error the controller after abort() has been called, then it should lose');
 
-promise_test(t => {
+promise_test(() => {
   const ws = recordingWritableStream({
     start() {
       return Promise.reject(error1);
     }
   });
-  return promise_rejects(t, error1, ws.abort('done'), 'abort() should reject if start() rejects')
-      .then(() =>
-      assert_array_equals(ws.events, [], 'abort() should be not be called if start() rejects'));
-}, 'stream abort() promise should reject if sink start() rejects');
+  return ws.abort('done').then(() =>
+      assert_array_equals(ws.events, ['abort', 'done'], 'abort() should still be called if start() rejects'));
+}, 'stream abort() promise should still resolve if sink start() rejects');
 
 promise_test(t => {
   const ws = new WritableStream();
@@ -1120,21 +1118,25 @@ promise_test(t => {
 }, 'writer abort() during sink start() should replace the writer.ready promise synchronously');
 
 promise_test(t => {
-  const promises = [];
-  const resolved = [];
+  const events = [];
   const ws = recordingWritableStream();
   const writer = ws.getWriter();
-  promises.push(promise_rejects(t, new TypeError(), writer.write(1), 'first write() should reject')
-      .then(() => resolved.push('write1')));
-  promises.push(writer.abort('a')
-      .then(() => resolved.push('abort')));
-  promises.push(promise_rejects(t, new TypeError(), writer.write(2), 'second write() should reject')
-      .then(() => resolved.push('write2')));
-  promises.push(promise_rejects(t, new TypeError(), writer.close(), 'close() should reject')
-      .then(() => resolved.push('close')));
-  return Promise.all(promises)
+  const writePromise1 = writer.write(1);
+  const abortPromise = writer.abort('a');
+  const writePromise2 = writer.write(2);
+  const closePromise = writer.close();
+  writePromise1.catch(() => events.push('write1'));
+  abortPromise.then(() => events.push('abort'));
+  writePromise2.catch(() => events.push('write2'));
+  closePromise.catch(() => events.push('close'));
+  return Promise.all([
+    promise_rejects(t, new TypeError(), writePromise1, 'first write() should reject'),
+    abortPromise,
+    promise_rejects(t, new TypeError(), writePromise2, 'second write() should reject'),
+    promise_rejects(t, new TypeError(), closePromise, 'close() should reject')
+  ])
   .then(() => {
-    assert_array_equals(resolved, ['write2', 'close', 'write1', 'abort'],
+    assert_array_equals(events, ['write2', 'write1', 'abort', 'close'],
                         'promises should resolve in the standard order');
     assert_array_equals(ws.events, ['abort', 'a'], 'underlying sink write() should not be called');
   });
@@ -1159,17 +1161,19 @@ promise_test(t => {
     writeReject(error2);
     return Promise.all([
       promise_rejects(t, error2, writePromise, 'write() should reject with error2'),
-      promise_rejects(t, error1, abortPromise, 'abort() should reject with error1')
+      abortPromise
     ]);
   });
-}, 'abort() should be rejected with the error passed to controller.error() during pending write()');
+}, 'abort() should succeed despite rejection from write');
 
 promise_test(t => {
   let closeReject;
   let controller;
   const ws = new WritableStream({
-    close(c) {
+    start(c) {
       controller = c;
+    },
+    close() {
       return new Promise((resolve, reject) => {
         closeReject = reject;
       });
@@ -1183,9 +1187,115 @@ promise_test(t => {
     closeReject(error2);
     return Promise.all([
       promise_rejects(t, error2, closePromise, 'close() should reject with error2'),
-      promise_rejects(t, error1, abortPromise, 'abort() should reject with error1')
+      promise_rejects(t, error2, abortPromise, 'abort() should reject with error2')
     ]);
   });
-}, 'abort() should be rejected with the error passed to controller.error() during pending close()');
+}, 'abort() should be rejected with the rejection returned from close()');
+
+promise_test(t => {
+  let rejectWrite;
+  const ws = recordingWritableStream({
+    write() {
+      return new Promise((resolve, reject) => {
+        rejectWrite = reject;
+      });
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const writePromise = writer.write('1');
+    const abortPromise = writer.abort(error2);
+    rejectWrite(error1);
+    return Promise.all([
+      promise_rejects(t, error1, writePromise, 'write should reject'),
+      abortPromise,
+      promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with TypeError')
+    ]);
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', '1', 'abort', error2], 'abort sink method should be called');
+  });
+}, 'a rejecting sink.write() should not prevent sink.abort() from being called');
+
+promise_test(() => {
+  const ws = recordingWritableStream({
+    start() {
+      return Promise.reject(error1);
+    }
+  });
+  return ws.abort(error2)
+      .then(() => {
+        assert_array_equals(ws.events, ['abort', error2]);
+      });
+}, 'when start errors after stream abort(), underlying sink abort() should be called anyway');
+
+promise_test(t => {
+  const ws = new WritableStream();
+  const abortPromise1 = ws.abort();
+  const abortPromise2 = ws.abort();
+  return Promise.all([
+    abortPromise1,
+    promise_rejects(t, new TypeError(), abortPromise2, 'second abort() should reject')
+  ]);
+}, 'when calling abort() twice on the same stream, the second call should reject');
+
+promise_test(t => {
+  let controller;
+  let resolveWrite;
+  const ws = recordingWritableStream({
+    start(c) {
+      controller = c;
+    },
+    write() {
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const writePromise = writer.write('chunk');
+    controller.error(error1);
+    const abortPromise = writer.abort(error2);
+    resolveWrite();
+    return Promise.all([
+      writePromise,
+      promise_rejects(t, error1, abortPromise, 'abort() should reject')
+    ]).then(() => {
+      assert_array_equals(ws.events, ['write', 'chunk'], 'sink abort() should not be called');
+    });
+  });
+}, 'sink abort() should not be called if stream was erroring due to controller.error() before abort() was called');
+
+promise_test(t => {
+  let resolveWrite;
+  let size = 1;
+  const ws = recordingWritableStream({
+    write() {
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }
+  }, {
+    size() {
+      return size;
+    },
+    highWaterMark: 1
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const writePromise1 = writer.write('chunk1');
+    size = NaN;
+    const writePromise2 = writer.write('chunk2');
+    const abortPromise = writer.abort(error2);
+    resolveWrite();
+    return Promise.all([
+      writePromise1,
+      promise_rejects(t, new RangeError(), writePromise2, 'second write() should reject'),
+      promise_rejects(t, new RangeError(), abortPromise, 'abort() should reject')
+    ]).then(() => {
+      assert_array_equals(ws.events, ['write', 'chunk1'], 'sink abort() should not be called');
+    });
+  });
+}, 'sink abort() should not be called if stream was erroring due to bad strategy before abort() was called');
 
 done();

--- a/streams/writable-streams/close.js
+++ b/streams/writable-streams/close.js
@@ -26,39 +26,51 @@ promise_test(() => {
 }, 'fulfillment value of ws.close() call must be undefined even if the underlying sink returns a non-undefined ' +
     'value');
 
-promise_test(t => {
-  const passedError = new Error('error me');
+promise_test(() => {
   let controller;
+  let resolveClose;
   const ws = new WritableStream({
-    close(c) {
+    start(c) {
       controller = c;
-      return delay(50);
+    },
+    close() {
+      return new Promise(resolve => {
+        resolveClose = resolve;
+      });
     }
   });
 
   const writer = ws.getWriter();
 
-  return Promise.all([
-    writer.close(),
-    delay(10).then(() => controller.error(passedError)),
-    promise_rejects(t, passedError, writer.closed,
-                    'closed promise should be rejected with the passed error'),
-    delay(70).then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'))
-  ]);
-}, 'when sink calls error asynchronously while closing, the stream should become errored');
+  const closePromise = writer.close();
+  return flushAsyncEvents().then(() => {
+    controller.error(error1);
+    return flushAsyncEvents();
+  }).then(() => {
+    resolveClose();
+    return Promise.all([
+      closePromise,
+      writer.closed,
+      flushAsyncEvents().then(() => writer.closed)]);
+  });
+}, 'when sink calls error asynchronously while sink close is in-flight, the stream should not become errored');
 
-promise_test(t => {
+promise_test(() => {
+  let controller;
   const passedError = new Error('error me');
   const ws = new WritableStream({
-    close(controller) {
+    start(c) {
+      controller = c;
+    },
+    close() {
       controller.error(passedError);
     }
   });
 
   const writer = ws.getWriter();
 
-  return writer.close().then(() => promise_rejects(t, passedError, writer.closed, 'closed should stay rejected'));
-}, 'when sink calls error synchronously while closing, the stream should become errored');
+  return writer.close().then(() => writer.closed);
+}, 'when sink calls error synchronously while closing, the stream should not become errored');
 
 promise_test(t => {
   const ws = new WritableStream({
@@ -94,8 +106,12 @@ promise_test(() => {
 }, 'releaseLock on a stream with a pending write in which the stream has been errored');
 
 promise_test(() => {
+  let controller;
   const ws = new WritableStream({
-    close(controller) {
+    start(c) {
+      controller = c;
+    },
+    close() {
       controller.error(error1);
       return new Promise(() => {});
     }
@@ -107,7 +123,7 @@ promise_test(() => {
   return delay(0).then(() => {
     writer.releaseLock();
   });
-}, 'releaseLock on a stream with a pending close in which the stream has been errored');
+}, 'releaseLock on a stream with a pending close in which controller.error() was called');
 
 promise_test(() => {
   const ws = recordingWritableStream();
@@ -293,7 +309,7 @@ promise_test(() => {
   });
 }, 'promises must fulfill/reject in the expected order on closure');
 
-promise_test(t => {
+promise_test(() => {
   const ws = new WritableStream({});
 
   // Wait until the WritableStream starts so that the close() call gets processed. Otherwise, abort() will be
@@ -316,7 +332,7 @@ promise_test(t => {
         events.push('closed');
       })
     ]).then(() => {
-      assert_array_equals(events, ['closePromise', 'closed', 'abortPromise'],
+      assert_array_equals(events, ['closePromise', 'abortPromise', 'closed'],
                           'promises must fulfill/reject in the expected order');
     });
   });
@@ -337,27 +353,54 @@ promise_test(t => {
     const abortPromise = writer.abort(error2);
 
     const events = [];
+    closePromise.catch(() => events.push('closePromise'));
+    abortPromise.catch(() => events.push('abortPromise'));
+    writer.closed.catch(() => events.push('closed'));
     return Promise.all([
       promise_rejects(t, error1, closePromise,
-                      'closePromise must reject with the error returned from the sink\'s close method')
-      .then(() => {
-        events.push('closePromise');
-      }),
+                      'closePromise must reject with the error returned from the sink\'s close method'),
       promise_rejects(t, error1, abortPromise,
-                      'abortPromise must reject with the error returned from the sink\'s close method')
-      .then(() => {
-        events.push('abortPromise');
-      }),
-      promise_rejects(t, error1, writer.closed,
-                      'writer.closed must reject with the error returned from the sink\'s close method')
-      .then(() => {
-        events.push('closed');
-      })
+                      'abortPromise must reject with the error returned from the sink\'s close method'),
+      promise_rejects(t, new TypeError(), writer.closed,
+                      'writer.closed must reject with a TypeError indicating the stream was aborted')
     ]).then(() => {
-      assert_array_equals(events, ['closePromise', 'closed', 'abortPromise'],
+      assert_array_equals(events, ['closePromise', 'abortPromise', 'closed'],
                           'promises must fulfill/reject in the expected order');
     });
   });
 }, 'promises must fulfill/reject in the expected order on aborted and errored closure');
+
+promise_test(t => {
+  let resolveWrite;
+  let controller;
+  const ws = new WritableStream({
+    write(chunk, c) {
+      controller = c;
+      return new Promise(resolve => {
+        resolveWrite = resolve;
+      });
+    }
+  });
+  const writer = ws.getWriter();
+  return writer.ready.then(() => {
+    const writePromise = writer.write('c');
+    controller.error(error1);
+    const closePromise = writer.close();
+    let closeRejected = false;
+    closePromise.catch(() => {
+      closeRejected = true;
+    });
+    return flushAsyncEvents().then(() => {
+      assert_false(closeRejected);
+      resolveWrite();
+      return Promise.all([
+        writePromise,
+        promise_rejects(t, error1, closePromise, 'close() should reject')
+      ]).then(() => {
+        assert_true(closeRejected);
+      });
+    });
+  });
+}, 'close() should not reject until no sink methods are in flight');
 
 done();

--- a/streams/writable-streams/constructor.js
+++ b/streams/writable-streams/constructor.js
@@ -37,24 +37,23 @@ promise_test(t => {
 
   return Promise.all([
     writer.write('a'),
-    promise_rejects(t, error1, writer.closed, 'controller.error() in write() should errored the stream')
+    promise_rejects(t, error1, writer.closed, 'controller.error() in write() should error the stream')
   ]);
 }, 'controller argument should be passed to write method');
 
+// Older versions of the standard had the controller argument passed to close(). It wasn't useful, and so has been
+// removed. This test remains to identify implementations that haven't been updated.
 promise_test(t => {
   const ws = new WritableStream({
-    close(controller) {
-      controller.error(error1);
+    close(...args) {
+      t.step(() => {
+        assert_array_equals(args, [], 'no arguments should be passed to close');
+      });
     }
   });
 
-  const writer = ws.getWriter();
-
-  return Promise.all([
-    writer.close(),
-    promise_rejects(t, error1, writer.closed, 'controller.error() in close() should error the stream')
-  ]);
-}, 'controller argument should be passed to close method');
+  return ws.getWriter().close();
+}, 'controller argument should not be passed to close method');
 
 promise_test(() => {
   const ws = new WritableStream({}, {

--- a/streams/writable-streams/error.dedicatedworker.html
+++ b/streams/writable-streams/error.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>error.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('error.js'));
+</script>

--- a/streams/writable-streams/error.html
+++ b/streams/writable-streams/error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>error.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+
+
+<script src="error.js"></script>

--- a/streams/writable-streams/error.js
+++ b/streams/writable-streams/error.js
@@ -1,0 +1,69 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+const error2 = new Error('error2');
+error2.name = 'error2';
+
+promise_test(t => {
+  const ws = new WritableStream({
+    start(controller) {
+      controller.error(error1);
+    }
+  });
+  return promise_rejects(t, error1, ws.getWriter().closed, 'stream should be errored');
+}, 'controller.error() should error the stream');
+
+test(() => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  ws.abort();
+  controller.error(error1);
+}, 'controller.error() on erroring stream should not throw');
+
+promise_test(t => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  controller.error(error1);
+  controller.error(error2);
+  return promise_rejects(t, error1, ws.getWriter().closed, 'first controller.error() should win');
+}, 'surplus calls to controller.error() should be a no-op');
+
+promise_test(() => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ws.abort().then(() => {
+    controller.error(error1);
+  });
+}, 'controller.error() on errored stream should not throw');
+
+promise_test(() => {
+  let controller;
+  const ws = new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ws.getWriter().close().then(() => {
+    controller.error(error1);
+  });
+}, 'controller.error() on closed stream should not throw');
+
+done();

--- a/streams/writable-streams/error.serviceworker.https.html
+++ b/streams/writable-streams/error.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>error.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('error.js', 'Service worker test setup');
+</script>

--- a/streams/writable-streams/error.sharedworker.html
+++ b/streams/writable-streams/error.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>error.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('error.js'));
+</script>

--- a/streams/writable-streams/general.js
+++ b/streams/writable-streams/general.js
@@ -226,7 +226,7 @@ promise_test(() => {
   return writer2.ready;
 }, 'redundant releaseLock() is no-op');
 
-promise_test(t => {
+promise_test(() => {
   const events = [];
   const ws = new WritableStream();
   const writer = ws.getWriter();

--- a/streams/writable-streams/start.js
+++ b/streams/writable-streams/start.js
@@ -132,12 +132,12 @@ promise_test(t => {
   const writePromise = writer.write('a');
   const closePromise = writer.close();
   controller.error(error1);
+  resolveStart();
   return Promise.all([
     promise_rejects(t, error1, writePromise, 'write() should fail'),
     promise_rejects(t, error1, closePromise, 'close() should fail')
   ]).then(() => {
     assert_array_equals(ws.events, [], 'sink write() and close() should not have been called');
-    resolveStart();
   });
 }, 'controller.error() during async start should cause existing writes to fail');
 


### PR DESCRIPTION
Tests for changes in https://github.com/whatwg/streams/pull/721.

The expectations for a lot of assert() tests have changed due to the new consistent "first error wins" behaviour. Additional tests cover cases that were not covered or unclearly covered previously.

Notably, error.js is a new set of tests for controller.error(). Most of these verify that controller.error() does not throw in scenarios when the stream is not writable.

The removal of the controller argument to close() results in the addition of a start() method to the sink in a few tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5421)
<!-- Reviewable:end -->
