### PR TITLE
Add test for ::marker with font properties.

### DIFF
--- a/css/css-pseudo-4/marker-font-properties-ref.html
+++ b/css/css-pseudo-4/marker-font-properties-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: ::marker formatting with font properties reference file</title>
+<link rel="author" title="Daniel Bates" href="mailto:dbates@webkit.org">
+<style>
+li {
+    font-family: sans-serif;
+    font-size: 24px;
+    font-style: italic;
+    font-variant: small-caps;
+    font-weight: bold;
+    list-style-type: lower-alpha;
+    font-variant-numeric: tabular-nums;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li></li>
+</ol>
+</body>
+</html>

--- a/css/css-pseudo-4/marker-font-properties.html
+++ b/css/css-pseudo-4/marker-font-properties.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Test: ::marker formatting with font properties</title>
+<link rel="author" title="Daniel Bates" href="mailto:dbates@webkit.org">
+<link ref="match" href="marker-font-properties-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#marker-pseudo">
+<meta name="assert" content="Tests ::marker rendering with font properties">
+<style>
+li {
+    list-style-type: lower-alpha;
+}
+
+li::marker {
+    font-family: sans-serif;
+    font-size: 24px;
+    font-style: italic;
+    font-variant: small-caps;
+    font-weight: bold;
+}
+</style>
+</head>
+<body>
+<ol>
+    <li><span style="font-size: 24px"><!-- FIXME: Needed to ensure consistent baseline position with expected result in WebKit (why?). --></span></li>
+</ol>
+</body>
+</html>


### PR DESCRIPTION
We should add a test to ensure that ::marker renders correctly with various font properties.

For some reason adding "font-size: 24px" to ::marker makes its baseline differ from the baseline of the list item text in WebKit. I had to add a child <span> with font size 24px to the list item in the test to make the baseline of the marker consistent with baseline of the marker in the expected result at least in WebKit. This may be a bug in the implementation of markers in WebKit. I would not expect the presence of the <span> to interfere with the rendering in other browsers (though I am not aware of any other browser that has implemented ::marker, yet). Let me know if it is unacceptable to include the <span>.

For completeness, <https://bugs.webkit.org/show_bug.cgi?id=141477> tracks adding ::marker in WebKit.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
