### PR TITLE
Remove invalid messageerror test

### DIFF
--- a/webmessaging/messageerror.html
+++ b/webmessaging/messageerror.html
@@ -37,16 +37,6 @@ test(t => {
 
   document.body.setAttribute("onmessageerror", "window.messageErrorHappened = true;")
 
-  document.body.dispatchEvent(new Event("messageerror"));
-
-  assert_true(window.messageErrorHappened, "Dispatching the event must run the code");
-}, "The onmessageerror content attribute must execute when an event is dispatched on the body");
-
-test(t => {
-  t.add_cleanup(cleanup);
-
-  document.body.setAttribute("onmessageerror", "window.messageErrorHappened = true;")
-
   window.dispatchEvent(new Event("messageerror"));
 
   assert_true(window.messageErrorHappened, "Dispatching the event must run the code");


### PR DESCRIPTION
This is a follow-up to #5567. As pointed out in https://github.com/w3c/web-platform-tests/pull/5567/files#r114040410, this test is invalid. messageerror (and message) have their corresponding event handler content attributes on document.body, but with the actual event handler belonging to Window.

@binji to review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5746)
<!-- Reviewable:end -->
