### PR TITLE
Stop running python tests on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,8 +68,6 @@ matrix:
         - SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:MicrosoftEdge:14.14393 PLATFORM='Windows 10'
     - python: 2.7
       env: TOXENV=py27 HYPOTHESIS_PROFILE=ci SCRIPT=tools/ci/ci_unittest.sh
-    - python: 3.5
-      env: TOXENV=py35 HYPOTHESIS_PROFILE=ci SCRIPT=tools/ci/ci_unittest.sh
     - python: 3.6
       env: TOXENV=py36 HYPOTHESIS_PROFILE=ci SCRIPT=tools/ci/ci_unittest.sh
     - python: pypy-5.4

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,pypy
+envlist = py27,py36,pypy
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
Since we are running 3.6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6630)
<!-- Reviewable:end -->
