### PR TITLE
[selectors4] Add test for `focus` and `:focus-within` after `display: none`

### DIFF
--- a/css/selectors4/focus-display-none-001.html
+++ b/css/selectors4/focus-display-none-001.html
@@ -26,7 +26,7 @@
       window.requestAnimationFrame(() => {
         t.step(() => assert_false(input.matches(":focus"),
                                   "Check input doesn't match ':focus' after getting 'display: none'"));
-        input.style.display = "inline-block";
+        input.style.display = "inline";
         t.done();
       });
     });

--- a/css/selectors4/focus-display-none-001.html
+++ b/css/selectors4/focus-display-none-001.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors Level 4: focus</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-pseudo">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule-one">
+<meta name="assert" content="Checks ':focus' pseudo-class after 'display: none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="wrapper">
+  <input id="input">
+</div>
+<script>
+  "use strict";
+
+  const wrapper = document.getElementById("wrapper");
+  const input = document.getElementById("input");
+
+  async_test((t) => {
+    input.focus();
+    window.requestAnimationFrame(() => {
+      t.step(() => assert_true(input.matches(":focus"),
+                               "Check input matches ':focus' after being focused"));
+
+      input.style.display = "none";
+      window.requestAnimationFrame(() => {
+        t.step(() => assert_false(input.matches(":focus"),
+                                  "Check input doesn't match ':focus' after getting 'display: none'"));
+        input.style.display = "inline-block";
+        t.done();
+      });
+    });
+  }, "Test ':focus' after 'display:none' on input");
+
+  async_test((t) => {
+    input.focus();
+    window.requestAnimationFrame(() => {
+      t.step(() => assert_true(input.matches(":focus"),
+                               "Check input matches ':focus' after being focused"));
+
+      wrapper.style.display = "none";
+      window.requestAnimationFrame(() => {
+        t.step(() => assert_false(input.matches(":focus"),
+                                  "Check input doesn't match ':focus' after parent got 'display: none'"));
+        wrapper.style.display = "block";
+        t.done();
+      });
+    });
+  }, "Test ':focus' after 'display:none' on input's parent");
+</script>

--- a/css/selectors4/focus-within-009.html
+++ b/css/selectors4/focus-within-009.html
@@ -85,34 +85,10 @@
 
     test(
       function() {
-        target2.style.display = "none";
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container2", "sibling5", "target2"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container2", "sibling5", "target2"]);
-        assert_true(target2.matches(":focus"));
-      }, "Set display none on 'target2'");
-
-    test(
-      function() {
         target1.focus();
         assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
         assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
       }, "Focus 'target1' again");
-
-    test(
-      function() {
-        target2.focus();
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_true(target1.matches(":focus"));
-        assert_false(target2.matches(":focus"));
-      }, "Try to focus 'target2'");
-
-    test(
-      function() {
-        target2.style.display = "inline-block";
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-      }, "Set display back on 'target2'");
 
     test(
       function() {
@@ -123,34 +99,10 @@
 
     test(
       function() {
-        container2.style.display = "none";
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container2", "sibling5", "target2"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container2", "sibling5", "target2"]);
-        assert_true(target2.matches(":focus"));
-      }, "Set display none on 'container2'");
-
-    test(
-      function() {
         target1.focus();
         assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
         assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
       }, "Focus 'target1' once again");
-
-    test(
-      function() {
-        target2.focus();
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_true(target1.matches(":focus"));
-        assert_false(target2.matches(":focus"));
-      }, "Try to focus 'target2' again");
-
-    test(
-      function() {
-        container2.style.display = "block";
-        assert_array_equals(elementsStyledWithFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-        assert_array_equals(elementsMatchingFocusWithinSelector(), ["html", "body", "test", "container1", "sibling2", "target1"]);
-      }, "Set display back on 'container2'");
 
     test(
       function() {

--- a/css/selectors4/focus-within-display-none-001.html
+++ b/css/selectors4/focus-within-display-none-001.html
@@ -30,7 +30,7 @@
                                   "Check input doesn't match ':focus-within' after getting 'display: none'"));
         t.step(() => assert_false(wrapper.matches(":focus-within"),
                                  "Check wrapper doesn't match ':focus-within' after child got 'display: none'"));
-        input.style.display = "inline-block";
+        input.style.display = "inline";
         t.done();
       });
     });

--- a/css/selectors4/focus-within-display-none-001.html
+++ b/css/selectors4/focus-within-display-none-001.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors Level 4: focus-within</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule-one">
+<meta name="assert" content="Checks ':focus-within' pseudo-class after 'display: none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="wrapper">
+  <input id="input">
+</div>
+<script>
+  "use strict";
+
+  const wrapper = document.getElementById("wrapper");
+  const input = document.getElementById("input");
+
+  async_test((t) => {
+    input.focus();
+    window.requestAnimationFrame(() => {
+      t.step(() => assert_true(input.matches(":focus-within"),
+                               "Check input matches ':focus-within' after being focused"));
+      t.step(() => assert_true(wrapper.matches(":focus-within"),
+                               "Check wrapper matches ':focus-within' after child was focused"));
+
+      input.style.display = "none";
+      window.requestAnimationFrame(() => {
+        t.step(() => assert_false(input.matches(":focus-within"),
+                                  "Check input doesn't match ':focus-within' after getting 'display: none'"));
+        t.step(() => assert_false(wrapper.matches(":focus-within"),
+                                 "Check wrapper doesn't match ':focus-within' after child got 'display: none'"));
+        input.style.display = "inline-block";
+        t.done();
+      });
+    });
+  }, "Test ':focus-within' after 'display:none' on input");
+
+  async_test((t) => {
+    input.focus();
+    window.requestAnimationFrame(() => {
+      t.step(() => assert_true(input.matches(":focus-within"),
+                               "Check input matches ':focus-within' after being focused"));
+      t.step(() => assert_true(wrapper.matches(":focus-within"),
+                               "Check wrapper matches ':focus-within' after child was focused"));
+
+      wrapper.style.display = "none";
+      window.requestAnimationFrame(() => {
+        t.step(() => assert_false(input.matches(":focus-within"),
+                                  "Check input doesn't match ':focus-within' after parent got 'display: none'"));
+        t.step(() => assert_false(wrapper.matches(":focus-within"),
+                                 "Check wrapper doesn't match ':focus-within' after getting 'display: none'"));
+        wrapper.style.display = "block";
+        t.done();
+      });
+    });
+  }, "Test ':focus-within' after 'display:none' on input's parent");
+</script>


### PR DESCRIPTION
Chrome is the only browser with this behavior, but it seems the rest of them
agree this is a bug on their side. See http://crbug.com/491828 for more info.

This test is extracted from https://codereview.chromium.org/2795143004
and has been extended to check also what happens if `display: none` is used
on the input's parent.

Please @frivoal and/or @rune-opera, could you take a look? Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5685)
<!-- Reviewable:end -->
