### PR TITLE
[mediacapture-fromelement] Support Firefox moz-prefixed implementation in tests

### DIFF
--- a/mediacapture-fromelement/capture.html
+++ b/mediacapture-fromelement/capture.html
@@ -16,7 +16,8 @@ var makeAsyncTest = function(filename) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    var stream = video.captureStream() || video.mozCaptureStream();
+    var captureStream = (video.captureStream || video.mozCaptureStream);
+    var stream = captureStream.call();
 
     // onactive event is marked for deprecation (https://crbug.com/649328)
     stream.onactive = this.step_func_done(function() {

--- a/mediacapture-fromelement/capture.html
+++ b/mediacapture-fromelement/capture.html
@@ -3,6 +3,10 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="/common/vendor-prefix.js"
+        data-prefixed-prototypes=
+        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
+</script>
 </head>
 <body>
 <script>
@@ -16,8 +20,7 @@ var makeAsyncTest = function(filename) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    var captureStream = (video.captureStream || video.mozCaptureStream);
-    var stream = captureStream.call();
+    var stream = video.captureStream();
 
     // onactive event is marked for deprecation (https://crbug.com/649328)
     stream.onactive = this.step_func_done(function() {

--- a/mediacapture-fromelement/capture.html
+++ b/mediacapture-fromelement/capture.html
@@ -16,7 +16,7 @@ var makeAsyncTest = function(filename) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    var stream = video.captureStream();
+    var stream = video.captureStream() || video.mozCaptureStream();
 
     // onactive event is marked for deprecation (https://crbug.com/649328)
     stream.onactive = this.step_func_done(function() {

--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -18,7 +18,7 @@ var makeAsyncTest = function(filename, numTracks) {
 
     assert_true('captureStream' in video);
 
-    var stream = video.captureStream();
+    var stream = video.captureStream() || video.mozCaptureStream();
     assert_not_equals(stream, null, "error generating stream");
 
     // onactive event is marked for deprecation (https://crbug.com/649328)

--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -16,9 +16,8 @@ var makeAsyncTest = function(filename, numTracks) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    assert_true('captureStream' in video);
-
-    var stream = video.captureStream() || video.mozCaptureStream();
+    var captureStream = (video.captureStream || video.mozCaptureStream);
+    var stream = captureStream.call();
     assert_not_equals(stream, null, "error generating stream");
 
     // onactive event is marked for deprecation (https://crbug.com/649328)

--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -3,7 +3,6 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/resources/testharnessreport.js"></script>
 <script src="/common/vendor-prefix.js"
         data-prefixed-prototypes=
         '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>

--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -3,6 +3,11 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/vendor-prefix.js"
+        data-prefixed-prototypes=
+        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
+</script>
 </head>
 <body>
 <script>
@@ -16,8 +21,7 @@ var makeAsyncTest = function(filename, numTracks) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    var captureStream = (video.captureStream || video.mozCaptureStream);
-    var stream = captureStream.call();
+    var stream = video.captureStream();
     assert_not_equals(stream, null, "error generating stream");
 
     // onactive event is marked for deprecation (https://crbug.com/649328)

--- a/mediacapture-fromelement/ended.html
+++ b/mediacapture-fromelement/ended.html
@@ -17,9 +17,8 @@ var makeAsyncTest = function(filename) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    assert_true('captureStream' in video);
-
-    var stream = video.captureStream() || video.mozCaptureStream();
+    var captureStream = (video.captureStream || video.mozCaptureStream);
+    var stream = captureStream.call();
 
     stream.onremovetrack = this.step_func_done(function() {
       assert_true(video.ended, 'video must be ended');

--- a/mediacapture-fromelement/ended.html
+++ b/mediacapture-fromelement/ended.html
@@ -3,6 +3,10 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="/common/vendor-prefix.js"
+        data-prefixed-prototypes=
+        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
+</script>
 </head>
 <body>
 <script>
@@ -17,8 +21,7 @@ var makeAsyncTest = function(filename) {
     video.onerror = this.unreached_func("<video> error");
     video.play();
 
-    var captureStream = (video.captureStream || video.mozCaptureStream);
-    var stream = captureStream.call();
+    var stream = video.captureStream();
 
     stream.onremovetrack = this.step_func_done(function() {
       assert_true(video.ended, 'video must be ended');

--- a/mediacapture-fromelement/ended.html
+++ b/mediacapture-fromelement/ended.html
@@ -19,7 +19,7 @@ var makeAsyncTest = function(filename) {
 
     assert_true('captureStream' in video);
 
-    var stream = video.captureStream();
+    var stream = video.captureStream() || video.mozCaptureStream();
 
     stream.onremovetrack = this.step_func_done(function() {
       assert_true(video.ended, 'video must be ended');


### PR DESCRIPTION
Support Firefox moz-prefixed implementation of captureStream(), in parallel to the Chromium non-prefixed one.

@Pehrsons fyi.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
