### PR TITLE
Add idlharness.js test for Fullscreen

### DIFF
--- a/fullscreen/interfaces.html
+++ b/fullscreen/interfaces.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>Fullscreen IDL tests</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+<script>
+"use strict";
+
+function doTest([dom, fullscreen]) {
+  var idlArray = new IdlArray();
+  idlArray.add_untested_idls(dom);
+  idlArray.add_untested_idls('interface EventHandler {};');
+  idlArray.add_idls(fullscreen);
+  idlArray.add_objects({
+    Document: ['new Document'],
+    Element: ['document.createElementNS(null, "test")'],
+  });
+  idlArray.test();
+}
+
+function fetchText(url) {
+  return fetch(url).then((response) => response.text());
+}
+
+promise_test(() => {
+  return Promise.all(["/interfaces/dom.idl",
+                      "/interfaces/fullscreen.idl"].map(fetchText))
+    .then(doTest);
+}, "Test driver");
+</script>

--- a/interfaces/fullscreen.idl
+++ b/interfaces/fullscreen.idl
@@ -1,0 +1,17 @@
+partial interface Element {
+  Promise<void> requestFullscreen();
+};
+
+partial interface Document {
+  [LenientSetter] readonly attribute boolean fullscreenEnabled;
+  [LenientSetter, Unscopable] readonly attribute boolean fullscreen; // historical
+
+  Promise<void> exitFullscreen();
+
+  attribute EventHandler onfullscreenchange;
+  attribute EventHandler onfullscreenerror;
+};
+
+partial interface DocumentOrShadowRoot {
+  [LenientSetter] readonly attribute Element? fullscreenElement;
+};

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -8,7 +8,7 @@ policies and contribution forms [3].
 [3] http://www.w3.org/2004/10/27-testcases
 */
 
-/* For user documentation see docs/idlharness.md */
+/* For user documentation see docs/_writing-tests/idlharness.md */
 
 /**
  * Notes for people who want to edit this file (not just use it as a library):
@@ -1633,6 +1633,13 @@ IdlInterface.prototype.test_object = function(desc)
 IdlInterface.prototype.test_primary_interface_of = function(desc, obj, exception, expected_typeof)
 //@{
 {
+    // Only the object itself, not its members, are tested here, so if the
+    // interface is untested, there is nothing to do.
+    if (!this.untested)
+    {
+        return;
+    }
+
     // We can't easily test that its prototype is correct if there's no
     // interface object, or the object is from a different global environment
     // (not instanceof Object).  TODO: test in this case that its prototype at
@@ -1684,6 +1691,9 @@ IdlInterface.prototype.test_interface_of = function(desc, obj, exception, expect
     for (var i = 0; i < this.members.length; i++)
     {
         var member = this.members[i];
+        if (member.untested) {
+            continue;
+        }
         if (!exposed_in(exposure_set(member, this.exposureSet))) {
             test(function() {
                 assert_false(member.name in obj);
@@ -1891,6 +1901,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
     // TODO: Test calling setter on the interface prototype (should throw
     // TypeError in most cases).
     if (member.readonly
+    && !member.has_extended_attribute("LenientSetter")
     && !member.has_extended_attribute("PutForwards")
     && !member.has_extended_attribute("Replaceable"))
     {


### PR DESCRIPTION
Adding a whole other spec's IDL as untested isn't commonly done, so this
ran into multiple problems in idlharness.js, which were fixed:
 * test_primary_interface_of and test_interface_of were missing untested checks
 * the readonly (no setter) checks didn't know about [LenientSetter]

There's still no coverage for [LenientSetter] actually working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5903)
<!-- Reviewable:end -->
