### PR TITLE
Add readme to explain the usage of /.well-known/ directory

### DIFF
--- a/.well-known/README.md
+++ b/.well-known/README.md
@@ -1,0 +1,9 @@
+Well-Known URI Testing
+======================
+
+This directory is used for testing resources that are loaded based on the
+well-known URI standard. [[RFC5785](https://tools.ietf.org/html/rfc5785)]
+
+For other kinds of resource files, they should either be placed at
+[/common](../common) or the respective subdirectories for the
+particular standard.

--- a/.well-known/idp-proxy/README.md
+++ b/.well-known/idp-proxy/README.md
@@ -1,0 +1,12 @@
+Identity Provider Proxy
+=======================
+
+This directory is used for hosting the mock identity provider proxy script
+for testing the identity provider feature in WebRTC.
+[[ietf-rtcweb-security-arch](https://tools.ietf.org/html/draft-ietf-rtcweb-security-arch-12#section-5.6.5)]
+[[webrtc-pc](https://w3c.github.io/webrtc-pc/#sec.identity-proxy)]
+
+The script for identity provider proxy must be hosted at /.well-known/idp-proxy
+instead of the usual [/webrtc](../../webrtc) directory as it follows the
+well-known URI standard that derives the script URI from a given domain name.
+[[RFC5785](https://tools.ietf.org/html/rfc5785)]


### PR DESCRIPTION
This is a follow up on #6649 to explain about the usage of the .well-known/ directory and why mock-idp.js is placed there.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
