### PR TITLE
Historical tests for some SVGSVGElement APIs

### DIFF
--- a/svg/historical.html
+++ b/svg/historical.html
@@ -54,6 +54,10 @@ var removedMembers = {
   ],
   "SVGSVGElement": [
     "currentView",
+    "pixelUnitToMillimeterX",
+    "pixelUnitToMillimeterY",
+    "screenPixelToMillimeterX",
+    "screenPixelToMillimeterY",
     "useCurrentView",
     "viewport"
   ],


### PR DESCRIPTION
The pixelUnitToMillimeterX/Y and screenPixelToMillimeterX/Y
APIs have been removed from SVGSVGElement in SVG2:
http://www.w3.org/TR/SVG11/struct.html#InterfaceSVGSVGElement
http://www.w3.org/TR/SVG2/struct.html#InterfaceSVGSVGElement

Removed from chromium two years ago: https://crbug.com/537177
Still present in Firefox
(https://bugzilla.mozilla.org/show_bug.cgi?id=1133172), Edge and
WebKit.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
