### PR TITLE
Set up automated test running for WPT in headless mode.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -122,7 +122,8 @@ def env_options():
 
 
 def run_info_extras(**kwargs):
-    return {"e10s": kwargs["gecko_e10s"]}
+    return {"e10s": kwargs["gecko_e10s"],
+            "headless": "MOZ_HEADLESS" in os.environ}
 
 
 def update_properties():


### PR DESCRIPTION

Currently these are enabled for Linux and Windows, using the corresponding WPT
symbols with an "H" suffix to match the Mn->MnH convention followed by the
Marionette tests.

For Linux, the tests are set to run with a simulated 1600x1200 screen
resolution, which matches the Docker configuration. The default 1366x768 for
headless mode results in some unexpected failures due to windows not being
able to reach the full sizes the web platform tests expect.

For Windows, the simulated screen resolution is set to 1024x768, which is what
I've determined to be the resolution that Windows VMs run under within our
testing infrastructure. Setting a different screen resolution causes some web
platform tests to unexpectedly pass (in particular, several in
open-features-non-integer-height.html).

A "headless" variable is added to the environment that the WPT metadata
(.ini) files can access, indicating whether or not the test is running in
headless mode. This is used to mark the reftest bdi-neutral-wrapped.html as an
expected pass on Linux under headless mode: it normally fails (spuriously) due
to differences in scrollbar sizing, but scrollbars aren't rendered in headless
mode.

MozReview-Commit-ID: 3usazOoxx3q

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1373739 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6824)
<!-- Reviewable:end -->
