### PR TITLE
[selectors4] Remove setTimeout() calls on :focus-within Shadow DOM tests

### DIFF
--- a/css/selectors4/focus-within-shadow-001.html
+++ b/css/selectors4/focus-within-shadow-001.html
@@ -31,11 +31,9 @@ var shadow = document.getElementById('shadow-host').attachShadow({mode: 'open'})
 var template = document.getElementById('shadow-template');
 var instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
-window.setTimeout(function() {
-  var focusme = shadow.getElementById('focusme');
-  focusme.focus();
-  document.documentElement.classList.remove('reftest-wait');
-}, 0);
+var focusme = shadow.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
 </script>
 </body>
 </html>

--- a/css/selectors4/focus-within-shadow-002.html
+++ b/css/selectors4/focus-within-shadow-002.html
@@ -32,11 +32,9 @@ var shadow = document.getElementById('shadow-host').attachShadow({mode: 'open'})
 var template = document.getElementById('shadow-template');
 var instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
-window.setTimeout(function() {
-  var focusme = shadow.getElementById('focusme');
-  focusme.focus();
-  document.documentElement.classList.remove('reftest-wait');
-}, 0);
+var focusme = shadow.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
 </script>
 </body>
 </html>

--- a/css/selectors4/focus-within-shadow-003.html
+++ b/css/selectors4/focus-within-shadow-003.html
@@ -34,11 +34,9 @@ var shadow = document.getElementById('shadow-host').attachShadow({mode: 'open'})
 var template = document.getElementById('shadow-template');
 var instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
-window.setTimeout(function() {
-  var focusme = shadow.getElementById('focusme');
-  focusme.focus();
-  document.documentElement.classList.remove('reftest-wait');
-}, 0);
+var focusme = shadow.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
 </script>
 </body>
 </html>

--- a/css/selectors4/focus-within-shadow-004.html
+++ b/css/selectors4/focus-within-shadow-004.html
@@ -40,11 +40,9 @@ var shadow = document.getElementById('shadow-host').attachShadow({mode: 'open'})
 var template = document.getElementById('shadow-template');
 var instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
-window.setTimeout(function() {
-  var focusme = shadow.getElementById('focusme');
-  focusme.focus();
-  document.documentElement.classList.remove('reftest-wait');
-}, 0);
+var focusme = shadow.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
 </script>
 </body>
 </html>

--- a/css/selectors4/focus-within-shadow-005.html
+++ b/css/selectors4/focus-within-shadow-005.html
@@ -44,18 +44,14 @@ var template = document.getElementById('shadow-template');
 var instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
 
-window.setTimeout(function() {
 shadow = shadow.getElementById('nested-shadow-host').attachShadow({mode: 'open'});
 template = document.getElementById('nested-shadow-template');
 instance = document.importNode(template.content, true);
 shadow.appendChild(instance);
-}, 0);
 
-window.setTimeout(function() {
-  var focusme = shadow.getElementById('focusme');
-  focusme.focus();
-  document.documentElement.classList.remove('reftest-wait');
-}, 0);
+var focusme = shadow.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
 </script>
 </body>
 </html>


### PR DESCRIPTION
These calls were causing issues to run the tests on WebKit
and they don't seem needed to run the tests properly.

Maybe I'm missing some good reason for these `setTimeout()` class,
but for example `focus-within-shadow-006.html` doesn't have them.
If they're not really needed it'd be nice to remove them as that would make
things simpler to import these tests into WebKit.

Please @frivoal or @TakayoshiKochi take a look to this. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5594)
<!-- Reviewable:end -->
