### PR TITLE
Return value from assert_success.

### DIFF
--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -80,6 +80,7 @@ def assert_success(response, value=None):
     assert response.status == 200
     if value is not None:
         assert response.body["value"] == value
+    return response.body.get("value")
 
 def assert_dialog_handled(session, expected_text):
     result = session.transport.send("GET",


### PR DESCRIPTION

Return the contents of value, if it exists, after asserting the response
was successful.

assert_success can be passed a value which will assert that the response's
value matches an expected value.  If you want to compare a subsection
of the response it may be convenient to for the value to be returned
after it has been asserted that the response was a success.

MozReview-Commit-ID: 1dyzQIazYEN

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1388365 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6843)
<!-- Reviewable:end -->
