### PR TITLE
Add rollback and pranswer tests for set session description

### DIFF
--- a/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.setLocalDescription pranswer</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   generateOffer
+  //   generateAnswer
+  //   assert_session_desc_equals
+  //   test_state_change_event
+
+  /*
+    4.3.2.  Interface Definition
+      [Constructor(optional RTCConfiguration configuration)]
+      interface RTCPeerConnection : EventTarget {
+        Promise<void>                      setLocalDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? localDescription;
+        readonly attribute RTCSessionDescription? currentLocalDescription;
+        readonly attribute RTCSessionDescription? pendingLocalDescription;
+
+        Promise<void>                      setRemoteDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? remoteDescription;
+        readonly attribute RTCSessionDescription? currentRemoteDescription;
+        readonly attribute RTCSessionDescription? pendingRemoteDescription;
+        ...
+      };
+
+    4.6.2.  RTCSessionDescription Class
+      dictionary RTCSessionDescriptionInit {
+        required RTCSdpType type;
+                 DOMString  sdp = "";
+      };
+
+    4.6.1.  RTCSdpType
+      enum RTCSdpType {
+        "offer",
+        "pranswer",
+        "answer",
+        "rollback"
+      };
+   */
+
+  /*
+    4.3.1.6.  Set the RTCSessionSessionDescription
+      2.3.  If the description's type is invalid for the current signaling state of
+            connection, then reject p with a newly created InvalidStateError and abort
+            these steps.
+
+    [jsep]
+      5.5. If the type is "pranswer" or "answer", the PeerConnection
+           state MUST be either "have-remote-offer" or "have-local-pranswer".
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+
+    return generateOffer()
+    .then(offer =>
+      promise_rejects(t, 'InvalidStateError',
+        pc.setLocalDescription({ type: 'pranswer', sdp: offer.sdp })));
+
+  }, 'setLocalDescription(pranswer) from stable state should reject with InvalidStateError');
+
+  /*
+    4.3.1.6 Set the RTCSessionSessionDescription
+      2.2.2.  If description is set as a local description, then run one of the
+              following steps:
+        - If description is of type "pranswer", then set
+          connection.pendingLocalDescription to description and signaling state to
+          have-local-pranswer.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-remote-offer', 'have-local-pranswer']);
+
+    return generateOffer({ video: true })
+    .then(offer =>
+      pc.setRemoteDescription(offer)
+      .then(() => pc.createAnswer())
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setLocalDescription(pranswer)
+        .then(() => {
+          assert_equals(pc.signalingState, 'have-local-pranswer');
+
+          assert_session_desc_equals(pc.remoteDescription, offer);
+          assert_session_desc_equals(pc.pendingRemoteDescription, offer);
+          assert_equals(pc.currentRemoteDescription, null);
+
+          assert_session_desc_equals(pc.localDescription, pranswer);
+          assert_session_desc_equals(pc.pendingLocalDescription, pranswer);
+          assert_equals(pc.currentLocalDescription, null);
+
+          assert_equals(pc.pendingRemoteDescription, null);
+        });
+      }));
+  }, 'setLocalDescription(pranswer) should succeed');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-remote-offer', 'have-local-pranswer']);
+
+    return generateOffer({ video: true })
+    .then(offer =>
+      pc.setRemoteDescription(offer)
+      .then(() => pc.createAnswer())
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setLocalDescription(pranswer)
+        .then(() => pc.setLocalDescription(pranswer));
+      }));
+  }, 'setLocalDescription(pranswer) can be applied multiple times while still in have-local-pranswer');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-remote-offer', 'have-local-pranswer', 'stable']);
+
+    return generateOffer({ video: true })
+    .then(offer =>
+      pc.setRemoteDescription(offer)
+      .then(() => pc.createAnswer())
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setLocalDescription(pranswer)
+        .then(() => pc.setLocalDescription(answer))
+        .then(() => {
+          assert_equals(pc.signalingState, 'stable');
+          assert_session_desc_equals(pc.localDescription, answer);
+          assert_session_desc_equals(pc.remoteDescription, offer);
+
+          assert_session_desc_equals(pc.currentLocalDescription, answer);
+          assert_session_desc_equals(pc.currentRemoteDescription, offer);
+
+          assert_equals(pc.pendingLocalDescription, null);
+          assert_equals(pc.pendingRemoteDescription, null);
+        });
+      }));
+  }, 'setLocalDescription(answer) from have-local-pranswer state should succeed');
+
+</script>

--- a/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.setLocalDescription rollback</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   assert_session_desc_equals
+  //   test_state_change_event
+
+  /*
+    4.3.2.  Interface Definition
+      [Constructor(optional RTCConfiguration configuration)]
+      interface RTCPeerConnection : EventTarget {
+        Promise<void>                      setLocalDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? localDescription;
+        readonly attribute RTCSessionDescription? currentLocalDescription;
+        readonly attribute RTCSessionDescription? pendingLocalDescription;
+
+        Promise<void>                      setRemoteDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? remoteDescription;
+        readonly attribute RTCSessionDescription? currentRemoteDescription;
+        readonly attribute RTCSessionDescription? pendingRemoteDescription;
+        ...
+      };
+
+    4.6.2.  RTCSessionDescription Class
+      dictionary RTCSessionDescriptionInit {
+        required RTCSdpType type;
+                 DOMString  sdp = "";
+      };
+
+    4.6.1.  RTCSdpType
+      enum RTCSdpType {
+        "offer",
+        "pranswer",
+        "answer",
+        "rollback"
+      };
+   */
+
+  /*
+    4.3.1.6.  Set the RTCSessionSessionDescription
+      2.2.2.  If description is set as a local description, then run one of the
+              following steps:
+        - If description is of type "rollback", then this is a rollback. Set
+          connection.pendingLocalDescription to null and signaling state to stable.
+   */
+  promise_test(t=> {
+    const pc = new RTCPeerConnection();
+
+    test_state_change_event(t, pc, ['have-local-offer', 'stable']);
+
+    return pc.createOffer()
+    .then(offer => pc.setLocalDescription(offer))
+    .then(() => {
+      assert_equals(pc.signalingState, 'have-local-offer');
+      assert_not_equals(pc.localDescription, null);
+      assert_not_equals(pc.pendingLocalDescription, null);
+      assert_equals(pc.currentLocalDescription, null);
+
+      return pc.setLocalDescription({ type: 'rollback' });
+    })
+    .then(() => {
+      assert_equals(pc.signalingState, 'stable');
+      assert_equals(pc.localDescription, null);
+      assert_equals(pc.pendingLocalDescription, null);
+      assert_equals(pc.currentLocalDescription, null);
+    });
+  }, 'setLocalDescription(rollback) from have-local-offer state should reset back to stable state');
+
+</script>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.setRemoteDescription pranswer</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   generateOffer
+  //   generateAnswer
+  //   assert_session_desc_equals
+  //   test_state_change_event
+
+  /*
+    4.3.2.  Interface Definition
+      [Constructor(optional RTCConfiguration configuration)]
+      interface RTCPeerConnection : EventTarget {
+        Promise<void>                      setLocalDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? localDescription;
+        readonly attribute RTCSessionDescription? currentLocalDescription;
+        readonly attribute RTCSessionDescription? pendingLocalDescription;
+
+        Promise<void>                      setRemoteDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? remoteDescription;
+        readonly attribute RTCSessionDescription? currentRemoteDescription;
+        readonly attribute RTCSessionDescription? pendingRemoteDescription;
+        ...
+      };
+
+    4.6.2.  RTCSessionDescription Class
+      dictionary RTCSessionDescriptionInit {
+        required RTCSdpType type;
+                 DOMString  sdp = "";
+      };
+
+    4.6.1.  RTCSdpType
+      enum RTCSdpType {
+        "offer",
+        "pranswer",
+        "answer",
+        "rollback"
+      };
+   */
+
+  /*
+    4.3.1.6.  Set the RTCSessionSessionDescription
+      2.1.3.  If the description's type is invalid for the current signaling state of
+              connection, then reject p with a newly created InvalidStateError and abort
+              these steps.
+
+    [JSEP]
+      5.6.  If the type is "pranswer" or "answer", the PeerConnection state MUST be either
+            "have-local-offer" or "have-remote-pranswer".
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+
+    return generateOffer()
+    .then(offer =>
+      promise_rejects(t, 'InvalidStateError',
+        pc.setRemoteDescription({ type: 'pranswer', sdp: offer.sdp })));
+  }, 'setRemoteDescription(pranswer) from stable state should reject with InvalidStateError');
+
+  /*
+    4.3.1.6.  Set the RTCSessionSessionDescription
+      2.2.3.  Otherwise, if description is set as a remote description, then run one
+              of the following steps:
+        - If description is of type "pranswer", then set
+          connection.pendingRemoteDescription to description and signaling state
+          to have-remote-pranswer.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-local-offer', 'have-remote-pranswer']);
+
+    return pc.createOffer({ offerToReceiveVideo: true })
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer))
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setRemoteDescription(pranswer)
+        .then(() => {
+          assert_equals(pc.signalingState, 'have-remote-pranswer');
+
+          assert_session_desc_equals(pc.localDescription, offer);
+          assert_session_desc_equals(pc.pendingLocalDescription, offer);
+          assert_equals(pc.currentLocalDescription, null);
+
+          assert_session_desc_equals(pc.remoteDescription, pranswer);
+          assert_session_desc_equals(pc.pendingRemoteDescription, pranswer);
+          assert_equals(pc.currentRemoteDescription, null);
+        });
+      }));
+  }, 'setRemoteDescription(pranswer) from have-local-offer state should succeed');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-local-offer', 'have-remote-pranswer']);
+
+    return pc.createOffer({ offerToReceiveVideo: true })
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer))
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setRemoteDescription(pranswer)
+        .then(() => pc.setRemoteDescription(pranswer));
+      }));
+  }, 'setRemoteDescription(pranswer) multiple times should succeed');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    test_state_change_event(t, pc, ['have-local-offer', 'have-remote-pranswer', 'stable']);
+
+    return pc.createOffer({ offerToReceiveVideo: true })
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer))
+      .then(answer => {
+        const pranswer = { type: 'pranswer', sdp: answer.sdp };
+
+        return pc.setRemoteDescription(pranswer)
+        .then(() => pc.setRemoteDescription(answer))
+        .then(() => {
+          assert_equals(pc.signalingState, 'stable');
+
+          assert_session_desc_equals(pc.localDescription, offer);
+          assert_session_desc_equals(pc.currentLocalDescription, offer);
+          assert_equals(pc.pendingLocalDescription, null);
+
+          assert_session_desc_equals(pc.remoteDescription, answer);
+          assert_session_desc_equals(pc.currentRemoteDescription, answer);
+          assert_equals(pc.pendingRemoteDescription, null);
+        });
+      }));
+  }, 'setRemoteDescription(answer) from have-remote-pranswer state should succeed');
+
+</script>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCPeerConnection.prototype.setRemoteDescription rollback</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   generateOffer
+  //   assert_session_desc_equals
+  //   test_state_change_event
+
+  /*
+    4.3.2.  Interface Definition
+      [Constructor(optional RTCConfiguration configuration)]
+      interface RTCPeerConnection : EventTarget {
+        Promise<void>                      setLocalDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? localDescription;
+        readonly attribute RTCSessionDescription? currentLocalDescription;
+        readonly attribute RTCSessionDescription? pendingLocalDescription;
+
+        Promise<void>                      setRemoteDescription(
+            RTCSessionDescriptionInit description);
+
+        readonly attribute RTCSessionDescription? remoteDescription;
+        readonly attribute RTCSessionDescription? currentRemoteDescription;
+        readonly attribute RTCSessionDescription? pendingRemoteDescription;
+        ...
+      };
+
+    4.6.2.  RTCSessionDescription Class
+      dictionary RTCSessionDescriptionInit {
+        required RTCSdpType type;
+                 DOMString  sdp = "";
+      };
+
+    4.6.1.  RTCSdpType
+      enum RTCSdpType {
+        "offer",
+        "pranswer",
+        "answer",
+        "rollback"
+      };
+   */
+
+  /*
+    4.3.1.6.  Set the RTCSessionSessionDescription
+      2.2.3.  Otherwise, if description is set as a remote description, then run one
+              of the following steps:
+        - If description is of type "rollback", then this is a rollback.
+          Set connection.pendingRemoteDescription to null and signaling state to stable.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+
+    test_state_change_event(t, pc, ['have-remote-offer', 'stable']);
+
+    return generateOffer({ data: true })
+    .then(offer => pc.setRemoteDescription(offer))
+    .then(() => {
+      assert_equals(pc.signalingState, 'have-remote-offer');
+      assert_not_equals(pc.remoteDescription, null);
+      assert_not_equals(pc.pendingRemoteDescription, null);
+      assert_equals(pc.currentRemoteDescription, null);
+
+      return pc.setRemoteDescription({ type: 'rollback' });
+    })
+    .then(() => {
+      assert_equals(pc.signalingState, 'stable');
+      assert_equals(pc.remoteDescription, null);
+      assert_equals(pc.pendingRemoteDescription, null);
+      assert_equals(pc.currentRemoteDescription, null);
+    });
+  }, 'setRemoteDescription(rollback) in have-remote-offer state should revert to stable state');
+
+</script>


### PR DESCRIPTION
The new tests are added to new files as I plan to split the tests for set*Description into multiple files. The tests doesn't involve transceiver as they will be tested in separate PRs. Coverage report will be added after #6491 is merged.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
