### PR TITLE
form-autocomplete: Ensure tokens are converted to ASCII lowercase and split on whitespace

### DIFF
--- a/html/semantics/forms/the-form-element/form-autocomplete.html
+++ b/html/semantics/forms/the-form-element/form-autocomplete.html
@@ -47,12 +47,14 @@
   autocompletetest(document.forms.autocomplete_off, ["off", "off", "on", "off", ""], "form autocomplete attribute off");
   autocompletetest(document.forms.autocomplete_invalid, ["on", "on", "on", "off", ""], "form autocomplete attribute invalid");
 
-  var keywords = [ "name", "honorific-prefix", "given-name", "additional-name", "family-name", "honorific-suffix", "nickname", "username", "new-password", "current-password", "organization-title", "organization", "street-address", "address-line1", "address-line2", "address-line3", "address-level4", "address-level3", "address-level2", "address-level1", "country", "country-name", "postal-code", "cc-name", "cc-given-name", "cc-additional-name", "cc-family-name", "cc-number", "cc-exp", "cc-exp-month", "cc-exp-year", "cc-csc", "cc-type", "transaction-currency", "transaction-amount", "language", "bday", "bday-day", "bday-month", "bday-year", "sex", "url", "photo", "tel", "tel-country-code", "tel-national", "tel-area-code", "tel-local", "tel-local-prefix", "tel-local-suffix", "tel-extension", "email", "impp" ];
+  var keywords = [ "on", "off", "name", "honorific-prefix", "given-name", "additional-name", "family-name", "honorific-suffix", "nickname", "username", "new-password", "current-password", "organization-title", "organization", "street-address", "address-line1", "address-line2", "address-line3", "address-level4", "address-level3", "address-level2", "address-level1", "country", "country-name", "postal-code", "cc-name", "cc-given-name", "cc-additional-name", "cc-family-name", "cc-number", "cc-exp", "cc-exp-month", "cc-exp-year", "cc-csc", "cc-type", "transaction-currency", "transaction-amount", "language", "bday", "bday-day", "bday-month", "bday-year", "sex", "url", "photo", "tel", "tel-country-code", "tel-national", "tel-area-code", "tel-local", "tel-local-prefix", "tel-local-suffix", "tel-extension", "email", "impp" ];
 
   keywords.forEach(function(keyword) {
     test(function(){
       var input = document.createElement("input");
-      input.setAttribute("autocomplete", keyword);
+      // Include whitespace to test splitting tokens on whitespace.
+      // Convert to uppercase to ensure that the tokens are normalized to lowercase.
+      input.setAttribute("autocomplete", " " + keyword.toUpperCase() + "\t");
       assert_equals(input.autocomplete, keyword);
     }, keyword + " is an allowed autocomplete field name");
   });


### PR DESCRIPTION
Checking:
> 2. Let tokens be the result of splitting the attribute's value on ASCII whitespace.

and

> "ASCII case-insensitive match"

for each of the tokens handled in the processing model

from https://html.spec.whatwg.org/multipage/forms.html#autofill-processing-model

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5604)
<!-- Reviewable:end -->
