### PR TITLE
Clean up fixtures for session creation in wdspec.

### DIFF
--- a/webdriver/conftest.py
+++ b/webdriver/conftest.py
@@ -1,12 +1,13 @@
 import pytest
 from support.fixtures import (
-    create_frame, create_session, create_window, http, server_config, session,
+    configuration, create_frame, create_window, http, new_session, server_config, session,
     url)
 
+pytest.fixture(scope="session")(configuration)
 pytest.fixture()(create_frame)
-pytest.fixture()(create_session)
 pytest.fixture()(create_window)
 pytest.fixture()(http)
+pytest.fixture(scope="function")(new_session)
 pytest.fixture()(server_config)
 pytest.fixture(scope="function")(session)
 pytest.fixture()(url)


### PR DESCRIPTION
This introduces two fixtures for creating a multi-test session and a
longlived session. For performance it is important that we don't
ordinarily create a new session for each test, but it's also important
that specific tests are able to create new sessions with arbitary
capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5506)
<!-- Reviewable:end -->
