### PR TITLE
[testharness.js] `Test#add_cleanup` tests and fix

### DIFF
--- a/resources/test/tests/add_cleanup.html
+++ b/resources/test/tests/add_cleanup.html
@@ -1,0 +1,96 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test#add_cleanup</title>
+<script src="../../testharness.js"></script>
+<script src="../../testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+var log_sync;
+test(function(t) {
+  log_sync = "";
+  t.add_cleanup(function() { log_sync += "1"; });
+  t.add_cleanup(function() { log_sync += "2"; });
+  t.add_cleanup(function() { log_sync += "3"; });
+  t.add_cleanup(function() { log_sync += "4"; });
+  t.add_cleanup(function() { log_sync += "5"; });
+  log_sync += "0";
+}, "probe synchronous");
+
+test(function() {
+  if (log_sync !== "012345") {
+    throw new Error("Expected: '012345'. Actual: '" + log_sync + "'.");
+  }
+}, "Cleanup methods are invoked exactly once and in the expected sequence.");
+
+var complete, log_async;
+async_test(function(t) {
+  complete = t.step_func(function() {
+    if (log_async !== "012") {
+      throw new Error("Expected: '012'. Actual: '" + log_async + "'.");
+    }
+
+    t.done();
+  });
+}, "Cleanup methods are invoked following the completion of asynchronous tests");
+
+async_test(function(t) {
+  log_async = "";
+  t.add_cleanup(function() { log_async += "1"; });
+
+  setTimeout(t.step_func(function() {
+    t.add_cleanup(function() {
+      log_async += "2";
+      complete();
+    });
+    log_async += "0";
+    t.done();
+  }), 0);
+}, "probe asynchronous");
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null,
+    "stack": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Cleanup methods are invoked exactly once and in the expected sequence.",
+      "properties": {},
+      "message": null,
+      "stack": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Cleanup methods are invoked following the completion of asynchronous tests",
+      "properties": {},
+      "message": null,
+      "stack": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "probe asynchronous",
+      "properties": {},
+      "message": null,
+      "stack": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "probe synchronous",
+      "properties": {},
+      "message": null,
+      "stack": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/add_cleanup_err.html
+++ b/resources/test/tests/add_cleanup_err.html
@@ -12,21 +12,30 @@
 
 test(function(t) {
   t.add_cleanup(function() {
-    throw new Error('exception in cleanup method');
+    throw new Error('exception in cleanup function');
   });
-}, "Exceptions in cleanup cause harness failure.");
+}, "Exception in cleanup function causes harness failure.");
+
+test(function() {}, "This test should not be run.");
 </script>
 <script type="text/json" id="expected">
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Error: exception in cleanup method",
-    "stack": "(implementation-defined)"
+    "message": "Test named 'Exception in cleanup function causes harness failure.' specified 1 'cleanup' function, and 1 failed.",
+    "stack": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
-      "name": "Exceptions in cleanup cause harness failure.",
+      "name": "Exception in cleanup function causes harness failure.",
+      "properties": {},
+      "message": null,
+      "stack": null
+    },
+    {
+      "status_string": "NOTRUN",
+      "name": "This test should not be run.",
       "properties": {},
       "message": null,
       "stack": null

--- a/resources/test/tests/add_cleanup_err.html
+++ b/resources/test/tests/add_cleanup_err.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test#add_cleanup: error</title>
+<script src="../../testharness.js"></script>
+<script src="../../testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+"use strict";
+
+test(function(t) {
+  t.add_cleanup(function() {
+    throw new Error('exception in cleanup method');
+  });
+}, "Exceptions in cleanup cause harness failure.");
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "ERROR",
+    "message": "Error: exception in cleanup method",
+    "stack": "(implementation-defined)"
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Exceptions in cleanup cause harness failure.",
+      "properties": {},
+      "message": null,
+      "stack": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/add_cleanup_err_multi.html
+++ b/resources/test/tests/add_cleanup_err_multi.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test#add_cleanup: multiple functions with one in error</title>
+<script src="../../testharness.js"></script>
+<script src="../../testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+
+<script>
+"use strict";
+
+test(function(t) {
+    t.add_cleanup(function() {
+      throw new Error("exception in cleanup function");
+    });
+
+    // The following cleanup function defines a test so that the reported
+    // data demonstrates the intended run-time behavior, i.e. that
+    // `testharness.js` invokes all cleanup functions even when one or more
+    // throw errors.
+    t.add_cleanup(function() {
+      test(function() {}, "Verification test");
+    });
+  }, "Test with multiple cleanup functions");
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "ERROR",
+    "message": "Test named 'Test with multiple cleanup functions' specified 2 'cleanup' functions, and 1 failed.",
+    "stack": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Test with multiple cleanup functions",
+      "properties": {},
+      "message": null,
+      "stack": null
+    },
+    {
+      "status_string": "NOTRUN",
+      "name": "Verification test",
+      "properties": {},
+      "message": null,
+      "stack": null
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1323,7 +1323,8 @@ policies and contribution forms [3].
         }
         this.name = name;
 
-        this.phase = this.phases.INITIAL;
+        this.phase = tests.phase === tests.phases.ABORTED ?
+            this.phases.COMPLETE : this.phases.INITIAL;
 
         this.status = this.NOTRUN;
         this.timeout_id = null;
@@ -1519,11 +1520,35 @@ policies and contribution forms [3].
         this.cleanup();
     };
 
+    /*
+     * Invoke all specified cleanup functions. If one or more produce an error,
+     * the context is in an unpredictable state, so all further testing should
+     * be cancelled.
+     */
     Test.prototype.cleanup = function() {
+        var error_count = 0;
+        var total;
+
         forEach(this.cleanup_callbacks,
                 function(cleanup_callback) {
-                    cleanup_callback();
+                    try {
+                        cleanup_callback();
+                    } catch (e) {
+                        // Set test phase immediately so that tests declared
+                        // within subsequent cleanup functions are not run.
+                        tests.phase = tests.phases.ABORTED;
+                        error_count += 1;
+                    }
                 });
+
+        if (error_count > 0) {
+            total = this.cleanup_callbacks.length;
+            tests.status.status = tests.status.ERROR;
+            tests.status.message = "Test named '" + this.name +
+                "' specified " + total + " 'cleanup' function" +
+                (total > 1 ? "s" : "") + ", and " + error_count + " failed.";
+            tests.status.stack = null;
+        }
     };
 
     /*
@@ -1707,7 +1732,8 @@ policies and contribution forms [3].
             SETUP:1,
             HAVE_TESTS:2,
             HAVE_RESULTS:3,
-            COMPLETE:4
+            COMPLETE:4,
+            ABORTED:5
         };
         this.phase = this.phases.INITIAL;
 
@@ -1841,7 +1867,8 @@ policies and contribution forms [3].
     };
 
     Tests.prototype.all_done = function() {
-        return (this.tests.length > 0 && test_environment.all_loaded &&
+        return this.phase === this.phases.ABORTED ||
+            (this.tests.length > 0 && test_environment.all_loaded &&
                 this.num_pending === 0 && !this.wait_for_finish &&
                 !this.processing_callbacks &&
                 !this.pending_remotes.some(function(w) { return w.running; }));


### PR DESCRIPTION
@jgraham The first commit is dedicated to improving coverage (in support of my upcoming work to recognize Promises returned from cleanup functions). The second is a behavior change--from the commit message body:

> Prior to application of this patch, `testharness.js` did not catch
> errors thrown by cleanup functions. In this case, script execution was
> interrupted, so additional cleanup functions were not invoked. Further,
> any subsequently-defined tests were not run, but neither were they
> detected or reported. The framework reported the error via the global
> `onerror` event, exposing the implementation-defined `message` property
> in the resulting failure report.
>
> Ensure that script evaluation proceeds following an error thrown by a
> cleanup function. This includes invocation of any remaining cleanup
> functions and detection of remaining tests. Additional tests are
> explicitly not executed due to the general instability of the global
> state under these conditions, but they are reported with the status
> "NOTRUN". Update the reported test harness error message for this
> situation to describe the situation in terms that are consistent across
> implementations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6151)
<!-- Reviewable:end -->
