### PR TITLE
Assert upload.abort and upload.loadend events before abort,

### DIFF
--- a/XMLHttpRequest/abort-after-send.htm
+++ b/XMLHttpRequest/abort-after-send.htm
@@ -38,7 +38,7 @@
         client.abort()
         assert_true(control_flag)
         assert_equals(client.readyState, 0)
-        assert_xhr_event_order_matches([1, "loadstart(0,0,false)", 4, "abort(0,0,false)", "loadend(0,0,false)"])
+        assert_xhr_event_order_matches([1, "loadstart(0,0,false)", 4, "upload.abort(0,0,false)", "upload.loadend(0,0,false)", "abort(0,0,false)", "loadend(0,0,false)"])
         test.done()
       })
     </script>


### PR DESCRIPTION

Per https://xhr.spec.whatwg.org/#request-error-steps xhr.upload.onabort fires before xhr.onabort

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1345457 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6694)
<!-- Reviewable:end -->
