### PR TITLE
Add a lint check for 'web-platform.test.

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -939,6 +939,7 @@ LAYOUTTESTS APIS: css/css-regions/interactivity/*
 
 # Existing use of WEB-PLATFORM.TEST
 WEB-PLATFORM.TEST: clear-site-data/support/test_utils.sub.js
+WEB-PLATFORM.TEST: content-security-policy/base-uri/report-uri-does-not-respect-base-uri.sub.html
 WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8.sub.html
 WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8_1.sub.html
 WEB-PLATFORM.TEST: content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.html

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -306,6 +306,7 @@ SET TIMEOUT: acid/acid3/test.html
 
 # Travis
 W3C-TEST.ORG: .travis.yml
+WEB-PLATFORM.TEST: .travis.yml
 
 # Config
 WEB-PLATFORM.TEST: config.default.json

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -73,6 +73,9 @@ W3C-TEST.ORG: README.md
 W3C-TEST.ORG: */README.md
 W3C-TEST.ORG: docs/*
 SET TIMEOUT: docs/*
+WEB-PLATFORM.TEST:README.md
+WEB-PLATFORM.TEST:*/README.md
+WEB-PLATFORM.TEST:docs/*
 
 ## Helper scripts ##
 
@@ -303,6 +306,9 @@ SET TIMEOUT: acid/acid3/test.html
 
 # Travis
 W3C-TEST.ORG: .travis.yml
+
+# Config
+WEB-PLATFORM.TEST: config.default.json
 
 # Git submodules are not currently scanned
 *: tools/*
@@ -929,3 +935,23 @@ CONSOLE: payment-request/payment-request-response-id.html
 
 # Tests that use WebKit/Blink testing APIs
 LAYOUTTESTS APIS: css/css-regions/interactivity/*
+
+# Existing use of WEB-PLATFORM.TEST
+WEB-PLATFORM.TEST: clear-site-data/support/test_utils.sub.js
+WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8.sub.html
+WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8_1.sub.html
+WEB-PLATFORM.TEST: content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.html
+WEB-PLATFORM.TEST: content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.html
+WEB-PLATFORM.TEST: fetch/api/request/request-structure.html
+WEB-PLATFORM.TEST: html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
+WEB-PLATFORM.TEST: html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html
+WEB-PLATFORM.TEST: html/semantics/forms/the-label-element/label-attributes.html
+WEB-PLATFORM.TEST: longtask-timing/longtask-in-childiframe-crossorigin.html
+WEB-PLATFORM.TEST: longtask-timing/longtask-in-sibling-iframe-crossorigin.html
+WEB-PLATFORM.TEST: navigation-timing/nav2_test_attributes_values.html
+WEB-PLATFORM.TEST: navigation-timing/nav2_test_instance_accessors.html
+WEB-PLATFORM.TEST: service-workers/service-worker/update-bytecheck.https.html
+WEB-PLATFORM.TEST: webdriver/tests/cookies/add_cookie.py
+WEB-PLATFORM.TEST: webdriver/tests/cookies/get_named_cookie.py
+WEB-PLATFORM.TEST: webrtc/RTCPeerConnection-getIdentityAssertion.html
+WEB-PLATFORM.TEST: webrtc/identity-helper.js

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -329,6 +329,11 @@ class W3CTestOrgRegexp(Regexp):
     error = "W3C-TEST.ORG"
     description = "External w3c-test.org domain used"
 
+class WebPlatformTestRegexp(Regexp):
+    pattern = b"web\-platform\.test"
+    error = "WEB-PLATFORM.TEST"
+    description = "Internal web-platform.test domain used"
+
 class Webidl2Regexp(Regexp):
     pattern = b"webidl2\.js"
     error = "WEBIDL2.JS"
@@ -371,6 +376,7 @@ regexps = [item() for item in
             CRRegexp,
             SetTimeoutRegexp,
             W3CTestOrgRegexp,
+            WebPlatformTestRegexp,
             Webidl2Regexp,
             ConsoleRegexp,
             GenerateTestsRegexp,

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -100,6 +100,19 @@ def test_w3c_test_org():
             expected.append(("PARSE-FAILED", "Unable to parse file", filename, None))
         assert errors == expected
 
+def test_web_platform_test():
+    error_map = check_with_files(b"import('http://web-platform.test/')")
+
+    for (filename, (errors, kind)) in error_map.items():
+        check_errors(errors)
+
+        expected = [("WEB-PLATFORM.TEST", "Internal web-platform.test domain used", filename, 1)]
+        if kind == "python":
+            expected.append(("PARSE-FAILED", "Unable to parse file", filename, 1))
+        elif kind == "web-strict":
+            expected.append(("PARSE-FAILED", "Unable to parse file", filename, None))
+        assert errors == expected
+
 
 def test_webidl2_js():
     error_map = check_with_files(b"<script src=/resources/webidl2.js>")


### PR DESCRIPTION
Silly developers, including myself in #6849, tend to hard-code the string
'web-platform.test' when developing tests locally. This patch adds a lint
check to make that kind of mistake harder to make. Closes #6556.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6868)
<!-- Reviewable:end -->
