### PR TITLE
Make promise_test return promise of test completing

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -544,6 +544,7 @@ policies and contribution forms [3].
                     }));
             return donePromise;
         });
+      return tests.promise_tests;
     }
 
     function promise_rejects(test, expected, promise, description) {


### PR DESCRIPTION
This allows one to attach callback actions to perform after a test is completed. The promise returned is always resolved regardless of whether the test succeeds. This is consistent with the synchronous behavior of `test()` which always proceed to next line regardless of whether the inner function raised exception.

This PR is mainly for #5712 to perform optional async test loading before performing the main test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5718)
<!-- Reviewable:end -->
