### PR TITLE
[css-multicol-1] Make multicol-gap-001 test more robust

### DIFF
--- a/css/css-multicol-1/multicol-gap-001-ref.xht
+++ b/css/css-multicol-1/multicol-gap-001-ref.xht
@@ -6,7 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-08-05 -->
   <meta name="flags" content="image" />
   <style type="text/css"><![CDATA[
-  div {margin: 1.25em;}
+  div {margin: 1.25em; line-height: 1;}
 
   img {vertical-align: top;}
   ]]></style>


### PR DESCRIPTION
Add explicit `line-height` in reference file to avoid dependency on UA's default `normal` value.

The test and reference files fail to match if the default `line-height` computes to more than 1.25em, which may happen depending on the default font and how line metrics are computed. This occurs because the test file explicitly sets this value via the `font` shorthand, while the reference assumes that it can obtain the same gap by using `margin: 1.25em` on the `<div>`s.

This patch fixes the problem by explicitly setting `line-height: 1` in the reference file, to ensure that the height of the blank line will not exceed the `margin` values of the two test lines above and below it.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
