### PR TITLE
Streams: Verify branding checks work for null and undefined values

### DIFF
--- a/streams/readable-streams/brand-checks.js
+++ b/streams/readable-streams/brand-checks.js
@@ -148,4 +148,26 @@ test(() => {
 
 }, 'ReadableStreamController.prototype.error enforces a brand check');
 
+promise_test(t => {
+
+  return Promise.all([
+    methodRejects(t, ReadableStream.prototype, 'cancel', null),
+    methodRejects(t, ReadableStream.prototype, 'cancel', undefined)
+  ]);
+
+}, 'ReadableStream brand checks do not throw on null or undefined');
+
+promise_test(t => {
+
+  return Promise.all([
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'read', undefined),
+    methodRejects(t, ReadableStreamDefaultReader.prototype, 'read', null)
+  ]);
+
+}, 'ReadableStreamDefaultReader brand checks do not throw on null or undefined');
+
+// There is no way to check ReadableStreamDefaultController brand checks for
+// null or undefined behaviour because all methods throw for a failed brand
+// check.
+
 done();

--- a/streams/readable-streams/brand-checks.js
+++ b/streams/readable-streams/brand-checks.js
@@ -74,20 +74,20 @@ function realRSDefaultController() {
 promise_test(t => {
 
   return methodRejectsForAll(t, ReadableStream.prototype, 'cancel',
-                             [fakeRS(), realRSDefaultReader(), realRSDefaultController()]);
+                             [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStream.prototype.cancel enforces a brand check');
 
 test(() => {
 
   methodThrowsForAll(ReadableStream.prototype, 'getReader',
-                     [fakeRS(), realRSDefaultReader(), realRSDefaultController()]);
+                     [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStream.prototype.getReader enforces a brand check');
 
 test(() => {
 
-  methodThrowsForAll(ReadableStream.prototype, 'tee', [fakeRS(), realRSDefaultReader(), realRSDefaultController()]);
+  methodThrowsForAll(ReadableStream.prototype, 'tee', [fakeRS(), realRSDefaultReader(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStream.prototype.tee enforces a brand check');
 
@@ -101,28 +101,28 @@ test(() => {
 promise_test(t => {
 
   return getterRejectsForAll(t, ReadableStreamDefaultReader.prototype, 'closed',
-                             [fakeRSDefaultReader(), realRS(), realRSDefaultController()]);
+                             [fakeRSDefaultReader(), realRS(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStreamDefaultReader.prototype.closed enforces a brand check');
 
 promise_test(t => {
 
-  return methodRejects(t, ReadableStreamDefaultReader.prototype, 'cancel',
-                       [fakeRSDefaultReader(), realRS(), realRSDefaultController()]);
+  return methodRejectsForAll(t, ReadableStreamDefaultReader.prototype, 'cancel',
+                             [fakeRSDefaultReader(), realRS(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStreamDefaultReader.prototype.cancel enforces a brand check');
 
 promise_test(t => {
 
-  return methodRejects(t, ReadableStreamDefaultReader.prototype, 'read',
-                       [fakeRSDefaultReader(), realRS(), realRSDefaultController()]);
+  return methodRejectsForAll(t, ReadableStreamDefaultReader.prototype, 'read',
+                             [fakeRSDefaultReader(), realRS(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStreamDefaultReader.prototype.read enforces a brand check');
 
 test(() => {
 
   methodThrowsForAll(ReadableStreamDefaultReader.prototype, 'releaseLock',
-                     [fakeRSDefaultReader(), realRS(), realRSDefaultController()]);
+                     [fakeRSDefaultReader(), realRS(), realRSDefaultController(), undefined, null]);
 
 }, 'ReadableStreamDefaultReader.prototype.releaseLock enforces a brand check');
 
@@ -143,21 +143,21 @@ test(() => {
 test(() => {
 
   methodThrowsForAll(ReadableStreamDefaultController.prototype, 'close',
-                     [fakeRSDefaultController(), realRS(), realRSDefaultReader()]);
+                     [fakeRSDefaultController(), realRS(), realRSDefaultReader(), undefined, null]);
 
 }, 'ReadableStreamDefaultController.prototype.close enforces a brand check');
 
 test(() => {
 
   methodThrowsForAll(ReadableStreamDefaultController.prototype, 'enqueue',
-                     [fakeRSDefaultController(), realRS(), realRSDefaultReader()]);
+                     [fakeRSDefaultController(), realRS(), realRSDefaultReader(), undefined, null]);
 
 }, 'ReadableStreamDefaultController.prototype.enqueue enforces a brand check');
 
 test(() => {
 
   methodThrowsForAll(ReadableStreamDefaultController.prototype, 'error',
-                     [fakeRSDefaultController(), realRS(), realRSDefaultReader()]);
+                     [fakeRSDefaultController(), realRS(), realRSDefaultReader(), undefined, null]);
 
 }, 'ReadableStreamDefaultController.prototype.error enforces a brand check');
 

--- a/streams/resources/test-utils.js
+++ b/streams/resources/test-utils.js
@@ -3,13 +3,22 @@
 self.getterRejects = (t, obj, getterName, target) => {
   const getter = Object.getOwnPropertyDescriptor(obj, getterName).get;
 
-  return promise_rejects(t, new TypeError(), getter.call(target));
+  return promise_rejects(t, new TypeError(), getter.call(target), getterName + ' should reject with a TypeError');
+};
+
+self.getterRejectsForAll = (t, obj, getterName, targets) => {
+  return Promise.all(targets.map(target => getterRejects(t, obj, getterName, target)));
 };
 
 self.methodRejects = (t, obj, methodName, target, args) => {
   const method = obj[methodName];
 
-  return promise_rejects(t, new TypeError(), method.apply(target, args));
+  return promise_rejects(t, new TypeError(), method.apply(target, args),
+                         methodName + ' should reject with a TypeError');
+};
+
+self.methodRejectsForAll =  (t, obj, methodName, targets, args) => {
+  return Promise.all(targets.map(target => methodRejects(t, obj, methodName, target, args)));
 };
 
 self.getterThrows = (obj, getterName, target) => {
@@ -18,11 +27,19 @@ self.getterThrows = (obj, getterName, target) => {
   assert_throws(new TypeError(), () => getter.call(target), getterName + ' should throw a TypeError');
 };
 
+self.getterThrowsForAll = (obj, getterName, targets) => {
+  targets.forEach(target => getterThrows(obj, getterName, target));
+}
+
 self.methodThrows = (obj, methodName, target, args) => {
   const method = obj[methodName];
 
   assert_throws(new TypeError(), () => method.apply(target, args), methodName + ' should throw a TypeError');
 };
+
+self.methodThrowsForAll = (obj, methodName, targets, args) => {
+  targets.forEach(target => methodThrows(obj, methodName, target, args));
+}
 
 self.garbageCollect = () => {
   if (self.gc) {

--- a/streams/writable-streams/brand-checks.html
+++ b/streams/writable-streams/brand-checks.html
@@ -5,6 +5,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-
+<script src="../resources/test-utils.js"></script>
 
 <script src="brand-checks.js"></script>

--- a/streams/writable-streams/brand-checks.js
+++ b/streams/writable-streams/brand-checks.js
@@ -86,7 +86,6 @@ promise_test(t => {
   return Promise.all([
     methodRejects(t, WriterProto, 'abort', undefined),
     methodRejects(t, WriterProto, 'abort', null)]);
-
 }, 'WritableStreamDefaultWriter brand checks do not throw on null or undefined');
 
 // WritableStreamDefaultController brand checks cannot be tested for undefined

--- a/streams/writable-streams/brand-checks.js
+++ b/streams/writable-streams/brand-checks.js
@@ -109,6 +109,6 @@ promise_test(t => {
 test(() => {
   methodThrowsForAll(WritableStreamDefaultController.prototype, 'error',
                      [fakeWSDefaultController(), realWS(), realWSDefaultWriter(), undefined, null]);
-}, 'WritableStreamDefaultController.prototype.error enforces a branch check');
+}, 'WritableStreamDefaultController.prototype.error enforces a brand check');
 
 done();

--- a/streams/writable-streams/brand-checks.js
+++ b/streams/writable-streams/brand-checks.js
@@ -60,7 +60,7 @@ promise_test(t => {
     getterRejects(t, WriterProto, 'ready', realReadableStreamDefaultWriter())]);
 }, 'WritableStreamDefaultWriter.prototype.ready enforces a brand check');
 
-test(t => {
+promise_test(t => {
   return Promise.all([methodRejects(t, WriterProto, 'abort', fakeWritableStreamDefaultWriter()),
     methodRejects(t, WriterProto, 'abort', realReadableStreamDefaultWriter())]);
 
@@ -75,5 +75,22 @@ promise_test(t => {
   return Promise.all([methodRejects(t, WriterProto, 'close', fakeWritableStreamDefaultWriter()),
     methodRejects(t, WriterProto, 'close', realReadableStreamDefaultWriter())]);
 }, 'WritableStreamDefaultWriter.prototype.close enforces a brand check');
+
+promise_test(t => {
+  return Promise.all([
+    methodRejects(t, WritableStream.prototype, 'abort', undefined),
+    methodRejects(t, WritableStream.prototype, 'abort', null)]);
+}, 'WritableStream brand checks do not throw on null or undefined');
+
+promise_test(t => {
+  return Promise.all([
+    methodRejects(t, WriterProto, 'abort', undefined),
+    methodRejects(t, WriterProto, 'abort', null)]);
+
+}, 'WritableStreamDefaultWriter brand checks do not throw on null or undefined');
+
+// WritableStreamDefaultController brand checks cannot be tested for undefined
+// or null behaviour because error() always throws TypeError on a branding check
+// failure.
 
 done();

--- a/streams/writable-streams/brand-checks.js
+++ b/streams/writable-streams/brand-checks.js
@@ -5,9 +5,7 @@ if (self.importScripts) {
   self.importScripts('../resources/test-utils.js');
 }
 
-const ws = new WritableStream();
-const writer = ws.getWriter();
-const WritableStreamDefaultWriter = writer.constructor;
+const WritableStreamDefaultWriter = new WritableStream().getWriter().constructor;
 const WriterProto = WritableStreamDefaultWriter.prototype;
 const WritableStreamDefaultController = getWritableStreamDefaultControllerConstructor();
 
@@ -61,47 +59,56 @@ function realWSDefaultController() {
 
 test(() => {
   getterThrowsForAll(WritableStream.prototype, 'locked',
-                     [fakeWS(), realWSDefaultWriter(), realWSDefaultController()]);
+                     [fakeWS(), realWSDefaultWriter(), realWSDefaultController(), undefined, null]);
 }, 'WritableStream.prototype.locked enforces a brand check');
 
 promise_test(t => {
   return methodRejectsForAll(t, WritableStream.prototype, 'abort',
-                             [fakeWS(), realWSDefaultWriter(), realWSDefaultController()]);
+                             [fakeWS(), realWSDefaultWriter(), realWSDefaultController(), undefined, null]);
 }, 'WritableStream.prototype.abort enforces a brand check');
 
-test(t => {
+test(() => {
   methodThrowsForAll(WritableStream.prototype, 'getWriter',
-                     [fakeWS(), realWSDefaultWriter(), realWSDefaultController()]);
+                     [fakeWS(), realWSDefaultWriter(), realWSDefaultController(), undefined, null]);
 }, 'WritableStream.prototype.getWriter enforces a brand check');
 
 test(() => {
+  assert_throws(new TypeError(), () => new WritableStreamDefaultWriter(fakeWS()), 'constructor should throw');
+}, 'WritableStreamDefaultWriter constructor enforces a brand check');
+
+test(() => {
   getterThrowsForAll(WriterProto, 'desiredSize',
-                     [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                     [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.desiredSize enforces a brand check');
 
 promise_test(t => {
   return getterRejectsForAll(t, WriterProto, 'closed',
-                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.closed enforces a brand check');
 
 promise_test(t => {
   return getterRejectsForAll(t, WriterProto, 'ready',
-                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.ready enforces a brand check');
 
 promise_test(t => {
   return methodRejectsForAll(t, WriterProto, 'abort',
-                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.abort enforces a brand check');
 
 promise_test(t => {
   return methodRejectsForAll(t, WriterProto, 'write',
-                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.write enforces a brand check');
 
 promise_test(t => {
   return methodRejectsForAll(t, WriterProto, 'close',
-                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController()]);
+                             [fakeWSDefaultWriter(), realWS(), realWSDefaultController(), undefined, null]);
 }, 'WritableStreamDefaultWriter.prototype.close enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(WritableStreamDefaultController.prototype, 'error',
+                     [fakeWSDefaultController(), realWS(), realWSDefaultWriter(), undefined, null]);
+}, 'WritableStreamDefaultController.prototype.error enforces a branch check');
 
 done();


### PR DESCRIPTION
When a branding check fails for a Streams API method that returns a
Promise, a rejected Promise should be returned. Chrome had a bug where
a TypeError would be thrown in the specific case that `this` was null or
undefined. Add tests for these cases.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
