### PR TITLE
DOM: stop commenting out Exposed in the IDL

### DIFF
--- a/interfaces/dom.idl
+++ b/interfaces/dom.idl
@@ -1,5 +1,5 @@
-[Constructor(DOMString type, optional EventInit eventInitDict)/*,
- Exposed=(Window,Worker)*/]
+[Constructor(DOMString type, optional EventInit eventInitDict),
+ Exposed=(Window,Worker)]
 interface Event {
   readonly attribute DOMString type;
   readonly attribute EventTarget? target;
@@ -31,8 +31,8 @@ dictionary EventInit {
 };
 
 
-[Constructor(DOMString type, optional CustomEventInit eventInitDict)/*,
- Exposed=(Window,Worker)*/]
+[Constructor(DOMString type, optional CustomEventInit eventInitDict),
+ Exposed=(Window,Worker)]
 interface CustomEvent : Event {
   readonly attribute any detail;
 
@@ -44,7 +44,8 @@ dictionary CustomEventInit : EventInit {
 };
 
 
-[Constructor/*, Exposed=(Window,Worker)*/]
+[Constructor,
+ Exposed=(Window,Worker)]
 interface EventTarget {
   void addEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);
   void removeEventListener(DOMString type, EventListener? callback, optional (EventListenerOptions or boolean) options);


### PR DESCRIPTION
It’s not consistently done anyway and just causes confusing (and the
occasional merge conflict).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
