### PR TITLE
Add new IDL test for WebRTC interfaces

### DIFF
--- a/interfaces/webrtc-pc.idl
+++ b/interfaces/webrtc-pc.idl
@@ -1,3 +1,6 @@
+// IDL definition extracted from
+// https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
 dictionary RTCConfiguration {
     sequence<RTCIceServer>   iceServers;
     RTCIceTransportPolicy    iceTransportPolicy = "all";
@@ -11,13 +14,18 @@ dictionary RTCConfiguration {
 
 enum RTCIceCredentialType {
     "password",
-    "token"
+    "oauth"
+};
+
+dictionary RTCOAuthCredential {
+    required DOMString macKey;
+    required DOMString accessToken;
 };
 
 dictionary RTCIceServer {
     required (DOMString or sequence<DOMString>) urls;
              DOMString                          username;
-             DOMString                          credential;
+             (DOMString or RTCOAuthCredential)  credential;
              RTCIceCredentialType               credentialType = "password";
 };
 
@@ -56,31 +64,31 @@ interface RTCPeerConnection : EventTarget {
     Promise<RTCSessionDescriptionInit> createOffer(optional RTCOfferOptions options);
     Promise<RTCSessionDescriptionInit> createAnswer(optional RTCAnswerOptions options);
     Promise<void>                      setLocalDescription(RTCSessionDescriptionInit description);
-    readonly        attribute RTCSessionDescription?    localDescription;
-    readonly        attribute RTCSessionDescription?    currentLocalDescription;
-    readonly        attribute RTCSessionDescription?    pendingLocalDescription;
+    readonly attribute RTCSessionDescription? localDescription;
+    readonly attribute RTCSessionDescription? currentLocalDescription;
+    readonly attribute RTCSessionDescription? pendingLocalDescription;
     Promise<void>                      setRemoteDescription(RTCSessionDescriptionInit description);
-    readonly        attribute RTCSessionDescription?    remoteDescription;
-    readonly        attribute RTCSessionDescription?    currentRemoteDescription;
-    readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
+    readonly attribute RTCSessionDescription? remoteDescription;
+    readonly attribute RTCSessionDescription? currentRemoteDescription;
+    readonly attribute RTCSessionDescription? pendingRemoteDescription;
     Promise<void>                      addIceCandidate((RTCIceCandidateInit or RTCIceCandidate) candidate);
-    readonly        attribute RTCSignalingState         signalingState;
-    readonly        attribute RTCIceGatheringState      iceGatheringState;
-    readonly        attribute RTCIceConnectionState     iceConnectionState;
-    readonly        attribute RTCPeerConnectionState    connectionState;
-    readonly        attribute boolean?                  canTrickleIceCandidates;
-    static readonly attribute FrozenArray<RTCIceServer> defaultIceServers;
+    readonly attribute RTCSignalingState      signalingState;
+    readonly attribute RTCIceGatheringState   iceGatheringState;
+    readonly attribute RTCIceConnectionState  iceConnectionState;
+    readonly attribute RTCPeerConnectionState connectionState;
+    readonly attribute boolean?               canTrickleIceCandidates;
+    static sequence<RTCIceServer>      getDefaultIceServers();
     RTCConfiguration                   getConfiguration();
     void                               setConfiguration(RTCConfiguration configuration);
     void                               close();
-                    attribute EventHandler              onnegotiationneeded;
-                    attribute EventHandler              onicecandidate;
-                    attribute EventHandler              onicecandidateerror;
-                    attribute EventHandler              onsignalingstatechange;
-                    attribute EventHandler              oniceconnectionstatechange;
-                    attribute EventHandler              onicegatheringstatechange;
-                    attribute EventHandler              onconnectionstatechange;
-                    attribute EventHandler              onfingerprintfailure;
+             attribute EventHandler           onnegotiationneeded;
+             attribute EventHandler           onicecandidate;
+             attribute EventHandler           onicecandidateerror;
+             attribute EventHandler           onsignalingstatechange;
+             attribute EventHandler           oniceconnectionstatechange;
+             attribute EventHandler           onicegatheringstatechange;
+             attribute EventHandler           onconnectionstatechange;
+             attribute EventHandler           onfingerprintfailure;
 };
 
 partial interface RTCPeerConnection {
@@ -100,12 +108,17 @@ partial interface RTCPeerConnection {
                                   RTCPeerConnectionErrorCallback failureCallback);
 };
 
+callback RTCPeerConnectionErrorCallback = void (DOMException error);
+
+callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);
+
 enum RTCSignalingState {
     "stable",
     "have-local-offer",
     "have-remote-offer",
     "have-local-pranswer",
-    "have-remote-pranswer"
+    "have-remote-pranswer",
+    "closed"
 };
 
 enum RTCIceGatheringState {
@@ -133,12 +146,6 @@ enum RTCIceConnectionState {
     "closed"
 };
 
-callback RTCPeerConnectionErrorCallback = void (DOMException error);
-
-callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);
-
-callback RTCStatsCallback = void (RTCStatsReport report);
-
 enum RTCSdpType {
     "offer",
     "pranswer",
@@ -158,12 +165,13 @@ dictionary RTCSessionDescriptionInit {
              DOMString  sdp = "";
 };
 
-[Constructor(RTCIceCandidateInit candidateInitDict)]
+[Constructor(optional RTCIceCandidateInit candidateInitDict)]
 interface RTCIceCandidate {
     readonly attribute DOMString               candidate;
     readonly attribute DOMString?              sdpMid;
     readonly attribute unsigned short?         sdpMLineIndex;
     readonly attribute DOMString?              foundation;
+    readonly attribute RTCIceComponent?        component;
     readonly attribute unsigned long?          priority;
     readonly attribute DOMString?              ip;
     readonly attribute RTCIceProtocol?         protocol;
@@ -244,9 +252,10 @@ dictionary RTCCertificateExpiration {
 };
 
 interface RTCCertificate {
-    readonly attribute DOMTimeStamp                    expires;
-    readonly attribute FrozenArray<RTCDtlsFingerprint> fingerprints;
-    AlgorithmIdentifier getAlgorithm();
+    readonly attribute DOMTimeStamp expires;
+    sequence<RTCDtlsFingerprint> getFingerprints();
+    // At risk due to lack of implementers' interest.
+    AlgorithmIdentifier          getAlgorithm();
 };
 
 partial interface RTCPeerConnection {
@@ -278,10 +287,12 @@ interface RTCRtpSender {
     readonly attribute MediaStreamTrack? track;
     readonly attribute RTCDtlsTransport? transport;
     readonly attribute RTCDtlsTransport? rtcpTransport;
+    // Feature at risk
     static RTCRtpCapabilities getCapabilities(DOMString kind);
-    Promise<void>      setParameters(optional RTCRtpParameters parameters);
-    RTCRtpParameters   getParameters();
-    Promise<void>      replaceTrack(MediaStreamTrack withTrack);
+    Promise<void>           setParameters(optional RTCRtpParameters parameters);
+    RTCRtpParameters        getParameters();
+    Promise<void>           replaceTrack(MediaStreamTrack withTrack);
+    Promise<RTCStatsReport> getStats();
 };
 
 dictionary RTCRtpParameters {
@@ -290,7 +301,7 @@ dictionary RTCRtpParameters {
     sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
     RTCRtcpParameters                         rtcp;
     sequence<RTCRtpCodecParameters>           codecs;
-    RTCDegradationPreference                  degradationPreference = "balanced";
+    RTCDegradationPreference                  degradationPreference;
 };
 
 dictionary RTCRtpEncodingParameters {
@@ -300,10 +311,11 @@ dictionary RTCRtpEncodingParameters {
     RTCDtxStatus        dtx;
     boolean             active;
     RTCPriorityType     priority;
+    unsigned long       ptime;
     unsigned long       maxBitrate;
-    unsigned long       maxFramerate;
+    double              maxFramerate;
     DOMString           rid;
-    double              scaleResolutionDownBy = 1;
+    double              scaleResolutionDownBy;
 };
 
 enum RTCDtxStatus {
@@ -340,7 +352,7 @@ dictionary RTCRtpCodecParameters {
     unsigned short payloadType;
     DOMString      mimeType;
     unsigned long  clockRate;
-    unsigned short channels = 1;
+    unsigned short channels;
     DOMString      sdpFmtpLine;
 };
 
@@ -352,7 +364,7 @@ dictionary RTCRtpCapabilities {
 dictionary RTCRtpCodecCapability {
     DOMString      mimeType;
     unsigned long  clockRate;
-    unsigned short channels = 1;
+    unsigned short channels;
     DOMString      sdpFmtpLine;
 };
 
@@ -364,15 +376,24 @@ interface RTCRtpReceiver {
     readonly attribute MediaStreamTrack  track;
     readonly attribute RTCDtlsTransport? transport;
     readonly attribute RTCDtlsTransport? rtcpTransport;
-    static RTCRtpCapabilities          getCapabilities(DOMString kind);
-    RTCRtpParameters                   getParameters();
-    sequence<RTCRtpContributingSource> getContributingSources();
+    // Feature at risk
+    static RTCRtpCapabilities             getCapabilities(DOMString kind);
+    RTCRtpParameters                      getParameters();
+    sequence<RTCRtpContributingSource>    getContributingSources();
+    sequence<RTCRtpSynchronizationSource> getSynchronizationSources();
+    Promise<RTCStatsReport>               getStats();
 };
 
 interface RTCRtpContributingSource {
     readonly attribute DOMHighResTimeStamp timestamp;
     readonly attribute unsigned long       source;
     readonly attribute byte?               audioLevel;
+};
+
+interface RTCRtpSynchronizationSource {
+    readonly attribute DOMHighResTimeStamp timestamp;
+    readonly attribute unsigned long       source;
+    readonly attribute byte                audioLevel;
     readonly attribute boolean?            voiceActivityFlag;
 };
 
@@ -465,6 +486,7 @@ enum RTCIceComponent {
 interface RTCTrackEvent : Event {
     readonly attribute RTCRtpReceiver           receiver;
     readonly attribute MediaStreamTrack         track;
+    [SameObject]
     readonly attribute FrozenArray<MediaStream> streams;
     readonly attribute RTCRtpTransceiver        transceiver;
 };
@@ -478,7 +500,7 @@ dictionary RTCTrackEventInit : EventInit {
 
 partial interface RTCPeerConnection {
     readonly attribute RTCSctpTransport? sctp;
-    RTCDataChannel createDataChannel([TreatNullAs=EmptyString] USVString label,
+    RTCDataChannel createDataChannel(USVString label,
                                      optional RTCDataChannelInit dataChannelDict);
              attribute EventHandler      ondatachannel;
 };
@@ -575,9 +597,6 @@ dictionary RTCStats {
     DOMString           id;
 };
 
-enum RTCStatsType {
-};
-
 [Global,
  Exposed=RTCIdentityProviderGlobalScope]
 interface RTCIdentityProviderGlobalScope : WorkerGlobalScope {
@@ -644,6 +663,20 @@ partial dictionary MediaStreamConstraints {
 partial interface MediaStreamTrack {
     readonly attribute boolean      isolated;
              attribute EventHandler onisolationchange;
+};
+
+enum RTCErrorDetailType {
+    "data-channel-failure",
+    "idp-bad-script-failure",
+    "idp-execution-failure",
+    "idp-load-failure",
+    "idp-need-login",
+    "idp-timeout",
+    "idp-tls-failure",
+    "idp-token-expired",
+    "idp-token-invalid",
+    "sctp-failure",
+    "sdp-syntax-error"
 };
 
 [Exposed=Window,

--- a/webrtc/interfaces.html
+++ b/webrtc/interfaces.html
@@ -11,6 +11,7 @@
 
   // The following helper functions are called from RTCPeerConnection-helper.js:
   //   generateAnswer()
+  //   generateMediaStreamTrack()
 
   // Put the global IDL test objects under a parent object.
   // This allows easier search for the test cases when
@@ -32,6 +33,7 @@
   const asyncInitTasks = [
     asyncInitCertificate,
     asyncInitTransports,
+    asyncInitMediaStreamTrack,
   ];
 
   // Asynchronously generate an RTCCertificate
@@ -75,6 +77,18 @@
     });
   }
 
+  // Asynchoronously generate MediaStreamTrack from getUserMedia
+  function asyncInitMediaStreamTrack() {
+    return navigator.mediaDevices.getUserMedia({ audio: true })
+    .then(mediaStream => {
+      const tracks = mediaStream.getTracks();
+      assert_greater_than(tracks.length, 0,
+        'Expect media stream to have at least one track');
+
+      idlTestObjects.mediaStreamTrack = tracks[0];
+    });
+  }
+
   // Run all async test drivers, report and swallow any error
   // thrown/rejected. Proper test for correct initialization
   // of the objects are done in their respective test files.
@@ -98,7 +112,7 @@
     const idlArray = new IdlArray();
 
     idlArray.add_untested_idls('interface EventHandler {};');
-    idlArray.add_untested_idls('interface MediaStreamTrack {};');
+    idlArray.add_idls('interface MediaStreamTrack : EventTarget {};');
     idlArray.add_idls(idlText);
 
     idlArray.add_objects({
@@ -137,6 +151,11 @@
       'RTCDtlsTransport': ['idlTestObjects.dtlsTransport'],
 
       'RTCIceTransport': ['idlTestObjects.iceTransport'],
+
+      // Test on both MediaStreamTrack from getUserMedia and transceiver
+      'MediaStreamTrack': [
+        `idlTestObjects.mediaStreamTrack`,
+        `generateMediaStreamTrack('audio')`]
     });
 
     idlArray.test();

--- a/webrtc/interfaces.html
+++ b/webrtc/interfaces.html
@@ -1,57 +1,51 @@
 <!doctype html>
-<html>
-  <head>
-    <title>WebRTC IDL Tests</title>
-  </head>
-  <body>
-    <script src=/resources/testharness.js></script>
-    <script src=/resources/testharnessreport.js></script>
-    <script src=/resources/WebIDLParser.js></script>
-    <script src=/resources/idlharness.js></script>
-    <script>
-      'use strict';
+<title>WebRTC IDL Tests</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+<script>
+  'use strict';
 
-      function generateCertificate() {
-        if (!RTCPeerConnection.generateCertificate)
-          return null;
-        return RTCPeerConnection.generateCertificate({
-          name: 'RSASSA-PKCS1-v1_5',
-          modulusLength: 2048,
-          publicExponent: new Uint8Array([1, 0, 1]),
-          hash: 'SHA-256'
-        })
-        .catch(() => {}); // ignore error
-      }
+  function generateCertificate() {
+    if (!RTCPeerConnection.generateCertificate)
+      return null;
+    return RTCPeerConnection.generateCertificate({
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256'
+    })
+    .catch(() => {}); // ignore error
+  }
 
-      function doIdlTest([idlText, certificate]) {
-        const idlArray = new IdlArray();
+  function doIdlTest([idlText, certificate]) {
+    const idlArray = new IdlArray();
 
-        idlArray.add_untested_idls('interface EventHandler {};');
-        idlArray.add_untested_idls('interface MediaStreamTrack {};');
-        idlArray.add_idls(idlText);
+    idlArray.add_untested_idls('interface EventHandler {};');
+    idlArray.add_untested_idls('interface MediaStreamTrack {};');
+    idlArray.add_idls(idlText);
 
-        // TODO: Add object for all IDL interfaces
-        idlArray.add_objects({
-          'RTCPeerConnection': ['new RTCPeerConnection'],
-          'RTCSessionDescription': ['new RTCSessionDescription({ type: "offer" })'],
-          'RTCIceCandidate': ['new RTCIceCandidate'],
-          'RTCPeerConnectionIceEvent': ['new RTCPeerConnectionIceEvent("ice")'],
-          'RTCPeerConnectionIceErrorEvent': ['new RTCPeerConnectionIceErrorEvent("ice-error", { errorCode: 701 });'],
-        });
+    // TODO: Add object for all IDL interfaces
+    idlArray.add_objects({
+      'RTCPeerConnection': ['new RTCPeerConnection'],
+      'RTCSessionDescription': ['new RTCSessionDescription({ type: "offer" })'],
+      'RTCIceCandidate': ['new RTCIceCandidate'],
+      'RTCPeerConnectionIceEvent': ['new RTCPeerConnectionIceEvent("ice")'],
+      'RTCPeerConnectionIceErrorEvent': ['new RTCPeerConnectionIceErrorEvent("ice-error", { errorCode: 701 });'],
+    });
 
-        if (certificate) {
-          window.certificate = certificate;
-          idlArray.add_objects({'RTCCertificate': ['certificate']});
-        }
+    if (certificate) {
+      window.certificate = certificate;
+      idlArray.add_objects({'RTCCertificate': ['certificate']});
+    }
 
-        idlArray.test();
-      }
+    idlArray.test();
+  }
 
-      promise_test(() => {
-        return Promise.all([fetch('/interfaces/webrtc-pc.idl').then(response => response.text()),
-                            generateCertificate()])
-                      .then(doIdlTest);
-      }, 'Test driver');
-    </script>
-  </body>
-</html>
+  promise_test(() => {
+    return Promise.all([fetch('/interfaces/webrtc-pc.idl').then(response => response.text()),
+                        generateCertificate()])
+                  .then(doIdlTest);
+  }, 'Test driver');
+</script>

--- a/webrtc/interfaces.html
+++ b/webrtc/interfaces.html
@@ -1,4 +1,5 @@
 <!doctype html>
+<meta charset=utf-8>
 <title>WebRTC IDL Tests</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,61 +9,91 @@
 <script>
   'use strict';
 
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   generateAnswer()
+
   // Put the global IDL test objects under a parent object.
   // This allows easier search for the test cases when
-  // viewing the web page.
-  window.idlTestObjects = {
-    certificate: null,
-    sctp: null
+  // viewing the web page
+  const idlTestObjects = {};
+
+  // Helper function to create RTCTrackEvent object
+  function initTrackEvent() {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio');
+    const { sender, receiver } = transceiver;
+    const { track } = receiver;
+    return new RTCTrackEvent('track', {
+      receiver, track, transceiver
+    });
   }
 
-  function initCertificate() {
+  // List of async test driver functions
+  const asyncInitTasks = [
+    asyncInitCertificate,
+    asyncInitTransports,
+  ];
+
+  // Asynchronously generate an RTCCertificate
+  function asyncInitCertificate() {
     return RTCPeerConnection.generateCertificate({
       name: 'RSASSA-PKCS1-v1_5',
       modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: 'SHA-256'
-    })
-    .then(cert => {
-      idlTestObjects.certificate = cert
+    }).then(cert => {
+      idlTestObjects.certificate = cert;
     });
   }
 
-  function initSctp() {
+  // Asynchronously generate instances of
+  // RTCSctpTransport, RTCDtlsTransport,
+  // and RTCIceTransport
+  function asyncInitTransports() {
     const pc = new RTCPeerConnection();
     pc.createDataChannel('test');
+
+    // setting answer description initializes pc.sctp
     return pc.createOffer()
     .then(offer =>
       pc.setLocalDescription(offer)
       .then(() => generateAnswer(offer)))
     .then(answer => pc.setRemoteDescription(answer))
     .then(() => {
-      idlTestObjects.sctp = pc.sctp;
+      const sctpTransport = pc.sctp;
+      assert_true(sctpTransport instanceof RTCSctpTransport,
+        'Expect pc.sctp to be instance of RTCSctpTransport');
+      idlTestObjects.sctpTransport = sctpTransport;
+
+      const dtlsTransport = sctpTransport.transport;
+      assert_true(dtlsTransport instanceof RTCDtlsTransport,
+        'Expect sctpTransport.transport to be instance of RTCDtlsTransport');
+      idlTestObjects.dtlsTransport = dtlsTransport;
+
+      const iceTransport = dtlsTransport.transport;
+      idlTestObjects.iceTransport = iceTransport;
     });
   }
 
-  const asyncTasks = [
-    initCertificate,
-    initSctp,
-  ];
-
-  // Asynchronously initialize global objects and
-  // ignore any error thrown/rejected. Proper test
-  // for correct initialization of the objects are
-  // done in their respective test files.
+  // Run all async test drivers, report and swallow any error
+  // thrown/rejected. Proper test for correct initialization
+  // of the objects are done in their respective test files.
   function asyncInit() {
-    return Promise.all(asyncTasks.map(
+    return Promise.all(asyncInitTasks.map(
       task => {
-        try {
-          return task().catch(err => {
-            console.error(err);
-          })
-        } catch(err) {
-          console.error(err);
-        }
+        const t = async_test(`Test driver for ${task.name}`);
+        let promise;
+        t.step(() => {
+          promise = task().then(
+            t.step_func_done(),
+            t.step_func(err =>
+              assert_unreached(`Failed to run ${task.name}: ${err}`)));
+        });
+        return promise;
       }));
   }
 
+  // Main function to do the IDL test, using fetched IDL text
   function doIdlTest(idlText) {
     const idlArray = new IdlArray();
 
@@ -70,26 +101,61 @@
     idlArray.add_untested_idls('interface MediaStreamTrack {};');
     idlArray.add_idls(idlText);
 
-    // TODO: Add object for all IDL interfaces
     idlArray.add_objects({
-      'RTCPeerConnection': ['new RTCPeerConnection'],
-      'RTCSessionDescription': ['new RTCSessionDescription({ type: "offer" })'],
-      'RTCIceCandidate': ['new RTCIceCandidate'],
-      'RTCPeerConnectionIceEvent': ['new RTCPeerConnectionIceEvent("ice")'],
+      'RTCPeerConnection': [`new RTCPeerConnection()`],
+
+      'RTCSessionDescription': [`new RTCSessionDescription({ type: 'offer' })`],
+
+      'RTCIceCandidate': [`new RTCIceCandidate({ sdpMid: 1 })`],
+
+      'RTCDataChannel': [`new RTCPeerConnection().createDataChannel('')`],
+
+      'RTCRtpTransceiver': [`new RTCPeerConnection().addTransceiver('audio')`],
+
+      'RTCRtpSender': [`new RTCPeerConnection().addTransceiver('audio').sender`],
+
+      'RTCRtpReceiver': [`new RTCPeerConnection().addTransceiver('audio').receiver`],
+
+      'RTCPeerConnectionIceEvent': [`new RTCPeerConnectionIceEvent('ice')`],
+
       'RTCPeerConnectionIceErrorEvent':
-        ['new RTCPeerConnectionIceErrorEvent("ice-error", { errorCode: 701 });'],
-      'RTCRtpTransceiver': ['new RTCPeerConnection().addTransceiver("audio")'],
+        [`new RTCPeerConnectionIceErrorEvent('ice-error', { errorCode: 701 });`],
+
+      'RTCTrackEvent': [`initTrackEvent()`],
+
+      'RTCErrorEvent': [`new RTCErrorEvent('error')`],
+
+      'RTCDataChannelEvent': [`new RTCDataChannelEvent('channel',
+        { channel: new RTCPeerConnection().createDataChannel('') })`],
+
+      // Async initialized objects below
+
       'RTCCertificate': ['idlTestObjects.certificate'],
-      'RTCSctpTransport': ['idlTestObjects.sctp'],
+
+      'RTCSctpTransport': ['idlTestObjects.sctpTransport'],
+
+      'RTCDtlsTransport': ['idlTestObjects.dtlsTransport'],
+
+      'RTCIceTransport': ['idlTestObjects.iceTransport'],
     });
 
     idlArray.test();
   }
 
-  promise_test(() => {
+  promise_test(t => {
     return asyncInit()
     .then(() => fetch('/interfaces/webrtc-pc.idl'))
     .then(response => response.text())
     .then(doIdlTest);
-  }, 'Test driver');
+  }, 'Main test driver');
+
+  /*
+    TODO
+      RTCRtpContributingSource
+      RTCRtpSynchronizationSource
+      RTCDTMFSender
+      RTCDTMFToneChangeEvent
+      RTCIdentityProviderRegistrar
+      RTCIdentityAssertion
+   */
 </script>

--- a/webrtc/interfaces.html
+++ b/webrtc/interfaces.html
@@ -1,25 +1,69 @@
 <!doctype html>
 <title>WebRTC IDL Tests</title>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<script src=/resources/WebIDLParser.js></script>
-<script src=/resources/idlharness.js></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="./RTCPeerConnection-helper.js"></script>
 <script>
   'use strict';
 
-  function generateCertificate() {
-    if (!RTCPeerConnection.generateCertificate)
-      return null;
+  // Put the global IDL test objects under a parent object.
+  // This allows easier search for the test cases when
+  // viewing the web page.
+  window.idlTestObjects = {
+    certificate: null,
+    sctp: null
+  }
+
+  function initCertificate() {
     return RTCPeerConnection.generateCertificate({
       name: 'RSASSA-PKCS1-v1_5',
       modulusLength: 2048,
       publicExponent: new Uint8Array([1, 0, 1]),
       hash: 'SHA-256'
     })
-    .catch(() => {}); // ignore error
+    .then(cert => {
+      idlTestObjects.certificate = cert
+    });
   }
 
-  function doIdlTest([idlText, certificate]) {
+  function initSctp() {
+    const pc = new RTCPeerConnection();
+    pc.createDataChannel('test');
+    return pc.createOffer()
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer)))
+    .then(answer => pc.setRemoteDescription(answer))
+    .then(() => {
+      idlTestObjects.sctp = pc.sctp;
+    });
+  }
+
+  const asyncTasks = [
+    initCertificate,
+    initSctp,
+  ];
+
+  // Asynchronously initialize global objects and
+  // ignore any error thrown/rejected. Proper test
+  // for correct initialization of the objects are
+  // done in their respective test files.
+  function asyncInit() {
+    return Promise.all(asyncTasks.map(
+      task => {
+        try {
+          return task().catch(err => {
+            console.error(err);
+          })
+        } catch(err) {
+          console.error(err);
+        }
+      }));
+  }
+
+  function doIdlTest(idlText) {
     const idlArray = new IdlArray();
 
     idlArray.add_untested_idls('interface EventHandler {};');
@@ -32,20 +76,20 @@
       'RTCSessionDescription': ['new RTCSessionDescription({ type: "offer" })'],
       'RTCIceCandidate': ['new RTCIceCandidate'],
       'RTCPeerConnectionIceEvent': ['new RTCPeerConnectionIceEvent("ice")'],
-      'RTCPeerConnectionIceErrorEvent': ['new RTCPeerConnectionIceErrorEvent("ice-error", { errorCode: 701 });'],
+      'RTCPeerConnectionIceErrorEvent':
+        ['new RTCPeerConnectionIceErrorEvent("ice-error", { errorCode: 701 });'],
+      'RTCRtpTransceiver': ['new RTCPeerConnection().addTransceiver("audio")'],
+      'RTCCertificate': ['idlTestObjects.certificate'],
+      'RTCSctpTransport': ['idlTestObjects.sctp'],
     });
-
-    if (certificate) {
-      window.certificate = certificate;
-      idlArray.add_objects({'RTCCertificate': ['certificate']});
-    }
 
     idlArray.test();
   }
 
   promise_test(() => {
-    return Promise.all([fetch('/interfaces/webrtc-pc.idl').then(response => response.text()),
-                        generateCertificate()])
-                  .then(doIdlTest);
+    return asyncInit()
+    .then(() => fetch('/interfaces/webrtc-pc.idl'))
+    .then(response => response.text())
+    .then(doIdlTest);
   }, 'Test driver');
 </script>


### PR DESCRIPTION
I done some refactoring on the original interfaces.html and add new async test driver mechanism to run asynchronous initialization of the RTC*Transport objects and MediaStreamTrack.

This should now test all interfaces in webrtc-pc except:
- RTCRtpContributingSource
- RTCRtpSynchronizationSource
- RTCDTMFSender
- RTCDTMFToneChangeEvent
- RTCIdentityProviderRegistrar
- RTCIdentityAssertion

<!-- Reviewable:start -->

<!-- Reviewable:end -->
