### PR TITLE
gamepad: Update Gamepad's definition in the idlharness tests.

### DIFF
--- a/gamepad/idlharness-manual.html
+++ b/gamepad/idlharness-manual.html
@@ -43,8 +43,8 @@ interface Gamepad {
     readonly    attribute boolean             connected;
     readonly    attribute DOMHighResTimeStamp timestamp;
     readonly    attribute GamepadMappingType  mapping;
-    readonly    attribute double[]            axes;
-    readonly    attribute GamepadButton[]     buttons;
+    readonly    attribute FrozenArray<double> axes;
+    readonly    attribute FrozenArray<GamepadButton> buttons;
 };
 
 enum GamepadMappingType {

--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -26,8 +26,8 @@ interface Gamepad {
     readonly    attribute boolean             connected;
     readonly    attribute DOMHighResTimeStamp timestamp;
     readonly    attribute GamepadMappingType  mapping;
-    readonly    attribute double[]            axes;
-    readonly    attribute GamepadButton[]     buttons;
+    readonly    attribute FrozenArray<double> axes;
+    readonly    attribute FrozenArray<GamepadButton> buttons;
 };
 
 enum GamepadMappingType {


### PR DESCRIPTION
Follow-up to w3c/gamepad#62, which switched Gamepad#axes and Gamepad#buttons
to FrozenArray<>s.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
