### PR TITLE
Stability checker: escape vertical bar to avoid splitting table cells

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -632,6 +632,7 @@ def markdown_adjust(s):
     s = s.replace('\n', u'\\n')
     s = s.replace('\r', u'\\r')
     s = s.replace('`',  u'')
+    s = s.replace('|', u'\\|')
     return s
 
 


### PR DESCRIPTION
See https://github.com/w3c/web-platform-tests/pull/5528#issuecomment-293015848
`[[GetOwnProperty]] - Properties on cross-origin objects should be reported |own|`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5539)
<!-- Reviewable:end -->
