### PR TITLE
Drop support for createEvent("ErrorEvent"/"PopStateEvent");

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
+++ b/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
@@ -6,12 +6,6 @@
 <div id="log"></div>
 <script>
 test(function () {
-  var e = document.createEvent('PopStateEvent');
-  var eProto = Object.getPrototypeOf(e);
-  assert_equals(eProto, PopStateEvent.prototype);
-}, 'document.createEvent');
-
-test(function () {
   assert_false('initPopStateEvent' in PopStateEvent.prototype,
                'There should be no PopStateEvent#initPopStateEvent');
 }, 'initPopStateEvent');

--- a/workers/Worker_dispatchEvent_ErrorEvent.htm
+++ b/workers/Worker_dispatchEvent_ErrorEvent.htm
@@ -25,12 +25,6 @@ async_test(function(t) {
 });
 
 test(function() {
-  var e = document.createEvent("ErrorEvent");
-  var eProto = Object.getPrototypeOf(e);
-  assert_equals(eProto, ErrorEvent.prototype);
-}, "document.createEvent('ErrorEvent')");
-
-test(function() {
   var e = new ErrorEvent("error");
   assert_false("initErrorEvent" in e, "should not be supported");
 }, "initErrorEvent");


### PR DESCRIPTION

They were just dropped from the spec:

https://github.com/whatwg/dom/issues/362
https://github.com/whatwg/dom/pull/489

ErrorEvent we never supported anyway until it was added recently to
match the spec.  PopStateEvent is not supported by WebKit, Blink is
planning to try dropping support, our telemetry shows usage is
basically zero, and we never supported any way to initialize it anyway.

The changes to Document-createEvent.html and Document-createEvent.js are
taken from upstream.  The other wpt changes are new in this commit.

MozReview-Commit-ID: A6GzhLwL08l

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1388119 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6838)
<!-- Reviewable:end -->
