### PR TITLE
only check the mid-point while testing interpolation results in animations' web-platform-tests. r=hiro DONTBUILD (test-only)

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -85,9 +85,7 @@ const lengthType = {
       var animation = target.animate({ [idlName]: ['10px', '50px'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px' },
-                            { time: 500,  expected: '30px' },
-                            { time: 1000, expected: '50px' }]);
+                           [{ time: 500,  expected: '30px' }]);
     }, property + ' supports animating as a length');
 
     test(function(t) {
@@ -96,9 +94,7 @@ const lengthType = {
       var animation = target.animate({ [idlName]: ['1rem', '5rem'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px' },
-                            { time: 500,  expected: '30px' },
-                            { time: 1000, expected: '50px' }]);
+                           [{ time: 500,  expected: '30px' }]);
     }, property + ' supports animating as a length of rem');
   },
 
@@ -175,9 +171,7 @@ const percentageType = {
       var animation = target.animate({ [idlName]: ['10%', '50%'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10%' },
-                            { time: 500,  expected: '30%' },
-                            { time: 1000, expected: '50%' }]);
+                           [{ time: 500,  expected: '30%' }]);
     }, property + ' supports animating as a percentage');
   },
 
@@ -202,9 +196,7 @@ const integerType = {
       var animation = target.animate({ [idlName]: [-2, 2] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '-2' },
-                            { time: 500,  expected: '0' },
-                            { time: 1000, expected: '2' }]);
+                           [{ time: 500,  expected: '0' }]);
     }, property + ' supports animating as an integer');
   },
 
@@ -233,9 +225,7 @@ const lengthPercentageOrCalcType = {
       var animation = target.animate({ [idlName]: ['10px', '20%'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px' },
-                            { time: 500,  expected: 'calc(5px + 10%)' },
-                            { time: 1000, expected: '20%' }]);
+                           [{ time: 500,  expected: 'calc(5px + 10%)' }]);
     }, property + ' supports animating as combination units "px" and "%"');
 
     test(function(t) {
@@ -244,9 +234,7 @@ const lengthPercentageOrCalcType = {
       var animation = target.animate({ [idlName]: ['10%', '2em'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10%' },
-                            { time: 500,  expected: 'calc(10px + 5%)' },
-                            { time: 1000, expected: '20px' }]);
+                           [{ time: 500,  expected: 'calc(10px + 5%)' }]);
     }, property + ' supports animating as combination units "%" and "em"');
 
     test(function(t) {
@@ -255,9 +243,7 @@ const lengthPercentageOrCalcType = {
       var animation = target.animate({ [idlName]: ['1em', '2rem'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px' },
-                            { time: 500,  expected: '15px' },
-                            { time: 1000, expected: '20px' }]);
+                           [{ time: 500,  expected: '15px' }]);
     }, property + ' supports animating as combination units "em" and "rem"');
 
     test(function(t) {
@@ -266,9 +252,7 @@ const lengthPercentageOrCalcType = {
       var animation = target.animate({ [idlName]: ['10px', 'calc(1em + 20%)'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px' },
-                            { time: 500,  expected: 'calc(10px + 10%)' },
-                            { time: 1000, expected: 'calc(10px + 20%)' }]);
+                           [{ time: 500,  expected: 'calc(10px + 10%)' }]);
     }, property + ' supports animating as combination units "px" and "calc"');
 
     test(function(t) {
@@ -278,12 +262,8 @@ const lengthPercentageOrCalcType = {
         { [idlName]: ['calc(10px + 10%)', 'calc(1em + 1rem + 20%)'] },
         { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,
-                              expected: 'calc(10px + 10%)' },
-                            { time: 500,
-                              expected: 'calc(15px + 15%)' },
-                            { time: 1000,
-                              expected: 'calc(20px + 20%)' }]);
+                           [{ time: 500,
+                              expected: 'calc(15px + 15%)' }]);
     }, property + ' supports animating as a calc');
   },
 
@@ -382,9 +362,7 @@ const positiveNumberType = {
       var animation = target.animate({ [idlName]: [1.1, 1.5] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '1.1' },
-                            { time: 500,  expected: '1.3' },
-                            { time: 1000, expected: '1.5' }]);
+                           [{ time: 500,  expected: '1.3' }]);
     }, property + ' supports animating as a positive number');
   },
 
@@ -1160,9 +1138,7 @@ const positionType = {
       var animation = target.animate({ [idlName]: ['10px 10px', '50px 50px'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px 10px' },
-                            { time: 500,  expected: '30px 30px' },
-                            { time: 1000, expected: '50px 50px' }]);
+                           [{ time: 500,  expected: '30px 30px' }]);
     }, property + ' supports animating as a position');
 
     test(function(t) {
@@ -1171,9 +1147,7 @@ const positionType = {
       var animation = target.animate({ [idlName]: ['1rem 1rem', '5rem 5rem'] },
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(animation, idlName,
-                           [{ time: 0,    expected: '10px 10px' },
-                            { time: 500,  expected: '30px 30px' },
-                            { time: 1000, expected: '50px 50px' }]);
+                           [{ time: 500,  expected: '30px 30px' }]);
     }, property + ' supports animating as a position of rem');
 
     test(function(t) {
@@ -1183,9 +1157,7 @@ const positionType = {
                                      { duration: 1000, fill: 'both' });
       testAnimationSamples(
         animation, idlName,
-        [{ time: 0,    expected: calcFromPercentage(idlName, '10% 10%') },
-         { time: 500,  expected: calcFromPercentage(idlName, '30% 30%') },
-         { time: 1000, expected: calcFromPercentage(idlName, '50% 50%') }]);
+        [{ time: 500,  expected: calcFromPercentage(idlName, '30% 30%') }]);
     }, property + ' supports animating as a position of percent');
   },
 


### PR DESCRIPTION

In case of interpolation, we shall just check at 500ms.
No need to check 0ms and 1000ms.

MozReview-Commit-ID: FldqRXj0HLo

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1359786 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
