### PR TITLE
Bring mediacapture-streams tests to spec

### DIFF
--- a/mediacapture-streams/GUM-api.https.html
+++ b/mediacapture-streams/GUM-api.https.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>getUserMedia: test that getUserMedia is present (with or without vendor prefix)</title>
+<title>getUserMedia: test that getUserMedia is present</title>
 <link rel="author" title="Dominique Hazael-Massieux" href="mailto:dom@w3.org"/>
 <link rel="help" href="http://dev.w3.org/2011/webrtc/editor/getusermedia.html#navigatorusermedia">
 <meta name='assert' content='Check that the getUserMedia() method is present.'/>
@@ -9,15 +9,14 @@
 <body>
 <h1 class="instructions">Description</h1>
 <p class="instructions">This test checks for the presence of the
-<code>navigator.getUserMedia</code> method, taking vendor prefixes into account.</p>
+<code>navigator.mediaDevices.getUserMedia</code> method.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 test(function () {
-  assert_true(undefined !== navigator.getUserMedia, "navigator.getUserMedia exists");
-}, "getUserMedia() is present on navigator");
+  assert_true(undefined !== navigator.mediaDevices && undefined !== navigator.mediaDevices.getUserMedia, "navigator.mediaDevices.getUserMedia exists");
+}, "mediaDevices.getUserMedia() is present on navigator");
 </script>
 </body>
 </html>

--- a/mediacapture-streams/GUM-deny.https.html
+++ b/mediacapture-streams/GUM-deny.https.html
@@ -15,22 +15,18 @@
   <div id='log'></div>
   <script src=/resources/testharness.js></script>
   <script src=/resources/testharnessreport.js></script>
-  <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
   <script>
     var t = async_test("Tests that the error callback is triggered when permission is denied", {timeout:10000});
     t.step(function() {
-      navigator.getUserMedia(
-        {video: true},
-        t.step_func(function (stream) {
-        assert_unreached("The success callback should not be triggered since access is to be denied");
-        t.done();
-        }),
-        t.step_func(function (error) {
-          assert_equals(error.name, "securityError", "securityError returned as expected");
+      navigator.mediaDevices.getUserMedia({video: true})
+        .then(t.step_func(function (stream) {
+          assert_unreached("The success callback should not be triggered since access is to be denied");
+          t.done();
+        }), t.step_func(function (error) {
+          assert_equals(error.name, "NotAllowedError", "NotAllowedError returned as expected");
           assert_equals(error.constraintName, undefined, "constraintName attribute not set as expected");
           t.done();
-        })
-      );
+        }))
     });
   </script>
 </body>

--- a/mediacapture-streams/GUM-empty-option-param.https.html
+++ b/mediacapture-streams/GUM-empty-option-param.https.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>getUserMedia({}) aborts with NOT_SUPPORTED_ERR</title>
+<title>getUserMedia({}) rejects with TypeError</title>
 <link rel="author" title="Dominique Hazael-Massieux" href="mailto:dom@w3.org"/>
 <link rel="help" href="http://dev.w3.org/2011/webrtc/editor/getusermedia.html#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback">
 </head>
@@ -13,20 +13,17 @@ options parameter raises a NOT_SUPPORTED_ERR exception.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
-var t = async_test("Tests that getUserMedia raises a NOT_SUPPORTED_ERR exception when used with an empty options parameter");
+var t = async_test("Tests that getUserMedia is rejected with a TypeError when used with an empty options parameter");
 t.step( function () {
-  // TODO This is no longer what's in the spec, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22211
-  assert_throws("NOT_SUPPORTED_ERR",
-    function () {
-      navigator.getUserMedia({}, t.step_func(function (stream) {
-        assert_unreached("This should never be triggered since the constraints parameter is empty");
-        t.done();
-      }), t.step_func(function (error) {
-        assert_unreached("This should never be triggered since the constraints parameter is empty");
-      }));
-  });
+  navigator.mediaDevices.getUserMedia({})
+    .then(t.step_func(function () {
+      assert_unreached("This should never be triggered since the constraints parameter is empty");
+    }), t.step_func(function (error) {
+      assert_equals(error.name, "TypeError", "TypeError returned as expected");
+      assert_equals(error.constraintName, undefined, "constraintName attribute not set as expected");
+      t.done();
+    }));
   t.done();
 });
 

--- a/mediacapture-streams/GUM-impossible-constraint.https.html
+++ b/mediacapture-streams/GUM-impossible-constraint.https.html
@@ -15,20 +15,20 @@ constraint (width &gt;=1G) in getUserMedia works</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that setting an impossible constraint in getUserMedia fails", {timeout:10000});
 t.step(function() {
   // Note - integer conversion is weird for +inf and numbers > 2^32, so we
   // use a number less than 2^32 for testing.
-  navigator.getUserMedia({video: {width: {min:100000000}}}, t.step_func(function (stream) {
-    assert_unreached("a Video stream of width 100M cannot be created");
-    t.done();
-  }), t.step_func(function(error) {
-    assert_equals(error.name, "ConstraintNotSatisfiedError", "An impossible constraint triggers a ConstraintNotSatisfiedError");
-    assert_equals(error.constraintName, "width", "The name of the not satisfied error is given in error.constraintName");
-    t.done();
-  }));
+  navigator.mediaDevices.getUserMedia({video: {width: {min:100000000}}})
+    .then(t.step_func(function (stream) {
+      assert_unreached("a Video stream of width 100M cannot be created");
+      t.done();
+    }), t.step_func(function(error) {
+      assert_equals(error.name, "OverconstrainedError", "An impossible constraint triggers a OverconstrainedError");
+      assert_equals(error.constraint, "width", "The name of the not satisfied error is given in error.constraint");
+      t.done();
+    }));
 });
 </script>
 </body>

--- a/mediacapture-streams/GUM-optional-constraint.https.html
+++ b/mediacapture-streams/GUM-optional-constraint.https.html
@@ -14,18 +14,16 @@ getUserMedia is handled as optional</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that setting an optional constraint in getUserMedia is handled as optional", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {advanced: [{width: {min:1024, max: 800}}]}},
-      t.step_func(function (stream) {
-        assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
-        t.done();
-      }),
-      t.step_func(function(error) {
-        assert_unreached("an optional constraint can't stop us from obtaining a video stream");
-      }));
+  navigator.mediaDevices.getUserMedia({video: {advanced: [{width: {min:1024, max: 800}}]}})
+    .then(t.step_func(function (stream) {
+      assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
+      t.done();
+    }), t.step_func(function(error) {
+      assert_unreached("an optional constraint can't stop us from obtaining a video stream");
+    }));
 });
 </script>
 </body>

--- a/mediacapture-streams/GUM-trivial-constraint.https.html
+++ b/mediacapture-streams/GUM-trivial-constraint.https.html
@@ -14,17 +14,17 @@ constraint (width &gt;=0) in getUserMedia works</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that setting a trivial mandatory constraint in getUserMedia works", {timeout:10000});
 t.step(function() {
-  navigator.getUserMedia({video: {width: {min:0}}}, t.step_func(function (stream) {
-    assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
-    t.done();
-  }), t.step_func(function(error) {
-    assert_unreached("a Video stream of minimally zero width can always be created");
-    t.done();
-  }));
+  navigator.mediaDevices.getUserMedia({video: {width: {min:0}}})
+    .then(t.step_func(function (stream) {
+      assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");
+      t.done();
+    }), t.step_func(function(error) {
+      assert_unreached("a Video stream of minimally zero width can always be created");
+      t.done();
+    }));
 });
 </script>
 </body>

--- a/mediacapture-streams/GUM-unknownkey-option-param.https.html
+++ b/mediacapture-streams/GUM-unknownkey-option-param.https.html
@@ -1,37 +1,31 @@
 <!doctype html>
 <html>
 <head>
-<title>getUserMedia({doesnotexist:true}) aborts with NOT_SUPPORTED_ERR</title>
+<title>getUserMedia({doesnotexist:true}) rejects with TypeError</title>
 <link rel="author" title="Dominique Hazael-Massieux" href="mailto:dom@w3.org"/>
 <link rel="help" href="http://dev.w3.org/2011/webrtc/editor/getusermedia.html#widl-NavigatorUserMedia-getUserMedia-void-MediaStreamConstraints-constraints-NavigatorUserMediaSuccessCallback-successCallback-NavigatorUserMediaErrorCallback-errorCallback">
 </head>
 <body>
 <h1 class="instructions">Description</h1>
 <p class="instructions">This test checks that getUserMedia with an unknown value
-in the options parameter raises a NOT_SUPPORTED_ERR exception.</p>
+in the constraints parameter rejects with a TypeError.</p>
 
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
-test(function () {
-  // TODO This is no longer what's in the spec, see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22211
-  assert_throws(
-      "NOT_SUPPORTED_ERR",
-      function () {
-        navigator.getUserMedia(
-            {doesnotexist:true},
-            t.step_func(function (stream) {
-              assert_unreached("This should never be triggered since the constraints parameter is unrecognized");
-            }), t.step_func(function (error) {
-              assert_unreached("This should never be triggered since the constraints parameter is unrecognized");
-            }));
-      }
-  )
-  }
-);
-
+var t = async_test("Tests that getUserMedia is rejected with a TypeError when used with an unknown constraint");
+t.step(function () {
+  navigator.mediaDevices.getUserMedia({})
+    .then(t.step_func(function () {
+      assert_unreached("This should never be triggered since the constraints parameter only contains an unrecognized constraint");
+    }), t.step_func(function (error) {
+      assert_equals(error.name, "TypeError", "TypeError returned as expected");
+      assert_equals(error.constraintName, undefined, "constraintName attribute not set as expected");
+      t.done();
+    }));
+  t.done();
+});
 </script>
 </body>
 </html>

--- a/mediacapture-streams/MediaStream-MediaElement-preload-none.https.html
+++ b/mediacapture-streams/MediaStream-MediaElement-preload-none.https.html
@@ -6,7 +6,6 @@
         <link rel="author" title="Matthew Wolenetz" href="mailto:wolenetz@chromium.org"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
-        <script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"MediaStream"}]'></script>
     </head>
     <body>
         <p class="instructions">When prompted, accept to share your audio and video streams.</p>
@@ -38,23 +37,26 @@
             async_test(function(t)
             {
                 var aud = document.querySelector("audio");
-                navigator.getUserMedia({audio:true}, t.step_func(function(stream)
-                {
-                    testPreloadNone(t, aud, t.step_func(function()
-                    {
-                        aud.src = URL.createObjectURL(stream);
-                        t.add_cleanup(function() { URL.revokeObjectURL(aud.src); });
-                    }));
-                }), t.unreached_func("getUserMedia error callback was invoked."));
+                navigator.mediaDevices.getUserMedia({audio:true})
+                  .then(t.step_func(function(stream)
+                  {
+                      testPreloadNone(t, aud, t.step_func(function()
+                      {
+                          aud.src = URL.createObjectURL(stream);
+                          t.add_cleanup(function() { URL.revokeObjectURL(aud.src); });
+                      }));
+                  }),
+                  t.unreached_func("getUserMedia error callback was invoked."));
             }, "Test that preload 'none' is ignored for MediaStream object URL used as src");
 
             async_test(function(t)
             {
                 var vid = document.querySelector("video");
-                navigator.getUserMedia({video:true}, t.step_func(function(stream)
-                {
-                    testPreloadNone(t, vid, t.step_func(function() { vid.srcObject = stream; }));
-                }), t.unreached_func("getUserMedia error callback was invoked."));
+                navigator.mediaDevices.getUserMedia({video:true})
+                  .then(t.step_func(function(stream)
+                  {
+                      testPreloadNone(t, vid, t.step_func(function() { vid.srcObject = stream; }));
+                  }), t.unreached_func("getUserMedia error callback was invoked."));
             }, "Test that preload 'none' is ignored for MediaStream used as srcObject");
         </script>
     </body>

--- a/mediacapture-streams/MediaStream-MediaElement-srcObject.https.html
+++ b/mediacapture-streams/MediaStream-MediaElement-srcObject.https.html
@@ -17,38 +17,38 @@ via the <code>srcObject</code> attribute.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]' data-prefixed-prototypes='[{"ancestors":["HTMLMediaElement"],"name":"srcObject"}]'></script>
 <script>
 var vid = document.getElementById("vid");
 var t = async_test("Tests that a MediaStream can be assigned to a video element with srcObject", {timeout: 10000});
 t.step(function() {
-  navigator.getUserMedia({video: true}, t.step_func(function (stream) {
-    var testOncePlaying = function() {
-       assert_equals(vid.played.length, 1, "A MediaStream's timeline always consists of a single range");
-       assert_equals(vid.played.start(0), 0, "A MediaStream's timeline always consists of a single range");
-       assert_equals(vid.played.end(0), vid.currentTime, "A MediaStream's timeline always consists of a single range");
-       assert_equals(vid.readyState, vid.HAVE_ENOUGH_DATA, "Upon selecting a media stream, the UA sets readyState to HAVE_ENOUGH_DATA");
-       var time = vid.currentTime;
-       assert_throws("INVALID_STATE_ERR", function() {
-          vid.currentTime = 0;
-       });
-       assert_equals(vid.currentTime, time, "The UA MUST ignore attempts to set the currentTime attribute");
-       // TODO add test that duration must be set to currentTime
-       // when mediastream is destroyed
-       vid.removeEventListener("timeupdate", testOncePlaying, false);
-       t.done();
-    }
-    vid.addEventListener("timeupdate", t.step_func(testOncePlaying), false);
-    vid.srcObject = stream;
-    vid.play();
-    assert_true(!vid.seeking, "A MediaStream is not seekable");
-    assert_equals(vid.seekable.length, 0, "A MediaStream is not seekable");
-    assert_equals(vid.defaultPlaybackRate, 1, "playback rate is always 1");
-    assert_equals(vid.playbackRate, 1, "playback rate is always 1");
-    assert_equals(vid.buffered.length, 0, "A MediaStream cannot be preloaded.  Therefore, there is no buffered timeranges");
-    assert_equals(vid.duration, Infinity, " A MediaStream does not have a pre-defined duration. ");
-    assert_equals(vid.startDate, NaN, " A MediaStream does not specify a timeline offset");
-  }), function(error) {});
+  navigator.mediaDevices.getUserMedia({video: true})
+    .then(t.step_func(function (stream) {
+      var testOncePlaying = function() {
+         assert_equals(vid.played.length, 1, "A MediaStream's timeline always consists of a single range");
+         assert_equals(vid.played.start(0), 0, "A MediaStream's timeline always consists of a single range");
+         assert_equals(vid.played.end(0), vid.currentTime, "A MediaStream's timeline always consists of a single range");
+         assert_equals(vid.readyState, vid.HAVE_ENOUGH_DATA, "Upon selecting a media stream, the UA sets readyState to HAVE_ENOUGH_DATA");
+         var time = vid.currentTime;
+         assert_throws("INVALID_STATE_ERR", function() {
+            vid.currentTime = 0;
+         });
+         assert_equals(vid.currentTime, time, "The UA MUST ignore attempts to set the currentTime attribute");
+         // TODO add test that duration must be set to currentTime
+         // when mediastream is destroyed
+         vid.removeEventListener("timeupdate", testOncePlaying, false);
+         t.done();
+      }
+      vid.addEventListener("timeupdate", t.step_func(testOncePlaying), false);
+      vid.srcObject = stream;
+      vid.play();
+      assert_true(!vid.seeking, "A MediaStream is not seekable");
+      assert_equals(vid.seekable.length, 0, "A MediaStream is not seekable");
+      assert_equals(vid.defaultPlaybackRate, 1, "playback rate is always 1");
+      assert_equals(vid.playbackRate, 1, "playback rate is always 1");
+      assert_equals(vid.buffered.length, 0, "A MediaStream cannot be preloaded.  Therefore, there is no buffered timeranges");
+      assert_equals(vid.duration, Infinity, " A MediaStream does not have a pre-defined duration. ");
+      assert_equals(vid.startDate, NaN, " A MediaStream does not specify a timeline offset");
+    }), function(error) {});
 });
 </script>
 </body>

--- a/mediacapture-streams/MediaStream-add-audio-track.https.html
+++ b/mediacapture-streams/MediaStream-add-audio-track.https.html
@@ -14,16 +14,15 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that adding a track to a MediaStream works as expected", {timeout: 20000}); // longer timeout since requires double user interaction
 t.step(function () {
   var audio, video;
 
-  navigator.getUserMedia({audio: true}, gotAudio, function(error) {});
+  navigator.mediaDevices.getUserMedia({audio: true}).then(gotAudio);
   function gotAudio(stream) {
     audio = stream;
-    navigator.getUserMedia({video: true}, gotVideo, function(error) {});
+    navigator.mediaDevices.getUserMedia({video: true}).then(gotVideo);
   }
 
   function gotVideo(stream) {

--- a/mediacapture-streams/MediaStream-audio-only.https.html
+++ b/mediacapture-streams/MediaStream-audio-only.https.html
@@ -15,12 +15,11 @@ the success callback in getUserMedia has exactly one audio track.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var astream;
 var t = async_test("Tests that a MediaStream with exactly one audio track is returned", {timeout: 10000});
 t.step(function() {
-  navigator.getUserMedia({audio:true}, t.step_func(function (stream) {
+  navigator.mediaDevices.getUserMedia({audio:true}).then(t.step_func(function (stream) {
     astream = stream;
     assert_true(stream instanceof MediaStream, "getUserMedia success callback comes with a MediaStream object");
     assert_equals(stream.getAudioTracks().length, 1, "the media stream has exactly one audio track");

--- a/mediacapture-streams/MediaStream-finished-add.https.html
+++ b/mediacapture-streams/MediaStream-finished-add.https.html
@@ -16,16 +16,15 @@ MediaStream is allowed.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that adding a track to an inactive MediaStream is allowed", {timeout:20000});
 t.step(function () {
   var audio, video;
 
-  navigator.getUserMedia({audio:true}, gotAudio, function() {});
+  navigator.mediaDevices.getUserMedia({audio:true}).then(gotAudio);
   function gotAudio(stream) {
     audio = stream;
-    navigator.getUserMedia({video:true}, gotVideo, function() {});
+    navigator.mediaDevices.getUserMedia({video:true}).then(gotVideo);
   }
 
   function gotVideo(stream) {

--- a/mediacapture-streams/MediaStream-gettrackid.https.html
+++ b/mediacapture-streams/MediaStream-gettrackid.https.html
@@ -13,14 +13,11 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that MediaStream.getTrackById works as expected", {timeout: 10000});
 t.step(function () {
-  navigator.getUserMedia(
-      {video: true},
-      t.step_func(gotVideo),
-      t.step_func(function (error) {
+  navigator.mediaDevices.getUserMedia({video: true})
+      .then(t.step_func(gotVideo), t.step_func(function (error) {
         assert_unreached('Unexpected getUserMedia error: ' + error);
       }));
   function gotVideo(stream) {

--- a/mediacapture-streams/MediaStream-id-manual.https.html
+++ b/mediacapture-streams/MediaStream-id-manual.https.html
@@ -14,18 +14,17 @@ the success callback in getUserMedia has a correct id.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that a MediaStream with a correct id is returned");
 var allowedCharacters = /^[\u0021\u0023-\u0027\u002A-\u002B\u002D-\u002E\u0030-\u0039\u0041-\u005A\u005E-\u007E]*$/;
-if (window.navigator.getUserMedia) {
-  navigator.getUserMedia({video:true}, function (stream) {
-  t.step(function () {
-     assert_true(stream.id.length === 36, "the media stream id has 36 characters");
-     assert_regexp_match(stream.id, allowedCharacters, "the media stream id uses the set of allowed characters");
+if (window.navigator.mediaDevices && window.navigator.mediaDevices.getUserMedia) {
+  navigator.mediaDevices.getUserMedia({video:true}).then(function (stream) {
+    t.step(function () {
+       assert_true(stream.id.length === 36, "the media stream id has 36 characters");
+       assert_regexp_match(stream.id, allowedCharacters, "the media stream id uses the set of allowed characters");
+    });
+    t.done();
   });
-  t.done();
-}, function(error) {});
 }
 </script>
 </body>

--- a/mediacapture-streams/MediaStream-idl.https.html
+++ b/mediacapture-streams/MediaStream-idl.https.html
@@ -19,37 +19,39 @@ follows the algorithm set in the spec.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"},{"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var t = async_test("Tests that a MediaStream constructor follows the algorithm set in the spec", {timeout: 10000});
 t.step(function() {
-  navigator.getUserMedia({video: true, audio:true}, t.step_func(function (stream) {
-    var stream1 = new MediaStream();
-    assert_not_equals(stream.id, stream1.id, "Two different MediaStreams have different ids");
-    var stream2 = new MediaStream(stream);
-    assert_not_equals(stream.id, stream2.id, "A MediaStream constructed from another have different ids");
-    var audioTrack1 = stream.getAudioTracks()[0];
-    var videoTrack = stream.getVideoTracks()[0];
-    assert_equals(audioTrack1, stream2.getAudioTracks()[0], "A MediaStream constructed from another share the same audio track");
-    assert_equals(videoTrack, stream2.getVideoTracks()[0], "A MediaStream constructed from another share the same video track");
-    var stream4 = new MediaStream([audioTrack1]);
-    assert_equals(stream4.getTrackById(audioTrack1.id), audioTrack1, "a non-ended track gets added via the MediaStream constructor");
+  navigator.mediaDevices.getUserMedia({video: true, audio:true})
+    .then(t.step_func(function (stream) {
+      var stream1 = new MediaStream();
+      assert_not_equals(stream.id, stream1.id, "Two different MediaStreams have different ids");
+      var stream2 = new MediaStream(stream);
+      assert_not_equals(stream.id, stream2.id, "A MediaStream constructed from another have different ids");
+      var audioTrack1 = stream.getAudioTracks()[0];
+      var videoTrack = stream.getVideoTracks()[0];
+      assert_equals(audioTrack1, stream2.getAudioTracks()[0], "A MediaStream constructed from another share the same audio track");
+      assert_equals(videoTrack, stream2.getVideoTracks()[0], "A MediaStream constructed from another share the same video track");
+      var stream4 = new MediaStream([audioTrack1]);
+      assert_equals(stream4.getTrackById(audioTrack1.id), audioTrack1, "a non-ended track gets added via the MediaStream constructor");
 
-    var audioTrack2 = audioTrack1.clone();
-    audioTrack2.addEventListener("ended", t.unreached_func("ended event should not be fired by MediaStreamTrack.stop()."));
-    audioTrack2.stop();
+      var audioTrack2 = audioTrack1.clone();
+      audioTrack2.addEventListener("ended", t.unreached_func("ended event should not be fired by MediaStreamTrack.stop()."));
+      audioTrack2.stop();
+      assert_equals(audioTrack2.readyState, "ended", "a stopped track is marked ended synchronously");
 
-    var stream3 = new MediaStream([audioTrack2, videoTrack]);
-    assert_array_equals(stream3.getTracks(), [videoTrack], "an ended track doesn't get added via the MediaStream constructor");
-    assert_equals(stream3.getTrackById(videoTrack.id), videoTrack, "a non-ended track gets added via the MediaStream constructor even if the previous track was ended");
+      var stream3 = new MediaStream([audioTrack2, videoTrack]);
+      assert_equals(stream3.getTrackById(audioTrack2.id), audioTrack2, "an ended track gets added via the MediaStream constructor");
+      assert_equals(stream3.getTrackById(videoTrack.id), videoTrack, "a non-ended track gets added via the MediaStream constructor even if the previous track was ended");
 
-    var stream5 = new MediaStream([audioTrack2]);
-    assert_array_equals(stream5.getTracks(), [], "an ended track doesn't get added via the MediaStream constructor")
-    assert_false(stream5.active, "a MediaStream created using the MediaStream() constructor whose arguments are lists of MediaStreamTrack objects that are all ended, the MediaStream object MUST be created with its active attribute set to false");
+      var stream5 = new MediaStream([audioTrack2]);
+      assert_equals(stream5.getTrackById(audioTrack2.id), audioTrack2, "an ended track gets added via the MediaStream constructor");
+      assert_false(stream5.active, "a MediaStream created using the MediaStream() constructor whose arguments are lists of MediaStreamTrack objects that are all ended, the MediaStream object MUST be created with its active attribute set to false");
 
-    // Use a timeout to detect a misfire of the ended event.
-    t.step_timeout(t.step_func_done());
-  }), function(error) {});
+      // Use a timeout to detect a misfire of the ended event.
+      t.step_timeout(t.step_func_done());
+    })
+  );
 });
 </script>
 </body>

--- a/mediacapture-streams/MediaStream-removetrack.https.html
+++ b/mediacapture-streams/MediaStream-removetrack.https.html
@@ -14,15 +14,14 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that a removal from a MediaStream works as expected", {timeout:10000});
 t.step(function () {
   var audio;
-  navigator.getUserMedia({audio:true}, gotAudio, function(error) {});
+  navigator.mediaDevices.getUserMedia({audio:true}).then(gotAudio);
   function gotAudio(stream) {
      audio = stream;
-     navigator.getUserMedia({video:true}, gotVideo, function(error) {});
+     navigator.mediaDevices.getUserMedia({video:true}).then(gotVideo);
   }
 
   function gotVideo(stream) {

--- a/mediacapture-streams/MediaStream-video-only.https.html
+++ b/mediacapture-streams/MediaStream-video-only.https.html
@@ -15,11 +15,10 @@ the success callback in getUserMedia has exactly one video track and no audio.</
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"MediaStream"}]'></script>
 <script>
 var t = async_test("Tests that a MediaStream with at least one video track is returned");
 t.step(function() {
-  navigator.getUserMedia({video: true}, t.step_func(function (stream) {
+  navigator.mediaDevices.getUserMedia({video: true}).then(t.step_func(function (stream) {
     assert_true(stream instanceof MediaStream, "getUserMedia success callback comes with a MediaStream object");
     assert_equals(stream.getAudioTracks().length, 0, "the media stream has zero audio track");
     assert_equals(stream.getVideoTracks().length, 1, "the media stream has exactly one video track");

--- a/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-audio-is-silence.https.html
+++ b/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-audio-is-silence.https.html
@@ -17,12 +17,12 @@ Web Audio API</a>.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}, {"ancestors":["window"], "name":"AudioContext"}]'></script>
+<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["window"], "name":"AudioContext"}]'></script>
 <script>
 var t = async_test("Tests that a disabled audio track in a MediaStream is rendered as silence", {timeout: 200000});
 var aud = document.getElementById("aud");
 t.step(function() {
-  navigator.getUserMedia({audio: true}, t.step_func(function (stream) {
+  navigator.mediaDevices.getUserMedia({audio: true}).then(t.step_func(function (stream) {
     var ctx = new AudioContext();
     var streamSource = ctx.createMediaStreamSource(stream);
     var silenceDetector = ctx.createScriptProcessor(1024);

--- a/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html
+++ b/mediacapture-streams/MediaStreamTrack-MediaElement-disabled-video-is-black.https.html
@@ -16,40 +16,38 @@ MediaStream is rendered as blackness.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]' data-prefixed-prototypes='[{"ancestors":["HTMLMediaElement"],"name":"srcObject"}]'></script>
+<script src="/common/vendor-prefix.js" data-prefixed-prototypes='[{"ancestors":["HTMLMediaElement"],"name":"srcObject"}]'></script>
 <script>
 var vid = document.getElementById("vid");
 var cv = document.createElement("canvas");
 var t = async_test("Tests that a disabled video track in a MediaStream is rendered as blackness", {timeout: 10000});
 t.step(function() {
-  navigator.getUserMedia(
-      {video: true},
-      t.step_func(function (stream) {
-        var testOncePlaying = function() {
-          if (stream.getVideoTracks()[0].enabled) {
-            stream.getVideoTracks()[0].enabled = false;
-            return;
-          }
+  navigator.mediaDevices.getUserMedia({video: true})
+    .then(t.step_func(function (stream) {
+      if (stream.getVideoTracks()[0].enabled) {
+        stream.getVideoTracks()[0].enabled = false;
+      }
 
-          vid.removeEventListener("timeupdate", testOncePlaying, false);
-          cv.width = vid.offsetWidth;
-          cv.height = vid.offsetHeight;
-          var ctx = cv.getContext("2d");
-          ctx.drawImage(vid,0,0);
-          var imageData = ctx.getImageData(0, 0, cv.width, cv.height);
-          for (var i = 0; i < imageData.data.length; i+=4) {
-            assert_equals(imageData.data[i], 0, "No red component in pixel #" + i);
-            assert_equals(imageData.data[i + 1], 0, "No green component in pixel #" + i);
-            assert_equals(imageData.data[i + 2], 0, "No blue component in pixel #" + i);
-            assert_equals(imageData.data[i + 3], 255, "No transparency in pixel #" + i);
-          }
-          t.done();
+      var testOnceLoadeddata = t.step_func(function() {
+        vid.removeEventListener("loadeddata", testOnceLoadeddata, false);
+        cv.width = vid.offsetWidth;
+        cv.height = vid.offsetHeight;
+        var ctx = cv.getContext("2d");
+        ctx.drawImage(vid,0,0);
+        var imageData = ctx.getImageData(0, 0, cv.width, cv.height);
+        for (var i = 0; i < imageData.data.length; i+=4) {
+          assert_equals(imageData.data[i], 0, "No red component in pixel #" + i);
+          assert_equals(imageData.data[i + 1], 0, "No green component in pixel #" + i);
+          assert_equals(imageData.data[i + 2], 0, "No blue component in pixel #" + i);
+          assert_equals(imageData.data[i + 3], 255, "No transparency in pixel #" + i);
         }
-        vid.srcObject = stream;
-        vid.play();
-        vid.addEventListener("timeupdate", t.step_func(testOncePlaying), false);
-      }),
-      function(error) {});
+        t.done();
+      });
+
+      vid.srcObject = stream;
+      vid.play();
+      vid.addEventListener("loadeddata", testOnceLoadeddata, false);
+    })));
 });
 </script>
 </body>

--- a/mediacapture-streams/MediaStreamTrack-end-manual.https.html
+++ b/mediacapture-streams/MediaStreamTrack-end-manual.https.html
@@ -16,11 +16,10 @@ correctly set into inactive state when permission is revoked.</p>
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that the video MediaStreamTrack objects are properly ended on permission revocation", {timeout: 20000}); // longer timeout since requires user interaction
 t.step(function () {
-  navigator.getUserMedia({audio: true,video: true}, t.step_func(function (stream) {
+  navigator.mediaDevices.getUserMedia({audio: true,video: true}).then(t.step_func(function (stream) {
     var vidTrack = stream.getVideoTracks()[0];
     assert_equals(vidTrack.readyState, "live", "The video track object is in live state");
     var audTrack = stream.getAudioTracks()[0];

--- a/mediacapture-streams/MediaStreamTrack-id.https.html
+++ b/mediacapture-streams/MediaStreamTrack-id.https.html
@@ -13,11 +13,11 @@
 <div id='log'></div>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that distinct mediastream tracks have distinct ids ", {timeout: 10000});
 t.step(function () {
-  navigator.getUserMedia({video: true, audio: true}, t.step_func(gotStream), t.step_func(function(error) {t.assert_unreached("Access to audio and video stream is granted");}));
+  navigator.mediaDevices.getUserMedia({video: true, audio: true})
+    .then(t.step_func(gotStream), t.step_func(function(error) {t.assert_unreached("Access to audio and video stream is granted");}));
   function gotStream(stream) {
     assert_not_equals(stream.getVideoTracks()[0], stream.getAudioTracks()[0].id, "audio and video tracks have distinct ids");
     t.done();

--- a/mediacapture-streams/MediaStreamTrack-init.https.html
+++ b/mediacapture-streams/MediaStreamTrack-init.https.html
@@ -20,7 +20,6 @@ object returned by the success callback in getUserMedia is correctly initialized
 <script src=/resources/testharnessreport.js></script>
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
-<script src="/common/vendor-prefix.js" data-prefixed-objects='[{"ancestors":["navigator"], "name":"getUserMedia"}]'></script>
 <script>
 var t = async_test("Tests that the video MediaStreamTrack objects are properly initialized", {timeout:10000});
 var track = null
@@ -52,19 +51,20 @@ idl_array.add_idls("interface MediaStreamTrack : EventTarget {\
 };");
 
 t.step(function () {
-  navigator.getUserMedia({video: true}, t.step_func(function (stream) {
-    var videoTracks = stream.getVideoTracks();
-    assert_equals(videoTracks.length, 1, "There is exactly one video track in the media stream");
-    track = videoTracks[0];
-    idl_array.add_objects({MediaStreamTrack: ["track"]});
-    idl_array.test();
-    assert_equals(track.readyState, "live", "The track object is in live state");
-    assert_equals(track.kind, "video", "The track object is of video kind");
-    // Not clear that this is required by the spec,
-    // see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22212
-    assert_true(track.enabled, "The track object is enabed");
-    t.done();
-  }), function (error) {});
+  navigator.mediaDevices.getUserMedia({video: true})
+    .then(t.step_func(function (stream) {
+      var videoTracks = stream.getVideoTracks();
+      assert_equals(videoTracks.length, 1, "There is exactly one video track in the media stream");
+      track = videoTracks[0];
+      idl_array.add_objects({MediaStreamTrack: ["track"]});
+      idl_array.test();
+      assert_equals(track.readyState, "live", "The track object is in live state");
+      assert_equals(track.kind, "video", "The track object is of video kind");
+      // Not clear that this is required by the spec,
+      // see https://www.w3.org/Bugs/Public/show_bug.cgi?id=22212
+      assert_true(track.enabled, "The track object is enabed");
+      t.done();
+    }));
 });
 </script>
 </body>


### PR DESCRIPTION
- Primarily moves navigator.getUserMedia (w/ prefix) to
navigator.mediaDevices.getUserMedia.
- Also brings other items to spec as found while running these tests in Firefox

<!-- Reviewable:start -->

<!-- Reviewable:end -->
