### PR TITLE
Use the internal reftest implementation by default on Linux and OSX,

### DIFF
--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -396,6 +396,10 @@ def check_args(kwargs):
         kwargs['extra_prefs'] = [tuple(prefarg.split('=', 1)) for prefarg in
                                  kwargs['extra_prefs']]
 
+    if kwargs["reftest_internal"] is None:
+        # Default to the internal reftest implementation on Linux and OSX
+        kwargs["reftest_internal"] = sys.platform.startswith("linux") or sys.platform.startswith("darwin")
+
     return kwargs
 
 


### PR DESCRIPTION

This is faster and works better in some cases (e.g. with SVG). However
it doesn't work correctly on Windows yet, so remains disabled there by default.

MozReview-Commit-ID: AXyeFUGfVgx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1363428 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6414)
<!-- Reviewable:end -->
