### PR TITLE
Add tests for the messageerror IDL attribute in service workers

### DIFF
--- a/service-workers/service-worker/interfaces.https.html
+++ b/service-workers/service-worker/interfaces.https.html
@@ -13,7 +13,9 @@ test(function() {
       {
         register: 'function',
         getRegistration: 'function',
-        oncontrollerchange: EVENT_HANDLER
+        oncontrollerchange: EVENT_HANDLER,
+        onmessage: EVENT_HANDLER,
+        onmessageerror: EVENT_HANDLER
       });
   }, 'Interfaces and attributes of ServiceWorkerContainer');
 

--- a/service-workers/service-worker/resources/interfaces-worker.sub.js
+++ b/service-workers/service-worker/resources/interfaces-worker.sub.js
@@ -15,7 +15,8 @@ test(function() {
                        onactivate: EVENT_HANDLER,
                        onfetch: EVENT_HANDLER,
                        oninstall: EVENT_HANDLER,
-                       onmessage: EVENT_HANDLER
+                       onmessage: EVENT_HANDLER,
+                       onmessageerror: EVENT_HANDLER
                      });
   }, 'ServiceWorkerGlobalScope');
 


### PR DESCRIPTION
Follows https://github.com/w3c/ServiceWorker/pull/1130. The actual situations in which this will be called is being tested as part of #5003.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5628)
<!-- Reviewable:end -->
