### PR TITLE
Return window to normal state.

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -13,7 +13,10 @@ default_host = "http://127.0.0.1"
 default_port = "4444"
 
 def _ensure_valid_window(session):
-    """If current window is not open anymore, ensure to have a valid one selected."""
+    """If current window is not open anymore, ensure to have a valid
+    one selected.
+
+    """
     try:
         session.window_handle
     except webdriver.NoSuchWindowException:
@@ -32,6 +35,20 @@ def _dismiss_user_prompts(session):
             pass
 
     session.window_handle = current_window
+
+
+def _restore_normal_window_state(session):
+    """If the window is maximized, minimized, or fullscreened it will
+    be returned to normal state.
+
+    """
+    state = session.window.state
+    if state == "maximized":
+        session.window.maximize()
+    elif state == "minimized":
+        session.window.minimize()
+    elif state == "fullscreen":
+        session.window.fullscreen()
 
 
 def _restore_windows(session):
@@ -135,6 +152,7 @@ def session(configuration, request):
     # finalisers are popped off a stack,
     # making their ordering reverse
     request.addfinalizer(lambda: _switch_to_top_level_browsing_context(_current_session))
+    request.addfinalizer(lambda: _restore_normal_window_state(_current_session))
     request.addfinalizer(lambda: _restore_windows(_current_session))
     request.addfinalizer(lambda: _dismiss_user_prompts(_current_session))
     request.addfinalizer(lambda: _ensure_valid_window(_current_session))


### PR DESCRIPTION

If a test leaves the window in maximized, minimized, or fullscreen
state it should be returned to the normal state the next time a session
is requested.

MozReview-Commit-ID: IALlITFVz1w

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1388365 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6840)
<!-- Reviewable:end -->
