### PR TITLE
WIP for .any replacement

### DIFF
--- a/docs/_writing-tests/testharness.md
+++ b/docs/_writing-tests/testharness.md
@@ -21,31 +21,29 @@ all test types.
 
 ## Auto-generated test boilerplate
 
-While most JavaScript tests require a certain amount of HTML
-boilerplate to include the test library, etc., tests which are
-expressible purely in script (e.g. tests for workers) can have all the
-needed HTML and script boilerplate auto-generated.
+Tests for HTML documents, and dedicated, shared, and service workers, can be written as simple
+JavaScript files without boilerplate by following conventions established below.
 
-### Standalone window tests
+### Standalone HTML document tests (Window global object)
 
-Tests that only require a script file running in window scope can use
-standalone window tests. In this case the test is a javascript file
-with the extension `.window.js`. This is sourced from a generated
-document which sources `testharness.js`, `testharnessreport.js` and
-the test script. For a source script with the name
-`example.window.js`, the corresponding test resource will be
-`example.window.html`.
+Tests that only require JavaScript running in an HTML document can be written using a `*.window.js`
+resource. The boilerplate will be generated automatically when you load `*.window.html`. E.g., for
+`example.window.js` the corresponding (generated) test resource will be `example.window.html`.
 
-### Standalone workers tests
+### Standalone worker tests (DedicatedWorkerGlobalScope, SharedWorkerGlobalScope, and ServiceWorkerGlobalScope global objects)
 
-Tests that only require assertions in a dedicated worker scope can use
-standalone workers tests. In this case, the test is a JavaScript file
-with extension `.worker.js` that imports `testharness.js`. The test can
-then use all the usual APIs, and can be run from the path to the
-JavaScript file with the `.js` removed.
+Tests that need to run in dedicated, shared, and service workers can be written using a
+`*.worker.js` resource (with boilerplate at `*.worker.html`, `*.worker.sharedworker.html`, and
+`*.worker.serviceworker.https.html`). To exclude service workers, use a `*.worker-no-sw.js` resource
+(with boilerplate at `*.worker-no-sw.html` and `*.worker-no-sw.sharedworker.html`). To
+exclusively target service workers, use `*.serviceworker.js` (with boilerplate at
+`*.serviceworker.https.html`).
 
-For example, one could write a test for the `FileReaderSync` API by
-creating a `FileAPI/FileReaderSync.worker.js` as follows:
+Note that service workers also require the `.https` signifier as they only work in
+[secure contexts](https://w3c.github.io/webappsec-secure-contexts/).
+
+For example, one could write a test for the `FileReaderSync` API by creating a
+`FileAPI/FileReaderSync.worker-no-sw.js` as follows:
 
     importScripts("/resources/testharness.js");
     test(function () {
@@ -55,20 +53,20 @@ creating a `FileAPI/FileReaderSync.worker.js` as follows:
     }, "FileReaderSync#readAsText.");
     done();
 
-This test could then be run from `FileAPI/FileReaderSync.worker.html`.
+This test could then be run from `FileAPI/FileReaderSync.worker-no-sw.html` and
+`FileAPI/FileReaderSync.worker-no-sw.sharedworker.html`.
 
-### Multi-global tests
+### Standalone HTML document and worker tests
 
-Tests for features that exist in multiple global scopes can be written
-in a way that they are automatically run in a window scope and a
-worker scope.
-
-In this case, the test is a JavaScript file with extension `.any.js`.
-The test can then use all the usual APIs, and can be run from the path to the
-JavaScript file with the `.js` replaced by `.worker.html` or `.html`.
+Tests for features that span HTML documents and workers can be written using a `*.window-worker.js`
+resource (with boilerplate at `*.window-worker.html`, `*.window-worker.worker.html`,
+`*.window-worker.sharedworker.html`, and `*.window-worker.serviceworker.https.html`). To exclude
+service workers, use a `*.window-worker-no-sw.js` resource (with boilerplate at
+`*.window-worker-no-sw.html`, `*.window-worker-no-sw.worker.html`, and
+`*.window-worker-no-sw.sharedworker.html`).
 
 For example, one could write a test for the `Blob` constructor by
-creating a `FileAPI/Blob-constructor.any.js` as follows:
+creating a `FileAPI/Blob-constructor.window-worker.js` as follows:
 
     test(function () {
       var blob = new Blob();
@@ -77,8 +75,9 @@ creating a `FileAPI/Blob-constructor.any.js` as follows:
       assert_false(blob.isClosed);
     }, "The Blob constructor.");
 
-This test could then be run from `FileAPI/Blob-constructor.any.worker.html` as well
-as `FileAPI/Blob-constructor.any.html`.
+This test could then be run from `FileAPI/Blob-constructor.window-worker.html` as well as
+`FileAPI/Blob-constructor.window-worker.serviceworker.https.html` and the other worker locations as
+per above.
 
 To check if your test is run from a window or worker you can use the following two methods that will
 be made available by the framework:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -142,10 +142,10 @@ self.GLOBAL = {
 """
 
 class WorkerHandler(HtmlWrapperHandler):
-    path_replace = [(".worker.html", ".worker.js", ".worker.worker.js"),
-                    (".worker-no-sw.html", ".worker-no-sw.js", ".worker-no-sw.worker.js"),
-                    (".window-worker.worker.html", ".window-worker.js", ".window-worker.worker.js"),
-                    (".window-worker-no-sw.worker.html", ".window-worker-no-sw.js", ".window-worker-no-sw.worker.js")]
+    path_replace = [(".worker-no-sw.html", ".worker-no-sw.js", ".worker-no-sw.w.js"),
+                    (".window-worker.worker.html", ".window-worker.js", ".window-worker.w.js"),
+                    (".window-worker-no-sw.worker.html", ".window-worker-no-sw.js", ".window-worker-no-sw.w.js"),
+                    (".worker.html", ".worker.js", ".worker.w.js")]
     wrapper = """<!doctype html>
 <meta charset=utf-8>
 <script src="/resources/testharness.js"></script>
@@ -158,10 +158,10 @@ fetch_tests_from_worker(new Worker("%(path)s"));
 """
 
 class SharedWorkerHandler(HtmlWrapperHandler):
-    path_replace = [(".worker.sharedworker.html", ".worker.js", ".worker.worker.js"),
-                    (".worker-no-sw.sharedworker.html", ".worker-no-sw.js", ".worker-no-sw.worker.js"),
-                    (".window-worker.sharedworker.html", ".window-worker.js", ".window-worker.worker.js"),
-                    (".window-worker-no-sw.sharedworker.html", ".window-worker-no-sw.js", ".window-worker-no-sw.worker.js")]
+    path_replace = [(".worker.sharedworker.html", ".worker.js", ".worker.w.js"),
+                    (".worker-no-sw.sharedworker.html", ".worker-no-sw.js", ".worker-no-sw.w.js"),
+                    (".window-worker.sharedworker.html", ".window-worker.js", ".window-worker.w.js"),
+                    (".window-worker-no-sw.sharedworker.html", ".window-worker-no-sw.js", ".window-worker-no-sw.w.js")]
     wrapper = """<!doctype html>
 <meta charset=utf-8>
 %(meta)s
@@ -174,9 +174,9 @@ fetch_tests_from_worker(new SharedWorker("%(path)s"));
 """
 
 class ServiceWorkerHandler(HtmlWrapperHandler):
-    path_replace = [(".serviceworker.https.html", ".serviceworker.js", ".serviceworker.worker.js"),
-                    (".worker.serviceworker.https.html", ".worker.js", ".worker.worker.js"),
-                    (".window-worker.serviceworker.https.html", ".window-worker.js", ".window-worker.worker.js")]
+    path_replace = [(".worker.serviceworker.https.html", ".worker.js", ".worker.w.js"),
+                    (".window-worker.serviceworker.https.html", ".window-worker.js", ".window-worker.w.js"),
+                    (".serviceworker.https.html", ".serviceworker.js", ".serviceworker.w.js")]
     wrapper = """<!doctype html>
 <meta charset=utf-8>
 %(meta)s
@@ -198,7 +198,7 @@ class ServiceWorkerHandler(HtmlWrapperHandler):
 """
 
 class WorkerJavaScriptHandler(WrapperHandler):
-    path_replace = [(".worker.js", ".js")]
+    path_replace = [(".w.js", ".js")]
     wrapper = """importScripts("/resources/testharness.js");
 %(meta)s
 self.GLOBAL = {
@@ -263,12 +263,10 @@ class RoutesBuilder(object):
 
         routes = [
             ("GET", "*.window.html", WindowHandler),
-            ("GET", "*.worker.html", WorkerHandler),
             ("GET", "*.worker.sharedworker.html", SharedWorkerHandler),
             ("GET", "*.worker.serviceworker.https.html", ServiceWorkerHandler),
             ("GET", "*.worker-no-sw.html", WorkerHandler),
             ("GET", "*.worker-no-sw.sharedworker.html", SharedWorkerHandler),
-            ("GET", "*.serviceworker.https.html", ServiceWorkerHandler),
             ("GET", "*.window-worker.html", WindowHandler),
             ("GET", "*.window-worker.worker.html", WorkerHandler),
             ("GET", "*.window-worker.sharedworker.html", SharedWorkerHandler),
@@ -276,7 +274,9 @@ class RoutesBuilder(object):
             ("GET", "*.window-worker-no-sw.html", WindowHandler),
             ("GET", "*.window-worker-no-sw.worker.html", WorkerHandler),
             ("GET", "*.window-worker-no-sw.sharedworker.html", SharedWorkerHandler),
-            ("GET", "*.worker.js", WorkerJavaScriptHandler),
+            ("GET", "*.worker.html", WorkerHandler),
+            ("GET", "*.serviceworker.https.html", ServiceWorkerHandler),
+            ("GET", "*.w.js", WorkerJavaScriptHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -174,7 +174,7 @@ fetch_tests_from_worker(new SharedWorker("%(path)s"));
 """
 
 class ServiceWorkerHandler(HtmlWrapperHandler):
-    path_replace = [(".serviceworker.https.html", ".serviceworker.js", ".serviceworker.worker.js")
+    path_replace = [(".serviceworker.https.html", ".serviceworker.js", ".serviceworker.worker.js"),
                     (".worker.serviceworker.https.html", ".worker.js", ".worker.worker.js"),
                     (".window-worker.serviceworker.https.html", ".window-worker.js", ".window-worker.worker.js")]
     wrapper = """<!doctype html>

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -122,35 +122,7 @@ class HtmlWrapperHandler(WrapperHandler):
             return '<script src="%s"></script>' % attribute
         return None
 
-
-class WorkersHandler(HtmlWrapperHandler):
-    path_replace = [(".any.worker.html", ".any.js", ".any.worker.js"),
-                    (".worker.html", ".worker.js")]
-    wrapper = """<!doctype html>
-<meta charset=utf-8>
-%(meta)s
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id=log></div>
-<script>
-fetch_tests_from_worker(new Worker("%(path)s"));
-</script>
-"""
-
-
 class WindowHandler(HtmlWrapperHandler):
-    path_replace = [(".window.html", ".window.js")]
-    wrapper = """<!doctype html>
-<meta charset=utf-8>
-%(meta)s
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<div id=log></div>
-<script src="%(path)s"></script>
-"""
-
-
-class AnyHtmlHandler(HtmlWrapperHandler):
     path_replace = [(".any.html", ".any.js")]
     wrapper = """<!doctype html>
 <meta charset=utf-8>
@@ -167,9 +139,52 @@ self.GLOBAL = {
 <script src="%(path)s"></script>
 """
 
+class WorkerHandler(HtmlWrapperHandler):
+    path_replace = [(".worker.html", ".worker.js", ".worker.worker.js"),
+                    (".worker-no-sw.html", ".worker-no-sw.js", ".worker-no-sw.worker.js"),
+                    (".window-worker.worker.html", ".window-worker.js", ".window-worker.worker.js"),
+                    (".window-worker-no-sw.worker.html", ".window-worker-no-sw.js", ".window-worker-no-sw.worker.js")]
+    wrapper = """<!doctype html>
+<meta charset=utf-8>
+%(meta)s
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new Worker("%(path)s"));
+</script>
+"""
 
-class AnyWorkerHandler(WrapperHandler):
-    path_replace = [(".any.worker.js", ".any.js")]
+class SharedWorkerHandler(HtmlWrapperHandler):
+    path_replace = [(".any.worker.html", ".any.js", ".any.worker.js"),
+                    (".worker.html", ".worker.js")]
+    wrapper = """<!doctype html>
+<meta charset=utf-8>
+%(meta)s
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new SharedWorker("%(path)s"));
+</script>
+"""
+
+class ServiceWorkerHandler(HtmlWrapperHandler):
+    path_replace = [(".any.worker.html", ".any.js", ".any.worker.js"),
+                    (".worker.html", ".worker.js")]
+    wrapper = """<!doctype html>
+<meta charset=utf-8>
+%(meta)s
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+fetch_tests_from_worker(new SharedWorker("%(path)s"));
+</script>
+"""
+
+class WorkerJavaScriptHandler(WrapperHandler):
+    path_replace = [(".worker.js", ".js")]
     wrapper = """%(meta)s
 self.GLOBAL = {
   isWindow: function() { return false; },
@@ -233,10 +248,21 @@ class RoutesBuilder(object):
         self.mountpoint_routes[url_base] = []
 
         routes = [
-            ("GET", "*.worker.html", WorkersHandler),
             ("GET", "*.window.html", WindowHandler),
-            ("GET", "*.any.html", AnyHtmlHandler),
-            ("GET", "*.any.worker.js", AnyWorkerHandler),
+            ("GET", "*.worker.html", WorkerHandler),
+            ("GET", "*.worker.sharedworker.html", SharedWorkerHandler),
+            ("GET", "*.worker.serviceworker.html", ServiceWorkerHandler),
+            ("GET", "*.worker-no-sw.html", WorkerHandler),
+            ("GET", "*.worker-no-sw.sharedworker.html", SharedWorkerHandler),
+            ("GET", "*.serviceworker.html", ServiceWorkerHandler),
+            ("GET", "*.window-worker.html", WindowHandler),
+            ("GET", "*.window-worker.worker.html", WorkerHandler),
+            ("GET", "*.window-worker.sharedworker.html", SharedWorkerHandler),
+            ("GET", "*.window-worker.serviceworker.html", ServiceWorkerHandler),
+            ("GET", "*.window-worker-no-sw.html", WindowHandler),
+            ("GET", "*.window-worker-no-sw.worker.html", WorkerHandler),
+            ("GET", "*.window-worker-no-sw.sharedworker.html", SharedWorkerHandler),
+            ("GET", "*.worker.js", WorkerJavaScriptHandler),
             ("GET", "*.asis", handlers.AsIsHandler),
             ("*", "*.py", handlers.PythonScriptHandler),
             ("GET", "*", handlers.FileHandler)


### PR DESCRIPTION
This is not ready, but gives us a place to discuss how to do #4210 more concretely. Further commits welcome as I have to go for the day.

* ServiceWorker is not done yet, but should be something like https://github.com/jakearchibald/web-platform-tests/commit/08ec0240d01338ac62039bb0040cff20e48c41d9#diff-54595105eb1b125bb44120e81a893f4eL161.
* It would be nice if the various worker handler classes could share more code. Their results are nearly identical.
* Rather than using `<script>` and `importScripts()` to import the original file in WindowHandler and WorkerJavaScriptHandler, wouldn't it be nicer if we just inlined it?

Note that this does change @jgraham's setup slightly by always exposing isWindow/isWorker for these shortcut tests. I don't think that's a problem, but we could avoid it at the cost of more handler duplication.

Also if we change this it'll need some downstream coordination since I believe browsers are using the current setup already.

cc @domenic @jakearchibald

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6756)
<!-- Reviewable:end -->
