### PR TITLE
[presentation-api] Check both addEventListener and onxxx

### DIFF
--- a/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html
+++ b/presentation-api/controlling-ua/PresentationAvailability_onchange-manual.https.html
@@ -14,20 +14,20 @@
     // prevent the default timeout
     setup({explicit_timeout: true});
 
-    var notice = document.getElementById('notice');
+    const notice = document.getElementById('notice');
 
-    promise_test(function(t) {
+    promise_test(t => {
       // clean up the instruction notice when the test ends
-      t.add_cleanup(function() {
-          notice.parentNode.removeChild(notice);
+      t.add_cleanup(() => {
+        notice.parentNode.removeChild(notice);
       });
 
       // initialize a presentation request
-      var request = new PresentationRequest(presentationUrls);
+      const request = new PresentationRequest(presentationUrls);
 
-      var availability, previousState, timeout;
+      let availability, previousState, timeout;
 
-      function wait() {
+      const wait = () => {
         notice.textContent = 'Please wait for a moment... (It might take long time)';
 
         // set timeout to observe the presentation availability
@@ -35,9 +35,9 @@
           t.force_timeout();
           t.done();
         }, 90000);
-      }
+      };
 
-      function setup() {
+      const setup = () => {
         // save the current value of the presentation availability
         previousState = availability.value;
 
@@ -45,34 +45,45 @@
         notice.textContent = 'Please make your presentation displays '
                           + (previousState ? 'unavailable' : 'available')
                           + ' and click this button: ';
-        var button = document.createElement('button');
+        const button = document.createElement('button');
         button.textContent = 'Start Monitoring';
         button.onclick = wait;
         notice.appendChild(button);
-      }
+      };
 
-      var check = t.step_func(function(a) {
+      // check the event and its attributes
+      const checkEvent = evt => {
+        clearTimeout(timeout);
+        timeout = undefined;
+
+        assert_true(evt.isTrusted && !evt.bubbles && !evt.cancelable && evt instanceof Event, 'A simple event is fired.');
+        assert_equals(evt.type, 'change', 'The event name is "change".');
+        assert_equals(evt.target, availability, 'event.target is the presentation availability.');
+        assert_not_equals(previousState, availability.value, 'Value of the presentation availability is changed.');
+        setup();
+      };
+
+      const watchEvent = (obj, watcher, type) => {
+        const watchHandler = new Promise(resolve => {
+          obj['on' + type] = evt => { resolve(evt); };
+        });
+        return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+          assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+          return results[0];
+        });
+      };
+
+      // check the change of PresentationAvailability.value twice; "true to false" and "false to true"
+      return request.getAvailability().then(a => {
         availability = a;
         setup();
 
-        availability.onchange = t.step_func(function(evt) {
-          clearTimeout(timeout);
-          timeout = undefined;
-
-          // check the event and its attributes
-          assert_true(evt.isTrusted && !evt.bubbles && !evt.cancelable && evt instanceof Event, 'A simple event is fired.');
-          assert_equals(evt.type, 'change', 'The event name is "change".');
-          assert_equals(evt.target, availability, 'event.target is the presentation availability.');
-          assert_not_equals(previousState, availability.value, 'Value of the presentation availability is changed.');
-          setup();
-        });
-
         // wait until a "change" event is fired twice
         var eventWatcher = new EventWatcher(t, availability, 'change');
-        return eventWatcher.wait_for(['change', 'change']);
+        return watchEvent(availability, eventWatcher, 'change')
+          .then(checkEvent)
+          .then(() => { return eventWatcher.wait_for('change'); })
+          .then(checkEvent);
       });
-
-      // check the change of PresentationAvailability.value twice; "true to false" and "false to true"
-      return request.getAvailability().then(check);
     });
 </script>

--- a/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html
+++ b/presentation-api/controlling-ua/PresentationConnection_onmessage-manual.https.html
@@ -36,103 +36,109 @@
         return !!p && !!q && p.every((item, index) => { return item === q[index]; });
     };
 
-    presentBtn.onclick = () => {
-        presentBtn.disabled = true;
+    promise_test(t => {
+        const clickWatcher = new EventWatcher(t, presentBtn, 'click');
+        const request = new PresentationRequest(presentationUrls);
         const stash = new Stash(stashIds.toController, stashIds.toReceiver);
+        let connection, watcher, eventWatcher;
 
-        promise_test(t => {
-            let connection, watcher, eventWatcher;
-            const request = new PresentationRequest(presentationUrls);
+        const checkEvent = event => {
+            assert_true(event.isTrusted, 'a trusted event is fired');
+            assert_true(event instanceof MessageEvent, 'The event uses the MessageEvent interface');
+            assert_false(event.bubbles, 'the event does not bubble');
+            assert_false(event.cancelable, 'the event is not cancelable');
+        };
 
-            const checkEvent = event => {
-                assert_true(event.isTrusted, 'a trusted event is fired');
-                assert_true(event instanceof MessageEvent, 'The event uses the MessageEvent interface');
-                assert_false(event.bubbles, 'the event does not bubble');
-                assert_false(event.cancelable, 'the event is not cancelable');
-            };
-
-            t.add_cleanup(() => {
-                if (connection) {
-                    if (connection.state === 'connecting') {
-                        connection.onconnect = event => {
-                            connection.terminate();
-                        };
-                    }
-                    else if (connection.state === 'connected')
-                        connection.terminate();
-                    else if (connection.state === 'closed') {
-                        request.reconnect(connection.id).then(c => {
-                            c.terminate();
-                        });
-                    }
-                }
-                const notice = document.getElementById('notice');
-                notice.parentNode.removeChild(notice);
-                stash.stop();
+        const watchEvent = (obj, watcher, type) => {
+            const watchHandler = new Promise(resolve => {
+                obj['on' + type] = evt => { resolve(evt); };
             });
-
-            return request.start().then(c => {
-                connection = c;
-                assert_equals(connection.state, 'connecting', 'the initial state of the presentation connection is "connecting"');
-                assert_equals(connection.binaryType, 'arraybuffer', 'the default value of binaryType is "arraybuffer"');
-
-                // enable timeout again, cause no user action is needed from here.
-                t.step_timeout(() => {
-                    t.force_timeout();
-                    t.done();
-                }, 5000);
-
-                watcher = new EventWatcher(t, connection, 'connect');
-                return watcher.wait_for('connect');
-            }).then(() => {
-                return stash.init();
-            }).then(() => {
-                eventWatcher = new EventWatcher(t, connection, 'message');
-                // Tell receiving page to start sending messages, and wait for first message
-                return Promise.all([
-                    stash.send('onmessage'),
-                    eventWatcher.wait_for('message')
-                ]).then(results => results[1]);
-            }).then(event => {
-                checkEvent(event);
-                assert_equals(event.data, message1, 'receive a string correctly');
-                return eventWatcher.wait_for('message');
-            }).then(event => {
-                checkEvent(event);
-                assert_equals(event.data, message2, 'receive a string correctly');
-                return eventWatcher.wait_for('message');
-            }).then(event => {
-                checkEvent(event);
-                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
-                return eventWatcher.wait_for('message');
-            }).then(event => {
-                checkEvent(event);
-                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
-                return eventWatcher.wait_for('message');
-            }).then(event => {
-                checkEvent(event);
-                assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
-                assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
-
-                connection.binaryType = 'blob';
-                return Promise.all([
-                    stash.send('blob'),
-                    eventWatcher.wait_for('message')
-                ]).then(results => results[1]);
-            }).then(event => {
-                assert_true(event.data instanceof Blob, 'receive binary data as Blob');
-                return new Promise((resolve, reject) => {
-                    const reader = new FileReader();
-                    reader.onload = resolve;
-                    reader.onerror = reject;
-                    reader.readAsArrayBuffer(event.data);
-                });
-            }).then(event => {
-                assert_true(compare(event.target.result, message5), 'receive a Blob correctly');
-                connection.terminate();
+            return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+                assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+                return results[0];
             });
+        };
+
+        t.add_cleanup(() => {
+            if (connection) {
+                connection.onconnect = () => { connection.terminate(); };
+                if (connection.state === 'closed')
+                    request.reconnect(connection.id);
+                else
+                    connection.terminate();
+            }
+            const notice = document.getElementById('notice');
+            notice.parentNode.removeChild(notice);
+            stash.stop();
         });
-    };
+
+        return Promise.all([
+            clickWatcher.wait_for('click'),
+            stash.init()
+        ]).then(() => {
+            presentBtn.disabled = true;
+            return request.start();
+        }).then(c => {
+            connection = c;
+            assert_equals(connection.state, 'connecting', 'the initial state of the presentation connection is "connecting"');
+            assert_equals(connection.binaryType, 'arraybuffer', 'the default value of binaryType is "arraybuffer"');
+
+            // enable timeout again, cause no user action is needed from here.
+            t.step_timeout(() => {
+                t.force_timeout();
+                t.done();
+            }, 5000);
+
+            watcher = new EventWatcher(t, connection, 'connect');
+            return watcher.wait_for('connect');
+        }).then(() => {
+            return stash.init();
+        }).then(() => {
+            eventWatcher = new EventWatcher(t, connection, 'message');
+            // Tell receiving page to start sending messages, and wait for first message
+            return Promise.all([
+                stash.send('onmessage'),
+                watchEvent(connection, eventWatcher, 'message')
+            ]).then(results => results[1]);
+        }).then(event => {
+            checkEvent(event);
+            assert_equals(event.data, message1, 'receive a string correctly');
+            return watchEvent(connection, eventWatcher, 'message');
+        }).then(event => {
+            checkEvent(event);
+            assert_equals(event.data, message2, 'receive a string correctly');
+            return watchEvent(connection, eventWatcher, 'message');
+        }).then(event => {
+            checkEvent(event);
+            assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+            assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a receiving user agent)');
+            return watchEvent(connection, eventWatcher, 'message');
+        }).then(event => {
+            checkEvent(event);
+            assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+            assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a receiving user agent)');
+            return watchEvent(connection, eventWatcher, 'message');
+        }).then(event => {
+            checkEvent(event);
+            assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
+            assert_true(compare(event.data, message5), 'receive an ArrayBuffer correctly (originally an ArrayBufferView at a receiving user agent)');
+
+            connection.binaryType = 'blob';
+            return Promise.all([
+                stash.send('blob'),
+                watchEvent(connection, eventWatcher, 'message')
+            ]).then(results => results[1]);
+        }).then(event => {
+            assert_true(event.data instanceof Blob, 'receive binary data as Blob');
+            return new Promise((resolve, reject) => {
+                const reader = new FileReader();
+                reader.onload = resolve;
+                reader.onerror = reject;
+                reader.readAsArrayBuffer(event.data);
+            });
+        }).then(event => {
+            assert_true(compare(event.target.result, message5), 'receive a Blob correctly');
+            connection.terminate();
+        });
+    });
 </script>

--- a/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_onconnectionavailable-manual.https.html
@@ -22,51 +22,62 @@
     // --------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - begin
     // --------------------------------------------------------------------------
-    presentBtn.onclick = () => {
-        presentBtn.disabled = true;
+    promise_test(t => {
+        const clickWatcher = new EventWatcher(t, presentBtn, 'click');
+        const request = new PresentationRequest(presentationUrls);
+        let connection;
 
-        promise_test(t => {
-            let connection;
-            const request = new PresentationRequest(presentationUrls);
+        t.add_cleanup(() => {
+            if (connection) {
+                connection.onconnect = () => { connection.terminate(); };
+                if (connection.state === 'closed')
+                    request.reconnect(connection.id);
+                else
+                    connection.terminate();
+            }
+        });
 
-            t.add_cleanup(() => {
-                if (connection) {
-                    connection.onconnect = () => { connection.terminate(); };
-                    if (connection.state === 'closed')
-                        request.reconnect(connection.id);
-                    else
-                        connection.terminate();
-                }
+        const watchEvent = (obj, watcher, type) => {
+            const watchHandler = new Promise(resolve => {
+                obj['on' + type] = evt => { resolve(evt); };
             });
+            return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+                assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+                return results[0];
+            });
+        };
+
+        return clickWatcher.wait_for('click').then(() => {
+            presentBtn.disabled = true;
 
             // Note: During starting a presentation, the connectionavailable event is fired (step 9)
             //       after the promise P is resolved (step 8).
-            return request.start().then(c => {
-                connection = c;
-                assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
-                assert_true(!!connection.id, 'The connection ID is set.');
-                assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
-                assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
+            return request.start();
+        }).then(c => {
+            connection = c;
+            assert_equals(connection.state, 'connecting', 'The initial state of the presentation connection is "connecting".');
+            assert_true(!!connection.id, 'The connection ID is set.');
+            assert_true(typeof connection.id === 'string', 'The connection ID is a string.');
+            assert_true(connection instanceof PresentationConnection, 'The connection is an instance of PresentationConnection.');
 
-                const eventWatcher = new EventWatcher(t, request, 'connectionavailable');
-                const timeout = new Promise((_, reject) => {
-                    // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
-                    // or the presentation fails to be started.
-                    t.step_timeout(() => { reject('The connectionavailable event was not fired (timeout).'); }, 5000);}
-                );
-                return Promise.race([ eventWatcher.wait_for('connectionavailable'), timeout ]);
-            }).then(evt => {
-                assert_true(evt instanceof PresentationConnectionAvailableEvent, 'An event using PresentationConnectionAvailableEvent is fired.');
-                assert_true(evt.isTrusted, 'The event is a trusted event.');
-                assert_false(evt.bubbles, 'The event does not bubbles.');
-                assert_false(evt.cancelable, 'The event is not cancelable.');
-                assert_equals(evt.type, 'connectionavailable', 'The event name is "connectionavailable".');
-                assert_equals(evt.target, request, 'event.target is the presentation request.');
-                assert_true(evt.connection instanceof PresentationConnection, 'event.connection is a presentation connection.');
-                assert_equals(evt.connection, connection, 'event.connection is set to the presentation which the promise is resolved with.');
-            });
+            const eventWatcher = new EventWatcher(t, request, 'connectionavailable');
+            const timeout = new Promise((_, reject) => {
+                // This test fails if request.onconnectionavailable is not invoked although the presentation is started successfully
+                // or the presentation fails to be started.
+                t.step_timeout(() => { reject('The connectionavailable event was not fired (timeout).'); }, 5000);}
+            );
+            return Promise.race([ watchEvent(request, eventWatcher, 'connectionavailable'), timeout ]);
+        }).then(evt => {
+            assert_true(evt instanceof PresentationConnectionAvailableEvent, 'An event using PresentationConnectionAvailableEvent is fired.');
+            assert_true(evt.isTrusted, 'The event is a trusted event.');
+            assert_false(evt.bubbles, 'The event does not bubbles.');
+            assert_false(evt.cancelable, 'The event is not cancelable.');
+            assert_equals(evt.type, 'connectionavailable', 'The event name is "connectionavailable".');
+            assert_equals(evt.target, request, 'event.target is the presentation request.');
+            assert_true(evt.connection instanceof PresentationConnection, 'event.connection is a presentation connection.');
+            assert_equals(evt.connection, connection, 'event.connection is set to the presentation which the promise is resolved with.');
         });
-    }
+    });
     // ------------------------------------------------------------------------
     // Start New PresentationRequest.onconnectionavailable Test (success) - end
     // ------------------------------------------------------------------------

--- a/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
@@ -53,6 +53,16 @@
         return checkConnectionList(evt.connection, 'connect');
       };
 
+      const watchEvent = (obj, watcher, type) => {
+        const watchHandler = new Promise(resolve => {
+          obj['on' + type] = evt => { resolve(evt); };
+        });
+        return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+          assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+          return results[0];
+        });
+      };
+
       // Step 1: check the first connection in "connected" state
       let connection = list.connections[0];
       assert_equals(number, 1, 'A presentation connection list is populated with a first presentation connection.');
@@ -70,12 +80,12 @@
       .then(() => {
         stash.send(JSON.stringify({ type: 'ok' }));
         eventWatcher = new EventWatcher(t, list, 'connectionavailable');
-        return eventWatcher.wait_for('connectionavailable')
+        return watchEvent(list, eventWatcher, 'connectionavailable')
       }).then(checkEvent)
       // Step 4: check the second connection (with <iframe>) in "connected" state
       .then(() => {
         stash.send(JSON.stringify({ type: 'ok' }));
-        return eventWatcher.wait_for('connectionavailable');
+        return watchEvent(list, eventWatcher, 'connectionavailable')
       }).then(checkEvent);
     });
   });

--- a/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
@@ -31,13 +31,13 @@
         return receiver.connectionList.then(list => {
           connections = list.connections;
           if (action === 'close') {
-            assert_true(connections.length === number && connections.includes(connection),
-              'A closed presentation connection remains in the set of presentation controllers.');
+            assert_true(connections.length === number - 1 && connections.includes(connection),
+              'A closed presentation connection is removed from the set of presentation controllers.');
           } else if (action === 'connect') {
             assert_true(connections.length === number + 1 && connections.includes(connection),
               'A new presentation connection is added to the set of presentation controllers.');
-            number = connections.length;
           }
+          number = connections.length;
         });
       };
 

--- a/presentation-api/receiving-ua/support/PresentationConnection_onclose_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnection_onclose_receiving-ua.html
@@ -28,6 +28,16 @@
     assert_equals(evt.reason, reason, 'The reason for closing the presentation connection is "' + reason + '".');
   };
 
+  const watchEvent = (obj, watcher, type) => {
+    const watchHandler = new Promise(resolve => {
+      obj['on' + type] = evt => { resolve(evt); };
+    });
+    return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+      assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+      return results[0];
+    });
+  };
+
   promise_test(t => {
     return navigator.presentation.receiver.connectionList.then(list => {
       let connection = list.connections[0];
@@ -37,16 +47,16 @@
       connection.close();
       let watchClose = new EventWatcher(t, connection, 'close');
       const watchNewConnection = new EventWatcher(t, list, 'connectionavailable');
-      return watchClose.wait_for('close').then(evt => {
+      return watchEvent(connection, watchClose, 'close').then(evt => {
         checkCloseEvent(evt, connection, 'closed');
 
         // Step 2: check a connection closed by the controlling user agent
         stash.send(JSON.stringify({ type: 'ok' }));
-        return watchNewConnection.wait_for('connectionavailable')
+        return watchNewConnection.wait_for('connectionavailable');
       }).then(evt => {
         connection = evt.connection;
         watchClose = new EventWatcher(t, connection, 'close');
-        return watchClose.wait_for('close');
+        return watchEvent(connection, watchClose, 'close');
       }).then(evt => {
         checkCloseEvent(evt, connection, 'closed');
 
@@ -54,7 +64,7 @@
         connection.close();
         return Promise.race([
           new Promise(resolve => { t.step_timeout(resolve, 1000); }),
-          watchClose.wait_for('close').then(() => {
+          watchEvent(connection, watchClose, 'close').then(() => {
             assert_unreached('Invoking PresentationConnection.close() in the "closed" state causes nothing.'); })
         ]);
       }).then(() => {
@@ -67,7 +77,7 @@
         stash.send(JSON.stringify({ type: 'ok' }));
         watchClose = new EventWatcher(t, connection, 'close');
         return Promise.race([
-          watchClose.wait_for('close'),
+          watchEvent(connection, watchClose, 'close'),
           new Promise(resolve => { t.step_timeout(() => { resolve(null); }, 3000); })
         ]);
       }).then(evt => {

--- a/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnection_onmessage_receiving-ua.html
@@ -43,6 +43,16 @@ navigator.presentation.receiver.connectionList.then(list => {
     assert_false(event.cancelable, 'the event is not cancelable');
   };
 
+  const watchEvent = (obj, watcher, type) => {
+    const watchHandler = new Promise(resolve => {
+      obj['on' + type] = evt => { resolve(evt); };
+    });
+    return Promise.all([ watchHandler, watcher.wait_for(type) ]).then(results => {
+      assert_equals(results[0], results[1], 'Both on' + type + ' and addEventListener pass the same event object.');
+      return results[0];
+    });
+  };
+
   const connection = list.connections[0];
 
   promise_test(t => {
@@ -56,21 +66,21 @@ navigator.presentation.receiver.connectionList.then(list => {
     return eventWatcher.wait_for('message').then(evt => {
       checkEvent(evt);
       assert_equals(event.data, message1, 'receive a string correctly');
-      return eventWatcher.wait_for('message');
+      return watchEvent(connection, eventWatcher, 'message');
     }).then(event => {
       checkEvent(event);
       assert_equals(event.data, message2, 'receive a string correctly');
-      return eventWatcher.wait_for('message');
+      return watchEvent(connection, eventWatcher, 'message');
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
       assert_true(compare(event.data, message3), 'receive an ArrayBuffer correctly (originally a Blob at a controlling user agent)');
-      return eventWatcher.wait_for('message');
+      return watchEvent(connection, eventWatcher, 'message');
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
       assert_true(compare(event.data, message4), 'receive an ArrayBuffer correctly (originally an ArrayBuffer at a controlling user agent)');
-      return eventWatcher.wait_for('message');
+      return watchEvent(connection, eventWatcher, 'message');
     }).then(event => {
       checkEvent(event);
       assert_true(event.data instanceof ArrayBuffer, 'receive binary data as ArrayBuffer');
@@ -79,7 +89,7 @@ navigator.presentation.receiver.connectionList.then(list => {
       connection.binaryType = 'blob';
       return Promise.all([
         stash.send(JSON.stringify({ type: 'blob' })),
-        eventWatcher.wait_for('message')
+        watchEvent(connection, eventWatcher, 'message')
       ]).then(results => results[1]);
     }).then(event => {
       assert_true(event.data instanceof Blob, 'receive binary data as Blob');


### PR DESCRIPTION
This PR updates tests except ones addressed in #5794, so that these tests check both addEventListener and `onxxx`.

Also, the `onclose` test for a receiving user agent is updated as per https://github.com/w3c/presentation-api/pull/426.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
