### PR TITLE
Add test on pending promise behavior after PeerConnection is closed

### DIFF
--- a/webrtc/pending-promise-after-close.html
+++ b/webrtc/pending-promise-after-close.html
@@ -5,12 +5,25 @@
 <script type="text/javascript">
   'use strict';
 
-  function test_never_resolved(test_func, testName) {
+  /*
+   * Test that if a peer connection is closed when there is
+   * pending operation, the promise of that operation is
+   * never resolved. This helper function takes in a
+   * test function that accepts a peer connection and
+   * a close function. The test function is called once
+   * with a real closePc function and once with a noop
+   * function. Because the test still needs to end
+   * somehow without waiting forever for the timeout,
+   * we wait for the promise returned from the second
+   * unclosed pc to resolve, and conclude the test to
+   * pass if the first promise is still not yet resolved.
+   */
+  function test_never_resolved(testFunc, testName) {
     async_test(t => {
       const pc1 = new RTCPeerConnection();
       const closePc1 = () => pc1.close();
 
-      test_func(pc1, closePc1)
+      testFunc(pc1, closePc1)
       .then(
         t.step_func(result => {
           assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`);
@@ -19,14 +32,10 @@
          assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`);
         }));
 
-      t.step_timeout(() => {
-        t.done();
-      }, 1000);
-
       const pc2 = new RTCPeerConnection();
       const closePc2 = () => {}; // noop (don't close)
 
-      test_func(pc2, closePc2)
+      testFunc(pc2, closePc2)
       .then(
         t.step_func_done(),
         t.step_func(err => {
@@ -66,12 +75,12 @@
     return p;
   }, 'pending addIceCandidate() should never resolve if closed');
 
-  test_never_resolved(pc => {
+  test_never_resolved((pc, closePc) => {
     return pc.createOffer()
-    .then(offer => pc.setLocalDescription(offer))
+    .then(offer => pc.setRemoteDescription(offer))
     .then(() => {
       const p = pc.createAnswer();
-      pc.close();
+      closePc();
       return p;
     });
   }, 'pending createAnswer() should never resolve if closed');

--- a/webrtc/pending-promise-after-close.html
+++ b/webrtc/pending-promise-after-close.html
@@ -1,87 +1,81 @@
 <!doctype html>
-<html>
-<head>
-  <title>Test pending promises behavior when RTCPeerConnection object is closed</title>
-</head>
-<body>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <script type="text/javascript">
-    'use strict';
+<title>Test pending promises behavior when RTCPeerConnection object is closed</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script type="text/javascript">
+  'use strict';
 
-    function test_never_resolved(test_func, testName) {
-      async_test(t => {
-        const pc1 = new RTCPeerConnection();
-        const closePc1 = () => pc1.close();
+  function test_never_resolved(test_func, testName) {
+    async_test(t => {
+      const pc1 = new RTCPeerConnection();
+      const closePc1 = () => pc1.close();
 
-        test_func(pc1, closePc1)
-        .then(
-          t.step_func(result => {
-            assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`);
-          }),
-          t.step_func(err => {
-           assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`);
-          }));
+      test_func(pc1, closePc1)
+      .then(
+        t.step_func(result => {
+          assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`);
+        }),
+        t.step_func(err => {
+         assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`);
+        }));
 
-        t.step_timeout(() => {
-          t.done();
-        }, 1000);
+      t.step_timeout(() => {
+        t.done();
+      }, 1000);
 
-        const pc2 = new RTCPeerConnection();
-        const closePc2 = () => {}; // noop (don't close)
+      const pc2 = new RTCPeerConnection();
+      const closePc2 = () => {}; // noop (don't close)
 
-        test_func(pc2, closePc2)
-        .then(
-          t.step_func_done(),
-          t.step_func(err => {
-            assert_unreached(`Operating on unclosed peer connection should succeed. Instead it is rejected with: ${err}`);
-          }));
+      test_func(pc2, closePc2)
+      .then(
+        t.step_func_done(),
+        t.step_func(err => {
+          assert_unreached(`Operating on unclosed peer connection should succeed. Instead it is rejected with: ${err}`);
+        }));
 
-       }, testName);
-    }
+     }, testName);
+  }
 
-    test_never_resolved((pc, closePc) => {
-      const p = pc.createOffer();
+  test_never_resolved((pc, closePc) => {
+    const p = pc.createOffer();
+    closePc();
+    return p;
+  }, 'pending createOffer() should never resolve if closed');
+
+  test_never_resolved((pc, closePc) => {
+    return pc.createOffer()
+    .then(offer => {
+      const p = pc.setLocalDescription(offer);
       closePc();
       return p;
-    }, 'pending createOffer() should never resolve if closed');
+    });
+  }, 'pending setLocalDescription should never resolve if closed');
 
-    test_never_resolved((pc, closePc) => {
-      return pc.createOffer()
-      .then(offer => {
-        const p = pc.setLocalDescription(offer);
-        closePc();
-        return p;
-      });
-    }, 'pending setLocalDescription should never resolve if closed');
-
-    test_never_resolved((pc, closePc) => {
-      return pc.createOffer()
-      .then(offer => {
-        const p = pc.setRemoteDescription(offer);
-        closePc();
-        return p;
-      });
-    }, 'pending setRemoteDescription should never resolve if closed');
-
-    test_never_resolved((pc, closePc) => {
-      const p = pc.addIceCandidate(new RTCIceCandidate({}));
+  test_never_resolved((pc, closePc) => {
+    return pc.createOffer()
+    .then(offer => {
+      const p = pc.setRemoteDescription(offer);
       closePc();
       return p;
-    }, 'pending addIceCandidate() should never resolve if closed');
+    });
+  }, 'pending setRemoteDescription should never resolve if closed');
 
-    test_never_resolved(pc => {
-      return pc.createOffer()
-      .then(offer => pc.setLocalDescription(offer))
-      .then(() => {
-        const p = pc.createAnswer();
-        pc.close();
-        return p;
-      });
-    }, 'pending createAnswer() should never resolve if closed');
+  test_never_resolved((pc, closePc) => {
+    const p = pc.addIceCandidate(new RTCIceCandidate({}));
+    closePc();
+    return p;
+  }, 'pending addIceCandidate() should never resolve if closed');
 
-    // TODO: Add test on methods on other classes as well
+  test_never_resolved(pc => {
+    return pc.createOffer()
+    .then(offer => pc.setLocalDescription(offer))
+    .then(() => {
+      const p = pc.createAnswer();
+      pc.close();
+      return p;
+    });
+  }, 'pending createAnswer() should never resolve if closed');
 
-  </script>
-</body>
-</html>
+  // TODO: Add test on methods on other classes as well
+
+</script>

--- a/webrtc/pending-promise-after-close.html
+++ b/webrtc/pending-promise-after-close.html
@@ -1,61 +1,84 @@
 <!doctype html>
 <html>
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <title>Test pending promises behavior when RTCPeerConnection object is closed</title>
 </head>
 <body>
-  <!-- These files are in place when executing on W3C. -->
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script type="text/javascript">
-    'use strict'
+    'use strict';
 
     function test_never_resolved(test_func, testName) {
       async_test(t => {
-        const pc = new RTCPeerConnection();
+        const pc1 = new RTCPeerConnection();
+        const closePc1 = () => pc1.close();
 
-        test_func(pc).then(
+        test_func(pc1, closePc1)
+        .then(
           t.step_func(result => {
-            assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`)
+            assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`);
           }),
           t.step_func(err => {
-           assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`)
+           assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`);
           }));
-
-        // Close the PeerConnection before enqueued operation is executed.
-        pc.close();
 
         t.step_timeout(() => {
           t.done();
-        }, 2000);
+        }, 1000);
 
-      }, testName);
+        const pc2 = new RTCPeerConnection();
+        const closePc2 = () => {}; // noop (don't close)
+
+        test_func(pc2, closePc2)
+        .then(
+          t.step_func_done(),
+          t.step_func(err => {
+            assert_unreached(`Operating on unclosed peer connection should succeed. Instead it is rejected with: ${err}`);
+          }));
+
+       }, testName);
     }
 
-    test_never_resolved(pc =>
-      pc.createOffer(),
-      'pending createOffer() should never resolve if closed');
+    test_never_resolved((pc, closePc) => {
+      const p = pc.createOffer();
+      closePc();
+      return p;
+    }, 'pending createOffer() should never resolve if closed');
 
-    test_never_resolved(pc =>
-      pc.setLocalDescription({ type: 'offer' }),
-      'pending setLocalDescription() should never resolve if closed');
+    test_never_resolved((pc, closePc) => {
+      return pc.createOffer()
+      .then(offer => {
+        const p = pc.setLocalDescription(offer);
+        closePc();
+        return p;
+      });
+    }, 'pending setLocalDescription should never resolve if closed');
 
-    test_never_resolved(pc =>
-      pc.setRemoteDescription({ type: 'offer' }),
-      'pending setRemoteDescription() should never resolve if closed');
+    test_never_resolved((pc, closePc) => {
+      return pc.createOffer()
+      .then(offer => {
+        const p = pc.setRemoteDescription(offer);
+        closePc();
+        return p;
+      });
+    }, 'pending setRemoteDescription should never resolve if closed');
 
-    test_never_resolved(pc =>
-      pc.addIceCandidate(new RTCIceCandidate()),
-      'pending addIceCandidate() should never resolve if closed');
+    test_never_resolved((pc, closePc) => {
+      const p = pc.addIceCandidate(new RTCIceCandidate({}));
+      closePc();
+      return p;
+    }, 'pending addIceCandidate() should never resolve if closed');
 
-    test_never_resolved(pc =>
-      pc.createOffer(),
-      'pending createOffer() should never resolve if closed');
-
-    test_never_resolved(pc =>
-      pc.createAnswer(),
-      'pending createAnswer() should never resolve if closed');
+    test_never_resolved(pc => {
+      return pc.createOffer()
+      .then(offer => pc.setLocalDescription(offer))
+      .then(() => {
+        const p = pc.createAnswer();
+        pc.close();
+        return p;
+      });
+    }, 'pending createAnswer() should never resolve if closed');
 
     // TODO: Add test on methods on other classes as well
 

--- a/webrtc/pending-promise-after-close.html
+++ b/webrtc/pending-promise-after-close.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Test pending promises behavior when RTCPeerConnection object is closed</title>
+</head>
+<body>
+  <!-- These files are in place when executing on W3C. -->
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script type="text/javascript">
+    'use strict'
+
+    function test_never_resolved(test_func, testName) {
+      async_test(t => {
+        const pc = new RTCPeerConnection();
+
+        test_func(pc).then(
+          t.step_func(result => {
+            assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`)
+          }),
+          t.step_func(err => {
+           assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`)
+          }));
+
+        // Close the PeerConnection before enqueued operation is executed.
+        pc.close();
+
+        t.step_timeout(() => {
+          t.done();
+        }, 2000);
+
+      }, testName);
+    }
+
+    test_never_resolved(pc =>
+      pc.createOffer(),
+      'pending createOffer() should never resolve if closed');
+
+    test_never_resolved(pc =>
+      pc.setLocalDescription({ type: 'offer' }),
+      'pending setLocalDescription() should never resolve if closed');
+
+    test_never_resolved(pc =>
+      pc.setRemoteDescription({ type: 'offer' }),
+      'pending setRemoteDescription() should never resolve if closed');
+
+    test_never_resolved(pc =>
+      pc.addIceCandidate(new RTCIceCandidate()),
+      'pending addIceCandidate() should never resolve if closed');
+
+    test_never_resolved(pc =>
+      pc.createOffer(),
+      'pending createOffer() should never resolve if closed');
+
+    test_never_resolved(pc =>
+      pc.createAnswer(),
+      'pending createAnswer() should never resolve if closed');
+
+    // TODO: Add test on methods on other classes as well
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
For some reason I do not understand, the webrtc-pc spec states that pending promises inside operation queues should never be resolved when a `RTCPeerConnection` object is closed. (w3c/webrtc-pc#150)

I create a file to specifically this behavior, since the descriptions in spec is a bit hard to follow.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
