### PR TITLE
Test how document.fullscreenElement changes when removing elements

### DIFF
--- a/fullscreen/api/document-exit-fullscreen-twice-manual.html
+++ b/fullscreen/api/document-exit-fullscreen-twice-manual.html
@@ -18,11 +18,17 @@ async_test(t => {
     const secondPromise = document.exitFullscreen();
     assert_equals(document.fullscreenElement, div, "fullscreenElement after second exitFullscreen()");
 
-    document.onfullscreenchange = t.step_func(() => {
+    document.onfullscreenchange = t.step_func(event => {
       assert_equals(document.fullscreenElement, null);
-      // Ensure that there's only one fullscreenchange event.
-      document.onfullscreenchange = t.unreached_func("second fullscreenchange event");
-      t.step_timeout(() => {
+      assert_equals(event.target, div);
+
+      // There will also be a second fullscreenchange event. Even though the
+      // fullscreen element had already changed, the target is still the same
+      // due to the "If pendingDoc's fullscreen element is not pending" logic.
+      document.onfullscreenchange = t.step_func(event => {
+        assert_equals(document.fullscreenElement, null);
+        assert_equals(event.target, div);
+
         // Done, but if a promise was returned, assert that it is resolved and
         // not rejected. This test does not fail if promises aren't implemented.
         if (secondPromise) {
@@ -30,7 +36,7 @@ async_test(t => {
         } else {
           t.done();
         }
-      }, 0);
+      });
     });
   });
   document.onfullscreenerror = t.unreached_func("fullscreenerror event");

--- a/fullscreen/model/move-to-iframe-manual.html
+++ b/fullscreen/model/move-to-iframe-manual.html
@@ -7,6 +7,7 @@
 <iframe></iframe>
 <script>
 async_test(t => {
+  t.add_cleanup(() => document.exitFullscreen());
   const div = document.querySelector("div");
   const iframe = document.querySelector("iframe");
   document.onfullscreenchange = t.step_func(event => {
@@ -16,6 +17,9 @@ async_test(t => {
     assert_equals(div.ownerDocument, document);
     iframe.contentDocument.body.appendChild(div);
     assert_not_equals(div.ownerDocument, document);
+    // Moving /div/ removes it from the top layer and thus the fullscreen
+    // element synchronously becomes null.
+    assert_equals(document.fullscreenElement, null);
 
     div.onfullscreenchange = t.unreached_func("fullscreenchange fired on element");
     iframe.contentDocument.onfullscreenchange = t.unreached_func("fullscreenchange fired on other document");

--- a/fullscreen/model/move-to-inactive-document-manual.html
+++ b/fullscreen/model/move-to-inactive-document-manual.html
@@ -6,6 +6,7 @@
 <div></div>
 <script>
 async_test(t => {
+  t.add_cleanup(() => document.exitFullscreen());
   const div = document.querySelector("div");
   document.onfullscreenchange = t.step_func(event => {
     const inactiveDocument = document.implementation.createDocument(null, "");

--- a/fullscreen/model/remove-child-manual.html
+++ b/fullscreen/model/remove-child-manual.html
@@ -10,12 +10,15 @@
 <script>
 async_test(function(t)
 {
+    t.add_cleanup(() => document.exitFullscreen());
     var parent = document.getElementById("parent");
     trusted_request(t, parent);
     document.onfullscreenchange = t.step_func(function()
     {
         assert_equals(document.fullscreenElement, parent);
         parent.textContent = ""; // removes all children
+        // The fullscreen element should not be affected.
+        assert_equals(document.fullscreenElement, parent);
         document.onfullscreenchange = t.unreached_func("fullscreenchange event");
         // A fullscreenchange event would be fired after an async section
         // and an animation frame task, so wait until after that.

--- a/fullscreen/model/remove-first-manual.html
+++ b/fullscreen/model/remove-first-manual.html
@@ -10,6 +10,7 @@
 <script>
 async_test(function(t)
 {
+    t.add_cleanup(() => document.exitFullscreen());
     var first = document.getElementById("first");
     trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function(event)
@@ -23,6 +24,9 @@ async_test(function(t)
             assert_equals(document.fullscreenElement, last);
             assert_equals(event.target, last);
             first.remove();
+            // Both /first/ and /last/ were removed from the top layer and
+            // thus the fullscreen element synchronously becomes null.
+            assert_equals(document.fullscreenElement, null);
             document.onfullscreenchange = t.step_func_done(function(event)
             {
                 assert_equals(document.fullscreenElement, null);

--- a/fullscreen/model/remove-last-manual.html
+++ b/fullscreen/model/remove-last-manual.html
@@ -29,10 +29,11 @@ async_test(function(t)
             assert_equals(document.fullscreenElement, first);
             document.onfullscreenchange = t.step_func_done(function(event)
             {
-                // When the asynchronous steps of "exit fullscreen" ran, only
-                // /first/ was in the top layer, and thus we exited fully.
-                assert_equals(document.fullscreenElement, null);
-                assert_equals(event.target, first);
+                // When the asynchronous steps of "exit fullscreen" ran, /last/
+                // was no longer connected to the document, and so the event
+                // has the document as its target.
+                assert_equals(document.fullscreenElement, first);
+                assert_equals(event.target, document);
             });
         });
     });

--- a/fullscreen/model/remove-last-manual.html
+++ b/fullscreen/model/remove-last-manual.html
@@ -10,6 +10,7 @@
 <script>
 async_test(function(t)
 {
+    t.add_cleanup(() => document.exitFullscreen());
     var first = document.getElementById("first");
     trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function(event)
@@ -23,10 +24,15 @@ async_test(function(t)
             assert_equals(document.fullscreenElement, last);
             assert_equals(event.target, last);
             last.remove();
+            // Because /last/ was removed from the top layer, only /first/
+            // remains and it becomes the new fullscreen element synchronously.
+            assert_equals(document.fullscreenElement, first);
             document.onfullscreenchange = t.step_func_done(function(event)
             {
-                assert_equals(document.fullscreenElement, first);
-                assert_equals(event.target, document);
+                // When the asynchronous steps of "exit fullscreen" ran, only
+                // /first/ was in the top layer, and thus we exited fully.
+                assert_equals(document.fullscreenElement, null);
+                assert_equals(event.target, first);
             });
         });
     });

--- a/fullscreen/model/remove-parent-manual.html
+++ b/fullscreen/model/remove-parent-manual.html
@@ -10,6 +10,7 @@
 <script>
 async_test(function(t)
 {
+    t.add_cleanup(() => document.exitFullscreen());
     var child = document.getElementById("child");
     trusted_request(t, child);
     document.onfullscreenchange = t.step_func(function(event)
@@ -17,6 +18,9 @@ async_test(function(t)
         assert_equals(document.fullscreenElement, child);
         assert_equals(event.target, child);
         child.parentNode.remove();
+        // Because /child/ was removed from the top layer, the fullscreen
+        // element becomes null synchronously.
+        assert_equals(document.fullscreenElement, null);
         document.onfullscreenchange = t.step_func_done(function(event)
         {
             assert_equals(document.fullscreenElement, null);

--- a/fullscreen/model/remove-single-manual.html
+++ b/fullscreen/model/remove-single-manual.html
@@ -8,12 +8,16 @@
 <script>
 async_test(function(t)
 {
+    t.add_cleanup(() => document.exitFullscreen());
     var single = document.getElementById("single");
     document.onfullscreenchange = t.step_func(function(event)
     {
         assert_equals(document.fullscreenElement, single);
         assert_equals(event.target, single);
         single.remove();
+        // Because /single/ was removed from the top layer, the fullscreen
+        // element becomes null synchronously.
+        assert_equals(document.fullscreenElement, null);
         document.onfullscreenchange = t.step_func_done(function(event)
         {
             assert_equals(document.fullscreenElement, null);

--- a/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-remove.html
+++ b/html/semantics/interactive-elements/the-dialog-element/dialog-showModal-remove.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>dialog element: removing from document after showModal()</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal">
+<link rel=help href="https://fullscreen.spec.whatwg.org/#removing-steps">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<dialog></dialog>
+<script>
+async_test(t => {
+  const dialog = document.querySelector('dialog')
+  dialog.showModal()
+  assert_true(dialog.open)
+  // The dialog element is now in top layer. Removing it should synchronously
+  // remove it from top layer, but should leave it in a strange limbo state.
+  dialog.addEventListener('close', t.unreached_func('close event'))
+  dialog.remove()
+  assert_true(dialog.open)
+  // if an event was queued, it would fire before this timeout
+  step_timeout(t.step_func_done(() => {
+    assert_true(dialog.open)
+    // pass if no close event was fired
+  }))
+})
+</script>


### PR DESCRIPTION
Apart from the event.target tests, these pass in Firefox Nightly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
