### PR TITLE
offsetParent_element_test.html should not expect SVG element to have …

### DIFF
--- a/cssom-view/offsetParent_element_test.html
+++ b/cssom-view/offsetParent_element_test.html
@@ -109,7 +109,7 @@ test(function() {
     assert_equals(none_element_child_video.offsetParent,null);
     assert_equals(none_element_child_audio.offsetParent,null);
     assert_equals(none_element_child_canvas.offsetParent,null);
-    assert_equals(none_element_child_svg.offsetParent,null);
+    assert_equals(none_element_child_svg.offsetParent,undefined);
 }, "Valid the algorithm rule of offsetParent check step 1",
 { assert: "The offsetParent attribute algorithm rule checking passed!" }
 );


### PR DESCRIPTION
…offsetParent property

offsetParent_element_test.html should not expect SVG element to have offsetParent property.

offsetParent is only implemented by HTMLElement, not SVGElement:
- https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
- https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement

<!-- Reviewable:start -->

<!-- Reviewable:end -->
