### PR TITLE
HTML: use step() rather than step_func() to actually run assertion

### DIFF
--- a/html/dom/self-origin.sub.html
+++ b/html/dom/self-origin.sub.html
@@ -48,7 +48,7 @@ function nextMessageTest() {
 
 window.onmessage = function(e) {
   var testData = messageTests[curTest++];
-  testData[3].step_func(function() {
+  testData[3].step(function() {
     assert_equals(e.data, testData[2])
   });
   testData[3].done();


### PR DESCRIPTION
The assertion was not run, so all tests pass regardless of actual
origin.

Found while investigating https://github.com/whatwg/html/issues/2568

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5633)
<!-- Reviewable:end -->
