### PR TITLE
Fix broken test Document.currentScript.html

### DIFF
--- a/html/dom/documents/dom-tree-accessors/Document.currentScript.html
+++ b/html/dom/documents/dom-tree-accessors/Document.currentScript.html
@@ -14,7 +14,6 @@ var data = {
   "dom-inline" : [],
   "dom-ext" : [],
   "nested" : ["nested-outer","nested-inner","nested-outer"],
-  "script-exec" : ["script-exec-before-after","script-exec-before-after"],
   "script-load-error" : [null],
   "script-window-error" : ["script-error-compile","script-error-runtime"],
   "timeout" : [null],


### PR DESCRIPTION
d0411c37 removed the actual test here for
beforescriptexecute/afterscriptexecute, but didn't remove the
async_test(), so it just times out.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
