### PR TITLE
Add idlType.idlType to check whether an operation returns a Promise

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -78,7 +78,7 @@ function minOverloadLength(overloads)
 function throwOrReject(a_test, operation, fn, obj, args,  message, cb)
 //@{
 {
-    if (operation.idlType.generic !== "Promise") {
+    if (operation.idlType.idlType !== "Promise") {
         assert_throws(new TypeError(), function() {
             fn.apply(obj, args);
         }, message);
@@ -1293,7 +1293,7 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 format_value(member.name));
 
             if (!member.has_extended_attribute("LenientThis")) {
-                if (member.idlType.generic !== "Promise") {
+                if (member.idlType.idlType !== "Promise") {
                     assert_throws(new TypeError(), function() {
                         self[this.name].prototype[member.name];
                     }.bind(this), "getting property on prototype object must throw TypeError");
@@ -1930,7 +1930,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
         // attribute, then return undefined.
         // "Otherwise, throw a TypeError."
         if (!member.has_extended_attribute("LenientThis")) {
-            if (member.idlType.generic !== "Promise") {
+            if (member.idlType.idlType !== "Promise") {
                 assert_throws(new TypeError(), function() {
                     desc.get.call({});
                 }.bind(this), "calling getter on wrong object type must throw TypeError");

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -78,7 +78,8 @@ function minOverloadLength(overloads)
 function throwOrReject(a_test, operation, fn, obj, args,  message, cb)
 //@{
 {
-    if (operation.idlType.idlType !== "Promise") {
+    if (operation.idlType.generic !== "Promise" &&
+        operation.idlType.idlType !== "Promise" ) {
         assert_throws(new TypeError(), function() {
             fn.apply(obj, args);
         }, message);
@@ -1293,7 +1294,7 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 format_value(member.name));
 
             if (!member.has_extended_attribute("LenientThis")) {
-                if (member.idlType.idlType !== "Promise") {
+                if (member.idlType.generic !== "Promise") {
                     assert_throws(new TypeError(), function() {
                         self[this.name].prototype[member.name];
                     }.bind(this), "getting property on prototype object must throw TypeError");
@@ -1930,7 +1931,7 @@ IdlInterface.prototype.do_interface_attribute_asserts = function(obj, member, a_
         // attribute, then return undefined.
         // "Otherwise, throw a TypeError."
         if (!member.has_extended_attribute("LenientThis")) {
-            if (member.idlType.idlType !== "Promise") {
+            if (member.idlType.generic !== "Promise") {
                 assert_throws(new TypeError(), function() {
                     desc.get.call({});
                 }.bind(this), "calling getter on wrong object type must throw TypeError");


### PR DESCRIPTION
According to the source code of WebIDL2 (https://github.com/w3c/web-platform-tests/blob/master/resources/webidl2/lib/webidl2.js#L192), for a type ```Promise<Object>```, ```idlType.idlType``` should be ```Promise```, but ```idlType.generic``` is ```Object```. So in idlharness.js, idlType should be used to decide whether a ```promise_rejects()``` is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6133)
<!-- Reviewable:end -->
