### PR TITLE
[geometry] DOMMatrix a-f getters don't invoke m11-m42 getters

### DIFF
--- a/css/geometry-1/DOMMatrix-a-f-alias.html
+++ b/css/geometry-1/DOMMatrix-a-f-alias.html
@@ -10,6 +10,12 @@ function defineThrowingGetter(object, attribute) {
    });
 }
 
+function defineThrowingSetter(object, attribute) {
+   Object.defineProperty(object, attribute, {
+     set: () => assert_unreached(`setter for ${attribute}`)
+   });
+}
+
 ["DOMMatrix", "DOMMatrixReadOnly"].forEach((constr) => {
   [
     ["a", "m11"],
@@ -30,6 +36,22 @@ function defineThrowingGetter(object, attribute) {
        defineThrowingGetter(matrix, aliasAttribute);
        assert_equals(matrix[mAttribute], 0);
      }, `${constr} getting ${mAttribute} with throwing getter for ${aliasAttribute}`);
+
+     if (constr === "DOMMatrix") {
+       test(() => {
+         const matrix = new self[constr]([0, 0, 0, 0, 0, 0]);
+         defineThrowingSetter(matrix, mAttribute);
+         matrix[aliasAttribute] = 1;
+         assert_equals(matrix[aliasAttribute], 1);
+       }, `${constr} setting ${aliasAttribute} with throwing setter for ${mAttribute}`);
+
+       test(() => {
+         const matrix = new self[constr]([0, 0, 0, 0, 0, 0]);
+         defineThrowingSetter(matrix, aliasAttribute);
+         matrix[mAttribute] = 1;
+         assert_equals(matrix[mAttribute], 1);
+       }, `${constr} setting ${mAttribute} with throwing setter for ${aliasAttribute}`);
+     }
    });
 });
 </script>

--- a/css/geometry-1/DOMMatrix-a-f-alias.html
+++ b/css/geometry-1/DOMMatrix-a-f-alias.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Geometry Interfaces: DOMMatrix and DOMMatrixReadOnly a-f alias attributes</title>
+<link rel="help" href="https://drafts.fxtf.org/geometry/#DOMMatrix">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+function defineThrowingGetter(object, attribute) {
+   Object.defineProperty(object, attribute, {
+     get: () => assert_unreached(`getter for ${attribute}`)
+   });
+}
+
+["DOMMatrix", "DOMMatrixReadOnly"].forEach((constr) => {
+  [
+    ["a", "m11"],
+    ["b", "m12"],
+    ["c", "m21"],
+    ["d", "m22"],
+    ["e", "m41"],
+    ["f", "m42"],
+  ].forEach(([aliasAttribute, mAttribute]) => {
+     test(() => {
+       const matrix = new self[constr]([0, 0, 0, 0, 0, 0]);
+       defineThrowingGetter(matrix, mAttribute);
+       assert_equals(matrix[aliasAttribute], 0);
+     }, `${constr} getting ${aliasAttribute} with throwing getter for ${mAttribute}`);
+
+     test(() => {
+       const matrix = new self[constr]([0, 0, 0, 0, 0, 0]);
+       defineThrowingGetter(matrix, aliasAttribute);
+       assert_equals(matrix[mAttribute], 0);
+     }, `${constr} getting ${mAttribute} with throwing getter for ${aliasAttribute}`);
+   });
+});
+</script>


### PR DESCRIPTION
Test for https://github.com/w3c/fxtf-drafts/commit/fc9cbb2eaaca015a08ff25f15c3b5992e99ed0a6

<!-- Reviewable:start -->

<!-- Reviewable:end -->
