### PR TITLE
Make running tests for resources not depend on the serve command

### DIFF
--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -21,7 +21,7 @@ class WPTServer(object):
     def start(self):
         self.devnull = open(os.devnull, 'w')
         self.proc = subprocess.Popen(
-            [os.path.join(self.wpt_root, 'serve'), '--config=' + _CONFIG_FILE],
+            [os.path.join(self.wpt_root, 'wpt'), 'serve', '--config=' + _CONFIG_FILE],
             stdout=self.devnull,
             stderr=self.devnull,
             cwd=self.wpt_root)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6758)
<!-- Reviewable:end -->
