### PR TITLE
Ignore mime type parameters in nosniff

### DIFF
--- a/fetch/nosniff/image.html
+++ b/fetch/nosniff/image.html
@@ -3,17 +3,25 @@
 <div id=log></div>
 <script>
   // Note: images get always sniffed, nosniff doesn't do anything
-  var passes = ["", "?type=", "?type=x", "?type=x/x", "?type=image/gif", "?type=image/png", "?type=image/png;blah"]
+  var passes = [null, "", "x", "x/x", "image/gif", "image/png", "image/png;blah"]
 
-  passes.forEach(function(urlpart) {
+  const get_url = (mime) => {
+    let url = "resources/image.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    return url
+  }
+
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var img = document.createElement("img")
       img.onerror = t.unreached_func("Unexpected error event")
       img.onload = t.step_func_done(function(){
         assert_equals(img.width, 96)
       })
-      img.src = "resources/image.py" + urlpart
+      img.src = get_url(mime)
       document.body.appendChild(img)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>

--- a/fetch/nosniff/importscripts.js
+++ b/fetch/nosniff/importscripts.js
@@ -3,15 +3,26 @@ function log(w) { this.postMessage(w) }
 function f() { log("FAIL") }
 function p() { log("PASS") }
 
-["", "?type=", "?type=x", "?type=x/x"].forEach(function(urlpart) {
+const get_url = (mime, outcome) => {
+  let url = "resources/js.py"
+  if (mime != null) {
+      url += "?type=" + encodeURIComponent(mime)
+  }
+  if (outcome) {
+    url += "&outcome=p"
+  }
+  return url
+}
+
+[null, "", "x", "x/x"].forEach(function(mime) {
   try {
-    importScripts("resources/js.py" + urlpart)
+    importScripts(get_url(mime))
   } catch(e) {
-    (e.name == "NetworkError") ? p() : log("FAIL (no NetworkError exception): " + urlpart)
+    (e.name == "NetworkError") ? p() : log("FAIL (no NetworkError exception): " + mime)
   }
 
 })
-importScripts("resources/js.py?type=text/javascript&outcome=p")
-importScripts("resources/js.py?type=text/ecmascript&outcome=p")
-importScripts("resources/js.py?type=text/ecmascript;blah&outcome=p")
+importScripts(get_url("text/javascript", true))
+importScripts(get_url("text/ecmascript", true))
+importScripts(get_url("text/ecmascript;blah", true))
 log("END")

--- a/fetch/nosniff/script.html
+++ b/fetch/nosniff/script.html
@@ -4,29 +4,40 @@
 <script>
   var log = function() {}, // see comment below
       p = function() {}, // see comment below
-      fails = ["", "?type=", "?type=x", "?type=x/x"],
-      passes = ["?type=text/javascript", "?type=text/ecmascript", "?type=text/ecmascript;blah"]
+      fails = [null, "", "x", "x/x"],
+      passes = ["text/javascript", "text/ecmascript", "text/ecmascript;blah"]
 
   // Ideally we'd also check whether the scripts in fact execute, but that would involve
   // timers and might get a bit racy without cross-browser support for the execute events.
 
-  fails.forEach(function(urlpart) {
+  const get_url = (mime, outcome) => {
+    let url = "resources/js.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    if (outcome) {
+      url += "&outcome=p"
+    }
+    return url
+  }
+
+  fails.forEach(function(mime) {
     async_test(function(t) {
       var script = document.createElement("script")
       script.onerror = t.step_func_done(function(){})
       script.onload = t.unreached_func("Unexpected load event")
-      script.src = "resources/js.py" + urlpart
+      script.src = get_url(mime)
       document.body.appendChild(script)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 
-  passes.forEach(function(urlpart) {
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var script = document.createElement("script")
       script.onerror = t.unreached_func("Unexpected error event")
       script.onload = t.step_func_done(function(){})
-      script.src = "resources/js.py" + urlpart + "&outcome=p"
+      script.src = get_url(mime, true)
       document.body.appendChild(script)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>

--- a/fetch/nosniff/stylesheet.html
+++ b/fetch/nosniff/stylesheet.html
@@ -3,28 +3,36 @@
 <script src=/resources/testharnessreport.js></script>
 <div id=log></div>
 <script>
-  var fails = ["", "?type=", "?type=x", "?type=x/x"],
-      passes = ["?type=text/css", "?type=text/css;blah"]
+  var fails = [null, "", "x", "x/x"],
+      passes = ["text/css", "text/css;charset=utf-8", "text/css;blah"]
 
-  fails.forEach(function(urlpart) {
+  const get_url = (mime) => {
+    let url = "resources/css.py"
+    if (mime != null) {
+        url += "?type=" + encodeURIComponent(mime)
+    }
+    return url
+  }
+
+  fails.forEach(function(mime) {
     async_test(function(t) {
       var link = document.createElement("link")
       link.rel = "stylesheet"
       link.onerror = t.step_func_done(function(){})
       link.onload = t.unreached_func("Unexpected load event")
-      link.href = "resources/css.py" + urlpart
+      link.href = get_url(mime)
       document.body.appendChild(link)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 
-  passes.forEach(function(urlpart) {
+  passes.forEach(function(mime) {
     async_test(function(t) {
       var link = document.createElement("link")
       link.rel = "stylesheet"
       link.onerror = t.unreached_func("Unexpected error event")
       link.onload = t.step_func_done(function(){})
-      link.href = "resources/css.py" + urlpart
+      link.href = get_url(mime)
       document.body.appendChild(link)
-    }, "URL query: " + urlpart)
+    }, "URL query: " + mime)
   })
 </script>


### PR DESCRIPTION

This patch implements the following changes:
- Only check for the toplevel/sublevel part of the mime type when
  deciding if it's a js or css resource, ignoring the mime parameters.
- Fix the wpt tests that did not escape url parameters properly and
  also used an invalid syntax for the mime parameter.
- Update the wpt manifest.

Upstreamed from https://github.com/servo/servo/pull/16869 [ci skip]