### PR TITLE
Update flex tests to use TOC link rather than propdef

### DIFF
--- a/css/css-flexbox-1/Flexible-order.html
+++ b/css/css-flexbox-1/Flexible-order.html
@@ -6,7 +6,7 @@
 
 <link rel="match" href="reference/Flexible-order-ref.html">
 <link rel="author" title="KeynesQu" href="mailto:keynesqu@sohu.com" />
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property" />
 
 <style>
 

--- a/css/css-flexbox-1/align-items-001.htm
+++ b/css/css-flexbox-1/align-items-001.htm
@@ -4,7 +4,7 @@
         <title>CSS Test: A flex container with the 'align-items' property set to 'center'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
         <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line." />

--- a/css/css-flexbox-1/align-items-002.htm
+++ b/css/css-flexbox-1/align-items-002.htm
@@ -4,7 +4,7 @@
         <title>CSS Test: A flex container with the 'align-items' property set to 'flex-start'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
         <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line." />

--- a/css/css-flexbox-1/align-items-003.htm
+++ b/css/css-flexbox-1/align-items-003.htm
@@ -4,7 +4,7 @@
         <title>CSS Test: A flex container with the 'align-items' property set to 'flex-end'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
         <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line." />

--- a/css/css-flexbox-1/align-items-004.htm
+++ b/css/css-flexbox-1/align-items-004.htm
@@ -4,7 +4,7 @@
         <title>CSS Test: A flex container with the 'align-items' property set to 'baseline'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
         <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="ahem">
         <meta name="assert" content="This test checks that the flex container with 'align-items: baseline' places each flex item's margin box so that their baselines align." />

--- a/css/css-flexbox-1/align-items-005.htm
+++ b/css/css-flexbox-1/align-items-005.htm
@@ -4,7 +4,7 @@
         <title>CSS Test: A flex container with the 'align-items' property set to 'stretch'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
         <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line." />

--- a/css/css-flexbox-1/align-self-001.html
+++ b/css/css-flexbox-1/align-self-001.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'flex-start' aligns the flex items to the start edge of cross axis">

--- a/css/css-flexbox-1/align-self-002.html
+++ b/css/css-flexbox-1/align-self-002.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'flex-end' aligns the flex items to the end edge of cross axis">

--- a/css/css-flexbox-1/align-self-003.html
+++ b/css/css-flexbox-1/align-self-003.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'center' centered the flex items in the cross axis within the line">

--- a/css/css-flexbox-1/align-self-004.html
+++ b/css/css-flexbox-1/align-self-004.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'stretch' makes the cross size of the item's margin box

--- a/css/css-flexbox-1/align-self-005.html
+++ b/css/css-flexbox-1/align-self-005.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'stretch' will be invalid while cross size of the flex item set exact number">

--- a/css/css-flexbox-1/align-self-006.html
+++ b/css/css-flexbox-1/align-self-006.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'baseline' aligns the flex items to the baseline of content">
 <style>

--- a/css/css-flexbox-1/align-self-007.html
+++ b/css/css-flexbox-1/align-self-007.html
@@ -4,8 +4,8 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'auto' aligns flex items to start edge of cross-axis when 'align-items' set 'flex-start'">

--- a/css/css-flexbox-1/align-self-008.html
+++ b/css/css-flexbox-1/align-self-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'auto' aligns flex items to end edge of cross-axis when 'align-items' set 'flex-end'">

--- a/css/css-flexbox-1/align-self-009.html
+++ b/css/css-flexbox-1/align-self-009.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'auto' will center flex items the flex items in the cross axis when 'align-items' set 'center'">

--- a/css/css-flexbox-1/align-self-010.html
+++ b/css/css-flexbox-1/align-self-010.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'auto' aligns the flex items to the baseline of content when 'align-items' set 'baseline'">
 <style>

--- a/css/css-flexbox-1/align-self-011.html
+++ b/css/css-flexbox-1/align-self-011.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property set 'auto' makes the cross size of the item's margin box

--- a/css/css-flexbox-1/align-self-012.html
+++ b/css/css-flexbox-1/align-self-012.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The initial value of 'align-self' property is 'auto'">

--- a/css/css-flexbox-1/align-self-013.html
+++ b/css/css-flexbox-1/align-self-013.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" title="8.3. Cross-axis Alignment: the 'align-items' and 'align-self' properties">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self" />
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property" />
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'align-self' property is invalid if applied to flex container">

--- a/css/css-flexbox-1/css-box-justify-content.html
+++ b/css/css-flexbox-1/css-box-justify-content.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <title>flexbox |css-box-justify-content</title>
 <link rel="author" href="mailto:ava656094@gmail.com" title="xiaoxia">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="reference/css-box-justify-content-ref.html">
 <style>
 #flexbox {

--- a/css/css-flexbox-1/css-flexbox-column-reverse-wrap-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-column-reverse-wrap-reverse.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column wrap-reverse, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-column-reverse-wrap.html
+++ b/css/css-flexbox-1/css-flexbox-column-reverse-wrap.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column wrap, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-column-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-column-reverse.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-column-wrap-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-column-wrap-reverse.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column wrap-reverse, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-column-wrap.html
+++ b/css/css-flexbox-1/css-flexbox-column-wrap.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column wrap, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-column.html
+++ b/css/css-flexbox-1/css-flexbox-column.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>CSS Flexbox Test: flex direction: row</title>
     <link rel="author" title="Naoki Okada" href="mailto:somathor@gmail.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <link rel="match" href="css-flexbox-column-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="Test checks that when writing mode is vertical and flex-flow: column, the flex container is vertical.">

--- a/css/css-flexbox-1/css-flexbox-height-animation-stretch.html
+++ b/css/css-flexbox-1/css-flexbox-height-animation-stretch.html
@@ -3,7 +3,7 @@
 <head>
 	<title>CSS Flexbox Test: Items stretch correctly while content is animating</title>
 	<link rel="author" title="Micky Brunetti" href="mailto:micky2be@gmail.com">
-	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 	<link rel="match" href="css-flexbox-height-animation-stretch-ref.html"/>
 	<meta name="flags" content="">
 	<meta name="assert" content="Items should stretch vertically in all time">

--- a/css/css-flexbox-1/css-flexbox-img-expand-evenly.html
+++ b/css/css-flexbox-1/css-flexbox-img-expand-evenly.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Eiji Kitamura" href="mailto:agektmr@gmail.com">
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="reference/css-flexbox-img-expand-evenly-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row-reverse-wrap-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-row-reverse-wrap-reverse.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row-reverse-wrap.html
+++ b/css/css-flexbox-1/css-flexbox-row-reverse-wrap.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-row-reverse.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row-wrap-reverse.html
+++ b/css/css-flexbox-1/css-flexbox-row-wrap-reverse.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row-wrap.html
+++ b/css/css-flexbox-1/css-flexbox-row-wrap.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-row.html
+++ b/css/css-flexbox-1/css-flexbox-row.html
@@ -7,8 +7,8 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
-    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
+    <link rel="help" href="http://www.w3.org/TR/css-writing-modes-3/#block-flow">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-row-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/css-flexbox-test1.html
+++ b/css/css-flexbox-1/css-flexbox-test1.html
@@ -7,7 +7,7 @@
     <link rel="reviewer" title="Elika J Etemad" href="http://fantasai.inkedblade.net/contact" />
     <!-- You must have at least one spec link, but may have as many as are covered in the test. -->
     <!-- Be sure to make the main testing area first in the order -->
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
     <!-- The match link is only required if this is a reftest -->
     <link rel="match" href="css-flexbox-test1-ref.html">
     <meta name="flags" content="">

--- a/css/css-flexbox-1/flex-basis-001.html
+++ b/css/css-flexbox-1/flex-basis-001.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - positive number</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set positive number, the actual value of test element size is same as the positive number">

--- a/css/css-flexbox-1/flex-basis-002.html
+++ b/css/css-flexbox-1/flex-basis-002.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - positive number</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property specified correct value, the actual value of test element size is same as to the value of 'flex-basis' property, and the 'width' property is invalid.">

--- a/css/css-flexbox-1/flex-basis-003.html
+++ b/css/css-flexbox-1/flex-basis-003.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - negative number(width not specified)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set negative number, the tested element is not shown when width not set either.">

--- a/css/css-flexbox-1/flex-basis-004.html
+++ b/css/css-flexbox-1/flex-basis-004.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - negative number(width specified)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set negative number, the actual width of tested element is

--- a/css/css-flexbox-1/flex-basis-005.html
+++ b/css/css-flexbox-1/flex-basis-005.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - 0</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set '0', the actual width of tested element is same as 0.">

--- a/css/css-flexbox-1/flex-basis-006.html
+++ b/css/css-flexbox-1/flex-basis-006.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - 0%</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set '0%', the actual width of tested element is same as 0.">

--- a/css/css-flexbox-1/flex-basis-007.html
+++ b/css/css-flexbox-1/flex-basis-007.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - auto</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set 'auto', the actual width of tested element same as the value which specified by width property.">

--- a/css/css-flexbox-1/flex-basis-008.html
+++ b/css/css-flexbox-1/flex-basis-008.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-basis - 50%</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Intel" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+<link rel="help" title="7.3.3. The 'flex-basis' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-basis' property set positive percentage, the actual width of tested element same as the percentage of flex container size.">

--- a/css/css-flexbox-1/flex-box-wrap.html
+++ b/css/css-flexbox-1/flex-box-wrap.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Flexbox Test: flex-wrap: wrap</title>
     <link rel="author" title="Tsuyoshi Tokuda" href="mailto:tokuda109@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
     <link rel="match" href="reference/flex-box-wrap-ref.html">
     <meta name="flags" content="">
     <meta name="assert" content="the test passes if you see green box.">

--- a/css/css-flexbox-1/flex-flow-001.html
+++ b/css/css-flexbox-1/flex-flow-001.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row nowrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-001-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row nowrap' controls the flex container is single-line">

--- a/css/css-flexbox-1/flex-flow-002.html
+++ b/css/css-flexbox-1/flex-flow-002.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row wrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row wrap' controls the flex container is multi-line">

--- a/css/css-flexbox-1/flex-flow-003.html
+++ b/css/css-flexbox-1/flex-flow-003.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row wrap-reverse</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row wrap-reverse' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-004.html
+++ b/css/css-flexbox-1/flex-flow-004.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row-reverse nowrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-001-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row-reverse nowrap' controls the flex container is single-line,

--- a/css/css-flexbox-1/flex-flow-005.html
+++ b/css/css-flexbox-1/flex-flow-005.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row-reverse wrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row-reverse wrap' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-006.html
+++ b/css/css-flexbox-1/flex-flow-006.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - row-reverse wrap-reverse</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'row-reverse wrap-reverse' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-007.html
+++ b/css/css-flexbox-1/flex-flow-007.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column nowrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-007-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column nowrap' controls the flex container is single-line,

--- a/css/css-flexbox-1/flex-flow-008.html
+++ b/css/css-flexbox-1/flex-flow-008.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column wrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column wrap' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-009.html
+++ b/css/css-flexbox-1/flex-flow-009.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column wrap-reverse</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column wrap-reverse' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-010.html
+++ b/css/css-flexbox-1/flex-flow-010.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column-reverse nowrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-007-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column-reverse nowrap' controls the flex container is single-line,

--- a/css/css-flexbox-1/flex-flow-011.html
+++ b/css/css-flexbox-1/flex-flow-011.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column-reverse wrap</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column-reverse wrap' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-flow-012.html
+++ b/css/css-flexbox-1/flex-flow-012.html
@@ -3,9 +3,9 @@
 <title>CSS Flexbox Test: flex-flow - column-reverse wrap-reverse</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" title="5.3. Flex Direction and Wrap: the 'flex-flow' shorthand" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flex-flow-002-ref.html">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-flow' property set 'column-reverse wrap-reverse' controls the flex container is multi-line

--- a/css/css-flexbox-1/flex-grow-001.xht
+++ b/css/css-flexbox-1/flex-grow-001.xht
@@ -3,7 +3,7 @@
  <head>
   <title>CSS Test: Flex-grow Property of Block-level Flex Items</title>
   <link rel="author" title="Hanrui Gao" href="mailto:hanrui.gao@gmail.com"/>
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow"/>
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property"/>
   <link rel="match" href="flex-grow-001-ref.xht"/>
   <meta name="flags" content="" />
   <meta name="assert" content="'flex-grow' property specifies the flex grow factor, which determines how much the flex item will grow relative to the rest of the flex items in the flex container when positive free space is distributed." />

--- a/css/css-flexbox-1/flex-grow-002.html
+++ b/css/css-flexbox-1/flex-grow-002.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-grow - 0(initial value)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-grow' property initial value is '0', the flex item will keep the width when 'flex-grow' set '0'">

--- a/css/css-flexbox-1/flex-grow-003.html
+++ b/css/css-flexbox-1/flex-grow-003.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-grow - negative number</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-grow' property set negative number, the flex item will not grow.">

--- a/css/css-flexbox-1/flex-grow-004.html
+++ b/css/css-flexbox-1/flex-grow-004.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-grow - (invalid when no space distributed)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-grow' property is invalid when the flex container has no space distributed.">

--- a/css/css-flexbox-1/flex-grow-005.html
+++ b/css/css-flexbox-1/flex-grow-005.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-grow - (invalid when applied to flex container)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The 'flex-grow' property is invalid when the property applied to flex container.">

--- a/css/css-flexbox-1/flex-grow-006.html
+++ b/css/css-flexbox-1/flex-grow-006.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-grow - positive number(fill all space)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="Test checks that all space of flex container will be filled when there is only one flex item and 'flex-grow' set any positive number.">

--- a/css/css-flexbox-1/flex-grow-007.html
+++ b/css/css-flexbox-1/flex-grow-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Flexbox Test: flex-grow - less than one</title>
 <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com">
-<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" title="7.3.1. The 'flex-grow' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="Test checks that remaining free space is calculated from 'flex-grow' set to positive number less than one.">

--- a/css/css-flexbox-1/flex-lines/multi-line-wrap-reverse-column-reverse.html
+++ b/css/css-flexbox-1/flex-lines/multi-line-wrap-reverse-column-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container multiline wrapping-reverse in column-reverse direction.</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="match" href="multi-line-wrap-reverse-column-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container reverse-wraps blocks multiline in column-reverse direction.">

--- a/css/css-flexbox-1/flex-lines/multi-line-wrap-reverse-row-reverse.html
+++ b/css/css-flexbox-1/flex-lines/multi-line-wrap-reverse-row-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container multiline wrapping-reverse in row-reverse direction.</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="match" href="multi-line-wrap-reverse-row-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container reverse-wraps blocks multiline in row-reverse direction.">

--- a/css/css-flexbox-1/flex-lines/multi-line-wrap-with-column-reverse.html
+++ b/css/css-flexbox-1/flex-lines/multi-line-wrap-with-column-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container multiline wrapping in column-reverse direction</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="match" href="multi-line-wrap-with-column-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container wraps blocks multiline in column-reverse direction.">

--- a/css/css-flexbox-1/flex-lines/multi-line-wrap-with-row-reverse.html
+++ b/css/css-flexbox-1/flex-lines/multi-line-wrap-with-row-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container multiline wrapping in row-reverse direction</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction-property">
   <link rel="match" href="multi-line-wrap-with-row-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container wraps blocks multiline in row-reverse direction.">

--- a/css/css-flexbox-1/flex-margin-no-collapse.html
+++ b/css/css-flexbox-1/flex-margin-no-collapse.html
@@ -3,7 +3,7 @@
 <head>
 	<title>CSS Flexible Box Test: flex item margins</title>
 	<link rel="author" title="Ping Huang" href="mailto:phuangce@gmail.com" />
-	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction">
+	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property-direction">
 	<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#item-margins">
 	<link rel="match" href="reference/flex-margin-no-collapse-ref.html">
 	<meta name="assert" content="The vertical gap between two green boxs should be 100px." />

--- a/css/css-flexbox-1/flex-shrink-001.html
+++ b/css/css-flexbox-1/flex-shrink-001.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - number(positive)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property set positive number determines how much the flex item will shrink relative to the rest of the flex items in the flex container when negative free space is distributed">

--- a/css/css-flexbox-1/flex-shrink-002.html
+++ b/css/css-flexbox-1/flex-shrink-002.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - number(negative)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property set negative is invalid to shrink flex items when negative free space is distributed">

--- a/css/css-flexbox-1/flex-shrink-003.html
+++ b/css/css-flexbox-1/flex-shrink-003.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - 1(initial value)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property initial value is 1">

--- a/css/css-flexbox-1/flex-shrink-004.html
+++ b/css/css-flexbox-1/flex-shrink-004.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - number(flex container has enough space)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property is invalid when flex container has enough space to load flex items">

--- a/css/css-flexbox-1/flex-shrink-005.html
+++ b/css/css-flexbox-1/flex-shrink-005.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - 0</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property set 0 will ignore the flex container">

--- a/css/css-flexbox-1/flex-shrink-006.html
+++ b/css/css-flexbox-1/flex-shrink-006.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - 0(one of flex-shrinks sets 0, another not)</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex item whose flex-shrink property of set 0 will displayed on the top of all flex items">

--- a/css/css-flexbox-1/flex-shrink-007.html
+++ b/css/css-flexbox-1/flex-shrink-007.html
@@ -3,7 +3,7 @@
 <title>CSS Flexbox Test: flex-shrink - applied to flex container</title>
 <link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="author" title="Shiyou Tan" href="mailto:shiyoux.tan@intel.com">
-<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.2. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="The flex-shrink property applied to flex container is invalid, all flex items will use the default value 1">

--- a/css/css-flexbox-1/flex-shrink-008.html
+++ b/css/css-flexbox-1/flex-shrink-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Flexbox Test: flex-shrink - less than one</title>
 <link rel="author" title="Geoffrey Sneddon" href="mailto:me@gsnedders.com">
-<link rel="help" title="7.3.1. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" title="7.3.1. The 'flex-shrink' property" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
 <meta name="flags" content="">
 <meta name="assert" content="Test checks that remaining free space is calculated from 'flex-shrink' set to positive number less than one.">

--- a/css/css-flexbox-1/flex-wrap-001.htm
+++ b/css/css-flexbox-1/flex-wrap-001.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with 'flex-flow' set to 'wrap'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex container with 'flex-flow: wrap' is a multi-line flex container." />
         <style type="text/css">

--- a/css/css-flexbox-1/flex-wrap_nowrap.html
+++ b/css/css-flexbox-1/flex-wrap_nowrap.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: flex-wrap_nowrap</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property" />
     <link rel="stylesheet" href="support/test-style.css">
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can identify the flex-wrap value nowrap." />

--- a/css/css-flexbox-1/flex-wrap_wrap-reverse.html
+++ b/css/css-flexbox-1/flex-wrap_wrap-reverse.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: flex-wrap_wrap-reverse</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property" />
     <link rel="stylesheet" href="support/test-style.css">
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can identify the flex-wrap value wrap-reverse." />

--- a/css/css-flexbox-1/flex-wrap_wrap.html
+++ b/css/css-flexbox-1/flex-wrap_wrap.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: flex-wrap_wrap</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property" />
     <link rel="stylesheet" href="support/test-style.css">
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the display can recognize inline-flex value." />

--- a/css/css-flexbox-1/flexbox-flex-wrap-default.htm
+++ b/css/css-flexbox-1/flexbox-flex-wrap-default.htm
@@ -4,7 +4,7 @@
 		<title>CSS Flexbox Test: Flex-wrap defaults to nowrap</title>
 		<link rel="author" title="Gavin Elster" href="mailto:gavin.elster@me.com">
 		<link rel="reviewer" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
-		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 		<link rel="match" href="reference/flexbox-flex-wrap-nowrap-ref.htm" />
 		<meta name="flags" content="">
 		<meta name="assert" content="Test checks that flex elements default to flex-wrap: nowrap if flex-wrap is not set. With wrapping disabled, the .green flex item should extend outside the bounds of its container, as it is set to flex:none.">

--- a/css/css-flexbox-1/flexbox-flex-wrap-flexing.html
+++ b/css/css-flexbox-1/flexbox-flex-wrap-flexing.html
@@ -8,7 +8,7 @@
     <meta name="flags" content="">
     <link rel="match" href="flexbox-flex-wrap-flexing-ref.html"/>
     <meta name="assert" content="Flex items given more space after line breaking should flex wider">
-    <meta name="assert" content="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+    <meta name="assert" content="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
     <meta name="assert" content="http://www.w3.org/TR/css-flexbox-1/#flex-property">
     <style>
         .container {

--- a/css/css-flexbox-1/flexbox-flex-wrap-nowrap.htm
+++ b/css/css-flexbox-1/flexbox-flex-wrap-nowrap.htm
@@ -4,7 +4,7 @@
 		<title>CSS Flexbox Test: Flex-wrap = nowrap</title>
 		<link rel="author" title="Gavin Elster" href="mailto:gavin.elster@me.com">
 		<link rel="reviewer" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
-		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 		<link rel="match" href="reference/flexbox-flex-wrap-nowrap-ref.htm" />
 		<meta name="flags" content="">
 		<meta name="assert" content="Test checks that flex elements set to flex-wrap: nowrap will not wrap their flex items. With wrapping disabled, the .green flex item should extend outside the bounds of its container, as it is set to flex:none.">

--- a/css/css-flexbox-1/flexbox-flex-wrap-wrap-reverse.htm
+++ b/css/css-flexbox-1/flexbox-flex-wrap-wrap-reverse.htm
@@ -4,7 +4,7 @@
 		<title>CSS Flexbox Test: Flex-wrap = wrap-reverse</title>
 		<link rel="author" title="Gavin Elster" href="mailto:gavin.elster@me.com">
 		<link rel="reviewer" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
-		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 		<link rel="match" href="reference/flexbox-flex-direction-ref.htm" />
 		<meta name="flags" content="">
 		<meta name="assert" content="Test checks that flex elements wrap left-to-right and bottom-to-top within their flex container when flex-wrap = 'wrap-reverse'. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">

--- a/css/css-flexbox-1/flexbox-flex-wrap-wrap.htm
+++ b/css/css-flexbox-1/flexbox-flex-wrap-wrap.htm
@@ -4,7 +4,7 @@
 		<title>CSS Flexbox Test: Flex-wrap = wrap</title>
 		<link rel="author" title="Gavin Elster" href="mailto:gavin.elster@me.com">
 		<link rel="reviewer" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact">
-		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+		<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 		<link rel="match" href="reference/flexbox-flex-direction-ref.htm" />
 		<meta name="flags" content="">
 		<meta name="assert" content="Test checks that flex elements wrap left-to-right within their flex container when flex-wrap = 'wrap', matching the writing direction. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">

--- a/css/css-flexbox-1/flexbox-order-from-lowest.html
+++ b/css/css-flexbox-1/flexbox-order-from-lowest.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container layout starts with lowest order item</title>
   <link rel="author" title="Sylvain Galineau" href="mailto:galineau@adobe.com">
   <link rel="reviewer" title="Arron Eicholz" href="mailto:arronei@microsoft.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
   <meta name="flags" content="">
   <meta name="assert" content="This test check that a flex container layous out its content starting with the lowest numbered ordinal group and going up">
   <style>

--- a/css/css-flexbox-1/flexbox-order-only-flexitems.html
+++ b/css/css-flexbox-1/flexbox-order-only-flexitems.html
@@ -4,7 +4,7 @@
   <title>CSS Test: order only affects flex items</title>
   <link rel="author" title="Sylvain Galineau" href="mailto:galineau@adobe.com">
   <link rel="reviewer" title="Arron Eicholz" href="mailto:arronei@microsoft.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
   <meta name="flags" content="">
   <meta name="assert" content="This test check that the order property has no effect on elements that are not flex items">
   <style>

--- a/css/css-flexbox-1/flexbox_align-items-baseline.html
+++ b/css/css-flexbox-1/flexbox_align-items-baseline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: baseline</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-baseline-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-center-2.html
+++ b/css/css-flexbox-1/flexbox_align-items-center-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-center-2-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-center.html
+++ b/css/css-flexbox-1/flexbox_align-items-center.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-center-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-flexend-2.html
+++ b/css/css-flexbox-1/flexbox_align-items-flexend-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-flexend-2-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-flexend.html
+++ b/css/css-flexbox-1/flexbox_align-items-flexend.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-flexend-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-flexstart-2.html
+++ b/css/css-flexbox-1/flexbox_align-items-flexstart-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-flexstart-2-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-flexstart.html
+++ b/css/css-flexbox-1/flexbox_align-items-flexstart.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-flexstart-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-stretch-2.html
+++ b/css/css-flexbox-1/flexbox_align-items-stretch-2.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: stretch</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-stretch-2-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-items-stretch.html
+++ b/css/css-flexbox-1/flexbox_align-items-stretch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-items: stretch</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-items-stretch-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-auto.html
+++ b/css/css-flexbox-1/flexbox_align-self-auto.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: auto</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-auto-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-baseline.html
+++ b/css/css-flexbox-1/flexbox_align-self-baseline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: baseline</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-baseline-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-center.html
+++ b/css/css-flexbox-1/flexbox_align-self-center.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-center-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-flexend.html
+++ b/css/css-flexbox-1/flexbox_align-self-flexend.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-flexend-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-flexstart.html
+++ b/css/css-flexbox-1/flexbox_align-self-flexstart.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-flexstart-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_align-self-stretch.html
+++ b/css/css-flexbox-1/flexbox_align-self-stretch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | align-self: stretch</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <link rel="match" href="flexbox_align-self-stretch-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flex-natural-variable-zero-basis.html
+++ b/css/css-flexbox-1/flexbox_flex-natural-variable-zero-basis.html
@@ -2,7 +2,7 @@
 <title>flexbox | flex: larger integer, zero basis</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-basis">
+	href="http://www.w3.org/TR/css-flexbox-1/#flex-basis-property">
 <link rel="match" href="flexbox_flex-natural-variable-zero-basis-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-column-reverse-wrap-reverse.html
+++ b/css/css-flexbox-1/flexbox_flow-column-reverse-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-column-reverse-wrap-reverse-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-column-reverse-wrap.html
+++ b/css/css-flexbox-1/flexbox_flow-column-reverse-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-column-reverse-wrap-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-column-wrap-reverse.html
+++ b/css/css-flexbox-1/flexbox_flow-column-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-column-wrap-reverse-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-column-wrap.html
+++ b/css/css-flexbox-1/flexbox_flow-column-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-column-wrap-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-row-wrap-reverse.html
+++ b/css/css-flexbox-1/flexbox_flow-row-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: row wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-row-wrap-reverse-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_flow-row-wrap.html
+++ b/css/css-flexbox-1/flexbox_flow-row-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: row wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="match" href="flexbox_flow-row-wrap-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-center-overflow.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-center-overflow.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: center / overflow</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-center-overflow-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-center.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-center.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-center-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-flex-end.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-flex-end.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-flex-end-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-flex-start.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-flex-start.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-flex-start-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacearound-negative.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacearound-negative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | justify-content: space-around / negative</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacearound-negative-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacearound-only.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacearound-only.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: space-around | single item</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacearound-only-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacearound.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacearound.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: space-around</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacearound-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacebetween-negative.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacebetween-negative.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: space-between / negative</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacebetween-negative-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacebetween-only.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacebetween-only.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: space-between | single item</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacebetween-only-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_justifycontent-spacebetween.html
+++ b/css/css-flexbox-1/flexbox_justifycontent-spacebetween.html
@@ -2,7 +2,7 @@
 <title>flexbox | justify-content: space-between</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_justifycontent-spacebetween-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_object.html
+++ b/css/css-flexbox-1/flexbox_object.html
@@ -2,7 +2,7 @@
 <title>flexbox | object fallback as a flex item</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_object-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_order-abspos-space-around.html
+++ b/css/css-flexbox-1/flexbox_order-abspos-space-around.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | order; justify-content: space-around</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <link rel="match" href="flexbox_order-abspos-space-around-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_order-box.html
+++ b/css/css-flexbox-1/flexbox_order-box.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap-reverse; order</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <link rel="match" href="flexbox_order-box-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_order-noninteger-invalid.html
+++ b/css/css-flexbox-1/flexbox_order-noninteger-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap-reverse; order</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <link rel="match" href="flexbox_empty-ref.html">
 <link rel="flags" content="invalid">
 <style>

--- a/css/css-flexbox-1/flexbox_order.html
+++ b/css/css-flexbox-1/flexbox_order.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap-reverse; order</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <link rel="match" href="flexbox_order-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_rowspan.html
+++ b/css/css-flexbox-1/flexbox_rowspan.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flexcontainers in cells with rowspan</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flexbox_rowspan-ref.html">
 <style>
 table {

--- a/css/css-flexbox-1/flexbox_rtl-flow-reverse.html
+++ b/css/css-flexbox-1/flexbox_rtl-flow-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column wrap-reverse | rtl</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <link rel="match" href="flexbox_rtl-flow-reverse-ref.html">

--- a/css/css-flexbox-1/flexbox_rtl-flow.html
+++ b/css/css-flexbox-1/flexbox_rtl-flow.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column wrap | rtl</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <link rel="match" href="flexbox_rtl-flow-ref.html">

--- a/css/css-flexbox-1/flexbox_rtl-order.html
+++ b/css/css-flexbox-1/flexbox_rtl-order.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | flex-flow: column-reverse wrap-reverse; order | rtl</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <link rel="match" href="flexbox_rtl-order-ref.html">

--- a/css/css-flexbox-1/flexbox_width-overflow.html
+++ b/css/css-flexbox-1/flexbox_width-overflow.html
@@ -2,7 +2,7 @@
 <title>flexbox | overflow</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+	href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <link rel="match" href="flexbox_empty-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_wrap-long.html
+++ b/css/css-flexbox-1/flexbox_wrap-long.html
@@ -2,7 +2,7 @@
 <title>flexbox | flex-wrap: wrap / long items</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+	href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flexbox_wrap-long-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_wrap-reverse.html
+++ b/css/css-flexbox-1/flexbox_wrap-reverse.html
@@ -2,7 +2,7 @@
 <title>flexbox | flex-wrap: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+	href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flexbox_wrap-reverse-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/flexbox_wrap.html
+++ b/css/css-flexbox-1/flexbox_wrap.html
@@ -2,7 +2,7 @@
 <title>flexbox | flex-wrap: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help"
-	href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+	href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <link rel="match" href="flexbox_wrap-ref.html">
 <style>
 div {

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-baseline.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-baseline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: baseline</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-center.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-center.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-flex-end.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-flex-end.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-flex-start.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-flex-start.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: invalid</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-stretch.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-items-stretch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-items: stretch</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-items">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-baseline.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-baseline.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: baseline</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-center.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-center.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-flex-end.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-flex-end.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-flex-start.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-flex-start.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: invalid</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-stretch.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_align-self-stretch.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | align-self: stretch</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-align-self">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#align-items-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column-reverse nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column-reverse wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column-reverse">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-column.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: column</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-column">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row-reverse nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-nowrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row-reverse wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row-reverse wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row-reverse">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap-reverse">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <script src="/resources/testharness.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-row.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: row</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-direction-row">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-flow-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-flow: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-flow-property">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#valdef-flex-wrap-wrap">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-0.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-0.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-grow: 0</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-grow: negative</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-number.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-grow-number.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-grow: number</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-0-auto.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-0-auto.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: 0 auto</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-auto.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-auto.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: auto</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-initial.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-initial.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: initial</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: invalid</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-none.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-none.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: auto</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-number.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand-number.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: number</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shorthand.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex: invalid</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-0.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-0.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-shrink: 0</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-shrink: negative</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-number.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-shrink-number.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-shrink: number</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-wrap: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-nowrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-nowrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-wrap: nowrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-wrap-reverse.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-wrap-reverse.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-wrap: wrap-reverse</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-wrap.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_flex-wrap-wrap.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | flex-wrap: wrap</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-center.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-center.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | justify-content: center</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-flex-end.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-flex-end.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | justify-content: flex-end</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-flex-start.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-flex-start.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | justify-content: flex-start</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-space-around.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-space-around.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | justify-content: space-around</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-space-between.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_justify-content-space-between.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | justify-content: space-between</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-inherit.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-inherit.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | order: -1</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-integer.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-integer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | order: integer</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-invalid.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | order: noninteger</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-negative.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order-negative.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | order: -1</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order.html
+++ b/css/css-flexbox-1/getcomputedstyle/flexbox_computedstyle_order.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | computed style | order: 0</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <meta name="flags" content="dom">

--- a/css/css-flexbox-1/interactive/flexbox_interactive_flex-grow-transitions.html
+++ b/css/css-flexbox-1/interactive/flexbox_interactive_flex-grow-transitions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | transitioned flex-grow</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-grow">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-grow-property">
 <meta name="flags" content="interact">
 <style>
 div {

--- a/css/css-flexbox-1/interactive/flexbox_interactive_flex-shrink-transitions-invalid.html
+++ b/css/css-flexbox-1/interactive/flexbox_interactive_flex-shrink-transitions-invalid.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | invalid flex-shrink transition</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <meta name="flags" content="interact">
 <style>
 div {

--- a/css/css-flexbox-1/interactive/flexbox_interactive_flex-shrink-transitions.html
+++ b/css/css-flexbox-1/interactive/flexbox_interactive_flex-shrink-transitions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>flexbox | transitioned flex-shrink</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink">
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-shrink-property">
 <meta name="flags" content="interact">
 <style>
 div {

--- a/css/css-flexbox-1/justify-content-001.htm
+++ b/css/css-flexbox-1/justify-content-001.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with 'justify-content' property set to 'center'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line." />

--- a/css/css-flexbox-1/justify-content-002.htm
+++ b/css/css-flexbox-1/justify-content-002.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with the 'justify-content' property set to 'flex-start'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line." />

--- a/css/css-flexbox-1/justify-content-003.htm
+++ b/css/css-flexbox-1/justify-content-003.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with the 'justify-content' property set to 'flex-end'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line." />

--- a/css/css-flexbox-1/justify-content-004.htm
+++ b/css/css-flexbox-1/justify-content-004.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with the 'justify-content' property set to 'space-between'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line." />

--- a/css/css-flexbox-1/justify-content-005.htm
+++ b/css/css-flexbox-1/justify-content-005.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: A flex container with the 'justify-content' property set to 'space-around'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
         <link rel="match" href="reference/justify-content-001-ref.html">
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line, with half-size spaces on either end." />

--- a/css/css-flexbox-1/justify-content_center.html
+++ b/css/css-flexbox-1/justify-content_center.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: justify-content_center</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can identify the justify-content value center." />
     <style>

--- a/css/css-flexbox-1/justify-content_flex-end.html
+++ b/css/css-flexbox-1/justify-content_flex-end.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: justify-content_flex-end</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can indentify the justify-content value flex-end." />
     <style>

--- a/css/css-flexbox-1/justify-content_flex-start.html
+++ b/css/css-flexbox-1/justify-content_flex-start.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: justify-content_flex-start</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can indentify the justify-content value flex-start." />
     <style>

--- a/css/css-flexbox-1/justify-content_space-around.html
+++ b/css/css-flexbox-1/justify-content_space-around.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: justify-content_space-around</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can indentify the justy-content value space-around." />
     <style>

--- a/css/css-flexbox-1/justify-content_space-between.html
+++ b/css/css-flexbox-1/justify-content_space-between.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: justify-content_space-between</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-justify-content" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#justify-content-property" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can indentify the justify-content value space-between." />
     <style>

--- a/css/css-flexbox-1/order-001.htm
+++ b/css/css-flexbox-1/order-001.htm
@@ -3,7 +3,7 @@
     <head>
         <title>CSS Test: The 'order' property on flex items set to a value of '-1'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order" />
+        <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that a flex container will lay out its content in the order specified by the ordinal groups." />
         <style type="text/css">

--- a/css/css-flexbox-1/order/order-with-column-reverse.html
+++ b/css/css-flexbox-1/order/order-with-column-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container layout lowest order with column-reverse direction</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins" href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
   <link rel="match" href="order-with-column-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with column-reverse direction.">
   <style>

--- a/css/css-flexbox-1/order/order-with-row-reverse.html
+++ b/css/css-flexbox-1/order/order-with-row-reverse.html
@@ -4,7 +4,7 @@
   <title>CSS Test: flex container layout lowest order with row-reverse direction</title>
   <link rel="author" title="tmtysk" href="mailto:tmtysk@gmail.com">
   <link rel="reviewer" title="Tab Atkins, Jr." href="mailto:jackalmage@gmail.com">
-  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+  <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
   <meta name="flags" content="">
   <link rel="match" href="order-with-row-reverse-ref.html">
   <meta name="assert" content="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with row-reverse direction.">

--- a/css/css-flexbox-1/order_value.html
+++ b/css/css-flexbox-1/order_value.html
@@ -3,7 +3,7 @@
   <head>
     <title>CSS Flexible Box Test: order_check</title>
     <link rel="author" title="Intel" href="http://www.intel.com" />
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order" />
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property" />
     <link rel="stylesheet" href="support/test-style.css">
     <meta name="flags" content="" />
     <meta name="assert" content="Check if the web engine can indentify order property." />

--- a/css/css-flexbox-1/ttwf-reftest-flex-order.html
+++ b/css/css-flexbox-1/ttwf-reftest-flex-order.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Flexible Box Test: order proprety - value</title>
     <link rel="author" title="haosdent" href="mailto:haosdent@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-order">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#order-property">
     <link rel="match" href="reference/ttwf-reftest-flex-order-ref.html">
     <meta name="assert" content="Statement describing what the test case is asserting">
     <style type="text/css">

--- a/css/css-flexbox-1/ttwf-reftest-flex-wrap-reverse.html
+++ b/css/css-flexbox-1/ttwf-reftest-flex-wrap-reverse.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Flexible Box Test: flex-wrap proprety - wrap-reverse</title>
     <link rel="author" title="haosdent" href="mailto:haosdent@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
     <link rel="match" href="reference/ttwf-reftest-flex-wrap-reverse-ref.html">
     <meta name="assert" content="Statement describing what the test case is asserting">
     <style type="text/css">

--- a/css/css-flexbox-1/ttwf-reftest-flex-wrap.html
+++ b/css/css-flexbox-1/ttwf-reftest-flex-wrap.html
@@ -3,7 +3,7 @@
 <head>
     <title>CSS Flexible Box Test: flex-wrap proprety - wrap</title>
     <link rel="author" title="haosdent" href="mailto:haosdent@gmail.com">
-    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap">
+    <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-wrap-property">
     <link rel="match" href="reference/ttwf-reftest-flex-wrap-ref.html">
     <meta name="assert" content="Statement describing what the test case is asserting">
     <style type="text/css">


### PR DESCRIPTION
We discussed this on the last working [group call](https://log.csswg.org/irc.w3.org/css/2017-05-24/#e814132), as I'd like to make progress on the flex test suite to proceed to rec. Part of this is ensuring that tests that are categorized together should be linking to the same place. The only thing this does is change from using propdef-y to its related TOC link instead. I'm going to add the spec owners as reviewers so this can hopefully get merged in quickly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
