### PR TITLE
Fix scrollIntoView-empty-args.html flakiness

### DIFF
--- a/cssom-view/scrollIntoView-empty-args.html
+++ b/cssom-view/scrollIntoView-empty-args.html
@@ -2,49 +2,77 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <title>Check End Position of scrollIntoView when arg is not fully specified</title>
-<div id="container" style="height: 2500px; width: 2500px;">
-  <div id="content" style="height: 500px; width: 500px;margin-left: 1000px; margin-right: 1000px; margin-top: 1000px;margin-bottom: 1000px;background-color: red">
-  </div>
-</div>
-<script>
-add_completion_callback(() => document.getElementById("container").remove());
-var content_height = 500;
-var content_width = 500;
-var window_height = document.documentElement.clientHeight;
-var window_width = document.documentElement.clientWidth;
-var content = document.getElementById("content");
 
-function instantScrollToTestArgs(arg, expected_x, expected_y) {
-  window.scrollTo(0, 0);
-  assert_not_equals(window.scrollX, expected_x);
-  assert_not_equals(window.scrollY, expected_y);
-  if (arg == "omitted")
-    content.scrollIntoView();
-  else
-    content.scrollIntoView(arg);
-  assert_approx_equals(window.scrollX, expected_x, 1);
-  assert_approx_equals(window.scrollY, expected_y, 1);
+<style>
+#container {
+ position: relative;
+ height: 1000px;
+ width: 800px;
+ overflow: scroll;
 }
 
-test(t => {
-  instantScrollToTestArgs("omitted",
-    content.offsetLeft + content_width - window_width,
-    content.offsetTop);
-  instantScrollToTestArgs(true,
-    content.offsetLeft + content_width - window_width,
-    content.offsetTop);
-  instantScrollToTestArgs(false,
-    content.offsetLeft + content_width - window_width,
-    content.offsetTop + content_height - window_height);
-  instantScrollToTestArgs({},
-    content.offsetLeft + (content_width - window_width) / 2,
-    content.offsetTop + (content_height - window_height) / 2);
-  instantScrollToTestArgs(null,
-    content.offsetLeft + (content_width - window_width) / 2,
-    content.offsetTop + (content_height - window_height) / 2);
-  instantScrollToTestArgs(undefined,
-    content.offsetLeft + content_width - window_width,
-    content.offsetTop);
-}, "scrollIntoView should behave correctly when the arg is not fully specified as ScrollIntoViewOptions");
+#content {
+ position: absolute;
+ height: 500px;
+ width: 400px;
+ left: 1000px;
+ top: 1000px;
+ background-color: red;
+}
+</style>
+
+<div id="container">
+  <div id="filler" style="height: 2500px; width: 2500px"></div>
+  <div id="content">I must become visible</div>
+</div>
+
+<script>
+add_completion_callback(() => document.getElementById("container").remove());
+var content = document.getElementById("content");
+var container = document.getElementById("container");
+
+var remaining_width = container.clientWidth - content.clientWidth;
+var remaining_height = container.clientHeight - content.clientHeight;
+
+function instantScrollToTestArgs(arg, expected_x, expected_y) {
+  test(t => {
+    container.scrollTo(0, 0);
+
+    assert_not_equals(container.scrollLeft, expected_x);
+    assert_not_equals(container.scrollTop, expected_y);
+    if (arg == "omitted")
+      content.scrollIntoView();
+    else
+      content.scrollIntoView(arg);
+    assert_approx_equals(container.scrollTop, expected_y, 1, "verify scroll top");
+    assert_approx_equals(container.scrollLeft, expected_x, 1, "verify scroll left");
+
+  }, "scrollIntoView should behave correctly when the arg is " + arg);
+}
+
+// expected alignment: inline => nearest, block => start 
+instantScrollToTestArgs("omitted",
+  content.offsetLeft - remaining_width ,
+  content.offsetTop);
+
+// expected alignment: inline => nearest, block => start 
+instantScrollToTestArgs(true,
+  content.offsetLeft - remaining_width,
+  content.offsetTop);
+
+// expected alignment: inline => nearest, block => end 
+instantScrollToTestArgs(false,
+  content.offsetLeft - remaining_width,
+  content.offsetTop - remaining_height);
+
+// expected alignment: inline => center, block => center 
+instantScrollToTestArgs({},
+  content.offsetLeft - remaining_width / 2,
+  content.offsetTop - remaining_height / 2);
+
+// expected alignment: inline => center, block => center 
+instantScrollToTestArgs(null,
+  content.offsetLeft - remaining_width / 2,
+  content.offsetTop - remaining_height / 2);
 
 </script>

--- a/cssom-view/scrollIntoView-empty-args.html
+++ b/cssom-view/scrollIntoView-empty-args.html
@@ -50,32 +50,32 @@
     }, "scrollIntoView should behave correctly when the arg is " + arg);
   }
 
-  // expected alignment: inline => nearest, block => start 
+  // expected alignment: inline => nearest, block => start
   instantScrollToTestArgs("omitted",
     content.offsetLeft - remaining_width,
     content.offsetTop);
 
-  // expected alignment: inline => nearest, block => start 
+  // expected alignment: inline => nearest, block => start
   instantScrollToTestArgs(true,
     content.offsetLeft - remaining_width,
     content.offsetTop);
 
-  // expected alignment: inline => nearest, block => end 
+  // expected alignment: inline => nearest, block => end
   instantScrollToTestArgs(false,
     content.offsetLeft - remaining_width,
     content.offsetTop - remaining_height);
 
-  // expected alignment: inline => center, block => center 
+  // expected alignment: inline => center, block => center
   instantScrollToTestArgs({},
     content.offsetLeft - remaining_width / 2,
     content.offsetTop - remaining_height / 2);
 
-  // expected alignment: inline => center, block => center 
+  // expected alignment: inline => center, block => center
   instantScrollToTestArgs(null,
     content.offsetLeft - remaining_width / 2,
     content.offsetTop - remaining_height / 2);
 
-  // expected alignment: inline => nearest, block => start 
+  // expected alignment: inline => nearest, block => start
   instantScrollToTestArgs(undefined,
     content.offsetLeft - remaining_width,
     content.offsetTop);

--- a/cssom-view/scrollIntoView-empty-args.html
+++ b/cssom-view/scrollIntoView-empty-args.html
@@ -4,21 +4,21 @@
 <title>Check End Position of scrollIntoView when arg is not fully specified</title>
 
 <style>
-#container {
- position: relative;
- height: 1000px;
- width: 800px;
- overflow: scroll;
-}
+  #container {
+    position: relative;
+    height: 1000px;
+    width: 800px;
+    overflow: scroll;
+  }
 
-#content {
- position: absolute;
- height: 500px;
- width: 400px;
- left: 1000px;
- top: 1000px;
- background-color: red;
-}
+  #content {
+    position: absolute;
+    height: 500px;
+    width: 400px;
+    left: 1000px;
+    top: 1000px;
+    background-color: red;
+  }
 </style>
 
 <div id="container">
@@ -27,52 +27,57 @@
 </div>
 
 <script>
-add_completion_callback(() => document.getElementById("container").remove());
-var content = document.getElementById("content");
-var container = document.getElementById("container");
+  add_completion_callback(() => document.getElementById("container").remove());
+  var content = document.getElementById("content");
+  var container = document.getElementById("container");
 
-var remaining_width = container.clientWidth - content.clientWidth;
-var remaining_height = container.clientHeight - content.clientHeight;
+  var remaining_width = container.clientWidth - content.clientWidth;
+  var remaining_height = container.clientHeight - content.clientHeight;
 
-function instantScrollToTestArgs(arg, expected_x, expected_y) {
-  test(t => {
-    container.scrollTo(0, 0);
+  function instantScrollToTestArgs(arg, expected_x, expected_y) {
+    test(t => {
+      container.scrollTo(0, 0);
 
-    assert_not_equals(container.scrollLeft, expected_x);
-    assert_not_equals(container.scrollTop, expected_y);
-    if (arg == "omitted")
-      content.scrollIntoView();
-    else
-      content.scrollIntoView(arg);
-    assert_approx_equals(container.scrollTop, expected_y, 1, "verify scroll top");
-    assert_approx_equals(container.scrollLeft, expected_x, 1, "verify scroll left");
+      assert_not_equals(container.scrollLeft, expected_x);
+      assert_not_equals(container.scrollTop, expected_y);
+      if (arg == "omitted")
+        content.scrollIntoView();
+      else
+        content.scrollIntoView(arg);
+      assert_approx_equals(container.scrollTop, expected_y, 1, "verify scroll top");
+      assert_approx_equals(container.scrollLeft, expected_x, 1, "verify scroll left");
 
-  }, "scrollIntoView should behave correctly when the arg is " + arg);
-}
+    }, "scrollIntoView should behave correctly when the arg is " + arg);
+  }
 
-// expected alignment: inline => nearest, block => start 
-instantScrollToTestArgs("omitted",
-  content.offsetLeft - remaining_width ,
-  content.offsetTop);
+  // expected alignment: inline => nearest, block => start 
+  instantScrollToTestArgs("omitted",
+    content.offsetLeft - remaining_width,
+    content.offsetTop);
 
-// expected alignment: inline => nearest, block => start 
-instantScrollToTestArgs(true,
-  content.offsetLeft - remaining_width,
-  content.offsetTop);
+  // expected alignment: inline => nearest, block => start 
+  instantScrollToTestArgs(true,
+    content.offsetLeft - remaining_width,
+    content.offsetTop);
 
-// expected alignment: inline => nearest, block => end 
-instantScrollToTestArgs(false,
-  content.offsetLeft - remaining_width,
-  content.offsetTop - remaining_height);
+  // expected alignment: inline => nearest, block => end 
+  instantScrollToTestArgs(false,
+    content.offsetLeft - remaining_width,
+    content.offsetTop - remaining_height);
 
-// expected alignment: inline => center, block => center 
-instantScrollToTestArgs({},
-  content.offsetLeft - remaining_width / 2,
-  content.offsetTop - remaining_height / 2);
+  // expected alignment: inline => center, block => center 
+  instantScrollToTestArgs({},
+    content.offsetLeft - remaining_width / 2,
+    content.offsetTop - remaining_height / 2);
 
-// expected alignment: inline => center, block => center 
-instantScrollToTestArgs(null,
-  content.offsetLeft - remaining_width / 2,
-  content.offsetTop - remaining_height / 2);
+  // expected alignment: inline => center, block => center 
+  instantScrollToTestArgs(null,
+    content.offsetLeft - remaining_width / 2,
+    content.offsetTop - remaining_height / 2);
+
+  // expected alignment: inline => nearest, block => start 
+  instantScrollToTestArgs(undefined,
+    content.offsetLeft - remaining_width,
+    content.offsetTop);
 
 </script>

--- a/cssom-view/scrollIntoView-empty-args.html
+++ b/cssom-view/scrollIntoView-empty-args.html
@@ -36,7 +36,7 @@
 
   function instantScrollToTestArgs(arg, expected_x, expected_y) {
     test(t => {
-      container.scrollTo(0, 0);
+      container.scrollTop = container.scrollLeft = 0;
 
       assert_not_equals(container.scrollLeft, expected_x);
       assert_not_equals(container.scrollTop, expected_y);


### PR DESCRIPTION
The original test was flaky as it depended on the window size. Instead rewrite the test to make it
use an inner scroller div whose size does not depend on the window.

Made a few more modification as well:
 - Make every test its own individual test so that failures are per test
 - Add comment to each test specifying the expected alignment
 - Use different hight/width values to ensure we don't make accidental mistake
 
This test verifies this spec: https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview

<!-- Reviewable:start -->

<!-- Reviewable:end -->
