### PR TITLE
Expand coverage on value-changing/selection-changing tests

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-after-content-change.html
+++ b/html/semantics/forms/textfieldselection/selection-after-content-change.html
@@ -13,7 +13,7 @@
 // This helper ensures that when the selection direction is reset, it always is reset to the same value consistently
 // (which must be one of either "none" or "forward"). This helps catch bugs like one observed in Chrome, where textareas
 // reset to "none" but inputs reset to "forward".
-let observedResetSelectionDirection
+let observedResetSelectionDirection;
 function assertSelectionDirectionIsReset(element) {
   if (!observedResetSelectionDirection) {
     assert_true(element.selectionDirection === "none" || element.selectionDirection === "forward",
@@ -26,34 +26,34 @@ function assertSelectionDirectionIsReset(element) {
   }
 }
 
-runTest("input out of document", () => {
+runInputTest("input out of document", () => {
   const input = document.createElement("input");
   input.value = "hello";
   return input;
 });
 
-runTest("input in document", () => {
+runInputTest("input in document", () => {
   return document.querySelector("#i1");
 });
 
-runTest("input in document, with focus", () => {
+runInputTest("input in document, with focus", () => {
   const input = document.querySelector("#i1");
   input.value = "hello";
   input.focus();
   return input;
 });
 
-runTest("textarea out of document", () => {
+runTextareaTest("textarea out of document", () => {
   const textarea = document.createElement("textarea");
   textarea.value = "hello";
   return textarea;
 });
 
-runTest("textarea in document", () => {
+runTextareaTest("textarea in document", () => {
   return document.querySelector("#t1");
 });
 
-runTest("textarea in document, with focus", () => {
+runTextareaTest("textarea in document, with focus", () => {
   const textarea = document.querySelector("#t1");
   textarea.value = "hello";
   textarea.focus();
@@ -92,26 +92,49 @@ function runTest(descriptor, elementFactory) {
   }, `${descriptor}: selection must change when setting a different value`);
 }
 
-test(() => {
-  const textarea = document.querySelector("#t1");
-  textarea.value = "hell\no";
-  textarea.setSelectionRange(1, 3, "backward");
+function runInputTest(descriptor, elementFactory) {
+  runTest(descriptor, elementFactory);
 
-  assert_equals(textarea.selectionStart, 1, "Sanity check: selectionStart was set correctly");
-  assert_equals(textarea.selectionEnd, 3, "Sanity check: selectionEnd was set correctly");
-  assert_equals(textarea.selectionDirection, "backward", "Sanity check: selectionDirection was set correctly");
+  test(() => {
+    const input = elementFactory();
+    input.setSelectionRange(1, 3, "backward");
 
-  textarea.value = "hell\r\no";
+    assert_equals(input.selectionStart, 1, "Sanity check: selectionStart was set correctly");
+    assert_equals(input.selectionEnd, 3, "Sanity check: selectionEnd was set correctly");
+    assert_equals(input.selectionDirection, "backward", "Sanity check: selectionDirection was set correctly");
 
-  assert_equals(textarea.selectionStart, 1, "selectionStart must not change when setting to CRLF");
-  assert_equals(textarea.selectionEnd, 3, "selectionEnd must not change when setting to CRLF");
-  assert_equals(textarea.selectionDirection, "backward", "selectionDirection must not change when setting to CRLF");
+    input.value = "he\nllo";
 
-  textarea.value = "hell\ro";
+    assert_equals(input.selectionStart, 1, "selectionStart must not change");
+    assert_equals(input.selectionEnd, 3, "selectionEnd must not change");
+    assert_equals(input.selectionDirection, "backward", "selectionDirection must not change");
+  }, `${descriptor}: selection must not change when setting a value that becomes the same after the value ` +
+     `sanitization algorithm`);
+}
 
-  assert_equals(textarea.selectionStart, 1, "selectionStart must not change when setting to CR");
-  assert_equals(textarea.selectionEnd, 3, "selectionEnd must not change when setting to CR");
-  assert_equals(textarea.selectionDirection, "backward", "selectionDirection must not change when setting to CR");
-}, "textarea in document: selection must not change when setting the same normalized value");
+function runTextareaTest(descriptor, elementFactory) {
+  runTest(descriptor, elementFactory);
 
+  test(() => {
+    const textarea = elementFactory();
+    textarea.value = "hell\no";
+    textarea.setSelectionRange(1, 3, "backward");
+
+    assert_equals(textarea.selectionStart, 1, "Sanity check: selectionStart was set correctly");
+    assert_equals(textarea.selectionEnd, 3, "Sanity check: selectionEnd was set correctly");
+    assert_equals(textarea.selectionDirection, "backward", "Sanity check: selectionDirection was set correctly");
+
+    textarea.value = "hell\r\no";
+
+    assert_equals(textarea.selectionStart, 1, "selectionStart must not change when setting to CRLF");
+    assert_equals(textarea.selectionEnd, 3, "selectionEnd must not change when setting to CRLF");
+    assert_equals(textarea.selectionDirection, "backward", "selectionDirection must not change when setting to CRLF");
+
+    textarea.value = "hell\ro";
+
+    assert_equals(textarea.selectionStart, 1, "selectionStart must not change when setting to CR");
+    assert_equals(textarea.selectionEnd, 3, "selectionEnd must not change when setting to CR");
+    assert_equals(textarea.selectionDirection, "backward", "selectionDirection must not change when setting to CR");
+  }, `${descriptor}: selection must not change when setting the same normalized value`);
+}
 </script>

--- a/html/semantics/forms/textfieldselection/selection-after-content-change.html
+++ b/html/semantics/forms/textfieldselection/selection-after-content-change.html
@@ -33,7 +33,9 @@ runInputTest("input out of document", () => {
 });
 
 runInputTest("input in document", () => {
-  return document.querySelector("#i1");
+  const input = document.querySelector("#i1");
+  input.value = "hello";
+  return input;
 });
 
 runInputTest("input in document, with focus", () => {
@@ -50,7 +52,9 @@ runTextareaTest("textarea out of document", () => {
 });
 
 runTextareaTest("textarea in document", () => {
-  return document.querySelector("#t1");
+  const textarea = document.querySelector("#t1");
+  textarea.value = "hello";
+  return textarea;
 });
 
 runTextareaTest("textarea in document, with focus", () => {


### PR DESCRIPTION
This is a follow-up to #5147. It tests the clarification at https://github.com/whatwg/html/pull/2560. While there, it also adds additional textarea test cases for line-ending normalization; previously the test only tested an in-document textarea.

@bzbarsky to review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5610)
<!-- Reviewable:end -->
