### PR TITLE
[selectors4] Use specific reference for focus-within-006

### DIFF
--- a/css/selectors4/focus-within-006-ref.html
+++ b/css/selectors4/focus-within-006-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang=en class="reftest-wait">
+<meta charset="utf-8">
+<title>Selectors Level 4: focus-within Reference File</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<style>
+:focus {
+  outline: none;
+
+  /* Make the caret invisible
+     since it matches the color of the text, which is transparent,
+     while keeping the text readable thanks to its shadow.
+     Not using the caret-color property as it is too new to be relied on. */
+  color: transparent; text-shadow: black 0px 0px 0px;
+}
+
+div {
+  border: solid 15px green;
+}
+</style>
+<p>Test passes if, when the element below is focused,
+it is surrounded by a thick green border.
+There must be no red or blue once it is focused.</p>
+<div>
+  <input id="focusme" value="Focus this element">
+</div>
+<script>
+var focusme = document.getElementById('focusme');
+focusme.focus();
+document.documentElement.classList.remove('reftest-wait');
+</script>
+</html>

--- a/css/selectors4/focus-within-006.html
+++ b/css/selectors4/focus-within-006.html
@@ -5,12 +5,10 @@
 <link rel="author" title="Keyong Li" href="mailto:kli79@bloomberg.net">
 <link rel="author" title="Florian Rivoal" href="mailto:florian@rivoal.net">
 <link rel="help" href="https://drafts.csswg.org/selectors-4/#focus-within-pseudo">
-<link rel="match" href="focus-within-001-ref.html">
+<link rel="match" href="focus-within-006-ref.html">
 <meta name="assert" content="Test that :focus-within works on form controls, using an input element.">
 <style>
-/* Suppress things that cannot be reproduced in the reference file */
 :focus {
-  all: initial;
   outline: none;
 
   /* Make the caret invisible


### PR DESCRIPTION
This test was having some troubles to be run in WebKit,
using a specific reference file for it fixes the issue.

One problem was that WebKit selects the content of the input
when it's focused, which doesn't happen on Chrome and Firefox.
Another issue was the difference in the initial font between WebKit
and other browsers (see http://webkit.org/b/168258).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
