### PR TITLE
Test initial selection and behavior when switching type for various form controls

### DIFF
--- a/html/semantics/forms/textfieldselection/helpers.js
+++ b/html/semantics/forms/textfieldselection/helpers.js
@@ -1,0 +1,17 @@
+"use strict";
+
+// This helper ensures that when the selection direction is reset, it always is reset to the same value consistently
+// (which must be one of either "none" or "forward"). This helps catch bugs like one observed in Chrome, where textareas
+// reset to "none" but inputs reset to "forward".
+let observedResetSelectionDirection;
+window.assertSelectionDirectionIsReset = element => {
+  if (!observedResetSelectionDirection) {
+    assert_in_array(element.selectionDirection, ["none", "forward"],
+      "selectionDirection must be set to either none or forward");
+    observedResetSelectionDirection = element.selectionDirection;
+  } else {
+    assert_equals(element.selectionDirection, observedResetSelectionDirection,
+      `selectionDirection must be reset to ${observedResetSelectionDirection} (which was previously observed to be ` +
+      `the value after resetting the selection direction)`);
+  }
+};

--- a/html/semantics/forms/textfieldselection/initial-selection.html
+++ b/html/semantics/forms/textfieldselection/initial-selection.html
@@ -47,7 +47,6 @@ test(() => {
   document.body.appendChild(el);
   assert_equals(el.selectionStart, 0, "selectionStart before");
   assert_equals(el.selectionStart, 0, "selectionEnd before");
-  el.defaultValue = "value";
 }, "Created by script, in document: textarea");
 
 test(() => {
@@ -57,7 +56,6 @@ test(() => {
     document.body.appendChild(el);
     assert_equals(el.selectionStart, 0, "selectionStart before " + type);
     assert_equals(el.selectionStart, 0, "selectionEnd before " + type);
-    el.defaultValue = "value";
   }
 }, "Created by script, in document: input");
 
@@ -70,7 +68,6 @@ test(() => {
   el.selectionStart = el.selectionStart;
   assert_equals(el.selectionStart, 0, "selectionStart before");
   assert_equals(el.selectionStart, 0, "selectionEnd before");
-  el.defaultValue = "value";
 }, "Created by script, in document, trigger setter first: textarea");
 
 test(() => {
@@ -81,7 +78,6 @@ test(() => {
     el.selectionStart = el.selectionStart;
     assert_equals(el.selectionStart, 0, "selectionStart before " + type);
     assert_equals(el.selectionStart, 0, "selectionEnd before " + type);
-    el.defaultValue = "value";
   }
 }, "Created by script, in document, trigger setter first: input");
 </script>

--- a/html/semantics/forms/textfieldselection/initial-selection.html
+++ b/html/semantics/forms/textfieldselection/initial-selection.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Initial cursor position in text entry controls</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#textFieldSelection">
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="container">
+  <input type="text" value="value" autofocus>
+  <input type="text" value="value">
+  <input type="search" value="value">
+  <input type="tel" value="value">
+  <input type="password" value="value">
+  <textarea>hello</textarea>
+</div>
+
+<script>
+"use strict";
+test(() => {
+  for (const el of Array.from(document.querySelector("#container").children)) {
+    const label = el.localName +
+      (el.type ? " " + el.type : "") +
+      (el.autofocus ? " autofocus" : "");
+    assert_equals(el.selectionStart, 0, "selectionStart " + label);
+    assert_equals(el.selectionEnd, 0, "selectionEnd " + label);
+  }
+}, "Created by the parser");
+
+test(() => {
+  const el = document.createElement("textarea");
+  assert_equals(el.selectionStart, 0, "selectionStart");
+  assert_equals(el.selectionStart, 0, "selectionEnd");
+}, "Created by script, out of document: textarea");
+
+test(() => {
+  const el = document.createElement("input");
+  for (const type of ["text", "search", "tel", "password"]) {
+    el.type = type;
+    assert_equals(el.selectionStart, 0, "selectionStart " + type);
+    assert_equals(el.selectionStart, 0, "selectionEnd " + type);
+  }
+}, "Created by script, out of document: input");
+
+test(() => {
+  const el = document.createElement("textarea");
+  document.body.appendChild(el);
+  assert_equals(el.selectionStart, 0, "selectionStart before");
+  assert_equals(el.selectionStart, 0, "selectionEnd before");
+  el.defaultValue = "value";
+}, "Created by script, in document: textarea");
+
+test(() => {
+  const el = document.createElement("input");
+  for (const type of ["text", "search", "tel", "password"]) {
+    el.type = type;
+    document.body.appendChild(el);
+    assert_equals(el.selectionStart, 0, "selectionStart before " + type);
+    assert_equals(el.selectionStart, 0, "selectionEnd before " + type);
+    el.defaultValue = "value";
+  }
+}, "Created by script, in document: input");
+
+// The "trigger setter first" tests are related to WebKit inconsistencies; see
+// https://github.com/whatwg/html/issues/2424. (However, they pass in WebKit, as we don't test
+// the selectionStart/End values *after* setting defaultValue in these tests.)
+test(() => {
+  const el = document.createElement("textarea");
+  document.body.appendChild(el);
+  el.selectionStart = el.selectionStart;
+  assert_equals(el.selectionStart, 0, "selectionStart before");
+  assert_equals(el.selectionStart, 0, "selectionEnd before");
+  el.defaultValue = "value";
+}, "Created by script, in document, trigger setter first: textarea");
+
+test(() => {
+  const el = document.createElement("input");
+  for (const type of ["text", "search", "tel", "password"]) {
+    el.type = type;
+    document.body.appendChild(el);
+    el.selectionStart = el.selectionStart;
+    assert_equals(el.selectionStart, 0, "selectionStart before " + type);
+    assert_equals(el.selectionStart, 0, "selectionEnd before " + type);
+    el.defaultValue = "value";
+  }
+}, "Created by script, in document, trigger setter first: input");
+</script>

--- a/html/semantics/forms/textfieldselection/selection-after-content-change.html
+++ b/html/semantics/forms/textfieldselection/selection-after-content-change.html
@@ -3,28 +3,13 @@
 <title>Selection indices after content change</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="helpers.js"></script>
 
 <input id="i1" type="text" value="hello">
 <textarea id="t1">hello</textarea>
 
 <script>
 "use strict";
-
-// This helper ensures that when the selection direction is reset, it always is reset to the same value consistently
-// (which must be one of either "none" or "forward"). This helps catch bugs like one observed in Chrome, where textareas
-// reset to "none" but inputs reset to "forward".
-let observedResetSelectionDirection;
-function assertSelectionDirectionIsReset(element) {
-  if (!observedResetSelectionDirection) {
-    assert_in_array(element.selectionDirection, ["none", "forward"],
-      "selectionDirection must be set to either none or forward");
-    observedResetSelectionDirection = element.selectionDirection;
-  } else {
-    assert_equals(element.selectionDirection, observedResetSelectionDirection,
-      `selectionDirection must be reset to ${observedResetSelectionDirection} (which was previously observed to be ` +
-      `the value after resetting the selection direction)`);
-  }
-}
 
 runInputTest("input out of document", () => {
   const input = document.createElement("input");

--- a/html/semantics/forms/textfieldselection/selection-after-type-change.html
+++ b/html/semantics/forms/textfieldselection/selection-after-type-change.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selection properties resetting, or not, when changing type</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#input-type-change">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="helpers.js"></script>
+
+<body>
+<script>
+"use strict";
+test(() => {
+  const el = document.createElement("input");
+  document.body.appendChild(el);
+
+  el.setAttribute("value", "hey");
+  el.selectionStart = 1;
+  el.selectionEnd = 2;
+  el.selectionDirection = "backward";
+
+  el.setAttribute("type", "search");
+  assert_equals(el.selectionStart, 1, "selectionStart");
+  assert_equals(el.selectionEnd, 2, "selectionEnd");
+  assert_equals(el.selectionDirection, "backward", "selectionDirection");
+}, "Input switching from a selectable type to other selectable type");
+
+test(() => {
+  const el = document.createElement("input");
+  document.body.appendChild(el);
+
+  el.setAttribute("value", "hey");
+  el.selectionStart = 1;
+  el.selectionEnd = 2;
+  el.selectionDirection = "backward";
+
+  el.setAttribute("type", "checkbox");
+  assert_equals(el.selectionStart, null, "selectionStart");
+  assert_equals(el.selectionEnd, null, "selectionEnd");
+  assert_equals(el.selectionDirection, null, "selectionDirection");
+}, "Input switching from a selectable type to an unselectable type");
+
+test(() => {
+  const el = document.createElement("input");
+  document.body.appendChild(el);
+
+  el.setAttribute("value", "hey");
+  el.selectionStart = 1;
+  el.selectionEnd = 2;
+  el.selectionDirection = "backward";
+
+  el.setAttribute("type", "checkbox");
+  el.setAttribute("type", "text");
+  assert_equals(el.selectionStart, 0, "selectionStart");
+  assert_equals(el.selectionEnd, 0, "selectionEnd");
+  assertSelectionDirectionIsReset(el);
+}, "Input switching from a selectable type to an unselectable type and then back");
+
+test(() => {
+  const el = document.createElement("input");
+  document.body.appendChild(el);
+
+  el.setAttribute("value", "hey");
+  el.selectionStart = 3;
+  el.selectionEnd = 3;
+  el.selectionDirection = "backward";
+
+  el.setAttribute("type", "checkbox");
+  el.setAttribute("value", "ab");
+  el.setAttribute("type", "text");
+  assert_equals(el.selectionStart, 0, "selectionStart");
+  assert_equals(el.selectionEnd, 0, "selectionEnd");
+  assertSelectionDirectionIsReset(el);
+}, "Input switching from a selectable type to an unselectable type and then back with the value changing in between");
+</script>

--- a/html/semantics/forms/textfieldselection/selection-value-interactions.html
+++ b/html/semantics/forms/textfieldselection/selection-value-interactions.html
@@ -80,6 +80,8 @@ for (var data of elemData) {
   test(function() {
     var el = data.factory();
     this.add_cleanup(() => el.remove());
+    assert_equals(el.selectionStart, 0, "selectionStart before setting defaultValue");
+    assert_equals(el.selectionEnd, 0, "selectionEnd before setting defaultValue");
     el.defaultValue = sometext;
     assert_true(sometext.length > 8,
                 "sometext too short, test won't work right");


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2770.

/cc @bzbarsky. Not sure if this would have caught https://bugzilla.mozilla.org/show_bug.cgi?id=1337392; advice appreciated on more cases to add.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
