### PR TITLE
Remove more tests on "If IsClosed is true, abort these steps"

### DIFF
--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -2,15 +2,11 @@
 <title>Test RTCPeerConnection.prototype.addIceCandidate</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="RTCPeerConnection-helper.js"></script>
 <script>
   'use strict';
 
   // Test is based on the following editor draft:
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.htm
-
-  // The following helper functions are called from RTCPeerConnection-helper.js:
-  // test_never_resolve
 
   /*
     4.3.2.  Interface Definition
@@ -501,53 +497,6 @@ a=rtcp-rsize
           ufrag: ufrag
         })));
   }, 'Add candidate with sdpMid belonging to different ufrag should reject with OperationError');
-
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.setRemoteDescription(sessionDesc)
-    .then(() => {
-      const promise = pc.addIceCandidate({
-        candidate: invalidCandidateStr,
-        sdpMid, sdpMLineIndex, ufrag
-      });
-
-      pc.close();
-      return promise;
-    });
-  }, 'Add candidate with invalid candidate string should never resolve when pc is closed');
-
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.setRemoteDescription(sessionDesc)
-    .then(() => {
-      const promise = pc.addIceCandidate({
-        candidate: candidateStr1,
-        sdpMid: 'invalid',
-        sdpMLineIndex, ufrag
-      });
-
-      pc.close();
-      return promise;
-    });
-  }, 'Add candidate with invalid sdpMid should never resolve when pc is closed');
-
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.setRemoteDescription(sessionDesc)
-    .then(() => {
-      const promise = pc.addIceCandidate({
-        candidate: candidateStr1,
-        sdpMLineIndex: 2,
-        ufrag
-      });
-
-      pc.close();
-      return promise;
-    });
-  }, 'Add candidate with invalid sdpMLineIndex should never resolve when pc is closed');
 
   /*
     TODO

--- a/webrtc/RTCPeerConnection-createAnswer.html
+++ b/webrtc/RTCPeerConnection-createAnswer.html
@@ -13,7 +13,6 @@
   // The following helper functions are called from RTCPeerConnection-helper.js:
   //   generateOffer()
   //   generateAnswer()
-  //   test_never_resolve()
 
   /*
    * 4.3.2. createAnswer()
@@ -60,18 +59,6 @@
         pc.createAnswer());
     });
   }, 'createAnswer() when connection is closed reject with InvalidStateError');
-
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return generateOffer({ data: true })
-    .then(offer => pc.setRemoteDescription(offer))
-    .then(() => {
-      const promise = pc.createAnswer();
-      pc.close();
-      return promise;
-    });
-  }, 'createAnswer() when connection is closed in parallel should never resolve');
 
   /*
    *  TODO

--- a/webrtc/RTCPeerConnection-createOffer.html
+++ b/webrtc/RTCPeerConnection-createOffer.html
@@ -16,7 +16,6 @@
   //   countAudioLine()
   //   countVideoLine()
   //   test_state_change_event()
-  //   test_never_resolve()
   //   assert_session_desc_equals()
 
   /*
@@ -64,15 +63,6 @@
     return promise_rejects(t, 'InvalidStateError',
       pc.createOffer());
   }, 'createOffer() after connection is closed should reject with InvalidStateError');
-
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-    const promise = pc.createOffer();
-
-    pc.close();
-    return promise;
-
-  }, 'createOffer() when connection is closed halfway should never resolve');
 
   /*
    *  Final steps to create an offer

--- a/webrtc/RTCPeerConnection-onnegotiationneeded.html
+++ b/webrtc/RTCPeerConnection-onnegotiationneeded.html
@@ -3,13 +3,16 @@
 <title>Test RTCPeerConnection.prototype.onnegotiationneeded</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
 <script>
   'use strict';
 
   // Test is based on the following editor draft:
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
-  /* Helper Functions */
+  // The following helper functions are called from RTCPeerConnection-helper.js:
+  //   generateAnswer
+  //   test_never_resolve
 
   // Listen to the negotiationneeded event on a peer connection
   // Returns a promise that resolves when the first event is fired.
@@ -57,33 +60,6 @@
         secondResolved = true;
       }, reject);
     });
-  }
-
-  // Run a test function that return a promise that should
-  // never be resolved. For lack of better options,
-  // we wait for a time out and pass the test if the
-  // promise doesn't resolve within that time.
-  function test_never_resolve(testFunc, testName) {
-    async_test(t => {
-      testFunc(t)
-      .then(
-        t.step_func(result => {
-          assert_unreached(`Pending promise should never be resolved. Instead it is fulfilled with: ${result}`);
-        }),
-        t.step_func(err => {
-          assert_unreached(`Pending promise should never be resolved. Instead it is rejected with: ${err}`);
-        }));
-
-      t.step_timeout(t.step_func_done(), 200)
-    }, testName);
-  }
-
-  // Helper function to generate answer based on given offer using a freshly
-  // created RTCPeerConnection object
-  function generateAnswer(offer) {
-    const pc = new RTCPeerConnection();
-    return pc.setRemoteDescription(offer)
-    .then(() => pc.createAnswer());
   }
 
   /*

--- a/webrtc/RTCPeerConnection-setLocalDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-offer.html
@@ -15,7 +15,6 @@
   //   assert_session_desc_not_equals
   //   assert_session_desc_equals
   //   test_state_change_event
-  //   test_never_resolve
 
   /*
     4.3.2.  Interface Definition
@@ -144,20 +143,5 @@
             assert_equals(pc.currentLocalDescription, null);
           }))));
   }, 'Creating and setting offer multiple times should succeed');
-
-  /*
-    4.3.1.6.  Set the RTCSessionSessionDescription
-      2.2.1.  If connection's [[IsClosed]] slot is true, then abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return pc.createOffer()
-    .then(offer => {
-      const promise = pc.setLocalDescription(offer);
-      pc.close();
-      return promise;
-    });
-  }, 'setLocalDescription(offer) should never resolve if connection is closed in parallel')
 
 </script>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -14,7 +14,6 @@
   //   generateOffer()
   //   assert_session_desc_equals()
   //   test_state_change_event()
-  //   test_never_resolve()
 
   /*
     4.3.2.  Interface Definition
@@ -86,21 +85,6 @@
         assert_equals(pc.currentRemoteDescription, null);
       }));
   }, 'Setting remote description multiple times with different offer should succeed');
-
-  /*
-    4.3.1.6.  Set the RTCSessionSessionDescription
-      2.2.1.  If connection's [[IsClosed]] slot is true, then abort these steps.
-   */
-  test_never_resolve(t => {
-    const pc = new RTCPeerConnection();
-
-    return generateOffer()
-    .then(offer => {
-      const promise = pc.setRemoteDescription(offer);
-      pc.close();
-      return promise;
-    });
-  }, 'setRemoteDescription(offer) should never resolve if connection is closed in parallel')
 
   /*
     4.3.1.6.  Set the RTCSessionSessionDescription


### PR DESCRIPTION
This is a succession of #6616. It do some removal again on some removal undone by #6629. I also removed a couple more tests I missed out that in #6616 that test on the behavior of enqueue operations if-closed-then-abort race condition.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
