### PR TITLE
Fix custom element registry define test

### DIFF
--- a/custom-elements/custom-element-registry/define.html
+++ b/custom-elements/custom-element-registry/define.html
@@ -12,6 +12,7 @@
   // https://html.spec.whatwg.org/multipage/scripting.html#element-definition
 
   // Use window from iframe to isolate the test.
+  const iframe = document.getElementById("iframe");
   const testWindow = iframe.contentDocument.defaultView;
   const customElements = testWindow.customElements;
 


### PR DESCRIPTION

The test relies on DOM elements with ids beind added
as properties of the window. Servo does not do this, and
this is not a best practice.

Upstreamed from https://github.com/servo/servo/pull/17112 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6283)
<!-- Reviewable:end -->
