### PR TITLE
Add initial test for RTCPeerConnection ondatachannel

### DIFF
--- a/webrtc/RTCPeerConnection-ondatachannel.html
+++ b/webrtc/RTCPeerConnection-ondatachannel.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.ondatachannel</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  // exchangeIceCandidates
+  // doSignalingHandshake
+
+  /*
+    6.2.  RTCDataChannel
+      interface RTCDataChannel : EventTarget {
+        readonly attribute USVString           label;
+        readonly attribute boolean             ordered;
+        readonly attribute unsigned short?     maxPacketLifeTime;
+        readonly attribute unsigned short?     maxRetransmits;
+        readonly attribute USVString           protocol;
+        readonly attribute boolean             negotiated;
+        readonly attribute unsigned short?     id;
+        readonly attribute RTCPriorityType     priority;
+        readonly attribute RTCDataChannelState readyState;
+        ...
+      };
+
+      When an underlying data transport is to be announced (the other peer
+      created a channel with negotiated unset or set to false), the user
+      agent of the peer that did not initiate the creation process must
+      queue a task to run the following steps:
+        1.  If the associated RTCPeerConnection object's [[isClosed]] slot
+            is true, abort these steps.
+        2.  Let channel be a newly created RTCDataChannel object.
+        3.  Let configuration be an information bundle received from the
+            other peer as a part of the process to establish the underlying
+            data transport described by the WebRTC DataChannel Protocol
+            specification [RTCWEB-DATA-PROTOCOL].
+        4.  Initialize channel's label, ordered, maxPacketLifeTime,
+            maxRetransmits, protocol, negotiated and id attributes to their
+            corresponding values in configuration.
+        5.  Set channel's readyState attribute to connecting.
+        6.  Fire a datachannel event named datachannel with channel at the
+            RTCPeerConnection object.
+
+    6.3.  RTCDataChannelEvent
+      Firing a datachannel event named e with a RTCDataChannel channel means
+      that an event with the name e, which does not bubble (except where
+      otherwise stated) and is not cancelable (except where otherwise stated),
+      and which uses the RTCDataChannelEvent interface with the channel
+      attribute set to channel, must be created and dispatched at the given
+      target.
+
+      [Constructor(DOMString type, RTCDataChannelEventInit eventInitDict)]
+      interface RTCDataChannelEvent : Event {
+        readonly attribute RTCDataChannel channel;
+      };
+
+    4.4.  State Definitions
+      enum RTCIceGatheringState {
+        "complete",
+        ...
+      };
+
+        complete
+          At least one RTCIceTransport exists, and all RTCIceTransport s are in
+          the completed gathering state.
+
+      enum RTCIceConnectionState {
+        "connected",
+        "completed",
+        ...
+      };
+
+        connected
+          All RTCIceTransport s are in the connected, completed or closed state
+          and at least one of them is in the connected state.
+
+        completed
+          All RTCIceTransport s are in the completed or closed state and at least
+          one of them is in the completed state.
+
+      enum RTCPeerConnectionState {
+        "connected",
+        ...
+      };
+
+        connected
+          All RTCIceTransport s and RTCDtlsTransport s are in the connected,
+          completed or closed state and at least of them is in the connected
+          or completed state.
+
+    5.5.  RTCDtlsTransport Interface
+      enum RTCDtlsTransportState {
+        "connected",
+        ...
+      };
+
+        connected
+          DTLS has completed negotiation of a secure connection.
+
+
+    5.6.  RTCIceTransport Interface
+      enum RTCIceGathererState {
+        "complete",
+        ...
+      };
+
+        complete
+          The RTCIceTransport has completed gathering and the end-of-candidates
+          indication for this transport has been sent. It will not gather candidates
+          again until an ICE restart causes it to restart.
+
+      enum RTCIceTransportState {
+        "connected",
+        "completed",
+        ...
+      };
+
+        connected
+          The RTCIceTransport has found a usable connection, but is still
+          checking other candidate pairs to see if there is a better connection.
+          It may also still be gathering and/or waiting for additional remote
+          candidates.
+
+        completed
+          The RTCIceTransport has finished gathering, received an indication
+          that there are no more remote candidates, finished checking all
+          candidate pairs and found a connection.
+   */
+
+  // Assert that when datachannel event is fired on the other side,
+  // The SCTP, DTLS, and ICE transports should all be connected.
+  // This is because the data channel can only be negotiated to
+  // the remote peer through a connected SCTP transport.
+  // And since the peer connection we are testing have only one
+  // transport of each kind, the various connection states of the
+  // peer connection should all be in connected states.
+  function assert_sctp_connected(pc) {
+    assert_equals(pc.iceGatheringState, 'complete',
+      'Expect pc.iceGatheringState to be complete');
+
+    // Need verification - the underlying RTCIceTransport state
+    // may be connected instead of completed when the DTLS
+    // connection is established
+    assert_true(
+      pc.iceConnectionState === 'completed' ||
+      pc.iceConnectionState === 'connected',
+      'Expect pc.iceConnectionState to be either completed or connected');
+
+    assert_equals(pc.connectionState, 'connected',
+      'Expect pc.connectionState to be connected');
+
+    assert_own_property(pc, 'sctp');
+
+    const sctpTransport = pc.sctp;
+
+    assert_true(sctpTransport instanceof RTCSctpTransport,
+      'Expect sctpTransport to instance of RTCSctpTransport');
+
+    const dtlsTransport = sctp.transport;
+    assert_true(dtlsTransport instanceof RTCDtlsTransport,
+      'Expect dtlsTransport to be instance of RTCDtlsTransport');
+
+    assert_equals(dtlsTransport.state, 'connected',
+      'Expect dtlsTransport to be in connected state');
+
+    const iceTransport = dtlsTransport.transport;
+    assert_true(iceTransport instanceof RTCIceTransport,
+      'Expect iceTransport to be instance of RTCIceTransport');
+
+    assert_equals(
+      iceTransport.gathererState === 'complete' ||
+      iceTransport.gathererState === 'gathering',
+      'Expect iceTransport gatherer state to be either complete or gathering');
+
+    assert_true(
+      iceTransport.state === 'completed' ||
+      iceTransport.state === 'connected',
+      'Expect iceTransport transport state to be either completed or completed');
+  }
+
+  async_test(t => {
+    const localPc = new RTCPeerConnection();
+    const remotePc = new RTCPeerConnection();
+
+    let eventCount = 0;
+
+    const onDataChannel = t.step_func(event => {
+      eventCount++;
+      assert_equals(eventCount, 1,
+        'Expect data channel event to fire exactly once');
+
+      assert_true(event instanceof RTCDataChannelEvent,
+        'Expect event to be instance of RTCDataChannelEvent');
+
+      const { channel } = event;
+      assert_true(channel instanceof RTCDataChannel,
+        'Expect channel to be instance of RTCDataChannel');
+
+      const { readyState } = channel;
+
+      // The spec requires readyState to be connecting at first,
+      // but it may quickly change to open before the callback
+      // is invoked, especially with local connections.
+      assert_true(readyState === 'connecting' || readyState === 'open',
+        'Expect channel ready state to be either connecting or open');
+
+      assert_sctp_connected(localPc);
+      assert_sctp_connected(remotePc);
+    });
+
+    const localChannel = localPc.createDataChannel('test');
+
+    remotePc.addEventListener('datachannel', onDataChannel);
+    exchangeIceCandidates(localPc, remotePc);
+    doSignalingHandshake(localPc, remotePc);
+
+  }, 'datachannel event should fire when new data channel is announced to the remote peer');
+
+</script>

--- a/webrtc/RTCPeerConnection-ondatachannel.html
+++ b/webrtc/RTCPeerConnection-ondatachannel.html
@@ -16,33 +16,8 @@
 
   /*
     6.2.  RTCDataChannel
-      interface RTCDataChannel : EventTarget {
-        readonly attribute USVString           label;
-        readonly attribute boolean             ordered;
-        readonly attribute unsigned short?     maxPacketLifeTime;
-        readonly attribute unsigned short?     maxRetransmits;
-        readonly attribute USVString           protocol;
-        readonly attribute boolean             negotiated;
-        readonly attribute unsigned short?     id;
-        readonly attribute RTCPriorityType     priority;
-        readonly attribute RTCDataChannelState readyState;
-        ...
-      };
-
-      When an underlying data transport is to be announced (the other peer
-      created a channel with negotiated unset or set to false), the user
-      agent of the peer that did not initiate the creation process must
-      queue a task to run the following steps:
-        1.  If the associated RTCPeerConnection object's [[isClosed]] slot
-            is true, abort these steps.
+      When an underlying data transport is to be announced
         2.  Let channel be a newly created RTCDataChannel object.
-        3.  Let configuration be an information bundle received from the
-            other peer as a part of the process to establish the underlying
-            data transport described by the WebRTC DataChannel Protocol
-            specification [RTCWEB-DATA-PROTOCOL].
-        4.  Initialize channel's label, ordered, maxPacketLifeTime,
-            maxRetransmits, protocol, negotiated and id attributes to their
-            corresponding values in configuration.
         5.  Set channel's readyState attribute to connecting.
         6.  Fire a datachannel event named datachannel with channel at the
             RTCPeerConnection object.
@@ -55,12 +30,10 @@
       attribute set to channel, must be created and dispatched at the given
       target.
 
-      [Constructor(DOMString type, RTCDataChannelEventInit eventInitDict)]
       interface RTCDataChannelEvent : Event {
         readonly attribute RTCDataChannel channel;
       };
    */
-
   async_test(t => {
     const localPc = new RTCPeerConnection();
     const remotePc = new RTCPeerConnection();
@@ -75,6 +48,9 @@
       assert_true(event instanceof RTCDataChannelEvent,
         'Expect event to be instance of RTCDataChannelEvent');
 
+      assert_equals(event.bubbles, false);
+      assert_equals(event.cancelable, false);
+
       const { channel } = event;
       assert_true(channel instanceof RTCDataChannel,
         'Expect channel to be instance of RTCDataChannel');
@@ -88,7 +64,7 @@
         'Expect channel ready state to be either connecting or open');
     });
 
-    const localChannel = localPc.createDataChannel('test');
+    localPc.createDataChannel('test');
 
     remotePc.addEventListener('datachannel', onDataChannel);
     exchangeIceCandidates(localPc, remotePc);
@@ -96,4 +72,106 @@
 
   }, 'datachannel event should fire when new data channel is announced to the remote peer');
 
+  /*
+    6.2.  RTCDataChannel
+      interface RTCDataChannel : EventTarget {
+        readonly attribute USVString           label;
+        readonly attribute boolean             ordered;
+        readonly attribute unsigned short?     maxPacketLifeTime;
+        readonly attribute unsigned short?     maxRetransmits;
+        readonly attribute USVString           protocol;
+        readonly attribute boolean             negotiated;
+        readonly attribute unsigned short?     id;
+        readonly attribute RTCPriorityType     priority;
+        readonly attribute RTCDataChannelState readyState;
+        ...
+      };
+
+      When an underlying data transport is to be announced
+        3.  Let configuration be an information bundle received from the
+            other peer as a part of the process to establish the underlying
+            data transport described by the WebRTC DataChannel Protocol
+            specification [RTCWEB-DATA-PROTOCOL].
+        4.  Initialize channel's label, ordered, maxPacketLifeTime,
+            maxRetransmits, protocol, negotiated and id attributes to their
+            corresponding values in configuration.
+   */
+  async_test(t => {
+    const localPc = new RTCPeerConnection();
+    const remotePc = new RTCPeerConnection();
+
+    const onDataChannel = t.step_func_done(event => {
+      const remoteChannel = event.channel;
+      assert_true(remoteChannel instanceof RTCDataChannel,
+        'Expect channel to be instance of RTCDataChannel');
+
+      assert_equals(remoteChannel.label, 'test');
+      assert_equals(remoteChannel.id, 8);
+      assert_equals(remoteChannel.ordered, false);
+      assert_equals(remoteChannel.maxRetransmits, 1);
+      assert_equals(remoteChannel.protocol, 'custom');
+      assert_equals(remoteChannel.priority, 'high');
+    });
+
+    const localChannel = localPc.createDataChannel('test', {
+      id: 8,
+      ordered: false,
+      maxRetransmits: 1,
+      protocol: 'custom',
+      priority: 'high'
+    });
+
+    assert_equals(localChannel.label, 'test');
+    assert_equals(localChannel.id, 8);
+    assert_equals(localChannel.ordered, false);
+    assert_equals(localChannel.maxRetransmits, 1);
+    assert_equals(localChannel.protocol, 'custom');
+    assert_equals(localChannel.priority, 'high');
+
+    remotePc.addEventListener('datachannel', onDataChannel);
+    exchangeIceCandidates(localPc, remotePc);
+    doSignalingHandshake(localPc, remotePc);
+  }, 'Data channel created on remote peer should match the same configuration as local peer');
+
+  /*
+    6.2.  RTCDataChannel
+      Dictionary RTCDataChannelInit Members
+        negotiated
+          The default value of false tells the user agent to announce the
+          channel in-band and instruct the other peer to dispatch a corresponding
+          RTCDataChannel object. If set to true, it is up to the application
+          to negotiate the channel and create a RTCDataChannel object with the
+          same id at the other peer.
+   */
+  async_test(t => {
+    const localPc = new RTCPeerConnection();
+    const remotePc = new RTCPeerConnection();
+
+    const onDataChannel = t.unreached_func('datachannel event should not be fired');
+
+    localPc.createDataChannel('test', {
+      negotiated: true
+    });
+
+    remotePc.addEventListener('datachannel', onDataChannel);
+    exchangeIceCandidates(localPc, remotePc);
+    doSignalingHandshake(localPc, remotePc);
+
+    t.step_timeout(t.step_func_done(), 200);
+
+  }, 'Data channel created with negotiated set to true should not fire datachannel event on remote peer');
+
+  /*
+    Non-testable
+    6.2.  RTCDataChannel
+      When an underlying data transport is to be announced
+        1.  If the associated RTCPeerConnection object's [[isClosed]] slot
+            is true, abort these steps.
+
+    The above step is not testable because to reach it we would have to
+    close the peer connection after the remote peer call
+    setLocalDescription(answer) but before the underlying data transport
+    is connected. This require the promise callback for setLocalDescription()
+    to be called at the right moment, which is not always possible.
+   */
 </script>

--- a/webrtc/RTCPeerConnection-ondatachannel.html
+++ b/webrtc/RTCPeerConnection-ondatachannel.html
@@ -59,130 +59,7 @@
       interface RTCDataChannelEvent : Event {
         readonly attribute RTCDataChannel channel;
       };
-
-    4.4.  State Definitions
-      enum RTCIceGatheringState {
-        "complete",
-        ...
-      };
-
-        complete
-          At least one RTCIceTransport exists, and all RTCIceTransport s are in
-          the completed gathering state.
-
-      enum RTCIceConnectionState {
-        "connected",
-        "completed",
-        ...
-      };
-
-        connected
-          All RTCIceTransport s are in the connected, completed or closed state
-          and at least one of them is in the connected state.
-
-        completed
-          All RTCIceTransport s are in the completed or closed state and at least
-          one of them is in the completed state.
-
-      enum RTCPeerConnectionState {
-        "connected",
-        ...
-      };
-
-        connected
-          All RTCIceTransport s and RTCDtlsTransport s are in the connected,
-          completed or closed state and at least of them is in the connected
-          or completed state.
-
-    5.5.  RTCDtlsTransport Interface
-      enum RTCDtlsTransportState {
-        "connected",
-        ...
-      };
-
-        connected
-          DTLS has completed negotiation of a secure connection.
-
-
-    5.6.  RTCIceTransport Interface
-      enum RTCIceGathererState {
-        "complete",
-        ...
-      };
-
-        complete
-          The RTCIceTransport has completed gathering and the end-of-candidates
-          indication for this transport has been sent. It will not gather candidates
-          again until an ICE restart causes it to restart.
-
-      enum RTCIceTransportState {
-        "connected",
-        "completed",
-        ...
-      };
-
-        connected
-          The RTCIceTransport has found a usable connection, but is still
-          checking other candidate pairs to see if there is a better connection.
-          It may also still be gathering and/or waiting for additional remote
-          candidates.
-
-        completed
-          The RTCIceTransport has finished gathering, received an indication
-          that there are no more remote candidates, finished checking all
-          candidate pairs and found a connection.
    */
-
-  // Assert that when datachannel event is fired on the other side,
-  // The SCTP, DTLS, and ICE transports should all be connected.
-  // This is because the data channel can only be negotiated to
-  // the remote peer through a connected SCTP transport.
-  // And since the peer connection we are testing have only one
-  // transport of each kind, the various connection states of the
-  // peer connection should all be in connected states.
-  function assert_sctp_connected(pc) {
-    assert_equals(pc.iceGatheringState, 'complete',
-      'Expect pc.iceGatheringState to be complete');
-
-    // Need verification - the underlying RTCIceTransport state
-    // may be connected instead of completed when the DTLS
-    // connection is established
-    assert_true(
-      pc.iceConnectionState === 'completed' ||
-      pc.iceConnectionState === 'connected',
-      'Expect pc.iceConnectionState to be either completed or connected');
-
-    assert_equals(pc.connectionState, 'connected',
-      'Expect pc.connectionState to be connected');
-
-    assert_own_property(pc, 'sctp');
-
-    const sctpTransport = pc.sctp;
-
-    assert_true(sctpTransport instanceof RTCSctpTransport,
-      'Expect sctpTransport to instance of RTCSctpTransport');
-
-    const dtlsTransport = sctp.transport;
-    assert_true(dtlsTransport instanceof RTCDtlsTransport,
-      'Expect dtlsTransport to be instance of RTCDtlsTransport');
-
-    assert_equals(dtlsTransport.state, 'connected',
-      'Expect dtlsTransport to be in connected state');
-
-    const iceTransport = dtlsTransport.transport;
-    assert_true(iceTransport instanceof RTCIceTransport,
-      'Expect iceTransport to be instance of RTCIceTransport');
-
-    assert_equals(
-      iceTransport.gathererState === 'complete' ||
-      iceTransport.gathererState === 'gathering',
-      'Expect iceTransport gatherer state to be either complete or gathering');
-
-    assert_true(
-      iceTransport.state === 'completed' ||
-      iceTransport.state === 'connected',
-      'Expect iceTransport transport state to be either completed or completed');
-  }
 
   async_test(t => {
     const localPc = new RTCPeerConnection();
@@ -190,7 +67,7 @@
 
     let eventCount = 0;
 
-    const onDataChannel = t.step_func(event => {
+    const onDataChannel = t.step_func_done(event => {
       eventCount++;
       assert_equals(eventCount, 1,
         'Expect data channel event to fire exactly once');
@@ -209,9 +86,6 @@
       // is invoked, especially with local connections.
       assert_true(readyState === 'connecting' || readyState === 'open',
         'Expect channel ready state to be either connecting or open');
-
-      assert_sctp_connected(localPc);
-      assert_sctp_connected(remotePc);
     });
 
     const localChannel = localPc.createDataChannel('test');


### PR DESCRIPTION
~This is a work in progress.~ (edit: done) I added one basic test for establishing data channel connection with a remote peer and fire a `datachannel` event.

~I also make use of this to test the state change of the peer connection and `RTC*Transport` objects. The idea is that for the `datachannel` event to be fired on a remote peer, it must first establish an SCTP connection and send the data channel negotiation through a `DATA_CHANNEL_OPEN` message. In other words by that time the `RTCDtlsTransport` and `RTCIceTransport` should have all been in connected state.~

~Other than that, since the test connection only have one `RTCDtlsTransport` and one `RTCIceTransport` and we know their final state, we can also test on the peer connection state.~

~There is only one thing that I am not very certain. Currently running on the test on Chrome, the `RTCIceConnectionState` is `connected` instead of `completed`. I am not sure if under TrickleICE, a DTLS connection can be established while the ICE agent is still attempting connection with each candidate pair. The current assumption for the test is that this is allowed, and the assertion allows the final `RTCIceConnectionState` to be either `connected` or `completed`. Would appreciate if anyone familar with this can confirm or correct me if I am wrong.~

(Edit: assumption was wrong and test is removed)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
