### PR TITLE
Revert our web-incompatible change to rel=noreferrer targeting behavior.

### DIFF
--- a/html/browsers/windows/noreferrer-window-name.html
+++ b/html/browsers/windows/noreferrer-window-name.html
@@ -36,5 +36,50 @@
 
     hyperlink1.click()
     hyperlink2.click()
-  })
+  }, "Following a noreferrer link with a named target should not cause creation of a window that can be targeted by another noreferrer link with the same named target");
+
+  async_test(function(t) {
+    var ifr = document.createElement("iframe");
+    ifr.name = "sufficientlyrandomwindownameamiright2";
+    ifr.onload = t.step_func(function() {
+      var hyperlink = document.body.appendChild(document.createElement("a"));
+      t.add_cleanup(function() {
+        hyperlink.remove();
+      });
+      hyperlink.rel = "noreferrer";
+      hyperlink.href = URL.createObjectURL(new Blob(["hello subframe"],
+                                                    { type: "text/html"}));
+      hyperlink.target = "sufficientlyrandomwindownameamiright2";
+      ifr.onload = t.step_func_done(function() {
+        assert_equals(ifr.contentDocument.documentElement.textContent,
+                      "hello subframe");
+      });
+      hyperlink.click();
+    });
+    document.body.appendChild(ifr);
+    t.add_cleanup(function() {
+      ifr.remove();
+    });
+  }, "Targeting a rel=noreferrer link at an existing named subframe should work");
+
+  async_test(function(t) {
+    var win = window.open("", "sufficientlyrandomwindownameamiright3");
+    t.add_cleanup(function() {
+      win.close();
+    });
+
+    var hyperlink = document.body.appendChild(document.createElement("a"));
+    t.add_cleanup(function() {
+      hyperlink.remove();
+    });
+    hyperlink.rel = "noreferrer";
+    hyperlink.href = URL.createObjectURL(new Blob(["hello window"],
+                                                  { type: "text/html"}));
+    hyperlink.target = "sufficientlyrandomwindownameamiright3";
+    win.onload = t.step_func_done(function() {
+      assert_equals(win.document.documentElement.textContent,
+                    "hello window");
+    });
+    hyperlink.click();
+  }, "Targeting a rel=noreferrer link at an existing named window should work");
 </script>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1358469 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5978)
<!-- Reviewable:end -->
