### PR TITLE
[idlharness.js] Expand test coverage

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -1137,81 +1137,14 @@ IdlInterface.prototype.test_self = function()
         }
     }.bind(this), this.name + " interface: existence and properties of interface prototype object");
 
-    if (this.is_global() && typeof Object.setPrototypeOf === "function") {
-        // These functions test WebIDL as of 2017-06-06.
-        // https://heycam.github.io/webidl/#platform-object-setprototypeof
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-            var newValue = Object.create(null);
-
-            assert_throws(new TypeError(), function() {
-                Object.setPrototypeOf(self[this.name].prototype, newValue);
-            });
-
-            assert_equals(
-                    Object.getPrototypeOf(self[this.name].prototype),
-                    originalValue,
-                    "original value not modified"
-                );
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to a new value via Object.setPrototypeOf " +
-            "should throw a TypeError");
-
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-            var newValue = Object.create(null);
-
-            assert_throws(new TypeError(), function() {
-                self[this.name].prototype.__proto__ = newValue;
-            });
-
-            assert_equals(
-                    Object.getPrototypeOf(self[this.name].prototype),
-                    originalValue,
-                    "original value not modified"
-                );
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to a new value via __proto__ " +
-            "should throw a TypeError");
-
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-            var newValue = Object.create(null);
-
-            assert_false(Reflect.setPrototypeOf(self[this.name].prototype.__proto__, newValue));
-
-            assert_equals(
-                    Object.getPrototypeOf(self[this.name].prototype),
-                    originalValue,
-                    "original value not modified"
-                );
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to a new value via Reflect.setPrototypeOf " +
-            "should return false");
-
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-
-            Object.setPrototypeOf(self[this.name].prototype, originalValue);
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to its original value via Object.setPrototypeOf " +
-            "should not throw");
-
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-
-            self[this.name].prototype.__proto__ = originalValue;
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to its original value via __proto__ " +
-            "should not throw");
-
-        test(function() {
-            var originalValue = Object.getPrototypeOf(self[this.name].prototype);
-
-            assert_true(Reflect.setPrototypeOf(self[this.name].prototype, originalValue));
-        }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
-            "of global platform object - setting to its original value via Reflect.setPrototypeOf " +
-            "should return true");
+    // "If the interface is declared with the [Global] or [PrimaryGlobal]
+    // extended attribute, or the interface is in the set of inherited
+    // interfaces for any other interface that is declared with one of these
+    // attributes, then the interface prototype object must be an immutable
+    // prototype exotic object."
+    // https://heycam.github.io/webidl/#interface-prototype-object
+    if (this.is_global()) {
+        this.test_immutable_prototype("interface prototype object", self[this.name].prototype);
     }
 
     test(function()
@@ -1248,6 +1181,110 @@ IdlInterface.prototype.test_self = function()
         assert_equals(self[this.name].prototype.constructor, self[this.name],
                       this.name + '.prototype.constructor is not the same object as ' + this.name);
     }.bind(this), this.name + ' interface: existence and properties of interface prototype object\'s "constructor" property');
+};
+
+//@}
+IdlInterface.prototype.test_immutable_prototype = function(type, obj)
+//@{
+{
+    if (typeof Object.setPrototypeOf !== "function") {
+        return;
+    }
+
+    test(function(t) {
+        var originalValue = Object.getPrototypeOf(obj);
+        var newValue = Object.create(null);
+
+        t.add_cleanup(function() {
+            try {
+                Object.setPrototypeOf(obj, originalValue);
+            } catch (err) {}
+        });
+
+        assert_throws(new TypeError(), function() {
+            Object.setPrototypeOf(obj, newValue);
+        });
+
+        assert_equals(
+                Object.getPrototypeOf(obj),
+                originalValue,
+                "original value not modified"
+            );
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to a new value via Object.setPrototypeOf " +
+        "should throw a TypeError");
+
+    test(function(t) {
+        var originalValue = Object.getPrototypeOf(obj);
+        var newValue = Object.create(null);
+
+        t.add_cleanup(function() {
+            var setter = Object.getOwnPropertyDescriptor(
+                Object.prototype, '__proto__'
+            ).set;
+
+            try {
+                setter.call(obj, originalValue);
+            } catch (err) {}
+        });
+
+        assert_throws(new TypeError(), function() {
+            obj.__proto__ = newValue;
+        });
+
+        assert_equals(
+                Object.getPrototypeOf(obj),
+                originalValue,
+                "original value not modified"
+            );
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to a new value via __proto__ " +
+        "should throw a TypeError");
+
+    test(function(t) {
+        var originalValue = Object.getPrototypeOf(obj);
+        var newValue = Object.create(null);
+
+        t.add_cleanup(function() {
+            try {
+                Reflect.setPrototypeOf(obj, originalValue);
+            } catch (err) {}
+        });
+
+        assert_false(Reflect.setPrototypeOf(obj, newValue));
+
+        assert_equals(
+                Object.getPrototypeOf(obj),
+                originalValue,
+                "original value not modified"
+            );
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to a new value via Reflect.setPrototypeOf " +
+        "should return false");
+
+    test(function() {
+        var originalValue = Object.getPrototypeOf(obj);
+
+        Object.setPrototypeOf(obj, originalValue);
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to its original value via Object.setPrototypeOf " +
+        "should not throw");
+
+    test(function() {
+        var originalValue = Object.getPrototypeOf(obj);
+
+        obj.__proto__ = originalValue;
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to its original value via __proto__ " +
+        "should not throw");
+
+    test(function() {
+        var originalValue = Object.getPrototypeOf(obj);
+
+        assert_true(Reflect.setPrototypeOf(obj, originalValue));
+    }.bind(this), this.name + " interface: internal [[SetPrototypeOf]] method " +
+        "of " + type + " - setting to its original value via Reflect.setPrototypeOf " +
+        "should return true");
 };
 
 //@}
@@ -1768,6 +1805,18 @@ IdlInterface.prototype.test_primary_interface_of = function(desc, obj, exception
     {
         return;
     }
+
+    // "The internal [[SetPrototypeOf]] method of every platform object that
+    // implements an interface with the [Global] or [PrimaryGlobal] extended
+    // attribute must execute the same algorithm as is defined for the
+    // [[SetPrototypeOf]] internal method of an immutable prototype exotic
+    // object."
+    // https://heycam.github.io/webidl/#platform-object-setprototypeof
+    if (this.is_global())
+    {
+        this.test_immutable_prototype("global platform object", obj);
+    }
+
 
     // We can't easily test that its prototype is correct if there's no
     // interface object, or the object is from a different global environment

--- a/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
@@ -1,0 +1,321 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>idlharness: Immutable prototypes</title>
+  <script src="../../testharness.js"></script>
+  <script src="../../testharnessreport.js"></script>
+  <script src="../../WebIDLParser.js"></script>
+  <script src="../../idlharness.js"></script>
+</head>
+<body>
+<script>
+"use strictt";
+
+Object.defineProperty(window, "Foo", {
+    enumerable: false,
+    writable: true,
+    configurable: true,
+    value: function Foo() {}
+  });
+Object.defineProperty(window.Foo, "prototype", {
+    writable: false,
+    value: window.Foo.prototype
+  });
+Foo.prototype[Symbol.toStringTag] = "Foo";
+
+var idlArray = new IdlArray();
+idlArray.add_untested_idls("interface EventTarget {};");
+idlArray.add_idls(
+    "[Global=Window, Exposed=Window]\n" +
+    "interface Window : EventTarget {};\n" +
+
+    "[Global=Window, Exposed=Window, Constructor()]\n" +
+	"interface Foo {};"
+  );
+idlArray.add_objects({
+  Foo: ["new Foo()"],
+  Window: ["window"]
+});
+idlArray.test();
+</script>
+<script type="text/json" id="expected">
+{
+    "summarized_status": {
+        "message": null,
+        "status_string": "OK",
+        "stack": null
+    },
+    "summarized_tests": [
+        {
+            "name": "Foo interface object length",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface object name",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: existence and properties of interface object",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: existence and properties of interface prototype object",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: existence and properties of interface prototype object's \"constructor\" property",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_throws: function \"function () {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Reflect.setPrototypeOf should return false",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_false: expected false got true",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via __proto__ should throw a TypeError",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_throws: function \"function () {\n            obj.__proto__ = newValue;\n        }\" did not throw",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Object.setPrototypeOf should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Reflect.setPrototypeOf should return true",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via __proto__ should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_throws: function \"function () {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Reflect.setPrototypeOf should return false",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_false: expected false got true",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via __proto__ should throw a TypeError",
+            "status_string": "FAIL",
+            "properties": {},
+            "message": "assert_throws: function \"function () {\n            obj.__proto__ = newValue;\n        }\" did not throw",
+            "stack": "(implementation-defined)"
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Object.setPrototypeOf should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Reflect.setPrototypeOf should return true",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via __proto__ should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Foo must be primary interface of new Foo()",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Stringification of new Foo()",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Stringification of window",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface object length",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface object name",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: existence and properties of interface object",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: existence and properties of interface prototype object",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: existence and properties of interface prototype object's \"constructor\" property",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Reflect.setPrototypeOf should return false",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via __proto__ should throw a TypeError",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Object.setPrototypeOf should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Reflect.setPrototypeOf should return true",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via __proto__ should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Reflect.setPrototypeOf should return false",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via __proto__ should throw a TypeError",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Object.setPrototypeOf should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Reflect.setPrototypeOf should return true",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via __proto__ should not throw",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        },
+        {
+            "name": "Window must be primary interface of window",
+            "status_string": "PASS",
+            "properties": {},
+            "message": null,
+            "stack": null
+        }
+    ],
+    "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>idlharness: Immutable prototypes</title>
-  <script src="../../testharness.js"></script>
-  <script src="../../testharnessreport.js"></script>
-  <script src="../../WebIDLParser.js"></script>
-  <script src="../../idlharness.js"></script>
+  <script src="../../../../testharness.js"></script>
+  <script src="../../../../testharnessreport.js"></script>
+  <script src="../../../../WebIDLParser.js"></script>
+  <script src="../../../../idlharness.js"></script>
 </head>
 <body>
 <script>
@@ -86,7 +86,7 @@ idlArray.test();
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function () {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
+            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
             "stack": "(implementation-defined)"
         },
         {
@@ -100,7 +100,7 @@ idlArray.test();
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function () {\n            obj.__proto__ = newValue;\n        }\" did not throw",
+            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw",
             "stack": "(implementation-defined)"
         },
         {
@@ -128,7 +128,7 @@ idlArray.test();
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function () {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
+            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
             "stack": "(implementation-defined)"
         },
         {
@@ -142,7 +142,7 @@ idlArray.test();
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function () {\n            obj.__proto__ = newValue;\n        }\" did not throw",
+            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw",
             "stack": "(implementation-defined)"
         },
         {


### PR DESCRIPTION
A previous patch introduced new tests intended to verify that global
platform objects were also immutable prototype objects. In actuality,
the new tests verified an unrelated condition: that interface prototype
objects were also immutable prototype objects.

Update idlharness to assert that both types of objects are immutable
prototype objects, and modify test expectation strings to correctly
describe each type. Introduce "cleanup" logic to avoid sub-test
interaction.

---

This is a correction/extension of https://github.com/w3c/web-platform-tests/pull/5788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6262)
<!-- Reviewable:end -->
