### PR TITLE
Get wptrun working in Windows with Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ is:
 ./wptrun product [tests]
 ```
 
+**On Windows**: for technical reasons the above will not work and you
+must instead run `python tools/wptrun.py products [tests]`.
+
 where `product` is currently `firefox` or `chrome` and `[tests]` is a
 list of paths to tests. This will attempt to automatically locate a
 browser instance and install required dependencies. The command is

--- a/tools/browserutils/browser.py
+++ b/tools/browserutils/browser.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import re
 import stat
 from abc import ABCMeta, abstractmethod
@@ -10,7 +11,7 @@ from utils import call, get, untar, unzip
 
 logger = logging.getLogger(__name__)
 
-uname = os.uname()
+uname = platform.uname()
 
 def path(path, exe):
     path = path.replace("/", os.path.sep)
@@ -117,7 +118,10 @@ class Firefox(Browser):
         return find_executable("firefox")
 
     def find_certutil(self):
-        return find_executable("certutil")
+        path = find_executable("certutil")
+        if os.path.splitdrive(path)[1].split(os.path.sep) == ["", "Windows", "system32", "certutil.exe"]:
+            return None
+        return path
 
     def find_webdriver(self):
         return find_executable("geckodriver")
@@ -177,10 +181,14 @@ class Firefox(Browser):
             dest = os.pwd
 
         version = self._latest_geckodriver_version()
+        format = "zip" if uname[0] == "Windows" else "tar.gz"
         logger.debug("Latest geckodriver release %s" % version)
-        url = ("https://github.com/mozilla/geckodriver/releases/download/%s/geckodriver-%s-%s.tar.gz" %
-               (version, version, self.platform_string_geckodriver()))
-        untar(get(url).raw, dest=dest)
+        url = ("https://github.com/mozilla/geckodriver/releases/download/%s/geckodriver-%s-%s.%s" %
+               (version, version, self.platform_string_geckodriver(), format))
+        if format == "zip":
+            unzip(get(url).raw, dest=dest)
+        else:
+            untar(get(url).raw, dest=dest)
         return find_executable(os.path.join(dest, "geckodriver"))
 
     def version(self, root):
@@ -237,7 +245,7 @@ class Chrome(Browser):
         url = "http://chromedriver.storage.googleapis.com/%s/chromedriver_%s.zip" % (latest,
                                                                                      self.platform_string())
         unzip(get(url).raw, dest)
-        path = os.path.join(dest, "chromedriver")
+        path = find_executable(dest, "chromedriver")
         st = os.stat(path)
         os.chmod(path, st.st_mode | stat.S_IEXEC)
         return path
@@ -266,3 +274,26 @@ class Chrome(Browser):
             else:
                 logger.critical("dbus not running and can't be started")
                 sys.exit(1)
+
+
+class Edge(Browser):
+    """Edge-specific interface.
+
+    Includes installation, webdriver installation, and wptrunner setup methods.
+    """
+
+    product = "edge"
+    requirements = "requirements_edge.txt"
+
+    def install(self):
+        return None
+
+    def find_webdriver(self):
+        return find_executable("MicrosoftWebDriver")
+
+    def install_webdriver(self, dest=None):
+        """Install latest Webdriver."""
+        raise NotImplementedError
+
+    def version(self):
+        raise NotImplementedError

--- a/tools/browserutils/utils.py
+++ b/tools/browserutils/utils.py
@@ -6,8 +6,6 @@ import tarfile
 import zipfile
 from io import BytesIO
 
-import requests
-
 logger = logging.getLogger(__name__)
 
 
@@ -107,6 +105,8 @@ class pwd(object):
 
 def get(url):
     """Issue GET request to a given URL and return the response."""
+    import requests
+
     logger.debug("GET %s" % url)
     resp = requests.get(url, stream=True)
     resp.raise_for_status()

--- a/tools/browserutils/virtualenv.py
+++ b/tools/browserutils/virtualenv.py
@@ -45,5 +45,8 @@ class Virtualenv(object):
             self.create()
         self.activate()
 
+    def install(self, *requirements):
+        call(self.pip_path, "install", *requirements)
+
     def install_requirements(self, requirements_path):
         call(self.pip_path, "install", "-r", requirements_path)

--- a/tools/wptrun.py
+++ b/tools/wptrun.py
@@ -1,14 +1,14 @@
 import argparse
 import os
+import platform
 import shutil
 import subprocess
 import sys
 import tarfile
 from distutils.spawn import find_executable
 
-from tools import localpaths
+import localpaths
 from browserutils import browser, utils, virtualenv
-from wptrunner import wptrunner, wptcommandline
 logger = None
 
 wpt_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -61,6 +61,21 @@ def args_general(kwargs):
     kwargs.set_if_none("metadata_root", wpt_root)
     kwargs.set_if_none("manifest_update", True)
 
+    if kwargs["ssl_type"] == "openssl":
+        if not find_executable(kwargs["openssl_binary"]):
+            if os.uname()[0] == "Windows":
+                exit("""OpenSSL binary not found. If you need HTTPS tests, install OpenSSL from
+
+https://slproweb.com/products/Win32OpenSSL.html
+
+Ensuring that libraries are added to /bin and add the resulting bin directory to
+your PATH.
+
+Otherwise run with --ssl-type=none""")
+            else:
+                exit("""OpenSSL not found. If you don't need HTTPS support run with --ssl-type=none,
+otherwise install OpenSSL and ensure that it's on your $PATH.""")
+
 
 def check_environ(product):
     if product != "firefox":
@@ -71,7 +86,7 @@ def check_environ(product):
                               "xn--n8j6ds53lwwkrqhv28a.web-platform.test",
                               "xn--lve-6lad.web-platform.test",
                               "nonexistent-origin.web-platform.test"])
-        if os.uname()[0] != "Windows":
+        if platform.uname()[0] != "Windows":
             hosts_path = "/etc/hosts"
         else:
             hosts_path = "C:\Windows\System32\drivers\etc\hosts"
@@ -193,8 +208,24 @@ def setup_chrome(venv, kwargs, prompt=True):
     venv.install_requirements(os.path.join(wpt_root, "tools", "wptrunner", chrome.requirements))
 
 
-def setup_edge(kwargs):
-    raise NotImplementedError
+def args_edge(venv, kwargs, edge, prompt=True):
+    if kwargs["webdriver_binary"] is None:
+        webdriver_binary = edge.find_webdriver()
+
+        if webdriver_binary is None:
+            exit("""Unable to find WebDriver and we aren't yet clever enough to work out which
+version to download. Please go to the following URL and install the correct
+version for your Edge/Windows release somewhere on the %PATH%:
+
+https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
+ """)
+        kwargs["webdriver_binary"] = webdriver_binary
+
+
+def setup_edge(venv, kwargs, prompt=True):
+    edge = browser.Edge()
+    args_edge(venv, kwargs, edge, prompt)
+    venv.install_requirements(os.path.join(wpt_root, "tools", "wptrunner", edge.requirements))
 
 
 def setup_sauce(kwargs):
@@ -207,11 +238,14 @@ def setup_servo(kwargs):
 
 product_setup = {
     "firefox": setup_firefox,
-    "chrome": setup_chrome
+    "chrome": setup_chrome,
+    "edge": setup_edge
 }
 
 
 def setup_wptrunner(venv, product, tests, wptrunner_args, prompt=True,):
+    from wptrunner import wptrunner, wptcommandline
+
     global logger
 
     wptparser = wptcommandline.create_parser()
@@ -244,10 +278,13 @@ def main():
     parser = create_parser()
     args = parser.parse_args()
 
-    venv = virtualenv.Virtualenv(os.path.join(wpt_root, "_venv"))
+    venv = virtualenv.Virtualenv(os.path.join(wpt_root, "_venv_%s") % platform.uname()[0])
     venv.start()
+    venv.install_requirements(os.path.join(wpt_root, "tools", "wptrunner", "requirements.txt"))
+    venv.install("requests")
 
     kwargs = setup_wptrunner(venv, args.product, args.tests, args.wptrunner_args, prompt=args.prompt)
+    from wptrunner import wptrunner
     wptrunner.start(**kwargs)
 
 

--- a/tools/wptrunner/requirements_edge.txt
+++ b/tools/wptrunner/requirements_edge.txt
@@ -1,0 +1,2 @@
+mozprocess >= 0.19
+selenium >= 2.41.0

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -8,6 +8,7 @@ envlist = {py27,pypy}-{base,b2g,chrome,firefox,servo}
 deps =
      pytest>=2.9
      pytest-cov
+     pytest-xdist
      -r{toxinidir}/requirements.txt
      chrome: -r{toxinidir}/requirements_chrome.txt
      firefox: -r{toxinidir}/requirements_firefox.txt

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -18,7 +18,7 @@ __wptrunner__ = {"product": "edge",
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
-def browser_kwargs(**kwargs):
+def browser_kwargs(test_type, run_info_data, **kwargs):
     return {"webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}
 

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -199,7 +199,15 @@ class TestEnvironment(object):
 
     def ensure_started(self):
         # Pause for a while to ensure that the server has a chance to start
-        time.sleep(2)
+        for _ in xrange(20):
+            failed = self.test_servers()
+            if not failed:
+                return
+            time.sleep(0.5)
+        raise EnvironmentError("Servers failed to start (scheme:port): %s" % ("%s:%s" for item in failed))
+
+    def test_servers(self):
+        failed = []
         for scheme, servers in self.servers.iteritems():
             for port, server in servers:
                 if self.test_server_port:
@@ -207,10 +215,9 @@ class TestEnvironment(object):
                     try:
                         s.connect((self.config["host"], port))
                     except socket.error:
-                        raise EnvironmentError(
-                            "%s server on port %d failed to start" % (scheme, port))
+                        failed.append((scheme, port))
                     finally:
                         s.close()
 
                 if not server.is_alive():
-                    raise EnvironmentError("%s server on port %d failed to start" % (scheme, port))
+                    failed.append((scheme, port))

--- a/wptrun
+++ b/wptrun
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
 
-from tools import wptrun
-wptrun.main()
+if __name__ == "__main__":
+    from tools import wptrun
+    wptrun.main()


### PR DESCRIPTION
Add edge support to wptrun, and add basic Windows support for other
browsers. This is still less well supported than under Linux because:

* wptrun can't be executed directly due to problems with
  multiprocessing. Instead one has to run `python tools/wptrun.py`.

* Finding browsers doesn't work well because we only look on the PATH,
  but ought to look in the registry.

* Downloading MicrosoftWebDriver for Edge isn't implemented since we
  don't yet have a way to work out which build we need for the current
  Windows version.

* OpenSSL must be installed by hand (this could perhaps be solved by
  shipping the certificates instead like we do with Firefox).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6025)
<!-- Reviewable:end -->
