### PR TITLE
webrtc: add SRD test with two m-lines

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -45,7 +45,7 @@
     .catch(test.step_func(function(e) {
       assert_unreached('Error ' + e.name + ': ' + e.message);
     }));
-  }, 'Triggers ontrack when called with a remote description and the MSID of the stream is is parsed.');
+  }, 'Triggers ontrack when called with a remote description and the MSID of the stream is is parsed');
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
@@ -82,6 +82,57 @@
       }));
   }, 'SDP type that is invalid for current signaling state should be rejected with InvalidStateError');
 
+  async_test(function(test) {
+    const sdp = 'v=0\r\n' +
+        'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+        's=-\r\n' +
+        't=0 0\r\n' +
+        'a=msid-semantic:WMS *\r\n' +
+        'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+        'c=IN IP4 0.0.0.0\r\n' +
+        'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
+        'a=ice-ufrag:someufrag\r\n' +
+        'a=ice-pwd:somelongpwdwithenoughrandomness\r\n' +
+        'a=fingerprint:sha-256 8C:71:B3:8D:A5:38:FD:8F:A4:2E:A2:65:6C:86:52:BC:E0:6E:94:F2:9F:7C:4D:B5:DF:AF:AA:6F:44:90:8D:F4\r\n' +
+        'a=setup:actpass\r\n' +
+        'a=rtcp-mux\r\n' +
+        'a=mid:mid1\r\n' +
+        'a=sendonly\r\n' +
+        'a=rtpmap:111 opus/48000/2\r\n' +
+        'a=msid:stream1 track1\r\n' +
+        'a=ssrc:1001 cname:some\r\n' +
+        'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+        'c=IN IP4 0.0.0.0\r\n' +
+        'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
+        'a=ice-ufrag:someufrag\r\n' +
+        'a=ice-pwd:somelongpwdwithenoughrandomness\r\n' +
+        'a=fingerprint:sha-256 8C:71:B3:8D:A5:38:FD:8F:A4:2E:A2:65:6C:86:52:BC:E0:6E:94:F2:9F:7C:4D:B5:DF:AF:AA:6F:44:90:8D:F4\r\n' +
+        'a=setup:actpass\r\n' +
+        'a=rtcp-mux\r\n' +
+        'a=mid:mid2\r\n' +
+        'a=sendonly\r\n' +
+        'a=rtpmap:111 opus/48000/2\r\n' +
+        'a=msid:stream2 track2\r\n' +
+        'a=ssrc:2002 cname:some\r\n';
+
+    var pc = new RTCPeerConnection(null);
+
+    var numTracks = 0;
+    pc.ontrack = test.step_func(function(event) {
+      numTracks++;
+    });
+
+    pc.setRemoteDescription(new RTCSessionDescription({type: 'offer', sdp: sdp}))
+    .then(test.step_func(function() {
+      test.step_timeout(test.step_func(function() {
+        assert_equals(numTracks, 2, 'ontrack was called twice');
+        test.done();
+      }));
+    }))
+    .catch(test.step_func(function(e) {
+      assert_unreached('Error ' + e.name + ': ' + e.message);
+    }));
+  }, 'Triggers ontrack twice when called with a remote description than contains two audio m-lines');
 </script>
 
 </body>


### PR DESCRIPTION
adds a setRemoteDescription test with two m-lines of the same kind.

@juberti @adamroach @ekr can you please check that this SDP is what JSEP has for what has been known as "unified plan"?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
