### PR TITLE
WebIDL and idlharness: Add a prototype class string test to WebIDL/ d…

### DIFF
--- a/WebIDL/ecmascript-binding/interface-prototype-object.html
+++ b/WebIDL/ecmascript-binding/interface-prototype-object.html
@@ -8,8 +8,12 @@
 // A specification issue was raised for this behavior.
 // https://www.w3.org/Bugs/Public/show_bug.cgi?id=28244
 test(function() {
-    assert_class_string(Object.getPrototypeOf(Document.prototype),
-                        'DocumentPrototype');
+  // Checks toString() behavior.
+  assert_class_string(Document.prototype, "DocumentPrototype");
+
+  assert_true(Document.prototype.hasOwnProperty(Symbol.toStringTag),
+              "An interface prototype object should have toStringTag property.");
+  assert_equals(Document.prototype[Symbol.toStringTag], "DocumentPrototype");
 }, "The class string of an interface prototype object is the concatenation of " +
    "the interface's identifier and the string 'Prototype'.");
 </script>

--- a/WebIDL/ecmascript-binding/interface-prototype-object.html
+++ b/WebIDL/ecmascript-binding/interface-prototype-object.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Interface prototype objects</title>
+<link rel="help" href="https://heycam.github.io/webidl/#interface-prototype-object">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+// A specification issue was raised for this behavior.
+// https://www.w3.org/Bugs/Public/show_bug.cgi?id=28244
+test(function() {
+    assert_class_string(Object.getPrototypeOf(Document.prototype),
+                        'DocumentPrototype');
+}, "The class string of an interface prototype object is the concatenation of " +
+   "the interface's identifier and the string 'Prototype'.");
+</script>

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1069,13 +1069,19 @@ IdlInterface.prototype.test_self = function()
         // "The class string of an interface prototype object is the
         // concatenation of the interface’s identifier and the string
         // “Prototype”."
-        assert_class_string(self[this.name].prototype, this.name + "Prototype",
-                            "class string of " + this.name + ".prototype");
+
+        // Skip these tests for now due to a specification issue about
+        // prototype name.
+        // https://www.w3.org/Bugs/Public/show_bug.cgi?id=28244
+
+        // assert_class_string(self[this.name].prototype, this.name + "Prototype",
+        //                     "class string of " + this.name + ".prototype");
+
         // String() should end up calling {}.toString if nothing defines a
         // stringifier.
         if (!this.has_stringifier()) {
-            assert_equals(String(self[this.name].prototype), "[object " + this.name + "Prototype]",
-                    "String(" + this.name + ".prototype)");
+            // assert_equals(String(self[this.name].prototype), "[object " + this.name + "Prototype]",
+            //         "String(" + this.name + ".prototype)");
         }
     }.bind(this), this.name + " interface: existence and properties of interface prototype object");
 


### PR DESCRIPTION
…irectory, and disable tests for it in idlharness.js.

Browser vendors don't agree on this behavior.
https://www.w3.org/Bugs/Public/show_bug.cgi?id=28244

Adds a test for the current specification to WebIDL/ directory, and disables
tests for it in idlharness.js because failures of these tests are too noisy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5653)
<!-- Reviewable:end -->
