### PR TITLE
Add initial test for RTCDTMFSender

### DIFF
--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -75,7 +75,7 @@ function test_tone_change_events(testFunc, toneChanges, desc) {
         const duration = now - lastEventTime;
 
         assert_approx_equals(duration, expectedDuration, 50,
-          `Expect tonechange event for ${tone} to be fired approximately after ${expectedDuration} seconds`);
+          `Expect tonechange event for "${tone}" to be fired approximately after ${expectedDuration} seconds`);
 
         lastEventTime = now;
 

--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -27,8 +27,10 @@ function createDtmfSender(pc = new RTCPeerConnection()) {
   Create an RTCDTMFSender and test tonechange events on it.
     testFunc
       Test function that is going to manipulate the DTMFSender.
-      It will be called with an RTCDTMFSender as first argument
-      and the associated RTCPeerConnection as second argument.
+      It will be called with:
+        t - the test object
+        sender - the created RTCDTMFSender
+        pc - the associated RTCPeerConnection as second argument.
     toneChanges
       Array of expected tonechange events fired. The elements
       are array of 3 items:
@@ -93,7 +95,7 @@ function test_tone_change_events(testFunc, toneChanges, desc) {
 
       dtmfSender.addEventListener('tonechange', onToneChange);
 
-      testFunc(dtmfSender, pc);
+      testFunc(t, dtmfSender, pc);
     })
     .catch(t.step_func(err => {
       assert_unreached(`Unexpected promise rejection: ${err}`);

--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -1,0 +1,112 @@
+'use strict';
+
+// Test is based on the following editor draft:
+// https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+// Code using this helper should also include RTCPeerConnection-helper.js
+// in the main HTML file
+
+// The following helper functions are called from RTCPeerConnection-helper.js:
+//   getTrackFromUserMedia
+
+// Create a RTCDTMFSender using getUserMedia()
+function createDtmfSender(pc = new RTCPeerConnection()) {
+  return getTrackFromUserMedia('audio')
+  .then(([track, mediaStream]) => {
+    const sender = pc.addTrack(track, mediaStream);
+    const dtmfSender = sender.dtmf;
+
+    assert_true(dtmfSender instanceof RTCDTMFSender,
+      'Expect audio sender.dtmf to be set to a RTCDTMFSender');
+
+    return dtmfSender;
+  });
+}
+
+/*
+  Create an RTCDTMFSender and test tonechange events on it.
+    testFunc
+      Test function that is going to manipulate the DTMFSender.
+      It will be called with an RTCDTMFSender as first argument
+      and the associated RTCPeerConnection as second argument.
+    toneChanges
+      Array of expected tonechange events fired. The elements
+      are array of 3 items:
+        expectedTone
+          The expected character in event.tone
+        expectedToneBuffer
+          The expected new value of dtmfSender.toneBuffer
+        expectedDuration
+          The rough time since beginning or last tonechange event
+          was fired.
+    desc
+      Test description.
+ */
+function test_tone_change_events(testFunc, toneChanges, desc) {
+  async_test(t => {
+    const pc = new RTCPeerConnection();
+
+    createDtmfSender(pc)
+    .then(dtmfSender => {
+      let lastEventTime = Date.now();
+
+      const onToneChange = t.step_func(ev => {
+        assert_true(ev instanceof RTCDTMFToneChangeEvent,
+          'Expect tone change event object to be an RTCDTMFToneChangeEvent');
+
+        const { tone } = ev;
+        assert_equals(typeof tone, 'string',
+          'Expect event.tone to be the tone string');
+
+        assert_greater_than(toneChanges.length, 0,
+          'More tonechange event is fired than expected');
+
+        const [
+          expectedTone, expectedToneBuffer, expectedDuration
+        ] = toneChanges.shift();
+
+        assert_equals(tone, expectedTone,
+          `Expect current event.tone to be ${expectedTone}`);
+
+        assert_equals(dtmfSender.toneBuffer, expectedToneBuffer,
+          `Expect dtmfSender.toneBuffer to be updated to ${expectedToneBuffer}`);
+
+        const now = Date.now();
+        const duration = now - lastEventTime;
+
+        assert_approx_equals(duration, expectedDuration, 50,
+          `Expect tonechange event for ${tone} to be fired approximately after ${expectedDuration} seconds`);
+
+        lastEventTime = now;
+
+        if(toneChanges.length === 0) {
+          // Wait for same duration as last expected duration + 100ms
+          // before passing test in case there are new tone events fired,
+          // in which case the test should fail.
+          t.step_timeout(
+            t.step_func(() => {
+              t.done();
+              pc.close();
+            }), expectedDuration + 100);
+        }
+      });
+
+      dtmfSender.addEventListener('tonechange', onToneChange);
+
+      testFunc(dtmfSender, pc);
+    })
+    .catch(t.step_func(err => {
+      assert_unreached(`Unexpected promise rejection: ${err}`);
+    }));
+  }, desc);
+}
+
+// Get the one and only tranceiver from pc.getTransceivers().
+// Assumes that there is only one tranceiver in pc.
+function getTransceiver(pc) {
+  const transceivers = pc.getTransceivers();
+  assert_equals(transceivers.length, 1,
+    'Expect there to be only one tranceiver in pc');
+
+  return transceivers[0];
+}

--- a/webrtc/RTCDTMFSender-insertDTMF.html
+++ b/webrtc/RTCDTMFSender-insertDTMF.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCDtmfSender</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script src="RTCDTMFSender-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCPeerConnection-helper.js
+  //   generateAnswer
+
+  // The following helper functions are called from RTCDTMFSender-helper.js
+  //   createDtmfSender
+  //   test_tone_change_events
+  //   getTransceiver
+
+  /*
+    7.  Peer-to-peer DTMF
+      partial interface RTCRtpSender {
+        readonly attribute RTCDTMFSender? dtmf;
+      };
+
+      interface RTCDTMFSender : EventTarget {
+        void insertDTMF(DOMString tones,
+                        optional unsigned long duration = 100,
+                        optional unsigned long interToneGap = 70);
+                 attribute EventHandler ontonechange;
+        readonly attribute DOMString    toneBuffer;
+      };
+
+      [Constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
+      interface RTCDTMFToneChangeEvent : Event {
+        readonly attribute DOMString tone;
+      };
+   */
+
+  /*
+    7.2.  insertDTMF
+      The tones parameter is treated as a series of characters.
+
+      The characters 0 through 9, A through D, #, and * generate the associated
+      DTMF tones.
+
+      The characters a to d MUST be normalized to uppercase on entry and are
+      equivalent to A to D.
+
+      As noted in [RTCWEB-AUDIO] Section 3, support for the characters 0 through 9,
+      A through D, #, and * are required.
+
+      The character ',' MUST be supported, and indicates a delay of 2 seconds
+      before processing the next character in the tones parameter.
+
+      All other characters (and only those other characters) MUST be considered
+      unrecognized.
+   */
+  promise_test(t => {
+    return createDtmfSender()
+    .then(dtmfSender => {
+      dtmfSender.insertDTMF('');
+      dtmfSender.insertDTMF('012345689');
+      dtmfSender.insertDTMF('ABCD');
+      dtmfSender.insertDTMF('abcd');
+      dtmfSender.insertDTMF('#*');
+      dtmfSender.insertDTMF(',');
+      dtmfSender.insertDTMF('0123456789ABCDabcd#*,');
+    });
+  }, 'insertDTMF() should succeed if tones contains valid DTMF characters');
+
+
+  /*
+    7.2.  insertDTMF
+      6.  If tones contains any unrecognized characters, throw an
+          InvalidCharacterError.
+   */
+  promise_test(t => {
+    return createDtmfSender()
+    .then(dtmfSender => {
+      assert_throws('InvalidCharacterError', () =>
+        // 'F' is invalid
+        dtmfSender.insertDTMF('123FFABC'));
+
+      assert_throws('InvalidCharacterError', () =>
+        // 'E' is invalid
+        dtmfSender.insertDTMF('E'));
+
+      assert_throws('InvalidCharacterError', () =>
+        // ' ' is invalid
+        dtmfSender.insertDTMF('# *'));
+    });
+  }, 'insertDTMF() should throw InvalidCharacterError if tones contains invalid DTMF characters');
+
+  /*
+    7.2.  insertDTMF
+      3.  If transceiver.stopped is true, throw an InvalidStateError.
+   */
+  test(t => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio');
+    const dtmfSender = transceiver.sender.dtmf;
+
+    transceiver.stop();
+    assert_throws('InvalidStateError', () => dtmfSender.insertDTMF(''));
+
+  }, 'insertDTMF() should throw InvalidStateError if transceiver is stopped');
+
+  /*
+    7.2.  insertDTMF
+      4.  If transceiver.currentDirection is recvonly or inactive, throw an InvalidStateError.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio', {
+      direction: 'recvonly'
+    });
+    const dtmfSender = transceiver.sender.dtmf;
+
+    return pc.createOffer()
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer)))
+    .then(() => {
+      assert_equals(transceiver.currentDirection, 'inactive');
+      assert_throws('InvalidStateError', () => dtmfSender.insertDTMF(''));
+    });
+  }, 'insertDTMF() should throw InvalidStateError if transceiver.currentDirection is recvonly');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio', {
+      direction: 'inactive'
+    });
+    const dtmfSender = transceiver.sender.dtmf;
+
+    return pc.createOffer()
+    .then(offer =>
+      pc.setLocalDescription(offer)
+      .then(() => generateAnswer(offer)))
+    .then(() => {
+      assert_equals(transceiver.currentDirection, 'inactive');
+      assert_throws('InvalidStateError', () => dtmfSender.insertDTMF(''));
+    });
+  }, 'insertDTMF() should throw InvalidStateError if transceiver.currentDirection is inactive');
+
+  /*
+    7.2.  insertDTMF
+      The characters a to d MUST be normalized to uppercase on entry and are
+      equivalent to A to D.
+
+      7.  Set the object's toneBuffer attribute to tones.
+   */
+  promise_test(() => {
+    return createDtmfSender()
+    .then(dtmfSender => {
+      dtmfSender.insertDTMF('123');
+      assert_equals(dtmfSender.toneBuffer, '123');
+
+      dtmfSender.insertDTMF('ABC');
+      assert_equals(dtmfSender.toneBuffer, 'ABC');
+
+      dtmfSender.insertDTMF('bcd');
+      assert_equals(dtmfSender.toneBuffer, 'BCD');
+    });
+  }, 'insertDTMF() should set toneBuffer to provided tones normalized, with old tones overridden');
+
+</script>

--- a/webrtc/RTCDTMFSender-insertDTMF.html
+++ b/webrtc/RTCDTMFSender-insertDTMF.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>RTCDtmfSender</title>
+<title>RTCDTMFSender.prototype.insertDTMF</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCPeerConnection-helper.js"></script>
@@ -31,11 +31,6 @@
                         optional unsigned long interToneGap = 70);
                  attribute EventHandler ontonechange;
         readonly attribute DOMString    toneBuffer;
-      };
-
-      [Constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
-      interface RTCDTMFToneChangeEvent : Event {
-        readonly attribute DOMString tone;
       };
    */
 

--- a/webrtc/RTCDTMFSender-ontonechange-long.html
+++ b/webrtc/RTCDTMFSender-ontonechange-long.html
@@ -40,7 +40,7 @@
       11.8. If the value of the duration parameter is less than 40, set it to 40.
             If, on the other hand, the value is greater than 6000, set it to 6000.
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.insertDTMF('A', 8000, 70);
   }, [
     ['A', '', 0],

--- a/webrtc/RTCDTMFSender-ontonechange-long.html
+++ b/webrtc/RTCDTMFSender-ontonechange-long.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<meta name="timeout" content="long">
+<title>RTCDtmfSender.prototype.ontonechange (Long Timeout)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script src="RTCDTMFSender-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCDTMFSender-helper.js
+  //   test_tone_change_events
+
+  /*
+    7.2.  insertDTMF
+      11.8. If the value of the duration parameter is less than 40, set it to 40.
+            If, on the other hand, the value is greater than 6000, set it to 6000.
+   */
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.insertDTMF('A', 8000, 70);
+  }, [
+    ['A', '', 0],
+    ['', '', 6070]
+  ],'insertDTMF with duration greater than 6000 should be clamped to 6000');
+
+</script>

--- a/webrtc/RTCDTMFSender-ontonechange-long.html
+++ b/webrtc/RTCDTMFSender-ontonechange-long.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <meta charset=utf-8>
 <meta name="timeout" content="long">
-<title>RTCDtmfSender.prototype.ontonechange (Long Timeout)</title>
+<title>RTCDTMFSender.prototype.ontonechange (Long Timeout)</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCPeerConnection-helper.js"></script>
@@ -14,6 +14,26 @@
 
   // The following helper functions are called from RTCDTMFSender-helper.js
   //   test_tone_change_events
+
+  /*
+    7.  Peer-to-peer DTMF
+      partial interface RTCRtpSender {
+        readonly attribute RTCDTMFSender? dtmf;
+      };
+
+      interface RTCDTMFSender : EventTarget {
+        void insertDTMF(DOMString tones,
+                        optional unsigned long duration = 100,
+                        optional unsigned long interToneGap = 70);
+                 attribute EventHandler ontonechange;
+        readonly attribute DOMString    toneBuffer;
+      };
+
+      [Constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
+      interface RTCDTMFToneChangeEvent : Event {
+        readonly attribute DOMString tone;
+      };
+   */
 
   /*
     7.2.  insertDTMF

--- a/webrtc/RTCDTMFSender-ontonechange-long.html
+++ b/webrtc/RTCDTMFSender-ontonechange-long.html
@@ -37,8 +37,8 @@
 
   /*
     7.2.  insertDTMF
-      11.8. If the value of the duration parameter is less than 40, set it to 40.
-            If, on the other hand, the value is greater than 6000, set it to 6000.
+      8. If the value of the duration parameter is less than 40, set it to 40.
+         If, on the other hand, the value is greater than 6000, set it to 6000.
    */
   test_tone_change_events((t, dtmfSender) => {
     dtmfSender.insertDTMF('A', 8000, 70);

--- a/webrtc/RTCDTMFSender-ontonechange.html
+++ b/webrtc/RTCDTMFSender-ontonechange.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCDtmfSender.prototype.ontonechange</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="RTCPeerConnection-helper.js"></script>
+<script src="RTCDTMFSender-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCDTMFSender-helper.js
+  //   test_tone_change_events
+  //   getTransceiver
+
+  /*
+    7.2.  insertDTMF
+      11. If a Playout task is scheduled to be run; abort these steps; otherwise queue
+          a task that runs the following steps (Playout task):
+        3.  If toneBuffer is an empty string, fire an event named tonechange with an
+            empty string at the RTCDTMFSender object and abort these steps.
+        4.  Remove the first character from toneBuffer and let that character be tone.
+        5.  Queue a task to be executed in duration + interToneGap ms from now that
+            runs the steps labelled Playout task.
+        6.  Fire an event named tonechange with a string consisting of tone at the
+            RTCDTMFSender object.
+   */
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.insertDTMF('123');
+  }, [
+    ['1', '23', 0],
+    ['2', '3', 170],
+    ['3', '', 170],
+    ['', '', 170]
+  ], 'insertDTMF with default duration and intertoneGap should fire tonechange events at the expected time');
+
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.insertDTMF('abc', 100, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 170],
+    ['C', '', 170],
+    ['', '', 170]
+  ], 'insertDTMF with explicit duration and intertoneGap should fire tonechange events at the expected time');
+
+  /*
+    7.2.  insertDTMF
+      11.8. If the value of the duration parameter is less than 40, set it to 40.
+            If, on the other hand, the value is greater than 6000, set it to 6000.
+   */
+  test_tone_change_events(dtmfSender => {
+      dtmfSender.insertDTMF('ABC', 10, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 110],
+    ['C', '', 110],
+    ['', '', 110]
+  ], 'insertDTMF with duration less than 40 should be clamped to 40');
+
+  /*
+    7.2.  insertDTMF
+      11.9. If the value of the interToneGap parameter is less than 30, set it to 30.
+   */
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.insertDTMF('ABC', 100, 10);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 130],
+    ['C', '', 130],
+    ['', '', 130]
+  ],
+  'insertDTMF with interToneGap less than 30 should be clamped to 30');
+
+  /*
+    [w3c/webrtc-pc#1373]
+    This step is added to handle the "," character correctly. "," supposed to delay the next
+    tonechange event by 2000ms.
+
+    7.2.  insertDTMF
+      11.5. If tone is "," delay sending tones for 2000 ms on the associated RTP media
+            stream, and queue a task to be executed in 2000 ms from now that runs the
+            steps labelled Playout task.
+   */
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.insertDTMF('A,B', 100, 70);
+
+  }, [
+    ['A', ',B', 0],
+    [',', 'B', 170],
+    ['B', '', 2000],
+    ['', '', 170]
+  ], 'insertDTMF with comma should delay next tonechange event for a constant 2000ms');
+
+  /*
+    7.2.  insertDTMF
+      11.1. If transceiver.stopped is true, abort these steps.
+   */
+  test_tone_change_events((dtmfSender, pc) => {
+    const transceiver = getTransceiver(pc);
+    dtmfSender.addEventListener('tonechange', ev => {
+      if(ev.tone === 'B') {
+        transceiver.stop();
+      }
+    });
+
+    dtmfSender.insertDTMF('ABC', 100, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 170]
+  ], 'insertDTMF with transceiver stopped in the middle should stop future tonechange events from firing');
+
+  /*
+    7.2.  insertDTMF
+      3.  If a Playout task is scheduled to be run, abort these steps;
+          otherwise queue a task that runs the following steps (Playout task):
+   */
+  test_tone_change_events((dtmfSender, pc) => {
+    dtmfSender.addEventListener('tonechange', ev => {
+      if(ev.tone === 'B') {
+        setTimeout(() =>
+          dtmfSender.insertDTMF('12', 100, 70),
+          10);
+      }
+    });
+
+    dtmfSender.insertDTMF('ABC', 100, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 170],
+    ['1', '2', 170],
+    ['2', '', 170],
+    ['', '', 170]
+  ], 'Changing toneBuffer in the middle of tonechange events should cause future tonechanges to be updated to new tones');
+
+  /*
+    7.2.  insertDTMF
+      3.  If a Playout task is scheduled to be run, abort these steps;
+          otherwise queue a task that runs the following steps (Playout task):
+   */
+  test_tone_change_events((dtmfSender, pc) => {
+    dtmfSender.addEventListener('tonechange', ev => {
+      if(ev.tone === 'B') {
+        dtmfSender.insertDTMF('');
+      }
+    });
+
+    dtmfSender.insertDTMF('ABC', 100, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 170],
+    ['', '', 170]
+  ], `Calling insertDTMF('') in the middle of tonechange events should stop future tonechange events from firing`);
+
+</script>

--- a/webrtc/RTCDTMFSender-ontonechange.html
+++ b/webrtc/RTCDTMFSender-ontonechange.html
@@ -45,9 +45,9 @@
         3.  If toneBuffer is an empty string, fire an event named tonechange with an
             empty string at the RTCDTMFSender object and abort these steps.
         4.  Remove the first character from toneBuffer and let that character be tone.
-        5.  Queue a task to be executed in duration + interToneGap ms from now that
+        6.  Queue a task to be executed in duration + interToneGap ms from now that
             runs the steps labelled Playout task.
-        6.  Fire an event named tonechange with a string consisting of tone at the
+        7.  Fire an event named tonechange with a string consisting of tone at the
             RTCDTMFSender object.
    */
   test_tone_change_events(dtmfSender => {
@@ -89,8 +89,8 @@
 
   /*
     7.2.  insertDTMF
-      11.8. If the value of the duration parameter is less than 40, set it to 40.
-            If, on the other hand, the value is greater than 6000, set it to 6000.
+      8. If the value of the duration parameter is less than 40, set it to 40.
+         If, on the other hand, the value is greater than 6000, set it to 6000.
    */
   test_tone_change_events((t, dtmfSender) => {
       dtmfSender.insertDTMF('ABC', 10, 70);
@@ -103,7 +103,7 @@
 
   /*
     7.2.  insertDTMF
-      11.9. If the value of the interToneGap parameter is less than 30, set it to 30.
+      9. If the value of the interToneGap parameter is less than 30, set it to 30.
    */
   test_tone_change_events((t, dtmfSender) => {
     dtmfSender.insertDTMF('ABC', 100, 10);

--- a/webrtc/RTCDTMFSender-ontonechange.html
+++ b/webrtc/RTCDTMFSender-ontonechange.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>RTCDtmfSender.prototype.ontonechange</title>
+<title>RTCDTMFSender.prototype.ontonechange</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="RTCPeerConnection-helper.js"></script>
@@ -11,9 +11,32 @@
   // Test is based on the following editor draft:
   // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
+  // The following helper functions are called from RTCPeerConnection-helper.js
+  //   generateAnswer
+
   // The following helper functions are called from RTCDTMFSender-helper.js
   //   test_tone_change_events
   //   getTransceiver
+
+  /*
+    7.  Peer-to-peer DTMF
+      partial interface RTCRtpSender {
+        readonly attribute RTCDTMFSender? dtmf;
+      };
+
+      interface RTCDTMFSender : EventTarget {
+        void insertDTMF(DOMString tones,
+                        optional unsigned long duration = 100,
+                        optional unsigned long interToneGap = 70);
+                 attribute EventHandler ontonechange;
+        readonly attribute DOMString    toneBuffer;
+      };
+
+      [Constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict)]
+      interface RTCDTMFToneChangeEvent : Event {
+        readonly attribute DOMString tone;
+      };
+   */
 
   /*
     7.2.  insertDTMF
@@ -34,7 +57,7 @@
     ['2', '3', 170],
     ['3', '', 170],
     ['', '', 170]
-  ], 'insertDTMF with default duration and intertoneGap should fire tonechange events at the expected time');
+  ], 'insertDTMF() with default duration and intertoneGap should fire tonechange events at the expected time');
 
   test_tone_change_events(dtmfSender => {
     dtmfSender.insertDTMF('abc', 100, 70);
@@ -43,7 +66,26 @@
     ['B', 'C', 170],
     ['C', '', 170],
     ['', '', 170]
-  ], 'insertDTMF with explicit duration and intertoneGap should fire tonechange events at the expected time');
+  ], 'insertDTMF() with explicit duration and intertoneGap should fire tonechange events at the expected time');
+
+  /*
+    7.2.  insertDTMF
+      10. If toneBuffer is an empty string, abort these steps.
+   */
+  async_test(t => {
+    createDtmfSender()
+    .then(dtmfSender => {
+      dtmfSender.addEventListener('tonechange',
+        t.unreached_func('Expect no tonechange event to be fired'));
+
+      dtmfSender.insertDTMF('', 100, 70);
+
+      t.step_timeout(t.step_func_done(), 300);
+    })
+    .catch(t.step_func(err => {
+      assert_unreached(`Unexpected promise rejection: ${err}`);
+    }));
+  }, `insertDTMF('') should not fire any tonechange event, including for '' tone`);
 
   /*
     7.2.  insertDTMF
@@ -57,7 +99,7 @@
     ['B', 'C', 110],
     ['C', '', 110],
     ['', '', 110]
-  ], 'insertDTMF with duration less than 40 should be clamped to 40');
+  ], 'insertDTMF() with duration less than 40 should be clamped to 40');
 
   /*
     7.2.  insertDTMF
@@ -71,7 +113,7 @@
     ['C', '', 130],
     ['', '', 130]
   ],
-  'insertDTMF with interToneGap less than 30 should be clamped to 30');
+  'insertDTMF() with interToneGap less than 30 should be clamped to 30');
 
   /*
     [w3c/webrtc-pc#1373]
@@ -109,19 +151,23 @@
   }, [
     ['A', 'BC', 0],
     ['B', 'C', 170]
-  ], 'insertDTMF with transceiver stopped in the middle should stop future tonechange events from firing');
+  ], 'insertDTMF() with transceiver stopped in the middle should stop future tonechange events from firing');
 
   /*
     7.2.  insertDTMF
       3.  If a Playout task is scheduled to be run, abort these steps;
           otherwise queue a task that runs the following steps (Playout task):
    */
-  test_tone_change_events((dtmfSender, pc) => {
+  test_tone_change_events(dtmfSender => {
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
-        setTimeout(() =>
-          dtmfSender.insertDTMF('12', 100, 70),
-          10);
+        // Set a timeout to make sure the toneBuffer
+        // is changed after the tonechange event listener
+        // by test_tone_change_events is called.
+        // This is to correctly test the expected toneBuffer.
+        setTimeout(() => {
+          dtmfSender.insertDTMF('12', 100, 70);
+        }, 10);
       }
     });
 
@@ -132,17 +178,44 @@
     ['1', '2', 170],
     ['2', '', 170],
     ['', '', 170]
-  ], 'Changing toneBuffer in the middle of tonechange events should cause future tonechanges to be updated to new tones');
+  ], 'Calling insertDTMF() in the middle of tonechange events should cause future tonechanges to be updated to new tones');
+
 
   /*
     7.2.  insertDTMF
       3.  If a Playout task is scheduled to be run, abort these steps;
           otherwise queue a task that runs the following steps (Playout task):
    */
-  test_tone_change_events((dtmfSender, pc) => {
+  test_tone_change_events(dtmfSender => {
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
-        dtmfSender.insertDTMF('');
+        setTimeout(() => {
+          dtmfSender.insertDTMF('12', 100, 70);
+          dtmfSender.insertDTMF('34', 100, 70);
+        }, 10);
+      }
+    });
+
+    dtmfSender.insertDTMF('ABC', 100, 70);
+  }, [
+    ['A', 'BC', 0],
+    ['B', 'C', 170],
+    ['3', '4', 170],
+    ['4', '', 170],
+    ['', '', 170]
+  ], 'Calling insertDTMF() multiple times in the middle of tonechange events should cause future tonechanges to be updated the last provided tones');
+
+  /*
+    7.2.  insertDTMF
+      3.  If a Playout task is scheduled to be run, abort these steps;
+          otherwise queue a task that runs the following steps (Playout task):
+   */
+  test_tone_change_events(dtmfSender => {
+    dtmfSender.addEventListener('tonechange', ev => {
+      if(ev.tone === 'B') {
+        setTimeout(() => {
+          dtmfSender.insertDTMF('');
+        }, 10);
       }
     });
 
@@ -152,5 +225,61 @@
     ['B', 'C', 170],
     ['', '', 170]
   ], `Calling insertDTMF('') in the middle of tonechange events should stop future tonechange events from firing`);
+
+  /*
+    7.2.  insertDTMF
+      11.2.  If transceiver.currentDirection is recvonly or inactive, abort these steps.
+   */
+  async_test(t => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio', { direction: 'sendrecv' });
+    const dtmfSender = transceiver.sender.dtmf;
+
+    // Since setRemoteDescription happens in parallel with tonechange event,
+    // We use a flag and allow tonechange events to be fired as long as
+    // the promise returned by setRemoteDescription is not yet resolved.
+    let remoteDescriptionIsSet = false;
+
+    // We only do basic tone verification and not check timing here
+    let expectedTones = ['A', 'B', 'C', 'D', ''];
+
+    const onToneChange = t.step_func(ev => {
+      assert_false(remoteDescriptionIsSet,
+        'Expect no tonechange event to be fired after currentDirection is changed to recvonly');
+
+      const { tone } = ev;
+      const expectedTone = expectedTones.shift();
+      assert_equals(tone, expectedTone,
+        `Expect fired event.tone to be ${expectedTone}`);
+
+      // Only change transceiver.currentDirection after the first
+      // tonechange event, to make sure that tonechange is triggered
+      // then stopped
+      if(tone === 'A') {
+        transceiver.setDirection('recvonly');
+
+        pc.createOffer()
+        .then(offer =>
+          pc.setLocalDescription(offer)
+          .then(() => generateAnswer(offer)))
+        .then(answer => pc.setRemoteDescription(answer))
+        .then(() => {
+          assert_equals(transceiver.currentDirection, 'recvonly');
+          remoteDescriptionIsSet = true;
+
+          // Pass the test if no further tonechange event is
+          // fired in the next 300ms
+          t.step_timeout(t.step_func_done(), 300);
+        })
+        .catch(t.step_func(err => {
+          assert_unreached(`Unexpected promise rejection: ${err}`);
+        }));
+      }
+    });
+
+    dtmfSender.addEventListener('tonechange', onToneChange);
+    dtmfSender.insertDTMF('ABCD', 100, 70);
+
+  }, `Setting transceiver.currentDirection to recvonly in the middle of tonechange events should stop future tonechange events from firing`);
 
 </script>

--- a/webrtc/RTCDTMFSender-ontonechange.html
+++ b/webrtc/RTCDTMFSender-ontonechange.html
@@ -92,7 +92,7 @@
       11.8. If the value of the duration parameter is less than 40, set it to 40.
             If, on the other hand, the value is greater than 6000, set it to 6000.
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
       dtmfSender.insertDTMF('ABC', 10, 70);
   }, [
     ['A', 'BC', 0],
@@ -105,7 +105,7 @@
     7.2.  insertDTMF
       11.9. If the value of the interToneGap parameter is less than 30, set it to 30.
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.insertDTMF('ABC', 100, 10);
   }, [
     ['A', 'BC', 0],
@@ -125,7 +125,7 @@
             stream, and queue a task to be executed in 2000 ms from now that runs the
             steps labelled Playout task.
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.insertDTMF('A,B', 100, 70);
 
   }, [
@@ -139,7 +139,7 @@
     7.2.  insertDTMF
       11.1. If transceiver.stopped is true, abort these steps.
    */
-  test_tone_change_events((dtmfSender, pc) => {
+  test_tone_change_events((t, dtmfSender, pc) => {
     const transceiver = getTransceiver(pc);
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
@@ -158,14 +158,14 @@
       3.  If a Playout task is scheduled to be run, abort these steps;
           otherwise queue a task that runs the following steps (Playout task):
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
         // Set a timeout to make sure the toneBuffer
         // is changed after the tonechange event listener
         // by test_tone_change_events is called.
         // This is to correctly test the expected toneBuffer.
-        setTimeout(() => {
+        t.step_timeout(() => {
           dtmfSender.insertDTMF('12', 100, 70);
         }, 10);
       }
@@ -186,10 +186,10 @@
       3.  If a Playout task is scheduled to be run, abort these steps;
           otherwise queue a task that runs the following steps (Playout task):
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
-        setTimeout(() => {
+        t.step_timeout(() => {
           dtmfSender.insertDTMF('12', 100, 70);
           dtmfSender.insertDTMF('34', 100, 70);
         }, 10);
@@ -210,10 +210,10 @@
       3.  If a Playout task is scheduled to be run, abort these steps;
           otherwise queue a task that runs the following steps (Playout task):
    */
-  test_tone_change_events(dtmfSender => {
+  test_tone_change_events((t, dtmfSender) => {
     dtmfSender.addEventListener('tonechange', ev => {
       if(ev.tone === 'B') {
-        setTimeout(() => {
+        t.step_timeout(() => {
           dtmfSender.insertDTMF('');
         }, 10);
       }

--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -384,7 +384,6 @@ function getTrackFromUserMedia(kind) {
     const tracks = mediaStream.getTracks();
     assert_greater_than(tracks.length, 0,
       `Expect getUserMedia to return at least one track of kind ${kind}`);
-
     const [ track ] = tracks;
     return [track, mediaStream];
   });

--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -384,6 +384,7 @@ function getTrackFromUserMedia(kind) {
     const tracks = mediaStream.getTracks();
     assert_greater_than(tracks.length, 0,
       `Expect getUserMedia to return at least one track of kind ${kind}`);
+
     const [ track ] = tracks;
     return [track, mediaStream];
   });

--- a/webrtc/coverage/RTCDTMFSender.txt
+++ b/webrtc/coverage/RTCDTMFSender.txt
@@ -1,0 +1,122 @@
+Coverage is based on the following editor draft:
+https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+7.  insertDTMF
+
+    [Trivial]
+    - The tones parameter is treated as a series of characters.
+
+    [RTCDTMFSender-insertDTMF]
+    - The characters 0 through 9, A through D, #, and * generate the associated
+      DTMF tones.
+
+    [RTCDTMFSender-insertDTMF]
+    - The characters a to d MUST be normalized to uppercase on entry and are equivalent
+      to A to D.
+
+    [RTCDTMFSender-insertDTMF]
+    - As noted in [RTCWEB-AUDIO] Section 3, support for the characters 0 through 9,
+      A through D, #, and * are required.
+
+    [RTCDTMFSender-insertDTMF]
+    - The character ',' MUST be supported, and indicates a delay of 2 seconds before
+      processing the next character in the tones parameter.
+
+    [RTCDTMFSender-insertDTMF]
+    - All other characters (and only those other characters) MUST
+      be considered unrecognized.
+
+    [Trivial]
+    - The duration parameter indicates the duration in ms to use for each character passed
+      in the tones parameters.
+
+    [RTCDTMFSender-ontonechange]
+    - The duration cannot be more than 6000 ms or less than 40 ms.
+
+    [RTCDTMFSender-ontonechange]
+    - The default duration is 100 ms for each tone.
+
+    [RTCDTMFSender-ontonechange]
+    - The interToneGap parameter indicates the gap between tones in ms. The user agent
+      clamps it to at least 30 ms. The default value is 70 ms.
+
+    [Untestable]
+    - The browser MAY increase the duration and interToneGap times to cause the times
+      that DTMF start and stop to align with the boundaries of RTP packets but it MUST
+      not increase either of them by more than the duration of a single RTP audio packet.
+
+    [Trivial]
+    When the insertDTMF() method is invoked, the user agent MUST run the following steps:
+
+      [Trivial]
+      1.  let sender be the RTCRtpSender used to send DTMF.
+
+      [Trivial]
+      2.  Let transceiver be the RTCRtpTransceiver object associated with sender.
+
+      [RTCDTMFSender-insertDTMF]
+      3.  If transceiver.stopped is true, throw an InvalidStateError.
+
+      [RTCDTMFSender-insertDTMF]
+      4.  If transceiver.currentDirection is recvonly or inactive, throw an
+          InvalidStateError.
+
+      [Trivial]
+      5.  Let tones be the method's first argument.
+
+      [RTCDTMFSender-insertDTMF]
+      6.  If tones contains any unrecognized characters, throw an InvalidCharacterError.
+
+      [RTCDTMFSender-insertDTMF]
+      7.  Set the object's toneBuffer attribute to tones.
+
+      [RTCDTMFSender-ontonechange]
+      8.  If the value of the duration parameter is less than 40, set it to 40.
+
+          [RTCDTMFSender-ontonechange-long]
+          If, on the other hand, the value is greater than 6000, set it to 6000.
+
+      [RTCDTMFSender-ontonechange]
+      9.  If the value of the interToneGap parameter is less than 30, set it to 30.
+
+      [RTCDTMFSender-ontonechange]
+      10. If toneBuffer is an empty string, abort these steps.
+
+      [RTCDTMFSender-ontonechange]
+      11. If a Playout task is scheduled to be run; abort these steps;
+
+          [RTCDTMFSender-ontonechange]
+          otherwise queue a task that runs the following steps (Playout task):
+
+          [RTCDTMFSender-ontonechange]
+          1.  If transceiver.stopped is true, abort these steps.
+
+          [RTCDTMFSender-ontonechange]
+          2.  If transceiver.currentDirection is recvonly or inactive, abort these steps.
+
+          [RTCDTMFSender-ontonechange]
+          3.  If toneBuffer is an empty string, fire an event named tonechange with an
+              empty string at the RTCDTMFSender object and abort these steps.
+
+          [RTCDTMFSender-ontonechange]
+          4.  Remove the first character from toneBuffer and let that character be tone.
+
+          [Untestable]
+          5.  Start playout of tone for duration ms on the associated RTP media stream,
+              using the appropriate codec.
+
+          [RTCDTMFSender-ontonechange]
+          6.  Queue a task to be executed in duration + interToneGap ms from now that
+              runs the steps labelled Playout task.
+
+          [RTCDTMFSender-ontonechange]
+          7.  Fire an event named tonechange with a string consisting of tone at the
+              RTCDTMFSender object.
+
+Coverage Report
+
+  Tested        31
+  Not Tested     0
+  Untestable     1
+
+  Total         32


### PR DESCRIPTION
This adds test for the final uncovered section in webrtc-pc.

This test makes the assumption discussed in w3c/webrtc-pc#1415, that the `dtmf` attribute for `RTCRtpSender` is always set for audio transceivers. This is required as otherwise it is impossible to reliably obtain an instance of RTCDTMFSender.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
