### PR TITLE
Rework transition event tests

### DIFF
--- a/css/css-transitions-1/events-001.html
+++ b/css/css-transitions-1/events-001.html
@@ -1,210 +1,171 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <title>CSS Transitions Test: transitionend event for shorthand property</title>
-        <meta name="assert" content="Test checks that all transitionend events are triggered for shorthand property">
-        <link rel="help" title="2.1. The 'transition-property' Property" href="http://www.w3.org/TR/css3-transitions/#transition-property-property">
-        <link rel="help" title="5. Transition Events" href="http://www.w3.org/TR/css3-transitions/#transition-events">
-        <link rel="author" title="Rodney Rehm" href="http://rodneyrehm.de/en/">
-        <meta name="flags" content="dom">
+<head>
+<meta charset=utf-8>
+<title>CSS Transitions Test: transitionend event for shorthand property</title>
+<meta name="assert" content="This test checks that all transitionend events are triggered for shorthand property">
+<link rel="help" href="http://www.w3.org/TR/css3-transitions/#transition-property-property">
+<link rel="help" href="http://www.w3.org/TR/css3-transitions/#transition-events">
+<link rel="author" title="Rodney Rehm" href="http://rodneyrehm.de/en/">
 
-        <script src="/resources/testharness.js" type="text/javascript"></script>
-        <script src="/resources/testharnessreport.js" type="text/javascript"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="./support/helper.js"></script>
 
-        <script src="./support/vendorPrefix.js" type="text/javascript"></script>
-        <script src="./support/helper.js" type="text/javascript"></script>
-        <script src="./support/runParallelAsyncHarness.js" type="text/javascript"></script>
-        <script src="./support/generalParallelTest.js" type="text/javascript"></script>
-        <script src="./support/properties.js" type="text/javascript"></script>
+</head>
+<body>
 
-        <style type="text/css">
-            #offscreen {
-                position: absolute;
-                top: -100000px;
-                left: -100000px;
-                width: 100000px;
-                height: 100000px;
-            }
-        </style>
+<script>
+function assert_end_events_equal(evt, propertyName, elapsedTime,
+                                 pseudoElement = '') {
+  assert_equals(evt.propertyName, propertyName);
+  assert_times_equal(evt.elapsedTime, elapsedTime);
+  assert_equals(evt.pseudoElement, pseudoElement);
+}
 
-        <script id="metadata_cache">/*
-        {
-          "transition:all, changing padding-left / events": {},
-          "transition:all, changing padding / events": {},
-          "transition:all, changing padding but not padding-bottom / events": {},
-          "transition:padding, changing padding-left / events": {},
-          "transition:padding, changing padding / events": {},
-          "transition:padding, changing padding but not padding-bottom / events": {},
-          "transition:padding-left, changing padding-left / events": {},
-          "transition:padding-left, changing padding / events": {},
-          "transition:padding-left, changing padding but not padding-bottom / events": {}
-        }
-        */</script>
-    </head>
-    <body>
-        <!-- required by testharnessreport.js -->
-        <div id="log"></div>
-        <!-- elements used for testing -->
-        <div id="fixture" class="fixture">
-            <div class="container">
-                <div class="transition">Text sample</div>
-            </div>
-        </div>
-        <div id="offscreen"></div>
+function assert_end_event_batch_equal(evts, propertyNames, elapsedTime,
+                                      pseudoElement = '') {
+  assert_equals(evts.length, propertyNames.length,
+                'Test harness error: should have waited for the correct'
+                + ' number of events');
 
-        <!--
-            SEE ./support/README.md for an abstract explanation of the test procedure
-            http://test.csswg.org/source/contributors/rodneyrehm/submitted/css3-transitions/README.md
-        -->
+  evts.sort((a, b) => a.propertyName.localeCompare(b.propertyName));
+  propertyNames.sort((a, b) => a.localeCompare(b));
+  for (let evt of evts) {
+    assert_end_events_equal(evt, propertyNames.shift(), elapsedTime,
+                            pseudoElement);
+  }
+}
 
-        <script>
-            // For the keyword ‘all’, or if one of the identifiers listed is a shorthand property, implementations must
-            // start transitions for any of its longhand sub-properties that are animatable (or, for ‘all’, all animatable
-            // properties), using the duration, delay, and timing function at the index corresponding to the shorthand.
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
 
-            // this test takes its time, give it a minute to run
-            var timeout = 60000;
-            setup({timeout: timeout});
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:all changing padding-left');
 
-            var tests = [
-                {
-                    name: "transition:all, changing padding-left",
-                    transitions: 'all .1s linear .01s',
-                    from: {'padding-left': '1px'},
-                    to: {'padding-left': '10px'},
-                    expect: [
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:all, changing padding",
-                    transitions: 'all .1s linear .01s',
-                    from: {'padding': '1px'},
-                    to: {'padding': '10px'},
-                    expect: [
-                        'padding-top:0.1s',
-                        'padding-right:0.1s',
-                        'padding-bottom:0.1s',
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:all, changing padding but not padding-bottom",
-                    transitions: 'all .1s linear .01s',
-                    from: {'padding': '1px 1px 1px 1px'},
-                    to: {'padding': '10px 10px 1px 10px'},
-                    expect: [
-                        'padding-top:0.1s',
-                        'padding-right:0.1s',
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding, changing padding-left",
-                    transitions: 'padding .1s linear .01s',
-                    from: {'padding-left': '1px'},
-                    to: {'padding-left': '10px'},
-                    expect: [
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding, changing padding",
-                    transitions: 'padding .1s linear .01s',
-                    from: {'padding': '1px'},
-                    to: {'padding': '10px'},
-                    expect: [
-                        'padding-top:0.1s',
-                        'padding-right:0.1s',
-                        'padding-bottom:0.1s',
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding, changing padding but not padding-bottom",
-                    transitions: 'padding .1s linear .01s',
-                    from: {'padding': '1px 1px 1px 1px'},
-                    to: {'padding': '10px 10px 1px 10px'},
-                    expect: [
-                        'padding-top:0.1s',
-                        'padding-right:0.1s',
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding-left, changing padding-left",
-                    transitions: 'padding-left .1s linear .01s',
-                    from: {'padding-left': '1px'},
-                    to: {'padding-left': '10px'},
-                    expect: [
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding-left, changing padding",
-                    transitions: 'padding-left .1s linear .01s',
-                    from: {'padding': '1px'},
-                    to: {'padding': '10px'},
-                    expect: [
-                        'padding-left:0.1s'
-                    ]
-                }, {
-                    name: "transition:padding-left, changing padding but not padding-bottom",
-                    transitions: 'padding-left .1s linear .01s',
-                    from: {'padding': '1px 1px 1px 1px'},
-                    to: {'padding': '10px 10px 1px 10px'},
-                    expect: [
-                        'padding-left:0.1s'
-                    ]
-                }
-            ];
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
 
-            // general transition-duration
-            var duration = '0.5s';
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(4).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-bottom',
+                                   'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:all changing padding');
 
-            runParallelAsyncHarness({
-                // array of test data
-                tests: tests,
-                // the number of tests to run in parallel
-                testsPerSlice: 50,
-                // milliseconds to wait before calling teardown and ending test
-                duration: parseFloat(duration) * 1000,
-                // the global suite timeout
-                timeout: timeout,
-                // prepare individual test
-                setup: function(data, options) {
-                    var styles = {
-                        '.fixture': {},
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: all .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
 
-                        '.container': {},
-                        '.container.to': {},
-                        '.container.how': {},
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(3).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:all changing padding but not padding-bottom');
 
-                        '.transition': data.from,
-                        '.transition.to' : data.to,
-                        '.transition.how' : {transition: data.transitions}
-                    };
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
 
-                    generalParallelTest.setup(data, options);
-                    generalParallelTest.addStyles(data, options, styles);
-                },
-                // cleanup after individual test
-                teardown: generalParallelTest.teardown,
-                // invoked prior to running a slice of tests
-                sliceStart: generalParallelTest.sliceStart,
-                // invoked after running a slice of tests
-                sliceDone: generalParallelTest.sliceDone,
-                // test cases, make them as granular as possible
-                cases: {
-                    // test TransitionEnd events
-                    'events': {
-                        start: function(test, data, options) {
-                            // kick off the transition
-                            generalParallelTest.startTransition(data);
-                        },
-                        done: function(test, data, options) {
-                            // make sure we got the event for the tested property only
-                            test.step(generalParallelTest.assertExpectedEventsFunc(data, 'transition', data.expect));
-                        }
-                    }
-                },
-                // called once all tests are done
-                done: generalParallelTest.done
-            });
-        </script>
-    </body>
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding changing padding-left');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(4).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-bottom',
+                                   'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:padding changing padding');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for(Array(3).fill('transitionend'),
+                          { record: 'all' }).then(evts => {
+    assert_end_event_batch_equal(evts,
+                                 [ 'padding-left',
+                                   'padding-right',
+                                   'padding-top' ],
+                                 0.01);
+  });
+}, 'transition:padding changing padding but not padding-bottom');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding-left: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.paddingLeft = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding-left');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding');
+
+promise_test(t => {
+  const div = addDiv(t, { style: 'transition: padding-left .01s linear; ' +
+                                 'padding: 1px' });
+  getComputedStyle(div).paddingLeft;
+  div.style.padding = '10px 10px 1px 10px';
+
+  const watcher = new EventWatcher(t, div, [ 'transitionend' ]);
+  return watcher.wait_for('transitionend').then(evt => {
+    assert_end_events_equal(evt, 'padding-left', 0.01);
+  });
+}, 'transition:padding-left changing padding but not padding-bottom');
+</script>
+</body>
 </html>


### PR DESCRIPTION
I would like to simplify the tests in CSS transitions, beginning with the events tests so that I can add tests for the new `transitionrun`, `transitionstart`, and `transitioncancel` events.

I have a few concerns with the current tests:

* They seem overly complicated:
  * One is required to read an extra README simply to make head or tails of what the test is doing.
  * They require a lot of boilerplate.
  * They are far from minimal. When we were analyzing why `properties-value-implicit-001.html` was failing in [Mozilla bug 1356627](https://bugzilla.mozilla.org/show_bug.cgi?id=1356627) I discovered it was failing because somewhere deep in the test harness it was failing in the way it was waiting on `transitionend` events, something that seems completely unrelated to what should be under test in that file.
  * As a result it is time-consuming to reduce a failing test case for debugging.
* They make little use of existing `testharness.js` features such as `EventWatcher` etc. As a result, more unfamiliar boilerplate/libraries are required.
* They are brittle. In Gecko we had to [disable the entire css-transitions folder of tests](https://bugzilla.mozilla.org/show_bug.cgi?id=1356627) because they had so many intermittent failures.

I'd like to try rewriting these tests, keeping roughly the same test coverage, but taking a simpler approach.

Note that the changes to `EventWatcher` should be merged in #6634 and are not part of this PR.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
