### PR TITLE
Add tests for the messageerror IDL and content attributes

### DIFF
--- a/html/dom/resources/interfaces.idl
+++ b/html/dom/resources/interfaces.idl
@@ -1621,19 +1621,22 @@ interface DocumentAndElementEventHandlers {
 
 [NoInterfaceObject]
 interface WindowEventHandlers {
-           attribute EventHandler onafterprint;
-           attribute EventHandler onbeforeprint;
-           attribute OnBeforeUnloadEventHandler onbeforeunload;
-           attribute EventHandler onhashchange;
-           attribute EventHandler onlanguagechange;
-           attribute EventHandler onmessage;
-           attribute EventHandler onoffline;
-           attribute EventHandler ononline;
-           attribute EventHandler onpagehide;
-           attribute EventHandler onpageshow;
-           attribute EventHandler onpopstate;
-           attribute EventHandler onstorage;
-           attribute EventHandler onunload;
+  attribute EventHandler onafterprint;
+  attribute EventHandler onbeforeprint;
+  attribute OnBeforeUnloadEventHandler onbeforeunload;
+  attribute EventHandler onhashchange;
+  attribute EventHandler onlanguagechange;
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
+  attribute EventHandler onoffline;
+  attribute EventHandler ononline;
+  attribute EventHandler onpagehide;
+  attribute EventHandler onpageshow;
+  attribute EventHandler onpopstate;
+  attribute EventHandler onrejectionhandled;
+  attribute EventHandler onstorage;
+  attribute EventHandler onunhandledrejection;
+  attribute EventHandler onunload;
 };
 
 typedef (DOMString or Function) TimerHandler;
@@ -1871,23 +1874,24 @@ interface MessageChannel {
   readonly attribute MessagePort port2;
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), Transferable]
 interface MessagePort : EventTarget {
-  void postMessage(any message, optional sequence<Transferable> transfer);
+  void postMessage(any message, optional sequence<object> transfer = []);
   void start();
   void close();
 
   // event handlers
-           attribute EventHandler onmessage;
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
 };
-// MessagePort implements Transferable;
 
-[Constructor(DOMString channel), Exposed=(Window,Worker)]
+[Constructor(DOMString name), Exposed=(Window,Worker)]
 interface BroadcastChannel : EventTarget {
   readonly attribute DOMString name;
   void postMessage(any message);
   void close();
-           attribute EventHandler onmessage;
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
 };
 
 [Exposed=Worker]
@@ -1906,9 +1910,13 @@ interface WorkerGlobalScope : EventTarget {
 };
 
 [Global=(Worker,DedicatedWorker),Exposed=DedicatedWorker]
-/*sealed*/ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
-  void postMessage(any message, optional sequence<Transferable> transfer);
-           attribute EventHandler onmessage;
+interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
+  void postMessage(any message, optional sequence<object> transfer = []);
+
+  void close();
+
+  attribute EventHandler onmessage;
+  attribute EventHandler onmessageerror;
 };
 
 [Global=(Worker,SharedWorker),Exposed=SharedWorker]

--- a/webmessaging/messageerror.html
+++ b/webmessaging/messageerror.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>onmessageerror content attribute</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#handler-onmessageerror">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script>
+"use strict";
+window.messageErrorHappened = false;
+
+function cleanup() {
+  window.messageErrorHappened = false;
+  document.body.removeAttribute("onmessageerror");
+}
+
+test(() => {
+  assert_equals(document.body.onmessageerror, null, "body");
+  assert_equals(window.onmessageerror, null, "window");
+}, "The default value of onmessageerror is null");
+
+test(t => {
+  t.add_cleanup(cleanup);
+
+  document.body.setAttribute("onmessageerror", "window.messageErrorHappened = true;")
+  const compiledHandler = document.body.onmessageerror;
+
+  assert_equals(typeof compiledHandler, "function", "The onmessageerror property must be a function");
+  compiledHandler();
+  assert_true(window.messageErrorHappened, "Calling the handler must run the code");
+}, "The onmessageerror content attribute must be compiled into the onmessageerror property");
+
+test(t => {
+  t.add_cleanup(cleanup);
+
+  document.body.setAttribute("onmessageerror", "window.messageErrorHappened = true;")
+
+  document.body.dispatchEvent(new Event("messageerror"));
+
+  assert_true(window.messageErrorHappened, "Dispatching the event must run the code");
+}, "The onmessageerror content attribute must execute when an event is dispatched on the body");
+
+test(t => {
+  t.add_cleanup(cleanup);
+
+  document.body.setAttribute("onmessageerror", "window.messageErrorHappened = true;")
+
+  window.dispatchEvent(new Event("messageerror"));
+
+  assert_true(window.messageErrorHappened, "Dispatching the event must run the code");
+}, "The onmessageerror content attribute must execute when an event is dispatched on the window");
+</script>


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2530. As explained there, the circumstances in which this would actually be fired by the UA are not tested in this PR, waiting instead for #5003.

As a side effect this syncs various IDL snippets with the HTML Standard.

FYI @binji @mtrofin on the Blink side, @lars-t-hansen on the Gecko side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5567)
<!-- Reviewable:end -->
