### PR TITLE
Fix rotate_to_matrix.

### DIFF
--- a/web-animations/animation-model/animation-types/property-types.js
+++ b/web-animations/animation-model/animation-types/property-types.js
@@ -903,6 +903,16 @@ const transformListType = {
                                    0,   0,   0.5, 1] }]);
     }, property + ': mismatched 3D transforms');
 
+    test(function(t) {
+      var idlName = propertyToIDL(property);
+      var target = createTestElement(t, setup);
+      var animation =
+        target.animate({ [idlName]: ['rotateY(60deg)', 'none' ] }, 1000);
+
+      testAnimationSampleMatrices(animation, idlName,
+                   // rotateY(30deg) == rotate3D(0, 1, 0, 30deg)
+        [{ time: 500, expected: rotate3dToMatrix(0, 1, 0, Math.PI / 6) }]);
+    }, property + ': rotateY');
   },
 
   testAddition: function(property, setup) {


### PR DESCRIPTION

We used transposed matrices for rotate before this fix.

https://www.w3.org/TR/css-transforms-1/#Rotate3dDefined

MozReview-Commit-ID: 7LYi74vvIBo

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1384410 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6713)
<!-- Reviewable:end -->
