### PR TITLE
Add tests for scrollElement, scroll/client Width/Height to scrolling-…

### DIFF
--- a/cssom-view/scrolling-quirks-vs-nonquirks.html
+++ b/cssom-view/scrolling-quirks-vs-nonquirks.html
@@ -14,8 +14,17 @@
 <div id="log"></div>
 <script>
 function setBodyContent(body)  {
+  // Hide scrollbars and remove body margin to make measures more reliable.
+  body.style.overflow = "hidden";
   body.style.margin = 0;
-  body.innerHTML = "<div id='content' style='width: 700px; height: 900px; background: linear-gradient(135deg, red, blue);'></div>";
+
+  // Add an orange border to the body.
+  body.style.borderWidth = "10px 0px 0px 20px";
+  body.style.borderColor = "orange";
+  body.style.borderStyle = "solid";
+
+  // Create a 700x900 box with a green border.
+  body.innerHTML = "<div id='content' style='border-width: 30px 0px 0px 40px; border-style: solid; border-color: green; width: 660px; height: 870px; background: linear-gradient(135deg, red, blue);'></div>";
 }
 
 var quirksModeTest = async_test("Execution of tests in quirks mode");
@@ -23,10 +32,15 @@ var quirksFrame = document.getElementById("quirksframe");
 quirksFrame.onload = function() {
   var doc = quirksFrame.contentDocument;
   setBodyContent(doc.body);
+  var content = doc.getElementById("content");
 
   quirksModeTest.step(function () {
     assert_equals(doc.compatMode, "BackCompat", "Should be in quirks mode.");
   });
+
+  test(function () {
+    assert_equals(doc.scrollingElement, doc.body, "scrollingElement should be HTML body");
+  }, "scrollingElement in quirks mode");
 
   test(function () {
     doc.documentElement.scroll(50, 60);
@@ -42,6 +56,16 @@ quirksFrame.onload = function() {
   }, "scrollLeft/scrollTop on the root element in quirks mode");
 
   test(function () {
+    assert_equals(doc.documentElement.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.documentElement.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the root element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.documentElement.clientHeight, 910, "clientHeight should be 910");
+  }, "clientWidth/clientHeight on the root element in quirks mode");
+
+  test(function () {
     doc.body.scroll(90, 100);
     assert_equals(doc.body.scrollLeft, 90, "scrollLeft should be 90");
     assert_equals(doc.body.scrollTop, 100, "scrollTop should be 100");
@@ -54,6 +78,34 @@ quirksFrame.onload = function() {
     assert_equals(doc.body.scrollTop, 110, "scrollTop should be 110");
   }, "scrollLeft/scrollTop on the HTML body element in quirks mode");
 
+  test(function () {
+    assert_equals(doc.body.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.body.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the HTML body element in quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.body.clientHeight, 500, "clientHeight should be 500");
+  }, "clientWidth/clientHeight on the HTML body element in quirks mode");
+
+  test(function () {
+    doc.scrollingElement.scroll(0, 0);
+    content.scrollLeft = 130;
+    content.scrollTop = 140;
+    assert_equals(content.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(content.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollRight of the content in quirks mode");
+
+  test(function () {
+    assert_equals(content.scrollWidth, 660, "scrollWidth should be 660");
+    assert_equals(content.scrollHeight, 870, "scrollHeight should be 870");
+  }, "scrollWidth/scrollHeight of the content in quirks mode");
+
+  test(function () {
+    assert_equals(content.clientWidth, 660, "clientWidth should be 660");
+    assert_equals(content.clientHeight, 870, "clientHeight should be 870");
+  }, "clientWidth/clientHeight of the content in quirks mode");
+
   quirksModeTest.done();
 }
 quirksFrame.src = URL.createObjectURL(new Blob([""], { type: "text/html" }));
@@ -63,10 +115,15 @@ var nonQuirksFrame = document.getElementById("nonquirksframe");
 nonQuirksFrame.onload = function() {
   var doc = nonQuirksFrame.contentDocument;
   setBodyContent(doc.body);
+  var content = doc.getElementById("content");
 
   nonQuirksModeTest.step(function() {
     assert_equals(doc.compatMode, "CSS1Compat", "Should be in standards mode.");
   });
+
+  test(function () {
+    assert_equals(doc.scrollingElement, doc.documentElement, "scrollingElement should be documentElement");
+  }, "scrollingElement in non-quirks mode");
 
   test(function () {
     doc.documentElement.scroll(50, 60);
@@ -82,6 +139,16 @@ nonQuirksFrame.onload = function() {
   }, "scrollLeft/scrollTop on the root element in non-quirks mode");
 
   test(function () {
+    assert_equals(doc.documentElement.scrollWidth, 720, "scrollWidth should be 720");
+    assert_equals(doc.documentElement.scrollHeight, 910, "scrollHeight should be 910");
+  }, "scrollWidth/scrollHeight on the root element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.documentElement.clientWidth, 300, "clientWidth should be 300");
+    assert_equals(doc.documentElement.clientHeight, 500, "clientHeight should be 500");
+  }, "clientWidth/clientHeight on the root element in non-quirks mode");
+
+  test(function () {
     doc.body.scroll(90, 100);
     assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
     assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
@@ -93,6 +160,34 @@ nonQuirksFrame.onload = function() {
     assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
     assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
   }, "scrollLeft/scrollTop on the HTML body element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.scrollWidth, 700, "scrollWidth should be 700");
+    assert_equals(doc.body.scrollHeight, 900, "scrollHeight should be 900");
+  }, "scrollWidth/scrollHeight on the HTML body element in non-quirks mode");
+
+  test(function () {
+    assert_equals(doc.body.clientWidth, 280, "clientWidth should be 280");
+    assert_equals(doc.body.clientHeight, 900, "clientHeight should be 900");
+  }, "clientWidth/clientHeight on the HTML body element in non-quirks mode");
+
+  test(function () {
+    doc.scrollingElement.scroll(0, 0);
+    content.scrollLeft = 130;
+    content.scrollTop = 140;
+    assert_equals(content.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(content.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollLeft/scrollRight of the content in non-quirks mode");
+
+  test(function () {
+    assert_equals(content.scrollWidth, 660, "scrollWidth should be 660");
+    assert_equals(content.scrollHeight, 870, "scrollHeight should be 870");
+  }, "scrollWidth/scrollHeight of the content in non-quirks mode");
+
+  test(function () {
+    assert_equals(content.clientWidth, 660, "clientWidth should be ");
+    assert_equals(content.clientHeight, 870, "clientHeight should be 870");
+  }, "clientWidth/clientHeight of the content in non-quirks mode");
 
   nonQuirksModeTest.done();
 }

--- a/cssom-view/scrolling-quirks-vs-nonquirks.html
+++ b/cssom-view/scrolling-quirks-vs-nonquirks.html
@@ -49,6 +49,12 @@ quirksFrame.onload = function() {
   }, "scroll() on the root element in quirks mode");
 
   test(function () {
+    doc.documentElement.scrollBy(10, 20);
+    assert_equals(doc.documentElement.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.documentElement.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollBy() on the root element in quirks mode");
+
+  test(function () {
     doc.documentElement.scrollLeft = 70;
     doc.documentElement.scrollTop = 80;
     assert_equals(doc.documentElement.scrollLeft, 0, "scrollLeft should be 0");
@@ -70,6 +76,12 @@ quirksFrame.onload = function() {
     assert_equals(doc.body.scrollLeft, 90, "scrollLeft should be 90");
     assert_equals(doc.body.scrollTop, 100, "scrollTop should be 100");
   }, "scroll() on the HTML body element in quirks mode");
+
+  test(function () {
+    doc.body.scrollBy(10, 20);
+    assert_equals(doc.body.scrollLeft, 100, "scrollLeft should be 100");
+    assert_equals(doc.body.scrollTop, 120, "scrollTop should be 120");
+  }, "scrollBy() on the HTML body element in quirks mode");
 
   test(function () {
     doc.body.scrollLeft = 120;
@@ -132,6 +144,12 @@ nonQuirksFrame.onload = function() {
   }, "scroll() on the root element in non-quirks mode");
 
   test(function () {
+    doc.documentElement.scrollBy(10, 20);
+    assert_equals(doc.documentElement.scrollLeft, 60, "scrollLeft should be 60");
+    assert_equals(doc.documentElement.scrollTop, 80, "scrollTop should be 80");
+  }, "scrollBy() on the root element in non-quirks mode");
+
+  test(function () {
     doc.documentElement.scrollLeft = 70;
     doc.documentElement.scrollTop = 80;
     assert_equals(doc.documentElement.scrollLeft, 70, "scrollLeft should be 70");
@@ -153,6 +171,12 @@ nonQuirksFrame.onload = function() {
     assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
     assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
   }, "scroll() on the HTML body element in non-quirks mode");
+
+  test(function () {
+    doc.body.scrollBy(10, 20);
+    assert_equals(doc.body.scrollLeft, 0, "scrollLeft should be 0");
+    assert_equals(doc.body.scrollTop, 0, "scrollTop should be 0");
+  }, "scrollBy() on the HTML body element in non-quirks mode");
 
   test(function () {
     doc.body.scrollLeft = 120;


### PR DESCRIPTION
…quirks-vs-nonquirks test.

For completeness, I added tests for scrollElement and for an element != body, documentElement although these cases are (better) covered elsewhere.

cc' @RByers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5654)
<!-- Reviewable:end -->
