### PR TITLE
Add a test for URLSearchParams handling of non-ASCII keys in the record<> ctor,

### DIFF
--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -159,7 +159,8 @@ test(function() {
 [
   { "input": {"+": "%C2"}, "output": [["+", "%C2"]], "name": "object with +" },
   { "input": {c: "x", a: "?"}, "output": [["c", "x"], ["a", "?"]], "name": "object with two keys" },
-  { "input": [["c", "x"], ["a", "?"]], "output": [["c", "x"], ["a", "?"]], "name": "array with two keys" }
+  { "input": [["c", "x"], ["a", "?"]], "output": [["c", "x"], ["a", "?"]], "name": "array with two keys" },
+  { "input": {"a\0b": "42", "c\uD83D": "23", "d\u1234": "foo"}, "output": [["a\0b", "42"], ["c\uFFFD", "23"], ["d\u1234", "foo"]], "name": "object with NULL, non-ASCII, and surrogate keys" }
 ].forEach((val) => {
     test(() => {
         let params = new URLSearchParams(val.input),


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1353197 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
