### PR TITLE
Remove SVGZoomEvent; r=longsonr,smaug

### DIFF
--- a/svg/interfaces.html
+++ b/svg/interfaces.html
@@ -984,14 +984,6 @@ interface SVGScriptElement : SVGElement {
 
 SVGScriptElement implements SVGURIReference;
 
-interface SVGZoomEvent : UIEvent {
-  [SameObject] readonly attribute DOMRectReadOnly zoomRectScreen;
-  readonly attribute float previousScale;
-  [SameObject] readonly attribute DOMPointReadOnly previousTranslate;
-  readonly attribute float newScale;
-  [SameObject] readonly attribute DOMPointReadOnly newTranslate;
-};
-
 interface SVGAElement : SVGGraphicsElement {
   [SameObject] readonly attribute SVGAnimatedString target;
 };


### PR DESCRIPTION

Some code in SVGSVGElement.cpp might be unnecessary now, but Robert said
to leave it for a followup.

MozReview-Commit-ID: 8PpRGeGrREJ

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1314388 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
