### PR TITLE
Increase the HTTP connection timeout for WebDriver tests,

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -41,6 +41,7 @@ class Response(object):
 
         return cls(status, body)
 
+
 class HTTPWireProtocol(object):
     """Transports messages (commands and responses) over the WebDriver
     wire protocol.


### PR DESCRIPTION

The 5s timeout was not enough for debug builds. I don't really see a
reason to use something other than the default socket timeout here.

MozReview-Commit-ID: Fm5lgSI3lFb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1318724 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5979)
<!-- Reviewable:end -->
