### PR TITLE
Start converting scroll anchoring tests to web-platform-tests.


### DIFF
--- a/scroll-anchoring/README.md
+++ b/scroll-anchoring/README.md
@@ -1,0 +1,8 @@
+## Scroll Anchoring Web Platform Tests
+
+Scroll anchoring adjusts the scroll position to prevent visible jumps (or
+"reflows") when content changes above the viewport.
+
+* [explainer](https://github.com/WICG/ScrollAnchoring/blob/master/explainer.md)
+* [spec](https://wicg.github.io/ScrollAnchoring)
+* [file bug / view open issues](https://github.com/WICG/ScrollAnchoring/issues)

--- a/scroll-anchoring/anchoring-with-bounds-clamping.html
+++ b/scroll-anchoring/anchoring-with-bounds-clamping.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #changer { height: 1500px; }
+  #anchor {
+    width: 150px; height: 1000px; background-color: pink;
+  }
+</style>
+<div id="changer"></div>
+<div id="anchor"></div>
+<script>
+// Test that scroll anchoring interacts correctly with scroll bounds clamping:
+// There should be no visible jump even if the content shrinks such that the
+// new max scroll position is less than the previous scroll position.
+test(() => {
+  document.scrollingElement.scrollTop = 1600;
+  document.querySelector("#changer").style.height = "0";
+  assert_equals(document.scrollingElement.scrollTop, 100);
+});
+</script>

--- a/scroll-anchoring/basic.html
+++ b/scroll-anchoring/basic.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  body { height: 1000px }
+  div { height: 100px }
+</style>
+<div id="block1">abc</div>
+<div id="block2">def</div>
+<script>
+test(() => {
+  document.scrollingElement.scrollTop = 150;
+  document.querySelector("#block1").style.height = "200px";
+  assert_equals(document.scrollingElement.scrollTop, 250);
+});
+</script>

--- a/scroll-anchoring/clipped-scrollers-skipped.html
+++ b/scroll-anchoring/clipped-scrollers-skipped.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  body { height: 2000px; }
+  #scroller { overflow: scroll; width: 500px; height: 300px; }
+  .anchor {
+    position: relative; height: 100px; width: 150px;
+    background-color: #afa; border: 1px solid gray;
+  }
+  #forceScrolling { height: 500px; background-color: #fcc; }
+</style>
+<div id="scroller">
+  <div id="innerChanger"></div>
+  <div id="innerAnchor" class="anchor"></div>
+  <div id="forceScrolling"></div>
+</div>
+<div id="outerChanger"></div>
+<div id="outerAnchor" class="anchor"></div>
+<script>
+// Test that we ignore the clipped content when computing visibility otherwise
+// we may end up with an anchor that we think is in the viewport but is not.
+test(() => {
+  document.querySelector("#scroller").scrollTop = 100;
+  document.scrollingElement.scrollTop = 350;
+
+  document.querySelector("#innerChanger").style.height = "200px";
+  document.querySelector("#outerChanger").style.height = "150px";
+
+  assert_equals(document.querySelector("#scroller").scrollTop, 300);
+  assert_equals(document.scrollingElement.scrollTop, 500);
+});
+</script>


### PR DESCRIPTION
This patch converts three test cases (others will follow):
  ScrollAnchorTest.Basic
  ScrollAnchorTest.ClippedScrollersSkipped
  ScrollAnchorTest.AnchoringWhenContentRemoved

Bug: 725278
Change-Id: I66f30372cdcd5a23333bc4e95fcb65ca5bd80cb4
Reviewed-on: https://chromium-review.googlesource.com/511883
Reviewed-by: Ojan Vafai <ojan@chromium.org>
Commit-Queue: Steve Kobes <skobes@chromium.org>
Cr-Commit-Position: refs/heads/master@{#474305}

<!-- Reviewable:start -->

<!-- Reviewable:end -->
