### PR TITLE
Add --repo-root argument to lint script

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -13,7 +13,7 @@ import sys
 from collections import defaultdict
 
 from . import fnmatch
-from ..localpaths import repo_root
+from .. import localpaths
 from ..gitignore.gitignore import PathFilter
 
 from manifest.sourcefile import SourceFile, js_meta_re, python_meta_re
@@ -679,6 +679,8 @@ def parse_args():
                         help="Output markdown")
     parser.add_argument("--css-mode", action="store_true",
                         help="Run CSS testsuite specific lints")
+    parser.add_argument("--repo-root", help="The WPT directory. Use this"
+                        "option if the lint script exists outside the repository")
     return parser.parse_args()
 
 
@@ -687,6 +689,7 @@ def main(**kwargs):
         logger.critical("Cannot specify --json and --markdown")
         sys.exit(2)
 
+    repo_root = kwargs.get('repo_root') or localpaths.repo_root
     output_format = {(True, False): "json",
                      (False, True): "markdown",
                      (False, False): "normal"}[(kwargs.get("json", False),


### PR DESCRIPTION
Context for this patch: in Chromium we keep a local copy of the lint script in a separate location from our local copy of WPT. The lint script doesn't currently support being run outside of WPT.

Lint script: [third_party/WebKit/Tools/Scripts/webkitpy/thirdparty/wpt/wpt/lint](https://chromium.googlesource.com/chromium/src/+/master/third_party/WebKit/Tools/Scripts/webkitpy/thirdparty/wpt/wpt/lint)
WPT: [third_party/WebKit/LayoutTests/external/wpt/](https://chromium.googlesource.com/chromium/src/+/master/third_party/WebKit/LayoutTests/external/wpt/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6207)
<!-- Reviewable:end -->
