### PR TITLE
HTML: Fix various bugs in new colSpan/rowSpan tests

### DIFF
--- a/html/dom/elements-tabular.js
+++ b/html/dom/elements-tabular.js
@@ -87,8 +87,8 @@ var tabularElements = {
   },
   th: {
     // HTMLTableCellElement (Conforming)
-    colSpan: {type: "unsigned long", defaultVal: 1},
-    rowSpan: {type: "unsigned long", defaultVal: 1},
+    colSpan: {type: "clamped unsigned long", defaultVal: 1, min: 1, max: 1000},
+    rowSpan: {type: "clamped unsigned long", defaultVal: 1, min: 0, max: 65534},
     headers: "settable tokenlist",
     scope: {type: "enum", keywords: ["row", "col", "rowgroup", "colgroup"]},
     abbr: "string",

--- a/html/dom/reflection.js
+++ b/html/dom/reflection.js
@@ -483,7 +483,6 @@ ReflectionTests.typeMap = {
                      {toString:function() {return 2;}, valueOf: null},
                      {valueOf:function() {return 3;}}],
         "idlTests": [0, 1, 257, maxInt, "-0", maxInt + 1, maxUnsigned],
-        "idlIdlExpected": [0, 1, 257, maxInt, 0, null, null],
         "idlDomExpected": [0, 1, 257, maxInt, 0, null, null],
     },
     /**
@@ -719,6 +718,13 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
           if (domTests.indexOf(val) == -1) {
             domTests.push(val);
           }
+          if (idlTests.indexOf(val) == -1 && 0 <= val && val <= maxUnsigned) {
+            idlTests.push(val);
+            if (typeof val != "number") {
+              val = ReflectionTests.parseNonneg(val);
+            }
+            idlDomExpected.push(val > maxInt ? null : val);
+          }
         });
 
         // Rewrite expected values
@@ -734,6 +740,18 @@ ReflectionTests.reflects = function(data, idlName, idlObj, domName, domObj) {
               return data.max;
             }
             return parsed;
+        });
+        idlIdlExpected = idlTests.map(function(val) {
+            if (typeof val != "number") {
+              val = ReflectionTests.parseNonneg(val);
+            }
+            if (val < data.min) {
+              return data.min;
+            }
+            if (val > data.max) {
+              return data.max;
+            }
+            return val;
         });
         break;
     }


### PR DESCRIPTION
th was not updated at all, and expected values for IDL sets were not
being computed according to the spec's rules.  This is what comes of
writing tests without an implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5706)
<!-- Reviewable:end -->
