### PR TITLE
enable WPT interpolation tests for some SVG stroke related properties.

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1235,8 +1235,7 @@ var gCSSProperties = {
   },
   'stroke-dasharray': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeDasharrayProperty
-    types: [
-    ]
+    types: [ 'dasharray' ]
   },
   'stroke-dashoffset': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty
@@ -1260,13 +1259,11 @@ var gCSSProperties = {
   },
   'stroke-miterlimit': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty
-    types: [
-    ]
+    types: [ 'positiveNumber' ]
   },
   'stroke-opacity': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeOpacityProperty
-    types: [
-    ]
+    types: [ 'opacity' ]
   },
   'stroke-width': {
     // https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty


### PR DESCRIPTION

This includes stroke-{opacity, miterlimit, stroke-dasharray}.

In this patch, we added opacityType to enabled stroke-opacity's
animation tests. With the newly added opacityType, we should be
able to test other opacity like properties as well.

Re-use existing positiveNumberType for stroke-miterlimit.

As for stroke-dasharray, we add a separated type specifically for it. Note
that we haven't supported unitless length in servo and stylo yet, so I didn't
add tests for length. We should add some once we support unitless length
in servo and stylo.

MozReview-Commit-ID: HIUSyvKA2G3

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1360144 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5977)
<!-- Reviewable:end -->
