### PR TITLE
Allow |python wpt <command>| to work on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ line syntax is:
 ./wpt run product [tests]
 ```
 
-**On Windows**: for technical reasons the above will not work and you
-must instead run `python tools/wpt/wpt.py run products [tests]`.
+**On Windows**: You will need to preceed the prior command with
+`python` or the path to the python binary.
 
 where `product` is currently `firefox` or `chrome` and `[tests]` is a
 list of paths to tests. This will attempt to automatically locate a
@@ -184,8 +184,12 @@ then remove the `tools` and `resources` directories, as above.
 <span id="windows-notes">Windows Notes</span>
 =============================================
 
-Running wptserve with SSL enabled on Windows typically requires
-installing an OpenSSL distribution.
+On Windows `wpt` commands mut bre prefixed with `python` or the path
+to the python binary (if `python` is not in your `%PATH%`).
+
+Running `wpt serve` or `wpt run` with SSL enabled on Windows typically
+requires installing an OpenSSL
+distribution.
 [Shining Light](https://slproweb.com/products/Win32OpenSSL.html)
 provide a convenient installer that is known to work, but requires a
 little extra setup, i.e.:
@@ -210,7 +214,7 @@ will be `C:\\OpenSSL-Win32\\bin\\openssl.cfg`).
 Alternatively, you may also use
 [Bash on Ubuntu on Windows](https://msdn.microsoft.com/en-us/commandline/wsl/about)
 in the Windows 10 Anniversary Update build, then access your windows
-partition from there to launch wptserve.
+partition from there to launch `wpt` commands.
 
 Publication
 ===========

--- a/wpt.py
+++ b/wpt.py
@@ -1,0 +1,1 @@
+execfile("wpt")


### PR DESCRIPTION
On Windows wpt subcommands that used multiprocessing were broken
because multiprocessing in forking mode tries to re-import the top
level module in the forked process, and this doesn't work where the
module doesn't have a `.py` extension.

There are a couple of possible solutions to this problem
e.g. monkeypatching the multiprocessing module and various parts of
the import machinery will work with a bare-named module (this is
what's Mozilla's `mach` command does to solve this probelm). However
the simplest possible solution is to just add a `wpt.py` file that
runs `wpt`. This may be confusing for users, but it does at least get
things working again on Windows without being too horrifying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6907)
<!-- Reviewable:end -->
