### PR TITLE
Improve crash detection in wpt with e10s enabled,

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -119,6 +119,10 @@ class Browser(object):
         with which it should be instantiated"""
         return ExecutorBrowser, {}
 
+    def check_for_crashes(self):
+        """Check for crashes that didn't cause the browser process to terminate"""
+        return False
+
     def log_crash(self, process, test):
         """Return a list of dictionaries containing information about crashes that happend
         in the browser, or an empty list if no crashes occurred"""

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -177,6 +177,8 @@ class FirefoxBrowser(Browser):
             self.used_ports.add(self.marionette_port)
 
         env = os.environ.copy()
+        env["MOZ_CRASHREPORTER"] = "1"
+        env["MOZ_CRASHREPORTER_SHUTDOWN"] = "1"
         env["MOZ_DISABLE_NONLOCAL_CONNECTIONS"] = "1"
         env["STYLO_THREADS"] = str(self.stylo_threads)
 
@@ -310,6 +312,14 @@ class FirefoxBrowser(Browser):
     def executor_browser(self):
         assert self.marionette_port is not None
         return ExecutorBrowser, {"marionette_port": self.marionette_port}
+
+    def check_for_crashes(self):
+        dump_dir = os.path.join(self.profile.profile, "minidumps")
+
+        return bool(mozcrash.check_for_crashes(dump_dir,
+                                               symbols_path=self.symbols_path,
+                                               stackwalk_binary=self.stackwalk_binary,
+                                               quiet=True))
 
     def log_crash(self, process, test):
         dump_dir = os.path.join(self.profile.profile, "minidumps")

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -376,9 +376,17 @@ class ExecuteAsyncScriptRun(object):
             wait_timeout = None
 
         flag = self.result_flag.wait(wait_timeout)
-        if self.result[1] is None:
+
+        if self.result == (None, None):
             self.logger.debug("Timed out waiting for a result")
             self.result = False, ("EXTERNAL-TIMEOUT", None)
+        elif self.result[1] is None:
+            # We didn't get any data back from the test, so check if the
+            # browser is still responsive
+            if self.protocol.is_alive:
+                self.result = False, ("ERROR", None)
+            else:
+                self.result = False, ("CRASH", None)
         return self.result
 
     def _run(self):

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -223,6 +223,9 @@ class BrowserManager(object):
             self.init_timer.cancel()
         self.browser.cleanup()
 
+    def check_for_crashes(self):
+        self.browser.check_for_crashes()
+
     def log_crash(self, test_id):
         self.browser.log_crash(process=self.browser_pid, test=test_id)
 
@@ -548,6 +551,11 @@ class TestRunnerManager(threading.Thread):
         # Write the result of the test harness
         expected = test.expected()
         status = file_result.status if file_result.status != "EXTERNAL-TIMEOUT" else "TIMEOUT"
+
+        if file_result.status in  ("TIMEOUT", "EXTERNAL-TIMEOUT"):
+            if self.browser.check_for_crashes():
+                status = "CRASH"
+
         is_unexpected = expected != status
         if is_unexpected:
             self.unexpected_count += 1


### PR DESCRIPTION

Set MOZ_CRASHREPORTER_SHUTDOWN so that the browser terminates
immediately in the case of a content crash. This causes an early
return from executeAsyncScript, which also happens in cases with an
unhandled alert dialog, so check  if the connection is still alive to
distinguish between a crash and an error.

MozReview-Commit-ID: 6FYDwt15tI4

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1384063 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6830)
<!-- Reviewable:end -->
