### PR TITLE
Use assert_in_array instead of assert_true(x === y || x === z)

### DIFF
--- a/css/css-shapes-1/shape-outside/values/support/parsing-utils.js
+++ b/css/css-shapes-1/shape-outside/values/support/parsing-utils.js
@@ -19,7 +19,7 @@ function testComputedStyle(value, expected) {
     // so this check allows for testing that at least one of them passes.
     // Description of the 2 expecteds is below near calcTestValues.
     if(Object.prototype.toString.call( expected ) === '[object Array]' && expected.length == 2) {
-        assert_true(expected[0] == actual || expected[1] == actual)
+        assert_in_array(actual, expected);
     } else {
         assert_equals(actual, typeof expected !== 'undefined' ? expected : value);
     }
@@ -55,7 +55,7 @@ function testShapeMarginComputedStyle(value, expected) {
 
     // See comment above about multiple expected results
     if(Object.prototype.toString.call( expected ) === '[object Array]' && expected.length == 2) {
-        assert_true(expected[0] == actual || expected[1] == actual)
+        assert_in_array(actual, expected);
     } else {
         assert_equals(actual, !expected ? '0px' : expected);
     }
@@ -86,7 +86,7 @@ function testShapeThresholdComputedStyle(value, expected) {
 
     // See comment above about multiple expected results
     if(Object.prototype.toString.call( expected ) === '[object Array]' && expected.length == 2) {
-        assert_true(expected[0] == actual || expected[1] == actual)
+        assert_in_array(actual, expected);
     } else {
         assert_equals(actual, !expected ? '0' : expected);
     }

--- a/cssom-view/cssom-view-window-screen-interface.html
+++ b/cssom-view/cssom-view-window-screen-interface.html
@@ -30,7 +30,7 @@
             "window.screen.availWidth >= 0 && window.screen.availWidth <= window.screen.width");
         test(function(){assert_true(window.screen.availHeight >= 0 && window.screen.availHeight <= window.screen.height);},
             "window.screen.availHeight >= 0 && window.screen.availHeight <= window.screen.height");
-        test(function(){assert_true(window.screen.colorDepth == 0 || window.screen.colorDepth == 16 || window.screen.colorDepth == 24 || window.screen.colorDepth == 32);},
+        test(function(){assert_in_array(window.screen.colorDepth, [0, 16, 24, 32]);},
             "window.screen.colorDepth == 0 || window.screen.colorDepth == 16 || window.screen.colorDepth == 24 || window.screen.colorDepth == 32");
         test(function(){assert_equals(window.screen.pixelDepth, window.screen.colorDepth);},
             "window.screen.pixelDepth must return the value returned by window.screen.colorDepth");

--- a/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success.html
+++ b/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/broadcastchannel-success.html
@@ -30,7 +30,7 @@ promise_test(t => {
           return;
         }
 
-        assert_true(i === 0 || i === 1 || i === 2, `Any message events must come from expected sources; got ${i}`);
+        assert_in_array(i, [0, 1, 2], "Any message events must come from expected sources");
         ++soFar;
 
         if (soFar === 3) {

--- a/html/semantics/forms/textfieldselection/selection-after-content-change.html
+++ b/html/semantics/forms/textfieldselection/selection-after-content-change.html
@@ -16,7 +16,7 @@
 let observedResetSelectionDirection;
 function assertSelectionDirectionIsReset(element) {
   if (!observedResetSelectionDirection) {
-    assert_true(element.selectionDirection === "none" || element.selectionDirection === "forward",
+    assert_in_array(element.selectionDirection, ["none", "forward"],
       "selectionDirection must be set to either none or forward");
     observedResetSelectionDirection = element.selectionDirection;
   } else {

--- a/js/builtins/Promise-subclassing.html
+++ b/js/builtins/Promise-subclassing.html
@@ -143,7 +143,7 @@ promise_test(function testPromiseRace() {
                             "Next 3"]);
   assert_true(p instanceof LoggingPromise);
   return p.then(function(arg) {
-    assert_true(arg == 1 || arg == 2);
+    assert_in_array(arg, [1, 2]);
   });
 }, "Promise.race behavior");
 
@@ -159,7 +159,7 @@ promise_test(function testPromiseRaceNoSpecies() {
                             "Next 3"]);
   assert_true(p instanceof SpeciesLessPromise);
   return p.then(function(arg) {
-    assert_true(arg == 1 || arg == 2);
+    assert_in_array(arg, [1, 2]);
   });
 }, "Promise.race without species behavior");
 

--- a/resource-timing/resource-timing.js
+++ b/resource-timing/resource-timing.js
@@ -277,7 +277,7 @@ window.onload =
             // Per https://w3c.github.io/resource-timing/#performanceresourcetiming:
             //      "[If redirected, startTime] MUST return the same value as redirectStart. Otherwise,
             //      [startTime] MUST return the same value as fetchStart."
-            assert_true(actual.startTime == actual.redirectStart || actual.startTime == actual.fetchStart,
+            assert_in_array(actual.startTime, [actual.redirectStart, actual.fetchStart],
                 "startTime must be equal to redirectStart or fetchStart.");
 
             // redirectStart <= redirectEnd <= fetchStart <= domainLookupStart <= domainLookupEnd <= connectStart

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -617,7 +617,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
             return;
 
         case "object":
-            assert_true(typeof value == "object" || typeof value == "function", "wrong type: not object or function");
+            assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
             return;
     }
 
@@ -633,7 +633,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
         // in an infinite loop.  TODO: This means we don't have tests for
         // NoInterfaceObject interfaces, and we also can't test objects that
         // come from another self.
-        assert_true(typeof value == "object" || typeof value == "function", "wrong type: not object or function");
+        assert_in_array(typeof value, ["object", "function"], "wrong type: not object or function");
         if (value instanceof Object
         && !this.members[type].has_extended_attribute("NoInterfaceObject")
         && type in self)

--- a/workers/Worker_ErrorEvent_error.htm
+++ b/workers/Worker_ErrorEvent_error.htm
@@ -18,8 +18,7 @@ test(function() {
   worker.onmessage = t2.step_func(function(e) {
     ++messages;
     var data = e.data;
-    assert_true(data.source == "onerror" ||
-                data.source == "event listener");
+    assert_in_array(data.source, ["onerror", "event listener"]);
     assert_equals(data.value, "hello");
     if (messages == 2) {
       t2.done();


### PR DESCRIPTION
This is primarily beneficial because it provides better error messages when it fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5969)
<!-- Reviewable:end -->
