### PR TITLE
Use nsString instead nsCString for Worker names,

### DIFF
--- a/XMLHttpRequest/open-url-worker-origin.htm
+++ b/XMLHttpRequest/open-url-worker-origin.htm
@@ -17,7 +17,7 @@
             'Request URL test' : (location.href.replace(/[^/]*$/, ''))+'resources/requri.py?full'
         }
         // now start the worker
-        var worker = new Worker("resources/workerxhr-origin-referrer.js", true)
+        var worker = new Worker("resources/workerxhr-origin-referrer.js")
         worker.onmessage = function (e) {
             var subtest = async_test(e.data.test)
             subtest.step(function(){


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1364297 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5989)
<!-- Reviewable:end -->
