### PR TITLE
Align IDL record to C++ conversion with the spec when Symbol-named properties are involved.

### DIFF
--- a/fetch/api/headers/headers-record.html
+++ b/fetch/api/headers/headers-record.html
@@ -395,5 +395,4 @@ test(function() {
   assert_true(h.has("c"));
   assert_equals(h.get("c"), "d");
 }, "Operation with non-enumerable Symbol keys");
-
 </script>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1366032 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6368)
<!-- Reviewable:end -->
