### PR TITLE
[infra] Specify latest minor release of PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
       env: TOXENV=py35 HYPOTHESIS_PROFILE=ci SCRIPT=ci_unittest.sh
     - python: 3.6
       env: TOXENV=py36 HYPOTHESIS_PROFILE=ci SCRIPT=ci_unittest.sh
-    - python: pypy
+    - python: pypy-5.4
       env: TOXENV=pypy HYPOTHESIS_PROFILE=ci SCRIPT=ci_unittest.sh
   exclude:
     - env:  # exclude empty env from the top-level above


### PR DESCRIPTION
At approximately 14:14 EST on June 21, 2017, Travis jobs that specify
the Python version via the string `pypy` began failing consistently. At
the time of this writing, the TravisCI.org documentation claims that the
value `pypy` is valid [1], but recent statements from TravisCI
maintainers [2] contradict this:

> `pypy` and `pypy3` are not names we can support consistently going
> forward.
>
> Please use `pypy-x.y`.

(This issue may have been exacerbated by the recent release of new
machine images within the TravisCI infrastructure [3].)

Explicitly specify a major and minor version of PyPy

According to build log of the most recent successful job [4], the latest
"known good" value (which was previously selected automatically) is
5.4.1. Specify version "5.4" in order to satisfy the above
recommendation from the TravisCI team.

[1] https://docs.travis-ci.com/user/languages/python/#PyPy-Support
[2] https://github.com/travis-ci/travis-ci/issues/6865#issuecomment-307187192
[3] https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
[4] https://travis-ci.org/w3c/web-platform-tests/jobs/245400526

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6316)
<!-- Reviewable:end -->
