### PR TITLE
Support Document constructor.


### DIFF
--- a/dom/nodes/Document-constructor-svg.svg
+++ b/dom/nodes/Document-constructor-svg.svg
@@ -1,13 +1,12 @@
-<!doctype html>
-<meta charset=windows-1252>
+<?xml version="1.0" encoding="windows-1252"?>
 <!-- Using windows-1252 to ensure that new Document() doesn't inherit utf-8
      from the parent document. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+  width="100%" height="100%" viewBox="0 0 800 600">
 <title>Document constructor</title>
-<link rel=help href="https://dom.spec.whatwg.org/#dom-document">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id="log"></div>
-<script>
+<html:script src="/resources/testharness.js"></html:script>
+<html:script src="/resources/testharnessreport.js"></html:script>
+<html:script><![CDATA[
 test(function() {
   var doc = new Document();
   assert_true(doc instanceof Node, "Should be a Node");
@@ -43,12 +42,6 @@ test(function() {
   assert_equals(doc.charset, "UTF-8", "charset");
   assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
 }, "new Document(): characterSet aliases")
+]]></html:script>
+</svg>
 
-test(function() {
-  var doc = new Document();
-  var a = doc.createElement("a");
-  // In UTF-8: 0xC3 0xA4
-  a.href = "http://example.org/?\u00E4";
-  assert_equals(a.href, "http://example.org/?%C3%A4");
-}, "new Document(): URL parsing")
-</script>

--- a/dom/nodes/Document-constructor-xml.xml
+++ b/dom/nodes/Document-constructor-xml.xml
@@ -1,13 +1,15 @@
-<!doctype html>
-<meta charset=windows-1252>
+<?xml version="1.0" encoding="windows-1252"?>
 <!-- Using windows-1252 to ensure that new Document() doesn't inherit utf-8
      from the parent document. -->
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
 <title>Document constructor</title>
-<link rel=help href="https://dom.spec.whatwg.org/#dom-document">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-document" />
+</head>
+<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<div id="log"></div>
-<script>
+<script><![CDATA[
 test(function() {
   var doc = new Document();
   assert_true(doc instanceof Node, "Should be a Node");
@@ -43,12 +45,6 @@ test(function() {
   assert_equals(doc.charset, "UTF-8", "charset");
   assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
 }, "new Document(): characterSet aliases")
-
-test(function() {
-  var doc = new Document();
-  var a = doc.createElement("a");
-  // In UTF-8: 0xC3 0xA4
-  a.href = "http://example.org/?\u00E4";
-  assert_equals(a.href, "http://example.org/?%C3%A4");
-}, "new Document(): URL parsing")
-</script>
+]]></script>
+</body>
+</html>


### PR DESCRIPTION
|new Document()| creates a new Document instance.

Intent-to-implement-and-ship:
https://groups.google.com/a/chromium.org/forum/#!msg/Blink-dev/IxyBdzkSU98/LJ12LwjKAAAJ

This CL fixes 168 failures in external/wpt/.

WPT changes:
* Adds 'origin' check to dom/nodes/Document-constructor.html.
* Adds dom/nodes/Document-constructor-svg.svg
* Adds dom/nodes/Document-constructor-xml.xml

BUG=238234, 643043

Review-Url: https://codereview.chromium.org/2881323002
Cr-Commit-Position: refs/heads/master@{#473931}

<!-- Reviewable:start -->

<!-- Reviewable:end -->
