### PR TITLE
Change charset test script URL to avoid relying on network behavior

### DIFF
--- a/html/semantics/scripting-1/the-script-element/script-charset-01.html
+++ b/html/semantics/scripting-1/the-script-element/script-charset-01.html
@@ -52,7 +52,7 @@
    -->
 
   <script type="text/javascript"
-    src="serve-with-content-type.py?fn=external-script-windows1250.js&ct=text/javascript" charset="windows-1250">
+    src="serve-with-content-type.py?fn=external-script-windows1250.js&ct=text/javascript&noop" charset="windows-1250">
   </script>
   <script>
   //the charset is set correctly via content attribute in <script> above


### PR DESCRIPTION
While working on a double download [issue](https://bugs.webkit.org/show_bug.cgi?id=170122) in WebKit, I realized that this test relies on a certain network behavior on request charset change (reloading of said script) and therefore fails in Chrome and now in WebKit.

This minor PR rids the test of that reliance, and makes sure that the decoding of the resource in the specified charset happens regardless of it.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
