### PR TITLE
Invert the logic of the security.reset canvas test

### DIFF
--- a/2dcontext/tools/tests.yaml
+++ b/2dcontext/tools/tests.yaml
@@ -1057,7 +1057,7 @@
   expected: green
 
 - name: security.reset
-  desc: Resetting the canvas state does not reset the origin-clean flag
+  desc: Resetting the canvas state resets the origin-clean flag
   mozilla: { disabled } # relies on external resources
   testing:
     - initial.reset
@@ -1071,4 +1071,6 @@
     ctx.drawImage(document.getElementById('yellow.png'), 0, 0);
     @assert throws SECURITY_ERR canvas.toDataURL();
     canvas.width = 100;
-    @assert throws SECURITY_ERR canvas.toDataURL();
+    canvas.toDataURL();
+    ctx.getImageData(0, 0, 1, 1);
+    @assert true; // okay if there was no exception

--- a/html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
@@ -7,13 +7,8 @@
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
 
-<<<<<<< HEAD:html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
 <h1>security.reset.cross</h1>
-<p class="desc">Resetting the canvas state does not reset the origin-clean flag</p>
-=======
-<h1>security.reset</h1>
 <p class="desc">Resetting the canvas state resets the origin-clean flag</p>
->>>>>>> Invert the logic of the security.reset canvas test:html/semantics/embedded-content/the-canvas-element/security.reset.html
 
 
 <p class="output">Actual output:</p>

--- a/html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
@@ -7,8 +7,13 @@
 <link rel="stylesheet" href="/common/canvas-tests.css">
 <body class="show_output">
 
+<<<<<<< HEAD:html/semantics/embedded-content/the-canvas-element/security.reset.cross.html
 <h1>security.reset.cross</h1>
 <p class="desc">Resetting the canvas state does not reset the origin-clean flag</p>
+=======
+<h1>security.reset</h1>
+<p class="desc">Resetting the canvas state resets the origin-clean flag</p>
+>>>>>>> Invert the logic of the security.reset canvas test:html/semantics/embedded-content/the-canvas-element/security.reset.html
 
 
 <p class="output">Actual output:</p>
@@ -16,14 +21,16 @@
 
 <ul id="d"></ul>
 <script>
-var t = async_test("Resetting the canvas state does not reset the origin-clean flag");
+var t = async_test("Resetting the canvas state resets the origin-clean flag");
 _addTest(function(canvas, ctx) {
 
 canvas.width = 50;
 ctx.drawImage(document.getElementById('yellow.png'), 0, 0);
 assert_throws("SECURITY_ERR", function() { canvas.toDataURL(); });
 canvas.width = 100;
-assert_throws("SECURITY_ERR", function() { canvas.toDataURL(); });
+canvas.toDataURL();
+ctx.getImageData(0, 0, 1, 1);
+_assert(true, "true"); // okay if there was no exception
 
 
 });

--- a/html/semantics/embedded-content/the-canvas-element/security.reset.redirect.html
+++ b/html/semantics/embedded-content/the-canvas-element/security.reset.redirect.html
@@ -8,7 +8,7 @@
 <body class="show_output">
 
 <h1>security.reset.redirect</h1>
-<p class="desc">Resetting the canvas state does not reset the origin-clean flag</p>
+<p class="desc">Resetting the canvas state resets the origin-clean flag</p>
 
 
 <p class="output">Actual output:</p>
@@ -16,14 +16,16 @@
 
 <ul id="d"></ul>
 <script>
-var t = async_test("Resetting the canvas state does not reset the origin-clean flag");
+var t = async_test("Resetting the canvas state resets the origin-clean flag");
 _addTest(function(canvas, ctx) {
 
 canvas.width = 50;
 ctx.drawImage(document.getElementById('yellow.png'), 0, 0);
 assert_throws("SECURITY_ERR", function() { canvas.toDataURL(); });
 canvas.width = 100;
-assert_throws("SECURITY_ERR", function() { canvas.toDataURL(); });
+canvas.toDataURL();
+ctx.getImageData(0, 0, 1, 1);
+_assert(true, "true"); // okay if there was no exception
 
 
 });


### PR DESCRIPTION
The test was checking for the opposite behaviour of what is in the spec.
When a 2d canvas context is reset (e.g. setting the canvas size), the
origin-clean flag is supposed to be reset.

Discussion: https://github.com/whatwg/html/issues/2660
Spec:
http://w3c-test.org/html/semantics/embedded-content/the-canvas-element/security.reset.html

<!-- Reviewable:start -->

<!-- Reviewable:end -->
