### PR TITLE
Remove all tests on "If connection's [[IsClosed]] slot is true, abort these steps"

### DIFF
--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -169,27 +169,6 @@ a=rtcp-rsize
   }, 'Add ICE candidate before setting remote description should reject with InvalidStateError');
 
   /*
-    4.3.1.2.  Enqueue an operation
-      7.1.  If connection's [[isClosed]] slot is true, abort these steps.
-
-     4.3.2.  addIceCandidate
-      4.  Return the result of enqueuing the following steps:
-        1.  If remoteDescription is null return a promise rejected with a
-            newly created InvalidStateError.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    const promise = pc.addIceCandidate({
-      candidate: candidateStr1,
-      sdpMid, sdpMLineIndex, ufrag
-    });
-
-    pc.close();
-    return promise;
-  }, 'Add candidate when remote description is null should never resolve when pc is closed');
-
-  /*
     Success cases
    */
   promise_test(t => {
@@ -522,63 +501,6 @@ a=rtcp-rsize
           ufrag: ufrag
         })));
   }, 'Add candidate with sdpMid belonging to different ufrag should reject with OperationError');
-
-  /*
-    4.3.2.  addIceCandidate
-      3.  If both sdpMid and sdpMLineIndex are null, return a promise rejected
-          with a newly created TypeError.
-      4.  Return the result of enqueuing the following steps
-
-      (Rejects because step 3 comes first)
-
-    this test is being deferred until w3c/webrtc-pc#1345 is resolved
-
-  promise_test(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.setRemoteDescription(sessionDesc)
-    .then(() => {
-      const promise = pc.addIceCandidate({
-        candidate: candidateStr1,
-        sdpMid: null,
-        sdpMLineIndex: null
-      });
-
-      pc.close();
-      return promise_rejects(t, new TypeError(), promise);
-    });
-  }, 'Add candidate with both sdpMid and sdpMLineIndex null should still reject with TypeError after pc is closed');
-   */
-
-  /*
-    4.3.1.2.  Enqueue an operation
-      7.1.  If connection's [[isClosed]] slot is true, abort these steps.
-
-    4.3.2.  addIceCandidate
-      4.  Return the result of enqueuing the following steps
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.setRemoteDescription(sessionDesc)
-    .then(() => {
-      const promise = pc.addIceCandidate({
-        candidate: candidateStr1,
-        sdpMid, sdpMLineIndex, ufrag
-      });
-
-      pc.close();
-
-      // When pc is closed, the remote description is not modified
-      // even if succeed
-      t.step_timeout(t.step_func(() => {
-        assert_false(pc.remoteDescription.sdp.includes(candidateLine1),
-          'Candidate should not be added to SDP because pc is closed');
-      }), 80);
-
-      return promise;
-    });
-  }, 'Add valid candidate should never resolve when pc is closed');
 
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();

--- a/webrtc/RTCPeerConnection-onnegotiationneeded.html
+++ b/webrtc/RTCPeerConnection-onnegotiationneeded.html
@@ -120,20 +120,6 @@
     return awaitNegotiation(pc);
   }, 'task for negotiationneeded event should be enqueued for next tick');
 
-  /*
-    4.7.3.  Updating the Negotiation-Needed flag
-
-      To update the negotiation-needed flag
-      6.  Queue a task that runs the following steps:
-          1.  If connection's [[isClosed]] slot is true, abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-    pc.createDataChannel('test');
-    pc.close();
-    return awaitNegotiation(pc);
-  }, 'negotiationneeded event should not fire if connection is closed');
-
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
     pc.createDataChannel('foo');
@@ -216,7 +202,6 @@
       2.2.10. If connection's signaling state is now stable, update the negotiation-needed
               flag. If connection's [[NegotiationNeeded]] slot was true both before and after
               this update, queue a task that runs the following steps:
-        1.  If connection's [[IsClosed]] slot is true, abort these steps.
         2.  If connection's [[NegotiationNeeded]] slot is false, abort these steps.
         3.  Fire a simple event named negotiationneeded at connection.
    */
@@ -241,7 +226,6 @@
     4.7.3.  Updating the Negotiation-Needed flag
 
       To update the negotiation-needed flag
-      1.  If connection's [[isClosed]] slot is true, abort these steps.
       3.  If the result of checking if negotiation is needed is "false",
           clear the negotiation-needed flag by setting connection's
           [[needNegotiation]] slot to false, and abort these steps.
@@ -291,6 +275,12 @@
 
       stop
         11. Update the negotiation-needed flag for connection.
+
+    Untestable
+    4.7.3.  Updating the Negotiation-Needed flag
+      1.  If connection's [[isClosed]] slot is true, abort these steps.
+      6.  Queue a task that runs the following steps:
+          1.  If connection's [[isClosed]] slot is true, abort these steps.
    */
 
 </script>

--- a/webrtc/RTCPeerConnection-setLocalDescription.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription.html
@@ -146,23 +146,7 @@
           }))));
   }, 'Creating and setting offer multiple times should succeed');
 
-  /*
-    4.3.1.6.  Set the RTCSessionSessionDescription
-      2.2.1.  If connection's [[IsClosed]] slot is true, then abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.createOffer()
-    .then(offer => {
-      const promise = pc.setLocalDescription(offer);
-      pc.close();
-      return promise;
-    });
-  }, 'setLocalDescription(offer) should never resolve if connection is closed in parallel')
-
   /* setLocalDescription(answer) */
-
 
   /*
     4.3.1.6.  Set the RTCSessionSessionDescription

--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -91,21 +91,6 @@
 
   /*
     4.3.1.6.  Set the RTCSessionSessionDescription
-      2.2.1.  If connection's [[IsClosed]] slot is true, then abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return generateOffer()
-    .then(offer => {
-      const promise = pc.setRemoteDescription(offer);
-      pc.close();
-      return promise;
-    });
-  }, 'setRemoteDescription(offer) should never resolve if connection is closed in parallel')
-
-  /*
-    4.3.1.6.  Set the RTCSessionSessionDescription
       2.1.4.  If the content of description is not valid SDP syntax, then reject p with
               an RTCError (with errorDetail set to "sdp-syntax-error" and the
               sdpLineNumber attribute set to the line number in the SDP where the syntax

--- a/webrtc/RTCRtpSender-replaceTrack.html
+++ b/webrtc/RTCRtpSender-replaceTrack.html
@@ -220,29 +220,6 @@
   }, 'Calling replaceTrack on sender with similar track and and set to session description should resolve with sender.track set to new track');
 
   /*
-    5.2.  replaceTrack
-      Not 8.  If transceiver is not yet associated with a media description
-              [JSEP] (section 3.4.1.), then set sender's track attribute to
-              withTrack, and return a promise resolved with undefined.
-      10. Run the following steps in parallel:
-        3.  Queue a task that runs the following steps:
-          1.  If connection's [[isClosed]] slot is true, abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-    const track = generateMediaStreamTrack('audio');
-    const { transceiver: { sender } } = pc.addTransceiver('audio');
-
-    return pc.createOffer()
-    .then(offer => pc.setLocalDescription(offer))
-    .then(() => {
-      const promise = sender.replaceTrack(track);
-      pc.close();
-      return promise;
-    });
-  }, 'replaceTrack should never resolve if connection is closed in parallel');
-
-  /*
     TODO
       5.2.  replaceTrack
         To avoid track identifiers changing on the remote receiving end when
@@ -266,5 +243,7 @@
                 negotiating. Otherwise, have the sender switch seamlessly to
                 transmitting withTrack instead of the sender's existing track,
                 without negotiating.
+            3.  Queue a task that runs the following steps:
+              1.  If connection's [[isClosed]] slot is true, abort these steps.
    */
 </script>

--- a/webrtc/coverage/set-session-description.txt
+++ b/webrtc/coverage/set-session-description.txt
@@ -14,8 +14,7 @@ https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
     1.  If the process to apply description fails for any reason, then user agent
         MUST queue a task that runs the following steps:
 
-      [RTCPeerConnection-setLocalDescription]
-      [RTCPeerConnection-setRemoteDescription]
+      [Untestable]
       1.  If connection's [[IsClosed]] slot is true, then abort these steps.
 
       [Untestable]
@@ -47,8 +46,7 @@ https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
     2.  If description is applied successfully, the user agent MUST queue a task
         that runs the following steps:
 
-      [RTCPeerConnection-setLocalDescription]
-      [RTCPeerConnection-setRemoteDescription]
+      [Untestable]
       1.  If connection's [[isClosed]] slot is true, then abort these steps.
 
       [RTCPeerConnection-setLocalDescription]
@@ -218,7 +216,7 @@ https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
             flag. If connection's [[NegotiationNeeded]] slot was true both before and after
             this update, queue a task that runs the following steps:
 
-      [RTCPeerConnection-onnegotiationneeded]
+      [Untestable]
       1.  If connection's [[IsClosed]] slot is true, abort these steps.
 
       [RTCPeerConnection-onnegotiationneeded]


### PR DESCRIPTION
Fixes #6611 and #6612.

The steps require some very specific race conditions to be reacheable, and thus cannot reliably be tested. The original tests made some incorrect assumptions on the behavior of enqueuing operations to trigger the race condition. But as per discussion in w3c/webrtc-pc#1218, the steps for enqueing operations are designed specifically to match the legacy behavior of existing implementations. This puts us in an awkward position that we have to either write tests that pass on current implementations, or amend the spec so that it match the behavior of current implementations.

I can't see any other good way to test the statement _"If connection's [[IsClosed]] slot is true, abort these steps"_ that appear in various places in the spec. So I am marking them as untestable for now until we can figure some other way to test them.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
