### PR TITLE
Make client.Session#maximize a method.

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -263,7 +263,6 @@ class Window(object):
         body = {"x": x, "y": y}
         self.session.send_session_command("POST", "window/rect", body)
 
-    @property
     @command
     def maximize(self):
         return self.session.send_session_command("POST", "window/maximize")


### PR DESCRIPTION

The Maximize Window command is a POST endpoint and should consequently
be a method, not a property.

MozReview-Commit-ID: DJfKdhMIX75

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1381876 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6835)
<!-- Reviewable:end -->
