### PR TITLE
Cross-origin objects: make sure for..in enumeration works too

### DIFF
--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
@@ -256,15 +256,23 @@ addTest(function() {
 }, "[[DefineOwnProperty]] Should throw for cross-origin objects");
 
 /*
- * [[Enumerate]]
+ * EnumerateObjectProperties (backed by [[OwnPropertyKeys]])
  */
 
 addTest(function() {
-  for (var prop in C)
-    assert_unreached("Shouldn't have been able to enumerate " + prop + " on cross-origin Window");
-  for (var prop in C.location)
-    assert_unreached("Shouldn't have been able to enumerate " + prop + " on cross-origin Location");
-}, "[[Enumerate]] should return an empty iterator");
+  let i = 0;
+  for (var prop in C) {
+    i++;
+    assert_true(prop in whitelistedWindowPropNames, prop + " is not safelisted for a cross-origin Window");
+  }
+  assert_equals(i, whitelistedWindowPropNames.length, "Enumerate all safelisted cross-origin Window properties");
+  i = 0;
+  for (var prop in C.location) {
+    i++;
+    assert_true(prop in whitelistedLocationPropNames, prop + " is not safelisted for a cross-origin Location");
+  }
+  assert_equals(i, whitelistedLocationPropNames.length, "Enumerate all safelisted cross-origin Location properties");
+}, "Can only enumerate safelisted properties");
 
 /*
  * [[OwnPropertyKeys]]

--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
@@ -263,13 +263,13 @@ addTest(function() {
   let i = 0;
   for (var prop in C) {
     i++;
-    assert_true(prop in whitelistedWindowPropNames, prop + " is not safelisted for a cross-origin Window");
+    assert_true(whitelistedWindowPropNames.includes(prop), prop + " is not safelisted for a cross-origin Window");
   }
   assert_equals(i, whitelistedWindowPropNames.length, "Enumerate all safelisted cross-origin Window properties");
   i = 0;
   for (var prop in C.location) {
     i++;
-    assert_true(prop in whitelistedLocationPropNames, prop + " is not safelisted for a cross-origin Location");
+    assert_true(whitelistedLocationPropNames.includes(prop), prop + " is not safelisted for a cross-origin Location");
   }
   assert_equals(i, whitelistedLocationPropNames.length, "Enumerate all safelisted cross-origin Location properties");
 }, "Can only enumerate safelisted properties");


### PR DESCRIPTION
Follow-up for #6538.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
