### PR TITLE
Add a set_defaults method to wptrunner ManifestItem

### DIFF
--- a/tools/wptrunner/wptrunner/manifestinclude.py
+++ b/tools/wptrunner/wptrunner/manifestinclude.py
@@ -21,7 +21,6 @@ class IncludeManifest(ManifestItem):
         :param node: AST Node corresponding to this Node.
         """
         ManifestItem.__init__(self, node)
-        self.set("skip", "False")
         self.child_map = {}
 
     @classmethod
@@ -29,6 +28,10 @@ class IncludeManifest(ManifestItem):
         """Create an empty IncludeManifest tree"""
         node = DataNode(None)
         return cls(node)
+
+    def set_defaults(self):
+        if not self.has_key("skip"):
+            self.set("skip", "False")
 
     def append(self, child):
         ManifestItem.append(self, child)

--- a/tools/wptrunner/wptrunner/tests/test_testloader.py
+++ b/tools/wptrunner/wptrunner/tests/test_testloader.py
@@ -18,6 +18,7 @@ skip: true
   skip: false
 """
 
+
 def test_filter_unicode():
     tests = make_mock_manifest(("test", "a", 10), ("test", "a/b", 10),
                                ("test", "c", 10))

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
@@ -61,6 +61,8 @@ class Compiler(NodeVisitor):
         self.tree = tree
         self.output_node = self._initial_output_node(tree, **kwargs)
         self.visit(tree)
+        if hasattr(self.output_node, "set_defaults"):
+            self.output_node.set_defaults()
         assert self.output_node is not None
         return self.output_node
 

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/static.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/static.py
@@ -139,6 +139,9 @@ class ManifestItem(object):
             rv.extend("  %s" % line for line in str(item).split("\n"))
         return "\n".join(rv)
 
+    def set_defaults(self):
+        pass
+
     @property
     def is_empty(self):
         if self._data:


### PR DESCRIPTION
For include manifests we were trying to set a default skip value of
False in the case that nothing was set in the manifest itself. But
that didn't work well because the default was being applied before the
parsed tree was fully loaded.

This is solved by adding a set_defaults method to ManifestItem that's
called after completing loading of the tree, but before it is returned
to the caller, and using this to set the default skip value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6911)
<!-- Reviewable:end -->
