### PR TITLE
Fix basic-popup-and-iframe-tests.https.js to not depend on FileAPI issue 82

### DIFF
--- a/secure-contexts/basic-popup-and-iframe-tests.https.js
+++ b/secure-contexts/basic-popup-and-iframe-tests.https.js
@@ -73,7 +73,7 @@ const loadTypes = [
                eResultFromPostMessage),
   new LoadType("a blob: URI",
                eLoadInEverything,
-               URL.createObjectURL(new Blob(["<script>(opener||parent).postMessage(isSecureContext, '*')</script>"])),
+               URL.createObjectURL(new Blob(["<script>(opener||parent).postMessage(isSecureContext, '*')</script>"], {type: "text/html"})),
                eSecureIfCreatorSecure,
                eResultFromPostMessage),
   new LoadType("a srcdoc",


### PR DESCRIPTION
One of the subtests in basic-popup-and-iframe-tests.https.js checks that window.isSecureContext returns the correct result with respect to an iframe that loads a Blob URL. The Blob URL is constructed from raw data and does not have a type. Every browser vender currently does something different when loading such a Blob URL in an iframe and there is an on-going discussion on whether an agreement can be made. See <https://github.com/w3c/FileAPI/issues/82> for more details. The File API and Fetch standards explicitly describe how to handle loading a Blob URL with a type in an iframe. As the purpose of this test is to ensure conformance with the Secure Context spec, it seems sufficient to update the test to construct the Blob URL with type "text/html" and avoid <https://github.com/w3c/FileAPI/issues/82> at this time.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
