### PR TITLE
add force argument to Edge browser stop command

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -55,8 +55,8 @@ class EdgeBrowser(Browser):
         print self.server.url
         self.server.start()
 
-    def stop(self):
-        self.server.stop()
+    def stop(self, force=False):
+        self.server.stop(force=force)
 
     def pid(self):
         return self.server.pid


### PR DESCRIPTION
Passes force flag to `EdgeDriverServer(WebDriverServer).stop` in `/tools/wptrunner/wptrunner/webdriver_server.py`

- fixes #6341

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6425)
<!-- Reviewable:end -->
