### PR TITLE
Sync Mozilla reftests as of 2017-06-14

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/class-id-attr-selector-invalidation-01-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/class-id-attr-selector-invalidation-01-ref.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+div { color: green; }
+</style>
+<div>This should be green</div>
+<div>And this too</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/class-id-attr-selector-invalidation-01.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/class-id-attr-selector-invalidation-01.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: [id] and [class] attribute selectors are invalidated correctly.</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#attribute-selectors">
+<link rel="match" href="class-id-attr-selector-invalidation-01-ref.html">
+<style>
+[class="foo"] {
+  color: green;
+}
+[id="baz"] {
+  color: green;
+}
+</style>
+<div id="foo">This should be green</div>
+<div id="bar">And this too</div>
+<script>
+onload = function() {
+  document.documentElement.offsetTop;
+  foo.classList.add("foo");
+  bar.setAttribute("id", "baz");
+  document.documentElement.offsetTop;
+}
+</script>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/selectors4/reftest.list
@@ -9,3 +9,4 @@
 == dir-style-03b.html dir-style-03-ref.html
 == dir-style-04.html dir-style-04-ref.html
 == child-index-no-parent-01.html child-index-no-parent-01-ref.html
+== class-id-attr-selector-invalidation-01.html class-id-attr-selector-invalidation-01-ref.html


### PR DESCRIPTION
This sync's Mozilla's reftests as of [da66c4a05fda](https://hg.mozilla.org/mozilla-central/rev/da66c4a05fda49d457d9411a7092fed87cf9e53a).

This contains a [single change](https://hg.mozilla.org/mozilla-central/rev/2addc637dc89):
  user:        Emilio Cobos Álvarez <emilio@crisal.io> (@emilio)
  date:        Fri Jun 09 17:21:25 2017 +0200
  summary:     Bug 1368240: Implement a more fine-grained invalidation method. r=heycam
which was already reviewed by @heycam in [bug 1368240](https://bugzilla.mozilla.org/show_bug.cgi?id=1368240).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
