### PR TITLE
WritableStream: check for non-standard classes, methods or args

### DIFF
--- a/streams/writable-streams/properties.dedicatedworker.html
+++ b/streams/writable-streams/properties.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('properties.js'));
+</script>

--- a/streams/writable-streams/properties.html
+++ b/streams/writable-streams/properties.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+
+
+<script src="properties.js"></script>

--- a/streams/writable-streams/properties.js
+++ b/streams/writable-streams/properties.js
@@ -1,0 +1,179 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+// The purpose of this file is to test for objects, attributes and arguments that should not exist.
+// The test cases are generated from data tables to reduce duplication.
+// TODO(ricea): This file can be deleted when automatic IDL checking has advanced to cover these.
+
+for (const func of ['WritableStreamDefaultController', 'WritableStreamDefaultWriter']) {
+  test(() => {
+    assert_equals(self[func], undefined, `${func} should not be defined`);
+  }, `${func} should not be exported on the global object`);
+}
+
+// Now get hold of the symbols so we can test their properties.
+self.WritableStreamDefaultController = (() => {
+  let controller;
+  new WritableStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return controller.constructor;
+})();
+self.WritableStreamDefaultWriter = new WritableStream().getWriter().constructor;
+
+const expected = {
+  WritableStream: {
+    constructor: {
+      type: 'method',
+      length: 0
+    },
+    locked: {
+      type: 'getter'
+    },
+    abort: {
+      type: 'method',
+      length: 1
+    },
+    getWriter: {
+      type: 'method',
+      length: 0
+    }
+  },
+  WritableStreamDefaultController: {
+    constructor: {
+      type: 'method',
+      length: 4
+    },
+    error: {
+      type: 'method',
+      length: 1
+    }
+  },
+  WritableStreamDefaultWriter: {
+    constructor: {
+      type: 'method',
+      length: 1
+    },
+    closed: {
+      type: 'getter'
+    },
+    desiredSize: {
+      type: 'getter'
+    },
+    ready: {
+      type: 'getter'
+    },
+    abort: {
+      type: 'method',
+      length: 1
+    },
+    close: {
+      type: 'method',
+      length: 0
+    },
+    releaseLock: {
+      type: 'method',
+      length: 0
+    },
+    write: {
+      type: 'method',
+      length: 1
+    }
+  }
+};
+
+for (const c in expected) {
+  const properties = expected[c];
+  const prototype = self[c].prototype;
+  for (const name in properties) {
+    const fullName = `${c}.prototype.${name}`;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+    test(() => {
+      const { configurable, enumerable } = descriptor;
+      assert_true(configurable, `${name} should be configurable`);
+      assert_false(enumerable, `${name} should not be enumerable`);
+    }, `${fullName} should have standard properties`);
+    const type = properties[name].type;
+    switch (type) {
+      case 'getter':
+        test(() => {
+          const { writable, get, set } = descriptor;
+          assert_equals(writable, undefined, `${name} should not be a data descriptor`);
+          assert_equals(typeof get, 'function', `${name} should have a getter`);
+          assert_equals(set, undefined, `${name} should not have a setter`);
+        }, `${fullName} should be a getter`);
+        break;
+
+      case 'method':
+        test(() => {
+          assert_true(descriptor.writable, `${name} should be writable`);
+          assert_equals(typeof prototype[name], 'function', `${name} should be a function`);
+          assert_equals(prototype[name].length, properties[name].length,
+                        `${name} should take ${properties[name].length} arguments`);
+        }, `${fullName} should be a method`);
+        break;
+    }
+  }
+  test(() => {
+    const expectedPropertyNames = Object.keys(properties).sort();
+    const actualPropertyNames = Object.getOwnPropertyNames(prototype).sort();
+    assert_array_equals(actualPropertyNames, expectedPropertyNames,
+                        `${c} properties should match expected properties`);
+  }, `${c}.prototype should have no unexpected properties`);
+}
+
+const sinkMethods = {
+  start: {
+    length: 1,
+    trigger: () => {}
+  },
+  write: {
+    length: 2,
+    trigger: writer => writer.write()
+  },
+  close: {
+    length: 0,
+    trigger: writer => writer.close()
+  },
+  abort: {
+    length: 1,
+    trigger: writer => writer.abort()
+  }
+};
+
+for (const method in sinkMethods) {
+  const { length, trigger } = sinkMethods[method];
+
+  promise_test(() => {
+    let argCount;
+    const ws = new WritableStream({
+      [method](...args) {
+        argCount = args.length;
+      }
+    });
+    return Promise.resolve(trigger(ws.getWriter())).then(() => {
+      assert_equals(argCount, length, `${method} should be called with ${length} arguments`);
+    });
+  }, `sink method ${method} should be called with the right number of arguments`);
+
+  promise_test(() => {
+    let methodWasCalled = false;
+    function Sink() {}
+    Sink.prototype = {
+      [method]() {
+        methodWasCalled = true;
+      }
+    };
+    const ws = new WritableStream(new Sink());
+    return Promise.resolve(trigger(ws.getWriter())).then(() => {
+      assert_true(methodWasCalled, `${method} should be called`);
+    });
+  }, `sink method ${method} should be found via prototype chain`);
+}
+
+done();

--- a/streams/writable-streams/properties.js
+++ b/streams/writable-streams/properties.js
@@ -9,12 +9,12 @@ if (self.importScripts) {
 
 // Courtesy of André Bargull. Source is https://esdiscuss.org/topic/isconstructor#content-11.
 function IsConstructor(o) {
-   try {
-     new (new Proxy(o, {construct: () => ({})}));
-     return true;
-   } catch(e) {
-     return false;
-   }
+  try {
+    new new Proxy(o, { construct: () => ({}) })();
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 for (const func of ['WritableStreamDefaultController', 'WritableStreamDefaultWriter']) {
@@ -38,7 +38,7 @@ self.WritableStreamDefaultWriter = new WritableStream().getWriter().constructor;
 const expected = {
   WritableStream: {
     constructor: {
-      type: 'method',
+      type: 'constructor',
       length: 0
     },
     locked: {
@@ -55,7 +55,7 @@ const expected = {
   },
   WritableStreamDefaultController: {
     constructor: {
-      type: 'method',
+      type: 'constructor',
       length: 4
     },
     error: {
@@ -65,7 +65,7 @@ const expected = {
   },
   WritableStreamDefaultWriter: {
     constructor: {
-      type: 'method',
+      type: 'constructor',
       length: 1
     },
     closed: {
@@ -118,14 +118,19 @@ for (const c in expected) {
         }, `${fullName} should be a getter`);
         break;
 
+      case 'constructor':
       case 'method':
         test(() => {
           assert_true(descriptor.writable, `${name} should be writable`);
           assert_equals(typeof prototype[name], 'function', `${name} should be a function`);
           assert_equals(prototype[name].length, properties[name].length,
                         `${name} should take ${properties[name].length} arguments`);
-          assert_false(IsConstructor(prototype[name], `${name} should not be a constructor`);
-        }, `${fullName} should be a method`);
+          if (type === 'constructor') {
+            assert_true(IsConstructor(prototype[name]), `${name} should be a constructor`);
+          } else {
+            assert_false(IsConstructor(prototype[name]), `${name} should not be a constructor`);
+          }
+        }, `${fullName} should be a ${type}`);
         break;
     }
   }

--- a/streams/writable-streams/properties.js
+++ b/streams/writable-streams/properties.js
@@ -6,7 +6,16 @@ if (self.importScripts) {
 
 // The purpose of this file is to test for objects, attributes and arguments that should not exist.
 // The test cases are generated from data tables to reduce duplication.
-// TODO(ricea): This file can be deleted when automatic IDL checking has advanced to cover these.
+
+// Courtesy of André Bargull. Source is https://esdiscuss.org/topic/isconstructor#content-11.
+function IsConstructor(o) {
+   try {
+     new (new Proxy(o, {construct: () => ({})}));
+     return true;
+   } catch(e) {
+     return false;
+   }
+}
 
 for (const func of ['WritableStreamDefaultController', 'WritableStreamDefaultWriter']) {
   test(() => {
@@ -115,6 +124,7 @@ for (const c in expected) {
           assert_equals(typeof prototype[name], 'function', `${name} should be a function`);
           assert_equals(prototype[name].length, properties[name].length,
                         `${name} should take ${properties[name].length} arguments`);
+          assert_false(IsConstructor(prototype[name], `${name} should not be a constructor`);
         }, `${fullName} should be a method`);
         break;
     }
@@ -124,7 +134,7 @@ for (const c in expected) {
     const actualPropertyNames = Object.getOwnPropertyNames(prototype).sort();
     assert_array_equals(actualPropertyNames, expectedPropertyNames,
                         `${c} properties should match expected properties`);
-  }, `${c}.prototype should have no unexpected properties`);
+  }, `${c}.prototype should have exactly the expected properties`);
 }
 
 const sinkMethods = {
@@ -175,7 +185,7 @@ for (const method in sinkMethods) {
     return Promise.resolve(trigger(ws.getWriter())).then(() => {
       assert_true(methodWasCalled, `${method} should be called`);
     });
-  }, `sink method ${method} should be found via prototype chain`);
+  }, `sink method ${method} should be called even when it's located on the prototype chain`);
 
   if (method !== 'start') {
     promise_test(t => {

--- a/streams/writable-streams/properties.serviceworker.https.html
+++ b/streams/writable-streams/properties.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('properties.js', 'Service worker test setup');
+</script>

--- a/streams/writable-streams/properties.sharedworker.html
+++ b/streams/writable-streams/properties.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('properties.js'));
+</script>


### PR DESCRIPTION
Add a new set of tests for WritableStream to verify that
- WritableStreamDefaultReader and WritableStreamDefaultController are not exported
  on the global object.
- No properties are present on the object prototypes that should not be.
- The methods and constructors expect no more parameters than they should.
- The sink methods are called with the right number of parameters.
- No sink properties are accessed that shouldn't be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5505)
<!-- Reviewable:end -->
