### PR TITLE
[testharness.js] Hide implementation details

### DIFF
--- a/resources/test/tests/add_cleanup_count.html
+++ b/resources/test/tests/add_cleanup_count.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Test#add_cleanup reported count</title>
+<script src="../../testharness.js"></script>
+<script src="../../testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+
+<script>
+promise_test(function(t) {
+	t.add_cleanup(function() {});
+	t.add_cleanup(function() {});
+	t.add_cleanup(function() { throw new Error(); });
+	new EventWatcher(t, document.body, []);
+
+    return Promise.resolve();
+}, 'test with 3 user-defined cleanup functions');
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "ERROR",
+    "message": "Test named 'test with 3 user-defined cleanup functions' specified 3 'cleanup' functions, and 1 failed.",
+    "stack": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "test with 3 user-defined cleanup functions",
+      "stack": null,
+      "message": null,
+      "properties": {}
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/add_cleanup_count.html
+++ b/resources/test/tests/add_cleanup_count.html
@@ -10,10 +10,10 @@
 
 <script>
 promise_test(function(t) {
-	t.add_cleanup(function() {});
-	t.add_cleanup(function() {});
-	t.add_cleanup(function() { throw new Error(); });
-	new EventWatcher(t, document.body, []);
+    t.add_cleanup(function() {});
+    t.add_cleanup(function() {});
+    t.add_cleanup(function() { throw new Error(); });
+    new EventWatcher(t, document.body, []);
 
     return Promise.resolve();
 }, 'test with 3 user-defined cleanup functions');

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1473,7 +1473,7 @@ policies and contribution forms [3].
     }
 
     /*
-     * Private method for registering cleanup functions. `testharnes.js`
+     * Private method for registering cleanup functions. `testharness.js`
      * internals should use this method instead of the public `add_cleanup`
      * method in order to hide implementation details from the harness status
      * message in the case errors.

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1490,7 +1490,7 @@ policies and contribution forms [3].
      */
     Test.prototype.add_cleanup = function(callback) {
         this._user_defined_cleanup_count += 1;
-		this._add_cleanup(callback);
+        this._add_cleanup(callback);
     };
 
     Test.prototype.force_timeout = function() {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -528,7 +528,7 @@ policies and contribution forms [3].
         }
         tests.promise_tests = tests.promise_tests.then(function() {
             var donePromise = new Promise(function(resolve) {
-                test.add_cleanup(resolve);
+                test._add_cleanup(resolve);
             });
             var promise = test.step(func, test, test);
             test.step(function() {
@@ -618,7 +618,7 @@ policies and contribution forms [3].
             }
         };
 
-        test.add_cleanup(stop_watching);
+        test._add_cleanup(stop_watching);
 
         return this;
     }
@@ -1347,6 +1347,7 @@ policies and contribution forms [3].
         this.steps = [];
 
         this.cleanup_callbacks = [];
+        this._user_defined_cleanup_count = 0;
 
         tests.push(this);
     }
@@ -1471,8 +1472,25 @@ policies and contribution forms [3].
         }), timeout * tests.timeout_multiplier);
     }
 
-    Test.prototype.add_cleanup = function(callback) {
+    /*
+     * Private method for registering cleanup functions. `testharnes.js`
+     * internals should use this method instead of the public `add_cleanup`
+     * method in order to hide implementation details from the harness status
+     * message in the case errors.
+     */
+    Test.prototype._add_cleanup = function(callback) {
         this.cleanup_callbacks.push(callback);
+    };
+
+    /*
+     * Schedule a function to be run after the test result is known, regardless
+     * of passing or failing state. The behavior of this function will not
+     * influence the result of the test, but if an exception is thrown, the
+     * test harness will report an error.
+     */
+    Test.prototype.add_cleanup = function(callback) {
+        this._user_defined_cleanup_count += 1;
+		this._add_cleanup(callback);
     };
 
     Test.prototype.force_timeout = function() {
@@ -1545,7 +1563,7 @@ policies and contribution forms [3].
                 });
 
         if (error_count > 0) {
-            total = this.cleanup_callbacks.length;
+            total = this._user_defined_cleanup_count;
             tests.status.status = tests.status.ERROR;
             tests.status.message = "Test named '" + this.name +
                 "' specified " + total + " 'cleanup' function" +


### PR DESCRIPTION
Introduce a "private" version of `Test#add_cleanup` so that test harness
status messages can more accurately reflect end user expectations.
Document both the "public" and "private" implementations with in-line
comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6244)
<!-- Reviewable:end -->
