### PR TITLE
Rewrite ES6 syntax from idlharness.js into ES5

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -423,8 +423,8 @@ IdlArray.prototype.is_json_type = function(type)
                                throw new Error("Interface " + id + " not found (implemented by " + thing.name + ")");
                            }
                            return mixin;
-                       });
-                       if (mixins.some(function(m) { m.has_to_json_regular_operation() } )) { return true; }
+                       }, this);
+                       if (mixins.some(function(m) { return m.has_to_json_regular_operation() } )) { return true; }
                    }
                    if (!thing.base) { return false; }
                    base = this.members[thing.base];

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -401,9 +401,11 @@ IdlArray.prototype.is_json_type = function(type)
                var map = new Map();
                while (stack.length)
                {
-                   stack.pop().members.forEach(m => map.set(m.name, m.idlType));
+                   stack.pop().members.forEach(function(m) {
+                       map.set(m.name, m.idlType)
+                   });
                }
-               return [...map.values()].every(this.is_json_type, this);
+               return Array.from(map.values()).every(this.is_json_type, this);
            }
            
            //  interface types that have a toJSON operation declared on themselves or
@@ -415,14 +417,14 @@ IdlArray.prototype.is_json_type = function(type)
                    if (thing.has_to_json_regular_operation()) { return true; }
                    var mixins = this.implements[thing.name];
                    if (mixins) {
-                       mixins = mixins.map(id => {
+                       mixins = mixins.map(function(id) {
                            var mixin = this.members[id];
                            if (!mixin) {
                                throw new Error("Interface " + id + " not found (implemented by " + thing.name + ")");
                            }
                            return mixin;
                        });
-                       if (mixins.some(m => m.has_to_json_regular_operation())) { return true; }
+                       if (mixins.some(function(m) { m.has_to_json_regular_operation() } )) { return true; }
                    }
                    if (!thing.base) { return false; }
                    base = this.members[thing.base];
@@ -1006,7 +1008,7 @@ function _traverse_inherited_and_consequential_interfaces(stack, callback) {
     callback(I);
     var mixins = I.array["implements"][I.name];
     if (mixins) {
-        mixins.forEach(id => {
+        mixins.forEach(function(id) {
             var mixin = I.array.members[id];
             if (!mixin) {
                 throw new Error("Interface " + id + " not found (implemented by " + I.name + ")");


### PR DESCRIPTION
Relevant to the discussion in #6266 

Why? So that it can run on platforms that do not support ES6 yet. In my particular case, that is iOS 9.3. I think I will probably run into similar issues on older Android WebView / Browser implementations as well, although I have yet to do that.

Worth noting that at least the File API Blob Constructor tests might need a similar rewrite (or perhaps, conditional execution) to support the various `[Symbol.iterator]: value` object definition syntax.

With these changes I was able to successfully load and run the File API Manual IDL tests in a UIWebView instance on iOS 9.3. Without these changes, the webview would barf up syntax errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6664)
<!-- Reviewable:end -->
