### PR TITLE
Added a test for <a download> error case

### DIFF
--- a/html/semantics/text-level-semantics/the-a-element/a-download-404.py
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-404.py
@@ -1,0 +1,2 @@
+def main(request, response):
+    return 404, [("Content-Type", "text/html")], 'Some content for the masses.' * 100

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Clicking on an &lt;a> element with a download attribute and href that leads to 404 should not navigate</title>
+<link rel="author" title="phistuck" href="mailto:user@domain.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="error-frame" src="resources/a-download-404.html"></iframe>
+<script>
+"use strict";
+async_test(function (t) {
+    const errorFrame = document.querySelector("#error-frame");
+    errorFrame.addEventListener("load", function () {
+        errorFrame.contentDocument.querySelector("#error-url").click();
+        t.step_timeout(function () {
+            t.done();
+        }, 1000);
+    });
+
+    errorFrame.contentWindow.addEventListener(
+        "beforeunload", t.unreached_func("Navigated instead of downloading"));
+}, "Do not navigate to 404 for anchor with download");
+</script>

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
@@ -5,6 +5,7 @@
 <link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<body>
 <script>
 "use strict";
 async_test(t => {
@@ -21,3 +22,4 @@ async_test(t => {
     document.body.appendChild(errorFrame);
 }, "Do not navigate to 404 for anchor with download");
 </script>
+</body>

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
@@ -1,24 +1,23 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Clicking on an &lt;a> element with a download attribute and href that leads to 404 should not navigate</title>
-<link rel="author" title="phistuck" href="mailto:user@domain.com">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-download">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<iframe id="error-frame" src="resources/a-download-404.html"></iframe>
 <script>
 "use strict";
-async_test(function (t) {
-    const errorFrame = document.querySelector("#error-frame");
+async_test(t => {
+    const errorFrame = document.createElement("iframe");
+    
     errorFrame.addEventListener("load", function () {
-        errorFrame.contentDocument.querySelector("#error-url").click();
-        t.step_timeout(function () {
-            t.done();
-        }, 1000);
-    });
+        errorFrame.contentWindow.addEventListener(
+            "beforeunload", t.unreached_func("Navigated instead of downloading"));
 
-    errorFrame.contentWindow.addEventListener(
-        "beforeunload", t.unreached_func("Navigated instead of downloading"));
+        errorFrame.contentDocument.querySelector("#error-url").click();
+        t.step_timeout(() => t.done(), 1000);
+    });
+    errorFrame.src = "resources/a-download-404.html";
+    document.body.appendChild(errorFrame);
 }, "Do not navigate to 404 for anchor with download");
 </script>

--- a/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
+++ b/html/semantics/text-level-semantics/the-a-element/a-download-click-404.html
@@ -10,7 +10,7 @@
 "use strict";
 async_test(t => {
     const errorFrame = document.createElement("iframe");
-    
+
     errorFrame.addEventListener("load", function () {
         errorFrame.contentWindow.addEventListener(
             "beforeunload", t.unreached_func("Navigated instead of downloading"));

--- a/html/semantics/text-level-semantics/the-a-element/resources/a-download-404.html
+++ b/html/semantics/text-level-semantics/the-a-element/resources/a-download-404.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<a id="error-url" href="../a-download-404.py" download="html.html">Click me</a>


### PR DESCRIPTION
According to the specification, <a download> should download (unless a user preference indicated otherwise), regardless of the fetching result (404, 200...) and not navigate.
This test verifies that navigation does not occur. It relies on a timeout, which might not be ideal, but I am not sure how else to decide that a navigation did not happen.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
