### PR TITLE
Add test for show(): If payment method consultation produces no suppo…

### DIFF
--- a/payment-request/payment-request-show-method.https.html
+++ b/payment-request/payment-request-show-method.https.html
@@ -37,4 +37,11 @@ promise_test(async t => {
   await promise_rejects(t, "AbortError", acceptPromise1);
 }, `If the user agent's "payment request is showing" boolean is true, then return a promise rejected with an "AbortError" DOMException.`);
 
+promise_test(async t => {
+  const request = new PaymentRequest(
+    [{ supportedMethods: "this-is-not-supported" }],
+    defaultDetails);
+  const acceptPromise = request.show();
+  await promise_rejects(t, "NotSupportedError", acceptPromise);
+}, `If payment method consultation produces no supported method of payment, then return a promise rejected with a "NotSupportedError" DOMException.`);
 </script>


### PR DESCRIPTION
…rted method of payment, then return a promise rejected with a "NotSupportedError" DOMException.

Per step 12 in [section 4.3 - show() method](https://w3c.github.io/payment-request/#show()-method):

> If this consultation produced no supported method of paying, then reject acceptPromise with a "NotSupportedError" DOMException, and set the user agent's payment request is showing boolean to false.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
