### PR TITLE
Streams: add missing "done()" to floating-point tests

### DIFF
--- a/streams/readable-streams/floating-point-total-queue-size.js
+++ b/streams/readable-streams/floating-point-total-queue-size.js
@@ -117,3 +117,5 @@ function setupTestStream() {
 
   return { reader: rs.getReader(), controller };
 }
+
+done();

--- a/streams/writable-streams/floating-point-total-queue-size.js
+++ b/streams/writable-streams/floating-point-total-queue-size.js
@@ -88,3 +88,5 @@ function setupTestStream() {
 
   return ws.getWriter();
 }
+
+done();


### PR DESCRIPTION
For tests to work in in Worker and SharedWorker contexts, the done() function
must be called so that testharness.js knows that no more tests will be
added. This call was missing
from *-streams/floating-point-total-queue-size.js. Add it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5589)
<!-- Reviewable:end -->
