### PR TITLE
Selection: Test empty() and setPosition()

### DIFF
--- a/selection/collapse-00.html
+++ b/selection/collapse-00.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Selection.collapse() tests</title>
+<title>Selection.collapse()/setPosition() tests</title>
 <meta name=timeout content=long>
 <div id=log></div>
 <script src=/resources/testharness.js></script>
@@ -9,6 +9,6 @@
 <script>
 "use strict";
 
-testCollapseSubSet(0, 30);
+testCollapseSubSet(0, 15);
 testDiv.style.display = "none";
 </script>

--- a/selection/collapse-15.html
+++ b/selection/collapse-15.html
@@ -9,6 +9,6 @@
 <script>
 "use strict";
 
-testCollapseSubSet(30);
+testCollapseSubSet(15, 30);
 testDiv.style.display = "none";
 </script>

--- a/selection/collapse-45.html
+++ b/selection/collapse-45.html
@@ -9,6 +9,6 @@
 <script>
 "use strict";
 
-testCollapseSubSet(30);
+testCollapseSubSet(30, 45);
 testDiv.style.display = "none";
 </script>

--- a/selection/collapse.js
+++ b/selection/collapse.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function testCollapse(range, point) {
+function testCollapse(range, point, method) {
     selection.removeAllRanges();
     var addedRange;
     if (range) {
@@ -10,46 +10,46 @@ function testCollapse(range, point) {
 
     if (point[0].nodeType == Node.DOCUMENT_TYPE_NODE) {
         assert_throws("INVALID_NODE_TYPE_ERR", function() {
-            selection.collapse(point[0], point[1]);
-        }, "Must throw INVALID_NODE_TYPE_ERR when collapse()ing if the node is a DocumentType");
+            selection[method](point[0], point[1]);
+        }, "Must throw INVALID_NODE_TYPE_ERR when " + method + "()ing if the node is a DocumentType");
         return;
     }
 
     if (point[1] < 0 || point[1] > getNodeLength(point[0])) {
         assert_throws("INDEX_SIZE_ERR", function() {
-            selection.collapse(point[0], point[1]);
-        }, "Must throw INDEX_SIZE_ERR when collapse()ing if the offset is negative or greater than the node's length");
+            selection[method](point[0], point[1]);
+        }, "Must throw INDEX_SIZE_ERR when " + method + "()ing if the offset is negative or greater than the node's length");
         return;
     }
 
     if (!document.contains(point[0])) {
         assertSelectionNoChange(function() {
-            selection.collapse(point[0], point[1]);
+            selection[method](point[0], point[1]);
         });
         return;
     }
 
-    selection.collapse(point[0], point[1]);
+    selection[method](point[0], point[1]);
 
     assert_equals(selection.rangeCount, 1,
-        "selection.rangeCount must equal 1 after collapse()");
+        "selection.rangeCount must equal 1 after " + method + "()");
     assert_equals(selection.focusNode, point[0],
-        "focusNode must equal the node we collapse()d to");
+        "focusNode must equal the node we " + method + "()d to");
     assert_equals(selection.focusOffset, point[1],
-        "focusOffset must equal the offset we collapse()d to");
+        "focusOffset must equal the offset we " + method + "()d to");
     assert_equals(selection.focusNode, selection.anchorNode,
-        "focusNode and anchorNode must be equal after collapse()");
+        "focusNode and anchorNode must be equal after " + method + "()");
     assert_equals(selection.focusOffset, selection.anchorOffset,
-        "focusOffset and anchorOffset must be equal after collapse()");
+        "focusOffset and anchorOffset must be equal after " + method + "()");
     if (range) {
         assert_equals(addedRange.startContainer, range.startContainer,
-            "collapse() must not change the startContainer of a preexisting Range");
+            method + "() must not change the startContainer of a preexisting Range");
         assert_equals(addedRange.endContainer, range.endContainer,
-            "collapse() must not change the endContainer of a preexisting Range");
+            method + "() must not change the endContainer of a preexisting Range");
         assert_equals(addedRange.startOffset, range.startOffset,
-            "collapse() must not change the startOffset of a preexisting Range");
+            method + "() must not change the startOffset of a preexisting Range");
         assert_equals(addedRange.endOffset, range.endOffset,
-            "collapse() must not change the endOffset of a preexisting Range");
+            method + "() must not change the endOffset of a preexisting Range");
     }
 }
 
@@ -91,7 +91,10 @@ function testCollapseSubSet(startIndex, optionalEndIndex) {
             }
         }, "Set up range " + i + " " + testRanges[i]);
         for (var j = 0; j < testPoints.length; j++) {
-            tests.push(["Range " + i + " " + testRanges[i] + ", point " + j + " " + testPoints[j], range, testPointsCached[j]]);
+            tests.push(["collapse() on " + testRanges[i] + " to " + testPoints[j],
+                        range, testPointsCached[j], "collapse"]);
+            tests.push(["setPosition() on " + testRanges[i] + " to " + testPoints[j],
+                        range, testPointsCached[j], "setPosition"]);
         }
     }
 

--- a/selection/removeAllRanges.html
+++ b/selection/removeAllRanges.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Selection.removeAllRanges() tests</title>
+<title>Selection.removeAllRanges()/empty() tests</title>
 <div id=log></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -12,33 +12,38 @@ testRanges.unshift("[]");
 
 var range = rangeFromEndpoints([paras[0].firstChild, 0, paras[0].firstChild, 1]);
 
-for (var i = 0; i < testRanges.length; i++) {
+function testRange(rangeDesc, method) {
     test(function() {
-        setSelectionForwards(eval(testRanges[i]));
-        selection.removeAllRanges();
+        setSelectionForwards(eval(rangeDesc));
+        selection[method]();
         assert_equals(selection.rangeCount, 0,
-            "After removeAllRanges(), rangeCount must be 0");
+            "After " + method + "(), rangeCount must be 0");
         // Test that it's forwards
         selection.addRange(range);
         assert_equals(selection.anchorOffset, selection.getRangeAt(0).startOffset,
-            "After removeAllRanges(), addRange() must be forwards, so anchorOffset must equal startOffset rather than endOffset");
+            "After " + method + "(), addRange() must be forwards, so anchorOffset must equal startOffset rather than endOffset");
         assert_equals(selection.focusOffset, selection.getRangeAt(0).endOffset,
-            "After removeAllRanges(), addRange() must be forwards, so focusOffset must equal endOffset rather than startOffset");
-    }, "Range " + i + " " + testRanges[i] + " forwards");
+            "After " + method + "(), addRange() must be forwards, so focusOffset must equal endOffset rather than startOffset");
+    }, method + " on " + rangeDesc + " forwards");
 
     // Copy-pasted from above
     test(function() {
-        setSelectionBackwards(eval(testRanges[i]));
-        selection.removeAllRanges();
+        setSelectionBackwards(eval(rangeDesc));
+        selection[method]();
         assert_equals(selection.rangeCount, 0,
-            "After removeAllRanges(), rangeCount must be 0");
+            "After " + method + "(), rangeCount must be 0");
         // Test that it's forwards
         selection.addRange(range);
         assert_equals(selection.anchorOffset, selection.getRangeAt(0).startOffset,
-            "After removeAllRanges(), addRange() must be forwards, so anchorOffset must equal startOffset rather than endOffset");
+            "After " + method + "(), addRange() must be forwards, so anchorOffset must equal startOffset rather than endOffset");
         assert_equals(selection.focusOffset, selection.getRangeAt(0).endOffset,
-            "After removeAllRanges(), addRange() must be forwards, so focusOffset must equal endOffset rather than startOffset");
-    }, "Range " + i + " " + testRanges[i] + " backwards");
+            "After " + method + "(), addRange() must be forwards, so focusOffset must equal endOffset rather than startOffset");
+    }, method + " on " + rangeDesc + " backwards");
+}
+
+for (var i = 0; i < testRanges.length; i++) {
+  testRange(testRanges[i], "removeAllRanges");
+  testRange(testRanges[i], "empty");
 }
 
 testDiv.style.display = "none";


### PR DESCRIPTION
Chrome passes all tests.  WebKit and Edge pass all the empty() tests,
and support setPosition(), but fail some of the setPosition() tests (at
a glance, the same as they were already failing for collapse()).
Firefox doesn't yet support these methods.

@rniwa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5684)
<!-- Reviewable:end -->
