### PR TITLE
Add a test to verify that allow-top-navigation-by-user-activation is …

### DIFF
--- a/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_allow_top_navigation-3.html
+++ b/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_allow_top_navigation-3.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Check that sandboxed iframe can perform navigation on the top frame
+           when allow-top-navigation is set (even when
+           allow-top-navigation-by-user-activation is set)</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <!-- Specifying both allow-top-navigation and
+         allow-top-navigation-by-user-activation is a document conformance
+         error: allow-top-navigation-by-user-activation will have no effect. -->
+    <iframe sandbox="allow-top-navigation allow-top-navigation-by-user-activation allow-scripts"></iframe>
+    <script>
+      if (opener) {
+        // We're the popup (i.e. a top frame).  Load into the iframe the page
+        // trying to modifying the top frame and transmit the result to our
+        // opener.
+        onmessage = function(e) {
+          opener.postMessage(e.data, "*")
+        }
+        document.querySelector("iframe").src = "support/iframe-that-performs-top-navigation-on-popup.html";
+      } else {
+        // We are the main test page.  Open ourselves as a popup, so that we can
+        // can experiment navigation of the top frame.
+        async_test(t => {
+          window.addEventListener("message", t.step_func_done(e => {
+            assert_equals(e.data, "can navigate");
+            e.source.close();
+          }));
+          window.open(location.href);
+        }, "Frames with `allow-top-navigation` should be able to navigate the top frame even when `allow-top-navigation-by-user-activation` is set.");
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
…ignored when allow-top-navigation is present.

This is similar to https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/http/tests/security/frameNavigation/sandbox-ALLOWED-top-navigation-with-two-flags.html but navigation is performed without user gesture (so allow-top-navigation is needed and allow-top-navigation-by-user-activation is not enough).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
