### PR TITLE
webrtc: remove setRemoteDescription / msid test

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -10,7 +10,7 @@
   <script src="/resources/testharnessreport.js"></script>
   <script type="text/javascript">
   // tests that ontrack is called and parses the msid information from the SDP and creates
-  // the streams and tracks with matching identifiers.
+  // the streams with matching identifiers.
   async_test(function(test) {
     const sdp = 'v=0\r\n' +
         'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
@@ -34,9 +34,6 @@
     var pc = new RTCPeerConnection(null);
 
     pc.ontrack = test.step_func(function(event) {
-      assert_equals(event.track.kind, 'audio', 'ontrack fires with an audio track');
-      assert_equals(event.track.id, 'track1', 'the track name is parsed from the MSID line');
-
       assert_equals(event.streams.length, 1, 'the track belongs to one MediaStream');
       assert_equals(event.streams[0].id, 'stream1', 'the stream name is parsed from the MSID line');
       test.done();
@@ -46,7 +43,7 @@
     .catch(test.step_func(function(e) {
       assert_unreached('Error ' + e.name + ': ' + e.message);
     }));
-  }, 'Triggers ontrack when called with a remote description and the MSID is parsed.');
+  }, 'Triggers ontrack when called with a remote description and the MSID of the stream is is parsed.');
 </script>
 
 </body>


### PR DESCRIPTION
since track ids are essentially meaningless. If the party calling
setRemoteDescription would have added a track before calling SRD
the assertion from this test would break.

See https://github.com/w3c/webrtc-pc/issues/1128 for some discussion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5602)
<!-- Reviewable:end -->
