### PR TITLE
Remove extra newline at end of WPT file for WPT Exporter testing

### DIFF
--- a/workers/semantics/multiple-workers/001.html
+++ b/workers/semantics/multiple-workers/001.html
@@ -38,4 +38,3 @@ async_test(function() {
 <!--
 */
 //-->
-

--- a/workers/semantics/xhr/004.html
+++ b/workers/semantics/xhr/004.html
@@ -32,5 +32,3 @@ function runtest() {
 <!--
 */
 //-->
-
-


### PR DESCRIPTION
Remove extra newline at end of WPT file for WPT Exporter testing

Bug: 700092
Change-Id: I60d34bfc70741f03bff10453ce0934631f0df0cd
Reviewed-on: https://chromium-review.googlesource.com/479676
Cr-Commit-Position: refs/heads/master@{#471374}
WPT-Export-Revision: dfd9f38d2f9735ea5f5e7b4de7ca9a95c6e025c6

<!-- Reviewable:start -->

<!-- Reviewable:end -->
