### PR TITLE
Convert old-tests/submission/Opera/script_scheduling/099.html to not use data: URI.

### DIFF
--- a/old-tests/submission/Opera/script_scheduling/scripts/include-11.js
+++ b/old-tests/submission/Opera/script_scheduling/scripts/include-11.js
@@ -1,4 +1,4 @@
 log("external script before adding iframe");
 var iframe = document.createElement("iframe");
-iframe.src = "data:text/html,<script>parent.log('script in iframe')</script>"
+iframe.srcdoc = "<script>parent.log('script in iframe')</script>"
 document.body.appendChild(iframe);


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1377245 [ci skip]