### PR TITLE
IndexedDB: Tests should self-cleanup

### DIFF
--- a/IndexedDB/idbdatabase_close.htm
+++ b/IndexedDB/idbdatabase_close.htm
@@ -33,6 +33,7 @@ open_rq.onsuccess = function(e) {
         assert_equals(blocked_fired, 1, 'block event fired #')
         assert_equals(upgradeneeded_fired, 2, 'second upgradeneeded event fired #')
 
+        rq.result.close();
         t.done();
     });
     rq.onerror = fail(t, 'Unexpected database deletion error');

--- a/IndexedDB/idbfactory_open10.htm
+++ b/IndexedDB/idbfactory_open10.htm
@@ -81,6 +81,8 @@
                 });
                 idx.getKey("Sicking").onsuccess = this.step_func(function(e) {
                     assert_equals(e.target.result, undefined, "getKey(Sicking)");
+
+                    db3.close();
                     this.done();
                 });
             });

--- a/IndexedDB/idbfactory_open11.htm
+++ b/IndexedDB/idbfactory_open11.htm
@@ -51,6 +51,8 @@
                 count_done++;
 
                 assert_equals(count_done, 3, "count_done");
+
+                db2.close();
                 this.done();
             });
         });

--- a/IndexedDB/idbfactory_open3.htm
+++ b/IndexedDB/idbfactory_open3.htm
@@ -17,6 +17,7 @@
         var open_rq2 = window.indexedDB.open(db.name);
         open_rq2.onsuccess = this.step_func(function(e) {
             assert_equals(e.target.result.version, 13, "db.version")
+            e.target.result.close();
             this.done();
         });
         open_rq2.onupgradeneeded = fail(this, 'Unexpected upgradeneeded')

--- a/IndexedDB/idbfactory_open6.htm
+++ b/IndexedDB/idbfactory_open6.htm
@@ -8,13 +8,14 @@
 <script>
     var open_rq = createdb(async_test(), undefined, 13);
     var did_upgrade = false;
+    var open_rq2;
 
     open_rq.onupgradeneeded = function() {};
     open_rq.onsuccess = function(e) {
         var db = e.target.result;
         db.close();
 
-        var open_rq2 = window.indexedDB.open(db.name, 14);
+        open_rq2 = window.indexedDB.open(db.name, 14);
         open_rq2.onupgradeneeded = function() {};
         open_rq2.onsuccess = this.step_func(open_previous_db);
         open_rq2.onerror = fail(this, 'Unexpected error')
@@ -24,6 +25,7 @@
         var open_rq3 = window.indexedDB.open(e.target.result.name, 13);
         open_rq3.onerror = this.step_func(function(e) {
             assert_equals(e.target.error.name, 'VersionError', 'e.target.error.name')
+            open_rq2.result.close();
             this.done();
         });
         open_rq3.onupgradeneeded = fail(this, 'Unexpected upgradeneeded')

--- a/IndexedDB/idbfactory_open7.htm
+++ b/IndexedDB/idbfactory_open7.htm
@@ -8,13 +8,14 @@
 <script>
     var open_rq = createdb(async_test(), undefined, 13);
     var did_upgrade = false;
+    var open_rq2;
 
     open_rq.onupgradeneeded = function() {};
     open_rq.onsuccess = function(e) {
         var db = e.target.result;
         db.close();
 
-        var open_rq2 = window.indexedDB.open(db.name, 14);
+        open_rq2 = window.indexedDB.open(db.name, 14);
         open_rq2.onupgradeneeded = function() {
             did_upgrade = true;
         };
@@ -26,6 +27,8 @@
         var open_rq3 = window.indexedDB.open(e.target.result.name);
         open_rq3.onsuccess = this.step_func(function(e) {
             assert_equals(e.target.result.version, 14, "db.version")
+            open_rq2.result.close();
+            open_rq3.result.close();
             this.done();
         });
         open_rq3.onupgradeneeded = fail(this, 'Unexpected upgradeneeded')

--- a/IndexedDB/idbobjectstore_deleteIndex.htm
+++ b/IndexedDB/idbobjectstore_deleteIndex.htm
@@ -35,6 +35,7 @@
             assert_throws('NotFoundError',
                 function() { index = objStore.index("index") });
             assert_equals(index, undefined);
+            db.close();
             t.done();
         }
     }

--- a/IndexedDB/idbrequest-onupgradeneeded.htm
+++ b/IndexedDB/idbrequest-onupgradeneeded.htm
@@ -17,8 +17,10 @@ function upgradeneeded_test(upgrade_func, success_func, error_func, description)
 
       open_request.onupgradeneeded = t.step_func(function() {
         t.add_cleanup(function() {
-          open_request.result.close(),
-          indexedDB.deleteDatabase(dbName);
+          if (open_request.result) {
+            open_request.result.close(),
+            indexedDB.deleteDatabase(dbName);
+          }
         });
         upgrade_func(t, open_request);
       });

--- a/IndexedDB/idbtransaction_objectStoreNames.html
+++ b/IndexedDB/idbtransaction_objectStoreNames.html
@@ -73,7 +73,8 @@ indexeddb_test(function(t, db, tx) {
             assert_array_equals(saved_tx.objectStoreNames, ['s2', 's3'],
                 'previous transaction objectStoreNames should be unchanged');
             assert_array_equals(db.objectStoreNames, saved_tx.objectStoreNames,
-                'connection and transaction objectStoreNames should match');
+                                'connection and transaction objectStoreNames should match');
+            db2.close();
             t.done();
         });
     }, 'IDBTransaction.objectStoreNames - value after close');


### PR DESCRIPTION
Ensure connections are closed before the test is done so that test cleanup can run.

For https://github.com/w3c/web-platform-tests/issues/4560

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5676)
<!-- Reviewable:end -->
