### PR TITLE
Run ci_stability.sh against Safari 10.1 instead of 10.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ matrix:
       python: "2.7"
       env:
         - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
-        - SCRIPT=ci_stability.sh PRODUCT=sauce:safari:10.0 PLATFORM='macOS 10.12'
+        - SCRIPT=ci_stability.sh PRODUCT=sauce:safari:10.1 PLATFORM='macOS 10.12'
     - os: linux
       python: "2.7"
       env:


### PR DESCRIPTION
Safari 10.1 was released in late March, and is available on OSX 10.12.4 and later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/5990)
<!-- Reviewable:end -->
