### PR TITLE
Skip resetting namespaced interfaces in client.Session.

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -390,10 +390,6 @@ class Session(object):
         self.send_command("DELETE", url)
 
         self.session_id = None
-        self.timeouts = None
-        self.window = None
-        self.find = None
-        self.extension = None
 
     def send_command(self, method, url, body=None):
         """

--- a/webdriver/tests/contexts/maximize_window.py
+++ b/webdriver/tests/contexts/maximize_window.py
@@ -9,30 +9,67 @@ def test_maximize_no_browsing_context(session, create_window):
     session.window_handle = create_window()
     session.close()
     result = session.transport.send("POST", "session/%s/window/maximize" % session.session_id)
-
     assert_error(result, "no such window")
 
 
-def test_maximize_rect_alert_prompt(session):
+def test_handle_user_prompt(session):
     # Step 2
     session.url = alert_doc
-
     result = session.transport.send("POST", "session/%s/window/maximize" % session.session_id)
-
     assert_error(result, "unexpected alert open")
 
 
-def test_maximize_payload(session):
-    # step 5
+def test_maximize(session):
+    before = session.window.size
+
+    # step 4
+    result = session.transport.send("POST", "session/%s/window/maximize" % session.session_id)
+    assert_success(result)
+
+    after = session.window.size
+    assert before != after
+
+
+def test_payload(session):
+    before = session.window.size
+
     result = session.transport.send("POST", "session/%s/window/maximize" % session.session_id)
 
+    # step 5
     assert result.status == 200
     assert isinstance(result.body["value"], dict)
-    assert "width" in result.body["value"]
-    assert "height" in result.body["value"]
-    assert "x" in result.body["value"]
-    assert "y" in result.body["value"]
-    assert isinstance(result.body["value"]["width"], float)
-    assert isinstance(result.body["value"]["height"], float)
-    assert isinstance(result.body["value"]["x"], float)
-    assert isinstance(result.body["value"]["y"], float)
+
+    rect = result.body["value"]
+    assert "width" in rect
+    assert "height" in rect
+    assert "x" in rect
+    assert "y" in rect
+    assert isinstance(rect["width"], float)
+    assert isinstance(rect["height"], float)
+    assert isinstance(rect["x"], float)
+    assert isinstance(rect["y"], float)
+
+    after = session.window.size
+    assert before != after
+
+
+def test_maximize_when_resized_to_max_size(session):
+    # Determine the largest available window size by first maximising
+    # the window and getting the window rect dimensions.
+    #
+    # Then resize the window to the maximum available size.
+    session.end()
+    available = session.window.maximize()
+    session.end()
+
+    session.window.size = (int(available["width"]), int(available["height"]))
+
+    # In certain window managers a window extending to the full available
+    # dimensions of the screen may not imply that the window is maximised,
+    # since this is often a special state.  If a remote end expects a DOM
+    # resize event, this may not fire if the window has already reached
+    # its expected dimensions.
+    before = session.window.size
+    session.window.maximize()
+    after = session.window.size
+    assert before == after


### PR DESCRIPTION

Resetting these interfaces means they will not be set up again if the
client.Session instance is reused.

MozReview-Commit-ID: 7JW61VrMFpD

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1381876 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6836)
<!-- Reviewable:end -->
