### PR TITLE
Make accumulation of transform lists with 'none' behave in the same way as interpolation;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/iterationComposite.html
+++ b/web-animations/interfaces/KeyframeEffect/iterationComposite.html
@@ -669,15 +669,18 @@ test(function(t) {
 
   anim.currentTime = anim.effect.timing.duration / 2;
   assert_equals(getComputedStyle(div).transform,
-    'matrix(1, 0, 0, 1, 5, 0)', // (0px + 10px) / 2
+    // translateX(none) -> translateX(10px) @ 50%
+    'matrix(1, 0, 0, 1, 5, 0)',
     'Animated transform list at 50s of the first iteration');
   anim.currentTime = anim.effect.timing.duration * 2;
   assert_equals(getComputedStyle(div).transform,
-    'matrix(1, 0, 0, 1, 0, 0)', // 'none' overrides any transforms.
+    // translateX(10px * 2 + none) -> translateX(10px * 2 + 10px) @ 0%
+    'matrix(1, 0, 0, 1, 20, 0)',
     'Animated transform list at 0s of the third iteration');
   anim.currentTime += anim.effect.timing.duration / 2;
   assert_equals(getComputedStyle(div).transform,
-    'matrix(1, 0, 0, 1, 15, 0)', // (0px + 10px*2)/2
+    // translateX(10px * 2 + none) -> translateX(10px * 2 + 10px) @ 50%
+    'matrix(1, 0, 0, 1, 25, 0)',
     'Animated transform list at 50s of the third iteration');
 }, 'iterationComposite of transform from none to translate');
 


### PR DESCRIPTION

MozReview-Commit-ID: LITXkeYN1VR

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1366627 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6364)
<!-- Reviewable:end -->
