### PR TITLE
Improve cssom/CSSStyleRule.html test

### DIFF
--- a/cssom/CSSStyleRule.html
+++ b/cssom/CSSStyleRule.html
@@ -67,7 +67,6 @@
             assert_idl_attribute(rule, "selectorText");
             assert_equals(typeof rule.selectorText, "string");
             assert_idl_attribute(rule, "style");
-            assert_readonly(rule, "style");
         }, "Existence, writability and type of CSSStyleRule attributes");
 
         test(function() {
@@ -85,6 +84,13 @@
             assert_equals(rule.style.padding, "5px");
             assert_equals(rule.style.border, "1px solid");
         }, "Mutability of CSSStyleRule's style attribute");
+
+        test(function() {
+            rule.style = "margin: 15px; padding: 2px;";
+
+            assert_equals(rule.style.margin, "15px", "margin");
+            assert_equals(rule.style.padding, "2px", "padding");
+        }, "CSSStyleRule's style has [PutForwards]");
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Stop using assert_readonly() on CSSStyleRule.style since it has side effects for
  attributes with [PutForwards]. This was causing the later "Mutability of
  CSSStyleRule's style attribute" test to fail unexpectedly in Firefox and Chrome.
- Add test coverage for setting CSSStyleRule.style since the attribute has [PutForwards].

<!-- Reviewable:start -->

<!-- Reviewable:end -->
