### PR TITLE
Update Selection.webidl to match spec

### DIFF
--- a/selection/interfaces.html
+++ b/selection/interfaces.html
@@ -6,7 +6,7 @@
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
 <script type=text/plain>
-// https://www.w3.org/TR/2016/WD-selection-api-20161206/
+// http://w3c.github.io/selection-api/#selection-interface
 interface Selection {
     readonly attribute Node?         anchorNode;
     readonly attribute unsigned long anchorOffset;


### PR DESCRIPTION

Practical changes:

1) Some additional method arguments are nullable or optional, which
matches Chrome/WebKit.  They make more sense non-nullable and
non-optional, but Chrome is afraid of the compat impact of changing.

2) Added [CEReactions] to deleteFromDocument().

MozReview-Commit-ID: Kg9EDubnEui

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1359371 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
