### PR TITLE
Remove function assert_array_approx_equals

### DIFF
--- a/webaudio/js/helpers.js
+++ b/webaudio/js/helpers.js
@@ -1,13 +1,3 @@
-function assert_array_approx_equals(actual, expected, epsilon, description)
-{
-  assert_true(actual.length === expected.length,
-              (description + ": lengths differ, expected " + expected.length + " got " + actual.length))
-
-  for (var i=0; i < actual.length; i++) {
-    assert_approx_equals(actual[i], expected[i], epsilon, (description + ": element " + i))
-  }
-}
-
 /*
   Returns an array (typed or not), of the passed array with removed trailing and ending
   zero-valued elements


### PR DESCRIPTION
 as it has been a generic assertion in testharness.js,
 see https://github.com/w3c/web-platform-tests/pull/5870

<!-- Reviewable:start -->

<!-- Reviewable:end -->
