### PR TITLE
Remove synchronous forks of drawImage tests, and enable proper asynchronous drawImage tests.

### DIFF
--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_1.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_1.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_1_ref.html>
 <style>
@@ -26,5 +27,6 @@ sourceImg.onload = function() {
   // 2 arguments, the dest origin is 0,0
   // The source canvas will copied to the 0,0 position of the destination canvas
   destCtx.drawImage(sourceImg, 0, 0);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_10.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_10.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_10_ref.html>
 <style>
@@ -30,5 +31,6 @@ sourceImg.onload = function() {
   // as if the destination was an infinite canvas
   // whose rendering was clipped to the dimensions of the scratch bitmap.
   destCtx.drawImage(sourceImg, 0, 0, 512, 512, 0, 0, 256, 256);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_11.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_11.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_11_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // The source area is clipped to fit the source image
   // and the destination are is clipped in the same proportion
   destCtx.drawImage(sourceImg, 0, 0, 2048, 2048, 0, 0, 800, 800);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_12.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_12.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_12_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // The source area is clipped to fit the source image
   // and the destination area is clipped in the same proportion
   destCtx.drawImage(sourceImg, -25, -25, 50, 50, 0, 0, 50, 50);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_2.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_2.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_2_ref.html>
 <style>
@@ -27,5 +28,6 @@ sourceImg.onload = function() {
   // 2 arguments, the dest origin is not 0,0
   // The source image will copied to the 25, 25 position of the destination canvas
   destCtx.drawImage(sourceImg, 25, 25);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_3.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_3.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_3_ref.html>
 <style>
@@ -27,5 +28,6 @@ sourceImg.onload = function() {
   // The source canvas will copied to the 50, 50 position of the destination canvas and
   // on an area of 50x50 pixels
   destCtx.drawImage(sourceImg, 50, 50, 50, 50);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_4.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_4.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_4_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // The source canvas will copied to the 50,50 position of the destination canvas
   // and it will be shrunk to a and area of 16x16
   destCtx.drawImage(sourceImg, 50, 50, 16, 16);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_5.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_5.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_5_ref.html>
 <style>
@@ -27,5 +28,6 @@ sourceImg.onload = function() {
   // over an area of 64x32 pixels
   // The copied image will be distorted along the x axis
   destCtx.drawImage(sourceImg, 50, 50, 64, 32);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_6.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_6.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_6_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // An area of 32x32 pixels of the source image will be copied to
   // an area of 32x32 pixels of the destination canvas
   destCtx.drawImage(sourceImg, 0, 0, 32, 32, 0, 0, 32, 32);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_7.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_7.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_7_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // An area of 32x32 pixels of the source image will be copied to
   // an area of 32x32 pixels of the destination canvas in the position 32,32
   destCtx.drawImage(sourceImg, 0, 0, 32, 32, 32, 32, 32, 32);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>

--- a/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_8.html
+++ b/2dcontext/drawing-images-to-the-canvas/drawimage_html_image_8.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <link rel=match href=drawimage_html_image_8_ref.html>
 <style>
@@ -28,5 +29,6 @@ sourceImg.onload = function() {
   // The source area is clipped to fit the source image
   // and the destination are is clipped in the same proportion
   destCtx.drawImage(sourceImg, 32, 32, 32, 32, 0, 0, 32, 32);
+  document.documentElement.classList.remove('reftest-wait');
 }
 </script>


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/14962 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5530)
<!-- Reviewable:end -->
