### PR TITLE
[presentation-api] Check connection establishment in reconnecting

### DIFF
--- a/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html
+++ b/presentation-api/controlling-ua/reconnectToPresentation_success-manual.https.html
@@ -15,6 +15,14 @@
 <iframe id="childFrame" src="support/iframe.html"></iframe>
 
 <script>
+    let receiverStack;
+    add_completion_callback(() => {
+        // overwrite a stack written in the test result
+        if (receiverStack) {
+            document.querySelector('#log pre').textContent = receiverStack;
+        }
+    });
+
     // disable timeout for manual tests
     setup({explicit_timeout: true});
     const startBtn = document.getElementById('startBtn');
@@ -22,11 +30,11 @@
 
     promise_test(t => {
         const startWatcher = new EventWatcher(t, startBtn, 'click');
-        let messageWatcher = new EventWatcher(t, window, 'message');
+        const messageWatcher = new EventWatcher(t, window, 'message');
         const request = new PresentationRequest(presentationUrls);
         let connection, eventWatcher;
 
-        t.add_cleanup(function() {
+        t.add_cleanup(() => {
             if (connection) {
                 connection.onconnect = () => { connection.terminate(); }
                 if (connection.state === 'closed')
@@ -34,6 +42,73 @@
                 else
                     connection.terminate();
             }
+        });
+
+        const waitForMessage = () => {
+            return messageWatcher.wait_for('message').then(evt => {
+                return evt.data.type === 'presentation-api' ? evt : waitForMessage();
+            });
+        };
+
+        // handle a test result received from a nested browsing context
+        const parseValue = value => {
+            let r;
+
+            // String
+            if (r = value.match(/^(\(string\)\s+)?"(.*)"$/))
+                return r[2];
+            // Object
+            else if (r = value.match(/^(\(object\)\s+)?object\s+"\[object\s+(.*)\]"$/))
+                return window[r[2]].prototype;
+            // undefined
+            else if (value === "undefined")
+                return undefined;
+            // Number, boolean, null
+            else {
+                if (r = value.match(/^(\(\S+\)\s+)?(\S+)$/)) {
+                    try {
+                        return JSON.parse(r[2]);
+                    } catch(e) {
+                        return value;
+                    }
+                }
+                else
+                    return value;
+            }
+        };
+
+        const parseResult = t.step_func(evt => {
+            const result = evt.data;
+            if (result.test.status === 0)
+                return evt;
+
+            receiverStack = result.test.stack;
+            const message = result.test.message;
+            let r = message.match(/^(assert_.*):\s+(.*)$/);
+            if (r) {
+                const assertion = r[1];
+                const body = r[2];
+                let args;
+                if (assertion === 'assert_equals') {
+                    if (r = body.match(/^((.*)\s+)?expected\s+((\(\S*\)\s+)?(\S+|(\S+\s+)?\".*\"))\s+but\s+got\s+((\(\S*\)\s+)?(\S+|(\S+\s+)?\".*\"))$/))
+                        args = [parseValue(r[7]), parseValue(r[3]), r[2]];
+                }
+                else if (assertion === 'assert_true') {
+                    if (r = body.match(/^((.*)\s+)?expected\s+(true|false)\s+got\s+(\S+|(\S+\s+)?\".*\")$/)) {
+                        args = [parseValue(r[4]), r[2]];
+                    }
+                }
+                else if (assertion === 'assert_unreached') {
+                    if (r = body.match(/^((.*)\s+)?Reached\s+unreachable\s+code$/))
+                        args = [r[2]];
+                }
+                if (args) {
+                    window[assertion](args[0], args[1], args[2]);
+                    return;
+                }
+            }
+            // default
+            assert_unreached('Test result received from a receiving user agent: ' + message + ': ');
         });
 
         return Promise.all([
@@ -80,28 +155,31 @@
             // Connection now closed, let's reconnect to it
             return request.reconnect(presentationId);
         }).then(c => {
+            // Check the presentation connection in "connecting" state
             assert_equals(c, connection, 'The promise is resolved with the existing presentation connection.');
             connection = c;
             assert_equals(connection.state, "connecting", "The connection state is set to 'connecting'.");
             assert_equals(connection.id, presentationId, "Ids of old and new connections must be equal.");
-            // Avoid an error caused by the EventWatcher (not expected event "connect")
+
             return eventWatcher.wait_for('connect');
-        }).then(() => {
+        }).then(evt => {
+            // Check the established presentation connection and its associated "connect" event
+            assert_true(evt.isTrusted && !evt.bubbles && !evt.cancelable && evt instanceof Event, 'A simple event is fired.');
+            assert_equals(evt.type, 'connect', 'The event name is "connect".');
+            assert_equals(evt.target, connection, 'event.target is the presentation connection.');
+            assert_equals(connection.state, 'connected', 'The presentation connection state is set to "connected".');
+
             // Request an iframe to reconnect the presentation with the current presentation ID
             childFrame.contentWindow.postMessage('reconnect?id=' + presentationId, '*');
-            return messageWatcher.wait_for('message');
-        }).then(evt => {
-            if (!(evt.data instanceof Object))
-                assert_unreached('An error occured when a nested browsing context tried to reconnect the existing presentation.');
-            assert_equals(evt.data.state, "connecting", "The connection state is set to 'connecting'.");
-            assert_equals(evt.data.id, presentationId, "Presentation connections in both top and nested browsing contexts share the same presentation ID.");
+            return waitForMessage().then(parseResult);
+        }).then(() => {
             // Wait until state of each presentation connection is set to "terminated"
             connection.terminate();
-            return Promise.all([ eventWatcher.wait_for('terminate'), messageWatcher.wait_for('message') ]);
+            return Promise.all([ eventWatcher.wait_for('terminate'), waitForMessage().then(parseResult) ]);
         }).then(() => {
             // Try to reconnect to the presentation, while all presentation connection have already been terminated
             return promise_rejects(t, 'NotFoundError', request.reconnect(presentationId),
                 'Reconnecting to a terminated presentation rejects a promise with a "NotFoundError" exception.');
-        })
+        });
     });
 </script>

--- a/presentation-api/controlling-ua/support/iframe.html
+++ b/presentation-api/controlling-ua/support/iframe.html
@@ -3,8 +3,21 @@
 <title>Presentation API - controlling ua - sandboxing</title>
 <link rel="author" title="Francois Daoust" href="https://www.w3.org/People/#fd">
 <link rel="help" href="http://w3c.github.io/presentation-api/#dom-presentationrequest-start">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 <script src="../common.js"></script>
 <script>
+    add_completion_callback((tests, status) => {
+      // remove unserializable attributes, then send the result to the parent window
+      // note: a single test result is supposed to appear here.
+      parent.window.postMessage(JSON.parse(JSON.stringify({
+        type: 'presentation-api', test: tests[0], status: status
+      })), '*');
+    });
+
+    // disable timeout for manual tests
+    setup({explicit_timeout: true});
+
     window.onmessage = function (ev) {
       try {
         // Presentation URLs are relative to the "controlling-ua" folder,
@@ -58,19 +71,70 @@
             });
         }
         else if (ev.data.match(/^reconnect\?id=(.*)$/)) {
-          var presentationId = RegExp.$1;
-          request = new PresentationRequest(urls);
-          request.reconnect(presentationId)
-            .then(function (c) {
-              var result = { state: c.state, id: c.id };
-              parent.window.postMessage(result, '*');
-              c.onterminate = function() {
-                parent.window.postMessage('terminated', '*');
-              };
-            })
-            .catch(function (err) {
-              parent.window.postMessage(err.name, '*');
+          promise_test(function (t) {
+            var presentationId = RegExp.$1;
+            var phase = -1, actual = -1, connection, waitConnection;
+            var description = [
+              "Phase #1: Promise is resolved",
+              "Phase #2: 'connectionavailable' event fired",
+              "Phase #3: 'connect' event fired"
+            ].map(d => { return '(Reconnecting in a nested browsing context) ' + d; });
+
+            var count = function(evt) { actual++; return evt; };
+            var checkPhase = function(evt) {
+              phase++;
+              assert_equals(description[actual], description[phase], 'Event order is incorrect.');
+              return evt;
+            };
+
+            request = new PresentationRequest(urls);
+
+            var eventWatcher = new EventWatcher(t, request, 'connectionavailable');
+            var waitConnectionavailable = eventWatcher.wait_for('connectionavailable').then(count).then(function (evt) {
+              connection = connection || evt.connection; return evt;
             });
+
+            return request.reconnect(presentationId).then(count).then(checkPhase).then(function (c) {
+              // Reconnecting Phase #1: Promise is resolved
+              connection = c;
+              assert_equals(connection.state, 'connecting', 'Check the initial state of the presentation connection.');
+              assert_equals(connection.id, presentationId, "The same presentation ID is set to the newly created presentation connection.");
+              assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+
+              var eventWatcher = new EventWatcher(t, connection, 'connect');
+              waitConnect = eventWatcher.wait_for('connect').then(count);
+
+              // Reconnecting Phase #2: "connectionavailable" event is fired
+              return waitConnectionavailable;
+            }).then(checkPhase).then(function (evt) {
+              assert_true(evt instanceof PresentationConnectionAvailableEvent, 'An event using PresentationConnectionAvailableEvent is fired.');
+              assert_true(evt.isTrusted, 'The event is a trusted event.');
+              assert_false(evt.bubbles, 'The event does not bubbles.');
+              assert_false(evt.cancelable, 'The event is not cancelable.');
+              assert_equals(evt.type, 'connectionavailable', 'The event name is "connectionavailable".');
+              assert_equals(evt.target, request, 'event.target is the presentation request.');
+              assert_true(evt.connection instanceof PresentationConnection, 'event.connection is a presentation connection.');
+              assert_equals(evt.connection, connection, 'event.connection is set to the presentation which the promise is resolved with.');
+
+              // Reconnecting Phase #3: "connect" event is fired
+              return waitConnect;
+            }).then(checkPhase).then(function (evt) {
+              assert_true(evt.isTrusted && !evt.bubbles && !evt.cancelable && evt instanceof Event, 'A simple event is fired.');
+              assert_equals(evt.type, 'connect', 'The event name is "connect".');
+              assert_equals(evt.target, connection, 'event.target is the presentation connection.');
+              assert_equals(connection.state, 'connected', 'The presentation connection state is set to "connected".');
+              parent.window.postMessage({ type: 'presentation-api', test: { status: 0 } }, '*');
+              var terminateWatcher = new EventWatcher(t, connection, 'terminate');
+
+              // "terminate" event is fired
+              return terminateWatcher.wait_for('terminate');
+            }).then(function (evt) {
+              assert_true(evt.isTrusted && !evt.bubbles && !evt.cancelable && evt instanceof Event, 'A simple event is fired.');
+              assert_equals(evt.type, 'terminate', 'The event name is "terminate".');
+              assert_equals(evt.target, connection, 'event.target is the presentation connection.');
+              assert_equals(connection.state, 'terminated', 'The presentation connection state is set to "terminated".');
+            });
+          });
         }
         else if (ev.data === 'getAvailability') {
           request = new PresentationRequest(urls);


### PR DESCRIPTION
This PR updates controlling-ua/reconnectToPresentation_success-manual.https.html so that the test checks connection establishment at the following steps:

- transitioning from "connecting" to "connected" when reconnecting a presentation connection in "closed" state in a top-level browsing context
- creating a new presentation connection when reconnecting in a nested browsing context

Also, order of the steps in connection establishment in a nested browsing context is checked in the same manner as controlling-ua/startNewPresentation_success-manual.https.html.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
