### PR TITLE
Fix up hyperlink to testharness.js documentation in resources/readme.md following move

### DIFF
--- a/resources/readme.md
+++ b/resources/readme.md
@@ -16,8 +16,7 @@ To use testharness.js you must include two scripts, in the order given:
 
 ## Full documentation ##
 
-Full user documentation for the API is in the
-[docs/api.md](https://github.com/w3c/testharness.js/blob/master/docs/api.md) file.
+Full user documentation for the API is at [http://web-platform-tests.org/writing-tests/testharness-api.html](http://web-platform-tests.org/writing-tests/testharness-api.html).
 
 You can also read a tutorial on 
 [Using testharness.js](http://darobin.github.com/test-harness-tutorial/docs/using-testharness.html).


### PR DESCRIPTION
@jgraham We should update the hyperlink to the testharness.js documentation in resources/readme.md following the merger of the <https://github.com/w3c/testharness.js> repository into the <https://github.com/w3c/web-platform-tests> repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5674)
<!-- Reviewable:end -->
