### PR TITLE
[check stability] Remove Chrome bug workaround

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
 import argparse
-from ConfigParser import SafeConfigParser
 import logging
 import os
 import re
@@ -10,10 +9,10 @@ import subprocess
 import sys
 import tarfile
 import zipfile
+from ConfigParser import RawConfigParser, SafeConfigParser
 from abc import ABCMeta, abstractmethod
 from cStringIO import StringIO as CStringIO
 from collections import defaultdict, OrderedDict
-from ConfigParser import RawConfigParser
 from io import BytesIO, StringIO
 
 import requests


### PR DESCRIPTION
The non-deterministic behavior that was previously causing instability
in Chrome test runs has recently been corrected in the Chrome project
itself [1]. This obviates the need for a local workaround. Revert the
workaround, but continue to allow failures in the continuous integration
environment so that this change may be validated.

This patch is the result of reverting two commits:

- Revert "[check stability] Apply DBUS configuration in C.I."
  This reverts commit 91c54d13629a66a3d5b8817fdcd8278a152871cb.
- Revert "Ensure dbus is running when stability check runs in Chrome."
  This reverts commit 0509dfe88e8209a0983b08eed655dfe52804fec2.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=713947#c13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6064)
<!-- Reviewable:end -->
