### PR TITLE
XMLHttpRequest: Check for lowercase header names in getAllResponseHeaders()

### DIFF
--- a/XMLHttpRequest/getresponseheader-chunked-trailer.htm
+++ b/XMLHttpRequest/getresponseheader-chunked-trailer.htm
@@ -18,7 +18,7 @@
               assert_equals(client.getResponseHeader('Trailer'), 'X-Test-Me')
               assert_equals(client.getResponseHeader('X-Test-Me'), null)
               assert_equals(client.getAllResponseHeaders().indexOf('Trailer header value'), -1)
-              assert_regexp_match(client.getAllResponseHeaders(), /Trailer:\sX-Test-Me/)
+              assert_regexp_match(client.getAllResponseHeaders(), /trailer:\sX-Test-Me/)
               assert_equals(client.responseText, "First chunk\r\nSecond chunk\r\nYet another (third) chunk\r\nYet another (fourth) chunk\r\n")
               test.done()
             }


### PR DESCRIPTION
After https://github.com/whatwg/xhr/pull/130, getAllResponseHeaders() runs
the "sort and combine" step described in the Fetch spec, which, as of
https://github.com/whatwg/fetch/pull/475, causes all header names to be
byte-lowercased.

The regular expression in getresponseheader-chunked-trailer.htm was still
trying to match "Trailer" instead of "trailer", which caused it to fail with
conformant implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5565)
<!-- Reviewable:end -->
