### PR TITLE
[testharness.js] Correct `Test#force_timeout`

### DIFF
--- a/resources/test/tests/force_timeout.html
+++ b/resources/test/tests/force_timeout.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test#force_timeout</title>
+</head>
+<body>
+<h1>Test#force_timeout</h1>
+<div id="log"></div>
+<script src="../../testharness.js"></script>
+<script src="../../testharnessreport.js"></script>
+<script>
+setup({ explicit_timeout: true });
+
+test(function(t) {
+    t.force_timeout();
+  }, 'test (synchronous)');
+
+async_test(function(t) {
+    setTimeout(function() {
+        t.force_timeout();
+      }, 0);
+  }, 'async_test');
+
+promise_test(function(t) {
+	t.force_timeout();
+
+	return new Promise(function() {});
+  }, 'promise_test');
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null,
+    "stack": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "TIMEOUT",
+      "name": "async_test",
+      "message": "Test timed out",
+      "stack": null,
+      "properties": {}
+    },
+    {
+      "status_string": "TIMEOUT",
+      "name": "promise_test",
+      "message": "Test timed out",
+      "stack": null,
+      "properties": {}
+    },
+    {
+      "status_string": "TIMEOUT",
+      "name": "test (synchronous)",
+      "message": "Test timed out",
+      "stack": null,
+      "properties": {}
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1469,11 +1469,6 @@ policies and contribution forms [3].
         this.cleanup_callbacks.push(callback);
     };
 
-    Test.prototype.force_timeout = function() {
-        this.set_status(this.TIMEOUT);
-        this.phase = this.phases.HAS_RESULT;
-    };
-
     Test.prototype.set_timeout = function()
     {
         if (this.timeout_length !== null) {
@@ -1499,6 +1494,8 @@ policies and contribution forms [3].
         this.phase = this.phases.HAS_RESULT;
         this.done();
     };
+
+    Test.prototype.force_timeout = Test.prototype.timeout;
 
     Test.prototype.done = function()
     {


### PR DESCRIPTION
Prior to the application of this patch, `testharness.js` would correctly
report tests that used the `force_timeout` method as "timed out,"
(ignoring subsequent erros), but it would only do so after the
harness-defined "timeout" period had elapsed. This behavior was in
direct conflict with the documentation, which described its effect as
"immediate" [1].

Update the implementation to expose the documented behavior.

[1]

> Occasionally tests may have a race between the harness timing out and
> a particular test failing; typically when the test waits for some
> event that never occurs. In this case it is possible to use
> `test.force_timeout()` in place of `assert_unreached()`, to
> immediately fail the test but with a status of `TIMEOUT`. This should
> only be used as a last resort when it is not possible to make the test
> reliable in some other way.

---

This should resolve gh-4519.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6143)
<!-- Reviewable:end -->
