### PR TITLE
Move to RectResponse aligning with the WebDriver crate;

### DIFF
--- a/webdriver/contexts.py
+++ b/webdriver/contexts.py
@@ -19,24 +19,6 @@ def window_position_supported(session):
     except webdriver.InvalidArgumentException:
         return True
 
-def test_window_size_types(http, session):
-    if not window_size_supported(session):
-        pytest.skip()
-
-    with http.get("/session/%s/window/size" % session.session_id) as resp:
-        assert resp.status == 200
-        body = json.load(resp)
-    assert "value" in body
-    assert "width" in body["value"]
-    assert "height" in body["value"]
-    assert isinstance(body["value"]["width"], int)
-    assert isinstance(body["value"]["height"], int)
-
-    size = session.window.size
-    assert isinstance(size, tuple)
-    assert isinstance(size[0], int)
-    assert isinstance(size[1], int)
-
 
 def test_window_resize(session):
     if not window_size_supported(session):


### PR DESCRIPTION

This uses the merged RectResponse from the WebDriver crate. It also moves the
types in the struct to floats which aligns with the WebDriver
specification as in
https://w3c.github.io/webdriver/webdriver-spec.html#get-element-rect
and in https://w3c.github.io/webdriver/webdriver-spec.html#dfn-window-rect

MozReview-Commit-ID: DWeXJEnc1p

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1371405 [ci skip]