### PR TITLE
[wptrunner] Guard against empty command_queue in BrowserManager.send_message

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -200,6 +200,12 @@ class BrowserManager(object):
         return succeeded
 
     def send_message(self, command, *args):
+        if not hasattr(self, 'command_queue'):
+            self.logger.error('BrowserManager.send_message cannot send message because no command_queue exists')
+            self.logger.error('Command, args:')
+            self.logger.error((command, args))
+            self.cleanup()
+            return
         self.command_queue.put((command, args))
 
     def init_timeout(self):

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -157,6 +157,7 @@ class BrowserManager(object):
         self.started = False
 
         self.init_timer = None
+        self.command_queue = command_queue
 
     def update_settings(self, test):
         browser_settings = self.browser.settings(test)
@@ -200,12 +201,6 @@ class BrowserManager(object):
         return succeeded
 
     def send_message(self, command, *args):
-        if not hasattr(self, 'command_queue'):
-            self.logger.error('BrowserManager.send_message cannot send message because no command_queue exists')
-            self.logger.error('Command, args:')
-            self.logger.error((command, args))
-            self.cleanup()
-            return
         self.command_queue.put((command, args))
 
     def init_timeout(self):


### PR DESCRIPTION
This happens when sending the message `'init_failed'` and causes wptrunner to hang since `self.command_queue` doesn't exist at that point.

This patch is something I'm using to keep wptrunner from getting stuck, but there is probably a cleaner solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5774)
<!-- Reviewable:end -->
