### PR TITLE
wai-aria: Updated tests

### DIFF
--- a/wai-aria/combobox_orientation_unspecified-manual.html
+++ b/wai-aria/combobox_orientation_unspecified-manual.html
@@ -59,7 +59,7 @@
                   "property",
                   "AXOrientation",
                   "is",
-                  "<nil>"
+                  "AXUnknownOrientation"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/feed-manual.html
+++ b/wai-aria/feed-manual.html
@@ -41,13 +41,13 @@
                   "property",
                   "AXSubrole",
                   "is",
-                  "<nil>"
+                  "AXApplicationGroup"
                ],
                [
                   "property",
                   "AXRoleDescription",
                   "is",
-                  "group"
+                  "feed"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/radiogroup_orientation_unspecified-manual.html
+++ b/wai-aria/radiogroup_orientation_unspecified-manual.html
@@ -59,7 +59,7 @@
                   "property",
                   "AXOrientation",
                   "is",
-                  "<nil>"
+                  "AXUnknownOrientation"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/region_without_name-manual.html
+++ b/wai-aria/region_without_name-manual.html
@@ -131,7 +131,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for region without name.</p>
-    <div role="region" id="test">
+    <div role="region" id="test" tabindex="-1">
     <article>This is article 1</article>
   </div>
 


### PR DESCRIPTION
* Correct expected results for AX API for the feed role
* Correct expected results for AX API null orientation value
* Set a tabindex to ensure div element being tested does not get pruned
  from the accessibility tree

<!-- Reviewable:start -->

<!-- Reviewable:end -->
