### PR TITLE
Assert that an unnecessary exitFullscreen()'s promise is resolved

### DIFF
--- a/fullscreen/api/document-exit-fullscreen-twice-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-twice-manual.html
@@ -12,18 +12,26 @@ async_test(t => {
     // We are now in fullscreen.
     assert_equals(document.fullscreenElement, div);
 
-    document.onfullscreenchange = t.step_func(() => {
-      assert_equals(document.fullscreenElement, null);
-      // Done, but ensure that there's only one fullscreenchange event.
-      document.onfullscreenchange = t.unreached_func("second fullscreenchange event");
-      setTimeout(t.step_func_done(), 0);
-    });
-
     // Exit fullscreen twice.
     document.exitFullscreen();
     assert_equals(document.fullscreenElement, div, "fullscreenElement after first exitFullscreen()");
-    document.exitFullscreen();
+    const secondPromise = document.exitFullscreen();
     assert_equals(document.fullscreenElement, div, "fullscreenElement after second exitFullscreen()");
+
+    document.onfullscreenchange = t.step_func(() => {
+      assert_equals(document.fullscreenElement, null);
+      // Ensure that there's only one fullscreenchange event.
+      document.onfullscreenchange = t.unreached_func("second fullscreenchange event");
+      t.step_timeout(() => {
+        // Done, but if a promise was returned, assert that it is resolved and
+        // not rejected. This test does not fail if promises aren't implemented.
+        if (secondPromise) {
+          secondPromise.then(t.step_func_done(), t.unreached_func("second promise rejected"));
+        } else {
+          t.done();
+        }
+      }, 0);
+    });
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");
 


### PR DESCRIPTION
This is a test for https://github.com/whatwg/fullscreen/pull/81

<!-- Reviewable:start -->

<!-- Reviewable:end -->
