### PR TITLE
Generic Sensor: Add sensor type to test names.

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -36,6 +36,7 @@ function reading_to_array(sensor) {
 }
 
 function runGenericSensorTests(sensorType) {
+  const prefix = sensorType.name + ": ";
   async_test(t => {
     let sensor = new sensorType();
     sensor.onreading = t.step_func_done(() => {
@@ -45,7 +46,7 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.onerror = t.step_func_done(unreached);
     sensor.start();
-  }, "Test that 'onreading' is called and sensor reading is valid");
+  }, prefix + "Test that 'onreading' is called and sensor reading is valid");
 
   async_test(t => {
     let sensor1 = new sensorType();
@@ -67,7 +68,7 @@ function runGenericSensorTests(sensorType) {
     sensor2.onerror = t.step_func_done(unreached);
     sensor1.start();
     sensor2.start();
-  }, "sensor reading is correct");
+  }, prefix + "sensor reading is correct");
 
   async_test(t => {
     let sensor = new sensorType();
@@ -85,7 +86,7 @@ function runGenericSensorTests(sensorType) {
         sensor.stop();
       });
     }, 1000);
-  }, "sensor timestamp is updated when time passes");
+  }, prefix + "sensor timestamp is updated when time passes");
 
   async_test(t => {
     let sensor = new sensorType();
@@ -98,7 +99,7 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.start();
     assert_false(sensor.activated);
-  }, "Test that sensor can be successfully created and its states are correct.");
+  }, prefix + "Test that sensor can be successfully created and its states are correct.");
 
   test(() => {
     let sensor, start_return;
@@ -107,7 +108,7 @@ function runGenericSensorTests(sensorType) {
     start_return = sensor.start();
     assert_equals(start_return, undefined);
     sensor.stop();
-  }, "sensor.start() returns undefined");
+  }, prefix + "sensor.start() returns undefined");
 
   test(() => {
     try {
@@ -120,7 +121,7 @@ function runGenericSensorTests(sensorType) {
     } catch (e) {
        assert_unreached(e.name + ": " + e.message);
     }
-  }, "no exception is thrown when calling start() on already started sensor");
+  }, prefix + "no exception is thrown when calling start() on already started sensor");
 
   test(() => {
     let sensor, stop_return;
@@ -129,7 +130,7 @@ function runGenericSensorTests(sensorType) {
     sensor.start();
     stop_return = sensor.stop();
     assert_equals(stop_return, undefined);
-  }, "sensor.stop() returns undefined");
+  }, prefix + "sensor.stop() returns undefined");
 
   test(() => {
     try {
@@ -142,7 +143,7 @@ function runGenericSensorTests(sensorType) {
     } catch (e) {
        assert_unreached(e.name + ": " + e.message);
     }
-  }, "no exception is thrown when calling stop() on already stopped sensor");
+  }, prefix + "no exception is thrown when calling stop() on already stopped sensor");
 
   promise_test(() => {
     return new Promise((resolve,reject) => {
@@ -169,7 +170,7 @@ function runGenericSensorTests(sensorType) {
         }
       }
     });
-  }, "throw a 'SecurityError' when constructing sensor object within iframe");
+  }, prefix + "throw a 'SecurityError' when constructing sensor object within iframe");
 
   async_test(t => {
     let sensor = new sensorType();
@@ -187,16 +188,18 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.onerror = t.step_func_done(unreached);
     sensor.start();
-  }, "sensor readings can not be fired on the background tab");
+  }, prefix + "sensor readings can not be fired on the background tab");
 }
 
 function runGenericSensorInsecureContext(sensorType) {
+  const prefix = sensorType.name + ": ";
   test(() => {
     assert_throws('SecurityError', () => { new sensorType(); });
-  }, "throw a 'SecurityError' when construct sensor in an insecure context");
+  }, prefix + "throw a 'SecurityError' when construct sensor in an insecure context");
 }
 
 function runGenericSensorOnerror(sensorType) {
+  const prefix = sensorType.name + ": ";
   async_test(t => {
     let sensor = new sensorType();
     sensor.onactivate = t.step_func_done(assert_unreached);
@@ -205,5 +208,5 @@ function runGenericSensorOnerror(sensorType) {
       assert_equals(event.error.name, 'NotReadableError');
     });
     sensor.start();
-  }, "'onerror' event is fired when sensor is not supported");
+  }, prefix + "'onerror' event is fired when sensor is not supported");
 }


### PR DESCRIPTION
This allows them to be uniquely identified by sensor, leading to messages
such as

    AbsoluteOrientationSensor: Test 'foo'

instead of just

    Test 'foo'

This is necessary after commit 222d14cc3 ("Generic Sensor: Add functionality
tests for OrientationSensor (#5870)"), which added multiple calls to
runGenericSensorOnerror() and runGenericSensorInsecureContext() in the same
test files, leading to error messages such as:

    Harness Error. harness_status.status = 1 , harness_status.message = 1
    duplicate test name: "throw a 'SecurityError' when construct sensor in
    an insecure context"

that cause the tests to fail even when all checks pass.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
