### PR TITLE
Accept partial dictionary definition in idlharness.js

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -208,7 +208,7 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls)
      */
     parsed_idls.forEach(function(parsed_idl)
     {
-        if (parsed_idl.type == "interface" && parsed_idl.partial)
+        if ((parsed_idl.type == "interface" || parsed_idl.type == "dictionary") && parsed_idl.partial)
         {
             this.partials.push(parsed_idl);
             return;


### PR DESCRIPTION
Quick fix for #5714.

I am not sure if this alone correctly fix the handling of partial dictionary. At least it stops idlharness from raising error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5717)
<!-- Reviewable:end -->
