### PR TITLE
[presentation-api] add test cases for sending/receiving messages by a receiving user agent

### DIFF
--- a/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html
@@ -53,18 +53,11 @@
           log.innerHTML = json.log;
           document.body.appendChild(log);
 
-          if (connection.state === 'connecting') {
-            connection.onconnect = () => {
+          connection.onconnect = () => { connection.terminate(); };
+          if (connection.state === 'closed')
+            request.reconnect(connection.id);
+          else
             connection.terminate();
-          }
-        }
-        else if (connection.state === 'closed') {
-          request.reconnect(connection.id).then(c => {
-            c.terminate();
-          });
-        }
-        else
-          connection.terminate();
         });
       };
     });

--- a/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationConnection_onmessage-manual.https.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Receiving a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#receiving-a-message-through-presentationconnection">
+<link rel="stylesheet" href="/resources/testharness.css">
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p>Click the button below and select the available presentation display, to start the manual test.</p>
+<button id="presentBtn">Start Presentation Test</button>
+
+<script>
+  const message1 = '1st';
+  const message2 = '2nd';
+  const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+  const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+  const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+  let connection;
+  const presentBtn = document.getElementById('presentBtn');
+  presentBtn.onclick = () => {
+    presentBtn.disabled = true;
+    const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+    const request = new PresentationRequest('support/PresentationConnection_onmessage_receiving-ua.html');
+
+    request.start().then(c => {
+      c.onconnect = () => {
+        connection = c;
+        connection.send(message1);              // string
+        connection.send(message2);              // string
+        connection.send(new Blob([message3]));  // Blob
+        connection.send(message4.buffer);       // ArrayBuffer
+        connection.send(message5);              // ArrayBufferView
+        return stash.receive().then(data => {
+          const result = JSON.parse(data);
+          if (result.type === 'blob') {
+            connection.send(message5);
+            return stash.receive();
+          }
+          else
+            return data;
+        }).then(result => {
+          const json = JSON.parse(result);
+
+          // notify receiver's results of a parent window (e.g. test runner)
+          if (window.opener && 'completion_callback' in window.opener) {
+            window.opener.completion_callback(json.tests, json.status);
+          }
+          // display receiver's results as HTML
+          const log = document.createElement('div');
+          log.id = 'log';
+          log.innerHTML = json.log;
+          document.body.appendChild(log);
+
+          if (connection.state === 'connecting') {
+            connection.onconnect = () => {
+            connection.terminate();
+          }
+        }
+        else if (connection.state === 'closed') {
+          request.reconnect(connection.id).then(c => {
+            c.terminate();
+          });
+        }
+        else
+          connection.terminate();
+        });
+      };
+    });
+  };
+</script>

--- a/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Sending a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#sending-a-message-through-presentationconnection">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="common.js"></script>
+<script src="support/stash.js"></script>
+
+<p>Click the button below and select the available presentation display, to start the manual test.</p>
+<button id="presentBtn">Start Presentation Test</button>
+
+<script>
+  setup({explicit_timeout: true});
+
+  const message1 = '1st';
+  const message2 = '2nd';
+  const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+  const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+  const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+  const toUint8Array = buf => {
+    return buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+  }
+
+  // compare two ArrayBuffer or Uint8Array
+  const compare = (a, b) => {
+    const p = toUint8Array(a);
+    const q = toUint8Array(b);
+    return !!p && !!q && p.every((item, index) => { return item === q[index]; });
+  };
+
+  let connection;
+
+  const presentBtn = document.getElementById('presentBtn');
+  presentBtn.onclick = () => {
+    presentBtn.disabled = true;
+    const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+    const request = new PresentationRequest('support/PresentationConnection_send_receiving-ua.html');
+
+    let eventWatcher;
+
+    promise_test(t => {
+      t.add_cleanup(() => {
+        if (connection.state === 'connecting') {
+          connection.onconnect = () => {
+            connection.terminate();
+          }
+        }
+        else if (connection.state === 'closed') {
+          request.reconnect(connection.id).then(c => {
+            c.terminate();
+          });
+        }
+        else
+          connection.terminate();
+      });
+
+      return request.start().then(c => {
+        // enable timeout again, cause no user action is needed from here.
+        t.step_timeout(() => {
+          t.force_timeout();
+          t.done();
+        }, 3000);
+
+        connection = c;
+        eventWatcher = new EventWatcher(t, connection, 'connect');
+        return eventWatcher.wait_for('connect');
+      }).then(() => {
+        return stash.init();
+      }).then(() => {
+        stash.send({ type: 'ok' });
+        eventWatcher = new EventWatcher(t, connection, 'message');
+        return eventWatcher.wait_for('message');
+      }).then(evt => {
+        assert_true(typeof evt.data === 'string' && evt.data === message1, 'send a string correctly');
+        return eventWatcher.wait_for('message');
+      }).then(evt => {
+        assert_true(typeof evt.data === 'string' && evt.data === message2, 'send a string correctly');
+        return eventWatcher.wait_for('message');
+      }).then(evt => {
+        assert_true(evt.data instanceof ArrayBuffer && compare(evt.data, message3), 'send a Blob correctly');
+        return eventWatcher.wait_for('message');
+      }).then(evt => {
+        assert_true(evt.data instanceof ArrayBuffer && compare(evt.data, message4), 'send an ArrayBuffer correctly');
+        return eventWatcher.wait_for('message');
+      }).then(evt => {
+        assert_true(evt.data instanceof ArrayBuffer && compare(evt.data, message5), 'send an ArrayBufferView correctly');
+        return stash.send({ type: 'ok' });
+      }).then(() => {
+        return stash.receive();
+      }).then(data => {
+        const result = JSON.parse(data);
+        if (!result.type || result.type !== 'error')
+          assert_unreached('an InvalidStateError is thrown if the state is "closed"');
+        else
+          assert_throws('InvalidStateError', () => {
+            throw new DOMException(result.message, result.name);
+          }, 'an InvalidStateError is thrown if the state is "closed"');
+      });
+    });
+  };
+</script>

--- a/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationConnection_send-manual.https.html
@@ -43,16 +43,9 @@
 
     promise_test(t => {
       t.add_cleanup(() => {
-        if (connection.state === 'connecting') {
-          connection.onconnect = () => {
-            connection.terminate();
-          }
-        }
-        else if (connection.state === 'closed') {
-          request.reconnect(connection.id).then(c => {
-            c.terminate();
-          });
-        }
+        connection.onconnect = () => { connection.terminate(); };
+        if (connection.state === 'closed')
+          request.reconnect(connection.id);
         else
           connection.terminate();
       });

--- a/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Receiving a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#receiving-a-message-through-presentationconnection">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../common.js"></script>
+<script src="stash.js"></script>
+
+<script>
+setup({explicit_timeout: true});
+
+const message1 = '1st';
+const message2 = '2nd';
+const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+const toUint8Array = buf => {
+  return buf instanceof ArrayBuffer ? new Uint8Array(buf) : buf;
+}
+
+// compare two ArrayBuffer or Uint8Array
+const compare = (a, b) => {
+  const p = toUint8Array(a);
+  const q = toUint8Array(b);
+  return !!p && !!q && p.every((item, index) => { return item === q[index]; });
+};
+
+const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+
+add_completion_callback((tests, status) => {
+  const log = document.getElementById('log');
+  stash.send(JSON.stringify({ type: 'result', tests: tests, status: status, log: log.innerHTML }));
+});
+
+navigator.presentation.receiver.connectionList.then(list => {
+  const checkEvent = event => {
+    assert_true(event.isTrusted, 'a trusted event is fired');
+    assert_true(event instanceof MessageEvent, 'The event uses the MessageEvent interface');
+    assert_false(event.bubbles, 'the event does not bubble');
+    assert_false(event.cancelable, 'the event is not cancelable');
+  };
+
+  const connection = list.connections[0];
+
+  promise_test(t => {
+    t.step_timeout(() => {
+      t.force_timeout();
+      t.done();
+    }, 3000);
+
+    assert_equals(connection.binaryType, 'arraybuffer', 'the default value of binaryType is "arraybuffer"');
+    const eventWatcher = new EventWatcher(t, connection, 'message');
+    return eventWatcher.wait_for('message').then(evt => {
+      checkEvent(evt);
+      assert_equals(event.data, message1, 'receive a string correctly');
+      return eventWatcher.wait_for('message');
+    }).then(event => {
+      checkEvent(event);
+      assert_equals(event.data, message2, 'receive a string correctly');
+      return eventWatcher.wait_for('message');
+    }).then(event => {
+      checkEvent(event);
+      assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+      assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
+      return eventWatcher.wait_for('message');
+    }).then(event => {
+      checkEvent(event);
+      assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+      assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
+      return eventWatcher.wait_for('message');
+    }).then(event => {
+      checkEvent(event);
+      assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+      assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
+
+      connection.binaryType = 'blob';
+      return Promise.all([
+        stash.send(JSON.stringify({ type: 'blob' })),
+        eventWatcher.wait_for('message')
+      ]).then(results => results[1]);
+    }).then(event => {
+      assert_true(event.data instanceof Blob, 'receive binary data as Blob');
+      return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = resolve;
+          reader.onerror = reject;
+          reader.readAsArrayBuffer(event.data);
+      });
+    }).then(event => {
+      assert_true(compare(event.target.result, message5), 'receive a Blob correctly');
+      connection.terminate();
+    });
+  });
+});
+</script>

--- a/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
@@ -64,17 +64,17 @@ navigator.presentation.receiver.connectionList.then(list => {
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-      assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
+      assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a controlling user agent)');
       return eventWatcher.wait_for('message');
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-      assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
+      assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a controlling user agent)');
       return eventWatcher.wait_for('message');
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-      assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
+      assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a controlling user agent)');
 
       connection.binaryType = 'blob';
       return Promise.all([

--- a/presentation-api/receiving-ua/support/PresentationConnection_send_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnection_send_receiving-ua.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+
+<meta charset="utf-8">
+<title>Sending a message through PresentationConnection</title>
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#sending-a-message-through-presentationconnection">
+<script src="../common.js"></script>
+<script src="stash.js"></script>
+
+<script>
+const stash = new Stash(stashIds.toReceiver, stashIds.toController);
+
+navigator.presentation.receiver.connectionList.then(list => {
+  const connection = list.connections[0];
+
+  const message1 = '1st';
+  const message2 = '2nd';
+  const message3 = new Uint8Array([51, 114, 100]);      // "3rd"
+  const message4 = new Uint8Array([52, 116, 104]);      // "4th"
+  const message5 = new Uint8Array([108, 97, 115, 116]); // "last"
+
+  // send messages
+  return stash.receive().then(() => {
+    connection.send(message1);              // string
+    connection.send(message2);              // string
+    connection.send(new Blob([message3]));  // Blob
+    connection.send(message4.buffer);       // ArrayBuffer
+    connection.send(message5);              // ArrayBufferView
+
+    return stash.receive();
+  }).then(() => {
+    // try to send a message in the "closed" state
+    // Note: a receiving user agent does not fire a "terminate" event
+    connection.close();
+    connection.onclose = () => {
+      try {
+        connection.send(message1);
+        stash.send(JSON.stringify({ type: 'ok' }));
+      } catch (e) {
+        stash.send(JSON.stringify({ type: 'error', name: e.name, message: e.message }));
+      }
+    };
+  });
+});
+</script>


### PR DESCRIPTION
This PR adds two tests to confirm whether a receiving user agent sends and receives text and binary messages through PresentationConnection correctly or not. These tests are almost equivalent to those for a controlling side (#4950).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5520)
<!-- Reviewable:end -->
