### PR TITLE
Generic Sensor: Add sensor type to test names.

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -45,7 +45,7 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.onerror = t.step_func_done(unreached);
     sensor.start();
-  }, "Test that 'onreading' is called and sensor reading is valid");
+  }, `${sensorType.name}: Test that 'onreading' is called and sensor reading is valid`);
 
   async_test(t => {
     let sensor1 = new sensorType();
@@ -67,7 +67,7 @@ function runGenericSensorTests(sensorType) {
     sensor2.onerror = t.step_func_done(unreached);
     sensor1.start();
     sensor2.start();
-  }, "sensor reading is correct");
+  }, `${sensorType.name}: sensor reading is correct`);
 
   async_test(t => {
     let sensor = new sensorType();
@@ -85,7 +85,7 @@ function runGenericSensorTests(sensorType) {
         sensor.stop();
       });
     }, 1000);
-  }, "sensor timestamp is updated when time passes");
+  }, `${sensorType.name}: sensor timestamp is updated when time passes`);
 
   async_test(t => {
     let sensor = new sensorType();
@@ -98,7 +98,7 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.start();
     assert_false(sensor.activated);
-  }, "Test that sensor can be successfully created and its states are correct.");
+  }, `${sensorType.name}: Test that sensor can be successfully created and its states are correct.`);
 
   test(() => {
     let sensor, start_return;
@@ -107,7 +107,7 @@ function runGenericSensorTests(sensorType) {
     start_return = sensor.start();
     assert_equals(start_return, undefined);
     sensor.stop();
-  }, "sensor.start() returns undefined");
+  }, `${sensorType.name}: sensor.start() returns undefined`);
 
   test(() => {
     try {
@@ -120,7 +120,7 @@ function runGenericSensorTests(sensorType) {
     } catch (e) {
        assert_unreached(e.name + ": " + e.message);
     }
-  }, "no exception is thrown when calling start() on already started sensor");
+  }, `${sensorType.name}: no exception is thrown when calling start() on already started sensor`);
 
   test(() => {
     let sensor, stop_return;
@@ -129,7 +129,7 @@ function runGenericSensorTests(sensorType) {
     sensor.start();
     stop_return = sensor.stop();
     assert_equals(stop_return, undefined);
-  }, "sensor.stop() returns undefined");
+  }, `${sensorType.name}: sensor.stop() returns undefined`);
 
   test(() => {
     try {
@@ -142,7 +142,7 @@ function runGenericSensorTests(sensorType) {
     } catch (e) {
        assert_unreached(e.name + ": " + e.message);
     }
-  }, "no exception is thrown when calling stop() on already stopped sensor");
+  }, `${sensorType.name}: no exception is thrown when calling stop() on already stopped sensor`);
 
   promise_test(() => {
     return new Promise((resolve,reject) => {
@@ -169,7 +169,7 @@ function runGenericSensorTests(sensorType) {
         }
       }
     });
-  }, "throw a 'SecurityError' when constructing sensor object within iframe");
+  }, `${sensorType.name}: throw a 'SecurityError' when constructing sensor object within iframe`);
 
   async_test(t => {
     let sensor = new sensorType();
@@ -187,13 +187,13 @@ function runGenericSensorTests(sensorType) {
     });
     sensor.onerror = t.step_func_done(unreached);
     sensor.start();
-  }, "sensor readings can not be fired on the background tab");
+  }, `${sensorType.name}: sensor readings can not be fired on the background tab`);
 }
 
 function runGenericSensorInsecureContext(sensorType) {
   test(() => {
     assert_throws('SecurityError', () => { new sensorType(); });
-  }, "throw a 'SecurityError' when construct sensor in an insecure context");
+  }, `${sensorType.name}: throw a 'SecurityError' when construct sensor in an insecure context`);
 }
 
 function runGenericSensorOnerror(sensorType) {
@@ -205,5 +205,5 @@ function runGenericSensorOnerror(sensorType) {
       assert_equals(event.error.name, 'NotReadableError');
     });
     sensor.start();
-  }, "'onerror' event is fired when sensor is not supported");
+  }, `${sensorType.name}: 'onerror' event is fired when sensor is not supported`);
 }


### PR DESCRIPTION
This allows them to be uniquely identified by sensor, leading to messages
such as

    AbsoluteOrientationSensor: Test 'foo'

instead of just

    Test 'foo'

This is necessary after commit 222d14cc3 ("Generic Sensor: Add functionality
tests for OrientationSensor (#5870)"), which added multiple calls to
runGenericSensorOnerror() and runGenericSensorInsecureContext() in the same
test files, leading to error messages such as:

    Harness Error. harness_status.status = 1 , harness_status.message = 1
    duplicate test name: "throw a 'SecurityError' when construct sensor in
    an insecure context"

that cause the tests to fail even when all checks pass.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
