### PR TITLE
[presentation-api] correct how to terminate a connection

### DIFF
--- a/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html
+++ b/presentation-api/receiving-ua/PresentationReceiver_create-manual.https.html
@@ -48,16 +48,9 @@
                 indexedDB.deleteDatabase(dbName);
 
                 if (connection) {
-                    if (connection.state === 'connecting') {
-                        connection.onconnect = () => {
-                            connection.terminate();
-                        }
-                    }
-                    else if (connection.state === 'closed') {
-                        request.reconnect(connection.id).then(c => {
-                            c.terminate();
-                        });
-                    }
+                    connection.onconnect = () => { connection.terminate(); };
+                    if (connection.state === 'closed')
+                        request.reconnect(connection.id);
                     else
                         connection.terminate();
                 }

--- a/presentation-api/receiving-ua/idlharness-manual.https.html
+++ b/presentation-api/receiving-ua/idlharness-manual.https.html
@@ -35,16 +35,9 @@
             log.innerHTML = json.log;
             document.body.appendChild(log);
 
-            if (connection.state === 'connecting') {
-                connection.onconnect = () => {
-                    connection.terminate();
-                }
-            }
-            else if (connection.state === 'closed') {
-                request.reconnect(connection.id).then(c => {
-                    c.terminate();
-                });
-            }
+            connection.onconnect = () => { connection.terminate(); };
+            if (connection.state === 'closed')
+                request.reconnect(connection.id);
             else
                 connection.terminate();
         });


### PR DESCRIPTION
This PR fixes the codes to terminate a presentation connection in a couple of tests for a receiving user agent, in the same manner as https://github.com/w3c/web-platform-tests/pull/5520#discussion_r111108766.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5550)
<!-- Reviewable:end -->
