### PR TITLE
Check the state of the script created event inside of the dispatch task

### DIFF
--- a/service-workers/service-worker/resources/extendable-event-async-waituntil.js
+++ b/service-workers/service-worker/resources/extendable-event-async-waituntil.js
@@ -43,7 +43,7 @@ self.addEventListener('message', function(event) {
         async_task_waituntil(event).then(reportResultExpecting('InvalidStateError'));
         break;
       case 'script-extendable-event':
-        Promise.resolve().then(new_event_waituntil);
+        self.dispatchEvent(new ExtendableEvent('nontrustedevent'));
         break;
     }
     event.source.postMessage('ACK');
@@ -70,13 +70,8 @@ self.addEventListener('fetch', function(event) {
     }
   });
 
-self.addEventListener('foo', function(event) {
-    try {
-      event.waitUntil(new Promise(() => {}));
-      reportResultExpecting('InvalidStateError')('OK');
-    } catch (error) {
-      reportResultExpecting('InvalidStateError')(error.name);
-    }
+self.addEventListener('nontrustedevent', function(event) {
+    sync_waituntil(event).then(reportResultExpecting('InvalidStateError'));
   });
 
 function reportResultExpecting(expectedResult) {
@@ -95,10 +90,6 @@ function sync_waituntil(event) {
       res(error.name);
     }
   });
-}
-
-function new_event_waituntil() {
-  self.dispatchEvent(new ExtendableEvent('foo'));
 }
 
 function async_microtask_waituntil(event) {

--- a/service-workers/service-worker/resources/extendable-event-async-waituntil.js
+++ b/service-workers/service-worker/resources/extendable-event-async-waituntil.js
@@ -46,6 +46,7 @@ self.addEventListener('message', function(event) {
         self.dispatchEvent(new ExtendableEvent('nontrustedevent'));
         break;
     }
+
     event.source.postMessage('ACK');
   });
 


### PR DESCRIPTION
This moves the state check point of the script created event from the
outside into the event dispatch task. Before this change, it could be
possible to pass the test without checking the isTrusted state when
"the pending promises count is zero and the dispatch flag is unset"
condition was met.

Spec issue: https://github.com/w3c/ServiceWorker/issues/1040.
Spec PR: https://github.com/w3c/ServiceWorker/pull/1166.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
