### PR TITLE
Add the 'cache' datatype.

### DIFF
--- a/clear-site-data/navigation.html
+++ b/clear-site-data/navigation.html
@@ -11,11 +11,16 @@
       /** Ensures that all datatypes are nonempty. */
       function populateDatatypes() {
         return Promise.all(TestUtils.DATATYPES.map(function(datatype) {
-          return datatype.add().then(datatype.isEmpty().then(function(isEmpty) {
-            assert_false(
-                isEmpty,
-                datatype.name + " has to be nonempty before the test starts.");
-          }));
+          return new Promise(function(resolve, reject) {
+            datatype.add().then(function() {
+              datatype.isEmpty().then(function(isEmpty) {
+                assert_false(
+                    isEmpty,
+                    datatype.name + " has to be nonempty before the test starts.");
+                resolve();
+              });
+            });
+          });
         }));
       }
 

--- a/clear-site-data/support/get-resource-to-cache.py
+++ b/clear-site-data/support/get-resource-to-cache.py
@@ -1,0 +1,14 @@
+# A support server that returns a resource to be cached for one year.
+#
+# However, if the request contains the "Cache-Control: only-if-cached;" header,
+# the server returns status code 500, since such a request should never have
+# reached it.
+def main(request, response):
+  if ("cache-control" in request._headers and
+      request._headers["cache-control"] == "only-if-cached"):
+    response.status = 500  # Internal server error.
+    return
+
+  return ([("Content-Type", "text/plain"),
+           ("Cache-Control", "max-age=31536000")],
+          "Resource to be cached for 365 days.")


### PR DESCRIPTION
- Add a `cache` datatype to `clear-site-data` datatypes
- `add()` is implemented as fetching a resource from a support server.
- `isEmpty()` is implemented as fetching the same resource with `Cache-Control: only-if-cached` plus special handling for user agents that do not support this header.
- Since this is the first datatype where the above two methods are asynchronous, it revealed a bug in `navigation.html` where the `add()` and `isEmpty()` Promises were executed in parallel rather than in sequence; this has been fixed

<!-- Reviewable:start -->

<!-- Reviewable:end -->
