### PR TITLE
Add --no-manifest-update option to wptrunner.

### DIFF
--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -16,7 +16,7 @@ fi
 
 if [[ $(./wpt test-jobs --includes wptrunner_unittest; echo $?) -eq 0 ]]; then
     if [ $TOXENV == "py27" ] || [ $TOXENV == "pypy" ]; then
-        cd wptrunner
+        cd tools/wptrunner
         tox
     fi
 else

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -47,8 +47,10 @@ def create_parser(product_choices=None):
 
 TEST is either the full path to a test file to run, or the URL of a test excluding
 scheme host and port.""")
-    parser.add_argument("--manifest-update", action="store_true", default=False,
+    parser.add_argument("--manifest-update", action="store_true", default=None,
                         help="Regenerate the test manifest.")
+    parser.add_argument("--no-manifest-update", action="store_false", dest="manifest_update",
+                        help="Prevent regeneration of the test manifest.")
 
     parser.add_argument("--timeout-multiplier", action="store", type=float, default=None,
                         help="Multiplier relative to standard test timeout to use")


### PR DESCRIPTION
This also defaults the manifest_update setting to None, so |wpt run| will
do a manifest update by default, as intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6678)
<!-- Reviewable:end -->
