### PR TITLE
Check default media type support with MediaSource.isTypeSupported()

### DIFF
--- a/media-source/interfaces.html
+++ b/media-source/interfaces.html
@@ -129,7 +129,7 @@ mediaSource = new MediaSource();
 video.src = URL.createObjectURL(mediaSource);
 mediaSource.addEventListener("sourceopen", function () {
   var defaultType ='video/webm;codecs="vp8,vorbis"';
-  if (video.canPlayType(defaultType)) {
+  if (MediaSource.isTypeSupported(defaultType)) {
     sourceBuffer = mediaSource.addSourceBuffer(defaultType);
   } else {
     sourceBuffer = mediaSource.addSourceBuffer('video/mp4');


### PR DESCRIPTION
Use MediaSource.isTypeSupported() instead of HTMLMediaElement.canPlayType() to avoid
failure when HTMLMediaElement supports default media type but not MediaSource.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
