### PR TITLE
Add a test to ensure that the selection is always collapsed to the end after setting the value of input and textarea elements using the DOM API;

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-value-interactions.html
+++ b/html/semantics/forms/textfieldselection/selection-value-interactions.html
@@ -92,4 +92,27 @@ for (var data of elemData) {
   }, `value dirty flag behavior after setRangeText on ${data.desc}`);
 }
 
+for (var tag of ['input', 'textarea']) {
+  test(function() {
+    var el = document.createElement(tag);
+    document.body.appendChild(el);
+    this.add_cleanup(() => el.remove());
+    el.value = "";
+    assert_equals(el.selectionStart, el.value.length,
+                 "element.selectionStart should be value.length");
+    assert_equals(el.selectionEnd, el.value.length,
+                  "element.selectionEnd should be value.length");
+    el.value = "foo";
+    assert_equals(el.selectionStart, el.value.length,
+                 "element.selectionStart should be value.length");
+    assert_equals(el.selectionEnd, el.value.length,
+                  "element.selectionEnd should be value.length");
+    el.value = "foobar";
+    assert_equals(el.selectionStart, el.value.length,
+                 "element.selectionStart should be value.length");
+    assert_equals(el.selectionEnd, el.value.length,
+                  "element.selectionEnd should be value.length");
+  }, `selection is always collapsed to the end after setting values on ${tag}`);
+}
+
 </script>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1385926 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6717)
<!-- Reviewable:end -->
