### PR TITLE
Install Firefox from Beta channel in CI

### DIFF
--- a/check_stability.py
+++ b/check_stability.py
@@ -189,11 +189,7 @@ class Firefox(Browser):
     def install(self):
         """Install Firefox."""
         call("pip", "install", "-r", os.path.join(wptrunner_root, "requirements_firefox.txt"))
-        index = get("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/")
-        latest = re.compile("<a[^>]*>(firefox-\d+\.\d(?:\w\d)?.en-US.linux-x86_64\.tar\.bz2)</a>")
-        filename = latest.search(index.text).group(1)
-        resp = get("https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/%s" %
-                   filename)
+        resp = get("https://download.mozilla.org/?product=firefox-beta-latest&os=linux64&lang=en-US")
         untar(resp.raw)
 
         if not os.path.exists("profiles"):

--- a/tools/browserutils/browser.py
+++ b/tools/browserutils/browser.py
@@ -59,7 +59,7 @@ class Firefox(Browser):
     requirements = "requirements_firefox.txt"
 
 
-    def platform_string(self):
+    def platform_string_certutil(self):
         platform = {
             "Linux": "linux",
             "Windows": "win",
@@ -78,7 +78,7 @@ class Firefox(Browser):
 
         return "%s%s" % (platform, bits)
 
-    def platform_string_geckodriver(self):
+    def platform_string(self):
         platform = {
             "Linux": "linux",
             "Windows": "win",
@@ -110,7 +110,7 @@ class Firefox(Browser):
         if dest is None:
             dest = os.getcwd()
 
-        resp = self.get_from_nightly("<a[^>]*>(firefox-\d+\.\d(?:\w\d)?.en-US.%s\.tar\.bz2)" % self.platform_string())
+        resp = get("https://download.mozilla.org/?product=firefox-beta-latest&os=%s&lang=en-US" % self.platform_string())
         untar(resp.raw, dest=dest)
         return os.path.join(dest, "firefox")
 
@@ -140,7 +140,7 @@ class Firefox(Browser):
             dest = split[0]
 
         resp = self.get_from_nightly(
-            "<a[^>]*>(firefox-\d+\.\d(?:\w\d)?.en-US.%s\.common\.tests.zip)</a>" % self.platform_string())
+            "<a[^>]*>(firefox-\d+\.\d(?:\w\d)?.en-US.%s\.common\.tests.zip)</a>" % self.platform_string_certutil())
         bin_path = path("bin/certutil", exe=True)
         unzip(resp.raw, dest=dest, limit=[bin_path])
 
@@ -184,7 +184,7 @@ class Firefox(Browser):
         format = "zip" if uname[0] == "Windows" else "tar.gz"
         logger.debug("Latest geckodriver release %s" % version)
         url = ("https://github.com/mozilla/geckodriver/releases/download/%s/geckodriver-%s-%s.%s" %
-               (version, version, self.platform_string_geckodriver(), format))
+               (version, version, self.platform_string(), format))
         if format == "zip":
             unzip(get(url).raw, dest=dest)
         else:


### PR DESCRIPTION
The latest build of Firefox available on the "Nightly" channel suffers
from timeout errors in automation. Switch the installation procedure to
instead source from the Beta channel in order to use a build that is
known to work today and is less susceptible to future regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6204)
<!-- Reviewable:end -->
