### PR TITLE
Refactor @font-feature-values test and make it match with spec.

### DIFF
--- a/css/css-fonts-3/test_font_feature_values_parsing.html
+++ b/css/css-fonts-3/test_font_feature_values_parsing.html
@@ -152,8 +152,8 @@ var testrules = [
   { rule: makeRule("--bongo", "@styleset { blah: 1; }"), invalid: true },
 
   /* ident tests */
-  { rule: _("@styleset { blah: 1; blah: 1; }"), serializationSame: true },
-  { rule: _("@styleset { blah: 1; de-blah: 1; blah: 2; }"), serializationSame: true },
+  { rule: _("@styleset { blah: 1; blah: 1; }"), serialization: _("@styleset { blah: 1; }") },
+  { rule: _("@styleset { blah: 1; de-blah: 1; blah: 2; }"), serialization: _("@styleset { blah: 2; de-blah: 1; }") },
   { rule: _("@styleset { \\tra-la: 1; }"), serialization: _("@styleset { tra-la: 1; }") },
   { rule: _("@styleset { b\\lah: 1; }"), serialization: _("@styleset { blah: 1; }") },
   { rule: _("@styleset { \\62 lah: 1; }"), serialization: _("@styleset { blah: 1; }") },


### PR DESCRIPTION
According to [spec][spec-link],
> If the same identifier is defined mulitple times for a given feature type and font family, the last defined value is used.

But currently we have two tests that checks otherwise. Tests should match with spec here.
cc @upsuper 

[spec-link]: https://drafts.csswg.org/css-fonts-3/#basic-syntax

<!-- Reviewable:start -->

<!-- Reviewable:end -->
