### PR TITLE
Streams: Test for pipeThrough undefined guard

### DIFF
--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -30,7 +30,9 @@ function duckTypedPassThroughTransform() {
   };
 }
 
-const uninterestingReadableWritablePair = { writable: new WritableStream(), readable: new ReadableStream() };
+function uninterestingReadableWritablePair() {
+  return { writable: new WritableStream(), readable: new ReadableStream() };
+}
 
 promise_test(() => {
   const readableEnd = sequentialReadableStream(5).pipeThrough(duckTypedPassThroughTransform());
@@ -84,7 +86,7 @@ test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair());
 
   // Test passes if this doesn't throw or crash.
 
@@ -100,7 +102,7 @@ test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair());
 
   // Test passes if this doesn't throw or crash.
 
@@ -113,7 +115,7 @@ promise_test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair());
 
   // The test harness should complain about unhandled rejections by then.
   return flushAsyncEvents();
@@ -138,7 +140,7 @@ test(() => {
   };
 
   // An incorrect implementation which uses an internal method to mark the promise as handled will throw or crash here.
-  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair());
 
   // An incorrect implementation that tries to mark the promise as handled by calling .then() or .catch() on the object
   // will fail these tests.

--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -155,10 +155,11 @@ test(() => {
     { writable: 'writable' },
     { readable: undefined, writable: 'writable' }
   ];
-  for (const pair of pairs) {
+  for (let i = 0; i < pairs.length; ++i) {
+    const pair = pairs[i];
     const rs = new ReadableStream();
     assert_throws(new TypeError(), () => rs.pipeThrough(pair),
-                  'pipeThrough should throw for argument ' + JSON.stringify(pair) + ';');
+                  `pipeThrough should throw for argument ${JSON.stringify(pair)} (index ${i});`);
   }
 }, 'undefined readable or writable arguments should cause pipeThrough() to throw');
 
@@ -166,8 +167,11 @@ test(() => {
   const invalidArguments = [null, 0, NaN, '', [], {}, false, () => {}];
   for (const arg of invalidArguments) {
     const rs = new ReadableStream();
-    assert_equals(arg, rs.pipeThrough({ writable: arg, readable: arg }),
-                  'pipeThrough() should not throw for ' + JSON.stringify(arg));
+    assert_equals(arg, rs.pipeThrough({ writable: new WritableStream(), readable: arg }),
+                  'pipeThrough() should not throw for readable: ' + JSON.stringify(arg));
+    const rs2 = new ReadableStream();
+    assert_equals(rs2, rs.pipeThrough({ writable: arg, readable: rs2 }),
+                  'pipeThrough() should not throw for writable: ' + JSON.stringify(arg));
   }
 }, 'invalid but not undefined arguments should not cause pipeThrough() to throw');
 

--- a/streams/readable-streams/pipe-through.js
+++ b/streams/readable-streams/pipe-through.js
@@ -98,11 +98,9 @@ test(() => {
   };
 
   ReadableStream.prototype.pipeThrough.call(thisValue, { readable: {}, writable: {} });
-  ReadableStream.prototype.pipeThrough.call(thisValue, { readable: {} }, {});
-  ReadableStream.prototype.pipeThrough.call(thisValue, { writable: {} }, {});
 
-  assert_equals(count, 3, 'pipeTo was called 3 times');
+  assert_equals(count, 1, 'pipeTo was called once');
 
-}, 'ReadableStream.prototype.pipeThrough should work with missing readable, writable, or options');
+}, 'ReadableStream.prototype.pipeThrough should work with missing options');
 
 done();


### PR DESCRIPTION
Verify that pipeThrough() throws when the readable or writable arguments
are undefined.

Also verify that other types are passed through to pipeTo() and the
return value.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
