### PR TITLE
[wptrunner] Fix subtest messages not being captured in --log-wptreport

### DIFF
--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -44,6 +44,8 @@ class WptreportFormatter(BaseFormatter):
     def test_status(self, data):
         subtest = self.create_subtest(data)
         subtest["status"] = data["status"]
+        if "message" in data:
+            subtest["message"] = data["message"]
 
     def test_end(self, data):
         test = self.find_or_create_test(data)


### PR DESCRIPTION
Via https://github.com/GoogleChrome/wptdashboard/issues/53

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6854)
<!-- Reviewable:end -->
