### PR TITLE
Test a bit more that we don't add empty attributes with classList

### DIFF
--- a/dom/nodes/Element-classlist.html
+++ b/dom/nodes/Element-classlist.html
@@ -22,6 +22,10 @@ function checkModification(e, funcName, args, expectedRes, before, after,
   if (!Array.isArray(args)) {
     args = [args];
   }
+  if (before === null) {
+    assert_not_equals(after, "", "Test bug: we should never expect an empty " +
+                                 "string attribute to be added");
+  }
 
   test(function() {
     var shouldThrow = typeof(expectedException) === "string";
@@ -363,6 +367,7 @@ function testClassList(e, desc) {
                       after, expectedException, desc);
   }
 
+  checkForceToggle(null, "a", false, false, null);
   checkForceToggle("", "a", true, true, "a");
   checkForceToggle("a", "a", true, true, "a");
   checkForceToggle("a", "b", true, true, "a b");


### PR DESCRIPTION
We already expect this in the test for remove(), although the spec
doesn't actually say it.  This adds a test for force-toggle, and adds a
sanity check just in case anyone alters the test expectations
incorrectly in the future.

Strictly speaking this should not be merged until whatwg/dom#462 is
fixed, but in real life I don't see us wanting to mandate what the spec
actually says right now.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
