### PR TITLE
[cssom-view][geometry] Test re-introduction of DOMRectList

### DIFF
--- a/css/geometry-1/DOMRectList.html
+++ b/css/geometry-1/DOMRectList.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Geometry interfaces: DOMRectList</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=x>x</div>
+<script>
+setup(() => {
+  window.domRectList = document.getElementById('x').getClientRects();
+});
+
+test(() => {
+  assert_false('DOMRectList' in window);
+}, 'DOMRectList [NoInterfaceObject]');
+
+test(() => {
+  assert_true(domRectList instanceof Array);
+}, 'DOMRectList [LegacyArrayClass]');
+
+test(() => {
+  assert_equals(domRectList.length, 1);
+}, 'DOMRectList length');
+
+test(() => {
+  assert_equals(domRectList[-1], undefined, 'domRectList[-1]');
+  assert_class_string(domRectList[0], 'DOMRect', 'domRectList[0]');
+  assert_equals(domRectList[1], undefined, 'domRectList[1]');
+}, 'DOMRectList indexed getter');
+
+test(() => {
+  assert_equals(domRectList.item(-1), null, 'domRectList.item(-1)');
+  assert_class_string(domRectList.item(0), 'DOMRect', 'domRectList.item(0)');
+  assert_equals(domRectList.item(1), null, 'domRectList.item(1)');
+  assert_equals(domRectList.item(0), domRectList[0], 'domRectList.item(0) should equal domRectList[0]');
+}, 'DOMRectList item()');
+</script>

--- a/css/geometry-1/DOMRectList.html
+++ b/css/geometry-1/DOMRectList.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <title>Geometry interfaces: DOMRectList</title>
+<link rel="help" href="https://drafts.fxtf.org/geometry-1/#DOMRectList">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <div id=x>x</div>

--- a/css/geometry-1/interfaces.html
+++ b/css/geometry-1/interfaces.html
@@ -9,4 +9,5 @@
 <script src=/resources/testharnessreport.js></script>
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
+<div id=log></div>
 <script src=support/interfaces.js></script>

--- a/css/geometry-1/structured-serialization.html
+++ b/css/geometry-1/structured-serialization.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://drafts.fxtf.org/geometry/#structured-serialization">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
 <script>
 function clone(obj) {
   return new Promise((resolve, reject) => {
@@ -156,4 +157,9 @@ function defineThrowingGetters(object, attrs) {
       throw new Error(`Test bug: ${constr} has no test for non-initial values`);
   }
 });
+
+promise_test((t) => {
+  const object = document.getElementById('log').getClientRects();
+  return clone(object).then(() => assert_unreached()).catch(() => t.done());
+}, 'DOMRectList clone');
 </script>

--- a/css/geometry-1/structured-serialization.html
+++ b/css/geometry-1/structured-serialization.html
@@ -160,6 +160,6 @@ function defineThrowingGetters(object, attrs) {
 
 promise_test((t) => {
   const object = document.getElementById('log').getClientRects();
-  return clone(object).then(() => assert_unreached()).catch(() => t.done());
-}, 'DOMRectList clone');
+  return promise_rejects(t, "DataCloneError", clone(object));
+}, 'DOMRectList clone');0
 </script>

--- a/css/geometry-1/support/interfaces.js
+++ b/css/geometry-1/support/interfaces.js
@@ -2,6 +2,11 @@
 
 var idlArray = new IdlArray();
 
+const domRectListList = [];
+if ("document" in self) {
+  domRectListList.push(document.getElementById('log').getClientRects());
+}
+
 function doTest(idl) {
   idlArray.add_idls(idl);
   idlArray.add_objects({
@@ -9,6 +14,7 @@ function doTest(idl) {
     DOMPoint: ["new DOMPoint()"],
     DOMRectReadOnly: ["new DOMRectReadOnly()"],
     DOMRect: ["new DOMRect()"],
+    DOMRectList: domRectListList,
     DOMQuad: ["new DOMQuad()"],
     DOMMatrixReadOnly: ["new DOMMatrixReadOnly()", "DOMMatrixReadOnly.fromMatrix({is2D: false})"],
     DOMMatrix: ["new DOMMatrix()", "DOMMatrix.fromMatrix({is2D: false})"],

--- a/cssom-view/DOMRectList.html
+++ b/cssom-view/DOMRectList.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<title>CSSOM View APIs that return a DOMRectList</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=x>x</div>
+<script>
+setup(() => {
+  window.element = document.getElementById('x');
+});
+
+test(() => {
+  const domRectList = element.getClientRects();
+  assert_class_string(domRectList, 'DOMRectList');
+  assert_class_string(domRectList.item(0), 'DOMRect');
+}, 'Element getClientRects()');
+
+test(() => {
+  const range = new Range();
+  range.selectNodeContents(element);
+  const domRectList = range.getClientRects();
+  assert_class_string(domRectList, 'DOMRectList');
+  assert_class_string(domRectList.item(0), 'DOMRect');
+}, 'Range getClientRects()');
+</script>

--- a/cssom-view/historical.html
+++ b/cssom-view/historical.html
@@ -6,6 +6,10 @@
 <div id="log"></div>
 <script>
 test(function() {
-  assert_false("DOMRectList" in self);
-}, "Support for DOMRectList");
+  assert_false("ClientRectList" in self);
+}, "Support for ClientRectList");
+
+test(function() {
+  assert_false("ClientRect" in self);
+}, "Support for ClientRect");
 </script>

--- a/interfaces/geometry.idl
+++ b/interfaces/geometry.idl
@@ -76,6 +76,13 @@ dictionary DOMRectInit {
     unrestricted double height = 0;
 };
 
+[NoInterfaceObject,
+ LegacyArrayClass]
+interface DOMRectList {
+    readonly attribute unsigned long length;
+    getter DOMRect? item(unsigned long index);
+};
+
 [Constructor(optional DOMPointInit p1, optional DOMPointInit p2,
              optional DOMPointInit p3, optional DOMPointInit p4),
  Exposed=(Window,Worker),


### PR DESCRIPTION
See https://github.com/w3c/csswg-drafts/issues/1479

idlharness.js currently does not test anything for interfaces
marked with [NoInterfaceObject], so this tests some IDL aspects
in css/geometry-1/DOMRectList.html instead.

Also test that ClientRect and ClientRectList are not supported.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
