### PR TITLE
gamepad: Update spec reference links.

### DIFF
--- a/gamepad/events-manual.html
+++ b/gamepad/events-manual.html
@@ -2,8 +2,8 @@
 <html>
 <head>
 <title>Manual Gamepad events tests</title>
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#the-gamepadconnected-event">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#the-gamepaddisconnected-event">
+<link rel="help" href="https://w3c.github.io/gamepad/#the-gamepadconnected-event">
+<link rel="help" href="https://w3c.github.io/gamepad/#the-gamepaddisconnected-event">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/gamepad/getgamepads-polling-manual.html
+++ b/gamepad/getgamepads-polling-manual.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Manual Gamepad getGamepads polling tests</title>
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<link rel="help" href="https://w3c.github.io/gamepad/#navigator-interface-extension">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/gamepad/idlharness-manual.html
+++ b/gamepad/idlharness-manual.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <title>Manual Gamepad IDL tests</title>
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepad-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadbutton-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadevent-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepad-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepadbutton-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepadevent-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#navigator-interface-extension">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>

--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -2,10 +2,10 @@
 <html>
 <head>
 <title>Gamepad IDL tests</title>
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepad-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadbutton-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#gamepadevent-interface">
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#navigator-interface-extension">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepad-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepadbutton-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#gamepadevent-interface">
+<link rel="help" href="https://w3c.github.io/gamepad/#navigator-interface-extension">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>

--- a/gamepad/timestamp-manual.html
+++ b/gamepad/timestamp-manual.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <title>Manual Gamepad timestamp tests</title>
-<link rel="help" href="https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html#widl-Gamepad-timestamp">
+<link rel="help" href="https://w3c.github.io/gamepad/#dom-gamepad-timestamp">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>


### PR DESCRIPTION
Refer to GitHub instead of the old W3C hg repository.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
