### PR TITLE
Remove non-existent 'textContent' element from svg/interfaces.html

### DIFF
--- a/svg/interfaces.html
+++ b/svg/interfaces.html
@@ -1312,8 +1312,6 @@ var ellipse = document.createElementNS("http://www.w3.org/2000/svg", "ellipse");
 var line = document.createElementNS("http://www.w3.org/2000/svg", "line");
 var polyline = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
 var polygon = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
-var textContent = document.createElementNS("http://www.w3.org/2000/svg",
-                                           "textContent");
 var text = document.createElementNS("http://www.w3.org/2000/svg", "text");
 var tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
 var tref = document.createElementNS("http://www.w3.org/2000/svg", "tref");
@@ -1484,7 +1482,6 @@ idlArray.add_objects({
   SVGLineElement: ['line'],
   SVGPolylineElement: ['polyline'],
   SVGPolygonElement: ['polygon'],
-  SVGTextContentElement: ['textContent'],
   SVGTextElement: ['text'],
   SVGTSpanElement: ['tspan'],
   SVGTRefElement: ['tref'],


### PR DESCRIPTION
SVGTextContentElement is inherited by the various text elements
(<text>, <tspan>, et.c), but has no directly corresponding element.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
