### PR TITLE
Make ECDH derive_bits_keys tests run on Safari/Firefox and correct HK…

### DIFF
--- a/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_bits.js
@@ -200,6 +200,8 @@ function run_test() {
                                             false, ["deriveBits", "deriveKey"])
                             .then(function(key) {
                                 privateKeys[namedCurve] = key;
+                            }, function(key) {
+                                privateKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -209,6 +211,8 @@ function run_test() {
                                             false, ["deriveKey"])
                             .then(function(key) {
                                 noDeriveBitsKeys[namedCurve] = key;
+                            }, function(key) {
+                                noDeriveBitsKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -218,6 +222,8 @@ function run_test() {
                                             false, [])
                             .then(function(key) {
                                 publicKeys[namedCurve] = key;
+                            }, function(key) {
+                                publicKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -225,6 +231,8 @@ function run_test() {
             var operation = subtle.generateKey({name: "ECDSA", namedCurve: namedCurve}, false, ["sign", "verify"])
                             .then(function(keyPair) {
                                 ecdsaKeyPairs[namedCurve] = keyPair;
+                            }, function(key) {
+                                ecdsaKeyPairs[namedCurve] = undefined;
                             });
             promises.push(operation);
         });

--- a/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
+++ b/WebCryptoAPI/derive_bits_keys/ecdh_keys.js
@@ -169,6 +169,8 @@ function run_test() {
                                             false, ["deriveBits", "deriveKey"])
                             .then(function(key) {
                                 privateKeys[namedCurve] = key;
+                            }, function(key) {
+                                privateKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -178,6 +180,8 @@ function run_test() {
                                             false, ["deriveBits"])
                             .then(function(key) {
                                 noDeriveKeyKeys[namedCurve] = key;
+                            }, function(key) {
+                                noDeriveKeyKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -187,6 +191,8 @@ function run_test() {
                                             false, [])
                             .then(function(key) {
                                 publicKeys[namedCurve] = key;
+                            }, function(key) {
+                                publicKeys[namedCurve] = undefined;
                             });
             promises.push(operation);
         });
@@ -194,6 +200,8 @@ function run_test() {
             var operation = subtle.generateKey({name: "ECDSA", namedCurve: namedCurve}, false, ["sign", "verify"])
                             .then(function(keyPair) {
                                 ecdsaKeyPairs[namedCurve] = keyPair;
+                            }, function(key) {
+                                ecdsaKeyPairs[namedCurve] = undefined;
                             });
             promises.push(operation);
         });

--- a/WebCryptoAPI/derive_bits_keys/hkdf.js
+++ b/WebCryptoAPI/derive_bits_keys/hkdf.js
@@ -86,7 +86,7 @@ function run_test() {
                             // - illegal name for hash algorithm (NotSupportedError)
                             var badHash = hashName.substring(0, 3) + hashName.substring(4);
                             promise_test(function(test) {
-                                var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash};
+                                var badAlgorithm = {name: "HKDF", salt: salts[saltSize], info: infos[infoSize], hash: badHash};
                                 return subtle.deriveKey(badAlgorithm, baseKeys[derivedKeySize], derivedKeyType.algorithm, true, derivedKeyType.usages)
                                 .then(function(key) {
                                     assert_unreached("bad hash name should have thrown an NotSupportedError");
@@ -143,9 +143,9 @@ function run_test() {
                         promise_test(function(test) {
                             return subtle.deriveBits(algorithm, baseKeys[derivedKeySize], null)
                             .then(function(derivation) {
-                                assert_unreached("null length should have thrown an TypeError");
+                                assert_unreached("null length should have thrown an OperationError");
                             }, function(err) {
-                                assert_equals(err.name, "TypeError", "deriveBits with null length correctly threw OperationError: " + err.message);
+                                assert_equals(err.name, "OperationError", "deriveBits with null length correctly threw OperationError: " + err.message);
                             });
                         }, testName + " with null length");
 
@@ -162,7 +162,7 @@ function run_test() {
                         // - illegal name for hash algorithm (NotSupportedError)
                         var badHash = hashName.substring(0, 3) + hashName.substring(4);
                         promise_test(function(test) {
-                            var badAlgorithm = {name: "HKDF", salt: salts[saltSize], hash: badHash};
+                            var badAlgorithm = {name: "HKDF", salt: salts[saltSize], info: infos[infoSize], hash: badHash};
                             return subtle.deriveBits(badAlgorithm, baseKeys[derivedKeySize], 256)
                             .then(function(derivation) {
                                 assert_unreached("bad hash name should have thrown an NotSupportedError");


### PR DESCRIPTION
…DF derive_bits_keys tests

For ECDH tests, add rejection handlers for ECDH key generations such that tests can continue.

For HKDF, infos are missing for bad hash tests, and therefore TypeErrors will return instead of OperationErrors for those tests. Added infos. Also, for null length, HKDF should return OperationError instead of TypeError.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
