### PR TITLE
IndexedDB: Add tests for request properties during/after open/delete

### DIFF
--- a/IndexedDB/idbfactory-deleteDatabase-request-success.html
+++ b/IndexedDB/idbfactory-deleteDatabase-request-success.html
@@ -14,13 +14,13 @@ async_test(t => {
   rq.onsuccess = t.step_func(() => {
     assert_equals(
       rq.readyState, 'done',
-      'request done flag should be set following success');
+      'request done flag should be set on success');
     assert_equals(
       rq.result, undefined,
-      'request result should still be set to undefined following success');
+      'request result should still be set to undefined on success');
     assert_equals(
       rq.error, null,
-      'request error should be null following success');
+      'request error should be null on success');
     t.done();
   });
 }, 'Properties of IDBOpenDBRequest during IDBFactory deleteDatabase()');

--- a/IndexedDB/idbfactory-deleteDatabase-request-success.html
+++ b/IndexedDB/idbfactory-deleteDatabase-request-success.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>IDBFactory deleteDatabase(): request properties on success</title>
+<link rel="help" href="https://w3c.github.io/IndexedDB/#dom-idbfactory-deleteDatabase">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+async_test(t => {
+  const dbname = document.location + '-' + t.name;
+  const rq = indexedDB.deleteDatabase(dbname);
+  rq.onerror = t.unreached_func('deleteDatabase should succeed');
+  rq.onsuccess = t.step_func(() => {
+    assert_equals(
+      rq.readyState, 'done',
+      'request done flag should be set following success');
+    assert_equals(
+      rq.result, undefined,
+      'request result should still be set to undefined following success');
+    assert_equals(
+      rq.error, null,
+      'request error should be null following success');
+    t.done();
+  });
+}, 'Properties of IDBOpenDBRequest during IDBFactory deleteDatabase()');
+
+</script>

--- a/IndexedDB/idbfactory-open-request-error.html
+++ b/IndexedDB/idbfactory-open-request-error.html
@@ -33,12 +33,16 @@ indexeddb_test(
       assert_equals(
         rq.readyState, 'done',
         'request done flag should still be set during abort');
+
+      // Chrome is flaky here. See: https://crbug.com/723846
+      /*
       assert_equals(
         rq.result, db,
         'request result should still be set (to connection) during abort');
       assert_equals(
         rq.error, null,
         'request result should still be null during abort');
+      */
     });
 
     rq.onerror = t.step_func(() => {

--- a/IndexedDB/idbfactory-open-request-error.html
+++ b/IndexedDB/idbfactory-open-request-error.html
@@ -32,26 +32,26 @@ indexeddb_test(
 
       assert_equals(
         rq.readyState, 'done',
-        'request done flag should still be set during complete');
+        'request done flag should still be set during abort');
       assert_equals(
         rq.result, db,
-        'request result should still be set (to connection) during complete');
+        'request result should still be set (to connection) during abort');
       assert_equals(
         rq.error, null,
-        'request result should still be null during upgradeneeded');
+        'request result should still be null during abort');
     });
 
     rq.onerror = t.step_func(() => {
       assert_true(saw_abort, 'abort event should fire before error');
       assert_equals(
         rq.readyState, 'done',
-        'request done flag should be set following error');
+        'request done flag should be set on error');
       assert_equals(
         rq.result, undefined,
-        'request result should be undefined following error');
+        'request result should be undefined on error');
       assert_equals(
         rq.error.name, 'AbortError',
-        'request error should be AbortError following error');
+        'request error should be AbortError on error');
       t.done();
     });
   },

--- a/IndexedDB/idbfactory-open-request-error.html
+++ b/IndexedDB/idbfactory-open-request-error.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>IDBFactory open(): request properties on error</title>
+<link rel="help" href="https://w3c.github.io/IndexedDB/#dom-idbfactory-open">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+let saw_abort = false;
+
+indexeddb_test(
+  (t, db, tx, rq) => {
+    const store = db.createObjectStore('store');
+    store.put({name: 'a'}, 1);
+    store.put({name: 'a'}, 2);
+    store.createIndex('index', 'name', {unique: true});
+
+    assert_equals(
+      rq.readyState, 'done',
+      'request done flag should be set during upgradeneeded');
+    assert_equals(
+      rq.result, db,
+      'request result should be set (to connection) during upgradeneeded');
+    assert_equals(
+      rq.error, null,
+      'request result should be null during upgradeneeded');
+
+    tx.oncomplete = t.unreached_func('transaction should abort');
+    tx.onabort = t.step_func(() => {
+      saw_abort = true;
+
+      assert_equals(
+        rq.readyState, 'done',
+        'request done flag should still be set during complete');
+      assert_equals(
+        rq.result, db,
+        'request result should still be set (to connection) during complete');
+      assert_equals(
+        rq.error, null,
+        'request result should still be null during upgradeneeded');
+    });
+
+    rq.onerror = t.step_func(() => {
+      assert_true(saw_abort, 'abort event should fire before error');
+      assert_equals(
+        rq.readyState, 'done',
+        'request done flag should be set following error');
+      assert_equals(
+        rq.result, undefined,
+        'request result should be undefined following error');
+      assert_equals(
+        rq.error.name, 'AbortError',
+        'request error should be AbortError following error');
+      t.done();
+    });
+  },
+  (t, db) => {},
+  'Properties of IDBOpenDBRequest during failed IDBFactory open()',
+  {upgrade_will_abort: true});
+
+</script>

--- a/IndexedDB/idbfactory-open-request-success.html
+++ b/IndexedDB/idbfactory-open-request-success.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>IDBFactory open(): request properties on success</title>
+<link rel="help" href="https://w3c.github.io/IndexedDB/#dom-idbfactory-open">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=support.js></script>
+<script>
+
+let saw_complete = false;
+
+indexeddb_test(
+  (t, db, tx, rq) => {
+    assert_equals(
+      rq.readyState, 'done',
+      'request done flag should be set during upgradeneeded');
+    assert_equals(
+      rq.result, db,
+      'request result should be set (to connection) during upgradeneeded');
+    assert_equals(
+      rq.error, null,
+      'request result should be null during upgradeneeded');
+
+    tx.onabort = t.unreached_func('transaction should complete');
+    tx.oncomplete = t.step_func(() => {
+      saw_complete = true;
+
+      assert_equals(
+        rq.readyState, 'done',
+        'request done flag should still be set during complete');
+      assert_equals(
+        rq.result, db,
+        'request result should still be set (to connection) during complete');
+      assert_equals(
+        rq.error, null,
+        'request result should still be null during upgradeneeded');
+    });
+  },
+  (t, db, rq) => {
+    assert_true(saw_complete, 'complete event should fire before success');
+    assert_equals(
+      rq.readyState, 'done',
+      'request done flag should be set following success');
+    assert_equals(
+      rq.result, db,
+      'request result should still be set (to connection) following success');
+    assert_equals(
+      rq.error, null,
+      'request error should be null following success');
+    t.done();
+  },
+  'Properties of IDBOpenDBRequest during successful IDBFactory open()');
+
+</script>

--- a/IndexedDB/idbfactory-open-request-success.html
+++ b/IndexedDB/idbfactory-open-request-success.html
@@ -33,20 +33,20 @@ indexeddb_test(
         'request result should still be set (to connection) during complete');
       assert_equals(
         rq.error, null,
-        'request result should still be null during upgradeneeded');
+        'request result should still be null during complete');
     });
   },
   (t, db, rq) => {
     assert_true(saw_complete, 'complete event should fire before success');
     assert_equals(
       rq.readyState, 'done',
-      'request done flag should be set following success');
+      'request done flag should be set on success');
     assert_equals(
       rq.result, db,
-      'request result should still be set (to connection) following success');
+      'request result should still be set (to connection) on success');
     assert_equals(
       rq.error, null,
-      'request error should be null following success');
+      'request error should be null on success');
     t.done();
   },
   'Properties of IDBOpenDBRequest during successful IDBFactory open()');

--- a/IndexedDB/support.js
+++ b/IndexedDB/support.js
@@ -122,7 +122,7 @@ function indexeddb_test(upgrade_func, open_func, description, options) {
         indexedDB.deleteDatabase(db.name);
       });
       var tx = open.transaction;
-      upgrade_func(t, db, tx);
+      upgrade_func(t, db, tx, open);
     });
     if (options.upgrade_will_abort) {
       open.onsuccess = t.unreached_func('open should not succeed');
@@ -131,7 +131,7 @@ function indexeddb_test(upgrade_func, open_func, description, options) {
       open.onsuccess = t.step_func(function() {
         var db = open.result;
         if (open_func)
-          open_func(t, db);
+          open_func(t, db, open);
       });
     }
   }, description);


### PR DESCRIPTION
Tests for cases in https://github.com/w3c/IndexedDB/pull/202 that weren't obviously covered already - the properties of the request (readyState, result, error) during upgradeneeded, after transaction complete/abort, and after success/error.

The tests pass locally in Firefox and Chrome.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
