### PR TITLE
Use monospace fonts in css-writing-modes tests that need it.

### DIFF
--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-008-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-008-ref.xht
@@ -17,6 +17,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin: 8px 0px;
     }

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-008.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-008.xht
@@ -68,6 +68,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-left: 100px;
       margin-right: 100px;

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-020-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-020-ref.xht
@@ -17,6 +17,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin: 8px 0px;
     }

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-020.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vlr-020.xht
@@ -68,6 +68,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-left: 0px;
       margin-right: 0px;

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-008-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-008-ref.xht
@@ -17,6 +17,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin: 8px 0px;
     }

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-008.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-008.xht
@@ -68,6 +68,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-left: 100px;
       margin-right: 100px;

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-020-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-020-ref.xht
@@ -17,6 +17,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin: 8px 0px;
     }

--- a/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-020.xht
+++ b/css/css-writing-modes-3/sizing-orthog-htb-in-vrl-020.xht
@@ -68,6 +68,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-left: 0px;
       margin-right: 0px;

--- a/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-008-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-008-ref.xht
@@ -23,6 +23,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
     }
 

--- a/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-008.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-008.xht
@@ -63,6 +63,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-bottom: 100px;
       margin-top: 100px;

--- a/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-020-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-020-ref.xht
@@ -22,6 +22,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
     }
 

--- a/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-020.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vlr-in-htb-020.xht
@@ -63,6 +63,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-bottom: 0px;
       margin-top: 0px;

--- a/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-008-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-008-ref.xht
@@ -23,6 +23,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
     }
 

--- a/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-008.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-008.xht
@@ -63,6 +63,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-bottom: 100px;
       margin-top: 100px;

--- a/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-020-ref.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-020-ref.xht
@@ -22,6 +22,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
     }
 

--- a/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-020.xht
+++ b/css/css-writing-modes-3/sizing-orthog-vrl-in-htb-020.xht
@@ -63,6 +63,7 @@
   body
     {
       font-size: 16px;
+      font-family: monospace;
       line-height: 1.25; /* therefore, each line box is 20px tall */
       margin-bottom: 0px;
       margin-top: 0px;


### PR DESCRIPTION
This changes a set of css-writing-mode tests that depend on consistent character widths for digits (and those widths matching ch units) to use monospace fonts, which are far more likely to guarantee consistent character widths.

This is as discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1362255#c26 (comments 26, 28, and 29).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
