### PR TITLE
Revert "PaymentRequest: fixes allowpaymentrequest test errors (#6418)"

### DIFF
--- a/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
@@ -14,25 +14,48 @@ async_test((t) => {
   iframe.src = "https://{{domains[www1]}}:{{ports[https][0]}}" + path + "echo-PaymentRequest.html";
   iframe.onload = t.step_func(() => {
     if (i === 0) {
+      // 2. The iframe has now loaded (the first load).
+      // The allowpaymentrequest flag is set.
       iframe.allowPaymentRequest = false;
+      // 3. The allowpaymentrequest attribute has now been removed.
+      // The allowpaymentrequest flag is *still set* for the document.
     }
+    // 4. (first load) Ask the subdocument to invoke PaymentRequest and post back the result.
+    // 7. (second load) Ask the subdocument to invoke PaymentRequest and post back the result.
     iframe.contentWindow.postMessage('What is the result of new PaymentRequest(...)?', '*');
   });
 
   window.onmessage = t.step_func((e) => {
     i++;
     if (i === 1) {
+      // 5. This is the first message we receive, from the first load.
+      // Since the allowpaymentrequest flag was set, we expect success.
       assert_equals(e.data.message, 'Success', 'before navigation');
 
-      // Navigate the iframe. This will fire a second 'load' event on the iframe.
+      // 6. Navigate the iframe. This will fire a second 'load' event on the iframe.
+      // At this time, the iframe does not have an allowpaymentrequest attribute.
+      // https://html.spec.whatwg.org/#the-location-interface:dom-location-href-3
+      // https://html.spec.whatwg.org/#location-object-setter-navigate
+      // https://html.spec.whatwg.org/#location-object-navigate
+      // https://html.spec.whatwg.org/#navigate step 12
+      // https://html.spec.whatwg.org/#process-a-navigate-response step 5
+      // https://html.spec.whatwg.org/#read-html
+      // https://html.spec.whatwg.org/#initialise-the-document-object step 8
+      // https://html.spec.whatwg.org/#set-the-allow*-flags step 3 does *not* set the allowpaymentrequest flag.
       iframe.contentWindow.location.href = iframe.src + '?2';
     } else {
+      // 8. This is the second message we receive, from the second load.
+      // Since the allowpaymentrequest flag was not set, we expect an exception.
       assert_equals(e.data.message, 'Exception', 'after navigation');
       assert_array_equals(e.data.details, [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */], 'after navigation');
       t.done();
     }
   });
 
+  // 1. The browsing context for the iframe is created when the iframe is inserted to the document.
+  // https://html.spec.whatwg.org/#the-iframe-element:creating-a-new-browsing-context
+  // https://html.spec.whatwg.org/#creating-a-new-browsing-context step 11
+  // https://html.spec.whatwg.org/#set-the-allow*-flags step 3 sets the allowpaymentrequest flag.
   document.body.appendChild(iframe);
 });
 </script>

--- a/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
@@ -13,7 +13,7 @@ async_test((t) => {
   const path = location.pathname.substring(0, location.pathname.lastIndexOf('/') + 1);
   iframe.src = "https://{{domains[www1]}}:{{ports[https][0]}}" + path + "echo-PaymentRequest.html";
   iframe.onload = t.step_func(() => {
-    if (i === 1) {
+    if (i === 0) {
       iframe.allowPaymentRequest = false;
     }
     iframe.contentWindow.postMessage('What is the result of new PaymentRequest(...)?', '*');

--- a/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/removing-allowpaymentrequest.https.sub.html
@@ -21,6 +21,7 @@ async_test((t) => {
       // The allowpaymentrequest flag is *still set* for the document.
     }
     // 4. (first load) Ask the subdocument to invoke PaymentRequest and post back the result.
+    // (See below for steps 5 and 6.)
     // 7. (second load) Ask the subdocument to invoke PaymentRequest and post back the result.
     iframe.contentWindow.postMessage('What is the result of new PaymentRequest(...)?', '*');
   });

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
@@ -23,7 +23,7 @@ async_test((t) => {
 
   window.onmessage = t.step_func_done((e) => {
     assert_equals(e.data.message, 'Exception');
-    assert_array_equals(e.data.details, [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */]);
+    assert_array_equals(e.data.details, [true /* ex instanceof DOMException */, DOMException.SECURITY_ERR, 'SecurityError']);
   });
 
   document.body.appendChild(iframe);

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
@@ -18,7 +18,8 @@ async_test((t) => {
   });
 
   window.onmessage = t.step_func_done((e) => {
-    assert_equals(e.data.message, 'Success');
+    assert_equals(e.data.message, 'Exception');
+    assert_array_equals(e.data.details, [true /* ex instanceof DOMException*/, 18 /* ex.code */, 'SecurityError' /* ex.name */]);
   });
 
   document.body.appendChild(iframe);

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest-timing.https.sub.html
@@ -6,6 +6,10 @@
 <script>
 // Set allowpaymentrequest attribute in a timeout after <iframe> has been inserted to the document.
 // The iframe's response is delayed so it happens after the attribute is set.
+// The allowpaymentrequest flag is *not* set when the browsing context is created
+// (when the <iframe> is inserted), because there's no attribute at that time,
+// and the flag stays as not set when the attribute is added because per spec
+// the flag is only set when a browsing context is created and when it's navigated.
 
 async_test((t) => {
   const iframe = document.createElement('iframe');

--- a/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
+++ b/payment-request/allowpaymentrequest/setting-allowpaymentrequest.https.sub.html
@@ -13,7 +13,7 @@ async_test((t) => {
   const path = location.pathname.substring(0, location.pathname.lastIndexOf('/') + 1);
   iframe.src = "https://{{domains[www1]}}:{{ports[https][0]}}" + path + "echo-PaymentRequest.html";
   iframe.onload = t.step_func(() => {
-    if (i === 1) {
+    if (i === 0) {
       iframe.allowPaymentRequest = true;
     }
     iframe.contentWindow.postMessage('What is the result of new PaymentRequest(...)?', '*');


### PR DESCRIPTION
Also document what removing-allowpaymentrequest.https.sub.html is doing.

See https://github.com/w3c/web-platform-tests/pull/6418#issuecomment-322732608

cc @AmazingJaze @marcoscaceres @rsolomakhin

<!-- Reviewable:start -->

<!-- Reviewable:end -->
