### PR TITLE
Mozilla reftest export 20170410

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait test">
   <head>
     <meta charset="utf-8">
     <title>CSS Test: :focus-within selector</title>
@@ -8,7 +8,6 @@
     <link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
     <meta name="assert" content="Test checks :focus-within works after focus change">
     <link rel="match" href="focus-within-1-ref.html">
-    <meta name="flags" content="interact">
     <style type="text/css">
       div {
         border: solid 15px blue;
@@ -33,6 +32,7 @@
       var child2 = document.getElementById('child2');
       child2.focus();
       document.body.offsetWidth;
+      document.documentElement.classList.remove('reftest-wait');
     </script>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
   <head>
     <meta charset="utf-8">
     <title>CSS Test: :focus-within selector</title>
@@ -8,7 +8,6 @@
     <link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
     <meta name="assert" content="Test checks :focus-within should not apply after element removed.">
     <link rel="match" href="focus-within-2-ref.html">
-    <meta name="flags" content="interact">
     <style type="text/css">
       div {
         border: solid 15px green;
@@ -31,6 +30,7 @@
       var parent = document.getElementById("parent");
       parent.removeChild(child);
       document.body.offsetWidth;
+      document.documentElement.classList.remove('reftest-wait');
     </script>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-3.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/focus-within-3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
   <head>
     <meta charset="utf-8">
     <title>CSS Test: :focus-within selector</title>
@@ -8,7 +8,6 @@
     <link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
     <meta name="assert" content="Test checks :focus-within should not work for iframe">
     <link rel="match" href="focus-within-3-ref.html">
-    <meta name="flags" content="interact">
     <style type="text/css">
       div:focus-within {
         border: solid 15px red;
@@ -21,7 +20,14 @@
   <body>
     <p>Test passes if, when the element inside the iframe is focused, there is no red border surrounded.</p>
     <div>
-      <iframe src="focus-within-1.html" width="300px" height="300px" frameborder="0" tabindex="1"><p>Your browser does not support iframes.</p></iframe>
+      <iframe id="iframe" src="focus-within-1.html" width="300px" height="300px" frameborder="0" tabindex="1"><p>Your browser does not support iframes.</p></iframe>
     </div>
+    <script>
+      var iframe = document.getElementById("iframe");
+      iframe.addEventListener("load", function() {
+        while (iframe.contentWindow.document.documentElement.classList.contains("reftest-wait")) {}
+        document.documentElement.classList.remove('reftest-wait');
+      });
+    </script>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/sync-tests.sh
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/sync-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MOZTREE="$HOME/builds/clean-mozilla-central/"
+MOZTREE="$HOME/builds/clean-mozilla-central/mozilla/"
 
 cd "$(dirname "$0")"
 

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/variables/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/variables/reftest.list
@@ -1,4 +1,3 @@
-
 == variable-declaration-01.html support/color-green-ref.html
 == variable-declaration-02.html support/color-green-ref.html
 == variable-declaration-03.html support/color-green-ref.html


### PR DESCRIPTION
This is an export of Mozilla's reftests.  The one change was https://hg.mozilla.org/mozilla-central/rev/83eeccc86bab which was already reviewed before it landed.  This is also related to #5370.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5518)
<!-- Reviewable:end -->
