### PR TITLE
Make sure trickle responses aren't cached

### DIFF
--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -76,5 +76,11 @@ class TestTrickle(TestUsingServer):
         self.assertEqual(resp.read(), expected)
         self.assertGreater(6, t1-t0)
 
+    def test_headers(self):
+        resp = self.request("/document.txt", query="pipe=trickle(d0.01))")
+        self.assertEqual(resp.info()["Cache-Control"], "no-cache, no-store, must-revalidate")
+        self.assertEqual(resp.info()["Pragma"], "no-cache")
+        self.assertEqual(resp.info()["Expires"], "0")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -77,7 +77,7 @@ class TestTrickle(TestUsingServer):
         self.assertGreater(6, t1-t0)
 
     def test_headers(self):
-        resp = self.request("/document.txt", query="pipe=trickle(d0.01))")
+        resp = self.request("/document.txt", query="pipe=trickle(d0.01)")
         self.assertEqual(resp.info()["Cache-Control"], "no-cache, no-store, must-revalidate")
         self.assertEqual(resp.info()["Pragma"], "no-cache")
         self.assertEqual(resp.info()["Expires"], "0")

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -231,6 +231,10 @@ def trickle(request, response, delays):
     content = resolve_content(response)
     offset = [0]
 
+    response.headers.set("Cache-Control", "no-cache, no-store, must-revalidate")
+    response.headers.set("Pragma", "no-cache")
+    response.headers.set("Expires", "0")
+
     def add_content(delays, repeat=False):
         for i, (item_type, value) in enumerate(delays):
             if item_type == "bytes":

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -231,9 +231,12 @@ def trickle(request, response, delays):
     content = resolve_content(response)
     offset = [0]
 
-    response.headers.set("Cache-Control", "no-cache, no-store, must-revalidate")
-    response.headers.set("Pragma", "no-cache")
-    response.headers.set("Expires", "0")
+    if not ("Cache-Control" in response.headers or
+            "Pragma" in response.headers or
+            "Expires" in response.headers):
+        response.headers.set("Cache-Control", "no-cache, no-store, must-revalidate")
+        response.headers.set("Pragma", "no-cache")
+        response.headers.set("Expires", "0")
 
     def add_content(delays, repeat=False):
         for i, (item_type, value) in enumerate(delays):


### PR DESCRIPTION
Occasionally, I've seen browsers decide to cache trickle responses; this obviously causes breakage as they then load instantly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6732)
<!-- Reviewable:end -->
