### PR TITLE
Add per-test-queue metadata to wptrunner, r=ato,maja_zf

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -469,7 +469,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, reftest_internal=False,
                  reftest_screenshot="unexpected",
-                 **kwargs):
+                 group_metadata=None, **kwargs):
         """Marionette-based executor for reftests"""
         RefTestExecutor.__init__(self,
                                  browser,
@@ -487,6 +487,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
         self.close_after_done = close_after_done
         self.has_window = False
         self.original_pref_values = {}
+        self.group_metadata = group_metadata
 
         with open(os.path.join(here, "reftest.js")) as f:
             self.script = f.read()
@@ -564,9 +565,9 @@ class InternalRefTestImplementation(object):
 
     def setup(self, screenshot="unexpected"):
         data = {"screenshot": screenshot}
-        if self.executor.queue_metadata is not None:
+        if self.executor.group_metadata is not None:
             data["urlCount"] = {urlparse.urljoin(self.executor.server_url(key[0]), key[1]):value
-                                for key, value in self.executor.queue_metadata.get("url_count", {}).iteritems()
+                                for key, value in self.executor.group_metadata.get("url_count", {}).iteritems()
                                 if value > 1}
         self.executor.protocol.marionette.set_context(self.executor.protocol.marionette.CONTEXT_CHROME)
         self.executor.protocol.marionette._send_message("reftest:setup", data)


### PR DESCRIPTION

This adds a metadata object associated with each test queue, and uses
it to pass cache information into the marionette internal reftest
implementation so that we are able to cache only those canvases that
will be reused.

MozReview-Commit-ID: zASrlvnri3

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1363428 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6412)
<!-- Reviewable:end -->
