### PR TITLE
Cue text parsing tests

### DIFF
--- a/webvtt/parsing/cue-text-parsing/buildtests.py
+++ b/webvtt/parsing/cue-text-parsing/buildtests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import urllib.parse

--- a/webvtt/parsing/cue-text-parsing/buildtests.py
+++ b/webvtt/parsing/cue-text-parsing/buildtests.py
@@ -1,11 +1,13 @@
 #!/usr/bin/python
 
 import os
-import urllib
+import urllib.parse
 import hashlib
 
-doctmpl = """<!doctype html>
+doctmpl = """\
+<!doctype html>
 <title>WebVTT cue data parser test %s</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
 <style>video { display:none }</style>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -17,51 +19,53 @@ doctmpl = """<!doctype html>
 runTests([
 %s
 ]);
-</script>"""
+</script>
+"""
 
 testobj = "{name:'%s', input:'%s', expected:'%s'}"
 
 def appendtest(tests, input, expected):
-    tests.append(testobj % (hashlib.sha1(input).hexdigest(), urllib.quote(input[:-1]),  urllib.quote(expected[:-1])))
+    tests.append(testobj % (hashlib.sha1(input.encode('UTF-8')).hexdigest(), urllib.parse.quote(input[:-1]),  urllib.parse.quote(expected[:-1])))
 
 files = os.listdir('dat/')
 for file in files:
     if os.path.isdir('dat/'+file) or file[0] == ".":
         continue
+
     tests = []
     input = ""
     expected = ""
     state = ""
-    f = open('dat/'+file, "r")
-    while 1:
-        line = f.readline()
-        if not line:
-            if state != "":
-                appendtest(tests, input, expected)
-                input = ""
-                expected = ""
-                state = ""
-            break
-        if line[0] == "#":
-            state = line
-            if line == "#document-fragment\n":
-                expected = expected + line
-        elif state == "#data\n":
-            input = input + line
-        elif state == "#errors\n":
-            pass
-        elif state == "#document-fragment\n":
-            if line == "\n":
-                appendtest(tests, input, expected)
-                input = ""
-                expected = ""
-                state = ""
+    with open('dat/'+file, "r") as f:
+        while True:
+            line = f.readline()
+            if not line:
+                if state != "":
+                    appendtest(tests, input, expected)
+                    input = ""
+                    expected = ""
+                    state = ""
+                break
+
+            if line[0] == "#":
+                state = line
+                if line == "#document-fragment\n":
+                    expected += bytes(line, 'UTF-8').decode('unicode-escape')
+            elif state == "#data\n":
+                input += bytes(line, 'UTF-8').decode('unicode-escape')
+            elif state == "#errors\n":
+                pass
+            elif state == "#document-fragment\n":
+                if line == "\n":
+                    appendtest(tests, input, expected)
+                    input = ""
+                    expected = ""
+                    state = ""
+                else:
+                    expected += bytes(line, 'UTF-8').decode('unicode-escape')
             else:
-                expected = expected + line
-        else:
-            raise Exception("failed to parse file "+file+" line:"+line+" (state: "+state+")")
-    f.close()
-    barename = file.replace(".dat", "")
-    out = open('tests/'+barename+".html", "w")
-    out.write(doctmpl % (barename, ",\n".join(tests)))
-    out.close()
+                raise Exception("failed to parse file %s:%s (state: %s)" % (file, line, state))
+
+    name = os.path.splitext(file)[0]
+    with open('tests/'+name+".html", "w") as out:
+        out.write(doctmpl % (name, ",\n".join(tests)))

--- a/webvtt/parsing/cue-text-parsing/dat/entities.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/entities.dat
@@ -8,7 +8,7 @@
 &amp
 #errors
 #document-fragment
-| "&amp"
+| "&"
 
 #data
 &amp;
@@ -20,7 +20,7 @@
 &AMP;
 #errors
 #document-fragment
-| "&AMP;"
+| "&"
 
 #data
 &lt;
@@ -50,7 +50,7 @@ a&rlm;b
 &quot;
 #errors
 #document-fragment
-| "&quot;"
+| "\u0022"
 
 #data
 &nbsp;
@@ -62,7 +62,7 @@ a&rlm;b
 &copy;
 #errors
 #document-fragment
-| "&copy;"
+| "\u00A9"
 
 #data
 &&
@@ -99,16 +99,52 @@ a&rlm;b
 &#32;
 #errors
 #document-fragment
-| "&#32;"
+| " "
 
 #data
 &#x20;
 #errors
 #document-fragment
-| "&#x20;"
+| " "
 
 #data
 &;
 #errors
 #document-fragment
 | "&;"
+
+#data
+&ClockwiseContourIntegral;
+#errors
+#document-fragment
+| "\u2232"
+
+#data
+&nsubE;
+#errors
+#document-fragment
+| "\u2AC5\u0338"
+
+#data
+&notin;
+#errors
+#document-fragment
+| "\u2209"
+
+#data
+&not;
+#errors
+#document-fragment
+| "\u00AC"
+
+#data
+&not
+#errors
+#document-fragment
+| "\u00AC"
+
+#data
+&notit;
+#errors
+#document-fragment
+| "\u00ACit"

--- a/webvtt/parsing/cue-text-parsing/dat/entities.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/entities.dat
@@ -38,13 +38,13 @@
 a&lrm;b
 #errors
 #document-fragment
-| "a‎b"
+| "a\u200Eb"
 
 #data
 a&rlm;b
 #errors
 #document-fragment
-| "a‏b"
+| "a\u200Fb"
 
 #data
 &quot;
@@ -56,7 +56,7 @@ a&rlm;b
 &nbsp;
 #errors
 #document-fragment
-| " "
+| "\u00A0"
 
 #data
 &copy;

--- a/webvtt/parsing/cue-text-parsing/dat/tags.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/tags.dat
@@ -9,18 +9,17 @@
 #document-fragment
 
 #data
-<	
+<\t
 #errors
 #document-fragment
 
 #data
-<
-
+<\n
 #errors
 #document-fragment
 
 #data
-< 
+<\x20
 #errors
 #document-fragment
 
@@ -54,3 +53,162 @@ c>x
 #document-fragment
 | <span>
 |   "x"
+
+#data
+<c>test
+#errors
+#document-fragment
+| <span>
+|   "test"
+
+#data
+a<c.d e>b</c>c
+#errors
+#document-fragment
+| "a"
+| <span>
+|   class="d"
+|   "b"
+| "c"
+
+#data
+<i>test
+#errors
+#document-fragment
+| <i>
+|   "test"
+
+#data
+a<i.d e>b</i>c
+#errors
+#document-fragment
+| "a"
+| <i>
+|   class="d"
+|   "b"
+| "c"
+
+#data
+<b>test
+#errors
+#document-fragment
+| <b>
+|   "test"
+
+#data
+a<b.d e>b</b>c
+#errors
+#document-fragment
+| "a"
+| <b>
+|   class="d"
+|   "b"
+| "c"
+
+#data
+<u>test
+#errors
+#document-fragment
+| <u>
+|   "test"
+
+#data
+a<u.d e>b</u>c
+#errors
+#document-fragment
+| "a"
+| <u>
+|   class="d"
+|   "b"
+| "c"
+
+#data
+<ruby>test
+#errors
+#document-fragment
+| <ruby>
+|   "test"
+
+#data
+a<ruby.f g>b<rt.h j>c</rt>d</ruby>e
+#errors
+#document-fragment
+| "a"
+| <ruby>
+|   class="f"
+|   "b"
+|   <rt>
+|     class="h"
+|     "c"
+|   "d"
+| "e"
+
+#data
+<rt>test
+#errors
+#document-fragment
+| "test"
+
+#data
+<v>test
+#errors
+#document-fragment
+| <span>
+|   title=""
+|   "test"
+
+#data
+<v a>test
+#errors
+#document-fragment
+| <span>
+|   title="a"
+|   "test"
+
+#data
+<v a b>test
+#errors
+#document-fragment
+| <span>
+|   title="a b"
+|   "test"
+
+#data
+<v.a>test
+#errors
+#document-fragment
+| <span>
+|   class="a"
+|   title=""
+|   "test"
+
+#data
+<v.a.b>test
+#errors
+#document-fragment
+| <span>
+|   class="a b"
+|   title=""
+|   "test"
+
+#data
+a<v.d e>b</v>c
+#errors
+#document-fragment
+| "a"
+| <span>
+|   class="d"
+|   title="e"
+|   "b"
+| "c"
+
+#data
+a<lang.d e>b</lang>c
+#errors
+#document-fragment
+| "a"
+| <span>
+|   class="d"
+|   lang="e"
+|   "b"
+| "c"

--- a/webvtt/parsing/cue-text-parsing/dat/text.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/text.dat
@@ -1,0 +1,29 @@
+#data
+text
+#errors
+#document-fragment
+| "text"
+
+#data
+text1\ntext2
+#errors
+#document-fragment
+| "text1\ntext2"
+
+#data
+foo\x00bar
+#errors
+#document-fragment
+| "foo\uFFFDbar"
+
+#data
+\u2713
+#errors
+#document-fragment
+| "\u2713"
+
+#data
+text1\n\ntext2
+#errors
+#document-fragment
+| "text1"

--- a/webvtt/parsing/cue-text-parsing/dat/timestamps.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/timestamps.dat
@@ -14,6 +14,11 @@
 #document-fragment
 
 #data
+<00:\x0000:00.500>
+#errors
+#document-fragment
+
+#data
 <00:00.500
 #errors
 #document-fragment

--- a/webvtt/parsing/cue-text-parsing/dat/tree-building.dat
+++ b/webvtt/parsing/cue-text-parsing/dat/tree-building.dat
@@ -5,47 +5,6 @@ test
 | "test"
 
 #data
-<c>test
-#errors
-#document-fragment
-| <span>
-|   "test"
-
-#data
-<i>test
-#errors
-#document-fragment
-| <i>
-|   "test"
-
-#data
-<b>test
-#errors
-#document-fragment
-| <b>
-|   "test"
-
-#data
-<u>test
-#errors
-#document-fragment
-| <u>
-|   "test"
-
-#data
-<ruby>test
-#errors
-#document-fragment
-| <ruby>
-|   "test"
-
-#data
-<rt>test
-#errors
-#document-fragment
-| "test"
-
-#data
 <ruby>test<rt>test
 #errors
 #document-fragment
@@ -127,45 +86,3 @@ test
 |     <b>
 |       "test"
 | "test"
-
-#data
-<v>test
-#errors
-#document-fragment
-| <span>
-|   title=""
-|   "test"
-
-#data
-<v a>test
-#errors
-#document-fragment
-| <span>
-|   title="a"
-|   "test"
-
-#data
-<v a b>test
-#errors
-#document-fragment
-| <span>
-|   title="a b"
-|   "test"
-
-#data
-<v.a>test
-#errors
-#document-fragment
-| <span>
-|   class="a"
-|   title=""
-|   "test"
-
-#data
-<v.a.b>test
-#errors
-#document-fragment
-| <span>
-|   class="a b"
-|   title=""
-|   "test"

--- a/webvtt/parsing/cue-text-parsing/tests/entities.html
+++ b/webvtt/parsing/cue-text-parsing/tests/entities.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>WebVTT cue data parser test entities</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
 <style>video { display:none }</style>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>

--- a/webvtt/parsing/cue-text-parsing/tests/entities.html
+++ b/webvtt/parsing/cue-text-parsing/tests/entities.html
@@ -11,23 +11,29 @@
 <script>
 runTests([
 {name:'3686fc0cdc60dc536e75df054b0bd372273db2cc', input:'%26', expected:'%23document-fragment%0A%7C%20%22%26%22'},
-{name:'f1869f6e2853635eec81cc3afa3e2b8148ccbdc0', input:'%26amp', expected:'%23document-fragment%0A%7C%20%22%26amp%22'},
+{name:'f1869f6e2853635eec81cc3afa3e2b8148ccbdc0', input:'%26amp', expected:'%23document-fragment%0A%7C%20%22%26%22'},
 {name:'92d76530d723b6b4e4ef8280c01cf1c80f9bebdb', input:'%26amp%3B', expected:'%23document-fragment%0A%7C%20%22%26%22'},
-{name:'261cd4e9df4a12535b66a0c39e9635aab2bb19aa', input:'%26AMP%3B', expected:'%23document-fragment%0A%7C%20%22%26AMP%3B%22'},
+{name:'261cd4e9df4a12535b66a0c39e9635aab2bb19aa', input:'%26AMP%3B', expected:'%23document-fragment%0A%7C%20%22%26%22'},
 {name:'1a2269cdb73bf97ec6a99b0edabfe646c471b67e', input:'%26lt%3B', expected:'%23document-fragment%0A%7C%20%22%3C%22'},
 {name:'44ceb90884cceeeccb4f7024e3598f7dc5ceebfa', input:'%26gt%3B', expected:'%23document-fragment%0A%7C%20%22%3E%22'},
 {name:'05def72af03fc2b1617da950d871b9fd0ba20e5a', input:'a%26lrm%3Bb', expected:'%23document-fragment%0A%7C%20%22a%E2%80%8Eb%22'},
 {name:'da999a55445eca43aa41e039ec439c1a812db297', input:'a%26rlm%3Bb', expected:'%23document-fragment%0A%7C%20%22a%E2%80%8Fb%22'},
-{name:'0fd9e3823b62c028c1d50e35b1f3ee3df02a62eb', input:'%26quot%3B', expected:'%23document-fragment%0A%7C%20%22%26quot%3B%22'},
+{name:'0fd9e3823b62c028c1d50e35b1f3ee3df02a62eb', input:'%26quot%3B', expected:'%23document-fragment%0A%7C%20%22%22%22'},
 {name:'e7387003fbacb22b706796c98b781eb4ebf5ff85', input:'%26nbsp%3B', expected:'%23document-fragment%0A%7C%20%22%C2%A0%22'},
-{name:'216cd0e914b9f2ccd04eff6d02a0b1ce24441d95', input:'%26copy%3B', expected:'%23document-fragment%0A%7C%20%22%26copy%3B%22'},
+{name:'216cd0e914b9f2ccd04eff6d02a0b1ce24441d95', input:'%26copy%3B', expected:'%23document-fragment%0A%7C%20%22%C2%A9%22'},
 {name:'2cdf20980d17a5d077299215e6a7e97f3c6b07e2', input:'%26%26', expected:'%23document-fragment%0A%7C%20%22%26%26%22'},
 {name:'83f4500c0bd8598480713997a041d8f70fd3f11e', input:'%261', expected:'%23document-fragment%0A%7C%20%22%261%22'},
 {name:'2c6b2ba38a08eca45370f28a5b7df2aa463fb3dc', input:'%261%3B', expected:'%23document-fragment%0A%7C%20%22%261%3B%22'},
 {name:'f4bb977c0a06851bdd19260c035a766c5c8ea093', input:'%26%3C', expected:'%23document-fragment%0A%7C%20%22%26%22'},
 {name:'b1fff1ac42688d16e00f6c758d84e5152e39702d', input:'%26%3Cc', expected:'%23document-fragment%0A%7C%20%22%26%22%0A%7C%20%3Cspan%3E'},
-{name:'bd68f6beda2c2264e61dff7359c1ad48bc0a9934', input:'%26%2332%3B', expected:'%23document-fragment%0A%7C%20%22%26%2332%3B%22'},
-{name:'5b77a0be23453dfe6eea59d43bb0708f89e1df82', input:'%26%23x20%3B', expected:'%23document-fragment%0A%7C%20%22%26%23x20%3B%22'},
-{name:'87986551b0e6180cb279f2aa4cdddf77daa90c11', input:'%26%3B', expected:'%23document-fragment%0A%7C%20%22%26%3B%22'}
+{name:'bd68f6beda2c2264e61dff7359c1ad48bc0a9934', input:'%26%2332%3B', expected:'%23document-fragment%0A%7C%20%22%20%22'},
+{name:'5b77a0be23453dfe6eea59d43bb0708f89e1df82', input:'%26%23x20%3B', expected:'%23document-fragment%0A%7C%20%22%20%22'},
+{name:'87986551b0e6180cb279f2aa4cdddf77daa90c11', input:'%26%3B', expected:'%23document-fragment%0A%7C%20%22%26%3B%22'},
+{name:'e3ac2060b915f0f499b2863f999dcdb38a5db79b', input:'%26ClockwiseContourIntegral%3B', expected:'%23document-fragment%0A%7C%20%22%E2%88%B2%22'},
+{name:'31c8a5ecfa5c54d8c0ec5b4ee8f0bbea0d6d40af', input:'%26nsubE%3B', expected:'%23document-fragment%0A%7C%20%22%E2%AB%85%CC%B8%22'},
+{name:'9ed59950764468c4ef2948d71cf75c3f2b60c74d', input:'%26notin%3B', expected:'%23document-fragment%0A%7C%20%22%E2%88%89%22'},
+{name:'71a6efcfab81264fb95bb3234c59687c11c72baf', input:'%26not%3B', expected:'%23document-fragment%0A%7C%20%22%C2%AC%22'},
+{name:'86d7c20ca3c060f9e699c7da43927c4a07a5d569', input:'%26not', expected:'%23document-fragment%0A%7C%20%22%C2%AC%22'},
+{name:'314cd94292df37044e90ce27b5606bf8ec636b94', input:'%26notit%3B', expected:'%23document-fragment%0A%7C%20%22%C2%ACit%22'}
 ]);
 </script>

--- a/webvtt/parsing/cue-text-parsing/tests/tags.html
+++ b/webvtt/parsing/cue-text-parsing/tests/tags.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>WebVTT cue data parser test tags</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
 <style>video { display:none }</style>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -18,6 +19,24 @@ runTests([
 {name:'0d7df935b172f2a1b357b94596d68f2443f30f8b', input:'%3Cc.', expected:'%23document-fragment%0A%7C%20%3Cspan%3E'},
 {name:'cd1d6dd274e03ae8fc56bc4ef163998d9ff24496', input:'%3C/', expected:'%23document-fragment'},
 {name:'fca1a11d42b735453117f42456360e88082a3fd7', input:'%3Cc%3E%3C/%3Ex', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20%22x%22'},
-{name:'fe3b6277edf5c2f84e7a6779eddd0cac30552bca', input:'%3Cc%3E%3C/%0Ac%3Ex', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20%22x%22'}
+{name:'fe3b6277edf5c2f84e7a6779eddd0cac30552bca', input:'%3Cc%3E%3C/%0Ac%3Ex', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20%22x%22'},
+{name:'6ceded63b53eeab3681a0fc540e959ca88f7dce9', input:'%3Cc%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20%22test%22'},
+{name:'cdcdb0d5d6a975c5612eabcbea5d732ff3bc9f56', input:'a%3Cc.d%20e%3Eb%3C/c%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'},
+{name:'71de37451e7d5524eacc8a190d21cd64c4304e14', input:'%3Ci%3Etest', expected:'%23document-fragment%0A%7C%20%3Ci%3E%0A%7C%20%20%20%22test%22'},
+{name:'70f72cc4d2139d9e8c33189a1a9b89ecd6014a15', input:'a%3Ci.d%20e%3Eb%3C/i%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Ci%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'},
+{name:'985284b688a09f1f55e3c9aab49d7e4ca11f870a', input:'%3Cb%3Etest', expected:'%23document-fragment%0A%7C%20%3Cb%3E%0A%7C%20%20%20%22test%22'},
+{name:'39c36af6d6850bc474f1d9962c1133933fd50dd0', input:'a%3Cb.d%20e%3Eb%3C/b%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cb%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'},
+{name:'fa6993eaa94404648d8b52e2830e53369404fdcb', input:'%3Cu%3Etest', expected:'%23document-fragment%0A%7C%20%3Cu%3E%0A%7C%20%20%20%22test%22'},
+{name:'45221829445210412642152bfb22fa2ed222d46e', input:'a%3Cu.d%20e%3Eb%3C/u%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cu%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'},
+{name:'e4d351e1a6b40a7dace801b722efaa200c4895f2', input:'%3Cruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22'},
+{name:'a8481eabd1dcac1d02e57e74d499e2395ac171cd', input:'a%3Cruby.f%20g%3Eb%3Crt.h%20j%3Ec%3C/rt%3Ed%3C/ruby%3Ee', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cruby%3E%0A%7C%20%20%20class%3D%22f%22%0A%7C%20%20%20%22b%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20class%3D%22h%22%0A%7C%20%20%20%20%20%22c%22%0A%7C%20%20%20%22d%22%0A%7C%20%22e%22'},
+{name:'68e1d0376f827ebe0c047751a2067594ff41b612', input:'%3Crt%3Etest', expected:'%23document-fragment%0A%7C%20%22test%22'},
+{name:'ab2024b4e65ed64a751adbe8aae1e84ee61bf3e6', input:'%3Cv%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'},
+{name:'10f4823ffb17c71654c4602bc45c58300e3ecbcc', input:'%3Cv%20a%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22a%22%0A%7C%20%20%20%22test%22'},
+{name:'909924ef392fb20c9526acfa4f18f891eda61a0c', input:'%3Cv%20a%20b%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22a%20b%22%0A%7C%20%20%20%22test%22'},
+{name:'e5ca35cc29404efc0ebd58aa5f6efefc86fc5287', input:'%3Cv.a%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22a%22%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'},
+{name:'e535c486dac7dc571463b150adc55fd841bc3008', input:'%3Cv.a.b%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22a%20b%22%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'},
+{name:'bb7abafab60a0ea63f57420759fac4093148ecc8', input:'a%3Cv.d%20e%3Eb%3C/v%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20title%3D%22e%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'},
+{name:'b53365151e0b2434837d6cce15c3d51e666a813e', input:'a%3Clang.d%20e%3Eb%3C/lang%3Ec', expected:'%23document-fragment%0A%7C%20%22a%22%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22d%22%0A%7C%20%20%20lang%3D%22e%22%0A%7C%20%20%20%22b%22%0A%7C%20%22c%22'}
 ]);
 </script>

--- a/webvtt/parsing/cue-text-parsing/tests/text.html
+++ b/webvtt/parsing/cue-text-parsing/tests/text.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>WebVTT cue data parser test text</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
+<style>video { display:none }</style>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/html/syntax/parsing/template.js></script>
+<script src=/html/syntax/parsing/common.js></script>
+<script src=../common.js></script>
+<div id=log></div>
+<script>
+runTests([
+{name:'aa785adca3fcdfe1884ae840e13c6d294a2414e8', input:'text', expected:'%23document-fragment%0A%7C%20%22text%22'},
+{name:'3979f3c0c7664ee8a9f78854626bc7bc39b86c96', input:'text1%0Atext2', expected:'%23document-fragment%0A%7C%20%22text1%0Atext2%22'},
+{name:'6805ac5ddce21cfceb4eccf04a6a9013760f5d5b', input:'foo%00bar', expected:'%23document-fragment%0A%7C%20%22foo%EF%BF%BDbar%22'},
+{name:'5cfbdbe32701516fc90c3786da1db4716ac09fb8', input:'%E2%9C%93', expected:'%23document-fragment%0A%7C%20%22%E2%9C%93%22'},
+{name:'a34d27ca7b23f07db6ec2e32226fca105e958db6', input:'text1%0A%0Atext2', expected:'%23document-fragment%0A%7C%20%22text1%22'}
+]);
+</script>

--- a/webvtt/parsing/cue-text-parsing/tests/timestamps.html
+++ b/webvtt/parsing/cue-text-parsing/tests/timestamps.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>WebVTT cue data parser test timestamps</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
 <style>video { display:none }</style>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -12,6 +13,7 @@ runTests([
 {name:'54c245f3fbe7a3e25398b13971d44f2bb3a5f947', input:'%3C0', expected:'%23document-fragment'},
 {name:'5e190a1b4541fcb10e403af111c14ef152fecb0d', input:'%3C0.500', expected:'%23document-fragment'},
 {name:'92b97d3497836259e0b9305e27f2b91ea1dc9b31', input:'%3C0%3A00.500', expected:'%23document-fragment'},
+{name:'2f0e84518d356cb1e56a366296fa491c5bed1e3a', input:'%3C00%3A%0000%3A00.500%3E', expected:'%23document-fragment'},
 {name:'47fa4306a695161da88533d456ce94829e53b13d', input:'%3C00%3A00.500', expected:'%23document-fragment%0A%7C%20%3C%3Ftimestamp%2000%3A00%3A00.500%3E'},
 {name:'c1036a4322c1852e02e5a1843a9a81dfca6d7af3', input:'%3C00%3A00%3A00.500', expected:'%23document-fragment%0A%7C%20%3C%3Ftimestamp%2000%3A00%3A00.500%3E'},
 {name:'70ec34d828ca661a583c651207becb968bb41653', input:'test%3C00%3A00%3A00.500%3Etest', expected:'%23document-fragment%0A%7C%20%22test%22%0A%7C%20%3C%3Ftimestamp%2000%3A00%3A00.500%3E%0A%7C%20%22test%22'},

--- a/webvtt/parsing/cue-text-parsing/tests/tree-building.html
+++ b/webvtt/parsing/cue-text-parsing/tests/tree-building.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <title>WebVTT cue data parser test tree-building</title>
+<link rel="help" href="https://w3c.github.io/webvtt/#cue-text-parsing-rules">
 <style>video { display:none }</style>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -10,12 +11,6 @@
 <script>
 runTests([
 {name:'4e1243bd22c66e76c2ba9eddc1f91394e57f9f83', input:'test', expected:'%23document-fragment%0A%7C%20%22test%22'},
-{name:'6ceded63b53eeab3681a0fc540e959ca88f7dce9', input:'%3Cc%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20%22test%22'},
-{name:'71de37451e7d5524eacc8a190d21cd64c4304e14', input:'%3Ci%3Etest', expected:'%23document-fragment%0A%7C%20%3Ci%3E%0A%7C%20%20%20%22test%22'},
-{name:'985284b688a09f1f55e3c9aab49d7e4ca11f870a', input:'%3Cb%3Etest', expected:'%23document-fragment%0A%7C%20%3Cb%3E%0A%7C%20%20%20%22test%22'},
-{name:'fa6993eaa94404648d8b52e2830e53369404fdcb', input:'%3Cu%3Etest', expected:'%23document-fragment%0A%7C%20%3Cu%3E%0A%7C%20%20%20%22test%22'},
-{name:'e4d351e1a6b40a7dace801b722efaa200c4895f2', input:'%3Cruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22'},
-{name:'68e1d0376f827ebe0c047751a2067594ff41b612', input:'%3Crt%3Etest', expected:'%23document-fragment%0A%7C%20%22test%22'},
 {name:'2564487cfc7e317428fb437ef8de8de4f4963426', input:'%3Cruby%3Etest%3Crt%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%22test%22'},
 {name:'9b1902c975558eeaff4afbaf0a6dc100e1978769', input:'%3Cruby%3Etest%3Crt%3Etest%3C/rt%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%22test%22%0A%7C%20%20%20%22test%22'},
 {name:'119c596ea09649d3bd03934485e3067e89377412', input:'%3Cruby%3Etest%3Crt%3Etest%3C/rt%3E%3C/ruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%22test%22%0A%7C%20%22test%22'},
@@ -23,11 +18,6 @@ runTests([
 {name:'325c1e590e74f1ff33ca5b4838c04cf6b6dd71ba', input:'%3Cruby%3Etest%3Crt%3E%3Cb%3Etest%3C/rt%3E%3C/ruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%3Cb%3E%0A%7C%20%20%20%20%20%20%20%22test%22%0A%7C%20%20%20%20%20%20%20%22test%22'},
 {name:'92847ed2694c9639ba96f4cc61e2215362a74904', input:'%3Cruby%3Etest%3Crt%3E%3Cb%3Etest%3C/ruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%3Cb%3E%0A%7C%20%20%20%20%20%20%20%22test%22%0A%7C%20%20%20%20%20%20%20%22test%22'},
 {name:'c0da62d1c8716ca544c96799f06ac7e4664500fb', input:'%3Cruby%3Etest%3Crt%3E%3Cb%3Etest%3C/rt%3E%3C/ruby%3E%3C/b%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%3Cb%3E%0A%7C%20%20%20%20%20%20%20%22test%22%0A%7C%20%20%20%20%20%22test%22'},
-{name:'b85bd616672eba0591718182ef32e3307d223bb0', input:'%3Cruby%3Etest%3Crt%3E%3Cb%3Etest%3C/rt%3E%3C/b%3E%3C/ruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%3Cb%3E%0A%7C%20%20%20%20%20%20%20%22test%22%0A%7C%20%22test%22'},
-{name:'ab2024b4e65ed64a751adbe8aae1e84ee61bf3e6', input:'%3Cv%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'},
-{name:'10f4823ffb17c71654c4602bc45c58300e3ecbcc', input:'%3Cv%20a%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22a%22%0A%7C%20%20%20%22test%22'},
-{name:'909924ef392fb20c9526acfa4f18f891eda61a0c', input:'%3Cv%20a%20b%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20title%3D%22a%20b%22%0A%7C%20%20%20%22test%22'},
-{name:'e5ca35cc29404efc0ebd58aa5f6efefc86fc5287', input:'%3Cv.a%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22a%22%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'},
-{name:'e535c486dac7dc571463b150adc55fd841bc3008', input:'%3Cv.a.b%3Etest', expected:'%23document-fragment%0A%7C%20%3Cspan%3E%0A%7C%20%20%20class%3D%22a%20b%22%0A%7C%20%20%20title%3D%22%22%0A%7C%20%20%20%22test%22'}
+{name:'b85bd616672eba0591718182ef32e3307d223bb0', input:'%3Cruby%3Etest%3Crt%3E%3Cb%3Etest%3C/rt%3E%3C/b%3E%3C/ruby%3Etest', expected:'%23document-fragment%0A%7C%20%3Cruby%3E%0A%7C%20%20%20%22test%22%0A%7C%20%20%20%3Crt%3E%0A%7C%20%20%20%20%20%3Cb%3E%0A%7C%20%20%20%20%20%20%20%22test%22%0A%7C%20%22test%22'}
 ]);
 </script>


### PR DESCRIPTION
Improved test build script to handle character escape sequences, use python3 and put newlines at end of files.
Replaced special characters with escape sequences.
Added missing tests for cue-text parsing, specifically for handling tag annotations/classes for all tag types.

There might be an issue with timestamp tags. On firefox they serialize like this: `<01:00:00.000> → <?timestamp 3600>`, which seems reasonable but not what the tests expect. I haven't been able to determine which one the spec demands.

I'm also a little unsure as to why `&quot;` would not be converted to `"` in `entities.dat`.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
