### PR TITLE
Extend test coverage in urlsearchparams-constructor.html

### DIFF
--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -80,6 +80,17 @@ test(function() {
 }, 'Parse +');
 
 test(function() {
+    const testValue = '+15555555555';
+    const params = new URLSearchParams();
+    params.set('query', testValue);
+    var newParams = new URLSearchParams(params.toString());
+
+    assert_equals(params.toString(), 'query=%2B15555555555');
+    assert_equals(params.get('query'), testValue);
+    assert_equals(newParams.get('query'), testValue);
+}, 'Parse encoded +');
+
+test(function() {
     var params = new URLSearchParams('a=b c');
     assert_equals(params.get('a'), 'b c');
     params = new URLSearchParams('a b=c');


### PR DESCRIPTION
Extend test coverage in urlsearchparams-constructor.html to cover a WebKit
bug when parsing an encoded '+'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5736)
<!-- Reviewable:end -->
