### PR TITLE
 css/css3-selectors/i18n tests lack visible results

### DIFF
--- a/css/css3-selectors/i18n/css3-selectors-lang-001.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-001.html
@@ -8,15 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box:lang(es) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-002.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-002.html
@@ -8,15 +8,18 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box:lang(es) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
 
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test" lang="es"><div id="box">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-004.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-004.html
@@ -9,17 +9,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(es) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-005.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-005.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(es) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-006.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-006.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(es-MX) { width: 100px; }
+#box:lang(es-MX) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -28,7 +30,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A :lang value will NOT match a lang attribute value when the former contains more subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-007.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-007.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(es-MX) { width: 100px; }
+#box:lang(es-MX) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -28,7 +30,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "When the :lang value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-008.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-008.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(en-GB) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-009.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-009.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(en-GB) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-010.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-010.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(en-GB) { width: 100px; }
+#box:lang(en-GB) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -28,7 +30,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A :lang value and a lang attribute value will NOT match if their region subtags differ.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-011.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-011.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(az-Arab-IR) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-012.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-012.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(az-Arab-IR) { width: 100px; }
+#box:lang(az-Arab-IR) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -28,7 +30,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A :lang value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-014.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-014.html
@@ -8,17 +8,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(cs-CZ) { width: 100px; }
+#box:lang(cs-CZ) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -28,7 +30,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A :lang value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-015.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-015.html
@@ -9,17 +9,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
 #box:lang(az-Arab-IR) { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-016.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-016.html
@@ -9,17 +9,19 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest:lang(xx) { display:none; }
-#box:lang(es) { width: 100px; }
+#box:lang(es) { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to :lang support. If :lang is not supported, a messa
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A :lang value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-021.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-021.html
@@ -8,15 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang|='es'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-022.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-022.html
@@ -8,20 +8,23 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang|='es'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang|='es'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
 
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test" lang="es"><div id="box">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value that matches an identical lang attribute value on the parent element will NOT produce styling.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-024.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-024.html
@@ -9,18 +9,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='es'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-025.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-025.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='es'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-026.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-026.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='es-MX'] { width: 100px; }
+#box[lang|='es-MX'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value will NOT match a lang attribute value when the former contains more subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-027.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-027.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='es'] { width: 100px; }
+#box[lang|='es'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "When the lang|= value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-028.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-028.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='en-GB'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-029.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-029.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='en-GB'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-030.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-030.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='es-GB'] { width: 100px; }
+#box[lang|='es-GB'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value and a lang attribute value will NOT match if their region subtags differ.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-031.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-031.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='az-Arab-IR'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-032.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-032.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='az-Arab-IR'] { width: 100px; }
+#box[lang|='az-Arab-IR'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-034.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-034.html
@@ -8,18 +8,20 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='cs-CZ'] { width: 100px; }
+#box[lang|='cs-CZ'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -29,7 +31,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-035.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-035.html
@@ -9,18 +9,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
 #box[lang|='az-Arab-IR'] { width: 100px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-036.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-036.html
@@ -9,18 +9,20 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
  		#colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
 		#colonlangcontroltest[lang|=xx] { display:none; }
-#box[lang|='es'] { width: 100px; }
+#box[lang|='es'] { width: 50px; }
 #relevance[lang|='yy'] { display:none; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 <p lang='xx' id='colonlangcontroltest'>This test failed because it relies on [lang|=..] for results, but [lang|=..] is not supported by this browser.
 
 
@@ -30,7 +32,7 @@ This tests a detail related to [lang|=..] support. If [lang|=..] is not supporte
 <script>
 test(function() {
 assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A [lang|='es'] value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-041.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-041.html
@@ -8,15 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang='es'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-042.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-042.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='es'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='es'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test" lang="es"><div id="box">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang|= value that matches an identical lang attribute value on the parent element will NOT produce styling.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-044.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-044.html
@@ -9,15 +9,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang='es'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="ES">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-045.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-045.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='es'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='es'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es-MX">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value will NOT match a lang attribute value when the latter contains additional subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-046.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-046.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='es-MX'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='es-MX'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value will NOT match a lang attribute value when the former contains more subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-047.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-047.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='es'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='es'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="mx-es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "When the lang= value uses a single subtag, it will NOT match against an attribute value where it appears in a different position.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-048.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-048.html
@@ -8,15 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang='en-GB'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-049.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-049.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='en-GB'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='en-GB'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-GB-scouse">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value with multiple subtags will NOT match a lang attribute value with multiple subtags if the latter has more subtags, even if the first two subtags are the same.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-050.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-050.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='en-GB'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='en-GB'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="en-US">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value and a lang attribute value will NOT match if their region subtags differ.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-051.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-051.html
@@ -8,15 +8,17 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang='az-Arab-IR'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-Arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-052.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-052.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='az-Arab-IR'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='az-Arab-IR'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value with language, script and region subtags will NOT match a lang attribute value with the script subtag missing.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-054.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-054.html
@@ -8,20 +8,22 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='cs-CZ'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='cs-CZ'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="cs-Latn-CZ">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A lang= value with language and region subtags will NOT match a lang attribute value with language, script and region subtags.");
 </script>
 

--- a/css/css3-selectors/i18n/css3-selectors-lang-055.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-055.html
@@ -9,15 +9,17 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
+.test div { width: 50px; height: 50px; background-color: blue; }
 #box[lang='az-Arab-IR'] { width: 100px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" lang="az-arab-IR">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>

--- a/css/css3-selectors/i18n/css3-selectors-lang-056.html
+++ b/css/css3-selectors/i18n/css3-selectors-lang-056.html
@@ -9,20 +9,22 @@
 <script src="/resources/testharnessreport.js"></script>
 <meta name='flags' content='HTMLonly'>
 <style type='text/css'>
-.test div { width: 50px; }
-#box[lang='es'] { width: 100px; }
+.test div { width: 100px; height: 50px; background-color: blue; }
+#box[lang='es'] { width: 50px; }
+.ref { width: 100px; height: 50px; background-color: blue; }
 </style>
 </head>
 <body>
 
 
-
+<p>The following two blocks should be <strong>identical</strong>.</p>
 <div class="test"><div id="box" xml:lang="es">&#xA0;</div></div>
+<p class="ref">&#xA0;</p>
 
 
 <script>
 test(function() {
-assert_equals(document.getElementById('box').offsetWidth, 50);
+assert_equals(document.getElementById('box').offsetWidth, 100);
 }, "A [lang='es'] value that matches an identical xml:lang attribute value will NOT produce styling in pages served as HTML.");
 </script>
 


### PR DESCRIPTION
The current css/css3-selectors/i18n tests each check the width of a `div` that has a transparent background and that contains only `&#xA0;`.

This PR gives each `div` being tested a blue background and a fixed height.  It also adds a reference `p` with the correct height, width, and background color to each test.

In some tests, the existing `width` values are transposed so that the desired width is 100px for all of these tests.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
