### PR TITLE
WIP: webdriver tests for Get Status command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ webdriver/.idea
 .DS_Store
 *.rej
 _venv
+webdriver/.cache

--- a/webdriver/status.py
+++ b/webdriver/status.py
@@ -1,0 +1,21 @@
+import pytest
+import json
+
+
+def test_get_status_no_session(http):
+    with http.get("/status") as response:
+        # GET /status should never return an error
+        assert response.status == 200
+
+        # parse JSON response and unwrap 'value' property
+        parsed_obj = json.loads(response.read().decode('utf-8'))
+        value = parsed_obj["value"]
+
+        # Let body be a new JSON Object with the following properties:
+        # "ready"
+        #       The remote end's readiness state.
+        assert value["ready"] in [True, False]
+        # "message"
+        #       An implementation-defined string explaining the remote end's
+        #       readiness state.
+        assert isinstance(value["message"], basestring)

--- a/webdriver/support/http_request.py
+++ b/webdriver/support/http_request.py
@@ -1,6 +1,7 @@
 import contextlib
 import httplib
 
+
 class HTTPRequest(object):
     def __init__(self, host, port):
         self.host = host


### PR DESCRIPTION
Try my hand at a simple test or two. One issue I ran into immediately is getting data out of `GET /status` when there is no running session. I was getting a proper `200` status response from the call, but apparently an empty response body. Not sure if this is a geckodriver thing or something I'm doing wrong.

Obviously open to feedback on any part of this! Unsure about conventions and so on for this project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6521)
<!-- Reviewable:end -->
