### PR TITLE
Use the origin of the actual image response when determining if a canvas is origin clean.

### DIFF
--- a/common/canvas-tests.js
+++ b/common/canvas-tests.js
@@ -101,4 +101,5 @@ function addCrossOriginRedirectYellowImage()
     img.className = "resource";
     img.src = get_host_info().HTTP_ORIGIN + "/common/redirect.py?location=" +
         get_host_info().HTTP_REMOTE_ORIGIN + "/images/yellow.png";
+    document.body.appendChild(img);
 }


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/16913 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6280)
<!-- Reviewable:end -->
