### PR TITLE
Add tests that the playback rate is updated silently

### DIFF
--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -58,6 +58,34 @@ test(function(t) {
 
 test(function(t) {
   var div = createDiv(t);
+  var animation = div.animate({}, { duration: 200 * MS_PER_SEC,
+                                    delay: -100 * MS_PER_SEC });
+  assert_equals(animation.playState, 'pending',
+    'The playState is pending before we call reverse');
+
+  animation.reverse();
+
+  assert_equals(animation.playState, 'pending',
+    'The playState is still pending after calling reverse');
+}, 'Reversing an animation does not cause it to leave the pending state');
+
+promise_test(function(t) {
+  var div = createDiv(t);
+  var animation = div.animate({}, { duration: 200 * MS_PER_SEC,
+                                    delay: -100 * MS_PER_SEC });
+  var readyResolved = false;
+  animation.ready.then(() => { readyResolved = true; });
+
+  animation.reverse();
+
+  return Promise.resolve(() => {
+    assert_false(readyResolved,
+                 'ready promise should not have been resolved yet');
+  });
+}, 'Reversing an animation does not cause it to resolve the ready promise');
+
+test(function(t) {
+  var div = createDiv(t);
   var animation = div.animate({}, 100 * MS_PER_SEC);
   animation.currentTime = 200 * MS_PER_SEC;
   animation.reverse();


### PR DESCRIPTION

The spec[1] says:

  Silently set the animation playback rate of animation to -animation playback
  rate.

  This must be done silently or else we may end up resolving the current
  ready promise when we do the compensatory seek despite the fact that we are
  most likely not exiting the pending play state.

This patch add tests that we don't exit the pending play state when calling
reverse() or resolve the ready promise.

[1] https://w3c.github.io/web-animations/#reverse-an-animation

MozReview-Commit-ID: 1X42O5yKpk9

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343589 [ci skip]