### PR TITLE
Add mozlog logger that goes via a queue,

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -6,7 +6,7 @@ import socket
 import sys
 import time
 
-from mozlog import get_default_logger, handlers
+from mozlog import get_default_logger, handlers, proxy
 
 from wptlogging import LogLevelRewriter
 
@@ -167,6 +167,8 @@ class TestEnvironment(object):
         # Downgrade errors to warnings for the server
         log_filter = LogLevelRewriter(log_filter, ["error"], "warning")
         server_logger.component_filter = log_filter
+
+        server_logger = proxy.QueuedProxyLogger(server_logger)
 
         try:
             #Set as the default logger for wptserve


### PR DESCRIPTION

This allows subprocesses to log to a shared stream via a queue, so that we
avoid the overhead of a multiprocessing Lock around all log access, but still
avoid races where two processes try to log simultaneously. It's mostly useful
where one process is responsible for the majority of logging, but some messages
will be generated in child processes.

MozReview-Commit-ID: ABl6cvpb6qI

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1368342 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6375)
<!-- Reviewable:end -->
