### PR TITLE
Correct test.

### DIFF
--- a/media-source/mediasource-seekable.html
+++ b/media-source/mediasource-seekable.html
@@ -33,9 +33,12 @@
     {
         var initSegment = MediaSourceUtil.extractSegmentData(mediaData, segmentInfo.init);
         test.expectEvent(mediaElement, 'durationchange', 'mediaElement got duration after initsegment');
+        test.expectEvent(sourceBuffer, 'update');
+        test.expectEvent(sourceBuffer, 'updateend');
         sourceBuffer.appendBuffer(initSegment);
         test.waitForExpectedEvents(function()
         {
+            assert_false(sourceBuffer.updating, "updating attribute is false");
             test.expectEvent(mediaElement, 'durationchange', 'mediaElement got infinity duration');
             mediaSource.duration = Infinity;
             test.waitForExpectedEvents(function()


### PR DESCRIPTION

the durationchange event will be queued during the initialization segment received algorithm.
Only once the init segment has been fully processed will update/updateend be queued.

As such, the updateend event must be fired before being able to call appendBuffer once again.

MozReview-Commit-ID: GYQNOwWZ7DH

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1362165 [ci skip]