### PR TITLE
Add tests for replacement enabled and hashchange

### DIFF
--- a/html/browsers/browsing-the-web/scroll-to-fragid/forward-triggers-hashchange.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/forward-triggers-hashchange.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigating forward after replace() should still trigger hashchange</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#history-traversal">
+<link rel="author" href="mailto:d@domenic.me" title="Domenic Denicola">
+
+<!-- While writing ./replacement-enabled.html, a bug was discovered in Firefox where it does not
+fire hashchange when using history.forward(), at least under certain conditions. So, this test
+exercises that specifically. -->
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="navigate-helpers.js"></script>
+
+<body>
+
+<script>
+"use strict";
+let resolve, iframe;
+promise_test(() => {
+  iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  iframe.addEventListener("load", runTest);
+  document.body.appendChild(iframe);
+
+  return new Promise(r => resolve = r);
+});
+
+function runTest() {
+  iframe.removeEventListener("load", runTest);
+  const frameWindow = iframe.contentWindow;
+
+  resolve((async () => {
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#apple");
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#banana");
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#cat");
+
+    await navigateAndWaitForChange(frameWindow, w => w.history.back());
+    await navigateAndWaitForChange(frameWindow,
+      w => w.location.replace("/common/blank.html#zebra"));
+    await navigateAndWaitForChange(frameWindow, w => w.history.forward());
+  })());
+}
+</script>

--- a/html/browsers/browsing-the-web/scroll-to-fragid/navigate-helpers.js
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/navigate-helpers.js
@@ -1,0 +1,23 @@
+"use strict";
+
+// Usage examples:
+//   navigateAndWaitForChange(frameWindow, w => w.location.href = "...");
+//   navigateAndWaitForChange(frameWindow, w => w.history.back());
+//   navigateAndWaitForChange(frameWindow, w => w.history.back(), { assumeSuccessAfter: 100 });
+
+window.navigateAndWaitForChange = (w, navigationAction, { assumeSuccessAfter } = {}) => {
+  return new Promise(resolve => {
+    w.addEventListener("hashchange", listener);
+
+    function listener() {
+      w.removeEventListener("hashchange", listener);
+      resolve();
+    }
+
+    if (assumeSuccessAfter !== undefined) {
+      step_timeout(resolve, assumeSuccessAfter);
+    }
+
+    navigationAction(w);
+  });
+};

--- a/html/browsers/browsing-the-web/scroll-to-fragid/replacement-enabled.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/replacement-enabled.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigating to a fragment should not clear forward history</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#scroll-to-fragid">
+<link rel="help" href="https://github.com/whatwg/html/issues/2796">
+<link rel="help" href="https://github.com/whatwg/html/pull/2869">
+<link rel="author" href="mailto:d@domenic.me" title="Domenic Denicola">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="navigate-helpers.js"></script>
+
+<body>
+
+<script>
+"use strict";
+let resolve, iframe;
+promise_test(() => {
+  iframe = document.createElement("iframe");
+  iframe.src = "/common/blank.html";
+  iframe.addEventListener("load", runTest);
+  document.body.appendChild(iframe);
+
+  return new Promise(r => resolve = r);
+});
+
+function runTest() {
+  iframe.removeEventListener("load", runTest);
+  const frameWindow = iframe.contentWindow;
+
+  resolve((async () => {
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#apple");
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#banana");
+    await navigateAndWaitForChange(frameWindow, w => w.location.href = "/common/blank.html#cat");
+
+    assert_equals(frameWindow.location.hash, "#cat");
+
+    // Might not be 4 (= 3 for iframe + 1 initial) due to cross-browser differences or if people are
+    // running this test in a window that has previously been places. The important thing for this
+    // test is the delta from this value.
+    const afterThreeNavigations = frameWindow.history.length;
+
+    await navigateAndWaitForChange(frameWindow, w => w.history.back());
+
+    assert_equals(frameWindow.location.hash, "#banana");
+    assert_equals(frameWindow.history.length, afterThreeNavigations,
+      "back() must not change the history length");
+
+    await navigateAndWaitForChange(frameWindow,
+      w => w.location.replace("/common/blank.html#zebra"));
+
+    assert_equals(frameWindow.location.hash, "#zebra");
+    assert_equals(frameWindow.history.length, afterThreeNavigations,
+      "replace() must not change the history length");
+
+    // As of the time of this writing (2017-08-14), Firefox is not firing hashchange on forward, so
+    // we automatically assume navigation succeeded after 100 ms. A sibling test will test this
+    // particular Firefox bug.
+    await navigateAndWaitForChange(frameWindow, w => w.history.forward(),
+      { assumeSuccessAfter: 100 });
+
+    assert_equals(frameWindow.location.hash, "#cat");
+    assert_equals(frameWindow.history.length, afterThreeNavigations,
+      "forward() must not change the history length");
+
+  })());
+}
+
+</script>


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/2869 by adapting https://github.com/whatwg/html/issues/2796. In the process, discovered a Firefox-specific bug around history.forward() and hashchange, so added a pared-down version of the test for that in particular.

/cc @ForbesLindesay

<!-- Reviewable:start -->

<!-- Reviewable:end -->
