### PR TITLE
Make fetch-response-xhr.https.html not depend on window.event.

### DIFF
--- a/service-workers/service-worker/resources/fetch-response-xhr-iframe.https.html
+++ b/service-workers/service-worker/resources/fetch-response-xhr-iframe.https.html
@@ -26,7 +26,7 @@ function coalesce_headers_test() {
 
       return new Promise(function(resolve) {
           window.addEventListener('message', function handle(evt) {
-              if (event.data !== 'ACK') {
+              if (evt.data !== 'ACK') {
                 return;
               }
 
@@ -40,7 +40,7 @@ function coalesce_headers_test() {
 window.addEventListener('message', function(evt) {
     var port;
 
-    if (event.data !== 'START') {
+    if (evt.data !== 'START') {
       return;
     }
 


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1369874 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6382)
<!-- Reviewable:end -->
