### PR TITLE
Make incomplete byte sequences near HTML EOF emit a REPLACEMENT CHARACTER.

### DIFF
--- a/encoding/eof-shift_jis-ref.html
+++ b/encoding/eof-shift_jis-ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset=shift_jis>
+<title>Shift_JIS file ending with a truncated sequence</title>
+One-byte truncated sequence:&#xFFFD;

--- a/encoding/eof-shift_jis.html
+++ b/encoding/eof-shift_jis.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=shift_jis>
+<title>Shift_JIS file ending with a truncated sequence</title>
+<link rel=match href=/encoding/eof-shift_jis-ref.html>
+One-byte truncated sequence:�

--- a/encoding/eof-utf-8-one-ref.html
+++ b/encoding/eof-utf-8-one-ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a one-byte truncated sequence</title>
+One-byte truncated sequence:&#xFFFD;

--- a/encoding/eof-utf-8-one.html
+++ b/encoding/eof-utf-8-one.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a one-byte truncated sequence</title>
+<link rel=match href="eof-utf-8-one-ref.html">
+One-byte truncated sequence:ð

--- a/encoding/eof-utf-8-three-ref.html
+++ b/encoding/eof-utf-8-three-ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a three-byte truncated sequence</title>
+Three-byte truncated sequence:&#xFFFD;

--- a/encoding/eof-utf-8-three.html
+++ b/encoding/eof-utf-8-three.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a three-byte truncated sequence</title>
+<link rel=match href="eof-utf-8-three-ref.html">
+Three-byte truncated sequence:ðŸ’

--- a/encoding/eof-utf-8-two-ref.html
+++ b/encoding/eof-utf-8-two-ref.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a two-byte truncated sequence</title>
+Two-byte truncated sequence:&#xFFFD;

--- a/encoding/eof-utf-8-two.html
+++ b/encoding/eof-utf-8-two.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>UTF-8 file ending with a two-byte truncated sequence</title>
+<link rel=match href="eof-utf-8-two-ref.html">
+Two-byte truncated sequence:ðŸ


### PR DESCRIPTION

MozReview-Commit-ID: 6NF4rMWxyVu

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=562590 [ci skip]