### PR TITLE
[presentation-api] Update two tests for PresentationRequest

### DIFF
--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>PresentationRequest.onconnectionavailable (manual test)</title>
+<title>Firing a connectionavailable event at a controlling user agent</title>
 <link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
 <link rel="help" href="https://w3c.github.io/presentation-api/#starting-a-presentation">
 <script src="/resources/testharness.js"></script>
@@ -17,43 +17,57 @@
     // ----------
     // DOM Object
     // ----------
-    var presentBtn = document.getElementById("presentBtn");
+    const presentBtn = document.getElementById('presentBtn');
 
     // --------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - begin
     // --------------------------------------------------------------------------
-    var startPresentation = function () {
+    presentBtn.onclick = () => {
         presentBtn.disabled = true;
-        promise_test(function (t) {
-            var connection;
-            t.add_cleanup(function() {
-                if(connection)
-                    connection.terminate();
+
+        promise_test(t => {
+            let connection;
+            const request = new PresentationRequest(presentationUrls);
+
+            t.add_cleanup(() => {
+                if (connection) {
+                    connection.onconnect = () => { connection.terminate(); };
+                    if (connection.state === 'closed')
+                        request.reconnect(connection.id);
+                    else
+                        connection.terminate();
+                }
             });
 
-            // Note: During starting a presentation, the connectionavailable event is fired (step 20)
-            //       after the promise P is resolved (step 19).
-            return new Promise(function(resolve, reject) {
-                var request = new PresentationRequest(presentationUrls);
-                request.onconnectionavailable = function (evt) {
-                    resolve(evt.connection);
-                };
-                // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
-                // or the presentation fails to be started
-                request.start().then(function(c) {
-                    connection = c;
-                    t.step_timeout(function() { assert_unreached('The connectionavailable event was not fired.'); }, 5000);
-                }, reject);
-            }).then(function(c) {
+            // Note: During starting a presentation, the connectionavailable event is fired (step 9)
+            //       after the promise P is resolved (step 8).
+            return request.start().then(c => {
                 connection = c;
                 assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
                 assert_true(!!connection.id, 'The connection ID is set.');
                 assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
                 assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+
+                const eventWatcher = new EventWatcher(t, request, 'connectionavailable');
+                const timeout = new Promise(resolve => { t.step_timeout(resolve, 5000); });
+                return Promise.race([ eventWatcher.wait_for('connectionavailable'), timeout ]);
+            }).then(evt => {
+                // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
+                // or the presentation fails to be started.
+                if (!evt)
+                    assert_unreached('The connectionavailable event was not fired.');
+
+                assert_true(evt instanceof PresentationConnectionAvailableEvent, 'An event using PresentationConnectionAvailableEvent is fired.');
+                assert_true(evt.isTrusted, 'The event is a trusted event.');
+                assert_false(evt.bubbles, 'The event does not bubbles.');
+                assert_false(evt.cancelable, 'The event is not cancelable.');
+                assert_equals(evt.type, 'connectionavailable', 'The event name is "connectionavailable".');
+                assert_equals(evt.target, request, 'event.target is the presentation request.');
+                assert_true(evt.connection instanceof PresentationConnection, 'event.connection is a presentation connection.');
+                assert_equals(evt.connection, connection, 'event.connection is set to the presentation which the promise is resolved with.');
             });
-        }, 'The connectionavailable event was fired successfully.');
+        });
     }
-    presentBtn.onclick = startPresentation;
     // ------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - end
     // ------------------------------------------------------------------------

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
@@ -49,14 +49,13 @@
                 assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
 
                 const eventWatcher = new EventWatcher(t, request, 'connectionavailable');
-                const timeout = new Promise(resolve => { t.step_timeout(resolve, 5000); });
+                const timeout = new Promise((_, reject) => {
+                    // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
+                    // or the presentation fails to be started.
+                    t.step_timeout(() => { reject('The connectionavailable event was not fired (timeout).'); }, 5000);}
+                );
                 return Promise.race([ eventWatcher.wait_for('connectionavailable'), timeout ]);
             }).then(evt => {
-                // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
-                // or the presentation fails to be started.
-                if (!evt)
-                    assert_unreached('The connectionavailable event was not fired.');
-
                 assert_true(evt instanceof PresentationConnectionAvailableEvent, 'An event using PresentationConnectionAvailableEvent is fired.');
                 assert_true(evt.isTrusted, 'The event is a trusted event.');
                 assert_false(evt.bubbles, 'The event does not bubbles.');

--- a/presentation-api/controlling-ua/PresentationRequest_success.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_success.https.html
@@ -1,43 +1,24 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API PresentationRequest for Controlling User Agent (Success)</title>
+<title>Constructing a PresentationRequest</title>
 <link rel="author" title="Franck William Taffo" href="http://www.fokus.fraunhofer.de">
-<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs/">
+<link rel="help" href="http://w3c.github.io/presentation-api/#constructing-a-presentationrequest">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
-    test(function() {
-        try {
-            var request = new PresentationRequest('presentation.html');
-            assert_true(request instanceof PresentationRequest);
-        }
-        catch (ex) {
-            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
-        }
-    }, 'Call PresentationRequest constructor with a valid relative presentation URL. No Exception expected.');
+    test(() => {
+        let request = new PresentationRequest('presentation.html');
+        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with a relative presentation URL is constructed successfully.');
 
-    test(function() {
-        try {
-            var request = new PresentationRequest('http://example.org/');
-            assert_true(request instanceof PresentationRequest);
-        }
-        catch (ex) {
-            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
-        }
-    }, 'Call PresentationRequest constructor with a valid absolute presentation URL. No Exception expected.');
+        request = new PresentationRequest('https://example.org/');
+        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an absolute presentation URL is constructed successfully.');
 
-    test(function() {
-        try {
-            var request = new PresentationRequest([
-                'presentation.html',
-                'http://example.org/presentation/'
-            ]);
-            assert_true(request instanceof PresentationRequest);
-        }
-        catch (ex) {
-            assert_unreached('PresentationRequest constructor threw an unexpected exception "' + ex.name + '"');
-        }
-    }, 'Call PresentationRequest constructor with a set of valid presentation URLs. No Exception expected.');
-
+        request = new PresentationRequest([
+            'presentation.html',
+            'https://example.org/presentation/'
+        ]);
+        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an array of presentation URLs is constructed successfully.');
+    });
 </script>


### PR DESCRIPTION
This PR updates a couple of tests for PresentationRequest:

- PresentationRequest_success.https.html:
  - `http://` in each presentation URL(s) is replaced with `https://`.
- PresentationRequest_onconnectionavailable-manual.https.html:
  - Terminating a connection in `t.add_cleanup` is improved.
  - `EventWatcher` is used to watch a `connectionavailable` event.
  - PresentationConnectionAvailableEvent is inspected as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5713)
<!-- Reviewable:end -->
