### PR TITLE
Fix formdata-blob.htm

### DIFF
--- a/XMLHttpRequest/formdata-blob.htm
+++ b/XMLHttpRequest/formdata-blob.htm
@@ -33,7 +33,7 @@
     return fd;
   }
 
-  do_test("formdata with blob", create_formdata(['key', new Blob(['value'], {type: 'text/x-value'})]), '\nkey=blob:text/x-value:5,');
+  do_test("formdata with blob", create_formdata(['key', new Blob(['value'], {type: 'text/x-value'})]), 'key=value,');
   do_test("formdata with named blob", create_formdata(['key', new Blob(['value'], {type: 'text/x-value'}), 'blob.txt']), '\nkey=blob.txt:text/x-value:5,');
   // If 3rd argument is given and 2nd is not a Blob, formdata.append() should throw
   var test = async_test('formdata.append() should throw if value is string and file name is given'); // needs to be async just because the others above are


### PR DESCRIPTION
The python file that it is hitting has the following code:
<details>

```python
def main(request, response):
    content = []

    for key, values in sorted(item for item in request.POST.items() if not hasattr(item[1][0], "filename")):
         content.append("%s=%s," % (key, values[0]))
    content.append("\n")

    for key, values in sorted(item for item in request.POST.items() if hasattr(item[1][0], "filename")):
        value = values[0]
        content.append("%s=%s:%s:%s," % (key,
                                         value.filename,
                                         value.headers["Content-Type"],
                                         len(value.file.read())))

return "".join(content)
```
</details>


Note that `content` has different values depending on whether the payload contains a filename or not. In the first test case, it's very clear that the blob does not contain a filename, thus the test should expect `key=value,` instead of `\nkey=blob:text/x-value:5,`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5517)
<!-- Reviewable:end -->
