### PR TITLE
add wpt interpolation test for mismatched 3D transforms.

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -884,6 +884,25 @@ const transformListType = {
         [{ time: 500, expected: rotate3dToMatrix(1, 1, 0, Math.PI * 2 / 4) }]);
     }, property + ': matrix3d');
 
+    // This test aims for forcing the two mismatched transforms to be
+    // decomposed into matrix3d before interpolation. Therefore, we not only
+    // test the interpolation, but also test the 3D matrix decomposition.
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      var animation =
+        target.animate({ [idlName]: ['scale(0.3)',
+                                     // scale(0.5) translateZ(1px)
+                                     'matrix3d(0.5, 0, 0, 0, 0, 0.5, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1)'] },
+                       1000);
+
+      testAnimationSampleMatrices(animation, idlName,
+        [{ time: 500,  expected: [ 0.4, 0,   0,   0,
+                                   0,   0.4, 0,   0,
+                                   0,   0,   1,   0,
+                                   0,   0,   0.5, 1] }]);
+    }, property + ': mismatched 3D transforms');
+
   },
 
   testAddition: function(property, setup) {


### PR DESCRIPTION

This test aims for forcing the two mismatched transforms to be decomposed into
matrix3d before interpolation. To do so, we need to:

1. make 'From' and 'To' to be two mismatched transforms,
2. at least one of the two transforms has to be a 3D transform.

In this way, we not only test the interpolation, but also test the correctness
of 3D matrix decomposition.

MozReview-Commit-ID: FAKu6GFVZRm

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1382517 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6709)
<!-- Reviewable:end -->
