### PR TITLE
DOM: Fix an incorrect result of getElementsByClassName() in quirks mode.


### DIFF
--- a/dom/nodes/getElementsByClassName-14.htm
+++ b/dom/nodes/getElementsByClassName-14.htm
@@ -2,15 +2,25 @@
 <html class="a A">
  <head>
   <title>document.getElementsByClassName(): case-insensitive (quirks mode)</title>
+  <link rel="help" href="https://dom.spec.whatwg.org/#concept-getelementsbyclassname">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
  </head>
  <body class="a a">
   <div id="log"></div>
-  <script>test(function() {
-             assert_array_equals(document.getElementsByClassName("A a"),
-                                 [document.documentElement, document.body]);
-          })
+  <div class="k"></div>
+  <div class="K"></div>
+  <div class="&#x212a;" id="kelvin"></div>
+  <script>
+test(function() {
+  assert_array_equals(document.getElementsByClassName("A a"),
+                      [document.documentElement, document.body]);
+})
+
+test(function() {
+  assert_array_equals(document.getElementsByClassName("\u212a"),
+                      [document.getElementById("kelvin")]);
+}, 'Unicode-case should be sensitive even in quirks mode.');
   </script>
  </body>
 </html>


### PR DESCRIPTION
document.getElementsByClassName('\u212a') matched to class="k" and class="K",
and did not match to class="&#x212a;".  It should match only to class="&#x212a;".

Element::ClassNames() stores ASCII-lower class string, however
getElementsByClassName() applied FoldCase().

Also, this CL removes a unused data member of ClassCollection.

BUG=725773,627682

Review-Url: https://codereview.chromium.org/2899243003
Cr-Commit-Position: refs/heads/master@{#474217}

<!-- Reviewable:start -->

<!-- Reviewable:end -->
