### PR TITLE
Add test for getting contributing/synchronization sources

### DIFF
--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -372,3 +372,18 @@ function generateMediaStreamTrack(kind) {
 
   return track;
 }
+
+// Obtain a MediaStreamTrack of kind using getUserMedia.
+// Return Promise of pair of track and associated mediaStream.
+// Assumes that there is at least one available device
+// to generate the track.
+function getTrackFromUserMedia(kind) {
+  return navigator.mediaDevices.getUserMedia({ [kind]: true })
+  .then(mediaStream => {
+    const tracks = mediaStream.getTracks();
+    assert_greater_than(tracks.length, 0,
+      `Expect getUserMedia to return at least one track of kind ${kind}`);
+    const [ track ] = tracks;
+    return [track, mediaStream];
+  });
+}

--- a/webrtc/RTCRtpReceiver-getContributingSources.html
+++ b/webrtc/RTCRtpReceiver-getContributingSources.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpReceiver.prototype.getContributingSources</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper function is called from RTCPeerConnection-helper.js
+  //   getTrackFromUserMedia
+  //   exchangeIceCandidates
+  //   doSignalingHandshake
+
+  /*
+    5.3.  RTCRtpReceiver Interface
+      interface RTCRtpReceiver {
+        ...
+        sequence<RTCRtpContributingSource>    getContributingSources();
+      };
+
+      interface RTCRtpContributingSource {
+        readonly attribute DOMHighResTimeStamp timestamp;
+        readonly attribute unsigned long       source;
+        readonly attribute byte?               audioLevel;
+      };
+
+      audioLevel
+        The audio level contained in the last RTP packet played from this source.
+        audioLevel will be the level value defined in [RFC6465] if the RFC 6465
+        header extension is present, and otherwise null. RFC 6465 defines the
+        level as a integral value from 0 to 127 representing the audio level in
+        negative decibels relative to the loudest signal that the system could
+        possibly encode. Thus, 0 represents the loudest signal the system could
+        possibly encode, and 127 represents silence.
+   */
+
+  promise_test(() => {
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    const ontrackPromise = new Promise(resolve => {
+      pc2.addEventListener('track', trackEvent => {
+        const { receiver } = trackEvent;
+        assert_true(receiver instanceof RTCRtpReceiver,
+          'Expect trackEvent.receiver to be instance of RTCRtpReceiver');
+
+        resolve(receiver);
+      });
+    });
+
+    return getTrackFromUserMedia('audio')
+    .then(([track, mediaStream]) => {
+      pc1.addTrack(track, mediaStream);
+      exchangeIceCandidates(pc1, pc2);
+      return doSignalingHandshake(pc1, pc2);
+    })
+    .then(() => ontrackPromise)
+    .then(receiver => {
+      const contributingSources = receiver.getContributingSources();
+      assert_greater_than(contributingSources.length, 0,
+        'Expect CSRCs to be available after RTP connection is established');
+
+      for(const csrc of contributingSources) {
+        assert_true(csrc instanceof RTCRtpContributingSource,
+          'Expect contributingSources elements to be instance of RTCRtpContributingSource');
+
+        assert_equals(typeof csrc.timestamp, 'number',
+          'Expect csrc.timestamp attribute to be DOMHighResTimeStamp');
+
+        assert_true(Number.isInteger(csrc.source) && csrc.source > 0,
+          'Expect CSRC identifier to be unsigned long');
+
+        if(csrc.audioLevel !== null) {
+          assert_true(Number.isInteger(csrc.audioLevel) &&
+             csrc.audioLevel >= 0 && csrc.audioLevel <= 127,
+            'Expect csrc.audioLevel to be either null or byte value from 0-127.');
+        }
+      }
+    });
+  }, `getContributingSources() should return list of CSRC after connection is established`);
+
+</script>

--- a/webrtc/RTCRtpReceiver-getSynchronizationSources.html
+++ b/webrtc/RTCRtpReceiver-getSynchronizationSources.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpReceiver.prototype.getSynchronizationSources</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  /*
+    5.3.  RTCRtpReceiver Interface
+      interface RTCRtpReceiver {
+        ...
+        sequence<RTCRtpSynchronizationSource> getSynchronizationSources();
+      };
+
+      interface RTCRtpSynchronizationSource {
+        readonly attribute DOMHighResTimeStamp timestamp;
+        readonly attribute unsigned long       source;
+        readonly attribute byte                audioLevel;
+        readonly attribute boolean?            voiceActivityFlag;
+      };
+   */
+
+  promise_test(() => {
+    const pc1 = new RTCPeerConnection();
+    const pc2 = new RTCPeerConnection();
+
+    const ontrackPromise = new Promise(resolve => {
+      pc2.addEventListener('track', trackEvent => {
+        const { receiver } = trackEvent;
+        assert_true(receiver instanceof RTCRtpReceiver,
+          'Expect trackEvent.receiver to be instance of RTCRtpReceiver');
+
+        resolve(receiver);
+      });
+    });
+
+    return getTrackFromUserMedia('audio')
+    .then(([track, mediaStream]) => {
+      pc1.addTrack(track, mediaStream);
+      exchangeIceCandidates(pc1, pc2);
+      return doSignalingHandshake(pc1, pc2);
+    })
+    .then(() => ontrackPromise)
+    .then(receiver => {
+      const syncSources = receiver.getSynchronizationSources();
+      assert_greater_than(syncSources.length, 0,
+        'Expect SSRCs to be available after RTP connection is established');
+
+      for(const ssrc of syncSources) {
+        assert_true(ssrc instanceof RTCRtpSynchronizationSource,
+          'Expect synchronizationSources elements to be instance of RTCSynchronizationSource');
+
+        assert_equals(typeof ssrc.timestamp, 'number',
+          'Expect ssrc.timestamp attribute to be DOMHighResTimeStamp');
+
+        assert_true(Number.isInteger(ssrc.source) && ssrc.source > 0,
+          'Expect SSRC identifier to be unsigned long');
+
+        assert_true(Number.isInteger(ssrc.audioLevel) &&
+          ssrc.audioLevel >= 0 && ssrc.audioLevel <= 127,
+          'Expect ssrc.audioLevel to be byte value from 0-127.');
+
+        if(ssrc.voiceActivityFlag !== null) {
+          assert_equals(typeof ssrc.voiceActivityFlag, 'boolean',
+            'Expect ssrc.voiceActivity to be either null or boolean');
+        }
+      }
+    });
+  }, `getContributingSources() should return list of CSRC after connection is established`);
+
+</script>


### PR DESCRIPTION
This adds tests for the `getContributingSources()` and `getSynchronizationSources()` on `RTCRtpReceiver`.

If I understand correctly, the methods should only return non-empty results after the RTP session is established. Right now I establish handshake between two peer connections, and get the sources after the `ontrack` event is fired at the remote peer. I am not sure if by that time there are enough information for the implementation to return meaningful results. The test does assertion that the returned array should have at least one element, because otherwise the test would be meaningless.

If there are better timing to get the SSRC/CSRC, feel free to let me know.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
