### PR TITLE
[service-workers] Specify type of expected error

### DIFF
--- a/service-workers/service-worker/fetch-request-fallback.https.html
+++ b/service-workers/service-worker/fetch-request-fallback.https.html
@@ -95,7 +95,7 @@ promise_frame_test(function(t, frame, worker) {
 promise_frame_test(function(t, frame, worker) {
     return promise_rejects(
         t,
-        null,
+        new Error(),
         frame.contentWindow.xhr(OTHER_BASE_URL),
         'SW fallbacked CORS-unsupported other origin XHR should fail.')
       .then(function() {
@@ -130,7 +130,7 @@ promise_frame_test(function(t, frame, worker) {
 promise_frame_test(function(t, frame, worker) {
     return promise_rejects(
         t,
-        null,
+        new Error(),
         frame.contentWindow.xhr(
           REDIRECT_URL + encodeURIComponent(OTHER_BASE_URL)),
         'SW fallbacked XHR which is redirected to CORS-unsupported ' +
@@ -183,7 +183,7 @@ promise_frame_test(function(t, frame, worker) {
 promise_frame_test(function(t, frame, worker) {
   return promise_rejects(
         t,
-        null,
+        new Error(),
         frame.contentWindow.load_image(OTHER_BASE_PNG_URL, 'anonymous'),
         'SW fallbacked CORS-unsupported other origin image request ' +
           'should fail.')
@@ -246,7 +246,7 @@ promise_frame_test(function(t, frame, worker) {
 promise_frame_test(function(t, frame, worker) {
   return promise_rejects(
         t,
-        null,
+        new Error(),
         frame.contentWindow.load_image(
             REDIRECT_URL + encodeURIComponent(OTHER_BASE_PNG_URL),
             'anonymous'),

--- a/service-workers/service-worker/resources/fetch-request-fallback-iframe.html
+++ b/service-workers/service-worker/resources/fetch-request-fallback-iframe.html
@@ -4,7 +4,7 @@ function xhr(url) {
       var request = new XMLHttpRequest();
       request.addEventListener(
         'error',
-        function(event) { reject(event); });
+        function() { reject(new Error()); });
       request.addEventListener(
         'load',
         function(event) { resolve(request.response); });
@@ -21,7 +21,7 @@ function load_image(url, cross_origin) {
         resolve();
       };
       img.onerror = function() {
-        reject();
+        reject(new Error());
       };
       if (cross_origin != '') {
         img.crossOrigin = cross_origin;


### PR DESCRIPTION
Recent improvements to the testing infrastructure have made it necessary
to explicitly specify the type of error produced when calling
`assert_throws`. Because the `promise_rejects` utility function uses
`assert_throws` internally, the improvement invalidated an existing
test.

Update the test's helper functions to reject Promises with instances of
the Error class, and update corresponding assertions to specify that
class.

---

@mkruisselbrink I'm not thrilled about this solution--the test now essentially
reads, "This helper function should throw the error we produced in the helper
function." In other words, it tends to direct attention towards the test code
rather than the browser behavior.

That said, the conditions we're testing do not themselves produce error
instances, so if we want to use `promise_rejects`, I don't think we can avoid
the synthetic assertion.

If you prefer, I could look in to phrasing this test by consistently resolving
the promise with additional data about the DOM event that caused the
resolution.

Let me know!

p.s. Thanks to @annevk for the additional enforcement, and shame on me for
relying on the old imprecise behavior.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
