### PR TITLE
[check stability] Apply DBUS configuration in C.I.

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -295,7 +295,16 @@ class Chrome(Browser):
         if "DBUS_SESSION_BUS_ADDRESS" not in os.environ:
             if find_executable("dbus-launch"):
                 logger.debug("Attempting to start dbus")
-                logger.debug(subprocess.check_output(["dbus-launch"]))
+                dbus_conf = subprocess.check_output(["dbus-launch"])
+                logger.debug(dbus_conf)
+
+                # From dbus-launch(1):
+                #
+                # > When dbus-launch prints bus information to standard output,
+                # > by default it is in a simple key-value pairs format.
+                for line in dbus_conf.strip().split("\n"):
+                    key, _, value = line.partition("=")
+                    os.environ[key] = value
             else:
                 logger.critical("dbus not running and can't be started")
                 sys.exit(1)


### PR DESCRIPTION
Although `dbus-launch` will start a new DBUS daemon process, making use
of this process requires variable runtime information such as the bus
address. By default, this is provided via the process's standard output
stream.

Explicitly parse and apply the output configuration so that it may be
inherited by the Chrome and ChromeDriver processes that are subsequently
created.

@jgraham I have not been able to verify this fix locally. In fact, running it
on my desktop environment causes a different kind of failure altogether. I
suspect this may be due to the fact that my environment already has a running
DBUS daemon, and the superfluousness of the one created here causes problems.
I've spent some time trying to reproduce the problem (and prove out this fix) in
an Ubuntu virtual machine (as provided by VirtualBox), but I haven't had any
luck there. There are many subtle differences between an authentic desktop
environment and a virtualized server environment, and I don't know the
difference well enough to trigger the bug.

So this patch is really more theoretical than anything. I'm planning on
continuing investigation tomorrow, but I wanted to share my latest thinking in
case you have ideas on how we could validate it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5709)
<!-- Reviewable:end -->
