### PR TITLE
Fetch: use a less confusing value to pass to Response.redirect()

### DIFF
--- a/fetch/api/response/response-consume-stream.html
+++ b/fetch/api/response/response-consume-stream.html
@@ -65,7 +65,7 @@ test(function() {
 }, "Getting an error Response stream");
 
 promise_test(function(test) {
-    assert_equals(Response.redirect(301).body, null);
+    assert_equals(Response.redirect("/").body, null);
 }, "Getting a redirect Response stream");
 
     </script>


### PR DESCRIPTION
Fixes #6144.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
