### PR TITLE
Add a test for reversing with an infinite target effect end and playback rate of zero

### DIFF
--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -135,6 +135,22 @@ test(function(t) {
   var div = createDiv(t);
   var animation = div.animate({}, {duration: 100 * MS_PER_SEC,
                                    iterations: Infinity});
+  animation.currentTime = -200 * MS_PER_SEC;
+  animation.playbackRate = 0;
+
+  try {
+    animation.reverse();
+  } catch (e) {
+    assert_unreached(`Unexpected exception when calling reverse(): ${e}`);
+  }
+}, 'Reversing animation when playbackRate = 0 and currentTime < 0 ' +
+   'and the target effect end is positive infinity should NOT throw an ' +
+   'exception');
+
+test(function(t) {
+  var div = createDiv(t);
+  var animation = div.animate({}, {duration: 100 * MS_PER_SEC,
+                                   iterations: Infinity});
   animation.playbackRate = -1;
   animation.currentTime = -200 * MS_PER_SEC;
   animation.reverse();


### PR DESCRIPTION

We already pass this test but it seemed like a useful test to add since I was
unsure if the early return we have in Animation::Reverse() is valid or not.

MozReview-Commit-ID: J38Euno3VP6

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343589 [ci skip]