### PR TITLE
Adding tests for RTCDataChannel id attribute.

### DIFF
--- a/webrtc/RTCDataChannel-id.html
+++ b/webrtc/RTCDataChannel-id.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCDataChannel id attribute</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+'use strict';
+
+// This and the test below verify that after a description is set that
+// negotiates the DTLS role used by SCTP, data channels with unset IDs
+// have IDs set according to the rules in rtcweb-data-channel.
+promise_test(test => {
+  const pc = new RTCPeerConnection;
+  const channel = pc.createDataChannel('');
+  return pc.createOffer()
+  .then(offer => pc.setLocalDescription(offer))
+  .then(() => {
+    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
+    // "active".
+    const answer = {
+      type: "answer",
+      sdp: pc.localDescription.sdp.replace("actpass", "active")
+    };
+    return pc.setRemoteDescription(answer);
+  })
+  .then(() => {
+    // Since the remote description had an "active" DTLS role, we're the server
+    // and should use odd data channel IDs, according to rtcweb-data-channel.
+    assert_equals(channel.id % 2, 1, 'id');
+    const another_channel = pc.createDataChannel('another');
+    assert_equals(another_channel.id % 2, 1, 'id');
+    assert_not_equals(channel.id, another_channel.id);
+  })
+}, "DTLS client uses odd data channel IDs");
+
+promise_test(test => {
+  const pc = new RTCPeerConnection;
+  const channel = pc.createDataChannel('');
+  return pc.createOffer()
+  .then(offer => pc.setLocalDescription(offer))
+  .then(() => {
+    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
+    // "passive".
+    const answer = {
+      type: "answer",
+      sdp: pc.localDescription.sdp.replace("actpass", "passive")
+    };
+    return pc.setRemoteDescription(answer);
+  })
+  .then(() => {
+    // Since the remote description had a "passive" DTLS role, we're the client
+    // and should use even data channel IDs, according to rtcweb-data-channel.
+    assert_equals(channel.id % 2, 0, 'id');
+    const another_channel = pc.createDataChannel('another');
+    assert_equals(another_channel.id % 2, 0, 'id');
+    assert_not_equals(channel.id, another_channel.id);
+  })
+}, "DTLS server uses even data channel IDs");
+
+</script>

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -54,9 +54,10 @@ async_test(test => {
   .then(function() {
     // Since the remote description had an "active" DTLS role, we're the server
     // and should use odd data channel IDs, according to rtcweb-data-channel.
-    assert_equals(channel.id, 1, 'id');
+    assert_equals(channel.id % 2, 1, 'id');
     const another_channel = pc.createDataChannel('another');
-    assert_equals(another_channel.id, 3, 'id');
+    assert_equals(another_channel.id % 2, 1, 'id');
+    assert_not_equals(channel.id, another_channel.id);
     test.done();
   })
   .catch(test.step_func(function(e) {
@@ -83,9 +84,10 @@ async_test(test => {
   .then(function() {
     // Since the remote description had a "passive" DTLS role, we're the client
     // and should use even data channel IDs, according to rtcweb-data-channel.
-    assert_equals(channel.id, 0, 'id');
+    assert_equals(channel.id % 2, 0, 'id');
     const another_channel = pc.createDataChannel('another');
-    assert_equals(another_channel.id, 2, 'id');
+    assert_equals(another_channel.id % 2, 0, 'id');
+    assert_not_equals(channel.id, another_channel.id);
     test.done();
   })
   .catch(test.step_func(function(e) {

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -35,66 +35,6 @@ test(() => {
   assert_equals(channel.priority, 'low', 'priority');
 }, 'createDataChannel defaults');
 
-async_test(test => {
-  const pc = new RTCPeerConnection;
-  const channel = pc.createDataChannel('');
-  pc.createOffer()
-  .then(function(offer) {
-    return pc.setLocalDescription(offer);
-  })
-  .then(function() {
-    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
-    // "active".
-    const answer = new RTCSessionDescription({
-      type: "answer",
-      sdp: pc.localDescription.sdp.replace("actpass", "active")
-    });
-    return pc.setRemoteDescription(answer);
-  })
-  .then(function() {
-    // Since the remote description had an "active" DTLS role, we're the server
-    // and should use odd data channel IDs, according to rtcweb-data-channel.
-    assert_equals(channel.id % 2, 1, 'id');
-    const another_channel = pc.createDataChannel('another');
-    assert_equals(another_channel.id % 2, 1, 'id');
-    assert_not_equals(channel.id, another_channel.id);
-    test.done();
-  })
-  .catch(test.step_func(function(e) {
-    assert_unreached('Error ' + e.name + ': ' + e.message);
-  }));
-}, "DTLS client uses odd data channel IDs");
-
-async_test(test => {
-  const pc = new RTCPeerConnection;
-  const channel = pc.createDataChannel('');
-  pc.createOffer()
-  .then(function(offer) {
-    return pc.setLocalDescription(offer);
-  })
-  .then(function() {
-    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
-    // "passive".
-    const answer = new RTCSessionDescription({
-      type: "answer",
-      sdp: pc.localDescription.sdp.replace("actpass", "passive")
-    });
-    return pc.setRemoteDescription(answer);
-  })
-  .then(function() {
-    // Since the remote description had a "passive" DTLS role, we're the client
-    // and should use even data channel IDs, according to rtcweb-data-channel.
-    assert_equals(channel.id % 2, 0, 'id');
-    const another_channel = pc.createDataChannel('another');
-    assert_equals(another_channel.id % 2, 0, 'id');
-    assert_not_equals(channel.id, another_channel.id);
-    test.done();
-  })
-  .catch(test.step_func(function(e) {
-    assert_unreached('Error ' + e.name + ': ' + e.message);
-  }));
-}, "DTLS server uses even data channel IDs");
-
 const labels = [
   ['"foo"', 'foo', 'foo'],
   ['null', null, 'null'],

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -29,10 +29,69 @@ test(() => {
   assert_equals(channel.maxRetransmits, null, 'maxRetransmits');
   assert_equals(channel.protocol, '', 'protocol');
   assert_equals(channel.negotiated, false, 'negotiated');
-  // Initial id value is not defined.
-  assert_equals(typeof channel.id, 'number', 'id type');
+  // Since no offer/answer exchange has occurred yet, the DTLS role is unknown
+  // and so the ID should be null.
+  assert_equals(channel.id, null, 'id');
   assert_equals(channel.priority, 'low', 'priority');
 }, 'createDataChannel defaults');
+
+async_test(test => {
+  const pc = new RTCPeerConnection;
+  const channel = pc.createDataChannel('');
+  pc.createOffer()
+  .then(function(offer) {
+    return pc.setLocalDescription(offer);
+  })
+  .then(function() {
+    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
+    // "active".
+    const answer = new RTCSessionDescription({
+      type: "answer",
+      sdp: pc.localDescription.sdp.replace("actpass", "active")
+    });
+    return pc.setRemoteDescription(answer);
+  })
+  .then(function() {
+    // Since the remote description had an "active" DTLS role, we're the server
+    // and should use odd data channel IDs, according to rtcweb-data-channel.
+    assert_equals(channel.id, 1, 'id');
+    const another_channel = pc.createDataChannel('another');
+    assert_equals(another_channel.id, 3, 'id');
+    test.done();
+  })
+  .catch(test.step_func(function(e) {
+    assert_unreached('Error ' + e.name + ': ' + e.message);
+  }));
+}, "DTLS client uses odd data channel IDs");
+
+async_test(test => {
+  const pc = new RTCPeerConnection;
+  const channel = pc.createDataChannel('');
+  pc.createOffer()
+  .then(function(offer) {
+    return pc.setLocalDescription(offer);
+  })
+  .then(function() {
+    // Turn our own offer SDP into valid answer SDP by setting the DTLS role to
+    // "passive".
+    const answer = new RTCSessionDescription({
+      type: "answer",
+      sdp: pc.localDescription.sdp.replace("actpass", "passive")
+    });
+    return pc.setRemoteDescription(answer);
+  })
+  .then(function() {
+    // Since the remote description had a "passive" DTLS role, we're the client
+    // and should use even data channel IDs, according to rtcweb-data-channel.
+    assert_equals(channel.id, 0, 'id');
+    const another_channel = pc.createDataChannel('another');
+    assert_equals(another_channel.id, 2, 'id');
+    test.done();
+  })
+  .catch(test.step_func(function(e) {
+    assert_unreached('Error ' + e.name + ': ' + e.message);
+  }));
+}, "DTLS server uses even data channel IDs");
 
 const labels = [
   ['"foo"', 'foo', 'foo'],


### PR DESCRIPTION
When no ID argument is provided, and the DTLS role hasn't been
determined, the id attribute should return `null`.

After the DTLS role is determined by an answer being applied with
"a=setup:active" (or "passive"), the null IDs should be replaced with
either odd or even IDs, depending on the negotiated role.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5742)
<!-- Reviewable:end -->
