### PR TITLE
Prevent default behaviour when testing function keys;

### DIFF
--- a/webdriver/actions/special_keys.py
+++ b/webdriver/actions/special_keys.py
@@ -11,12 +11,19 @@ def test_webdriver_special_key_sends_keydown(session,
                                              key_chain,
                                              name,
                                              expected):
+    if name.startswith("F"):
+        # Prevent default behavior for F1, etc., but only after keydown
+        # bubbles up to body. (Otherwise activated browser menus/functions
+        # may interfere with subsequent tests.)
+        session.execute_script("""
+            document.body.addEventListener("keydown",
+                    (e) => e.preventDefault());
+        """)
     key_chain.key_down(getattr(Keys, name)).perform()
     # only interested in keydown
     first_event = get_events(session)[0]
     # make a copy so we can throw out irrelevant keys and compare to events
     expected = dict(expected)
-
 
     del expected["value"]
     # check and remove keys that aren't in expected


### PR DESCRIPTION

F10, F7 and others activate browser menus in the Linux test environment,
so call preventDefault to stop it.

The default bevahiour interferes with tests running against the upcoming
beta build. Although nightly builds also have this behaviour, it doesn't
appear to intefere with the tests.

MozReview-Commit-ID: 1PiqmtG1SfB

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1358020 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6372)
<!-- Reviewable:end -->
