### PR TITLE
webrtc/dictionary-helper.js: follow up corrections to assert_dict_field

### DIFF
--- a/webrtc/dictionary-helper.js
+++ b/webrtc/dictionary-helper.js
@@ -39,10 +39,10 @@ function assert_array_field(object, field) {
 }
 
 function assert_dict_field(object, field) {
-  assert_equals(typeof object, 'object',
-    `Expect dictionary to be plain object`);
+  assert_equals(typeof object[field], 'object',
+    `Expect dictionary.${field} to be plain object`);
 
-  assert_not_equals(object, null,
+  assert_not_equals(object[field], null,
     `Expect dictionary.${field} to not be null`);
 }
 


### PR DESCRIPTION
The previous fix misunderstood the intent, this corrects that

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>

<!-- Reviewable:start -->

<!-- Reviewable:end -->
