### PR TITLE
Cross-origin objects: symbol properties are not enumerable

### DIFF
--- a/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
+++ b/html/browsers/origin/cross-origin-objects/cross-origin-objects.html
@@ -187,14 +187,16 @@ function checkPropertyDescriptor(desc, propName, expectWritable) {
   var isSymbol = (typeof(propName) == "symbol");
   propName = String(propName);
   assert_true(isObject(desc), "property descriptor for " + propName + " should exist");
-  assert_equals(desc.enumerable, true, "property descriptor for " + propName + " should be enumerable");
   assert_equals(desc.configurable, true, "property descriptor for " + propName + " should be configurable");
   if (isSymbol) {
+    assert_equals(desc.enumerable, false, "symbol-property descriptor for " + propName + " should not be enumerable");
     assert_true("value" in desc,
                 "property descriptor for " + propName + " should be a value descriptor");
     assert_equals(desc.value, undefined,
                   "symbol-named cross-origin visible prop " + propName +
                   " should come back as undefined");
+  } else {
+    assert_equals(desc.enumerable, true, "property descriptor for " + propName + " should be enumerable");
   }
   if ('value' in desc)
     assert_equals(desc.writable, expectWritable, "property descriptor for " + propName + " should have writable: " + expectWritable);

--- a/html/browsers/the-window-object/window-indexed-properties.html
+++ b/html/browsers/the-window-object/window-indexed-properties.html
@@ -17,6 +17,12 @@ test(function() {
   window[-1] = "foo";
   assert_equals(window[-1], "foo");
 });
+test(() => {
+  const desc = Object.getOwnPropertyDescriptor(window, "0");
+  assert_true(desc.configurable);
+  assert_true(desc.enumerable);
+  assert_false(desc.writable);
+}, "Ensure indexed properties have the correct configuration");
 test(function() {
   window[0] = "foo";
   assert_throws(new TypeError(), () => Object.defineProperty(window, 0, { value: "bar" }))


### PR DESCRIPTION
Second follow-up for #6538.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
