### PR TITLE
Don't require setting the wpt hosts configuration for servo,

### DIFF
--- a/tools/wptrun.py
+++ b/tools/wptrun.py
@@ -81,7 +81,7 @@ otherwise install OpenSSL and ensure that it's on your $PATH.""")
 
 
 def check_environ(product):
-    if product != "firefox":
+    if product not in ("firefox", "servo"):
         expected_hosts = ["web-platform.test",
                           "www.web-platform.test",
                           "www1.web-platform.test",


### PR DESCRIPTION

Servo reads the hosts from a file created at runtime, so this
configuration isn't required.

MozReview-Commit-ID: 20NoZyp3bJz

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1370203 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6381)
<!-- Reviewable:end -->
