### PR TITLE
Make expectations optional when testing the framework

### DIFF
--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -34,8 +34,8 @@ This should be followed by one or more `<script>` tags that interface with the
       }, 'This test is expected to fail.');
     </script>
 
-Finally, each test should include a summary of the expected results as a JSON
-string within a `<script>` tag with an `id` of expected, e.g.:
+Finally, each test may include a summary of the expected results as a JSON
+string within a `<script>` tag with an `id` of `"expected"`, e.g.:
 
     <script type="text/json" id="expected">
     {
@@ -56,3 +56,6 @@ string within a `<script>` tag with an `id` of expected, e.g.:
       "type": "complete"
     }
     </script>
+
+This is useful to test, for example, whether asserations that should fail or
+throw actually do.

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -45,9 +45,6 @@ class HTMLItem(pytest.Item, pytest.Collector):
         if not name:
             raise ValueError('No name found in file: %s' % filename)
 
-        if not self.expected:
-            raise ValueError('Expected JSON not found in file: %s' % filename)
-
         super(HTMLItem, self).__init__(name, parent)
 
 
@@ -77,12 +74,11 @@ class HTMLItem(pytest.Item, pytest.Collector):
         summarized[u'summarized_tests'].sort(key=lambda test_obj: test_obj.get('name'))
         summarized[u'type'] = actual['type']
 
-        if u'unit_test_mode' in self.expected:
-            assert summarized[u'summarized_status'][u'status_string'] == u'OK'
+        if not self.expected:
+            assert summarized[u'summarized_status'][u'status_string'] == u'OK', summarized[u'summarized_status'][u'message']
             for test in summarized[u'summarized_tests']:
-                assert test[u'status_string'] == u'PASS', test[u'message']
-                assert test[u'stack'] == None, test[u'message']
-                assert test[u'message'] == None, test[u'message']
+                msg = "%s\n%s:\n%s" % (test[u'name'], test[u'message'], test[u'stack'])
+                assert test[u'status_string'] == u'PASS', msg
         else:
             assert summarized == self.expected
 

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -77,7 +77,14 @@ class HTMLItem(pytest.Item, pytest.Collector):
         summarized[u'summarized_tests'].sort(key=lambda test_obj: test_obj.get('name'))
         summarized[u'type'] = actual['type']
 
-        assert summarized == self.expected
+        if u'unit_test_mode' in self.expected:
+            assert summarized[u'summarized_status'][u'status_string'] == u'OK'
+            for test in summarized[u'summarized_tests']:
+                assert test[u'status_string'] == u'PASS', test[u'message']
+                assert test[u'stack'] == None, test[u'message']
+                assert test[u'message'] == None, test[u'message']
+        else:
+            assert summarized == self.expected
 
     @staticmethod
     def _assert_sequence(nums):


### PR DESCRIPTION
This provides more consistency with the rest of the test suite and greatly simplifies test authoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6233)
<!-- Reviewable:end -->
