### PR TITLE
Test that worker global scope's name is replaceable

### DIFF
--- a/workers/name-property.html
+++ b/workers/name-property.html
@@ -14,6 +14,12 @@
 const worker = new Worker("support/name.js", { name: "my name" });
 fetch_tests_from_worker(worker);
 
+const worker2 = new Worker("support/name-as-accidental-global.js");
+fetch_tests_from_worker(worker2);
+
 const sharedWorker = new SharedWorker("support/name.js", { name: "my name" });
 fetch_tests_from_worker(sharedWorker);
+
+const sharedWorker2 = new SharedWorker("support/name-as-accidental-global.js");
+fetch_tests_from_worker(sharedWorker2);
 </script>

--- a/workers/support/name-as-accidental-global.js
+++ b/workers/support/name-as-accidental-global.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var name = "something else";
+
+// This just makes the test name not "Untitled"
+test(() => { }, "Declaring name as an accidental global must not cause a harness error");
+
+done();

--- a/workers/support/name.js
+++ b/workers/support/name.js
@@ -6,4 +6,13 @@ test(() => {
   assert_equals(self.name, "my name")
 }, `name property value for ${self.constructor.name}`);
 
+test(() => {
+  self.name = "something new";
+  const propDesc = Object.getOwnPropertyDescriptor(self, "name");
+  assert_equals(propDesc.value, "something new", "value");
+  assert_true(propDesc.configurable, "configurable");
+  assert_true(propDesc.writable, "writable");
+  assert_true(propDesc.enumerable, "enumerable");
+}, `name property is replaceable for ${self.constructor.name}`);
+
 done();


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2783.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
