### PR TITLE
Fix page-visibility/idlharness.html

### DIFF
--- a/page-visibility/idlharness.html
+++ b/page-visibility/idlharness.html
@@ -16,6 +16,10 @@
 <pre id='untested_idl' style='display:none'>
 interface Document {
 };
+
+[TreatNonCallableAsNull]
+callback EventHandlerNonNull = any (Event event);
+typedef EventHandlerNonNull? EventHandler;
 </pre>
 
 <pre id='idl'>


### PR DESCRIPTION
Add definition for EventHandler. Otherwise, the check for the onvisibilitychange
attribute fails event when present with error: "Unrecognized type EventHandler".

<!-- Reviewable:start -->

<!-- Reviewable:end -->
