### PR TITLE
enable border-spacing interpolation test.

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -259,8 +259,7 @@ var gCSSProperties = {
   },
   'border-spacing': {
     // https://drafts.csswg.org/css-tables/#propdef-border-spacing
-    types: [
-    ]
+    types: [ 'lengthPair' ]
   },
   'border-top-color': {
     // https://drafts.csswg.org/css-backgrounds-3/#border-top-color

--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -124,6 +124,49 @@ const lengthType = {
 
 };
 
+const lengthPairType = {
+  testInterpolation: function(property, setup) {
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      var animation = target.animate({ [idlName]: ['10px 10px', '50px 50px'] },
+                                     { duration: 1000, fill: 'both' });
+      testAnimationSamples(animation, idlName,
+                           [{ time: 500,  expected: '30px 30px' }]);
+    }, property + ' supports animating as a length pair');
+
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      var animation = target.animate({ [idlName]: ['1rem 1rem', '5rem 5rem'] },
+                                     { duration: 1000, fill: 'both' });
+      testAnimationSamples(animation, idlName,
+                           [{ time: 500,  expected: '30px 30px' }]);
+    }, property + ' supports animating as a length pair of rem');
+  },
+
+  testAddition: function(property, setup) {
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      target.style[idlName] = '10px 10px';
+      var animation = target.animate({ [idlName]: ['10px 10px', '50px 50px'] },
+                                     { duration: 1000, composite: 'add' });
+      testAnimationSamples(animation, idlName, [{ time: 0, expected: '20px 20px' }]);
+    }, property + ': length pair');
+
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      target.style[idlName] = '1rem 1rem';
+      var animation = target.animate({ [idlName]: ['1rem 1rem', '5rem 5rem'] },
+                                     { duration: 1000, composite: 'add' });
+      testAnimationSamples(animation, idlName, [{ time: 0, expected: '20px 20px' }]);
+    }, property + ': length pair of rem');
+  },
+
+};
+
 const percentageType = {
   testInterpolation: function(property, setup) {
     test(function(t) {
@@ -1217,6 +1260,7 @@ const types = {
   length: lengthType,
   percentage: percentageType,
   lengthPercentageOrCalc: lengthPercentageOrCalcType,
+  lengthPair: lengthPairType,
   positiveNumber: positiveNumberType,
   transformList: transformListType,
   visibility: visibilityType,


### PR DESCRIPTION

So far, we don't have a type to test anamations of a pair of length.
Since border-spacing consists two absolute lengths, we shall add this
new type.

MozReview-Commit-ID: Bo8VMWPLDHc

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1354437 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
