### PR TITLE
[geometry] Test that DOMMatrix CSS parsing is not exposed in workers

### DIFF
--- a/css/geometry-1/DOMMatrix-css-string.worker.js
+++ b/css/geometry-1/DOMMatrix-css-string.worker.js
@@ -1,0 +1,16 @@
+importScripts("/resources/testharness.js");
+
+['DOMMatrix', 'DOMMatrixReadOnly'].forEach(constr => {
+  test(() => {
+    assert_true(constr in self, `${constr} is not supported`);
+    assert_throws(new TypeError(), () => new self[constr]('matrix(1,0,0,1,0,0)') );
+  }, `${constr} constructor with string argument in worker`);
+});
+
+test(() => {
+  assert_false('setMatrixValue' in DOMMatrix.prototype, 'on prototype');
+  const matrix = new DOMMatrix();
+  assert_false('setMatrixValue' in matrix, 'on instance');
+}, 'DOMMatrix setMatrixValue in worker');
+
+done();

--- a/css/geometry-1/DOMMatrix-css-string.worker.js
+++ b/css/geometry-1/DOMMatrix-css-string.worker.js
@@ -4,7 +4,7 @@ importScripts("/resources/testharness.js");
 
 ['DOMMatrix', 'DOMMatrixReadOnly'].forEach(constr => {
   test(() => {
-    assert_true(constr in self, `${constr} is not supported`);
+    assert_true(constr in self, `${constr} should exist`);
     assert_throws(new TypeError(), () => new self[constr]('matrix(1,0,0,1,0,0)') );
   }, `${constr} constructor with string argument in worker`);
 });

--- a/css/geometry-1/DOMMatrix-css-string.worker.js
+++ b/css/geometry-1/DOMMatrix-css-string.worker.js
@@ -1,3 +1,5 @@
+// https://drafts.fxtf.org/geometry/#DOMMatrix
+
 importScripts("/resources/testharness.js");
 
 ['DOMMatrix', 'DOMMatrixReadOnly'].forEach(constr => {

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -769,6 +769,9 @@ CSS-COLLIDING-SUPPORT-NAME: css/css-display-3/support/util.js
 CSS-COLLIDING-SUPPORT-NAME: css/CSS2/normal-flow/support/replaced-min-max-1.png
 CSS-COLLIDING-SUPPORT-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/ui3/support/replaced-min-max-1.png
 
+# TODO https://github.com/w3c/web-platform-tests/issues/5770
+MISSING-LINK: css/geometry-1/DOMMatrix-css-string.worker.js
+
 WEBIDL2.JS:.gitmodules
 
 # Manual test that uses console.logs for feedback


### PR DESCRIPTION
Follows https://github.com/w3c/fxtf-drafts/pull/141.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
