### PR TITLE
[css-grid] Fix mistake in orthogonal-positioned-grid-items-013-ref.html

### DIFF
--- a/css/css-grid-1/abspos/orthogonal-positioned-grid-items-013-ref.html
+++ b/css/css-grid-1/abspos/orthogonal-positioned-grid-items-013-ref.html
@@ -3,9 +3,6 @@
 <title>CSS Grid Layout Test: Orthogonal positioned grid items reference file</title>
 <link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
 <style>
-body {
-    overflow: scroll;
-}
 #grid {
   display: grid;
   grid: 150px 100px / 200px 300px;


### PR DESCRIPTION
This reference file had a wrong "body { overflow: scroll; }"
that was there by mistake due to some testing.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
