### PR TITLE
[credential-management] Add omitted extended attr

### DIFF
--- a/credential-management/idl.https.html
+++ b/credential-management/idl.https.html
@@ -63,6 +63,7 @@
 
 </script>
 <script type="text/plain" id="tested">
+    [Exposed=Window, SecureContext]
     interface CredentialsContainer {
       Promise<Credential> get(optional CredentialRequestOptions options);
       Promise<Credential> store(Credential credential);


### PR DESCRIPTION
Insert extended attributes defined by the specification which were
previously omitted.

https://w3c.github.io/webappsec-credential-management/#framework-credential-management

<!-- Reviewable:start -->

<!-- Reviewable:end -->
