### PR TITLE
ReadableStream: pipeThrough() is not fooled by a fake Promise

### DIFF
--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -119,17 +119,9 @@ promise_test(() => {
 }, 'pipeThrough should mark a real promise from a fake readable as handled');
 
 test(() => {
-  let thenCalled = false
-  let catchCalled = false;
   const dummy = {
     pipeTo() {
       const fakePromise = Object.create(Promise.prototype);
-      fakePromise.then = () => {
-        thenCalled = true;
-      };
-      fakePromise.catch = () => {
-        catchCalled = true;
-      };
       assert_true(fakePromise instanceof Promise, 'fakePromise fools instanceof');
       return fakePromise;
     }
@@ -137,9 +129,8 @@ test(() => {
 
   ReadableStream.prototype.pipeThrough.call(dummy, { });
 
-  assert_false(thenCalled, 'then should not be called');
-  assert_false(catchCalled, 'catch should not be called');
-  // pipeThrough could also fail with a crash or exception.
+  // Test passes if this doesn't throw or crash.
+
 }, 'pipeThrough should not be fooled by an object whose instanceof Promise returns true');
 
 done();

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -118,4 +118,28 @@ promise_test(() => {
 
 }, 'pipeThrough should mark a real promise from a fake readable as handled');
 
+test(() => {
+  let thenCalled = false
+  let catchCalled = false;
+  const dummy = {
+    pipeTo() {
+      const fakePromise = Object.create(Promise.prototype);
+      fakePromise.then = () => {
+        thenCalled = true;
+      };
+      fakePromise.catch = () => {
+        catchCalled = true;
+      };
+      assert_true(fakePromise instanceof Promise, 'fakePromise fools instanceof');
+      return fakePromise;
+    }
+  };
+
+  ReadableStream.prototype.pipeThrough.call(dummy, { });
+
+  assert_false(thenCalled, 'then should not be called');
+  assert_false(catchCalled, 'catch should not be called');
+  // pipeThrough could also fail with a crash or exception.
+}, 'pipeThrough should not be fooled by an object whose instanceof Promise returns true');
+
 done();

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -135,11 +135,13 @@ test(() => {
     }
   };
 
+  // An incorrect implementation which uses an internal method to mark the promise as handled will throw or crash here.
   ReadableStream.prototype.pipeThrough.call(dummy, { });
 
+  // An incorrect implementation that tries to mark the promise as handled by calling .then() or .catch() on the object
+  // will fail these tests.
   assert_false(thenCalled, 'then should not be called');
   assert_false(catchCalled, 'catch should not be called');
-  // pipeThrough could also fail with a crash or exception.
 }, 'pipeThrough should not be fooled by an object whose instanceof Promise returns true');
 
 done();

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -119,9 +119,17 @@ promise_test(() => {
 }, 'pipeThrough should mark a real promise from a fake readable as handled');
 
 test(() => {
+  let thenCalled = false
+  let catchCalled = false;
   const dummy = {
     pipeTo() {
       const fakePromise = Object.create(Promise.prototype);
+      fakePromise.then = () => {
+        thenCalled = true;
+      };
+      fakePromise.catch = () => {
+        catchCalled = true;
+      };
       assert_true(fakePromise instanceof Promise, 'fakePromise fools instanceof');
       return fakePromise;
     }
@@ -129,8 +137,9 @@ test(() => {
 
   ReadableStream.prototype.pipeThrough.call(dummy, { });
 
-  // Test passes if this doesn't throw or crash.
-
+  assert_false(thenCalled, 'then should not be called');
+  assert_false(catchCalled, 'catch should not be called');
+  // pipeThrough could also fail with a crash or exception.
 }, 'pipeThrough should not be fooled by an object whose instanceof Promise returns true');
 
 done();


### PR DESCRIPTION
If an implementation used "instanceof" to detect a Promise in the implementation
of pipeThrough(), it would be fooled by Object.create(Promise). Add a test for
this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5519)
<!-- Reviewable:end -->
