### PR TITLE
Fix root README.md whitespace at EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ the promise of working across browsers and devices without needing extra
 layers of abstraction to paper over the gaps left by specification
 editors and implementors.
 
-Setting up the repo
+Setting Up the Repo
 ===================
 
-Clone or otherwise get  https://github.com/w3c/web-platform-tests 
+Clone or otherwise get https://github.com/w3c/web-platform-tests.
 
 Running the Tests
 =================


### PR DESCRIPTION
Reason: wpt lint compains about whitespace at the end of the line here.

This PR also removes another extra space and makes capitalization of the section title consistent with other sections.

@ianbjacobs does this look OK?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6748)
<!-- Reviewable:end -->
