### PR TITLE
wai-aria: Correct aria-haspopup assertions for macOS

### DIFF
--- a/wai-aria/button_haspopup_dialog-manual.html
+++ b/wai-aria/button_haspopup_dialog-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_emptystring-manual.html
+++ b/wai-aria/button_haspopup_emptystring-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "doesNotContain",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "doesNotContain",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_false-manual.html
+++ b/wai-aria/button_haspopup_false-manual.html
@@ -54,12 +54,6 @@
                   "actions",
                   "doesNotContain",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "doesNotContain",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_foo-manual.html
+++ b/wai-aria/button_haspopup_foo-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "doesNotContain",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "doesNotContain",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_grid-manual.html
+++ b/wai-aria/button_haspopup_grid-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_listbox-manual.html
+++ b/wai-aria/button_haspopup_listbox-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_menu-manual.html
+++ b/wai-aria/button_haspopup_menu-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_tree-manual.html
+++ b/wai-aria/button_haspopup_tree-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_true-manual.html
+++ b/wai-aria/button_haspopup_true-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/button_haspopup_unspecified-manual.html
+++ b/wai-aria/button_haspopup_unspecified-manual.html
@@ -60,12 +60,6 @@
                   "actions",
                   "doesNotContain",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "doesNotContain",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_dialog-manual.html
+++ b/wai-aria/combobox_haspopup_dialog-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_false-manual.html
+++ b/wai-aria/combobox_haspopup_false-manual.html
@@ -72,12 +72,6 @@
                   "actions",
                   "doesNotContain",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "doesNotContain",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_grid-manual.html
+++ b/wai-aria/combobox_haspopup_grid-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_listbox-manual.html
+++ b/wai-aria/combobox_haspopup_listbox-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_menu-manual.html
+++ b/wai-aria/combobox_haspopup_menu-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_tree-manual.html
+++ b/wai-aria/combobox_haspopup_tree-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_true-manual.html
+++ b/wai-aria/combobox_haspopup_true-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/combobox_haspopup_unspecified-manual.html
+++ b/wai-aria/combobox_haspopup_unspecified-manual.html
@@ -78,12 +78,6 @@
                   "actions",
                   "contains",
                   "AXShowMenu"
-               ],
-               [
-                  "property",
-                  "actions",
-                  "contains",
-                  "AXPress"
                ]
             ],
             "IAccessible2" : [


### PR DESCRIPTION
AXPress is independent of aria-haspopup. The Core AAM has been updated
accordingly. This brings the tests in alignment with the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
