### PR TITLE
Remove setTimeout call, unbreak master

### DIFF
--- a/encrypted-media/scripts/playback-persistent-license-events.js
+++ b/encrypted-media/scripts/playback-persistent-license-events.js
@@ -56,7 +56,7 @@ function runTest(config,qualifier) {
             }).then(test.step_func(function() {
                 _events.push(event.messageType + '-response-resolved');
                 if (event.messageType === 'license-release') {
-                    setTimeout(test.step_func(function() {
+                    test.step_timeout(function() {
                         checkEventSequence(_events, [
                             'generaterequest',
                             [    // potentially repeating
@@ -75,7 +75,7 @@ function runTest(config,qualifier) {
                             'keystatuseschange-empty'
                         ]);
                         test.done();
-                    } ), 100);
+                    }, 100);
                 }
             })).catch(onFailure);
         }


### PR DESCRIPTION
Sigh. #4241 broke master and nobody fixed it. Any API that is rebased
against master to avoid failing Edge (which is now ignored, thankfully)
will now fail because of this so let’s fix this…

<!-- Reviewable:start -->

<!-- Reviewable:end -->
