### PR TITLE
Make wptrun fail correctly when certutil not found

### DIFF
--- a/tools/browserutils/browser.py
+++ b/tools/browserutils/browser.py
@@ -119,6 +119,8 @@ class Firefox(Browser):
 
     def find_certutil(self):
         path = find_executable("certutil")
+        if path is None:
+            return None
         if os.path.splitdrive(path)[1].split(os.path.sep) == ["", "Windows", "system32", "certutil.exe"]:
             return None
         return path


### PR DESCRIPTION
This change makes wptrun correctly handle the case where it can’t find
the certutil binary.

Without this change you end up with the value of `path` being `None`
when it reaches this part of the tools/browserutils/browser.py code:

    if os.path.splitdrive(path)[1].split(os.path.sep) == ["", "Windows", "system32", "certutil.exe"]:

... which results in:

    AttributeError: 'NoneType' object has no attribute 'split'

So this change just early-returns `None` from there if `path` is `None`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6297)
<!-- Reviewable:end -->
