### PR TITLE
Allow running wpt directories by path on the command line,

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -51,6 +51,15 @@ class Manifest(object):
             for test in type_tests.get(path, set()):
                 yield test
 
+    def iterdir(self, dir_name):
+        if not dir_name.endswith(os.path.sep):
+            dir_name = dir_name + os.path.sep
+        for type_tests in self._data.values():
+            for path, tests in type_tests.iteritems():
+                if path.startswith(dir_name):
+                    for test in tests:
+                        yield test
+
     @property
     def reftest_nodes_by_url(self):
         if self._reftest_nodes_by_url is None:

--- a/tools/wptrunner/wptrunner/manifestinclude.py
+++ b/tools/wptrunner/wptrunner/manifestinclude.py
@@ -93,7 +93,8 @@ class IncludeManifest(ManifestItem):
                 for manifest, data in test_manifests.iteritems():
                     found = False
                     rel_path = os.path.relpath(path, data["tests_path"])
-                    for test in manifest.iterpath(rel_path):
+                    iterator = manifest.iterpath if os.path.isfile(path) else manifest.iterdir
+                    for test in iterator(rel_path):
                         if not hasattr(test, "url"):
                             continue
                         url = test.url


### PR DESCRIPTION

We regressed running entire directories when wptrunner was switched to
look up command parameters directly in the manifest rather than
iterating over prefix matches. For files that's OK, but for
directories the old behaviour is required.

MozReview-Commit-ID: HVL7rL1YuZx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1369471 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6379)
<!-- Reviewable:end -->
