### PR TITLE
Minor changes to wptrun for Python 2.7 and pip >= 7.0.0 compatibility.

### DIFF
--- a/tools/browserutils/browser.py
+++ b/tools/browserutils/browser.py
@@ -3,7 +3,7 @@ import os
 import re
 import stat
 from abc import ABCMeta, abstractmethod
-from configparser import RawConfigParser
+from ConfigParser import RawConfigParser
 from distutils.spawn import find_executable
 
 from utils import call, get, untar, unzip

--- a/tools/browserutils/virtualenv.py
+++ b/tools/browserutils/virtualenv.py
@@ -21,7 +21,7 @@ class Virtualenv(object):
     def create(self):
         if os.path.exists(self.path):
             shutil.rmtree(self.path)
-        call(self.virtualenv, "--no-download", self.path)
+        call(self.virtualenv, self.path)
 
     @property
     def bin_path(self):


### PR DESCRIPTION
- Using Python 2.7 compatible ConfigParser instead of 3.+ configparser.
- Removed `--no-download` argument as it has been removed in Pip 7.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6011)
<!-- Reviewable:end -->
