### PR TITLE
[css-tables] Remove explicit testharness.css links

### DIFF
--- a/css/work-in-progress/microsoft/css-tables/bounding-box-computation-1.html
+++ b/css/work-in-progress/microsoft/css-tables/bounding-box-computation-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/bounding-box-computation-2.html
+++ b/css/work-in-progress/microsoft/css-tables/bounding-box-computation-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/bounding-box-computation-3.html
+++ b/css/work-in-progress/microsoft/css-tables/bounding-box-computation-3.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/caption-side-1.html
+++ b/css/work-in-progress/microsoft/css-tables/caption-side-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/fixed-layout-1.html
+++ b/css/work-in-progress/microsoft/css-tables/fixed-layout-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/fixed-layout-2.html
+++ b/css/work-in-progress/microsoft/css-tables/fixed-layout-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/height-distribution/computing-row-measure-0.html
+++ b/css/work-in-progress/microsoft/css-tables/height-distribution/computing-row-measure-0.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/height-distribution/computing-row-measure-1.html
+++ b/css/work-in-progress/microsoft/css-tables/height-distribution/computing-row-measure-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/height-distribution/percentage-sizing-of-table-cell-children.html
+++ b/css/work-in-progress/microsoft/css-tables/height-distribution/percentage-sizing-of-table-cell-children.html
@@ -2,7 +2,6 @@
 <!--------------------------------------------------------------------------------------->
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 <script>
 

--- a/css/work-in-progress/microsoft/css-tables/html-to-css-mapping-1.html
+++ b/css/work-in-progress/microsoft/css-tables/html-to-css-mapping-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/html-to-css-mapping-2.html
+++ b/css/work-in-progress/microsoft/css-tables/html-to-css-mapping-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/html5-table-formatting-1.html
+++ b/css/work-in-progress/microsoft/css-tables/html5-table-formatting-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/html5-table-formatting-2.html
+++ b/css/work-in-progress/microsoft/css-tables/html5-table-formatting-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/html5-table-formatting-3.html
+++ b/css/work-in-progress/microsoft/css-tables/html5-table-formatting-3.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/html5-table-formatting-fixed-layout-1.html
+++ b/css/work-in-progress/microsoft/css-tables/html5-table-formatting-fixed-layout-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/table-model-fixup-2.html
+++ b/css/work-in-progress/microsoft/css-tables/table-model-fixup-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <style>
 	[inline] { display: inline !important; }

--- a/css/work-in-progress/microsoft/css-tables/table-model-fixup.html
+++ b/css/work-in-progress/microsoft/css-tables/table-model-fixup.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='./base.css' />
 <main>
 

--- a/css/work-in-progress/microsoft/css-tables/visibility-collapse-col-001.html
+++ b/css/work-in-progress/microsoft/css-tables/visibility-collapse-col-001.html
@@ -2,7 +2,6 @@
 <meta charset="utf-8">
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='base.css' />
 <link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#computing-the-table-width">

--- a/css/work-in-progress/microsoft/css-tables/visibility-collapse-row-001.html
+++ b/css/work-in-progress/microsoft/css-tables/visibility-collapse-row-001.html
@@ -2,7 +2,6 @@
 <meta charset="utf-8">
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='base.css' />
 <link rel="author" title="David Grogan" href="mailto:dgrogan@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#computing-the-table-height">

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/computing-column-measure-0.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/computing-column-measure-0.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/computing-column-measure-1.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/computing-column-measure-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/computing-table-width-0.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/computing-table-width-0.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/computing-table-width-1.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/computing-table-width-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-1.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-2.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-2.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-guess.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-guess.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-percent-guess.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-percent-guess.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-specified-guess.1.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-specified-guess.1.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />

--- a/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-specified-guess.html
+++ b/css/work-in-progress/microsoft/css-tables/width-distribution/distribution-algo-min-content-specified-guess.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
-<link rel='stylesheet' href='/resources/testharness.css'>
 <link rel='stylesheet' href='../base.css' />
 
 <link rel="author" title="Greg Whitworth" href="gwhit@microsoft.com" />


### PR DESCRIPTION
Work toward making these pass the linter and get upstreamed to master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5616)
<!-- Reviewable:end -->
