### PR TITLE
Remove outdated comment

### DIFF
--- a/dom/nodes/Element-classlist.html
+++ b/dom/nodes/Element-classlist.html
@@ -420,9 +420,6 @@ function testClassList(e, desc) {
   checkReplace(" ", "a", "b", " ");
   checkReplace(" a  \f", "a", "b", "b");
   checkReplace("a b c", "b", "d", "a d c");
-  // https://github.com/whatwg/dom/issues/442
-  // Implementations agree on the first one here, so I test it, but disagree on
-  // the second, so no test until the spec decides what to say.
   checkReplace("a b c", "c", "a", "a b");
   checkReplace("c b a", "c", "a", "a b");
   checkReplace("a b a", "a", "c", "c b");


### PR DESCRIPTION
#442 was resolved a long time ago.

Protip: set `git config --global core.commentChar "auto"` to avoid having commit summaries like this eaten when you try to edit them.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
