### PR TITLE
RTCRtpParameters: headerExtensions, rtcp, transactionId

### DIFF
--- a/webrtc/RTCPeerConnection-addTransceiver.html
+++ b/webrtc/RTCPeerConnection-addTransceiver.html
@@ -80,7 +80,7 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
-    assert_own_property(pc, 'addTransceiver');
+    assert_idl_attribute(pc, 'addTransceiver');
     assert_throws(new TypeError(), () => pc.addTransceiver('invalid'));
   }, 'addTransceiver() with string argument as invalid kind should throw TypeError');
 
@@ -126,7 +126,7 @@
   test(t => {
     const pc = new RTCPeerConnection();
 
-    assert_own_property(pc, 'addTransceiver');
+    assert_idl_attribute(pc, 'addTransceiver');
 
     const transceiver = pc.addTransceiver('audio');
     assert_true(transceiver instanceof RTCRtpTransceiver,
@@ -154,7 +154,7 @@
     assert_true(receiver instanceof RTCRtpReceiver,
       'Expect receiver to be instance of RTCRtpReceiver');
 
-    const track = receiver.track
+    const track = receiver.track;
     assert_true(track instanceof MediaStreamTrack,
       'Expect receiver.track to be instance of MediaStreamTrack');
 
@@ -171,7 +171,7 @@
   test(t => {
     const pc = new RTCPeerConnection();
 
-    assert_own_property(pc, 'addTransceiver');
+    assert_idl_attribute(pc, 'addTransceiver');
 
     const transceiver = pc.addTransceiver('video');
     assert_true(transceiver instanceof RTCRtpTransceiver,
@@ -198,7 +198,7 @@
     assert_true(receiver instanceof RTCRtpReceiver,
       'Expect receiver to be instance of RTCRtpReceiver');
 
-    const track = receiver.track
+    const track = receiver.track;
     assert_true(track instanceof MediaStreamTrack,
       'Expect receiver.track to be instance of MediaStreamTrack');
 
@@ -226,7 +226,7 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
-    assert_own_property(pc, 'addTransceiver');
+    assert_idl_attribute(pc, 'addTransceiver');
     assert_throws(new TypeError(), () =>
       pc.addTransceiver('audio', { direction: 'invalid' }));
   }, `addTransceiver() with invalid direction should throw TypeError`);
@@ -252,7 +252,7 @@
     assert_equals(sender.track, track,
       'Expect sender.track should be the track that is added');
 
-    const receiverTrack = receiver.track
+    const receiverTrack = receiver.track;
     assert_true(receiverTrack instanceof MediaStreamTrack,
       'Expect receiver.track to be instance of MediaStreamTrack');
 
@@ -302,6 +302,109 @@
 
   }, 'addTransceiver(track) multiple times should create multiple transceivers');
 
+
+  /*
+    5.1.  addTransceiver
+      6.  Verify that each rid value in sendEncodings is composed only of
+          case-sensitive alphanumeric characters (a-z, A-Z, 0-9) up to a maximum
+          of 16 characters. If one of the RIDs does not meet these requirements,
+          throw a TypeError.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection();
+    assert_idl_attribute(pc, 'addTransceiver');
+
+    assert_throws(new TypeError(), () =>
+      pc.addTransceiver('audio', {
+        sendEncodings: [{
+          rid: '@Invalid!'
+        }]
+      }));
+  }, 'addTransceiver() with rid containing invalid non-alphanumeric characters should throw TypeError');
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+    assert_idl_attribute(pc, 'addTransceiver');
+
+    assert_throws(new TypeError(), () =>
+      pc.addTransceiver('audio', {
+        sendEncodings: [{
+          rid: 'a'.repeat(17)
+        }]
+      }));
+  }, 'addTransceiver() with rid longer than 16 characters should throw TypeError');
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+    pc.addTransceiver('audio', {
+      sendEncodings: [{
+        rid: 'foo'
+      }]
+    });
+  }, `addTransceiver() with valid rid value should succeed`);
+
+  /*
+    5.1.  addTransceiver
+      7.  If any RTCRtpEncodingParameters dictionary in sendEncodings contains a
+          read-only parameter other than rid, throw an InvalidAccessError.
+
+      - The sendEncodings argument can be used to specify the number of offered
+        simulcast encodings, and optionally their RIDs and encoding parameters.
+        Aside from rid , all read-only parameters in the RTCRtpEncodingParameters
+        dictionaries, such as ssrc, must be left unset, or an error will be thrown.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection();
+
+    assert_throws('InvalidAccessError', () =>
+      pc.addTransceiver('audio', {
+        sendEncodings: [{
+          ssrc: 2
+        }]
+      }));
+  }, `addTransceiver() with readonly ssrc set should throw InvalidAccessError`);
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+
+    assert_throws('InvalidAccessError', () =>
+      pc.addTransceiver('audio', {
+        sendEncodings: [{
+          rtx: {
+            ssrc: 2
+          }
+        }]
+      }));
+  }, `addTransceiver() with readonly rtx set should throw InvalidAccessError`);
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+
+    assert_throws('InvalidAccessError', () =>
+      pc.addTransceiver('audio', {
+        sendEncodings: [{
+          fec: {
+            ssrc: 2
+          }
+        }]
+      }));
+  }, `addTransceiver() with readonly fec set should throw InvalidAccessError`);
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+    pc.addTransceiver('audio', {
+      sendEncodings: [{
+        dtx: 'enabled',
+        active: false,
+        priority: 'low',
+        ptime: 5,
+        maxBitrate: 8,
+        maxFramerate: 25,
+        rid: 'foo'
+      }]
+    });
+  }, `addTransceiver() with valid sendEncodings should succeed`);
+
   /*
     TODO
       5.1.  addTransceiver
@@ -312,24 +415,8 @@
         - Setting a new RTCSessionDescription may change mid to a non-null value,
           as defined in [JSEP] (section 5.5. and section 5.6.).
 
-        - The sendEncodings argument can be used to specify the number of offered
-          simulcast encodings, and optionally their RIDs and encoding parameters.
-          Aside from rid , all read-only parameters in the RTCRtpEncodingParameters
-          dictionaries, such as ssrc, must be left unset, or an error will be thrown.
-
         1.  If the dictionary argument is present, and it has a streams member, let
             streams be that list of MediaStream objects.
-
-        2.  If the dictionary argument is present, and it has a sendEncodings member,
-            let sendEncodings be that list of RTCRtpEncodingParameters objects.
-
-        6.  Verify that each rid value in sendEncodings is composed only of
-            case-sensitive alphanumeric characters (a-z, A-Z, 0-9) up to a maximum
-            of 16 characters. If one of the RIDs does not meet these requirements,
-            throw a TypeError.
-
-        7.  If any RTCRtpEncodingParameters dictionary in sendEncodings contains
-            a read-only parameter other than rid , throw an InvalidAccessError.
 
       5.2.  RTCRtpSender Interface
         Create an RTCRtpSender
@@ -378,11 +465,11 @@
 
     Coverage Report
                             Tested    Not-Tested  Non-Testable  Total
-      addTransceiver          11          4           3           18
+      addTransceiver          14          1           3           18
       Create Sender            3          4           0            7
       Create Receiver          8          1           0            9
       Create Transceiver       7          0           0            7
 
-      Total                   29          9           3           41
+      Total                   32          6           3           41
    */
 </script>

--- a/webrtc/RTCPeerConnection-getTransceivers.html
+++ b/webrtc/RTCPeerConnection-getTransceivers.html
@@ -7,7 +7,7 @@
   'use strict';
 
   // Test is based on the following editor draft:
-  // https://w3c.github.io/webrtc-pc/archives/20170515/webrtc.html
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
 
   /*
    *  5.1. RTCPeerConnection Interface Extensions
@@ -22,15 +22,15 @@
   test(t => {
     const pc = new RTCPeerConnection();
 
-    assert_own_property(pc, 'getSenders');
+    assert_idl_attribute(pc, 'getSenders');
     const senders = pc.getSenders();
     assert_array_equals([], senders, 'Expect senders to be empty array');
 
-    assert_own_property(pc, 'getReceivers');
+    assert_idl_attribute(pc, 'getReceivers');
     const receivers = pc.getReceivers();
     assert_array_equals([], receivers, 'Expect receivers to be empty array');
 
-    assert_own_property(pc, 'getTransceivers');
+    assert_idl_attribute(pc, 'getTransceivers');
     const transceivers = pc.getTransceivers();
     assert_array_equals([], transceivers, 'Expect transceivers to be empty array');
 

--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -361,7 +361,7 @@ function assert_equals_array_buffer(buffer1, buffer2) {
 function generateMediaStreamTrack(kind) {
   const pc = new RTCPeerConnection();
 
-  assert_own_property(pc, 'addTransceiver',
+  assert_idl_attribute(pc, 'addTransceiver',
     'Expect pc to have addTransceiver() method');
 
   const transceiver = pc.addTransceiver(kind);

--- a/webrtc/RTCRtpParameters-codecs.html
+++ b/webrtc/RTCRtpParameters-codecs.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters codecs</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      dictionary RTCRtpCodecParameters {
+        [readonly]
+        unsigned short payloadType;
+
+        [readonly]
+        DOMString      mimeType;
+
+        [readonly]
+        unsigned long  clockRate;
+
+        [readonly]
+        unsigned short channels;
+
+        [readonly]
+        DOMString      sdpFmtpLine;
+      };
+
+      getParameters
+          - The codecs sequence is populated based on the codecs that have been negotiated
+            for sending, and which the user agent is currently capable of sending.
+
+            If setParameters has removed or reordered codecs, getParameters MUST return
+            the shortened/reordered list. However, every time codecs are renegotiated by
+            a new offer/answer exchange, the list of codecs MUST be restored to the full
+            negotiated set, in the priority order indicated by the remote description,
+            in effect discarding the effects of setParameters.
+
+      codecs
+        - When using the setParameters method, the codecs sequence from the corresponding
+          call to getParameters can be reordered and entries can be removed, but entries
+          cannot be added, and the RTCRtpCodecParameters dictionary members cannot be modified.
+   */
+
+  // Get the first codec from param.codecs.
+  // Assert that param.codecs has at least one element
+  function getFirstCodec(param) {
+    const { codecs } = param;
+    assert_greater_than(codecs.length, 0);
+    return codecs[0];
+  }
+
+  /*
+    5.2.  setParameters
+      7.  If parameters.encodings.length is different from N, or if any parameter
+          in the parameters argument, marked as a Read-only parameter, has a value
+          that is different from the corresponding parameter value returned from
+          sender.getParameters(), abort these steps and return a promise rejected
+          with a newly created InvalidModificationError. Note that this also applies
+          to transactionId.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const codec = getFirstCodec(param);
+
+    if(codec.payloadType === undefined) {
+      codec.payloadType = 8;
+    } else {
+      codec.payloadType += 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with codec.payloadType modified should reject with InvalidModificationError');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const codec = getFirstCodec(param);
+
+    if(codec.mimeType === undefined) {
+      codec.mimeType = 'audio/piedpiper';
+    } else {
+      codec.mimeType = `${codec.mimeType}-modified`;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with codec.mimeType modified should reject with InvalidModificationError');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const codec = getFirstCodec(param);
+
+    if(codec.clockRate === undefined) {
+      codec.clockRate = 8000;
+    } else {
+      codec.clockRate += 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with codec.clockRate modified should reject with InvalidModificationError');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const codec = getFirstCodec(param);
+
+    if(codec.channels === undefined) {
+      codec.channels = 6;
+    } else {
+      codec.channels += 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with codec.channels modified should reject with InvalidModificationError');
+
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const codec = getFirstCodec(param);
+
+    if(codec.sdpFmtpLine === undefined) {
+      codec.sdpFmtpLine = 'a=fmtp:98 0-15';
+    } else {
+      codec.sdpFmtpLine = `${codec.sdpFmtpLine};foo=1`;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with codec.sdpFmtpLine modified should reject with InvalidModificationError');
+
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { codecs } = param;
+
+    codecs.push({
+      payloadType: 2,
+      mimeType: 'audio/piedpiper',
+      clockRate: 1000,
+      channels: 2
+    });
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, 'setParameters() with new codecs inserted should reject with InvalidModificationError');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { codecs } = param;
+
+    // skip and pass test if there is less than 2 codecs
+    if(codecs.length >= 2) {
+      const tmp = codecs[0];
+      codecs[0] = codecs[1];
+      codecs[1] = tmp;
+    }
+
+    return sender.setParameters(param);
+
+  }, 'setParameters with reordered codecs should succeed');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { codecs } = param;
+
+    param.codecs = codecs.slice(1);
+
+    return sender.setParameters(param);
+
+  }, 'setParameters with dropped codec should succeed');
+
+</script>

--- a/webrtc/RTCRtpParameters-degradationPreference.html
+++ b/webrtc/RTCRtpParameters-degradationPreference.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters degradationPreference</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      enum RTCDegradationPreference {
+        "maintain-framerate",
+        "maintain-resolution",
+        "balanced"
+      };
+
+      - degradationPreference is set to the last value passed into setParameters,
+        or the default value of "balanced" if setParameters hasn't been called.
+   */
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    assert_equals(param.degradationPreference, 'balanced',
+      'Expect initial param.degradationPreference to be balanced');
+
+    param.degradationPreference = 'maintain-framerate';
+
+    return pc.setParameters(param)
+    .then(() => {
+      const param = sender.getParameters();
+      validateSenderRtpParameters(param);
+
+      assert_equals(param.degradationPreference, 'maintain-framerate');
+    });
+  }, 'setParameters with degradationPreference set should succeed');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    assert_equals(param.degradationPreference, 'balanced',
+      'Expect initial param.degradationPreference to be balanced');
+
+    param.degradationPreference = undefined;
+
+    return pc.setParameters(param)
+    .then(() => {
+      const param = sender.getParameters();
+      validateSenderRtpParameters(param);
+
+      assert_equals(param.degradationPreference, undefined);
+    });
+  }, 'setParameters with degradationPreference unset should succeed');
+
+</script>

--- a/webrtc/RTCRtpParameters-encodings.html
+++ b/webrtc/RTCRtpParameters-encodings.html
@@ -1,0 +1,396 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters encodings</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.1.  RTCPeerConnection Interface Extensions
+      partial interface RTCPeerConnection {
+        RTCRtpTransceiver           addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
+                                                   optional RTCRtpTransceiverInit init);
+        ...
+      };
+
+      dictionary RTCRtpTransceiverInit {
+        RTCRtpTransceiverDirection         direction = "sendrecv";
+        sequence<MediaStream>              streams;
+        sequence<RTCRtpEncodingParameters> sendEncodings;
+      };
+
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      dictionary RTCRtpEncodingParameters {
+        [readonly]
+        unsigned long       ssrc;
+
+        [readonly]
+        RTCRtpRtxParameters rtx;
+
+        [readonly]
+        RTCRtpFecParameters fec;
+
+        RTCDtxStatus        dtx;
+        boolean             active;
+        RTCPriorityType     priority;
+        unsigned long       ptime;
+        unsigned long       maxBitrate;
+        double              maxFramerate;
+
+        [readonly]
+        DOMString           rid;
+
+        double              scaleResolutionDownBy;
+      };
+
+      dictionary RTCRtpRtxParameters {
+        [readonly]
+        unsigned long ssrc;
+      };
+
+      dictionary RTCRtpFecParameters {
+        [readonly]
+        unsigned long ssrc;
+      };
+
+      enum RTCDtxStatus {
+        "disabled",
+        "enabled"
+      };
+
+      enum RTCPriorityType {
+        "very-low",
+        "low",
+        "medium",
+        "high"
+      };
+
+      getParameters
+        - encodings is set to the value of the [[send encodings]] internal slot.
+   */
+
+  // Get the first encoding in param.encodings.
+  // Asserts that param.encodings has at least one element.
+  function getFirstEncoding(param) {
+    const { encodings } = param;
+    assert_equals(encodings.length, 1);
+    return encodings[0];
+  }
+
+  /*
+    5.1.  addTransceiver
+      7. Create an RTCRtpSender with track, streams and sendEncodings and let sender
+         be the result.
+
+    5.2.  create an RTCRtpSender
+      5.  Let sender have a [[send encodings]] internal slot, representing a list
+          of RTCRtpEncodingParameters dictionaries.
+      6.  If sendEncodings is given as input to this algorithm, and is non-empty,
+          set the [[send encodings]] slot to sendEncodings.
+
+          Otherwise, set it to a list containing a single RTCRtpEncodingParameters
+          with active set to true.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio');
+    const param = transceiver.sender.getParameters();
+    validateSenderRtpParameters(param);
+    const { encodings } = param;
+    const encoding = getFirstEncoding(param);
+
+    assert_equals(encoding.active, true);
+  }, 'addTransceiver() with undefined sendEncodings should have default encoding parameter with active set to true');
+
+  test(() => {
+    const pc = new RTCPeerConnection();
+    const transceiver = pc.addTransceiver('audio', { sendEncodings: [] });
+
+    const param = transceiver.sender.getParameters();
+    validateSenderRtpParameters(param);
+    const { encodings } = param;
+    const encoding = getFirstEncoding(param);
+
+    assert_equals(encoding.active, true);
+  }, 'addTransceiver() with empty list sendEncodings should have default encoding parameter with active set to true');
+
+  /*
+    5.2.  create an RTCRtpSender
+      To create an RTCRtpSender with a MediaStreamTrack , track, a list of MediaStream
+      objects, streams, and optionally a list of RTCRtpEncodingParameters objects,
+      sendEncodings, run the following steps:
+        5.  Let sender have a [[send encodings]] internal slot, representing a list
+            of RTCRtpEncodingParameters dictionaries.
+
+        6.  If sendEncodings is given as input to this algorithm, and is non-empty,
+            set the [[send encodings]] slot to sendEncodings.
+
+    5.2.  getParameters
+      - encodings is set to the value of the [[send encodings]] internal slot.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio', {
+      sendEncodings: [{
+        dtx: 'enabled',
+        active: false,
+        priority: 'low',
+        ptime: 5,
+        maxBitrate: 8,
+        maxFramerate: 25,
+        rid: 'foo'
+      }]
+    });
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+
+    assert_equals(encoding.dtx, 'enabled');
+    assert_equals(encoding.active, false);
+    assert_equals(encoding.priority, 'low');
+    assert_equals(encoding.ptime, 5);
+    assert_equals(encoding.maxBitrate, 8);
+    assert_equals(encoding.maxFramerate, 25);
+    assert_equals(encoding.rid, 'foo');
+
+  }, `sender.getParameters() should return sendEncodings set by addTransceiver()`);
+
+  /*
+    5.2.  setParameters
+      3.  Let N be the number of RTCRtpEncodingParameters stored in sender's internal
+          [[send encodings]] slot.
+      7.  If parameters.encodings.length is different from N, or if any parameter
+          in the parameters argument, marked as a Read-only parameter, has a value
+          that is different from the corresponding parameter value returned from
+          sender.getParameters(), abort these steps and return a promise rejected
+          with a newly created InvalidModificationError. Note that this also applies
+          to transactionId.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { encodings } = param;
+    assert_equals(encodings.length, 1);
+
+    // {} is valid RTCRtpEncodingParameters because all fields are optional
+    encodings.push({});
+    assert_equals(param.encodings.length, 2);
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `sender.setParameters() with mismatch number of encodings should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    param.encodings = undefined;
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `sender.setParameters() with encodings unset should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+    const { ssrc } = encoding;
+
+    // ssrc may not be set since it is optional
+    if(ssrc === undefined) {
+      encoding.ssrc = 2;
+    } else {
+      // If it is set, increase the number by 1 to make it different from original
+      encoding.ssrc = ssrc + 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified encoding.ssrc field should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+    const { rtx } = encoding;
+
+    if(rtx === undefined) {
+      encoding.rtx = { ssrc: 2 };
+    } else if(rtx.ssrc === undefined) {
+      rtx.ssrc = 2;
+    } else {
+      rtx.ssrc += 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified encoding.rtx field should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+    const { fec } = encoding;
+
+    if(fec === undefined) {
+      encoding.fec = { ssrc: 2 };
+    } else if(fec.ssrc === undefined) {
+      fec.ssrc = 2;
+    } else {
+      fec.ssrc += 1;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified encoding.fec field should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio', {
+      sendEncodings: [{ rid: 'foo' }],
+    });
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+
+    assert_equals(encoding.rid, 'foo');
+
+    encoding.rid = 'bar';
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified encoding.rid field should reject with InvalidModificationError`);
+
+  /*
+    5.2.  setParameters
+      8.  If the scaleResolutionDownBy parameter in the parameters argument has a
+          value less than 1.0, abort these steps and return a promise rejected with
+          a newly created RangeError.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+
+    encoding.scaleResolutionDownBy = 0.5;
+    return promise_rejects(t, 'RangeError',
+      sender.setParameters(param));
+
+  }, `setParameters() with encoding.scaleResolutionDownBy field set to less than 1.0 should reject with RangeError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+    const encoding = getFirstEncoding(param);
+
+    encoding.scaleResolutionDownBy = 1.5;
+    return sender.setParameters(param)
+    .then(() => {
+      const param = sender.getParameters();
+      validateSenderRtpParameters(param);
+      const encoding = getFirstEncoding(param);
+
+      assert_approx_equals(encoding.scaleResolutionDownBy, 1.5, 0.01);
+    });
+
+  }, `setParameters() with encoding.scaleResolutionDownBy field set to greater than 1.0 should succeed`);
+
+  // Helper function to test that modifying an encoding field should succeed
+  function test_modified_encoding(field, value1, value2, desc) {
+    promise_test(t => {
+      const pc = new RTCPeerConnection();
+      const { sender } = pc.addTransceiver('audio', {
+        sendEncodings: [{
+          [field]: value1
+        }]
+      });
+
+      const param = sender.getParameters();
+      validateSenderRtpParameters(param);
+      const encoding = getFirstEncoding(param);
+
+      assert_equals(encoding[field], value1);
+      encoding[field] = value2;
+
+      return sender.setParameters(param)
+      .then(() => {
+        const param = sender.getParameters();
+        validateSenderRtpParameters(param);
+        const encoding = getFirstEncoding(param);
+        assert_equals(encoding[field], value2);
+      });
+    }, desc);
+  }
+
+  test_modified_encoding('dtx', 'enabled', 'disabled',
+    'setParameters() with modified encoding.dtx should succeed');
+
+  test_modified_encoding('dtx', 'enabled', undefined,
+    'setParameters() with unset encoding.dtx should succeed');
+
+  test_modified_encoding('active', true, false,
+    'setParameters() with modified encoding.active should succeed');
+
+  test_modified_encoding('priority', 'very-low', 'high',
+    'setParameters() with modified encoding.priority should succeed');
+
+  test_modified_encoding('ptime', 2, 4,
+    'setParameters() with modified encoding.ptime should succeed');
+
+  test_modified_encoding('maxBitrate', 2, 4,
+    'setParameters() with modified encoding.maxBitrate should succeed');
+
+  test_modified_encoding('maxBitrate', 24, 16,
+    'setParameters() with modified encoding.maxFramerate should succeed');
+
+</script>

--- a/webrtc/RTCRtpParameters-headerExtensions.html
+++ b/webrtc/RTCRtpParameters-headerExtensions.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters headerExtensions</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      dictionary RTCRtpHeaderExtensionParameters {
+        [readonly]
+        DOMString      uri;
+
+        [readonly]
+        unsigned short id;
+
+        [readonly]
+        boolean        encrypted;
+      };
+
+      getParameters
+        - The headerExtensions sequence is populated based on the header extensions
+          that have been negotiated for sending.
+   */
+
+  /*
+    5.2.  setParameters
+      7.  If parameters.encodings.length is different from N, or if any parameter
+          in the parameters argument, marked as a Read-only parameter, has a value
+          that is different from the corresponding parameter value returned from
+          sender.getParameters(), abort these steps and return a promise rejected
+          with a newly created InvalidModificationError. Note that this also applies
+          to transactionId.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    param.headerExtensions = [{
+      uri: 'non-existent.example.org',
+      id: 404,
+      encrypted: false
+    }];
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified headerExtensions should reject with InvalidModificationError`);
+
+</script>

--- a/webrtc/RTCRtpParameters-helper.js
+++ b/webrtc/RTCRtpParameters-helper.js
@@ -1,0 +1,262 @@
+'use strict';
+
+// Test is based on the following editor draft:
+// https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+// Helper function for testing RTCRtpParameters dictionary fields
+
+// This file depends on dictionary-helper.js which should
+// be loaded from the main HTML file.
+
+/*
+  Validates the RTCRtpParameters returned from RTCRtpSender.prototype.getParameters
+
+  5.2.  RTCRtpSender Interface
+    getParameters
+      - transactionId is set to a new unique identifier, used to match this getParameters
+        call to a setParameters call that may occur later.
+
+      - encodings is set to the value of the [[SendEncodings]] internal slot.
+
+      - The headerExtensions sequence is populated based on the header extensions that
+        have been negotiated for sending.
+
+      - The codecs sequence is populated based on the codecs that have been negotiated
+        for sending, and which the user agent is currently capable of sending. If
+        setParameters has removed or reordered codecs, getParameters MUST return the
+        shortened/reordered list. However, every time codecs are renegotiated by a
+        new offer/answer exchange, the list of codecs MUST be restored to the full
+        negotiated set, in the priority order indicated by the remote description,
+        in effect discarding the effects of setParameters.
+
+      - rtcp.cname is set to the CNAME of the associated RTCPeerConnection. rtcp.reducedSize
+        is set to true if reduced-size RTCP has been negotiated for sending, and false otherwise.
+
+      - degradationPreference is set to the last value passed into setParameters, or the
+        default value of "balanced" if setParameters hasn't been called.
+ */
+function validateSenderRtpParameters(param) {
+  validateRtpParameters(param);
+
+  assert_not_equals(param.transactionId, undefined,
+    'Expect sender param.transactionId to be set');
+
+  assert_not_equals(param.rtcp.cname, undefined,
+    'Expect sender param.rtcp.cname to be set');
+
+  assert_not_equals(param.rtcp.reducedSize, undefined,
+    'Expect sender param.rtcp.reducedSize to be set to either true or false');
+}
+
+/*
+  Validates the RTCRtpParameters returned from RTCRtpReceiver.prototype.getParameters
+
+  5.3.  RTCRtpReceiver Interface
+    getParameters
+      When getParameters is called, the RTCRtpParameters dictionary is constructed
+      as follows:
+
+      - encodings is populated based on SSRCs and RIDs present in the current remote
+        description, including SSRCs used for RTX and FEC, if signaled. Every member
+        of the RTCRtpEncodingParameters dictionaries other than the SSRC and RID fields
+        is left undefined.
+
+      - The headerExtensions sequence is populated based on the header extensions that
+        the receiver is currently prepared to receive.
+
+      - The codecs sequence is populated based on the codecs that the receiver is currently
+        prepared to receive.
+
+      - rtcp.reducedSize is set to true if the receiver is currently prepared to receive
+        reduced-size RTCP packets, and false otherwise. rtcp.cname is left undefined.
+
+      - transactionId and degradationPreference are left undefined.
+ */
+function validateReceiverRtpParameters(param) {
+  validateRtpParameters(param);
+
+  assert_equals(param.transactionId, undefined,
+    'Expect receiver param.transactionId to be unset');
+
+  assert_not_equals(param.rtcp.reducedSize, undefined,
+    'Expect receiver param.rtcp.reducedSize to be set');
+
+  assert_equals(param.rtcp.cname, undefined,
+    'Expect receiver param.rtcp.cname to be unset');
+
+  assert_equals(param.degradationPreference, undefined,
+    'Expect receiver param.degradationPreference to be unset');
+}
+
+/*
+  dictionary RTCRtpParameters {
+    DOMString                                 transactionId;
+    sequence<RTCRtpEncodingParameters>        encodings;
+    sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+    RTCRtcpParameters                         rtcp;
+    sequence<RTCRtpCodecParameters>           codecs;
+    RTCDegradationPreference                  degradationPreference;
+  };
+
+  enum RTCDegradationPreference {
+    "maintain-framerate",
+    "maintain-resolution",
+    "balanced"
+  };
+ */
+function validateRtpParameters(param) {
+  assert_optional_string_field(param, 'transactionId');
+
+  assert_array_field(param, 'encodings');
+  for(const encoding of param.encodings) {
+    validateEncodingParameters(encoding);
+  }
+
+  assert_array_field(param, 'headerExtensions');
+  for(const headerExt of param.headerExtensions) {
+    validateHeaderExtensionParameters(headerExt);
+  }
+
+  assert_dict_field(param, 'rtcp');
+  validateRtcpParameters(param.rtcp);
+
+  assert_array_field(param, 'codecs');
+  for(const codec of param.codecs) {
+    validateCodecParameters(codec);
+  }
+
+  assert_optional_enum_field(param, 'degradationPreference',
+    ['maintain-framerate', 'maintain-resolution', 'balanced']);
+}
+
+/*
+  dictionary RTCRtpEncodingParameters {
+    [readonly]
+    unsigned long       ssrc;
+
+    [readonly]
+    RTCRtpRtxParameters rtx;
+
+    [readonly]
+    RTCRtpFecParameters fec;
+
+    RTCDtxStatus        dtx;
+    boolean             active;
+    RTCPriorityType     priority;
+    unsigned long       ptime;
+    unsigned long       maxBitrate;
+    double              maxFramerate;
+
+    [readonly]
+    DOMString           rid;
+
+    double              scaleResolutionDownBy;
+  };
+
+  dictionary RTCRtpRtxParameters {
+    [readonly]
+    unsigned long ssrc;
+  };
+
+  dictionary RTCRtpFecParameters {
+    [readonly]
+    unsigned long ssrc;
+  };
+
+  enum RTCDtxStatus {
+    "disabled",
+    "enabled"
+  };
+
+  enum RTCPriorityType {
+    "very-low",
+    "low",
+    "medium",
+    "high"
+  };
+ */
+function validateEncodingParameters(encoding) {
+  assert_optional_unsigned_int_field(encoding, 'ssrc');
+
+  assert_optional_dict_field(encoding, 'rtx');
+  if(encoding.rtx) {
+    assert_unsigned_int_field(encoding.rtx, 'ssrc');
+  }
+
+  assert_optional_dict_field(encoding, 'fec');
+  if(encoding.fec) {
+    assert_unsigned_int_field(encoding.fec, 'ssrc');
+  }
+
+  assert_optional_enum_field(encoding, 'dtx',
+    ['disabled', 'enabled']);
+
+  assert_optional_boolean_field(encoding, 'active');
+  assert_optional_enum_field(encoding, 'priority',
+    ['very-low', 'low', 'medium', 'high']);
+
+  assert_optional_unsigned_int_field(encoding, 'ptime');
+  assert_optional_unsigned_int_field(encoding, 'maxBitrate');
+  assert_optional_number_field(encoding, 'maxFramerate');
+
+  assert_optional_string_field(encoding, 'rid');
+  assert_optional_number_field(encoding, 'scaleResolutionDownBy');
+}
+
+/*
+  dictionary RTCRtcpParameters {
+    [readonly]
+    DOMString cname;
+
+    [readonly]
+    boolean   reducedSize;
+  };
+ */
+function validateRtcpParameters(rtcp) {
+  assert_optional_string_field(rtcp, 'cname');
+  assert_optional_boolean_field(rtcp, 'reducedSize');
+}
+
+/*
+  dictionary RTCRtpHeaderExtensionParameters {
+    [readonly]
+    DOMString      uri;
+
+    [readonly]
+    unsigned short id;
+
+    [readonly]
+    boolean        encrypted;
+  };
+ */
+function validateHeaderExtensionParameters(headerExt) {
+  assert_optional_string_field(headerExt, 'uri');
+  assert_optional_unsigned_int_field(headerExt, 'id');
+  assert_optional_boolean_field(headerExt, 'encrypted');
+}
+
+/*
+  dictionary RTCRtpCodecParameters {
+    [readonly]
+    unsigned short payloadType;
+
+    [readonly]
+    DOMString      mimeType;
+
+    [readonly]
+    unsigned long  clockRate;
+
+    [readonly]
+    unsigned short channels;
+
+    [readonly]
+    DOMString      sdpFmtpLine;
+  };
+ */
+function validateCodecParameters(codec) {
+  assert_optional_unsigned_int_field(codec, 'payloadType');
+  assert_optional_string_field(codec, 'mimeType');
+  assert_optional_unsigned_int_field(codec, 'clockRate');
+  assert_optional_unsigned_int_field(codec, 'channels');
+  assert_optional_string_field(codec, 'sdpFmtpLine');
+}

--- a/webrtc/RTCRtpParameters-rtcp.html
+++ b/webrtc/RTCRtpParameters-rtcp.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters rtcp</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      dictionary RTCRtcpParameters {
+        [readonly]
+        DOMString cname;
+
+        [readonly]
+        boolean   reducedSize;
+      };
+
+      getParameters
+        - rtcp.cname is set to the CNAME of the associated RTCPeerConnection.
+
+          rtcp.reducedSize is set to true if reduced-size RTCP has been negotiated for
+          sending, and false otherwise.
+   */
+
+  /*
+    5.2.  setParameters
+      7.  If parameters.encodings.length is different from N, or if any parameter
+          in the parameters argument, marked as a Read-only parameter, has a value
+          that is different from the corresponding parameter value returned from
+          sender.getParameters(), abort these steps and return a promise rejected
+          with a newly created InvalidModificationError. Note that this also applies
+          to transactionId.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { rtcp } = param;
+
+    if(rtcp === undefined) {
+      param.rtcp = { cname: 'foo' };
+
+    } else if(rtcp.cname === undefined) {
+      rtcp.cname = 'foo';
+
+    } else {
+      rtcp.cname = `${rtcp.cname}-modified`;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified rtcp.cname should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { rtcp } = param;
+
+    if(rtcp === undefined) {
+      param.rtcp = { reducedSize: true };
+
+    } else if(rtcp.reducedSize === undefined) {
+      rtcp.reducedSize = true;
+
+    } else {
+      rtcp.reducedSize = !rtcp.reducedSize;
+    }
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `setParameters() with modified rtcp.reducedSize should reject with InvalidModificationError`);
+
+</script>

--- a/webrtc/RTCRtpParameters-transactionId.html
+++ b/webrtc/RTCRtpParameters-transactionId.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>RTCRtpParameters transactionId</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="dictionary-helper.js"></script>
+<script src="RTCRtpParameters-helper.js"></script>
+<script>
+  'use strict';
+
+  // Test is based on the following editor draft:
+  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
+
+  // The following helper functions are called from RTCRtpParameters-helper.js:
+  //   validateSenderRtpParameters
+
+  /*
+    5.1.  RTCPeerConnection Interface Extensions
+      partial interface RTCPeerConnection {
+        RTCRtpTransceiver           addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
+                                                   optional RTCRtpTransceiverInit init);
+        ...
+      };
+
+      dictionary RTCRtpTransceiverInit {
+        RTCRtpTransceiverDirection         direction = "sendrecv";
+        sequence<MediaStream>              streams;
+        sequence<RTCRtpEncodingParameters> sendEncodings;
+      };
+
+      addTransceiver
+        2.  If the dictionary argument is present, and it has a sendEncodings member,
+            let sendEncodings be that list of RTCRtpEncodingParameters objects, or an
+            empty list otherwise.
+        7.  Create an RTCRtpSender with track, streams and sendEncodings and let
+            sender be the result.
+
+    5.2.  RTCRtpSender Interface
+      interface RTCRtpSender {
+        Promise<void>           setParameters(optional RTCRtpParameters parameters);
+        RTCRtpParameters        getParameters();
+      };
+
+      dictionary RTCRtpParameters {
+        DOMString                                 transactionId;
+        sequence<RTCRtpEncodingParameters>        encodings;
+        sequence<RTCRtpHeaderExtensionParameters> headerExtensions;
+        RTCRtcpParameters                         rtcp;
+        sequence<RTCRtpCodecParameters>           codecs;
+        RTCDegradationPreference                  degradationPreference;
+      };
+
+      getParameters
+        - transactionId is set to a new unique identifier, used to match this
+          getParameters call to a setParameters call that may occur later.
+   */
+
+  /*
+    5.2.  getParameters
+      - transactionId is set to a new unique identifier, used to match this
+        getParameters call to a setParameters call that may occur later.
+   */
+  test(() => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param1 = sender.getParameters();
+    const param2 = sender.getParameters();
+
+    validateSenderRtpParameters(param1);
+    validateSenderRtpParameters(param2);
+
+    assert_not_equals(param1.transactionId, param2.transactionId);
+
+  }, `sender.getParameters() should return different transaction IDs for each call`);
+
+  /*
+    5.2.  setParameters
+      7.  If parameters.encodings.length is different from N, or if any parameter
+          in the parameters argument, marked as a Read-only parameter, has a value
+          that is different from the corresponding parameter value returned from
+          sender.getParameters(), abort these steps and return a promise rejected
+          with a newly created InvalidModificationError. Note that this also applies
+          to transactionId.
+   */
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    const { transactionId } = param;
+    param.transactionId = `${transactionId}-modified`;
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `sender.setParameters() with transaction ID different from last getParameters() should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    param.transactionId = undefined;
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param));
+
+  }, `sender.setParameters() with transaction ID unset should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param = sender.getParameters();
+    validateSenderRtpParameters(param);
+
+    return sender.setParameters(param)
+    .then(() =>
+      promise_rejects(t, 'InvalidModificationError',
+        sender.setParameters(param)));
+
+  }, `setParameters() twice with the same parameters should reject with InvalidModificationError`);
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+    const { sender } = pc.addTransceiver('audio');
+
+    const param1 = sender.getParameters();
+    const param2 = sender.getParameters();
+
+    validateSenderRtpParameters(param1);
+    validateSenderRtpParameters(param2);
+
+    assert_not_equals(param1.transactionId, param2.transactionId);
+
+    return promise_rejects(t, 'InvalidModificationError',
+      sender.setParameters(param1));
+
+  }, `setParameters() with parameters older than last getParameters() should reject with InvalidModificationError`);
+
+</script>


### PR DESCRIPTION
This depends on https://github.com/w3c/web-platform-tests/pull/6739

Source: https://github.com/w3c/web-platform-tests/pull/6572

This content has already been thoroughly reviewed and appears here as a reduced set of changes in an attempt prevent CI failure.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
