### PR TITLE
Add new test for RTCConfiguration iceTransportPolicy

### DIFF
--- a/webrtc/RTCConfiguration-helper.js
+++ b/webrtc/RTCConfiguration-helper.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// Run a test function as two test cases.
+// The first test case test the configuration by passing a given config
+// to the constructor.
+// The second test case create an RTCPeerConnection object with default
+// configuration, then call setConfiguration with the provided config.
+// The test function is given a constructor function to create
+// a new instance of RTCPeerConnection with given config,
+// either directly as constructor parameter or through setConfiguration.
+function config_test(test_func, desc) {
+  test(() => {
+    test_func(config => new RTCPeerConnection(config));
+  }, `new RTCPeerConnection(config) - ${desc}`);
+
+  test(() => {
+    test_func(config => {
+      const pc = new RTCPeerConnection();
+      assert_own_property(pc, 'setConfiguration');
+      pc.setConfiguration(config);
+      return pc;
+    })
+  }, `setConfiguration(config) - ${desc}`);
+}

--- a/webrtc/RTCConfiguration-iceTransportPolicy.html
+++ b/webrtc/RTCConfiguration-iceTransportPolicy.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<title>RTCConfiguration iceTransportPolicy</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCConfiguration-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper function is called from RTCConfiguration-helper.js:
+  //   config_test
+
+  /*
+    [Constructor(optional RTCConfiguration configuration)]
+    interface RTCPeerConnection : EventTarget {
+      RTCConfiguration                   getConfiguration();
+      void                               setConfiguration(RTCConfiguration configuration);
+      ...
+    };
+
+    dictionary RTCConfiguration {
+      sequence<RTCIceServer>   iceServers;
+      RTCIceTransportPolicy    iceTransportPolicy = "all";
+    };
+
+    enum RTCIceTransportPolicy {
+      "relay",
+      "all"
+    };
+   */
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection() should have default iceTransportPolicy all`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: undefined });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection({ iceTransportPolicy: undefined }) should have default iceTransportPolicy all`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: 'all' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection({ iceTransportPolicy: 'all' }) should succeed`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
+  }, `new RTCPeerConnection({ iceTransportPolicy: 'relay' }) should succeed`);
+
+  /*
+    4.3.2. Set a configuration
+      8.  Set the ICE Agent's ICE transports setting to the value of
+          configuration.iceTransportPolicy. As defined in [JSEP] (section 4.1.16.),
+          if the new ICE transports setting changes the existing setting, no action
+          will be taken until the next gathering phase. If a script wants this to
+          happen immediately, it should do an ICE restart.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: 'all' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+
+    pc.setConfiguration({ iceTransportPolicy: 'relay' });
+    assert_equals(pc.getConfiguration(), iceTransportPolicy, 'relay');
+  }, `setConfiguration({ iceTransportPolicy: 'relay' }) with initial iceTransportPolicy all should succeed`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
+
+    pc.setConfiguration({ iceTransportPolicy: 'all' });
+    assert_equals(pc.getConfiguration(), iceTransportPolicy, 'all');
+  }, `setConfiguration({ iceTransportPolicy: 'all' }) with initial iceTransportPolicy relay should succeed`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
+
+    // default value for iceTransportPolicy is all
+    pc.setConfiguration({});
+    assert_equals(pc.getConfiguration(), iceTransportPolicy, 'all');
+  }, `setConfiguration({}) with initial iceTransportPolicy relay should set new value to all`);
+
+  config_test(makePc => {
+    assert_throws(new TypeError(), () =>
+      makePc({ iceTransportPolicy: 'invalid' }));
+  }, `with invalid iceTransportPolicy should throw TypeError`);
+
+  // "none" is in Blink and Gecko's IDL, but not in the spec.
+  config_test(makePc => {
+    assert_throws(new TypeError(), () =>
+      makePc({ iceTransportPolicy: 'none' }));
+  }, `with none iceTransportPolicy should throw TypeError`);
+
+  config_test(makePc => {
+    assert_throws(new TypeError(), () =>
+      makePc({ iceTransportPolicy: null }));
+  }, `with null iceTransportPolicy should throw TypeError`);
+
+  // iceTransportPolicy is called iceTransports in Blink.
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransports: 'relay' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection({ iceTransports: 'relay' }) should have no effect`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransports: 'invalid' });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection({ iceTransports: 'invalid' }) should have no effect`);
+
+  test(() => {
+    const pc = new RTCPeerConnection({ iceTransports: null });
+    assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
+  }, `new RTCPeerConnection({ iceTransports: null }) should have no effect`);
+
+</script>

--- a/webrtc/RTCPeerConnection-constructor.html
+++ b/webrtc/RTCPeerConnection-constructor.html
@@ -58,18 +58,6 @@ const testArgs = {
   // Blink and Gecko fall back to url, but it's not in the spec.
   '{ iceServers: [{ url: "stun:stun1.example.net" }] }': new TypeError,
 
-  // iceTransportPolicy
-  '{ iceTransportPolicy: null }': new TypeError,
-  '{ iceTransportPolicy: undefined }': false,
-  '{ iceTransportPolicy: "relay" }': false,
-  '{ iceTransportPolicy: "all" }': false,
-  '{ iceTransportPolicy: "invalid" }': new TypeError,
-  // "none" is in Blink and Gecko's IDL, but not in the spec.
-  '{ iceTransportPolicy: "none" }': new TypeError,
-  // iceTransportPolicy is called iceTransports in Blink.
-  '{ iceTransports: "invalid" }': false,
-  '{ iceTransports: "none" }': false,
-
   // rtcpMuxPolicy
   '{ rtcpMuxPolicy: null }': new TypeError,
   '{ rtcpMuxPolicy: undefined }': false,


### PR DESCRIPTION
This moves the constructor test for `iceTransportPolicy` out from RTCPeerConnection-constructor.html to a new file RTCConfiguration-iceTransportPolicy.html. It also tests on `getConfiguration()` and `setConfiguration()` and that `iceTransportPolicy` can be changed via `setConfiguration()`.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
