### PR TITLE
Add failing tests for video.removeTextTrack

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>HTMLMediaElement.removeTextTrack</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<div id=log></div>
+<script>
+var video = document.createElement('video');
+test(function(){
+    var t = video.addTextTrack('captions');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 1);
+    video.removeTextTrack(t);
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' captions');
+
+test(function(){
+    var t = video.addTextTrack('subtitles');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 1);
+    video.removeTextTrack(t);
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' subtitles');
+
+test(function(){
+    var t = video.addTextTrack('chapters');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 1);
+    video.removeTextTrack(t);
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' chapters');
+
+test(function(){
+    var t = video.addTextTrack('metadata');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 1);
+    video.removeTextTrack(t);
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' metadata');
+
+test(function(){
+    var t = video.addTextTrack('descriptions');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 1);
+    video.removeTextTrack(t);
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' descriptions');
+</script>
+

--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
@@ -49,5 +49,16 @@ test(function(){
     assert_equals(video.textTracks, video.textTracks);
     assert_equals(video.textTracks.length, 0);
 }, document.title + ' descriptions');
+
+test(function(){
+    var t = document.createElement('track').track;
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+    assert_throws('NOT_FOUND_ERROR', function() {
+        video.removeTextTrack(t);
+    }, 'standalone');
+    assert_equals(video.textTracks, video.textTracks);
+    assert_equals(video.textTracks.length, 0);
+}, document.title + ' orphaned track');
 </script>
 

--- a/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/HTMLElement/HTMLMediaElement/removeTextTrack.html
@@ -60,5 +60,17 @@ test(function(){
     assert_equals(video.textTracks, video.textTracks);
     assert_equals(video.textTracks.length, 0);
 }, document.title + ' orphaned track');
+
+
+test(function() {
+    var tel = document.createElement('track');
+    video.appendChild(tel);
+    assert_equals(video.textTracks.length, 1);
+    assert_true(video.contains(tel));
+    video.removeTextTrack(tel.track);
+    assert_false(video.contains(tel));
+    assert_equals(video.textTracks.length, 0);
+
+}, document.title + ' also remove associated track element');
 </script>
 


### PR DESCRIPTION
These are some failing tests for `video.removeTextTrack` based on feedback from https://github.com/whatwg/html/issues/1921.
Worked with @egreaves during textAV.tech to finally get it out the door.

As I mentioned in https://github.com/whatwg/html/issues/1921, I think that just removing the in-band track from the TextTrackList rather than throwing would be a better approach as it matches more closely what happens with the track elements. It'll also be a signal to the browser that we don't care about parsing the rest of this track until the source gets reset. However, I'm not sure that's the best approach nor do I know how I would go about writing tests for or against such a track.

In addition, once this method is available, authors that create text tracks and are actively adding cues to tracks would need to do null-checking or what not for removed text track.

Ultimately, I think `removeTextTrack` and `addTextTrack` should mirror removing and adding track elements to the video element as closely as possible.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
