### PR TITLE
Don't use empty contenteditable element

### DIFF
--- a/input-events/input-events-typing-data-manual.html
+++ b/input-events/input-events-typing-data-manual.html
@@ -9,7 +9,7 @@
 <br/>
 If a "PASS" result appears the test passes, otherwise it fails</p>
 <textarea id='plain'></textarea>
-<div id='rich' style='border-style: solid;' contenteditable></div>
+<div id='rich' style='border-style: solid;' contenteditable><br></div>
 <script>
 async_test(t => {
     const expectedResult = [


### PR DESCRIPTION
Some browsers (like Chrome) will magically make an empty contenteditable
element one line tall.  Others (like Firefox) will not, so it collapses
to zero height like any empty block element.  Put in a <br> to make it
compatible with all browsers.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
