### PR TITLE
reuse existing lengthPairType for positionType in web animations' web-platform-tests. r=hiro DONTBUILD (test-only)

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -1132,23 +1132,7 @@ const boxShadowListType = {
 
 const positionType = {
   testInterpolation: function(property, setup) {
-    test(function(t) {
-      var idlName = propertyToIDL(property);
-      var target = createTestElement(t, setup);
-      var animation = target.animate({ [idlName]: ['10px 10px', '50px 50px'] },
-                                     { duration: 1000, fill: 'both' });
-      testAnimationSamples(animation, idlName,
-                           [{ time: 500,  expected: '30px 30px' }]);
-    }, property + ' supports animating as a position');
-
-    test(function(t) {
-      var idlName = propertyToIDL(property);
-      var target = createTestElement(t, setup);
-      var animation = target.animate({ [idlName]: ['1rem 1rem', '5rem 5rem'] },
-                                     { duration: 1000, fill: 'both' });
-      testAnimationSamples(animation, idlName,
-                           [{ time: 500,  expected: '30px 30px' }]);
-    }, property + ' supports animating as a position of rem');
+    lengthPairType.testInterpolation(property, setup);
 
     test(function(t) {
       var idlName = propertyToIDL(property);
@@ -1162,23 +1146,7 @@ const positionType = {
   },
 
   testAddition: function(property, setup) {
-    test(function(t) {
-      var idlName = propertyToIDL(property);
-      var target = createTestElement(t, setup);
-      target.style[idlName] = '10px 10px';
-      var animation = target.animate({ [idlName]: ['10px 10px', '50px 50px'] },
-                                     { duration: 1000, composite: 'add' });
-      testAnimationSamples(animation, idlName, [{ time: 0, expected: '20px 20px' }]);
-    }, property + ': position');
-
-    test(function(t) {
-      var idlName = propertyToIDL(property);
-      var target = createTestElement(t, setup);
-      target.style[idlName] = '1rem 1rem';
-      var animation = target.animate({ [idlName]: ['1rem 1rem', '5rem 5rem'] },
-                                     { duration: 1000, composite: 'add' });
-      testAnimationSamples(animation, idlName, [{ time: 0, expected: '20px 20px' }]);
-    }, property + ': position of rem');
+    lengthPairType.testAddition(property, setup);
 
     test(function(t) {
       var idlName = propertyToIDL(property);


### PR DESCRIPTION

Since lengthPairType and positionType share the same testing logics, we shall
just reuse lengthPairType::{testInterpolation, testAddition} for positionType.

MozReview-Commit-ID: 1nBBHmTB3U9

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1359786 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
