### PR TITLE
Add --log-wptreport option to wptrunner

### DIFF
--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -28,13 +28,9 @@ class WptreportFormatter(BaseFormatter):
             }
         return self.raw_results[test_name]
 
-    def find_or_create_subtest(self, data):
+    def create_subtest(self, data):
         test = self.find_or_create_test(data)
         subtest_name = data["subtest"]
-
-        for i in range(len(test["subtests"])):
-            if test["subtests"][i]["name"] == subtest_name:
-                return test["subtests"][i]
 
         subtest = {
             "name": subtest_name,
@@ -46,14 +42,11 @@ class WptreportFormatter(BaseFormatter):
         return subtest
 
     def test_status(self, data):
-        subtest = self.find_or_create_subtest(data)
+        subtest = self.create_subtest(data)
         subtest["status"] = data["status"]
-        if data.get("message"):
-            if subtest["message"]:
-                subtest["message"] += ", " + data["message"]
-            else:
-                subtest["message"] = data["message"]
 
     def test_end(self, data):
         test = self.find_or_create_test(data)
         test["status"] = data["status"]
+        if "message" in data:
+            test["message"] = data["message"]

--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -1,0 +1,66 @@
+import json
+
+from collections import OrderedDict
+from mozlog.structured.formatters.base import BaseFormatter
+
+
+class WptreportFormatter(BaseFormatter):
+    """Formatter that produces results in the format that wpreport expects."""
+
+    def __init__(self):
+        self.raw_results = OrderedDict()
+
+    def suite_end(self, data):
+        results = OrderedDict()
+        results["results"] = []
+        for test_name in self.raw_results:
+            result = {"test": test_name}
+            result.update(self.raw_results[test_name])
+            results["results"].append(result)
+        return json.dumps(results)
+
+    def test_start(self, data):
+        self.start_times[data["test"]] = data["time"]
+
+    def find_or_create_test(self, data):
+        test_name = data["test"]
+        if self.raw_results.get(test_name):
+            return self.raw_results[test_name]
+
+        test = {
+            "subtests": [],
+            "status": "",
+            "message": None
+        }
+        self.raw_results[test_name] = test
+        return test
+
+    def find_or_create_subtest(self, data):
+        test = self.find_or_create_test(data)
+        subtest_name = data["subtest"]
+
+        for i in range(len(test["subtests"])):
+            if test["subtests"][i]["name"] == subtest_name:
+                return test["subtests"][i]
+
+        subtest = {
+            "name": subtest_name,
+            "status": "",
+            "message": None
+        }
+        test["subtests"].append(subtest)
+
+        return subtest
+
+    def test_status(self, data):
+        subtest = self.find_or_create_subtest(data)
+        subtest["status"] = data["status"]
+        if data.get("message"):
+            if subtest["message"]:
+                subtest["message"] += ", " + data["message"]
+            else:
+                subtest["message"] = data["message"]
+
+    def test_end(self, data):
+        test = self.find_or_create_test(data)
+        test["status"] = data["status"]

--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -1,6 +1,5 @@
 import json
 
-from collections import OrderedDict
 from mozlog.structured.formatters.base import BaseFormatter
 
 
@@ -8,10 +7,10 @@ class WptreportFormatter(BaseFormatter):
     """Formatter that produces results in the format that wpreport expects."""
 
     def __init__(self):
-        self.raw_results = OrderedDict()
+        self.raw_results = {}
 
     def suite_end(self, data):
-        results = OrderedDict()
+        results = {}
         results["results"] = []
         for test_name in self.raw_results:
             result = {"test": test_name}
@@ -19,21 +18,15 @@ class WptreportFormatter(BaseFormatter):
             results["results"].append(result)
         return json.dumps(results)
 
-    def test_start(self, data):
-        self.start_times[data["test"]] = data["time"]
-
     def find_or_create_test(self, data):
         test_name = data["test"]
-        if self.raw_results.get(test_name):
-            return self.raw_results[test_name]
-
-        test = {
-            "subtests": [],
-            "status": "",
-            "message": None
-        }
-        self.raw_results[test_name] = test
-        return test
+        if test_name not in self.raw_results:
+            self.raw_results[test_name] = {
+                "subtests": [],
+                "status": "",
+                "message": None
+            }
+        return self.raw_results[test_name]
 
     def find_or_create_subtest(self, data):
         test = self.find_or_create_test(data)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -7,6 +7,7 @@ from distutils.spawn import find_executable
 
 import config
 import wpttest
+import formatters
 
 
 def abs_path(path):
@@ -210,6 +211,8 @@ scheme host and port.""")
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "
                              "(equivalent to --include)")
+
+    commandline.log_formatters["wptreport"] = (formatters.WptreportFormatter, "wptreport format")
 
     commandline.add_logging_group(parser)
     return parser


### PR DESCRIPTION
This change adds a --log-wptreport option to wptrunner; the option
enables wptrunner to output test results in the JSON format that
wpreport[1] expects to consume as input.

[1] https://www.npmjs.com/package/wptreport

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6356)
<!-- Reviewable:end -->
