### PR TITLE
Change `supportedMethods` to DOMString in payment-request tests

### DIFF
--- a/payment-request/allowpaymentrequest/active-document-cross-origin.https.sub.html
+++ b/payment-request/allowpaymentrequest/active-document-cross-origin.https.sub.html
@@ -7,7 +7,7 @@
 <script>
 async_test((t) => {
   const iframe = document.getElementById('iframe');
-  const paymentArgs = [[{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
+  const paymentArgs = [[{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
 
   onload = () => {
     const win = window[0];

--- a/payment-request/allowpaymentrequest/active-document-same-origin.https.html
+++ b/payment-request/allowpaymentrequest/active-document-same-origin.https.html
@@ -6,7 +6,7 @@
 <script>
 async_test((t) => {
   const iframe = document.getElementById('iframe');
-  const paymentArgs = [[{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
+  const paymentArgs = [[{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
 
   onload = () => {
     const win = window[0];

--- a/payment-request/allowpaymentrequest/basic.https.html
+++ b/payment-request/allowpaymentrequest/basic.https.html
@@ -5,7 +5,7 @@
 <iframe id="iframe" allowpaymentrequest></iframe>
 <script>
 async_test((t) => {
-  const paymentArgs = [[{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
+  const paymentArgs = [[{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
 
   onload = t.step_func_done(() => {
     new window[0].PaymentRequest(...paymentArgs);

--- a/payment-request/allowpaymentrequest/echo-PaymentRequest.html
+++ b/payment-request/allowpaymentrequest/echo-PaymentRequest.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script>
 window.onmessage = (e) => {
-  const paymentArgs = [[{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
+  const paymentArgs = [[{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}}];
 
   if (e.data === 'What is the result of new PaymentRequest(...)?') {
     const result = {urlQuery: location.search.substring(1)}; // Used to distinguish subtests

--- a/payment-request/interfaces.https.html
+++ b/payment-request/interfaces.https.html
@@ -29,8 +29,8 @@ interface PaymentRequest : EventTarget {
              attribute EventHandler         onshippingoptionchange;
 };
 dictionary PaymentMethodData {
-    required sequence<DOMString> supportedMethods;
-             object              data;
+    required DOMString supportedMethods;
+             object    data;
 };
 dictionary PaymentCurrencyAmount {
     required DOMString currency;
@@ -51,7 +51,7 @@ dictionary PaymentDetailsUpdate : PaymentDetailsBase {
     PaymentItem total;
 };
 dictionary PaymentDetailsModifier {
-    required sequence<DOMString>   supportedMethods;
+    required DOMString             supportedMethods;
              PaymentItem           total;
              sequence<PaymentItem> additionalDisplayItems;
              object                data;
@@ -134,7 +134,7 @@ var idlArray = new IdlArray();
   }
 });
 idlArray.add_objects({
-  PaymentRequest: ["new PaymentRequest([{supportedMethods: ['foo']}], {total: {label: 'bar', amount: {currency: 'BAZ', value: '0'}}})"]
+  PaymentRequest: ["new PaymentRequest([{supportedMethods: 'foo'}], {total: {label: 'bar', amount: {currency: 'BAZ', value: '0'}}})"]
 });
 idlArray.test();
 </script>

--- a/payment-request/payment-allowed-by-feature-policy.https.sub.html
+++ b/payment-request/payment-allowed-by-feature-policy.https.sub.html
@@ -11,7 +11,7 @@
   var header = 'Feature-Policy header {"payment" : ["*"]}';
 
   test(() => {
-    var supportedInstruments = [ { supportedMethods: [ 'visa' ] } ];
+    var supportedInstruments = [ { supportedMethods: 'visa' } ];
     var details = {
       total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
     };

--- a/payment-request/payment-default-feature-policy.https.sub.html
+++ b/payment-request/payment-default-feature-policy.https.sub.html
@@ -11,7 +11,7 @@
   var header = 'Default "payment" feature policy ["self"]';
 
   test(() => {
-    var supportedInstruments = [ { supportedMethods: [ 'visa' ] } ];
+    var supportedInstruments = [ { supportedMethods: 'visa' } ];
     var details = {
       total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
     };

--- a/payment-request/payment-disabled-by-feature-policy.https.sub.html
+++ b/payment-request/payment-disabled-by-feature-policy.https.sub.html
@@ -11,7 +11,7 @@
   var header = 'Feature-Policy header {"payment" : []}';
 
   test(() => {
-    var supportedInstruments = [ { supportedMethods: [ 'visa' ] } ];
+    var supportedInstruments = [ { supportedMethods: 'visa' } ];
     var details = {
       total: { label: 'Test', amount: { currency: 'USD', value: '5.00' } }
     };

--- a/payment-request/payment-request-abort-method.https.html
+++ b/payment-request/payment-request-abort-method.https.html
@@ -12,7 +12,7 @@ setup(() => {}, {
   // not being explicitly handled.
   allow_uncaught_exception: true,
 });
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-canmakepayment-method.https.html
+++ b/payment-request/payment-request-canmakepayment-method.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {
@@ -101,7 +101,7 @@ promise_test(async t => {
   for (const method of unsupportedMethods) {
     try {
       const request = new PaymentRequest(
-        [{ supportedMethods: [method] }],
+        [{ supportedMethods: method }],
         defaultDetails
       );
       assert_false(

--- a/payment-request/payment-request-constructor-crash.https.html
+++ b/payment-request/payment-request-constructor-crash.https.html
@@ -29,7 +29,7 @@
 const ABUSIVE_AMOUNT = 100000;
 
 const basicCard = Object.freeze({
-  supportedMethods: ["basic-card"],
+  supportedMethods: "basic-card",
 });
 
 const defaultAmount = Object.freeze({
@@ -95,26 +95,26 @@ test(() => {
   assert_true(true, "Didn't crash");
 }, "Don't crash if there is a abusive number of payment methods in the methodData sequence");
 
+// PaymentMethodData.supportedMethods
 test(() => {
-  let supportedMethods = ["basic-card"];
+  const supportedMethods = "basic-card";
   // Smoke test
   try {
     new PaymentRequest([{ supportedMethods }], defaultDetails);
   } catch (err) {
     assert_true(false, "failed smoke test: " + err.stack);
   }
-  // Now, let's add an abusive number of supportedMethods to a single PaymentMethodData
-  for (let i = 0; i < ABUSIVE_AMOUNT; i++) {
-    supportedMethods.push(`https://example.com/${i}/evil_${Math.random()}`);
-  }
-  const evilMethodData = [{ supportedMethods }];
+  // Now, we make supportedMethods super large
+  const evilMethodData = [{
+    supportedMethods: supportedMethods.repeat(ABUSIVE_AMOUNT),
+  }];
   try {
     new PaymentRequest(evilMethodData, defaultDetails);
   } catch (err) {
     assert_equals(err.name, "TypeError", "must be a TypeError");
   }
   assert_true(true, "Didn't crash");
-}, "Don't crash if there is a abusive number of supported methods in one sequence");
+}, "Don't crash if PaymentMethodData.supportedMethods is an abusive length");
 
 // PaymentDetailsInit.id
 test(() => {

--- a/payment-request/payment-request-constructor-crash.https.html
+++ b/payment-request/payment-request-constructor-crash.https.html
@@ -10,7 +10,7 @@
     dictionary PaymentItem {
         required DOMString             label;
         required PaymentCurrencyAmount amount;
-                boolean               pending = false;
+                 boolean               pending = false;
     };
 
     dictionary PaymentDetailsBase {
@@ -93,7 +93,7 @@ test(() => {
     assert_equals(err.name, "TypeError", "must be a TypeError");
   }
   assert_true(true, "Didn't crash");
-}, "Don't crash if there is a abusive number of payment methods in the methodData sequence");
+}, "Don't crash if there is an abusive number of payment methods in the methodData sequence");
 
 // PaymentMethodData.supportedMethods
 test(() => {

--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {
@@ -56,7 +56,7 @@ test(() => {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
         },
       ],
       {
@@ -94,38 +94,12 @@ test(() => {
 }, "If the length of the methodData sequence is zero, then throw a TypeError");
 
 test(() => {
-  assert_throws(
-    {
-      name: "TypeError",
-    },
-    () => {
-      new PaymentRequest(
-        [
-          {
-            supportedMethods: [],
-          },
-        ],
-        {
-          total: {
-            label: "",
-            amount: {
-              currency: "USD",
-              value: "1.00",
-            },
-          },
-        }
-      );
-    }
-  );
-}, "If the length of the paymentMethod.supportedMethods sequence is zero, " + "then throw a TypeError");
-
-test(() => {
   let itThrows = false;
   try {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
           data: ["some-data"],
         },
       ],
@@ -149,7 +123,7 @@ test(() => {
   new PaymentRequest(
     [
       {
-        supportedMethods: ["basic-card"],
+        supportedMethods: "basic-card",
         data: {
           some: "data",
         },
@@ -178,7 +152,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
             data: recursiveDictionary,
           },
         ],
@@ -202,7 +176,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
             data: "a string",
           },
         ],
@@ -226,7 +200,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
             data: null,
           },
         ],
@@ -287,7 +261,7 @@ for (const amount of invalidTotalAmounts) {
         new PaymentRequest(
           [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
             },
           ],
           {
@@ -325,7 +299,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
           },
         ],
         {
@@ -352,7 +326,7 @@ for (const amount of invalidAmounts) {
         new PaymentRequest(
           [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
             },
           ],
           {
@@ -385,7 +359,7 @@ test(() => {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
           data: {
             supportedTypes: ["debit"],
           },
@@ -431,7 +405,7 @@ test(() => {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
         },
       ],
       {
@@ -566,7 +540,7 @@ for (const amount of invalidTotalAmounts) {
       },
       () => {
         const invalidModifier = {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
           total: {
             label: "",
             amount: {
@@ -578,7 +552,7 @@ for (const amount of invalidTotalAmounts) {
         new PaymentRequest(
           [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
             },
           ],
           {
@@ -605,7 +579,7 @@ for (const amount of invalidAmounts) {
       },
       () => {
         const invalidModifier = {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
           total: {
             label: "",
             amount: {
@@ -626,7 +600,7 @@ for (const amount of invalidAmounts) {
         new PaymentRequest(
           [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
             },
           ],
           {
@@ -651,7 +625,7 @@ test(() => {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
         },
       ],
       {
@@ -664,7 +638,7 @@ test(() => {
         },
         modifiers: [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
             data: ["some-data"],
           },
         ],
@@ -682,7 +656,7 @@ test(() => {
     new PaymentRequest(
       [
         {
-          supportedMethods: ["basic-card"],
+          supportedMethods: "basic-card",
         },
       ],
       {
@@ -695,7 +669,7 @@ test(() => {
         },
         modifiers: [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
             data: {
               some: "data",
             },
@@ -720,7 +694,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
           },
         ],
         {
@@ -733,7 +707,7 @@ test(() => {
           },
           modifiers: [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
               data: recursiveDictionary,
             },
           ],
@@ -749,7 +723,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
           },
         ],
         {
@@ -762,7 +736,7 @@ test(() => {
           },
           modifiers: [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
               data: "a string",
             },
           ],
@@ -778,7 +752,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
           },
         ],
         {
@@ -791,7 +765,7 @@ test(() => {
           },
           modifiers: [
             {
-              supportedMethods: ["basic-card"],
+              supportedMethods: "basic-card",
               data: null,
             },
           ],
@@ -811,7 +785,7 @@ test(() => {
       new PaymentRequest(
         [
           {
-            supportedMethods: ["basic-card"],
+            supportedMethods: "basic-card",
           },
         ],
         {

--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -616,7 +616,7 @@ for (const amount of invalidAmounts) {
         );
       }
     );
-  }, `If amount.value of additionalDisplayItems is is not a valid decimal monetary value (in this case "${amount}"), then throw a TypeError`);
+  }, `If amount.value of additionalDisplayItems is not a valid decimal monetary value (in this case "${amount}"), then throw a TypeError`);
 }
 
 test(() => {
@@ -681,7 +681,7 @@ test(() => {
     itThrows = true;
   }
   assert_false(itThrows, "shouldn't throw when given an object value");
-}, "Modifier data must be JSON-serializable object (a object in this case)");
+}, "Modifier data must be JSON-serializable object (an object in this case)");
 
 test(() => {
   const recursiveDictionary = {};

--- a/payment-request/payment-request-id.https.html
+++ b/payment-request/payment-request-id.https.html
@@ -8,10 +8,10 @@
 <script>
 async_test((t) => {
   onload = t.step_func_done(() => {
-    var request = new window[0].PaymentRequest([{supportedMethods: ['foo']}], {id: 'my_payment_id', total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
+    var request = new window[0].PaymentRequest([{supportedMethods: 'foo'}], {id: 'my_payment_id', total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
     assert_equals(request.id, 'my_payment_id', 'Payment identifier is not reflected correctly in PaymentRequest.id');
 
-    request = new window[0].PaymentRequest([{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
+    request = new window[0].PaymentRequest([{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
     assert_equals(request.id.length, 36, 'Generated payment identifier is not of correct length.');
   });
 });

--- a/payment-request/payment-request-in-iframe.html
+++ b/payment-request/payment-request-in-iframe.html
@@ -11,7 +11,7 @@ https://github.com/w3c/browser-payment-api/issues/2)</title>
 <script>
 window.top.test(function() {
     window.top.assert_throws({name: 'SecurityError'}, function() {
-        new PaymentRequest([{supportedMethods: ['foo']}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
+        new PaymentRequest([{supportedMethods: 'foo'}], {total: {label: 'label', amount: {currency: 'USD', value: '5.00'}}});
     }, 'If the browsing context of the script calling the constructor is not a top-level browsing context, then throw a SecurityError.');
 });
 </script>

--- a/payment-request/payment-request-onshippingaddresschange-attribute.https.html
+++ b/payment-request/payment-request-onshippingaddresschange-attribute.https.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-onshippingoptionchange-attribute.https.html
+++ b/payment-request/payment-request-onshippingoptionchange-attribute.https.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 "use strict";
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-response-id.html
+++ b/payment-request/payment-request-response-id.html
@@ -32,7 +32,7 @@
        }
 
        const supportedInstruments = [{
-         supportedMethods: ['https://android.com/pay'],
+         supportedMethods: 'https://android.com/pay',
          data: {
            merchantName: 'Rouslan Solomakhin',
            merchantId: '00184145120947117657',
@@ -47,7 +47,7 @@
            },
          },
        }, {
-         supportedMethods: ['basic-card'],
+         supportedMethods: 'basic-card',
          data: {
            supportedNetworks: ['unionpay', 'visa', 'mastercard', 'amex', 'discover',
              'diners', 'jcb', 'mir',

--- a/payment-request/payment-request-show-method.https.html
+++ b/payment-request/payment-request-show-method.https.html
@@ -7,7 +7,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 'use strict';
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-update-event-constructor.https.html
+++ b/payment-request/payment-request-update-event-constructor.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {

--- a/payment-request/payment-request-update-event-updatewith-method.https.html
+++ b/payment-request/payment-request-update-event-updatewith-method.https.html
@@ -6,7 +6,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-const basicCard = Object.freeze({ supportedMethods: ["basic-card"] });
+const basicCard = Object.freeze({ supportedMethods: "basic-card" });
 const defaultMethods = Object.freeze([basicCard]);
 const defaultDetails = Object.freeze({
   total: {


### PR DESCRIPTION
Revise per w3c/browser-payment-api#551

<!-- Reviewable:start -->

<!-- Reviewable:end -->
