### PR TITLE
Don't infinite loop when a test expects to crash,

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -154,6 +154,7 @@ class BrowserManager(object):
         self.browser = browser
         self.no_timeout = no_timeout
         self.browser_settings = None
+        self.last_test = None
 
         self.started = False
 
@@ -163,8 +164,9 @@ class BrowserManager(object):
         browser_settings = self.browser.settings(test)
         restart_required = ((self.browser_settings is not None and
                              self.browser_settings != browser_settings) or
-                            test.expected() == "CRASH")
+                            (self.last_test != test and test.expected() == "CRASH"))
         self.browser_settings = browser_settings
+        self.last_test = test
         return restart_required
 
     def init(self):


### PR DESCRIPTION

In order to avoid the leak checker complaining about missing output,
we restart the browser before running tests that are expected to
crash. But as part of that restart we end up checking again if a
restart is required and so end up in an infinite loop. To break out of
that loop we simply check if this is the same test as during the last
iteration, and don't ask to restart in that case.

MozReview-Commit-ID: 90gsmqVCRsD

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1373709 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6397)
<!-- Reviewable:end -->
