### PR TITLE
To make data-url.html pass.

### DIFF
--- a/workers/data-url.html
+++ b/workers/data-url.html
@@ -25,7 +25,8 @@ function assert_worker_construction_fails(test_desc, mime_type, worker_code) {
     w.onmessage = t.step_func_done(function(e) {
       assert_unreached('Should not receive any message back.');
     });
-    w.onerror = t.step_func_done(function() {
+    w.onerror = t.step_func_done(function(e) {
+      assert_true(true, 'Should throw ' + e.message);
     });
   }, test_desc);
 }
@@ -50,8 +51,9 @@ assert_worker_throws('Web SQL Database inaccessible', 'self.openDatabase("someDB
 assert_worker_sends_pass('cross-origin worker', '', 'fetch("/").then(() => self.postMessage("FAIL"), () => self.postMessage("PASS"))');
 
 // 'data:' workers have opaque origin
-assert_worker_sends_pass('worker has opaque origin', 'application/javascript', 'if (self.location.origin == "null") postMessage("PASS"); else postMessage("FAIL");');
+assert_worker_sends_pass('worker has opaque origin', 'application/javascript', 'if (self.location.origin == "null") {postMessage("PASS");} else {postMessage("FAIL");}');
 
+setup({allow_uncaught_exception:true});
 // invalid javascript will trigger an ErrorEvent
 assert_worker_construction_fails('invalid javascript produces error', 'application/javascript', '}x=3');
 


### PR DESCRIPTION

The original test in [1] will throw Syntax error, due to we strip whitespace in
[2]. The test 'else postMessage(..)' will become 'elsepostMessage(...)'
and cause ReferenceError: elsepostMessage is not defined. So I added {}
to fix the error.

Also in the last test [3], it will trigger error handler in the testing
framework, and the TestHarness will fail if there's an error thrown. So I
added 'setup({allow_uncaught_exception:true});' to fix this.

[1]: http://searchfox.org/mozilla-central/rev/f0e4ae5f8c40ba742214e89aba3f554da0b89a33/testing/web-platform/tests/workers/data-url.html#53
[2]: http://searchfox.org/mozilla-central/rev/f0e4ae5f8c40ba742214e89aba3f554da0b89a33/netwerk/protocol/data/nsDataHandler.cpp#92
[3]: http://searchfox.org/mozilla-central/rev/f0e4ae5f8c40ba742214e89aba3f554da0b89a33/testing/web-platform/tests/workers/data-url.html#56

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1340974 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6831)
<!-- Reviewable:end -->
