### PR TITLE
idlharness: Make descriptions match the assert_true/false expectations.

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -489,7 +489,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
 
     if (type.sequence)
     {
-        assert_true(Array.isArray(value), "is not array");
+        assert_true(Array.isArray(value), "should be an Array");
         if (!value.length)
         {
             // Nothing we can do.
@@ -500,7 +500,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
     }
 
     if (type.generic === "Promise") {
-        assert_true("then" in value, "Attribute with a Promise type has a then property");
+        assert_true("then" in value, "Attribute with a Promise type should have a then property");
         // TODO: Ideally, we would check on project fulfillment
         // that we get the right type
         // but that would require making the type check async
@@ -533,38 +533,38 @@ IdlArray.prototype.assert_type_is = function(value, type)
 
         case "byte":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(-128 <= value && value <= 127, "byte " + value + " not in range [-128, 127]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(-128 <= value && value <= 127, "byte " + value + " should be in range [-128, 127]");
             return;
 
         case "octet":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(0 <= value && value <= 255, "octet " + value + " not in range [0, 255]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(0 <= value && value <= 255, "octet " + value + " should be in range [0, 255]");
             return;
 
         case "short":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(-32768 <= value && value <= 32767, "short " + value + " not in range [-32768, 32767]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(-32768 <= value && value <= 32767, "short " + value + " should be in range [-32768, 32767]");
             return;
 
         case "unsigned short":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(0 <= value && value <= 65535, "unsigned short " + value + " not in range [0, 65535]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(0 <= value && value <= 65535, "unsigned short " + value + " should be in range [0, 65535]");
             return;
 
         case "long":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(-2147483648 <= value && value <= 2147483647, "long " + value + " not in range [-2147483648, 2147483647]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(-2147483648 <= value && value <= 2147483647, "long " + value + " should be in range [-2147483648, 2147483647]");
             return;
 
         case "unsigned long":
             assert_equals(typeof value, "number");
-            assert_equals(value, Math.floor(value), "not an integer");
-            assert_true(0 <= value && value <= 4294967295, "unsigned long " + value + " not in range [0, 4294967295]");
+            assert_equals(value, Math.floor(value), "should be an integer");
+            assert_true(0 <= value && value <= 4294967295, "unsigned long " + value + " should be in range [0, 4294967295]");
             return;
 
         case "long long":
@@ -574,7 +574,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
         case "unsigned long long":
         case "DOMTimeStamp":
             assert_equals(typeof value, "number");
-            assert_true(0 <= value, "unsigned long long is negative");
+            assert_true(0 <= value, "unsigned long long should be positive");
             return;
 
         case "float":
@@ -638,7 +638,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
         && !this.members[type].has_extended_attribute("NoInterfaceObject")
         && type in self)
         {
-            assert_true(value instanceof self[type], "not instanceof " + type);
+            assert_true(value instanceof self[type], "instanceof " + type);
         }
     }
     else if (this.members[type] instanceof IdlEnum)
@@ -838,11 +838,11 @@ IdlInterface.prototype.test_self = function()
         assert_own_property(self, this.name,
                             "self does not have own property " + format_value(this.name));
         var desc = Object.getOwnPropertyDescriptor(self, this.name);
-        assert_false("get" in desc, "self's property " + format_value(this.name) + " has getter");
-        assert_false("set" in desc, "self's property " + format_value(this.name) + " has setter");
-        assert_true(desc.writable, "self's property " + format_value(this.name) + " is not writable");
-        assert_false(desc.enumerable, "self's property " + format_value(this.name) + " is enumerable");
-        assert_true(desc.configurable, "self's property " + format_value(this.name) + " is not configurable");
+        assert_false("get" in desc, "self's property " + format_value(this.name) + " should not have a getter");
+        assert_false("set" in desc, "self's property " + format_value(this.name) + " should not have a setter");
+        assert_true(desc.writable, "self's property " + format_value(this.name) + " should be writable");
+        assert_false(desc.enumerable, "self's property " + format_value(this.name) + " should not be enumerable");
+        assert_true(desc.configurable, "self's property " + format_value(this.name) + " should be configurable");
 
         if (this.is_callback()) {
             // "The internal [[Prototype]] property of an interface object for
@@ -935,11 +935,11 @@ IdlInterface.prototype.test_self = function()
             // a Number."
             assert_own_property(self[this.name], "length");
             var desc = Object.getOwnPropertyDescriptor(self[this.name], "length");
-            assert_false("get" in desc, this.name + ".length has getter");
-            assert_false("set" in desc, this.name + ".length has setter");
-            assert_false(desc.writable, this.name + ".length is writable");
-            assert_false(desc.enumerable, this.name + ".length is enumerable");
-            assert_true(desc.configurable, this.name + ".length is not configurable");
+            assert_false("get" in desc, this.name + ".length should not have a getter");
+            assert_false("set" in desc, this.name + ".length should not have a setter");
+            assert_false(desc.writable, this.name + ".length should not be writable");
+            assert_false(desc.enumerable, this.name + ".length should not be enumerable");
+            assert_true(desc.configurable, this.name + ".length should be configurable");
 
             var constructors = this.extAttrs
                 .filter(function(attr) { return attr.name == "Constructor"; });
@@ -963,11 +963,11 @@ IdlInterface.prototype.test_self = function()
 
             assert_own_property(self[this.name], "name");
             var desc = Object.getOwnPropertyDescriptor(self[this.name], "name");
-            assert_false("get" in desc, this.name + ".name has getter");
-            assert_false("set" in desc, this.name + ".name has setter");
-            assert_false(desc.writable, this.name + ".name is writable");
-            assert_false(desc.enumerable, this.name + ".name is enumerable");
-            assert_true(desc.configurable, this.name + ".name is not configurable");
+            assert_false("get" in desc, this.name + ".name should not have a getter");
+            assert_false("set" in desc, this.name + ".name should not have a setter");
+            assert_false(desc.writable, this.name + ".name should not be writable");
+            assert_false(desc.enumerable, this.name + ".name should not be enumerable");
+            assert_true(desc.configurable, this.name + ".name should be configurable");
             assert_equals(self[this.name].name, this.name, "wrong value for " + this.name + ".name");
         }.bind(this), this.name + " interface object name");
     }
@@ -1010,11 +1010,11 @@ IdlInterface.prototype.test_self = function()
                     assert_equals(self[alias], self[this.name], "self." + alias + " should be the same value as self." + this.name);
                     var desc = Object.getOwnPropertyDescriptor(self, alias);
                     assert_equals(desc.value, self[this.name], "wrong value in " + alias + " property descriptor");
-                    assert_true(desc.writable, alias + " is not writable");
-                    assert_false(desc.enumerable, alias + " is enumerable");
-                    assert_true(desc.configurable, alias + " is not configurable");
-                    assert_false('get' in desc, alias + " has a getter");
-                    assert_false('set' in desc, alias + " has a setter");
+                    assert_true(desc.writable, alias + " should be writable");
+                    assert_false(desc.enumerable, alias + " should not be enumerable");
+                    assert_true(desc.configurable, alias + " should be configurable");
+                    assert_false('get' in desc, alias + " should not have a getter");
+                    assert_false('set' in desc, alias + " should not have a setter");
                 }
             } else {
                 for (alias of aliases) {
@@ -1054,11 +1054,11 @@ IdlInterface.prototype.test_self = function()
         assert_own_property(self[this.name], "prototype",
                             'interface "' + this.name + '" does not have own property "prototype"');
         var desc = Object.getOwnPropertyDescriptor(self[this.name], "prototype");
-        assert_false("get" in desc, this.name + ".prototype has getter");
-        assert_false("set" in desc, this.name + ".prototype has setter");
-        assert_false(desc.writable, this.name + ".prototype is writable");
-        assert_false(desc.enumerable, this.name + ".prototype is enumerable");
-        assert_false(desc.configurable, this.name + ".prototype is configurable");
+        assert_false("get" in desc, this.name + ".prototype should not have a getter");
+        assert_false("set" in desc, this.name + ".prototype should not have a setter");
+        assert_false(desc.writable, this.name + ".prototype should not be writable");
+        assert_false(desc.enumerable, this.name + ".prototype should not be enumerable");
+        assert_false(desc.configurable, this.name + ".prototype should not be configurable");
 
         // Next, test that the [[Prototype]] of the interface prototype object
         // is correct. (This is made somewhat difficult by the existence of
@@ -1163,11 +1163,11 @@ IdlInterface.prototype.test_self = function()
         assert_own_property(self[this.name].prototype, "constructor",
                             this.name + '.prototype does not have own property "constructor"');
         var desc = Object.getOwnPropertyDescriptor(self[this.name].prototype, "constructor");
-        assert_false("get" in desc, this.name + ".prototype.constructor has getter");
-        assert_false("set" in desc, this.name + ".prototype.constructor has setter");
-        assert_true(desc.writable, this.name + ".prototype.constructor is not writable");
-        assert_false(desc.enumerable, this.name + ".prototype.constructor is enumerable");
-        assert_true(desc.configurable, this.name + ".prototype.constructor in not configurable");
+        assert_false("get" in desc, this.name + ".prototype.constructor should not have a getter");
+        assert_false("set" in desc, this.name + ".prototype.constructor should not have a setter");
+        assert_true(desc.writable, this.name + ".prototype.constructor should be writable");
+        assert_false(desc.enumerable, this.name + ".prototype.constructor should not be enumerable");
+        assert_true(desc.configurable, this.name + ".prototype.constructor should be configurable");
         assert_equals(self[this.name].prototype.constructor, self[this.name],
                       this.name + '.prototype.constructor is not the same object as ' + this.name);
     }.bind(this), this.name + ' interface: existence and properties of interface prototype object\'s "constructor" property');
@@ -1198,11 +1198,11 @@ IdlInterface.prototype.test_member_const = function(member)
         // "The property has attributes { [[Writable]]: false,
         // [[Enumerable]]: true, [[Configurable]]: false }."
         var desc = Object.getOwnPropertyDescriptor(self[this.name], member.name);
-        assert_false("get" in desc, "property has getter");
-        assert_false("set" in desc, "property has setter");
-        assert_false(desc.writable, "property is writable");
-        assert_true(desc.enumerable, "property is not enumerable");
-        assert_false(desc.configurable, "property is configurable");
+        assert_false("get" in desc, "property should not have a getter");
+        assert_false("set" in desc, "property should not have a setter");
+        assert_false(desc.writable, "property should not be writable");
+        assert_true(desc.enumerable, "property should be enumerable");
+        assert_false(desc.configurable, "property should not be configurable");
     }.bind(this), this.name + " interface: constant " + member.name + " on interface object");
 
     // "In addition, a property with the same characteristics must
@@ -1225,11 +1225,11 @@ IdlInterface.prototype.test_member_const = function(member)
         assert_equals(self[this.name].prototype[member.name], constValue(member.value),
                       "property has wrong value");
         var desc = Object.getOwnPropertyDescriptor(self[this.name], member.name);
-        assert_false("get" in desc, "property has getter");
-        assert_false("set" in desc, "property has setter");
-        assert_false(desc.writable, "property is writable");
-        assert_true(desc.enumerable, "property is not enumerable");
-        assert_false(desc.configurable, "property is configurable");
+        assert_false("get" in desc, "property should not have a getter");
+        assert_false("set" in desc, "property should not have a setter");
+        assert_false(desc.writable, "property should not be writable");
+        assert_true(desc.enumerable, "property should be enumerable");
+        assert_false(desc.configurable, "property should not be configurable");
     }.bind(this), this.name + " interface: constant " + member.name + " on interface prototype object");
 };
 
@@ -1261,7 +1261,7 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 "The global object must have a property " +
                 format_value(member.name));
             assert_false(member.name in self[this.name].prototype,
-                "The prototype object must not have a property " +
+                "The prototype object should not have a property " +
                 format_value(member.name));
 
             var getter = Object.getOwnPropertyDescriptor(self, member.name).get;
@@ -1396,11 +1396,11 @@ IdlInterface.prototype.do_member_operation_asserts = function(memberHolderObject
     // "The property has attributes { [[Writable]]: B,
     // [[Enumerable]]: true, [[Configurable]]: B }, where B is false if the
     // operation is unforgeable on the interface, and true otherwise".
-    assert_false("get" in desc, "property has getter");
-    assert_false("set" in desc, "property has setter");
+    assert_false("get" in desc, "property should not have a getter");
+    assert_false("set" in desc, "property should not have a setter");
     assert_equals(desc.writable, !operationUnforgeable,
                   "property should be writable if and only if not unforgeable");
-    assert_true(desc.enumerable, "property is not enumerable");
+    assert_true(desc.enumerable, "property should be enumerable");
     assert_equals(desc.configurable, !operationUnforgeable,
                   "property should be configurable if and only if not unforgeable");
     // "The value of the property is a Function object whose
@@ -1483,9 +1483,9 @@ IdlInterface.prototype.test_member_iterable = function(member)
     test(function()
     {
         var descriptor = Object.getOwnPropertyDescriptor(self[interfaceName].prototype, Symbol.iterator);
-        assert_true(descriptor.writable, "property is not writable");
-        assert_true(descriptor.configurable, "property is not configurable");
-        assert_false(descriptor.enumerable, "property is enumerable");
+        assert_true(descriptor.writable, "property should be writable");
+        assert_true(descriptor.configurable, "property should be configurable");
+        assert_false(descriptor.enumerable, "property should not be enumerable");
         assert_equals(self[interfaceName].prototype[Symbol.iterator].name, isPairIterator ? "entries" : "values", "@@iterator function does not have the right name");
     }, "Testing Symbol.iterator property of iterable interface " + interfaceName);
 
@@ -1534,11 +1534,11 @@ IdlInterface.prototype.test_member_stringifier = function(member)
         // "The property has attributes { [[Writable]]: B,
         // [[Enumerable]]: true, [[Configurable]]: B }, where B is false if the
         // stringifier is unforgeable on the interface, and true otherwise."
-        assert_false("get" in desc, "property has getter");
-        assert_false("set" in desc, "property has setter");
+        assert_false("get" in desc, "property should not have a getter");
+        assert_false("set" in desc, "property should not have a setter");
         assert_equals(desc.writable, !stringifierUnforgeable,
                       "property should be writable if and only if not unforgeable");
-        assert_true(desc.enumerable, "property is not enumerable");
+        assert_true(desc.enumerable, "property should be enumerable");
         assert_equals(desc.configurable, !stringifierUnforgeable,
                       "property should be configurable if and only if not unforgeable");
         // "The value of the property is a Function object, which behaves as
@@ -1906,9 +1906,9 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
     // "G is the attribute getter, defined below; and
     // "S is the attribute setter, also defined below."
     var desc = Object.getOwnPropertyDescriptor(obj, member.name);
-    assert_false("value" in desc, 'property descriptor has value but is supposed to be accessor');
-    assert_false("writable" in desc, 'property descriptor has "writable" field but is supposed to be accessor');
-    assert_true(desc.enumerable, "property is not enumerable");
+    assert_false("value" in desc, 'property descriptor should not have a "value" field');
+    assert_false("writable" in desc, 'property descriptor should not have a "writable" field');
+    assert_true(desc.enumerable, "property should be enumerable");
     if (member.isUnforgeable)
     {
         assert_false(desc.configurable, "[Unforgeable] property must not be configurable");


### PR DESCRIPTION
An assertion in the form of `assert_true(foo.enumerable, "foo is not
enumerable")` leads to a confusing error message like this:

    assert_true: foo is not enumerable expected true got false

which is the opposite of what we are actually expecting.

Conversely, `assert_false(foo.enumerable, "foo is enumerable")` is also
more confusing than "foo is not enumerable", which is what we are expecting
and asserting.

Instead, standardize on making the descriptions match what we expect in the
calls to `assert_true()` and `assert_false()` and use constructions such as
"should be <foo>" or "should not have <foo>" instead of factual statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6001)
<!-- Reviewable:end -->
