### PR TITLE
Add IDL test for mediacapture-streams

### DIFF
--- a/interfaces/mediacapture-main.idl
+++ b/interfaces/mediacapture-main.idl
@@ -1,0 +1,254 @@
+[Exposed=Window,
+ Constructor,
+ Constructor(MediaStream stream),
+ Constructor(sequence<MediaStreamTrack> tracks)]
+interface MediaStream : EventTarget {
+    readonly attribute DOMString    id;
+    sequence<MediaStreamTrack> getAudioTracks();
+    sequence<MediaStreamTrack> getVideoTracks();
+    sequence<MediaStreamTrack> getTracks();
+    MediaStreamTrack?          getTrackById(DOMString trackId);
+    void                       addTrack(MediaStreamTrack track);
+    void                       removeTrack(MediaStreamTrack track);
+    MediaStream                clone();
+    readonly attribute boolean      active;
+             attribute EventHandler onaddtrack;
+             attribute EventHandler onremovetrack;
+};
+
+[Exposed=Window]
+interface MediaStreamTrack : EventTarget {
+    readonly attribute DOMString             kind;
+    readonly attribute DOMString             id;
+    readonly attribute DOMString             label;
+             attribute boolean               enabled;
+    readonly attribute boolean               muted;
+             attribute EventHandler          onmute;
+             attribute EventHandler          onunmute;
+    readonly attribute MediaStreamTrackState readyState;
+             attribute EventHandler          onended;
+    MediaStreamTrack       clone();
+    void                   stop();
+    MediaTrackCapabilities getCapabilities();
+    MediaTrackConstraints  getConstraints();
+    MediaTrackSettings     getSettings();
+    Promise<void>          applyConstraints(optional MediaTrackConstraints constraints);
+             attribute EventHandler          onoverconstrained;
+};
+
+enum MediaStreamTrackState {
+    "live",
+    "ended"
+};
+
+dictionary MediaTrackSupportedConstraints {
+    boolean width = true;
+    boolean height = true;
+    boolean aspectRatio = true;
+    boolean frameRate = true;
+    boolean facingMode = true;
+    boolean volume = true;
+    boolean sampleRate = true;
+    boolean sampleSize = true;
+    boolean echoCancellation = true;
+    boolean latency = true;
+    boolean channelCount = true;
+    boolean deviceId = true;
+    boolean groupId = true;
+};
+
+dictionary MediaTrackCapabilities {
+    LongRange           width;
+    LongRange           height;
+    DoubleRange         aspectRatio;
+    DoubleRange         frameRate;
+    sequence<DOMString> facingMode;
+    DoubleRange         volume;
+    LongRange           sampleRate;
+    LongRange           sampleSize;
+    sequence<boolean>   echoCancellation;
+    DoubleRange         latency;
+    LongRange           channelCount;
+    DOMString           deviceId;
+    DOMString           groupId;
+};
+
+dictionary MediaTrackConstraints : MediaTrackConstraintSet {
+    sequence<MediaTrackConstraintSet> advanced;
+};
+
+dictionary MediaTrackConstraintSet {
+    ConstrainLong      width;
+    ConstrainLong      height;
+    ConstrainDouble    aspectRatio;
+    ConstrainDouble    frameRate;
+    ConstrainDOMString facingMode;
+    ConstrainDouble    volume;
+    ConstrainLong      sampleRate;
+    ConstrainLong      sampleSize;
+    ConstrainBoolean   echoCancellation;
+    ConstrainDouble    latency;
+    ConstrainLong      channelCount;
+    ConstrainDOMString deviceId;
+    ConstrainDOMString groupId;
+};
+
+dictionary MediaTrackSettings {
+    long      width;
+    long      height;
+    double    aspectRatio;
+    double    frameRate;
+    DOMString facingMode;
+    double    volume;
+    long      sampleRate;
+    long      sampleSize;
+    boolean   echoCancellation;
+    double    latency;
+    long      channelCount;
+    DOMString deviceId;
+    DOMString groupId;
+};
+
+enum VideoFacingModeEnum {
+    "user",
+    "environment",
+    "left",
+    "right"
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, MediaStreamTrackEventInit eventInitDict)]
+interface MediaStreamTrackEvent : Event {
+    [SameObject]
+    readonly attribute MediaStreamTrack track;
+};
+
+dictionary MediaStreamTrackEventInit : EventInit {
+    required MediaStreamTrack track;
+};
+
+[Exposed=Window,
+ Constructor(DOMString type, OverconstrainedErrorEventInit eventInitDict)]
+interface OverconstrainedErrorEvent : Event {
+    readonly attribute OverconstrainedError? error;
+};
+
+dictionary OverconstrainedErrorEventInit : EventInit {
+    OverconstrainedError? error = null;
+};
+
+[Exposed=Window,
+ NoInterfaceObject]
+interface NavigatorUserMedia {
+    [SameObject]
+    readonly attribute MediaDevices mediaDevices;
+};
+
+Navigator implements NavigatorUserMedia;
+
+[Exposed=Window]
+interface MediaDevices : EventTarget {
+    attribute EventHandler ondevicechange;
+    Promise<sequence<MediaDeviceInfo>> enumerateDevices();
+};
+
+[Exposed=Window]
+interface MediaDeviceInfo {
+    readonly attribute DOMString       deviceId;
+    readonly attribute MediaDeviceKind kind;
+    readonly attribute DOMString       label;
+    readonly attribute DOMString       groupId;
+    serializer = {attribute};
+};
+
+enum MediaDeviceKind {
+    "audioinput",
+    "audiooutput",
+    "videoinput"
+};
+
+interface InputDeviceInfo : MediaDeviceInfo {
+    MediaTrackCapabilities getCapabilities();
+};
+
+partial interface NavigatorUserMedia {
+    void getUserMedia(MediaStreamConstraints constraints,
+                      NavigatorUserMediaSuccessCallback successCallback,
+                      NavigatorUserMediaErrorCallback errorCallback);
+};
+
+partial interface MediaDevices {
+    MediaTrackSupportedConstraints getSupportedConstraints();
+    Promise<MediaStream>           getUserMedia(optional MediaStreamConstraints constraints);
+};
+
+dictionary MediaStreamConstraints {
+    (boolean or MediaTrackConstraints) video = false;
+    (boolean or MediaTrackConstraints) audio = false;
+};
+
+callback NavigatorUserMediaSuccessCallback = void (MediaStream stream);
+
+callback NavigatorUserMediaErrorCallback = void (MediaStreamError error);
+
+typedef object MediaStreamError;
+
+[NoInterfaceObject]
+interface ConstrainablePattern {
+    Capabilities  getCapabilities();
+    Constraints   getConstraints();
+    Settings      getSettings();
+    Promise<void> applyConstraints(optional Constraints constraints);
+    attribute EventHandler onoverconstrained;
+};
+
+dictionary DoubleRange {
+    double max;
+    double min;
+};
+
+dictionary ConstrainDoubleRange : DoubleRange {
+    double exact;
+    double ideal;
+};
+
+dictionary LongRange {
+    long max;
+    long min;
+};
+
+dictionary ConstrainLongRange : LongRange {
+    long exact;
+    long ideal;
+};
+
+dictionary ConstrainBooleanParameters {
+    boolean exact;
+    boolean ideal;
+};
+
+dictionary ConstrainDOMStringParameters {
+    (DOMString or sequence<DOMString>) exact;
+    (DOMString or sequence<DOMString>) ideal;
+};
+
+typedef (long or ConstrainLongRange) ConstrainLong;
+
+typedef (double or ConstrainDoubleRange) ConstrainDouble;
+
+typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
+
+typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
+
+dictionary Capabilities {
+};
+
+dictionary Settings {
+};
+
+dictionary ConstraintSet {
+};
+
+dictionary Constraints : ConstraintSet {
+    sequence<ConstraintSet> advanced;
+};

--- a/mediacapture-streams/GUM-api.https.html
+++ b/mediacapture-streams/GUM-api.https.html
@@ -16,8 +16,8 @@
 <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 test(function () {
-          assert_true(undefined !== navigator.getUserMedia, "navigator.getUserMedia exists");
-      }, "getUserMedia() is present on navigator");
+  assert_true(undefined !== navigator.getUserMedia, "navigator.getUserMedia exists");
+}, "getUserMedia() is present on navigator");
 </script>
 </body>
 </html>

--- a/mediacapture-streams/GUM-deny.https.html
+++ b/mediacapture-streams/GUM-deny.https.html
@@ -2,37 +2,36 @@
 <html>
 <head>
   <title>getUserMedia() triggers error callback when auth is denied</title>
-<link rel="author" title="Dominique Hazael-Massieux" href="mailto:dom@w3.org"/>
-<link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#error-names">
-<link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaStreamError">
+  <link rel="author" title="Dr. A. Gouaillard" href="mailto:agouaillard@gmail.com"/>
+  <link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#methods-5">
+  <link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#navigatorusermediaerrorcallback">
 </head>
 <body>
-<p class="instructions">When prompted, <strong>please deny</strong> access to
-the video stream.</p>
-<h1 class="instructions">Description</h1>
-<p class="instructions">This test checks that the error callback is triggered
-when user denies access to the video stream.</p>
-
-<div id='log'></div>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
-<script>
-var t = async_test("Tests that the error callback is triggered when permission is denied", {timeout:10000});
-t.step(function() {
-  navigator.getUserMedia(
-    {video: true},
-    t.step_func(function (stream) {
-      assert_unreached("The success callback should not be triggered since access is to be denied");
-      t.done();
-    }),
-    t.step_func(function (error) {
-      assert_equals(error.name, "securityError", "securityError returned");
-      assert_equals(error.constraintName, undefined, "constraintName attribute not set for permission denied");
-      t.done();
-    })
-  );
-});
-</script>
+  <p class="instructions">When prompted, <strong>please deny</strong> access to
+    the video stream.</p>
+  <h1 class="instructions">Description</h1>
+  <p class="instructions">This test checks that the error callback is triggered
+    when user denies access to the video stream.</p>
+  <div id='log'></div>
+  <script src=/resources/testharness.js></script>
+  <script src=/resources/testharnessreport.js></script>
+  <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
+  <script>
+    var t = async_test("Tests that the error callback is triggered when permission is denied", {timeout:10000});
+    t.step(function() {
+      navigator.getUserMedia(
+        {video: true},
+        t.step_func(function (stream) {
+        assert_unreached("The success callback should not be triggered since access is to be denied");
+        t.done();
+        }),
+        t.step_func(function (error) {
+          assert_equals(error.name, "securityError", "securityError returned as expected");
+          assert_equals(error.constraintName, undefined, "constraintName attribute not set as expected");
+          t.done();
+        })
+      );
+    });
+  </script>
 </body>
 </html>

--- a/mediacapture-streams/MediaDevices-IDL-all.html
+++ b/mediacapture-streams/MediaDevices-IDL-all.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+  <head>
+    <title>getUserMedia: Non-Interactive test for mediaDevices APIs</title>
+    <link rel="author" title="Dr Alex Gouaillard" href="mailto:agouaillard@gmail.com"/>
+    <link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#mediadevices">
+    <link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#mediadevices-interface-extensions">
+    <meta name='assert' content='Check the mediaDevices APIs.'/>
+  </head>
+  <body>
+    <h1 class="instructions">Description</h1>
+    <p class="instructions">This test checks for the presence of the
+    <code>navigator.mediaDevices.getUserMedia</code> method.</p>
+    <div id='log'></div>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+    <script src=/resources/WebIDLParser.js></script>
+    <script src=/resources/idlharness.js></script>
+    <script>
+      var idl_array = new IdlArray();
+
+      idl_array.add_untested_idls("interface EventTarget {\
+        void addEventListener(DOMString type, EventListener? callback, optional boolean capture = false);\
+        void removeEventListener(DOMString type, EventListener? callback, optional boolean capture = false);\
+        boolean dispatchEvent(Event event);\
+      };");
+
+      idl_array.add_untested_idls("interface Navigator{\
+        readonly attribute MediaDevices mediaDevices;\
+      };");
+
+      idl_array.add_idls("[Exposed=Window]\
+        interface MediaDevices : EventTarget {\
+          attribute EventHandler ondevicechange;\
+          Promise<sequence<MediaDeviceInfo>> enumerateDevices ();\
+      };");
+
+      // TODO: fix the constraints argument (DrAlex)
+      idl_array.add_idls("partial interface MediaDevices {\
+        MediaTrackSupportedConstraints getSupportedConstraints ();\
+        Promise<MediaStream> getUserMedia();\
+      };");
+
+      idl_array.test();
+      done();
+
+    </script>
+  </body>
+</html>

--- a/mediacapture-streams/MediaDevices-IDL-all.html
+++ b/mediacapture-streams/MediaDevices-IDL-all.html
@@ -17,48 +17,29 @@
     <script src=/resources/WebIDLParser.js></script>
     <script src=/resources/idlharness.js></script>
     <script>
-      var idl_array = new IdlArray();
+      'use strict';
 
-      // dummies
-      idl_array.add_untested_idls("interface EventTarget {};");
-      idl_array.add_untested_idls("interface Navigator {};");
+      function doIdlTest(idlText) {
+        var idl_array = new IdlArray();
 
-      idl_array.add_untested_idls("\
-        [exposed=Window, NoInterfaceObject]\
-        interface NavigatorUserMedia {\
-          [SameObject]\
-          readonly attribute MediaDevices mediaDevices;\
-      };");
+        // dummies
+        idl_array.add_untested_idls("interface Navigator {};");
+        idl_array.add_untested_idls("interface EventTarget {};");
+        idl_array.add_untested_idls("interface EventHandler {};");
 
-      idl_array.add_idls("\
-        Navigator implements NavigatorUserMedia;\
-      ")
+        idl_array.add_untested_idls(idlText);
 
-      idl_array.add_idls("\
-        [Exposed=Window]\
-        interface MediaDevices : EventTarget {\
-          attribute EventHandler ondevicechange;\
-          Promise<sequence<MediaDeviceInfo>> enumerateDevices ();\
-      };");
+        idl_array.add_objects({"Navigator": ["navigator"]});
+        idl_array.add_objects({"MediaDevices":["navigator.mediaDevices"]});
+        idl_array.test();
+      }
 
-      // NOTE ALEX: slightly simplified to avoid bringing in too much
-      idl_array.add_idls("\
-        dictionary MediaStreamConstraints {\
-          boolean video = false;\
-          boolean audio = false;\
-      };")
+      promise_test(() => {
+        return fetch('/interfaces/mediacapture-main.idl')
+          .then(response => response.text())
+          .then(doIdlTest);
 
-      idl_array.add_idls("\
-        partial interface MediaDevices {\
-          MediaTrackSupportedConstraints getSupportedConstraints ();\
-          Promise<MediaStream> getUserMedia (MediaStreamConstraints constraints);\
-      };");
-
-      idl_array.add_objects({"Navigator": ["navigator"]});
-      idl_array.add_objects({"MediaDevices":["navigator.mediaDevices"]});
-      idl_array.test();
-      done();
-
+      }, 'Test driver')
     </script>
   </body>
 </html>

--- a/mediacapture-streams/MediaDevices-IDL-all.html
+++ b/mediacapture-streams/MediaDevices-IDL-all.html
@@ -19,28 +19,43 @@
     <script>
       var idl_array = new IdlArray();
 
-      idl_array.add_untested_idls("interface EventTarget {\
-        void addEventListener(DOMString type, EventListener? callback, optional boolean capture = false);\
-        void removeEventListener(DOMString type, EventListener? callback, optional boolean capture = false);\
-        boolean dispatchEvent(Event event);\
+      // dummies
+      idl_array.add_untested_idls("interface EventTarget {};");
+      idl_array.add_untested_idls("interface Navigator {};");
+
+      idl_array.add_untested_idls("\
+        [exposed=Window, NoInterfaceObject]\
+        interface NavigatorUserMedia {\
+          [SameObject]\
+          readonly attribute MediaDevices mediaDevices;\
       };");
 
-      idl_array.add_untested_idls("interface Navigator{\
-        readonly attribute MediaDevices mediaDevices;\
-      };");
+      idl_array.add_idls("\
+        Navigator implements NavigatorUserMedia;\
+      ")
 
-      idl_array.add_idls("[Exposed=Window]\
+      idl_array.add_idls("\
+        [Exposed=Window]\
         interface MediaDevices : EventTarget {\
           attribute EventHandler ondevicechange;\
           Promise<sequence<MediaDeviceInfo>> enumerateDevices ();\
       };");
 
-      // TODO: fix the constraints argument (DrAlex)
-      idl_array.add_idls("partial interface MediaDevices {\
-        MediaTrackSupportedConstraints getSupportedConstraints ();\
-        Promise<MediaStream> getUserMedia();\
+      // NOTE ALEX: slightly simplified to avoid bringing in too much
+      idl_array.add_idls("\
+        dictionary MediaStreamConstraints {\
+          boolean video = false;\
+          boolean audio = false;\
+      };")
+
+      idl_array.add_idls("\
+        partial interface MediaDevices {\
+          MediaTrackSupportedConstraints getSupportedConstraints ();\
+          Promise<MediaStream> getUserMedia (MediaStreamConstraints constraints);\
       };");
 
+      idl_array.add_objects({"Navigator": ["navigator"]});
+      idl_array.add_objects({"MediaDevices":["navigator.mediaDevices"]});
       idl_array.test();
       done();
 

--- a/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
+++ b/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
@@ -48,8 +48,6 @@ test(function(){
         if( list.length > 0 ) {
           _mediaInfo = list[0];
           MDI_idl.add_objects({MediaDeviceInfo: ["_mediaInfo"]});
-        } else {
-          assert_unreached("enumerateDevice exists, but returns an empty list. No devices? MediaDeviceInfo not tested.");
         }
         for(let media of list) {
           if( media.kind == "audioinput" ||

--- a/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
+++ b/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
@@ -18,51 +18,45 @@
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <script>
-"use strict";
+  "use strict";
 
-var _mediaInfo = null;
+  function doIdlTest(idlText) {
+    const MDI_idl = new IdlArray();
 
-var MDI_idl = new IdlArray();
+    MDI_idl.add_untested_idls("interface Navigator {};");
+    MDI_idl.add_idls(idlText);
 
-MDI_idl.add_idls("[Exposed=Window]\
-  interface MediaDeviceInfo {\
-    readonly        attribute DOMString       deviceId;\
-    readonly        attribute MediaDeviceKind kind;\
-    readonly        attribute DOMString       label;\
-    readonly        attribute DOMString       groupId;\
-    serializer = {attribute};\
-};");
+    assert_true(undefined !== navigator.mediaDevices.enumerateDevices,
+      "navigator.mediaDevices.enumerateDevices exists");
 
-MDI_idl.add_idls('\
-  enum MediaDeviceKind {\
-    "audioinput",\
-    "audiooutput",\
-    "videoinput"\
-};');
-
-test(function(){
-  assert_true(undefined !== navigator.mediaDevices.enumerateDevices, "navigator.mediaDevices.enumerateDevices exists");
-  promise_test(function() {
     return navigator.mediaDevices.enumerateDevices()
-      .then(function(list) {
-        if( list.length > 0 ) {
-          _mediaInfo = list[0];
-          MDI_idl.add_objects({MediaDeviceInfo: ["_mediaInfo"]});
+    .then(function(list) {
+      if( list.length > 0 ) {
+        window._mediaInfo = list[0];
+        MDI_idl.add_objects({MediaDeviceInfo: ["_mediaInfo"]});
+      }
+
+      for(const media of list) {
+        if( media.kind == "audioinput" ||
+            media.kind == "videoinput") {
+          // TODO -- Check InputDeviceInfo IDL, getCapabilities()
+        } else if ( media.kind == "audiooutput" ) {
+          // TODO -- pass
+        } else {
+          assert_unreached("media.kind should be one of 'audioinput', 'videoinput', or 'audiooutput'.")
         }
-        for(let media of list) {
-          if( media.kind == "audioinput" ||
-              media.kind == "videoinput") {
-            // TODO -- Check InputDeviceInfo IDL, getCapabilities()
-          } else if ( media.kind == "audiooutput" ) {
-            // TODO -- pass
-          } else {
-            assert_unreached("media.kind should be one of 'audioinput', 'videoinput', or 'audiooutput'.")
-          }
-        }
-        MDI_idl.test();
-      })
-  }, "Test that the calls resolves");
-}, "Test MediaDevices.enumerateDevices call and result. Types only.");
+      }
+
+      MDI_idl.test();
+    });
+  }
+
+  promise_test(() => {
+    return fetch('/interfaces/mediacapture-main.idl')
+      .then(response => response.text())
+      .then(doIdlTest);
+
+  }, "Test MediaDevices.enumerateDevices call and result. Types only.");
 </script>
 </body>
 </html>

--- a/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
+++ b/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html>
+<head>
+<title>enumerateDevices: test that enumerateDevices is present</title>
+<link rel="author" title="Dr Alex Gouaillard" href="mailto:agouaillard@gmail.com"/>
+<link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#methods-2">
+<link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#device-info">
+<link rel="help" href="http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaDeviceKind">
+<meta name='assert' content='Check that the enumerateDevices() method is present.'/>
+</head>
+<body>
+<h1 class="instructions">Description</h1>
+<p class="instructions">This test checks for the presence of the
+<code>navigator.mediaDevices.enumerateDevices()</code> method.</p>
+<div id='log'></div>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+<script>
+"use strict";
+
+var _mediaInfo = null;;
+
+var MDI_idl = new IdlArray();
+
+MDI_idl.add_idls("[Exposed=Window]\
+  interface MediaDeviceInfo {\
+    readonly        attribute DOMString       deviceId;\
+    readonly        attribute MediaDeviceKind kind;\
+    readonly        attribute DOMString       label;\
+    readonly        attribute DOMString       groupId;\
+    serializer = {attribute};\
+};");
+
+MDI_idl.add_idls('\
+  enum MediaDeviceKind {\
+    "audioinput",\
+    "audiooutput",\
+    "videoinput"\
+};');
+
+test(function(){
+  assert_true(undefined !== navigator.mediaDevices.enumerateDevices, "navigator.mediaDevices.enumerateDevices exists");
+  promise_test(function() {
+    return navigator.mediaDevices.enumerateDevices()
+      .then(function(list) {
+        if( list.length > 0 ) {
+          _mediaInfo = list[0];
+          MDI_idl.add_objects({MediaDeviceInfo: ["_mediaInfo"]});
+        }
+        for(let media of list) {
+          if( media.kind == "audioinput" ||
+              media.kind == "videoinput") {
+            // TODO -- Check InputDeviceInfo IDL, getCapabilities()
+          } else if ( media.kind == "audiooutput" ) {
+            // TODO -- pass
+          } else {
+            assert_unreached("media.kind should be one of 'audioinput', 'videoinput', or 'audiooutput'.")
+          }
+        }
+        MDI_idl.test();
+      })
+  }, "Test that the calls resolves");
+}, "Test MediaDevices.enumerateDevices call and result. Types only.");
+</script>
+</body>
+</html>

--- a/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
+++ b/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
@@ -20,7 +20,7 @@
 <script>
 "use strict";
 
-var _mediaInfo = null;;
+var _mediaInfo = null;
 
 var MDI_idl = new IdlArray();
 
@@ -48,6 +48,8 @@ test(function(){
         if( list.length > 0 ) {
           _mediaInfo = list[0];
           MDI_idl.add_objects({MediaDeviceInfo: ["_mediaInfo"]});
+        } else {
+          assert_unreached("enumerateDevice exists, but returns an empty list. No devices? MediaDeviceInfo not tested.");
         }
         for(let media of list) {
           if( media.kind == "audioinput" ||


### PR DESCRIPTION
This is a follow up on #2729 with me taking over the PR.

On top of the previous changes, I moved all IDL definitions to `/interfaces/mediacapture-main.idl` and modified the tests to fetch the IDLs from there.

<!-- Reviewable:start -->

<!-- Reviewable:end -->



