### PR TITLE
DOM: Incorrect test expectation

### DIFF
--- a/dom/nodes/Document-createElementNS.js
+++ b/dom/nodes/Document-createElementNS.js
@@ -26,7 +26,7 @@ var createElementNS_tests = [
   [null, "-foo", "INVALID_CHARACTER_ERR"],
   [null, ".foo", "INVALID_CHARACTER_ERR"],
   [null, ":foo", "INVALID_CHARACTER_ERR"],
-  [null, "f:oo", "INVALID_CHARACTER_ERR"],
+  [null, "f:oo", "NAMESPACE_ERR"],
   [null, "foo:", "INVALID_CHARACTER_ERR"],
   [null, "f:o:o", "INVALID_CHARACTER_ERR"],
   [null, ":", "INVALID_CHARACTER_ERR"],


### PR DESCRIPTION
#5161 (85470b46) was slightly overzealous.  f:oo matches the QName
production and so should still not throw an InvalidCharacterError, but
rather a NamespaceError.

@annevk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5622)
<!-- Reviewable:end -->
