### PR TITLE
[testharness.js] Introduce assert_array_approx_equals

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -683,6 +683,11 @@ asserts that `actual` and `expected` have the same
 length and the value of each indexed property in `actual` is the strictly equal
 to the corresponding property value in `expected`
 
+### `assert_array_approx_equals(actual, expected, epsilon, description)`
+asserts that `actual` and `expected` have the same
+length and each indexed property in `actual` is a number
+within ±`epsilon` of the corresponding property in `expected`
+
 ### `assert_approx_equals(actual, expected, epsilon, description)`
 asserts that `actual` is a number within ±`epsilon` of `expected`
 

--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -304,15 +304,15 @@
       }
     }, 
     {
-      "status_string": "PASS", 
-      "name": "basic assert_array_approx_equals test", 
-      "stack": null, 
-      "message": null, 
-      "properties": {}
-    }, 
-    {
       "status_string": "PASS",
       "name": "basic assert_approx_equals test",
+      "stack": null,
+      "message": null,
+      "properties": {}
+    },
+    {
+      "status_string": "PASS",
+      "name": "basic assert_array_approx_equals test",
       "stack": null,
       "message": null,
       "properties": {}

--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -74,6 +74,12 @@
     }
     test(basicAssertObjectEquals, "basic assert_object_equals test");
 
+    function basicAssertArrayApproxEquals()
+    {
+        assert_array_approx_equals([10, 11], [11, 10], 1, "[10, 11] is approximately (+/- 1) [11, 10]")
+    }
+    test(basicAssertArrayApproxEquals, "basic assert_array_approx_equals test");
+
     function basicAssertApproxEquals()
     {
         assert_approx_equals(10, 11, 1, "10 is approximately (+/- 1) 11")
@@ -299,11 +305,18 @@
     }, 
     {
       "status_string": "PASS", 
-      "name": "basic assert_approx_equals test", 
+      "name": "basic assert_array_approx_equals test", 
       "stack": null, 
       "message": null, 
       "properties": {}
     }, 
+    {
+      "status_string": "PASS",
+      "name": "basic assert_approx_equals test",
+      "stack": null,
+      "message": null,
+      "properties": {}
+    },
     {
       "status_string": "PASS", 
       "name": "basic assert_array_equals test", 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -971,6 +971,34 @@ policies and contribution forms [3].
     }
     expose(assert_array_equals, "assert_array_equals");
 
+    function assert_array_approx_equals(actual, expected, epsilon, description)
+    {
+        /*
+         * Test if two primitive arrays are equal withing +/- epsilon
+         */
+        assert(actual.length === expected.length,
+               "assert_array_approx_equals", description,
+               "lengths differ, expected ${expected} got ${actual}",
+               {expected:expected.length, actual:actual.length});
+
+        for (var i = 0; i < actual.length; i++) {
+            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+                   "assert_array_approx_equals", description,
+                   "property ${i}, property expected to be ${expected} but was ${actual}",
+                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
+                   actual:actual.hasOwnProperty(i) ? "present" : "missing"});
+            assert(typeof actual[i] === "number",
+                   "assert_array_approx_equals", description,
+                   "property ${i}, expected a number but got a ${type_actual}",
+                   {i:i, type_actual:typeof actual[i]});
+            assert(Math.abs(actual[i] - expected[i]) <= epsilon,
+                   "assert_array_approx_equals", description,
+                   "property ${i}, expected ${expected} +/- ${epsilon}, expected ${expected} but got ${actual}",
+                   {i:i, expected:expected[i], actual:actual[i]});
+        }
+    }
+    expose(assert_array_approx_equals, "assert_array_approx_equals");
+
     function assert_approx_equals(actual, expected, epsilon, description)
     {
         /*


### PR DESCRIPTION
Introduce a new assertion "assert_array_approx_equals" which had been used in following tests, thinking it would be beneficial to move to testharness.js. 

https://github.com/w3c/web-platform-tests/blob/master/webaudio/js/helpers.js
https://github.com/w3c/web-platform-tests/pull/5870/files#diff-fa1be1fe6b8a22ab248c4d2824a715e8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6682)
<!-- Reviewable:end -->
