### PR TITLE
Start enforcing references are named as such

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -484,12 +484,19 @@ def check_parsed(repo_root, path, f):
 
         assert ref_parts.path != ""
 
-        reference_file = os.path.join(repo_root, ref_parts.path[1:])
+        reference_sourcefile = SourceFile(repo_root, ref_parts.path[1:], "/")
+        reference_file = reference_sourcefile.path
         reference_rel = reftest_node.attrib.get("rel", "")
 
         if not os.path.isfile(reference_file):
             errors.append(("NON-EXISTENT-REF",
                      "Reference test with a non-existent '%s' relationship reference: '%s'" % (reference_rel, href), path, None))
+
+        if not reference_sourcefile.name_is_reference:
+            errors.append(("REF-IS-NOT-REF-NAMED",
+                           "Reference test points at '%s' which isn't a reference filename" % href,
+                           path,
+                           None))
 
     if len(source_file.timeout_nodes) > 1:
         errors.append(("MULTIPLE-TIMEOUT", "More than one meta name='timeout'", path, None))

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -346,7 +346,7 @@ class Manifest(object):
         changed_hashes = {}
 
         for item in reftest_nodes:
-            if item.url in has_inbound:
+            if item.url in has_inbound or item.source_file.name_is_reference:
                 # This is a reference
                 if isinstance(item, RefTest):
                     item = item.to_RefTestNode()
@@ -360,6 +360,9 @@ class Manifest(object):
                                                                  item.item_type)
                 reftests[item.source_file.rel_path].add(item)
             self._reftest_nodes_by_url[item.url] = item
+
+        # while currently obvious from the if/else, this is part of the API contract, so check!
+        assert len(reftest_nodes) == len(references) + len(reftests)
 
         return reftests, references, changed_hashes
 

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -269,6 +269,17 @@ def test_reftest_computation_chain_update_node_change():
                        ("support", test3.path, {test3})]
 
 
+def test_reftest_computation_ref_name():
+    m = manifest.Manifest()
+
+    s = SourceFileWithTest("foobar-ref.html", "0"*40, item.RefTestNode, [("/other.html", "==")])
+    test = s.manifest_items()[1][0]
+
+    assert m.update([(s, True)]) is True
+
+    assert list(m) == [("reftest_node", test.path, {test})]
+
+
 def test_iterpath():
     m = manifest.Manifest()
 


### PR DESCRIPTION
See <https://lists.w3.org/Archives/Public/public-test-infra/2016OctDec/0027.html> for some background on this. Also see #5843 when it comes to what expected behaviour is around some of the lint failures on this job.