### PR TITLE
Let resource URL protocol be configurable;

### DIFF
--- a/webdriver/support/fixtures.py
+++ b/webdriver/support/fixtures.py
@@ -174,14 +174,11 @@ def new_session(configuration, request):
 
 
 def url(server_config):
-    def inner(path, query="", fragment=""):
-        rv = urlparse.urlunsplit(("http",
-                                  "%s:%s" % (server_config["host"],
-                                             server_config["ports"]["http"][0]),
-                                  path,
-                                  query,
-                                  fragment))
-        return rv
+    def inner(path, protocol="http", query="", fragment=""):
+        port = server_config["ports"][protocol][0]
+        host = "%s:%s" % (server_config["host"], port)
+        return urlparse.urlunsplit((protocol, host, path, query, fragment))
+
     return inner
 
 def create_dialog(session):


### PR DESCRIPTION

The url fixture is used to access hosted files on the wptserve instance.
This patch makes it possible to choose between different wptserve HTTPDs
based on the protocol.

The default remains the HTTP protocol.

MozReview-Commit-ID: FvtMMUSlB4M

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1372595 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6688)
<!-- Reviewable:end -->
