### PR TITLE
Sync Mozilla tests as of 2017-07-28

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-10.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-10.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-11.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-11.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-12.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-12.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-13.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-13.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-14-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-14-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-14.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-14.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-15-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-15-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-15.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-15.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-3.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-4.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-5.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-6.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-7.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-8-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-8-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-8.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-9.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-9.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-block-page-break-inside-avoid-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-2-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-2-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-3.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-4.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-5-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-5-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-5.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-6-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-6-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-6.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-7-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-7-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-7.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-8-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-8-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-8.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-9-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-9-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-9.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-float-page-break-inside-avoid-9.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-inline-page-break-inside-avoid-1-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-inline-page-break-inside-avoid-1-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-inline-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-inline-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-row-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-row-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-row-page-break-inside-avoid-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-row-page-break-inside-avoid-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-3.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-4-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-4-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-4.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-5-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-5-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-5.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-6.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-7-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-7-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-7.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-8-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-8-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-8.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-rowgroup-page-break-inside-avoid-8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-2-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-2-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-2.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-3-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-3-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-3.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-3.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-4-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-4-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-4.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-4.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-5-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-5-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-5.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-5.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-6-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-6-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-6.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-6.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-7-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-7-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-7.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-7.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-8.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-8.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/css21/pagination/moz-css21-table-page-break-inside-avoid-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US" class="reftest-print">
+<html lang="en-US" class="reftest-paged">
 <head>
   <title>CSS Test: CSS 2.1 page-break-inside:avoid</title>
   <link rel="author" title="Mats Palmgren" href="https://bugzilla.mozilla.org/show_bug.cgi?id=685012">

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/reftest.list
@@ -27,6 +27,7 @@
 == mask-image-3c.html mask-image-3-ref.html
 == mask-image-3d.html mask-image-3-ref.html
 == mask-image-3e.html mask-image-3-ref.html
+# Due to SVG luminance, see bug 1372577, parent process doesn't use d2d for luminance.
 == mask-image-3f.html mask-image-3-ref.html
 == mask-image-3g.html mask-image-3-ref.html
 == mask-image-3h.html mask-image-3-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/multicol-height-002.xht
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/multicol-height-002.xht
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head class="reftest-print">
+ <head class="reftest-paged">
   <title>CSS Test: Percentage Computed Height on Multicol Child (Definite Multicol Height)</title>
   <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
   <link rel="help" href="http://www.w3.org/TR/css3-multicol/#the-multi-column-model" />

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reference/multicol-height-002.xht
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/multicol3/reference/multicol-height-002.xht
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
- <head class="reftest-print">
+ <head class="reftest-paged">
   <title>CSS Reftest Reference</title>
   <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
   <style type="text/css"><![CDATA[


### PR DESCRIPTION
This change was already reviewed in [Bug 1382327](https://bugzilla.mozilla.org/show_bug.cgi?id=1382327).

It's not clear to me that these tests belong in web-platform-tests, since I don't think we ever agreed to add paginated reftests to the CSS reftest format, though perhaps we *should* look into doing so officially...  However, renaming doesn't make this any worse or better since these are all of the tests in web-platform-tests that use reftest-print, and sync'ing this at least keeps the repositories in sync.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
