### PR TITLE
Adds CLI options for setting path to binary for selftests

### DIFF
--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -20,7 +20,7 @@ Currently, the tests should be run with FirefoxNightly.
 
 In order to specify the path to FirefoxNightly, use the following command-line option:
 
-    tox -- --binary-path=/path/to/FirefoxNightly
+    tox -- --binary=/path/to/FirefoxNightly
 
 ## Authoring Tests
 

--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -16,6 +16,12 @@ by executing the following command from this directory:
 
     tox
 
+Currently, the tests should be run with FirefoxNightly.
+
+In order to specify the path to FirefoxNightly, use the following command-line option:
+
+    tox -- --binary-path=/path/to/FirefoxNightly
+
 ## Authoring Tests
 
 Test cases are expressed as `.html` files located within the `tests/`

--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -16,9 +16,9 @@ by executing the following command from this directory:
 
     tox
 
-Currently, the tests should be run with FirefoxNightly.
+Currently, the tests should be run with Firefox Nightly.
 
-In order to specify the path to FirefoxNightly, use the following command-line option:
+In order to specify the path to Firefox Nightly, use the following command-line option:
 
     tox -- --binary=/path/to/FirefoxNightly
 

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -14,14 +14,14 @@ WPT_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
 HARNESS = os.path.join(HERE, 'harness.html')
 
 def pytest_addoption(parser):
-    parser.addoption("--binary-path", action="store", default=None, help="path to browser binary")
+    parser.addoption("--binary", action="store", default=None, help="path to browser binary")
 
 def pytest_collect_file(path, parent):
     if path.ext.lower() == '.html':
         return HTMLItem(str(path), parent)
 
 def pytest_configure(config):
-    config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary-path"))
+    config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary"))
     config.server = WPTServer(WPT_ROOT)
     config.server.start()
     config.add_cleanup(lambda: config.server.stop())

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -13,12 +13,15 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 WPT_ROOT = os.path.normpath(os.path.join(HERE, '..', '..'))
 HARNESS = os.path.join(HERE, 'harness.html')
 
+def pytest_addoption(parser):
+    parser.addoption("--binary-path", action="store", default=None, help="path to browser binary")
+
 def pytest_collect_file(path, parent):
     if path.ext.lower() == '.html':
         return HTMLItem(str(path), parent)
 
 def pytest_configure(config):
-    config.driver = webdriver.Firefox()
+    config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary-path"))
     config.server = WPTServer(WPT_ROOT)
     config.server.start()
     config.add_cleanup(lambda: config.server.stop())

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -10,4 +10,4 @@ deps =
   pyvirtualdisplay
   selenium
 
-commands = pytest -vv tests
+commands = pytest {posargs} -vv tests


### PR DESCRIPTION
This allows setting the path to the binary from tox like so:

    $ tox -- --binary-path=/path/to/FirefoxNightly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6744)
<!-- Reviewable:end -->
