### PR TITLE
url: Stop passing DOMException.prototype to URLSearchParams's constructor.

### DIFF
--- a/url/urlsearchparams-constructor.html
+++ b/url/urlsearchparams-constructor.html
@@ -23,9 +23,11 @@ test(function() {
 }, "URLSearchParams constructor, no arguments")
 
 test(() => {
-    params = new URLSearchParams(DOMException.prototype);
+    params = new URLSearchParams(DOMException);
     assert_equals(params.toString(), "INDEX_SIZE_ERR=1&DOMSTRING_SIZE_ERR=2&HIERARCHY_REQUEST_ERR=3&WRONG_DOCUMENT_ERR=4&INVALID_CHARACTER_ERR=5&NO_DATA_ALLOWED_ERR=6&NO_MODIFICATION_ALLOWED_ERR=7&NOT_FOUND_ERR=8&NOT_SUPPORTED_ERR=9&INUSE_ATTRIBUTE_ERR=10&INVALID_STATE_ERR=11&SYNTAX_ERR=12&INVALID_MODIFICATION_ERR=13&NAMESPACE_ERR=14&INVALID_ACCESS_ERR=15&VALIDATION_ERR=16&TYPE_MISMATCH_ERR=17&SECURITY_ERR=18&NETWORK_ERR=19&ABORT_ERR=20&URL_MISMATCH_ERR=21&QUOTA_EXCEEDED_ERR=22&TIMEOUT_ERR=23&INVALID_NODE_TYPE_ERR=24&DATA_CLONE_ERR=25")
-}, "URLSearchParams constructor, DOMException.prototype as argument")
+    assert_throws(new TypeError(), () => new URLSearchParams(DOMException.prototype),
+                  "Constructing a URLSearchParams from DOMException.prototype should throw due to branding checks");
+}, "URLSearchParams constructor, DOMException as argument")
 
 test(() => {
     params = new URLSearchParams('');


### PR DESCRIPTION
As of heycam/webidl#378, both

    new URLSearchParams(DOMException.prototype)
    DOMException.prototype.toString()

are supposed to throw an exception due to brand checks in properties such as
"name" and "message", which meant compliant implementations were always
failing one of the tests here.

Fix it by passing a `DOMException` instead: it has all the constants we need
and passes the required property checks. Also assert that the previous
behavior throws a TypeError.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
