### PR TITLE
[testharness] add link_to_spec and link_name properties to test().

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -63,8 +63,24 @@ test(function() {
 The function passed in is run in the `test()` call.
 
 `properties` is a javascript object for passing extra options to the
-test. Currently it is only used to provide test-specific
+test. `properties` can be used to provide test-specific
 metadata, as described in the [metadata](#metadata) section below.
+
+*   `properties.link_to_spec` can be used to provide a link to the relevant spec section,
+    definiton, or algorithm under test. It is displayed in the test results,
+    right after the test name like so: ([see spec](#)).
+    The link's text can be changed using `properties.link_name`.
+*   `properties.link_name` can be use to provide the name of the spec section,
+    definiton, or algorithm referenced by `properties.link_to_spec`.
+    It defaults to "spec" when missing.
+    Note that `properties.link_name` is prefixed by "see " when displayed
+    and the whole is enclosed in parentheses.
+
+It is recommended to consider link rot when adding reference to spec using
+`properties.link_to_spec` and `properties.link_name`.
+Only link to definitions, section names, etc. that you intend to keep stable.
+Avoid mentioning section numbers in `properties.link_name` as these tend
+to change faster than their title.
 
 ## Asynchronous Tests ##
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2412,10 +2412,10 @@ policies and contribution forms [3].
             "<th>Message</th></tr></thead>" +
             "<tbody>";
         for (var i = 0; i < tests.length; i++) {
-            var link_name = tests[i].properties.link_name || "spec";
+            var link_name = "see " + (tests[i].properties.link_name || "spec");
             var link_url = tests[i].properties.link_to_spec;
             var link_to_spec = link_url ?
-                " (<a href=" + JSON.stringify(link_url) + ">see " + escape_html(link_name) + "</a>)" : "";
+                " (<a href=" + JSON.stringify(link_url) + ">" + escape_html(link_name) + "</a>)" : "";
             html += '<tr class="' +
                 escape_html(status_class(status_text[tests[i].status])) +
                 '"><td>' +

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -2412,12 +2412,16 @@ policies and contribution forms [3].
             "<th>Message</th></tr></thead>" +
             "<tbody>";
         for (var i = 0; i < tests.length; i++) {
+            var link_name = tests[i].properties.link_name || "spec";
+            var link_url = tests[i].properties.link_to_spec;
+            var link_to_spec = link_url ?
+                " (<a href=" + JSON.stringify(link_url) + ">see " + escape_html(link_name) + "</a>)" : "";
             html += '<tr class="' +
                 escape_html(status_class(status_text[tests[i].status])) +
                 '"><td>' +
                 escape_html(status_text[tests[i].status]) +
                 "</td><td>" +
-                escape_html(tests[i].name) +
+                escape_html(tests[i].name) + link_to_spec
                 "</td><td>" +
                 (assertions ? escape_html(get_assertion(tests[i])) + "</td><td>" : "") +
                 escape_html(tests[i].message ? tests[i].message : " ") +


### PR DESCRIPTION
This allows idlharness to link to relevant sections of WebIDL.