### PR TITLE
Fix #6683: Declare global *.js and *.css files as UTF-8

### DIFF
--- a/common/PrefixedLocalStorage.js.headers
+++ b/common/PrefixedLocalStorage.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/PrefixedPostMessage.js.headers
+++ b/common/PrefixedPostMessage.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/canvas-frame.css.headers
+++ b/common/canvas-frame.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=utf-8

--- a/common/canvas-index.css.headers
+++ b/common/canvas-index.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=utf-8

--- a/common/canvas-spec.css.headers
+++ b/common/canvas-spec.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=utf-8

--- a/common/canvas-tests.css.headers
+++ b/common/canvas-tests.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css; charset=utf-8

--- a/common/canvas-tests.js.headers
+++ b/common/canvas-tests.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/css-paint-tests.js.headers
+++ b/common/css-paint-tests.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/get-host-info.sub.js.headers
+++ b/common/get-host-info.sub.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/media.js.headers
+++ b/common/media.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/object-association.js.headers
+++ b/common/object-association.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/performance-timeline-utils.js.headers
+++ b/common/performance-timeline-utils.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/reftest-wait.js.headers
+++ b/common/reftest-wait.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/stringifiers.js.headers
+++ b/common/stringifiers.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/test-setting-immutable-prototype.js.headers
+++ b/common/test-setting-immutable-prototype.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/utils.js.headers
+++ b/common/utils.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/common/vendor-prefix.js.headers
+++ b/common/vendor-prefix.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/chooser_service.mojom.js.headers
+++ b/resources/chromium/chooser_service.mojom.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/device.mojom.js.headers
+++ b/resources/chromium/device.mojom.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/device_manager.mojom.js.headers
+++ b/resources/chromium/device_manager.mojom.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/mojo_bindings.js.headers
+++ b/resources/chromium/mojo_bindings.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/string16.mojom.js.headers
+++ b/resources/chromium/string16.mojom.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/chromium/webusb-test.js.headers
+++ b/resources/chromium/webusb-test.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/idlharness.js.headers
+++ b/resources/idlharness.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/testharness.css.headers
+++ b/resources/testharness.css.headers
@@ -1,0 +1,1 @@
+Content-Type: text/css;charset=utf-8

--- a/resources/testharness.js.headers
+++ b/resources/testharness.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/testharnessreport.js.headers
+++ b/resources/testharnessreport.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8

--- a/resources/webidl2/lib/webidl2.js.headers
+++ b/resources/webidl2/lib/webidl2.js.headers
@@ -1,0 +1,1 @@
+Content-Type: text/javascript; charset=utf-8


### PR DESCRIPTION
Currently, none of these have any charset specified and this breaks when they are included from files that are not ASCII supersets.

Fixes #6683.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6685)
<!-- Reviewable:end -->
