### PR TITLE
Allow access to directories not ending with slash

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -282,9 +282,10 @@ class TestDirectoryHandler(TestUsingServer):
         assert resp.info()["Content-Type"] == "text/html"
 
     def test_subdirectory_no_trailing_slash(self):
+        # This seems to resolve the 301 transparently, so test for 200
         resp = self.request("/subdir")
-        assert resp.getcode() == 301
-        assert resp.info()["Location"].endswith("/subdir/")
+        assert resp.getcode() == 200
+        assert resp.info()["Content-Type"] == "text/html"
 
 
 class TestAsIsHandler(TestUsingServer):

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -285,7 +285,8 @@ class TestDirectoryHandler(TestUsingServer):
         with pytest.raises(HTTPError) as cm:
             self.request("/subdir")
 
-        assert cm.value.code == 404
+        assert resp.getcode() == 301
+        assert resp.info()["Location"].endswith("/subdir/")
 
 
 class TestAsIsHandler(TestUsingServer):

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -282,9 +282,7 @@ class TestDirectoryHandler(TestUsingServer):
         assert resp.info()["Content-Type"] == "text/html"
 
     def test_subdirectory_no_trailing_slash(self):
-        with pytest.raises(HTTPError) as cm:
-            self.request("/subdir")
-
+        resp = self.request("/subdir")
         assert resp.getcode() == 301
         assert resp.info()["Location"].endswith("/subdir/")
 

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -58,7 +58,9 @@ class DirectoryHandler(object):
         url_path = request.url_parts.path
 
         if not url_path.endswith("/"):
-            raise HTTPException(404)
+            response.status = 301
+            response.headers = [("Location", "%s/" % request.url)]
+            return
 
         path = filesystem_path(self.base_path, request, self.url_base)
 


### PR DESCRIPTION
Commit 8016c0f6 returns a 404 in this case.  I don't know why, maybe it
complicates subsequent processing?  This patch just pretends that there
was a slash at the end.  If that's not nice enough, a cleaner solution
is to issue a 301 to the URL with a slash, but I don't know how to do
that offhand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6775)
<!-- Reviewable:end -->
