### PR TITLE
Cleanup testharness-related code

### DIFF
--- a/geolocation-API/OWNERS
+++ b/geolocation-API/OWNERS
@@ -1,2 +1,3 @@
-@zqzhang
 @jdm
+@mcasas
+@zqzhang

--- a/geolocation-API/PositionOptions.https.html
+++ b/geolocation-API/PositionOptions.https.html
@@ -43,71 +43,50 @@ test(function() {
 
   try {
     geo.getCurrentPosition(
-        t86.step_func(function(pos) {
-          assert_unreached('A success callback was invoked unexpectedly');
-        }),
-        t86.step_func(function(err) {
+        t86.unreached_func('A success callback was invoked unexpectedly'),
+        t86.step_func_done(function(err) {
           assert_equals(err.code, err.TIMEOUT);
-          t86.done();
         }),
         {timeout: 0, maximumAge: 0}
     );
   } catch(e) {
-    t86.step(function() {
-      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-    });
+    t86.unreached_func('An exception was thrown unexpectedly: ' + e.message);
   }
 
   try {
     geo.watchPosition(
-        t88.step_func(function(pos) {
-          assert_unreached('A success callback was invoked unexpectedly');
-        }),
-        t88.step_func(function(err) {
+        t88.unreached_func('A success callback was invoked unexpectedly'),
+        t88.step_func_done(function(err) {
           assert_equals(err.code, err.TIMEOUT);
-          t88.done();
         }),
         {timeout: 0, maximumAge: 0}
     );
   } catch(e) {
-    t88.step(function() {
-      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-    });
+    t88.unreached_func('An exception was thrown unexpectedly: ' + e.message);
   }
 
   try {
     geo.getCurrentPosition(
-        t91.step_func(function(pos) {
-          assert_unreached('A success callback was invoked unexpectedly');
-        }),
-        t91.step_func(function(err) {
+        t91.unreached_func('A success callback was invoked unexpectedly'),
+        t91.step_func_done(function(err) {
           assert_equals(err.code, err.TIMEOUT);
-          t91.done();
         }),
         {timeout:-1, maximumAge: 0}
     );
   } catch(e) {
-    t91.step(function() {
-      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-    });
+    t91.unreached_func('An exception was thrown unexpectedly: ' + e.message);
   }
 
   try {
     geo.watchPosition(
-        t92.step_func(function(pos) {
-          assert_unreached('A success callback was invoked unexpectedly');
-          done();
-        }),
-        t92.step_func(function(err) {
+        t92.unreached_func('A success callback was invoked unexpectedly'),
+        t92.step_func_done(function(err) {
           assert_equals(err.code, err.TIMEOUT);
-          done();
         }),
         {timeout: -1, maximumAge: 0}
     );
   } catch(e) {
-    t92.step(function() {
-      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-    });
+    t92.unreached_func('An exception was thrown unexpectedly: ' + e.message);
   }
 }, 'PositionOptions tests');
 </script>

--- a/geolocation-API/PositionOptions.https.html
+++ b/geolocation-API/PositionOptions.https.html
@@ -50,7 +50,9 @@ test(function() {
         {timeout: 0, maximumAge: 0}
     );
   } catch(e) {
-    t86.unreached_func('An exception was thrown unexpectedly: ' + e.message);
+    t86.step(function() {
+      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
+    });
   }
 
   try {
@@ -62,7 +64,9 @@ test(function() {
         {timeout: 0, maximumAge: 0}
     );
   } catch(e) {
-    t88.unreached_func('An exception was thrown unexpectedly: ' + e.message);
+    t88.step(function() {
+      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
+    });
   }
 
   try {
@@ -74,7 +78,9 @@ test(function() {
         {timeout:-1, maximumAge: 0}
     );
   } catch(e) {
-    t91.unreached_func('An exception was thrown unexpectedly: ' + e.message);
+    t91.step(function() {
+      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
+    });
   }
 
   try {
@@ -86,7 +92,9 @@ test(function() {
         {timeout: -1, maximumAge: 0}
     );
   } catch(e) {
-    t92.unreached_func('An exception was thrown unexpectedly: ' + e.message);
+    t92.step(function() {
+      assert_unreached('An exception was thrown unexpectedly: ' + e.message);
+    });
   }
 }, 'PositionOptions tests');
 </script>

--- a/geolocation-API/clearWatch_TypeError.html
+++ b/geolocation-API/clearWatch_TypeError.html
@@ -18,6 +18,5 @@ test(function() {
   } catch(e) {
     assert_unreached('An exception was thrown unexpectedly: ' + e.message);
   }
-  done();
 }, 'Test that calling clearWatch with invalid watch IDs does not cause an exception');
 </script>

--- a/geolocation-API/getCurrentPosition_permission_allow.https.html
+++ b/geolocation-API/getCurrentPosition_permission_allow.https.html
@@ -14,31 +14,22 @@
 var t = async_test('User allows access, check that success callback is called or error callback is called with correct code.'),
     onSuccess, onError, hasMethodReturned = false;
 
-onSuccess = t.step_func(function(pos) {
+onSuccess = t.step_func_done(function(pos) {
   // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
-  test(function() {
-    assert_true(hasMethodReturned);
-  }, 'Check that getCurrentPosition returns synchronously before any callbacks are invoked.');
-
-  done();
+  assert_true(hasMethodReturned);
 });
 
-onError = t.step_func(function(err) {
+onError = t.step_func_done(function(err) {
   // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
-  test(function() {
-    assert_true(hasMethodReturned);
-  }, 'Check that getCurrentPosition returns synchronously before any callbacks are invoked.');
-
-  assert_true(!isUsingPreemptivePermission && err.code === err.POSITION_UNAVAILABLE);
-  done();
+  assert_true(hasMethodReturned);
+  assert_false(isUsingPreemptivePermission);
+  assert_equals(err.code, err.POSITION_UNAVAILABLE, errorToString(err));
 });
 
 try {
   geo.getCurrentPosition(onSuccess, onError);
   hasMethodReturned = true;
 } catch(e) {
-  t.step(function() {
-    assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-  });
+  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
 }
 </script>

--- a/geolocation-API/getCurrentPosition_permission_allow.https.html
+++ b/geolocation-API/getCurrentPosition_permission_allow.https.html
@@ -14,22 +14,21 @@
 var t = async_test('User allows access, check that success callback is called or error callback is called with correct code.'),
     onSuccess, onError, hasMethodReturned = false;
 
-onSuccess = t.step_func_done(function(pos) {
-  // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
-  assert_true(hasMethodReturned);
-});
+t.step(function() {
+  onSuccess = t.step_func_done(function(pos) {
+    // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
+    assert_true(hasMethodReturned);
+  });
 
-onError = t.step_func_done(function(err) {
-  // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
-  assert_true(hasMethodReturned);
-  assert_false(isUsingPreemptivePermission);
-  assert_equals(err.code, err.POSITION_UNAVAILABLE, errorToString(err));
-});
+  onError = t.step_func_done(function(err) {
+    // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00031
+    assert_true(hasMethodReturned);
+    assert_false(isUsingPreemptivePermission);
+    assert_equals(err.code, err.POSITION_UNAVAILABLE, errorToString(err));
+  });
 
-try {
   geo.getCurrentPosition(onSuccess, onError);
   hasMethodReturned = true;
-} catch(e) {
-  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
-}
+});
+
 </script>

--- a/geolocation-API/getCurrentPosition_permission_deny.https.html
+++ b/geolocation-API/getCurrentPosition_permission_deny.https.html
@@ -25,11 +25,8 @@ t.step(function() {
     assert_equals(err.code, err.PERMISSION_DENIED, errorToString(err));
   });
 
-try {
   geo.getCurrentPosition(onSuccess, onError);
   hasMethodReturned = true;
-} catch(e) {
-  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
-}
-</script>
+});
 
+</script>

--- a/geolocation-API/getCurrentPosition_permission_deny.https.html
+++ b/geolocation-API/getCurrentPosition_permission_deny.https.html
@@ -15,20 +15,21 @@ var t = async_test('User denies access, check that error callback is called with
     onSuccess, onError, hasMethodReturned = false;
 
 t.step(function() {
-  onSuccess = t.step_func(function(pos) {
+  onSuccess = t.step_func_done(function(pos) {
     assert_unreached('A success callback was invoked unexpectedly with position ' + positionToString(pos));
   });
 
-  onError =  t.step_func(function(err) {
+  onError =  t.step_func_done(function(err) {
     // http://dev.w3.org/geo/api/test-suite/t.html?00031
     assert_true(hasMethodReturned, 'Check that getCurrentPosition returns synchronously before any callbacks are invoked');
-    assert_equals(err.code, err.PERMISSION_DENIED,
-        'PossitionError code: ' + err.code, + ', message: ' + err.message);
-    done();
+    assert_equals(err.code, err.PERMISSION_DENIED, errorToString(err));
   });
 
+try {
   geo.getCurrentPosition(onSuccess, onError);
   hasMethodReturned = true;
-});
+} catch(e) {
+  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
+}
 </script>
 

--- a/geolocation-API/support.js
+++ b/geolocation-API/support.js
@@ -2,7 +2,7 @@ var geo;
 
 setup(function() {
   geo = navigator.geolocation;
-}, {explicit_done: true});
+});
 
 // The spec states that an implementation SHOULD acquire user permission before
 // beggining the position acquisition steps. If an implementation follows this

--- a/geolocation-API/watchPosition_permission_deny.https.html
+++ b/geolocation-API/watchPosition_permission_deny.https.html
@@ -14,18 +14,15 @@
 var t = async_test('Check that watchPosition returns synchronously before any callbacks are invoked.'),
     id, checkMethodHasReturned, hasMethodReturned = false;
 
-checkMethodHasReturned = t.step_func(function() {
+checkMethodHasReturned = t.step_func_done(function() {
   assert_true(hasMethodReturned);
-  done();
 });
 
 try {
   id = geo.watchPosition(checkMethodHasReturned, checkMethodHasReturned);
   hasMethodReturned = true;
 } catch(e) {
-  t.step(function() {
-    assert_unreached('An exception was thrown unexpectedly: ' + e.message);
-  });
+  t.unreached_func('An exception was thrown unexpectedly: ' + e.message);
 }
 
 // Rewrite http://dev.w3.org/geo/api/test-suite/t.html?00151


### PR DESCRIPTION
Couple of testharness-related changes to make it run correctly in Chromium: 

- removed usage of global `done()` function, relying instead on individual test cases (`step_func_done()` etc); this is because certain tests called the global `done()` but forgot to call the specific `this.done()`, which caused them to timeout. Moreover, at least in `PositionOptions.https.html`, calling this global done() in a
 single test essentially made it race the other test cases that didn't
 call it.
- using `step_func_done()`, `unreached_func()`, etc to simplify the  text.

(This PR is related to https://crbug.com/711032)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5559)
<!-- Reviewable:end -->
