### PR TITLE
Update capabilities with value returned from the remote end

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -376,6 +376,7 @@ class Session(object):
 
         value = self.send_command("POST", "session", body=body)
         self.session_id = value["sessionId"]
+        self.capabilities = value["capabilities"]
 
         if self.extension_cls:
             self.extension = self.extension_cls(self)


### PR DESCRIPTION

When a new session is created the server returns a few details of the
remote end. It replaces the contents of the capabilities variable with
what is returned so that it can be used when accessing it from the
session object.

MozReview-Commit-ID: DB4iMpYMKXU

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1364389 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6826)
<!-- Reviewable:end -->
