### PR TITLE
Require Chrome stability check to pass before merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ matrix:
     - env:  # exclude empty env from the top-level above
   allow_failures:
     - env: SCRIPT=css/build-css-testsuites.sh
-    - env:
-        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
-        - SCRIPT=ci_stability.sh PRODUCT=chrome:unstable
 script:
   - bash $SCRIPT
 cache:


### PR DESCRIPTION
Now that the issue with Chrome hanging is believed to be fixed it
makes sense to require Chrome stability tests to pass before PRs are merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5640)
<!-- Reviewable:end -->
