### PR TITLE
Use assert_idl_attribute instead of assert_own_property when testing an IDL method is implemented

### DIFF
--- a/webrtc/RTCCertificate.html
+++ b/webrtc/RTCCertificate.html
@@ -159,7 +159,7 @@
   promise_test(t => {
     return generateCertificate()
     .then(cert => {
-      assert_own_property(cert, 'getFingerprints');
+      assert_idl_attribute(cert, 'getFingerprints');
 
       const fingerprints = cert.getFingerprints();
       assert_true(Array.isArray(fingerprints),

--- a/webrtc/RTCConfiguration-bundlePolicy.html
+++ b/webrtc/RTCConfiguration-bundlePolicy.html
@@ -105,7 +105,7 @@
    */
   test(() => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
-    assert_own_property(pc, 'setConfiguration');
+    assert_idl_attribute(pc, 'setConfiguration');
 
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ bundlePolicy: 'max-compat' }));
@@ -113,7 +113,7 @@
 
   test(() => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
-    assert_own_property(pc, 'setConfiguration');
+    assert_idl_attribute(pc, 'setConfiguration');
 
     // the default value for bundlePolicy is balanced
     assert_throws('InvalidModificationError', () =>

--- a/webrtc/RTCConfiguration-helper.js
+++ b/webrtc/RTCConfiguration-helper.js
@@ -16,7 +16,7 @@ function config_test(test_func, desc) {
   test(() => {
     test_func(config => {
       const pc = new RTCPeerConnection();
-      assert_own_property(pc, 'setConfiguration');
+      assert_idl_attribute(pc, 'setConfiguration');
       pc.setConfiguration(config);
       return pc;
     })

--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -87,7 +87,7 @@
 
   test(() => {
     const pc = new RTCPeerConnection({ rtcpMuxPolicy: 'require' });
-    assert_own_property(pc, 'setConfiguration');
+    assert_idl_attribute(pc, 'setConfiguration');
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ rtcpMuxPolicy: 'negotiate' }));
 
@@ -107,7 +107,7 @@
       }
     }
 
-    assert_own_property(pc, 'setConfiguration');
+    assert_idl_attribute(pc, 'setConfiguration');
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ rtcpMuxPolicy: 'require' }));
 
@@ -127,7 +127,7 @@
       }
     }
 
-    assert_own_property(pc, 'setConfiguration');
+    assert_idl_attribute(pc, 'setConfiguration');
     // default value for rtcpMuxPolicy is require
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({}));

--- a/webrtc/RTCPeerConnection-getDefaultIceServers.html
+++ b/webrtc/RTCPeerConnection-getDefaultIceServers.html
@@ -35,7 +35,7 @@
    */
 
   test(() => {
-    assert_own_property(RTCPeerConnection, 'getDefaultIceServers');
+    assert_idl_attribute(RTCPeerConnection, 'getDefaultIceServers');
     const iceServers = RTCPeerConnection.getDefaultIceServers();
 
     assert_true(Array.isArray(iceServers),

--- a/webrtc/RTCPeerConnection-getDefaultIceServers.html
+++ b/webrtc/RTCPeerConnection-getDefaultIceServers.html
@@ -35,7 +35,6 @@
    */
 
   test(() => {
-    assert_idl_attribute(RTCPeerConnection, 'getDefaultIceServers');
     const iceServers = RTCPeerConnection.getDefaultIceServers();
 
     assert_true(Array.isArray(iceServers),

--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -361,7 +361,7 @@ function assert_equals_array_buffer(buffer1, buffer2) {
 function generateMediaStreamTrack(kind) {
   const pc = new RTCPeerConnection();
 
-  assert_own_property(pc, 'addTransceiver',
+  assert_idl_attribute(pc, 'addTransceiver',
     'Expect pc to have addTransceiver() method');
 
   const transceiver = pc.addTransceiver(kind);


### PR DESCRIPTION
When testing whether an IDL method is implemented, `assert_idl_attribute` should be used as the method should be found in the prototype chain instead of the instance's own property

<!-- Reviewable:start -->

<!-- Reviewable:end -->
