### PR TITLE
ES6 Modules nomodule attribute test cleanup

### DIFF
--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-async-classic-script.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-async-classic-script.html
@@ -17,12 +17,6 @@ waitForLoadEvent = new Promise((resolve) => {
     window.onload = resolve;
 });
 
-waitForAsyncScript = () => {
-    return new Promise((resolve) => {
-        waitForLoadEvent.then(() => setTimeout(resolve, 200));
-    });
-}
-
 promise_test(() => {
     window.executed = false;
     let loaded = false;
@@ -36,7 +30,7 @@ promise_test(() => {
     script.noModule = false;
     document.body.appendChild(script);
 
-    return waitForAsyncScript().then(() => {
+    return waitForLoadEvent.then(() => {
         assert_true(supportsNoModule);
         assert_true(executed);
         assert_true(loaded);
@@ -56,7 +50,7 @@ promise_test(() => {
     script.noModule = true;
     document.body.appendChild(script);
 
-    return waitForAsyncScript().then(() => {
+    return waitForLoadEvent.then(() => {
         assert_true(supportsNoModule);
         assert_false(executed);
         assert_false(loaded);

--- a/html/semantics/scripting-1/the-script-element/nomodule-set-on-synchronously-loaded-classic-scripts.html
+++ b/html/semantics/scripting-1/the-script-element/nomodule-set-on-synchronously-loaded-classic-scripts.html
@@ -36,11 +36,6 @@ test(() => {
     assert_false(errored);
 }, 'A synchronously loaded external classic script with nomodule content attribute must not run');
 
-
-waitForLoadEvent = new Promise((resolve) => {
-    window.onload = resolve;
-});
-
 </script>
 </body>
 </html>


### PR DESCRIPTION
**nomodule-set-on-async-classic-script.html**
Remove setTimeout API usage, which can be prone to issues when the test system is slow (i.e. VM on a busy host).  This test doesn't need the setTimeout usage though, since the platform should hold off from dispatching window's load event until all async scripts have been executed anyways.

**nomodule-set-on-synchronously-loaded-classic-scripts.html**
Removed dead code.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
