### PR TITLE
Get all wpt test types working with --try-test-paths try syntax;

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -710,9 +710,8 @@ class ManagerGroup(object):
     def run(self, test_type, tests):
         """Start all managers in the group"""
         self.logger.debug("Using %i processes" % self.size)
-
         type_tests = tests[test_type]
-        if type_tests is None:
+        if not type_tests:
             self.logger.info("No %s tests to run" % test_type)
             return
 


### PR DESCRIPTION

`try-test-paths` is set up to map anything under testing/web-platform
to the web-platform-tests flavour. By default, the web-platform-tests flavour
refers to the testharness test type for wptrunner, so we need to account for
reftest and wdspec test types.

This change causes mozharness to omit the test-type argument to wptrunner when
try-test-paths is being used, therefore making wptrunner determine the
appropriate test type for each requested test.

MozReview-Commit-ID: 7TDAShdDM4g

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1376974 [ci skip]