### PR TITLE
Check Stylo env var for WPT processing.

### DIFF
--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -77,6 +77,8 @@ class RunInfo(dict):
             self["debug"] = False
         if product == "firefox" and "stylo" not in self:
             self["stylo"] = False
+        if 'STYLO_FORCE_ENABLED' in os.environ:
+            self["stylo"] = True
         if extras is not None:
             self.update(extras)
 


### PR DESCRIPTION

Test harnesses may use STYLO_FORCE_ENABLED, so we need to check this value when
building WPT test conditions.

MozReview-Commit-ID: HXZZqBkRdOv

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1380082 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6702)
<!-- Reviewable:end -->
