### PR TITLE
Allow assert_success to be used without an expected value.

### DIFF
--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -68,16 +68,18 @@ def assert_error(response, error_code):
     assert isinstance(response.body["value"]["message"], basestring)
     assert isinstance(response.body["value"]["stacktrace"], basestring)
 
-def assert_success(response, value):
+def assert_success(response, value=None):
     """Verify that the provided wdclient.Response instance described a valid
     error response as defined by `dfn-send-an-error` and the provided error
     code.
-    :param response: wdclient.Response instance
-    :param value: expected value of the response body
-    """
 
+    :param response: wdclient.Response instance.
+    :param value: Expected value of the response body, if any.
+
+    """
     assert response.status == 200
-    assert response.body["value"] == value
+    if value is not None:
+        assert response.body["value"] == value
 
 def assert_dialog_handled(session, expected_text):
     result = session.transport.send("GET",


### PR DESCRIPTION

It happens that we receive responses that do not have a body value.
We want to be able to use assert_success with these as well.

MozReview-Commit-ID: B1f0Hn406Nj

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1381876 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6834)
<!-- Reviewable:end -->
