### PR TITLE
Disable loading mozlog plugin with pytest for wpt,

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -56,6 +56,7 @@ def run(path, server_config, session_config, timeout=0):
                      "--verbose",  # show each individual subtest
                      "--capture", "no",  # enable stdout/stderr from tests
                      "--basetemp", cache,  # temporary directory
+                     "-p", "no:mozlog",
                      path],
                     plugins=plugins)
 


### PR DESCRIPTION

Loading mozlog from within the executor process makes us prone to
deadlocks since we can't guarantee that the log mutex isn't acquired
when we fork() the parent process, and the python multiprocessing
module doesn't respect posix guidelines about execv()ing a new process
after a fork().

To avoid this specific instance of the probelm we stop pytest loading
the mozlog plugin which we aren't actually using but is loaded by
default when mozlog is available.

MozReview-Commit-ID: IIllNZVOUJz

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1354750 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6405)
<!-- Reviewable:end -->
