### PR TITLE
webmessaging: Always use an array to pass transferables via postMessage()

### DIFF
--- a/webmessaging/with-ports/027.html
+++ b/webmessaging/with-ports/027.html
@@ -6,14 +6,21 @@
 <script>
 async_test(function(t) {
   var channel = new MessageChannel();
-  channel[0] = channel.port1;
-  channel[1] = channel.port2;
-  channel.length = 2;
-  postMessage('', '*', channel);
+  postMessage('', '*', [channel.port1, channel.port2]);
   onmessage = t.step_func(function(e) {
     assert_equals(e.ports.length, 2);
     t.done();
   });
-});
+}, "MessageChannel's ports as MessagePort objects");
+
+test(() => {
+  var channel = new MessageChannel();
+  channel[0] = channel.port1;
+  channel[1] = channel.port2;
+  channel.length = 2;
+  assert_throws(new TypeError(),
+                () => { postMessage('', '*', channel) },
+                'Old-style WebIDL arrays must throw a type error');
+}, "Old-style array objects");
 </script>
 


### PR DESCRIPTION
027.html was still relying on deprecated WebIDL behavior that considered
objects with a `length` property to be convertible to sequences. Explicitly
use an array to list transferables to make sure the test passes in browsers
that convert objects to sequences via @@iterator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5538)
<!-- Reviewable:end -->
