### PR TITLE
Add a check for update() called during the script evaluation

### DIFF
--- a/service-workers/service-worker/ServiceWorkerGlobalScope/resources/update-worker.js
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/resources/update-worker.js
@@ -22,4 +22,6 @@ self.addEventListener('message', function(e) {
   });
 
 // update() during the script evaluation should be ignored.
-self.registration.update();
+self.registration.update().catch(function(e) {
+    events_seen.push(e.name.toLowerCase());
+  });

--- a/service-workers/service-worker/ServiceWorkerGlobalScope/update.https.html
+++ b/service-workers/service-worker/ServiceWorkerGlobalScope/update.https.html
@@ -25,6 +25,7 @@ promise_test(function(t) {
       .then(function() { return with_iframe(scope); })
       .then(function(frame2) {
           var expected_events_seen = [
+            'invalidstateerror', // by update() during the script evaluation.
             'updatefound',  // by register().
             'activate',
             'fetch',


### PR DESCRIPTION
As per the spec, registration.update() should throw when called on a
service worker before the install completes. This is to prevent a
failing installing worker from continuously trying update jobs. This
patch adds a string that checks if the update() called during the script
evaluation throws an InvalidStateError.

Fixes https://github.com/w3c/ServiceWorker/issues/1155.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
