### PR TITLE
fix a bug caused by missing underscore

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -600,7 +600,7 @@ class Element(object):
                 "value": selector}
 
         elem = self.send_element_command("POST", "element", body)
-        return self.session.element(elem)
+        return self.session._element(elem)
 
     @command
     def click(self):


### PR DESCRIPTION
The line [603](https://github.com/w3c/web-platform-tests/blob/99f333d0822e6788e200b8fae3cb758be99211ff/tools/webdriver/webdriver/client.py#L603) of [client.py](https://github.com/w3c/web-platform-tests/blob/99f333d0822e6788e200b8fae3cb758be99211ff/tools/webdriver/webdriver/client.py#L603) introduced by commit [404bb38](https://github.com/w3c/wpt-tools/commit/404bb38b1558368d529aa6ba90b2f14110f70083#diff-6c1f34f5989b21db58fa05ba2e66f3f6R361) is a typo.

I think this should be `return self.session._element(elem)`, otherwise each time I call `find_element`, it will complains _'Session' object has no attribute 'element'_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6743)
<!-- Reviewable:end -->
