### PR TITLE
Remove erroneous return from "setRemoteDescription(offer) with invalid SDP..."

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -84,10 +84,6 @@
       assert_true(err instanceof RTCError,
         'Expect err to be instance of RTCError');
     });
-
-    return promise_rejects(t,
-      new RTCError('sdp-syntax-error'),
-      );
   }, 'setRemoteDescription(offer) with invalid SDP should reject with RTCError');
 
   /*


### PR DESCRIPTION


Signed-off-by: Rick Waldron <waldron.rick@gmail.com>

<!-- Reviewable:start -->

<!-- Reviewable:end -->
