### PR TITLE
[tools] Add wptrunner log summarization script

### DIFF
--- a/tools/summarize_logs.py
+++ b/tools/summarize_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 import json
 import sys
 
@@ -17,23 +17,20 @@ def main():
     }
 
     This script expects to be fed results in the following way:
-    cat $LOGFILE | grep test_status | ./summarize_logs.py $SUMMARY_FILENAME
+    cat $LOGFILE | ./summarize_logs.py $SUMMARY_FILENAME
     """
+    assert sys.argv[1], 'Required argument: summary file path'
     summary_filename = sys.argv[1]
-    assert summary_filename, 'Required argument: summary file path'
     results = {}
     subtest_results_by_file = {}
 
     for line in sys.stdin:
         test_status = json.loads(line)
 
-        # To guard against irrelevant test lines
-        # Maybe warn if we find too many?
-        if test_status["action"] != "test_status":
+        if test_status["action"] not in ("test_status", "test_end"):
             continue
 
         test_file = test_status["test"]
-        subtest_name = test_status["subtest"]
         status = test_status["status"]
 
         if test_file not in results:

--- a/tools/wptrunner/summarize_logs.py
+++ b/tools/wptrunner/summarize_logs.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python3
+import json
+import sys
+
+
+def main():
+    """Transform wptrunner raw logs
+
+    The script expects wptrunner raw logs (newline-separated JSON generated
+    by --log-raw) to be passed via stdin. It then writes a JSON summary to
+    the provided filename. The schema of the object is:
+
+    {
+        "test/file/path.html": [$num_subtests_passing, $total_subtests],
+        "test/file/path2.html": [10, 20],
+        ...
+    }
+
+    This script expects to be fed results in the following way:
+    cat $LOGFILE | grep test_status | ./summarize_logs.py $SUMMARY_FILENAME
+    """
+    summary_filename = sys.argv[1]
+    assert summary_filename, 'Required argument: summary file path'
+    results = {}
+    subtest_results_by_file = {}
+
+    for line in sys.stdin:
+        test_status = json.loads(line)
+
+        # To guard against irrelevant test lines
+        # Maybe warn if we find too many?
+        if test_status["action"] != "test_status":
+            continue
+
+        test_file = test_status["test"]
+        subtest_name = test_status["subtest"]
+        status = test_status["status"]
+
+        if test_file not in results:
+            results[test_file] = [0, 1]
+        else:
+            results[test_file][1] += 1
+
+        if status == 'PASS':
+            results[test_file][0] += 1
+
+    with open(summary_filename, 'w') as f:
+        json.dump(results, f)
+
+    print('Wrote summary file %s' % summary_filename)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Here's a script I'm using to create a JSON summary of wptrunner results. @gsnedders said it'd be useful to have in the main repo.

Questions:
- [ ] I'm not sure whether this should live in `tools/wptrunner` or in a new directory.
- [ ] I added `#!/usr/bin/python3` but I can make this applicable to Python 2+3 if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5900)
<!-- Reviewable:end -->
