### PR TITLE
Fix skip-waiting and other WPT tests broken by request-end-to-end.https.html.

### DIFF
--- a/service-workers/service-worker/request-end-to-end.https.html
+++ b/service-workers/service-worker/request-end-to-end.https.html
@@ -7,7 +7,7 @@
 var t = async_test('Request: end-to-end');
 t.step(function() {
     var url = 'resources/request-end-to-end-worker.js';
-    var scope = 'resources/blank.html';
+    var scope = 'resources/blank.html?request-end-to-end';
 
     service_worker_unregister_and_register(t, url, scope)
       .then(onRegister)

--- a/service-workers/service-worker/skip-waiting-installed.https.html
+++ b/service-workers/service-worker/skip-waiting-installed.https.html
@@ -7,7 +7,7 @@
 <script>
 
 promise_test(function(t) {
-    var scope = 'resources/blank.html';
+    var scope = 'resources/blank.html?skip-waiting-installed';
     var url1 = 'resources/empty.js';
     var url2 = 'resources/skip-waiting-installed-worker.js';
     var frame, frame_sw, service_worker, registration, onmessage, oncontrollerchanged;

--- a/service-workers/service-worker/skip-waiting-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-using-registration.https.html
@@ -7,7 +7,7 @@
 <script>
 
 promise_test(function(t) {
-    var scope = 'resources/blank.html';
+    var scope = 'resources/blank.html?skip-waiting-using-registration';
     var url1 = 'resources/empty.js';
     var url2 = 'resources/skip-waiting-worker.js';
     var frame, frame_sw, sw_registration, oncontrollerchanged;

--- a/service-workers/service-worker/skip-waiting-without-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-without-using-registration.https.html
@@ -7,7 +7,7 @@
 <script>
 
 promise_test(function(t) {
-    var scope = 'resources/blank.html';
+    var scope = 'resources/blank.html?skip-waiting-without-using-registration';
     var url = 'resources/skip-waiting-worker.js';
     var frame, frame_sw, sw_registration;
 

--- a/service-workers/service-worker/skip-waiting.https.html
+++ b/service-workers/service-worker/skip-waiting.https.html
@@ -7,7 +7,7 @@
 <script>
 
 promise_test(function(t) {
-    var scope = 'resources/blank.html';
+    var scope = 'resources/blank.html?skip-waiting';
     var url1 = 'resources/empty.js';
     var url2 = 'resources/empty-worker.js';
     var url3 = 'resources/skip-waiting-worker.js';


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1351959 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
