### PR TITLE
Stop using Chrome's automation extension for testharness tests

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -44,6 +44,9 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     for (kwarg, capability) in [("binary", "binary"), ("binary_args", "args")]:
         if kwargs[kwarg] is not None:
             capabilities["chromeOptions"][capability] = kwargs[kwarg]
+    if test_type == "testharness":
+        capabilities["chromeOptions"]["useAutomationExtension"] = False
+        capabilities["chromeOptions"]["excludeSwitches"] = ["enable-automation"]
     executor_kwargs["capabilities"] = capabilities
     return executor_kwargs
 


### PR DESCRIPTION
This prevents ChromeDriver from using its automation extension for
testharness-based tests. When this extension is used, Chrome displays
a warning bar that changes the window size while a test is already
running, and this can cause test flake ([IntersectionObserver tests](https://github.com/w3c/web-platform-tests/pull/6216)
are running into this; also see [this discussion thread](https://groups.google.com/a/chromium.org/d/msg/platform-predictability/k1I70ez7suM/1iskWQeKAgAJ)). 

This change only affects testharness-based tests since older versions
of Chrome (like the currently shipping Chrome 59) require the extension
for reftests (in order to set the window size).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6348)
<!-- Reviewable:end -->
