### PR TITLE
Streams: Always set {readable, writable} when calling pipeThrough()

### DIFF
--- a/streams/piping/pipe-through.js
+++ b/streams/piping/pipe-through.js
@@ -30,6 +30,8 @@ function duckTypedPassThroughTransform() {
   };
 }
 
+const uninterestingReadableWritablePair = { writable: new WritableStream(), readable: new ReadableStream() };
+
 promise_test(() => {
   const readableEnd = sequentialReadableStream(5).pipeThrough(duckTypedPassThroughTransform());
 
@@ -82,7 +84,7 @@ test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, { });
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
 
   // Test passes if this doesn't throw or crash.
 
@@ -98,7 +100,7 @@ test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, { });
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
 
   // Test passes if this doesn't throw or crash.
 
@@ -111,7 +113,7 @@ promise_test(() => {
     }
   };
 
-  ReadableStream.prototype.pipeThrough.call(dummy, { });
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
 
   // The test harness should complain about unhandled rejections by then.
   return flushAsyncEvents();
@@ -119,7 +121,7 @@ promise_test(() => {
 }, 'pipeThrough should mark a real promise from a fake readable as handled');
 
 test(() => {
-  let thenCalled = false
+  let thenCalled = false;
   let catchCalled = false;
   const dummy = {
     pipeTo() {
@@ -136,7 +138,7 @@ test(() => {
   };
 
   // An incorrect implementation which uses an internal method to mark the promise as handled will throw or crash here.
-  ReadableStream.prototype.pipeThrough.call(dummy, { });
+  ReadableStream.prototype.pipeThrough.call(dummy, uninterestingReadableWritablePair);
 
   // An incorrect implementation that tries to mark the promise as handled by calling .then() or .catch() on the object
   // will fail these tests.


### PR DESCRIPTION
https://github.com/whatwg/streams/pull/759 will change pipeThrough() to check
that `readable` and `writable` are not undefined. Some existing tests depend on
pipeThrough() not checking this. Change them to pass defined values for
`readable` and `writable` so the change does not break them.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
