### PR TITLE
Add initial test for peer connection state changes

### DIFF
--- a/webrtc/RTCPeerConnection-connectionState.html
+++ b/webrtc/RTCPeerConnection-connectionState.html
@@ -8,11 +8,14 @@
   'use strict';
 
   // Test is based on the following editor draft:
-  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.htm
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  // exchangeIceCandidates
+  // doSignalingHandshake
 
   /*
     4.3.2.  Interface Definition
-
       interface RTCPeerConnection : EventTarget {
         ...
         readonly  attribute RTCPeerConnectionState connectionState;
@@ -20,7 +23,6 @@
       };
 
     4.4.3.  RTCPeerConnectionState Enum
-
       enum RTCPeerConnectionState {
         "new",
         "connecting",
@@ -30,36 +32,10 @@
         "closed"
       };
 
-      new
-        Any of the RTCIceTransports or RTCDtlsTransports are in the new
-        state and none of the transports are in the connecting, checking,
-        failed or disconnected state, or all transports are in the closed state.
-
-      connecting
-        Any of the RTCIceTransports or RTCDtlsTransports are in the
-        connecting or checking state and none of them is in the failed state.
-
-      connected
-        All RTCIceTransports and RTCDtlsTransports are in the connected,
-        completed or closed state and at least of them is in the connected
-        or completed state.
-
-      disconnected
-        Any of the RTCIceTransports or RTCDtlsTransports are in the disconnected
-        state and none of them are in the failed or connecting or checking state.
-
-      failed
-        Any of the RTCIceTransports or RTCDtlsTransports are in a failed state.
-
-      closed
-        The RTCPeerConnection object's [[isClosed]] slot is true.
-
     5.5.  RTCDtlsTransport Interface
-
       interface RTCDtlsTransport {
         readonly attribute RTCIceTransport       transport;
         readonly attribute RTCDtlsTransportState state;
-                 attribute EventHandler          onstatechange;
         ...
       };
 
@@ -71,28 +47,9 @@
         "failed"
       };
 
-      new
-        DTLS has not started negotiating yet.
-
-      connecting
-        DTLS is in the process of negotiating a secure connection.
-
-      connected
-        DTLS has completed negotiation of a secure connection.
-
-      closed
-        The transport has been closed.
-
-      failed
-        The transport has failed as the result of an error (such as a failure
-        to validate the remote fingerprint).
-
     5.6.  RTCIceTransport Interface
-
       interface RTCIceTransport {
         readonly attribute RTCIceTransportState state;
-                 attribute EventHandler         onstatechange;
-
         ...
       };
 
@@ -105,17 +62,32 @@
         "disconnected",
         "closed"
       };
+   */
 
+  /*
+    4.4.3.  RTCPeerConnectionState Enum
       new
-        The RTCIceTransport is gathering candidates and/or waiting for
-        remote candidates to be supplied, and has not yet started checking.
+        Any of the RTCIceTransports or RTCDtlsTransports are in the new
+        state and none of the transports are in the connecting, checking,
+        failed or disconnected state, or all transports are in the closed state.
+   */
+  test(t => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.connectionState, 'new');
+  }, 'Initial connectionState should be new');
 
-      checking
-        The RTCIceTransport has received at least one remote candidate and
-        is checking candidate pairs and has either not yet found a connection
-        or consent checks [RFC7675] have failed on all previously successful
-        candidate pairs. In addition to checking, it may also still be gathering.
+  /*
+    4.4.3.  RTCPeerConnectionState Enum
+      connected
+        All RTCIceTransports and RTCDtlsTransports are in the connected,
+        completed or closed state and at least of them is in the connected
+        or completed state.
 
+    5.5.  RTCDtlsTransportState
+      connected
+        DTLS has completed negotiation of a secure connection.
+
+    5.6.  RTCIceTransportState
       connected
         The RTCIceTransport has found a usable connection, but is still
         checking other candidate pairs to see if there is a better connection.
@@ -132,36 +104,7 @@
         there are no more remote candidates, finished checking all candidate
         pairs and found a connection. If consent checks [RFC7675] subsequently
         fail on all successful candidate pairs, the state transitions to "failed".
-
-      failed
-        The RTCIceTransport has finished gathering, received an indication that
-        there are no more remote candidates, finished checking all candidate pairs,
-        and all pairs have either failed connectivity checks or have lost consent.
-
-      disconnected
-        The ICE Agent has determined that connectivity is currently lost for this
-        RTCIceTransport . This is more aggressive than failed, and may trigger
-        intermittently (and resolve itself without action) on a flaky network.
-        The way this state is determined is implementation dependent.
-
-        Examples include:
-          Losing the network interface for the connection in use.
-          Repeatedly failing to receive a response to STUN requests.
-
-        Alternatively, the RTCIceTransport has finished checking all existing
-        candidates pairs and failed to find a connection (or consent checks
-        [RFC7675] once successful, have now failed), but it is still gathering
-        and/or waiting for additional remote candidates.
-
-      closed
-        The RTCIceTransport has shut down and is no longer responding to STUN requests.
    */
-
-  test(t => {
-    const pc = new RTCPeerConnection();
-    assert_equals(pc.connectionState, 'new');
-  }, 'Initial connectionState should be new');
-
   async_test(t => {
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
@@ -195,4 +138,70 @@
     doSignalingHandshake(pc1, pc2);
 
   }, 'connection with one data channel should eventually have connected connection state');
+
+  /*
+    TODO
+    4.4.3.  RTCPeerConnectionState Enum
+      connecting
+        Any of the RTCIceTransports or RTCDtlsTransports are in the
+        connecting or checking state and none of them is in the failed state.
+
+      disconnected
+        Any of the RTCIceTransports or RTCDtlsTransports are in the disconnected
+        state and none of them are in the failed or connecting or checking state.
+
+      failed
+        Any of the RTCIceTransports or RTCDtlsTransports are in a failed state.
+
+      closed
+        The RTCPeerConnection object's [[isClosed]] slot is true.
+
+     5.5. RTCDtlsTransportState
+      new
+        DTLS has not started negotiating yet.
+
+      connecting
+        DTLS is in the process of negotiating a secure connection.
+
+      closed
+        The transport has been closed.
+
+      failed
+        The transport has failed as the result of an error (such as a failure
+        to validate the remote fingerprint).
+
+    5.6.  RTCIceTransportState
+      new
+        The RTCIceTransport is gathering candidates and/or waiting for
+        remote candidates to be supplied, and has not yet started checking.
+
+      checking
+        The RTCIceTransport has received at least one remote candidate and
+        is checking candidate pairs and has either not yet found a connection
+        or consent checks [RFC7675] have failed on all previously successful
+        candidate pairs. In addition to checking, it may also still be gathering.
+
+      failed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate pairs,
+        and all pairs have either failed connectivity checks or have lost consent.
+
+      disconnected
+        The ICE Agent has determined that connectivity is currently lost for this
+        RTCIceTransport . This is more aggressive than failed, and may trigger
+        intermittently (and resolve itself without action) on a flaky network.
+        The way this state is determined is implementation dependent.
+
+        Examples include:
+          Losing the network interface for the connection in use.
+          Repeatedly failing to receive a response to STUN requests.
+
+        Alternatively, the RTCIceTransport has finished checking all existing
+        candidates pairs and failed to find a connection (or consent checks
+        [RFC7675] once successful, have now failed), but it is still gathering
+        and/or waiting for additional remote candidates.
+
+      closed
+        The RTCIceTransport has shut down and is no longer responding to STUN requests.
+   */
 </script>

--- a/webrtc/RTCPeerConnection-connectionState.html
+++ b/webrtc/RTCPeerConnection-connectionState.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.connectionState</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  /*
+    4.3.2.  Interface Definition
+
+      interface RTCPeerConnection : EventTarget {
+        ...
+        readonly  attribute RTCPeerConnectionState connectionState;
+                  attribute EventHandler           onconnectionstatechange;
+      };
+
+    4.4.3.  RTCPeerConnectionState Enum
+
+      enum RTCPeerConnectionState {
+        "new",
+        "connecting",
+        "connected",
+        "disconnected",
+        "failed",
+        "closed"
+      };
+
+      new
+        Any of the RTCIceTransports or RTCDtlsTransports are in the new
+        state and none of the transports are in the connecting, checking,
+        failed or disconnected state, or all transports are in the closed state.
+
+      connecting
+        Any of the RTCIceTransports or RTCDtlsTransports are in the
+        connecting or checking state and none of them is in the failed state.
+
+      connected
+        All RTCIceTransports and RTCDtlsTransports are in the connected,
+        completed or closed state and at least of them is in the connected
+        or completed state.
+
+      disconnected
+        Any of the RTCIceTransports or RTCDtlsTransports are in the disconnected
+        state and none of them are in the failed or connecting or checking state.
+
+      failed
+        Any of the RTCIceTransports or RTCDtlsTransports are in a failed state.
+
+      closed
+        The RTCPeerConnection object's [[isClosed]] slot is true.
+
+    5.5.  RTCDtlsTransport Interface
+
+      interface RTCDtlsTransport {
+        readonly attribute RTCIceTransport       transport;
+        readonly attribute RTCDtlsTransportState state;
+                 attribute EventHandler          onstatechange;
+        ...
+      };
+
+      enum RTCDtlsTransportState {
+        "new",
+        "connecting",
+        "connected",
+        "closed",
+        "failed"
+      };
+
+      new
+        DTLS has not started negotiating yet.
+
+      connecting
+        DTLS is in the process of negotiating a secure connection.
+
+      connected
+        DTLS has completed negotiation of a secure connection.
+
+      closed
+        The transport has been closed.
+
+      failed
+        The transport has failed as the result of an error (such as a failure
+        to validate the remote fingerprint).
+
+    5.6.  RTCIceTransport Interface
+
+      interface RTCIceTransport {
+        readonly attribute RTCIceTransportState state;
+                 attribute EventHandler         onstatechange;
+
+        ...
+      };
+
+      enum RTCIceTransportState {
+        "new",
+        "checking",
+        "connected",
+        "completed",
+        "failed",
+        "disconnected",
+        "closed"
+      };
+
+      new
+        The RTCIceTransport is gathering candidates and/or waiting for
+        remote candidates to be supplied, and has not yet started checking.
+
+      checking
+        The RTCIceTransport has received at least one remote candidate and
+        is checking candidate pairs and has either not yet found a connection
+        or consent checks [RFC7675] have failed on all previously successful
+        candidate pairs. In addition to checking, it may also still be gathering.
+
+      connected
+        The RTCIceTransport has found a usable connection, but is still
+        checking other candidate pairs to see if there is a better connection.
+        It may also still be gathering and/or waiting for additional remote
+        candidates. If consent checks [RFC7675] fail on the connection in use,
+        and there are no other successful candidate pairs available, then the
+        state transitions to "checking" (if there are candidate pairs remaining
+        to be checked) or "disconnected" (if there are no candidate pairs to
+        check, but the peer is still gathering and/or waiting for additional
+        remote candidates).
+
+      completed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate
+        pairs and found a connection. If consent checks [RFC7675] subsequently
+        fail on all successful candidate pairs, the state transitions to "failed".
+
+      failed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate pairs,
+        and all pairs have either failed connectivity checks or have lost consent.
+
+      disconnected
+        The ICE Agent has determined that connectivity is currently lost for this
+        RTCIceTransport . This is more aggressive than failed, and may trigger
+        intermittently (and resolve itself without action) on a flaky network.
+        The way this state is determined is implementation dependent.
+
+        Examples include:
+          Losing the network interface for the connection in use.
+          Repeatedly failing to receive a response to STUN requests.
+
+        Alternatively, the RTCIceTransport has finished checking all existing
+        candidates pairs and failed to find a connection (or consent checks
+        [RFC7675] once successful, have now failed), but it is still gathering
+        and/or waiting for additional remote candidates.
+
+      closed
+        The RTCIceTransport has shut down and is no longer responding to STUN requests.
+   */
+
+  test(t => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.connectionState, 'new');
+  }, 'Initial connectionState should be new');
+
+  async_test(t => {
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    const onConnectionStateChange = t.step_func(() => {
+      const { connectionState } = pc1;
+      if(connectionState === 'connected') {
+        const sctpTransport = pc1.sctp;
+
+        const dtlsTransport = sctpTransport.transport;
+        assert_equals(dtlsTransport.state, 'connected',
+          'Expect DTLS transport to be in connected state');
+
+        const iceTransport = dtlsTransport.transport
+        assert_true(iceTransport.state ===  'connected' ||
+          iceTransport.state === 'completed',
+          'Expect ICE transport to be in connected or completed state');
+
+        t.done();
+      }
+    });
+
+    pc1.createDataChannel('test');
+
+    assert_equals(pc1.onconnectionstatechange, null,
+      'Expect connection to have connectionstatechange event');
+
+    pc1.addEventListener('connectionstatechange', onConnectionStateChange);
+
+    exchangeIceCandidates(pc1, pc2);
+    doSignalingHandshake(pc1, pc2);
+
+  }, 'connection with one data channel should eventually have connected connection state');
+</script>

--- a/webrtc/RTCPeerConnection-iceConnectionState.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState.html
@@ -10,9 +10,12 @@
   // Test is based on the following editor draft:
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  // exchangeIceCandidates
+  // doSignalingHandshake
+
   /*
     4.3.2.  Interface Definition
-
       interface RTCPeerConnection : EventTarget {
         ...
         readonly  attribute RTCIceConnectionState  iceConnectionState;
@@ -20,7 +23,6 @@
       };
 
     4.4.4 RTCIceConnectionState Enum
-
       enum RTCIceConnectionState {
         "new",
         "checking",
@@ -31,35 +33,7 @@
         "closed"
       };
 
-      new
-        Any of the RTCIceTransports are in the new state and none of them
-        are in the checking, failed or disconnected state, or all
-        RTCIceTransport s are in the closed state.
-
-      checking
-        Any of the RTCIceTransport s are in the checking state and none of
-        them are in the failed or disconnected state.
-
-      connected
-        All RTCIceTransport s are in the connected, completed or closed state
-        and at least one of them is in the connected state.
-
-      completed
-        All RTCIceTransport s are in the completed or closed state and at least
-        one of them is in the completed state.
-
-      failed
-        Any of the RTCIceTransport s are in the failed state.
-
-      disconnected
-        Any of the RTCIceTransport s are in the disconnected state and none of
-        them are in the failed state.
-
-      closed
-        The RTCPeerConnection object's [[ isClosed]] slot is true.
-
     5.6.  RTCIceTransport Interface
-
       interface RTCIceTransport {
         readonly attribute RTCIceTransportState state;
                  attribute EventHandler         onstatechange;
@@ -76,10 +50,33 @@
         "disconnected",
         "closed"
       };
+   */
 
+  /*
+    4.4.4 RTCIceConnectionState Enum
       new
-        The RTCIceTransport is gathering candidates and/or waiting for
-        remote candidates to be supplied, and has not yet started checking.
+        Any of the RTCIceTransports are in the new state and none of them
+        are in the checking, failed or disconnected state, or all
+        RTCIceTransport s are in the closed state.
+   */
+  test(t => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.iceConnectionState, 'new');
+  }, 'Initial iceConnectionState should be new');
+
+  /*
+    4.4.4 RTCIceConnectionState Enum
+      checking
+        Any of the RTCIceTransport s are in the checking state and none of
+        them are in the failed or disconnected state.
+
+      connected
+        All RTCIceTransport s are in the connected, completed or closed state
+        and at least one of them is in the connected state.
+
+      completed
+        All RTCIceTransport s are in the completed or closed state and at least
+        one of them is in the completed state.
 
       checking
         The RTCIceTransport has received at least one remote candidate and
@@ -87,6 +84,7 @@
         or consent checks [RFC7675] have failed on all previously successful
         candidate pairs. In addition to checking, it may also still be gathering.
 
+    5.6.  enum RTCIceTransportState
       connected
         The RTCIceTransport has found a usable connection, but is still
         checking other candidate pairs to see if there is a better connection.
@@ -103,36 +101,7 @@
         there are no more remote candidates, finished checking all candidate
         pairs and found a connection. If consent checks [RFC7675] subsequently
         fail on all successful candidate pairs, the state transitions to "failed".
-
-      failed
-        The RTCIceTransport has finished gathering, received an indication that
-        there are no more remote candidates, finished checking all candidate pairs,
-        and all pairs have either failed connectivity checks or have lost consent.
-
-      disconnected
-        The ICE Agent has determined that connectivity is currently lost for this
-        RTCIceTransport . This is more aggressive than failed, and may trigger
-        intermittently (and resolve itself without action) on a flaky network.
-        The way this state is determined is implementation dependent.
-
-        Examples include:
-          Losing the network interface for the connection in use.
-          Repeatedly failing to receive a response to STUN requests.
-
-        Alternatively, the RTCIceTransport has finished checking all existing
-        candidates pairs and failed to find a connection (or consent checks
-        [RFC7675] once successful, have now failed), but it is still gathering
-        and/or waiting for additional remote candidates.
-
-      closed
-        The RTCIceTransport has shut down and is no longer responding to STUN requests.
    */
-
-  test(t => {
-    const pc = new RTCPeerConnection();
-    assert_equals(pc.iceConnectionState, 'new');
-  }, 'Initial iceConnectionState should be new');
-
   async_test(t => {
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
@@ -171,4 +140,46 @@
     doSignalingHandshake(pc1, pc2);
 
   }, 'connection with one data channel should eventually have connected connection state');
+
+  /*
+    TODO
+    4.4.4 RTCIceConnectionState Enum
+      failed
+        Any of the RTCIceTransport s are in the failed state.
+
+      disconnected
+        Any of the RTCIceTransport s are in the disconnected state and none of
+        them are in the failed state.
+
+      closed
+        The RTCPeerConnection object's [[ isClosed]] slot is true.
+
+    5.6.  enum RTCIceTransportState
+      new
+        The RTCIceTransport is gathering candidates and/or waiting for
+        remote candidates to be supplied, and has not yet started checking.
+
+      failed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate pairs,
+        and all pairs have either failed connectivity checks or have lost consent.
+
+      disconnected
+        The ICE Agent has determined that connectivity is currently lost for this
+        RTCIceTransport . This is more aggressive than failed, and may trigger
+        intermittently (and resolve itself without action) on a flaky network.
+        The way this state is determined is implementation dependent.
+
+        Examples include:
+          Losing the network interface for the connection in use.
+          Repeatedly failing to receive a response to STUN requests.
+
+        Alternatively, the RTCIceTransport has finished checking all existing
+        candidates pairs and failed to find a connection (or consent checks
+        [RFC7675] once successful, have now failed), but it is still gathering
+        and/or waiting for additional remote candidates.
+
+      closed
+        The RTCIceTransport has shut down and is no longer responding to STUN requests.
+   */
 </script>

--- a/webrtc/RTCPeerConnection-iceConnectionState.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.iceConnectionState</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  /*
+    4.3.2.  Interface Definition
+
+      interface RTCPeerConnection : EventTarget {
+        ...
+        readonly  attribute RTCIceConnectionState  iceConnectionState;
+                  attribute EventHandler           oniceconnectionstatechange;
+      };
+
+    4.4.4 RTCIceConnectionState Enum
+
+      enum RTCIceConnectionState {
+        "new",
+        "checking",
+        "connected",
+        "completed",
+        "failed",
+        "disconnected",
+        "closed"
+      };
+
+      new
+        Any of the RTCIceTransports are in the new state and none of them
+        are in the checking, failed or disconnected state, or all
+        RTCIceTransport s are in the closed state.
+
+      checking
+        Any of the RTCIceTransport s are in the checking state and none of
+        them are in the failed or disconnected state.
+
+      connected
+        All RTCIceTransport s are in the connected, completed or closed state
+        and at least one of them is in the connected state.
+
+      completed
+        All RTCIceTransport s are in the completed or closed state and at least
+        one of them is in the completed state.
+
+      failed
+        Any of the RTCIceTransport s are in the failed state.
+
+      disconnected
+        Any of the RTCIceTransport s are in the disconnected state and none of
+        them are in the failed state.
+
+      closed
+        The RTCPeerConnection object's [[ isClosed]] slot is true.
+
+    5.6.  RTCIceTransport Interface
+
+      interface RTCIceTransport {
+        readonly attribute RTCIceTransportState state;
+                 attribute EventHandler         onstatechange;
+
+        ...
+      };
+
+      enum RTCIceTransportState {
+        "new",
+        "checking",
+        "connected",
+        "completed",
+        "failed",
+        "disconnected",
+        "closed"
+      };
+
+      new
+        The RTCIceTransport is gathering candidates and/or waiting for
+        remote candidates to be supplied, and has not yet started checking.
+
+      checking
+        The RTCIceTransport has received at least one remote candidate and
+        is checking candidate pairs and has either not yet found a connection
+        or consent checks [RFC7675] have failed on all previously successful
+        candidate pairs. In addition to checking, it may also still be gathering.
+
+      connected
+        The RTCIceTransport has found a usable connection, but is still
+        checking other candidate pairs to see if there is a better connection.
+        It may also still be gathering and/or waiting for additional remote
+        candidates. If consent checks [RFC7675] fail on the connection in use,
+        and there are no other successful candidate pairs available, then the
+        state transitions to "checking" (if there are candidate pairs remaining
+        to be checked) or "disconnected" (if there are no candidate pairs to
+        check, but the peer is still gathering and/or waiting for additional
+        remote candidates).
+
+      completed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate
+        pairs and found a connection. If consent checks [RFC7675] subsequently
+        fail on all successful candidate pairs, the state transitions to "failed".
+
+      failed
+        The RTCIceTransport has finished gathering, received an indication that
+        there are no more remote candidates, finished checking all candidate pairs,
+        and all pairs have either failed connectivity checks or have lost consent.
+
+      disconnected
+        The ICE Agent has determined that connectivity is currently lost for this
+        RTCIceTransport . This is more aggressive than failed, and may trigger
+        intermittently (and resolve itself without action) on a flaky network.
+        The way this state is determined is implementation dependent.
+
+        Examples include:
+          Losing the network interface for the connection in use.
+          Repeatedly failing to receive a response to STUN requests.
+
+        Alternatively, the RTCIceTransport has finished checking all existing
+        candidates pairs and failed to find a connection (or consent checks
+        [RFC7675] once successful, have now failed), but it is still gathering
+        and/or waiting for additional remote candidates.
+
+      closed
+        The RTCIceTransport has shut down and is no longer responding to STUN requests.
+   */
+
+  test(t => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.iceConnectionState, 'new');
+  }, 'Initial iceConnectionState should be new');
+
+  async_test(t => {
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    const onIceConnectionStateChange = t.step_func(() => {
+      const { iceConnectionState } = pc1;
+
+      if(iceConnectionState === 'checking') {
+        const iceTransport = pc1.sctp.transport.transport;
+
+        assert_equals(iceTransport.state, 'checking',
+          'Expect ICE transport to be in checking state when iceConnectionState is checking');
+
+      } else if(iceConnectionState === 'connected') {
+        const iceTransport = pc1.sctp.transport.transport;
+
+        assert_equals(iceTransport.state, 'connected',
+          'Expect ICE transport to be in connected state when iceConnectionState is connected');
+
+      } else if(iceConnectionState === 'completed') {
+        const iceTransport = pc1.sctp.transport.transport;
+
+        assert_equals(iceTransport.state, 'completed',
+          'Expect ICE transport to be in connected state when iceConnectionState is completed');
+      }
+    });
+
+    pc1.createDataChannel('test');
+
+    assert_equals(pc1.oniceconnectionstatechange, null,
+      'Expect connection to have iceconnectionstatechange event');
+
+    pc1.addEventListener('iceconnectionstatechange', onIceConnectionStateChange);
+
+    exchangeIceCandidates(pc1, pc2);
+    doSignalingHandshake(pc1, pc2);
+
+  }, 'connection with one data channel should eventually have connected connection state');
+</script>

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -70,6 +70,29 @@
   }, 'Initial iceGatheringState should be new');
 
   async_test(t => {
+    const pc = new RTCPeerConnection();
+
+    const onIceGatheringStateChange = t.step_func(() => {
+      const { iceGatheringState } = pc;
+
+      if(iceGatheringState === 'complete') {
+        t.done();
+      }
+    });
+
+    assert_equals(pc.onicegatheringstatechange, null,
+      'Expect connection to have icegatheringstatechange event');
+
+    pc.addEventListener('icegatheringstatechange', onIceGatheringStateChange);
+
+    pc.createOffer({ offerToReceiveAudio: true })
+    .then(offer => pc.setLocalDescription(offer))
+    .then(err => t.step_func(err =>
+      assert_unreached(`Unhandled rejection ${err.name}: ${err.message}`)));
+
+  }, 'iceGatheringState should eventually become complete after setLocalDescription');
+
+  async_test(t => {
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
 
@@ -107,4 +130,5 @@
     doSignalingHandshake(pc1, pc2);
 
   }, 'connection with one data channel should eventually have connected connection state');
+
 </script>

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -10,9 +10,12 @@
   // Test is based on the following editor draft:
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  // exchangeIceCandidates
+  // doSignalingHandshake
+
   /*
     4.3.2.  Interface Definition
-
       interface RTCPeerConnection : EventTarget {
         ...
         readonly  attribute RTCIceGatheringState   iceGatheringState;
@@ -26,20 +29,7 @@
         "complete"
       };
 
-      new
-        Any of the RTCIceTransport s are in the new gathering state and
-        none of the transports are in the gathering state, or there are
-        no transports.
-
-      gathering
-        Any of the RTCIceTransport s are in the gathering state.
-
-      complete
-        At least one RTCIceTransport exists, and all RTCIceTransports are
-        in the completed gathering state.
-
     5.6.  RTCIceTransport Interface
-
       interface RTCIceTransport {
         readonly attribute RTCIceGathererState  gatheringState;
         ...
@@ -50,20 +40,15 @@
         "gathering",
         "complete"
       };
-
-      new
-        The RTCIceTransport was just created, and has not started gathering
-        candidates yet.
-
-      gathering
-        The RTCIceTransport is in the process of gathering candidates.
-
-      complete
-        The RTCIceTransport has completed gathering and the end-of-candidates
-        indication for this transport has been sent. It will not gather candidates
-        again until an ICE restart causes it to restart.
    */
 
+  /*
+    4.4.2.  RTCIceGatheringState Enum
+      new
+        Any of the RTCIceTransport s are in the new gathering state and
+        none of the transports are in the gathering state, or there are
+        no transports.
+   */
   test(t => {
     const pc = new RTCPeerConnection();
     assert_equals(pc.iceGatheringState, 'new');
@@ -92,6 +77,24 @@
 
   }, 'iceGatheringState should eventually become complete after setLocalDescription');
 
+  /*
+    4.4.2.  RTCIceGatheringState Enum
+      gathering
+        Any of the RTCIceTransport s are in the gathering state.
+
+      complete
+        At least one RTCIceTransport exists, and all RTCIceTransports are
+        in the completed gathering state.
+
+    5.6.  RTCIceGathererState
+      gathering
+        The RTCIceTransport is in the process of gathering candidates.
+
+      complete
+        The RTCIceTransport has completed gathering and the end-of-candidates
+        indication for this transport has been sent. It will not gather candidates
+        again until an ICE restart causes it to restart.
+   */
   async_test(t => {
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
@@ -131,4 +134,11 @@
 
   }, 'connection with one data channel should eventually have connected connection state');
 
+  /*
+    TODO
+    5.6.  RTCIceTransport Interface
+      new
+        The RTCIceTransport was just created, and has not started gathering
+        candidates yet.
+   */
 </script>

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -1,29 +1,110 @@
 <!doctype html>
-<html>
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>RTCPeerConnection ICEGatheringState tests</title>
-</head>
-<body>
-  <!-- These files are in place when executing on W3C. -->
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
-  <script type="text/javascript">
-  async_test(function(test) {
-    var pc = new RTCPeerConnection(null);
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.iceGatheringState</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
 
-    pc.onicegatheringstatechange = test.step_func(function(event) {
-      if (pc.iceGatheringState === 'complete') {
-        test.done();
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  /*
+    4.3.2.  Interface Definition
+
+      interface RTCPeerConnection : EventTarget {
+        ...
+        readonly  attribute RTCIceGatheringState   iceGatheringState;
+                  attribute EventHandler           onicegatheringstatechange;
+      };
+
+    4.4.2.  RTCIceGatheringState Enum
+      enum RTCIceGatheringState {
+        "new",
+        "gathering",
+        "complete"
+      };
+
+      new
+        Any of the RTCIceTransport s are in the new gathering state and
+        none of the transports are in the gathering state, or there are
+        no transports.
+
+      gathering
+        Any of the RTCIceTransport s are in the gathering state.
+
+      complete
+        At least one RTCIceTransport exists, and all RTCIceTransports are
+        in the completed gathering state.
+
+    5.6.  RTCIceTransport Interface
+
+      interface RTCIceTransport {
+        readonly attribute RTCIceGathererState  gatheringState;
+        ...
+      };
+
+      enum RTCIceGathererState {
+        "new",
+        "gathering",
+        "complete"
+      };
+
+      new
+        The RTCIceTransport was just created, and has not started gathering
+        candidates yet.
+
+      gathering
+        The RTCIceTransport is in the process of gathering candidates.
+
+      complete
+        The RTCIceTransport has completed gathering and the end-of-candidates
+        indication for this transport has been sent. It will not gather candidates
+        again until an ICE restart causes it to restart.
+   */
+
+  test(t => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.iceGatheringState, 'new');
+  }, 'Initial iceGatheringState should be new');
+
+  async_test(t => {
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    const onIceGatheringStateChange = t.step_func(() => {
+      const { iceGatheringState } = pc2;
+
+      if(iceGatheringState === 'gathering') {
+        const iceTransport = pc2.sctp.transport.transport;
+
+        assert_equals(iceTransport.gatheringState, 'gathering',
+          'Expect ICE transport to be in checking gatheringState when iceGatheringState is checking');
+
+      } else if(iceGatheringState === 'complete') {
+        const iceTransport = pc2.sctp.transport.transport;
+
+        assert_equals(iceTransport.gatheringState, 'complete',
+          'Expect ICE transport to be in complete gatheringState when iceGatheringState is complete');
+
+        t.done();
       }
     });
-    pc.createOffer({offerToReceiveAudio: 1})
-    .then(offer => pc.setLocalDescription(offer))
-    .catch(test.step_func(function(e) {
-      assert_unreached('Error ' + e.name + ': ' + e.message);
-    }));
-  }, 'Tests that the ICE gathering state ends up as "completed" after applying a local offer.');
-</script>
 
-</body>
-</html>
+    pc1.createDataChannel('test');
+
+    assert_equals(pc2.onicegatheringstatechange, null,
+      'Expect connection to have icegatheringstatechange event');
+
+    // Spec bug w3c/webrtc-pc#1382
+    // Because sctp is only defined when answer is set, we listen
+    // to pc2 so that we can be confident that sctp is defined
+    // when icegatheringstatechange event is fired.
+    pc2.addEventListener('icegatheringstatechange', onIceGatheringStateChange);
+
+    exchangeIceCandidates(pc1, pc2);
+    doSignalingHandshake(pc1, pc2);
+
+  }, 'connection with one data channel should eventually have connected connection state');
+</script>


### PR DESCRIPTION
~This is a work in progress.~ (Update: done)

I added few basic tests for the various connection state changes for the case when there is only one data channel. In this case there should be only one `RTCDtlsTransport` and one `RTCIceTransport` exist, accessible through the `sctp` attribute. With that we should be able to test for some states such as `completed`.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
