### PR TITLE
Add timeout expectation for a payment-request test

### DIFF
--- a/payment-request/payment-request-constructor-crash.https.html
+++ b/payment-request/payment-request-constructor-crash.https.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
+<meta name="timeout" content="long">
 <title>Crash tests PaymentRequest Constructor</title>
 <link rel="help" href="https://w3c.github.io/browser-payment-api/#constructor">
 <script src="/resources/testharness.js"></script>


### PR DESCRIPTION
Add timeout expectation meta tag for payment-request-constractor-crash
test, as it may take long time depending on build configuration.

Especially Chromium observed some timeout with debug builds
for this test (up to 18s on Mac/Win dbg builds, while 1-3s on
release builds).
Flakiness dashboard graph: https://goo.gl/HPWLD7

<!-- Reviewable:start -->

<!-- Reviewable:end -->
