### PR TITLE
Parse ranges for stretch in @font-face (fixup)

### DIFF
--- a/css-fonts/variations/font-parse-numeric-stretch-style-weight.html
+++ b/css-fonts/variations/font-parse-numeric-stretch-style-weight.html
@@ -87,8 +87,8 @@ var faceInvalidTests = {
     'a b c',
   ],
   'stretch': [
-    '0%', '60% 70% 80%', 'a%', 'a b c', '0.1', '-60% 80%', 'ultra-expannnned',
-    '50% 0'
+    '-0.5%', '-1%', '0%', 'calc(0% - 10%)', '60% 70% 80%', 'a%', 'a b c', '0.1',
+    '-60% 80%', 'ultra-expannnned', '50% 0'
   ],
 };
 


### PR DESCRIPTION
Allow ranges for font-stretch in @font-face, compare
https://drafts.csswg.org/css-fonts-4/#font-prop-desc

Bug: 749091
Change-Id: I79cafc1f7c496617bfb4eca21e28b4b451bdfae5
Reviewed-on: https://chromium-review.googlesource.com/582862
Commit-Queue: Dominik Röttsches <drott@chromium.org>
Reviewed-by: meade_UTC10 <meade@chromium.org>
Reviewed-by: Bugs Nash <bugsnash@chromium.org>
Cr-Commit-Position: refs/heads/master@{#491697}

<!-- Reviewable:start -->

<!-- Reviewable:end -->
