### PR TITLE
[selectors4] Add new test for `:focus-within` pseudo-class

### DIFF
--- a/css/selectors4/focus-within-010.html
+++ b/css/selectors4/focus-within-010.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang=en class="reftest-wait">
+<meta charset="utf-8">
+<title>Selectors Level 4: focus-within</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
+<link rel="match" href="focus-within-shadow-001-ref.html">
+<meta name="assert" content="Checks that :focus-within is still applied when focus moves from an element to one of its descendants.">
+<style>
+/* Suppress things that cannot be reproduced in the reference file */
+:focus {
+  outline: none;
+}
+
+#target {
+  display: none;
+}
+
+#wrapper:focus-within > #target {
+  display: block;
+}
+
+#target:focus {
+  border: solid 15px green;
+}
+</style>
+<p>Test passes if there is a green rectangle below.</p>
+<div id="wrapper" tabindex="1">
+  <div id="target" tabindex="2"></div>
+</div>
+<script>
+var wrapper = document.getElementById('wrapper');
+wrapper.focus();
+var target = document.getElementById('target');
+target.focus();
+document.documentElement.classList.remove('reftest-wait');
+</script>
+</html>


### PR DESCRIPTION
The test checks what happens when you move the focus from an element to any of its descendants. The goal is to verify that `:focus-within` is still applied in that case.

The test passes on Blink and WebKit but not in Gecko.

This is a very common use case, when you try to simulate `:hover` behavior with `:focus-within` for keyboard users ([see this simple menu example](http://jsbin.com/mimuyob/1/edit?html,css,output)).

Please @frivoal and/or @rune-opera take a look to this test. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5750)
<!-- Reviewable:end -->
