### PR TITLE
add sauce labs jobs and credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install -U requests
 env:  # required at the top-level for allow_failures to work below
   global:
-    - SAUCE_USERNAME=w3c_ttwf
+    - SAUCE_USERNAME=w3c-ttwf
 matrix:
   fast_finish: true
   include:
@@ -56,6 +56,16 @@ matrix:
       env:
         - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
         - SCRIPT=ci_stability.sh PRODUCT=chrome:unstable
+    - os: linux
+      python: "2.7"
+      env:
+        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
+        - SCRIPT=ci_stability.sh PRODUCT=sauce:safari:10.0 PLATFORM='macOS 10.12'
+    - os: linux
+      python: "2.7"
+      env:
+        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
+        - SCRIPT=ci_stability.sh PRODUCT=sauce:MicrosoftEdge:14.14393 PLATFORM='Windows 10'
     - python: 2.7
       env: TOXENV=py27 HYPOTHESIS_PROFILE=ci SCRIPT=ci_unittest.sh
     - python: 3.5


### PR DESCRIPTION
@plehegar: This is a PR that contains the changes required to start running Safari and Edge tests via Sauce Labs. There are two the additional things that you need to do with the credentials to make it work:

Dependencies:
- Ruby > 1.9.3
- TravisCI [Command Line Client](https://github.com/travis-ci/travis.rb#installation)

1. Line 24: Change `w3c_sauce_username` to the username you have for the W3C Sauce Labs account
2. In the same directory as .travis.yml, run: `travis encrypt --add addons.jwt SAUCE_ACCESS_KEY=the_sauce_key_from_your_sauce_account_page`
  - this should add a `addons.jwt.secure` section to the `.travis.yml` similar to https://github.com/bobholt/web-platform-tests/blob/340548f6c9a17039214a5cccd786c6b67358d76c/.travis.yml#L15-L16

The final commit should look a lot like [this](https://github.com/bobholt/web-platform-tests/pull/17/commits/340548f6c9a17039214a5cccd786c6b67358d76c) (without the webhook URL change or the change to the test in the other file).

Once that information is there, we should see test results (probably No Tests Run) from Safari and Edge. When you're done, I can add a dummy test commit to verify everything before merging.

Please let me know if you have any questions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5866)
<!-- Reviewable:end -->
