### PR TITLE
[webdriver] Introduce `assert_same_element`

### DIFF
--- a/webdriver/elements/active.py
+++ b/webdriver/elements/active.py
@@ -1,7 +1,6 @@
 import pytest
-from webdriver.client import element_key
 
-from support.asserts import assert_error, assert_success, assert_dialog_handled
+from support.asserts import assert_error, assert_success, assert_dialog_handled, assert_same_element
 from support.fixtures import create_dialog
 from support.inline import inline
 
@@ -16,12 +15,8 @@ def assert_result_is_active_element(session, result):
 
     if result.body["value"] is None:
         assert from_js == None
-        return
-
-    assert isinstance(result.body["value"], dict)
-    assert element_key in result.body["value"]
-
-    assert result.body["value"][element_key] == from_js[element_key]
+    else:
+        assert_same_element(session, result.body["value"], from_js)
 
 # > 1. If the current browsing context is no longer open, return error with
 # >    error code no such window.

--- a/webdriver/support/asserts.py
+++ b/webdriver/support/asserts.py
@@ -1,3 +1,6 @@
+from webdriver.client import Element, element_key
+from webdriver.error import WebDriverException
+
 # WebDriver specification ID: dfn-error-response-data
 errors = {
     "element click intercepted": 400,
@@ -90,3 +93,27 @@ def assert_dialog_handled(session, expected_text):
         assert (result.status == 200 and
                 result.body["value"] != expected_text), (
                "Dialog with text '%s' was not handled." % expected_text)
+
+def assert_same_element(session, a, b):
+    """Verify that two element references describe the same element."""
+    assert isinstance(a, dict), "Actual value is not a dictionary"
+    assert isinstance(b, dict), "Expected value is not a dictionary"
+    assert element_key in a, "Actual value does not describe an element"
+    assert element_key in b, "Expected value does not describe an element"
+
+    if a[element_key] == b[element_key]:
+        return
+
+    message = ("Expected element references to describe the same element, " +
+        "but they did not.")
+
+    # Attempt to provide more information, accounting for possible errors such
+    # as stale element references or not visible elements.
+    try:
+        a_markup = session.execute_script("return arguments[0].outerHTML;", args=[a])
+        b_markup = session.execute_script("return arguments[0].outerHTML;", args=[b])
+        message += " Actual: `%s`. Expected: `%s`." % (a_markup, b_markup)
+    except WebDriverException:
+        pass
+
+    raise AssertionError(message)


### PR DESCRIPTION
@andreastt This seemed like something that will be helpful as we expand coverage to more element-related tests. It's just an ergonomics thing, but I should still ask: do you think it's too early to justify the complexity?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
