### PR TITLE
Ensure we have a valid window handle before trying to wait,

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -176,6 +176,7 @@ class MarionetteProtocol(Protocol):
         if socket_timeout:
             self.marionette.timeout.script = socket_timeout / 2
 
+        self.marionette.switch_to_window(self.runner_handle)
         while True:
             try:
                 self.marionette.execute_async_script("")


### PR DESCRIPTION

If we switched to a window that is now closed (possible in a reftest
run, for example), we might end up calling execute_async_script
without a valid current window. The runner window is always supposed
to be open (and if it isn't then waiting won't make much sense
anyway), so switch to that before executing script in wait().

MozReview-Commit-ID: ERoN4sz5SuH

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1381858 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6707)
<!-- Reviewable:end -->
