### PR TITLE
Fix consume null body as formData tests

### DIFF
--- a/fetch/api/request/request-consume-empty.html
+++ b/fetch/api/request/request-consume-empty.html
@@ -11,14 +11,14 @@
   </head>
   <body>
     <script>
-    function checkBodyText(request) {
+    function checkBodyText(test, request) {
       return request.text().then(function(bodyAsText) {
         assert_equals(bodyAsText, "", "Resolved value should be empty");
         assert_false(request.bodyUsed);
       });
     }
 
-    function checkBodyBlob(request) {
+    function checkBodyBlob(test, request) {
       return request.blob().then(function(bodyAsBlob) {
         var promise = new Promise(function(resolve, reject) {
           var reader = new FileReader();
@@ -37,14 +37,14 @@
       });
     }
 
-    function checkBodyArrayBuffer(request) {
+    function checkBodyArrayBuffer(test, request) {
       return request.arrayBuffer().then(function(bodyAsArrayBuffer) {
         assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
         assert_false(request.bodyUsed);
       });
     }
 
-    function checkBodyJSON(request) {
+    function checkBodyJSON(test, request) {
       return request.json().then(
         function(bodyAsJSON) {
           assert_unreached("JSON parsing should fail");
@@ -54,27 +54,34 @@
         });
     }
 
-    function checkBodyFormData(request) {
+    function checkBodyFormData(test, request) {
       return request.formData().then(function(bodyAsFormData) {
         assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
         assert_false(request.bodyUsed);
      });
     }
 
-    function checkRequestWithNoBody(bodyType, checkFunction) {
-      promise_test(function(test) {
-        var request = new Request("", {"method": "POST"});
+    function checkBodyFormDataError(test, request) {
+      return promise_rejects(test, new TypeError(), request.formData()).then(function() {
         assert_false(request.bodyUsed);
-        return checkFunction(request);
+      });
+    }
+
+    function checkRequestWithNoBody(bodyType, checkFunction, headers = []) {
+      promise_test(function(test) {
+        var request = new Request("", {"method": "POST", "headers": headers});
+        assert_false(request.bodyUsed);
+        return checkFunction(test, request);
       }, "Consume request's body as " + bodyType);
     }
 
-    var formData = new FormData();
     checkRequestWithNoBody("text", checkBodyText);
     checkRequestWithNoBody("blob", checkBodyBlob);
     checkRequestWithNoBody("arrayBuffer", checkBodyArrayBuffer);
-    checkRequestWithNoBody("json", checkBodyJSON);
-    checkRequestWithNoBody("formData", checkBodyFormData);
+    checkRequestWithNoBody("json (error case)", checkBodyJSON);
+    checkRequestWithNoBody("formData with correct multipart type (error case)", checkBodyFormDataError, [["Content-Type", 'multipart/form-data; boundary="boundary"']]);
+    checkRequestWithNoBody("formData with correct urlencoded type", checkBodyFormData, [["Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"]]);
+    checkRequestWithNoBody("formData without correct type (error case)", checkBodyFormDataError);
 
     function checkRequestWithEmptyBody(bodyType, body, asText) {
       promise_test(function(test) {

--- a/fetch/api/response/response-consume-empty.html
+++ b/fetch/api/response/response-consume-empty.html
@@ -11,14 +11,14 @@
   </head>
   <body>
     <script>
-    function checkBodyText(response) {
+    function checkBodyText(test, response) {
       return response.text().then(function(bodyAsText) {
         assert_equals(bodyAsText, "", "Resolved value should be empty");
         assert_false(response.bodyUsed);
       });
     }
 
-    function checkBodyBlob(response) {
+    function checkBodyBlob(test, response) {
       return response.blob().then(function(bodyAsBlob) {
         var promise = new Promise(function(resolve, reject) {
           var reader = new FileReader();
@@ -37,14 +37,14 @@
       });
     }
 
-    function checkBodyArrayBuffer(response) {
+    function checkBodyArrayBuffer(test, response) {
       return response.arrayBuffer().then(function(bodyAsArrayBuffer) {
         assert_equals(bodyAsArrayBuffer.byteLength, 0, "Resolved value should be empty");
         assert_false(response.bodyUsed);
       });
     }
 
-    function checkBodyJSON(response) {
+    function checkBodyJSON(test, response) {
       return response.json().then(
         function(bodyAsJSON) {
           assert_unreached("JSON parsing should fail");
@@ -54,27 +54,34 @@
         });
     }
 
-    function checkBodyFormData(response) {
+    function checkBodyFormData(test, response) {
       return response.formData().then(function(bodyAsFormData) {
         assert_true(bodyAsFormData instanceof FormData, "Should receive a FormData");
         assert_false(response.bodyUsed);
      });
     }
 
-    function checkResponseWithNoBody(bodyType, checkFunction) {
-      promise_test(function(test) {
-        var response = new Response();
+    function checkBodyFormDataError(test, response) {
+      return promise_rejects(test, new TypeError(), response.formData()).then(function() {
         assert_false(response.bodyUsed);
-        return checkFunction(response);
+      });
+    }
+
+    function checkResponseWithNoBody(bodyType, checkFunction, headers = []) {
+      promise_test(function(test) {
+        var response = new Response(undefined, { "headers": headers });
+        assert_false(response.bodyUsed);
+        return checkFunction(test, response);
       }, "Consume response's body as " + bodyType);
     }
 
-    var formData = new FormData();
     checkResponseWithNoBody("text", checkBodyText);
     checkResponseWithNoBody("blob", checkBodyBlob);
     checkResponseWithNoBody("arrayBuffer", checkBodyArrayBuffer);
-    checkResponseWithNoBody("json", checkBodyJSON);
-    checkResponseWithNoBody("formData", checkBodyFormData);
+    checkResponseWithNoBody("json (error case)", checkBodyJSON);
+    checkResponseWithNoBody("formData with correct multipart type (error case)", checkBodyFormDataError, [["Content-Type", 'multipart/form-data; boundary="boundary"']]);
+    checkResponseWithNoBody("formData with correct urlencoded type", checkBodyFormData, [["Content-Type", "application/x-www-form-urlencoded;charset=UTF-8"]]);
+    checkResponseWithNoBody("formData without correct type (error case)", checkBodyFormDataError);
 
     function checkResponseWithEmptyBody(bodyType, body, asText) {
       promise_test(function(test) {


### PR DESCRIPTION
This tests different form related content types separately, uses correct
content types and fixes assertions. In particular, this checks that
invalid bodies raise TypeErrors.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
