### PR TITLE
Fixes a handful of tests dealing with PaymentRequest constructor and …

### DIFF
--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -451,12 +451,12 @@ test(() => {
   const shippingOptions = [defaultShippingOption];
   const details = Object.assign({}, defaultDetails, { shippingOptions });
   const request = new PaymentRequest(defaultMethods, details);
-  assert_equals(request.shippingOption, "PASS", "selected option must PASS");
+  assert_equals(request.shippingOption, null, "request.shippingOption must be null");
 }, "If there is no selected shipping option, then PaymentRequest.shippingOption remains null");
 
 test(() => {
   const selectedOption = Object.assign({}, defaultShippingOption, {
-    select: true,
+    selected: true,
     id: "PASS",
   });
   const shippingOptions = [selectedOption];
@@ -467,15 +467,15 @@ test(() => {
 
 test(() => {
   const failOption1 = Object.assign({}, defaultShippingOption, {
-    select: true,
+    selected: true,
     id: "FAIL1",
   });
   const failOption2 = Object.assign({}, defaultShippingOption, {
-    select: false,
+    selected: false,
     id: "FAIL2",
   });
   const passOption = Object.assign({}, defaultShippingOption, {
-    select: true,
+    selected: true,
     id: "PASS",
   });
   const shippingOptions = [failOption1, failOption2, passOption];
@@ -486,10 +486,10 @@ test(() => {
 
 test(() => {
   const selectedOption = Object.assign({}, defaultShippingOption, {
-    select: true,
+    selected: true,
   });
   const unselectedOption = Object.assign({}, defaultShippingOption, {
-    select: false,
+    selected: false,
   });
   const shippingOptions = [selectedOption, unselectedOption];
   const details = Object.assign({}, defaultDetails, { shippingOptions });


### PR DESCRIPTION
…selected shipping options.

The first fix in the file addresses a test whose intent it to verify that there is no default shippingoption if none were selected, but the actual assert is testing for the wrong value. Looks like a previous copy & paste error.
The second set of fixes address tests that are attempting to set the option.select property which doesn't exist. According to the spec, they should be setting the option.selected property.


//CC @marcoscaceres

<!-- Reviewable:start -->

<!-- Reviewable:end -->
