### PR TITLE
Add test names for NetInfo tests

### DIFF
--- a/netinfo/netinfo-basics.html
+++ b/netinfo/netinfo-basics.html
@@ -9,27 +9,27 @@
 test(function() {
       assert_in_array(navigator.connection.type,  ["bluetooth", "cellular",
         "ethernet", "mixed", "none", "other", "unknown", "wifi", "wimax"], 'type is unexpected');
- });
+}, "type attribute");
 
 test(function() {
       assert_greater_than_equal(navigator.connection.downlinkMax, 0);
- });
+}, "downlinkMax attribute");
 
 test(function() {
       assert_in_array(navigator.connection.effectiveType, ["slow-2g", "2g",
           "3g", "4g"], 'effectiveType is unexpected');
- });
+}, "effectiveType attribute");
 
 test(function() {
       assert_greater_than_equal(navigator.connection.rtt, 0);
       assert_equals(navigator.connection.rtt % 25, 0,
         'rtt must be a multiple of 25 msec');
- });
+}, "rtt attribute");
 
 test(function() {
       assert_greater_than_equal(navigator.connection.downlink, 0);
       var downlink  = navigator.connection.downlink ;
       assert_equals(((downlink  - Math.floor(downlink)) *1000) % 25, 0,
         'downlink must be a multiple of 25 kbps');
- });
+}, "downlink attribute");
 </script>


### PR DESCRIPTION
This was an exportable change from June 7, 2017 that the Blink WPT Exporter
missed. Original commit: https://crrev.com/ae909c654a.

More context on this auditing: https://crbug.com/737898

BUG=719108

Review-Url: https://codereview.chromium.org/2926103002
Cr-Commit-Position: refs/heads/master@{#477636}

<!-- Reviewable:start -->

<!-- Reviewable:end -->
