### PR TITLE
Fix lint to parse args after API change

### DIFF
--- a/lint
+++ b/lint
@@ -8,4 +8,5 @@ except ImportError:
           '"git submodule update --init --recursive"?')
     sys.exit(2)
 
-sys.exit(0 if lint.main() == 0 else 1)
+args = lint.parse_args()
+sys.exit(0 if lint.main(**vars(args)) == 0 else 1)


### PR DESCRIPTION
https://github.com/w3c/wpt-tools/commit/b26b982725715e4280789b6a7a7da34ab74ce958 from https://github.com/w3c/wpt-tools/pull/190 changed the API of `tools.lint`; `lint.main` no longer parses args, and it only does it itself if you run the script directly.

I don't know if this API change was deliberate, and I don't know if we should revert that on a branch given the plan to do the monorepoing as a single step.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5542)
<!-- Reviewable:end -->
