### PR TITLE
Add a test that the playback rate is unaffected when an exception is thrown

### DIFF
--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -122,6 +122,16 @@ test(function(t) {
    'and the target effect end is positive infinity should throw an exception');
 
 test(function(t) {
+  var animation = createDiv(t).animate({}, { duration: 100 * MS_PER_SEC,
+                                             iterations: Infinity });
+  animation.currentTime = -200 * MS_PER_SEC;
+
+  try { animation.reverse(); } catch(e) { }
+
+  assert_equals(animation.playbackRate, 1, 'playbackRate remains unchanged');
+}, 'When reversing throws an exception, the playback rate remains unchanged');
+
+test(function(t) {
   var div = createDiv(t);
   var animation = div.animate({}, {duration: 100 * MS_PER_SEC,
                                    iterations: Infinity});


### PR DESCRIPTION

The spec has been updated to clarify that this is the expected behavior:

  https://github.com/w3c/web-animations/commit/c80c9984cac1091c428c7d3203479698e0d745c1

MozReview-Commit-ID: 6TsNg7HWdRX

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343589 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5804)
<!-- Reviewable:end -->
