### PR TITLE
wai-aria: Add new test and update expectations for existing test

### DIFF
--- a/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html
@@ -47,7 +47,7 @@
                   "property",
                   "AXColumnIndexRange.length",
                   "isNot",
-                  "3"
+                  "2"
                ]
             ],
             "IAccessible2" : [
@@ -61,7 +61,7 @@
                   "property",
                   "colspan",
                   "isNot",
-                  "3"
+                  "2"
                ]
             ],
             "MSAA" : [
@@ -75,7 +75,7 @@
                   "property",
                   "colspan",
                   "isNot",
-                  "3"
+                  "2"
                ]
             ],
             "UIA" : [
@@ -89,7 +89,7 @@
                   "property",
                   "TableItem.ColumnSpan",
                   "isNot",
-                  "3"
+                  "2"
                ]
             ]
          },

--- a/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>cell aria-colspan 2 on td html colspan 3</title>
+    <title>cell aria-colspan 2 on td html colspan 3 with three actual columns</title>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -24,16 +24,10 @@
                   "ROLE_TABLE_CELL"
                ],
                [
-                  "property",
-                  "objectAttributes",
-                  "doesNotContain",
-                  "colspan:2"
-               ],
-               [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "doesNotContain",
-                  "column_span=2"
+                  "contains",
+                  "column_span=3"
                ]
             ],
             "AXAPI" : [
@@ -46,7 +40,7 @@
                [
                   "property",
                   "AXColumnIndexRange.length",
-                  "isNot",
+                  "is",
                   "3"
                ]
             ],
@@ -60,7 +54,7 @@
                [
                   "property",
                   "colspan",
-                  "isNot",
+                  "is",
                   "3"
                ]
             ],
@@ -74,7 +68,7 @@
                [
                   "property",
                   "colspan",
-                  "isNot",
+                  "is",
                   "3"
                ]
             ],
@@ -88,7 +82,7 @@
                [
                   "property",
                   "TableItem.ColumnSpan",
-                  "isNot",
+                  "is",
                   "3"
                ]
             ]
@@ -97,15 +91,18 @@
          "type" : "test"
       }
    ],
-   "title" : "cell aria-colspan 2 on td html colspan 3"
+   "title" : "cell aria-colspan 2 on td html colspan 3 with three actual columns"
 }
 
     ) ;
     </script>
   </head>
   <body>
-  <p>This test examines the ARIA properties for cell aria-colspan 2 on td html colspan 3.</p>
+  <p>This test examines the ARIA properties for cell aria-colspan 2 on td html colspan 3 with three actual columns.</p>
     <table>
+    <tr>
+      <td>1</td><td>2</td><td>3</td>
+    </tr>
     <tr>
       <td id="test" colspan="3" aria-colspan="2">test cell</td>
     </tr>

--- a/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html
@@ -32,8 +32,8 @@
                [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "contains",
-                  "row_span=3"
+                  "doesNotContain",
+                  "row_span=2"
                ]
             ],
             "AXAPI" : [
@@ -46,8 +46,8 @@
                [
                   "property",
                   "AXRowIndexRange.length",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "IAccessible2" : [
@@ -60,8 +60,8 @@
                [
                   "property",
                   "rowspan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "MSAA" : [
@@ -74,8 +74,8 @@
                [
                   "property",
                   "rowspan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "UIA" : [
@@ -88,8 +88,8 @@
                [
                   "property",
                   "TableItem.RowSpan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ]
          },

--- a/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>columnheader aria-rowspan 2 on th html rowspan 3</title>
+    <title>cell aria-rowspan 2 on td html rowspan 3 with three actual rows</title>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -21,19 +21,13 @@
                   "property",
                   "role",
                   "is",
-                  "ROLE_COLUMN_HEADER"
-               ],
-               [
-                  "property",
-                  "objectAttributes",
-                  "doesNotContain",
-                  "rowspan:2"
+                  "ROLE_TABLE_CELL"
                ],
                [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "doesNotContain",
-                  "row_span=2"
+                  "contains",
+                  "row_span=3"
                ]
             ],
             "AXAPI" : [
@@ -46,8 +40,8 @@
                [
                   "property",
                   "AXRowIndexRange.length",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "IAccessible2" : [
@@ -55,13 +49,13 @@
                   "property",
                   "role",
                   "is",
-                  "ROLE_SYSTEM_COLUMNHEADER"
+                  "ROLE_SYSTEM_CELL"
                ],
                [
                   "property",
                   "rowspan",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "MSAA" : [
@@ -69,13 +63,13 @@
                   "property",
                   "role",
                   "is",
-                  "ROLE_SYSTEM_COLUMNHEADER"
+                  "ROLE_SYSTEM_CELL"
                ],
                [
                   "property",
                   "rowspan",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "UIA" : [
@@ -83,13 +77,13 @@
                   "property",
                   "Control Type",
                   "is",
-                  "HeaderItem"
+                  "TableItem"
                ],
                [
                   "property",
-                  "HeaderItem.RowSpan",
-                  "isNot",
-                  "2"
+                  "TableItem.RowSpan",
+                  "is",
+                  "3"
                ]
             ]
          },
@@ -97,17 +91,24 @@
          "type" : "test"
       }
    ],
-   "title" : "columnheader aria-rowspan 2 on th html rowspan 3"
+   "title" : "cell aria-rowspan 2 on td html rowspan 3 with three actual rows"
 }
 
     ) ;
     </script>
   </head>
   <body>
-  <p>This test examines the ARIA properties for columnheader aria-rowspan 2 on th html rowspan 3.</p>
+  <p>This test examines the ARIA properties for cell aria-rowspan 2 on td html rowspan 3 with three actual rows.</p>
     <table>
     <tr>
-      <th id="test" role="columnheader" rowspan="3" aria-rowspan="2">test cell</th>
+      <td>1</td>
+      <td id="test" role="cell" rowspan="3" aria-rowspan="2">test cell</td>
+    </tr>
+    <tr>
+      <td>2</td>
+    </tr>
+    <tr>
+      <td>3</td>
     </tr>
   </table>
 

--- a/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html
@@ -32,8 +32,8 @@
                [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "contains",
-                  "column_span=3"
+                  "doesNotContain",
+                  "column_span=2"
                ]
             ],
             "AXAPI" : [
@@ -46,8 +46,8 @@
                [
                   "property",
                   "AXColumnIndexRange.length",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "IAccessible2" : [
@@ -60,8 +60,8 @@
                [
                   "property",
                   "colspan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "MSAA" : [
@@ -74,8 +74,8 @@
                [
                   "property",
                   "colspan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ],
             "UIA" : [
@@ -88,8 +88,8 @@
                [
                   "property",
                   "HeaderItem.ColumnSpan",
-                  "is",
-                  "3"
+                  "isNot",
+                  "2"
                ]
             ]
          },

--- a/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>columnheader aria-rowspan 2 on th html rowspan 3</title>
+    <title>columnheader aria-colspan 2 on th html colspan 3 with three actual columns</title>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -24,16 +24,10 @@
                   "ROLE_COLUMN_HEADER"
                ],
                [
-                  "property",
-                  "objectAttributes",
-                  "doesNotContain",
-                  "rowspan:2"
-               ],
-               [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "doesNotContain",
-                  "row_span=2"
+                  "contains",
+                  "column_span=3"
                ]
             ],
             "AXAPI" : [
@@ -45,9 +39,9 @@
                ],
                [
                   "property",
-                  "AXRowIndexRange.length",
-                  "isNot",
-                  "2"
+                  "AXColumnIndexRange.length",
+                  "is",
+                  "3"
                ]
             ],
             "IAccessible2" : [
@@ -59,9 +53,9 @@
                ],
                [
                   "property",
-                  "rowspan",
-                  "isNot",
-                  "2"
+                  "colspan",
+                  "is",
+                  "3"
                ]
             ],
             "MSAA" : [
@@ -73,9 +67,9 @@
                ],
                [
                   "property",
-                  "rowspan",
-                  "isNot",
-                  "2"
+                  "colspan",
+                  "is",
+                  "3"
                ]
             ],
             "UIA" : [
@@ -87,9 +81,9 @@
                ],
                [
                   "property",
-                  "HeaderItem.RowSpan",
-                  "isNot",
-                  "2"
+                  "TableItem.ColumnSpan",
+                  "is",
+                  "3"
                ]
             ]
          },
@@ -97,17 +91,20 @@
          "type" : "test"
       }
    ],
-   "title" : "columnheader aria-rowspan 2 on th html rowspan 3"
+   "title" : "columnheader aria-colspan 2 on th html colspan 3 with three actual columns"
 }
 
     ) ;
     </script>
   </head>
   <body>
-  <p>This test examines the ARIA properties for columnheader aria-rowspan 2 on th html rowspan 3.</p>
+  <p>This test examines the ARIA properties for columnheader aria-colspan 2 on th html colspan 3 with three actual columns.</p>
     <table>
     <tr>
-      <th id="test" role="columnheader" rowspan="3" aria-rowspan="2">test cell</th>
+      <th>1</th><th>2</th><th>3</th>
+    </tr>
+    <tr>
+      <th id="test" role="columnheader" colspan="3" aria-colspan="2">test cell</th>
     </tr>
   </table>
 

--- a/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html
+++ b/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>columnheader aria-rowspan 2 on th html rowspan 3</title>
+    <title>columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows</title>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -24,16 +24,10 @@
                   "ROLE_COLUMN_HEADER"
                ],
                [
-                  "property",
-                  "objectAttributes",
-                  "doesNotContain",
-                  "rowspan:2"
-               ],
-               [
                   "result",
                   "atk_table_cell_get_row_column_span()",
-                  "doesNotContain",
-                  "row_span=2"
+                  "contains",
+                  "row_span=3"
                ]
             ],
             "AXAPI" : [
@@ -46,8 +40,8 @@
                [
                   "property",
                   "AXRowIndexRange.length",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "IAccessible2" : [
@@ -60,8 +54,8 @@
                [
                   "property",
                   "rowspan",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "MSAA" : [
@@ -74,8 +68,8 @@
                [
                   "property",
                   "rowspan",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ],
             "UIA" : [
@@ -88,8 +82,8 @@
                [
                   "property",
                   "HeaderItem.RowSpan",
-                  "isNot",
-                  "2"
+                  "is",
+                  "3"
                ]
             ]
          },
@@ -97,17 +91,24 @@
          "type" : "test"
       }
    ],
-   "title" : "columnheader aria-rowspan 2 on th html rowspan 3"
+   "title" : "columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows"
 }
 
     ) ;
     </script>
   </head>
   <body>
-  <p>This test examines the ARIA properties for columnheader aria-rowspan 2 on th html rowspan 3.</p>
+  <p>This test examines the ARIA properties for columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows.</p>
     <table>
     <tr>
+      <th>1</th>
       <th id="test" role="columnheader" rowspan="3" aria-rowspan="2">test cell</th>
+    </tr>
+    <tr>
+      <th>2</th>
+    </tr>
+    <tr>
+      <th>3</th>
     </tr>
   </table>
 


### PR DESCRIPTION
The test to verify that the aria-colspan value was ignored as a result
of there being a colspan property on the td element also asserted that
the td element's value (3) was exposed. Because the rendered table only
has one column, the test as written is not reliable.

Limit the assertions of the existing test to verifying that the ARIA
value is ignored. Add a new test with three rendered columns to verify
the td element's value gets exposed instead.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
