### PR TITLE
📖  Fix meta documentation issue with custom elements child node test

### DIFF
--- a/custom-elements/reactions/ChildNode.html
+++ b/custom-elements/reactions/ChildNode.html
@@ -4,7 +4,7 @@
 <title>Custom Elements: CEReactions on ChildNode interface</title>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <meta name="assert" content="before, after, replaceWith, and remove of ChildNode interface must have CEReactions">
-<meta name="help" content="https://dom.spec.whatwg.org/#parentnode">
+<meta name="help" content="https://dom.spec.whatwg.org/#childnode">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../resources/custom-elements-helpers.js"></script>

--- a/custom-elements/reactions/ChildNode.html
+++ b/custom-elements/reactions/ChildNode.html
@@ -3,7 +3,7 @@
 <head>
 <title>Custom Elements: CEReactions on ChildNode interface</title>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
-<meta name="assert" content="before, after, after, replaceWith, and remove of ChildNode interface must have CEReactions">
+<meta name="assert" content="before, after, replaceWith, and remove of ChildNode interface must have CEReactions">
 <meta name="help" content="https://dom.spec.whatwg.org/#parentnode">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION
Addresses https://github.com/w3c/web-platform-tests/blob/master/custom-elements/reactions/ChildNode.html#L6-L7

- [x] 📖 Remove duplication in ChildNode assertion statement
- [x] 📖 Fix broken help link in custom-elements/reactions/ChildNode.html

Starting to see these more and more @TakayoshiKochi. Let me know if i should keep going. This is fun 😸  /cc @rniwa

<!-- Reviewable:start -->

<!-- Reviewable:end -->
