### PR TITLE
[css-grid] Updated meta-data tags to refer the relevant spec section.

### DIFF
--- a/css/css-grid-1/alignment/grid-content-distribution-001.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-001.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-001.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-002.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-002.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-002.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-003.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-003.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-003.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-003.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-004.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-004.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-004.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-004.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-005.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-005.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution default value</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-005.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution default value</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-006.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-006.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-006.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-007.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-007.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-007.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-008.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-008.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-008.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-009.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-009.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-009.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-009.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-010.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-010.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-010.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-010.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-011.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-011.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-011.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-011.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-012.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-012.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-012.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-012.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-013.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-013.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-013.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-013.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-014.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-014.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-014.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-014.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-015.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-015.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-015.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-015.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-016.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-016.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-016.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-016.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-017.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-017.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-017.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-017.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-019.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-019.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-019.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-019.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-020.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-020.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-020.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-020.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-021.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-021.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-021.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-021.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-022.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-022.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-022.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-022.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-023.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-023.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-023.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-023.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-024.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-024.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-024.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-024.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-025.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-025.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-025.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-025.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-stretch">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-001.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-001.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-evenly'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-001.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-001.html
@@ -2,9 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#distribution-values">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-evenly'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-002.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-002.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-between'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-002.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-002.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-between'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-003.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-003.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-around'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-003.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-003.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'space-around'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-004.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-004.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-004.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-004.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-005.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-005.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-005.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-005.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-006.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-006.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-006.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-006.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-007.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-007.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-007.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-007.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-008.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-008.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-008.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-008.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-009.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-009.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-009.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-009.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-evenly' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-evenly">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-evenly' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-010.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-010.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-010.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-010.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-011.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-011.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-011.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-011.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
+4<!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-012.html
@@ -1,4 +1,4 @@
-4<!DOCTYPE html>
+<!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-013.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-013.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-013.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-013.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-014.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-014.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-between">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-014.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-014.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-between' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-between' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-015.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-015.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-015.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-015.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 2x2 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-016.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-016.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-016.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-016.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-017.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-017.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-017.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-017.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 3x3 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-018.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-018.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-018.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-018.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-019.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-019.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-019.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-019.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'space-around' and gaps on 4x4 grid with collapsed tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#valdef-align-content-space-around">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution properties with 'space-around' value render correcly.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-020.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-020.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-020.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-020.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 2x2 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-021.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-021.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-021.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-021.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-022.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-022.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps with collapsed tracks on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-022.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-022.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps with collapsed tracks on 3x3 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-023.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-023.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-023.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-023.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' with collapsed tracks on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-200px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-024.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-024.html
@@ -2,8 +2,9 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps with collapsed tracks on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
 <link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">
 <style>

--- a/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-024.html
+++ b/css/css-grid-1/alignment/grid-content-distribution-with-collapsed-tracks-024.html
@@ -2,8 +2,8 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Content Distribution 'stretch' and gaps with collapsed tracks on 4x4 grid</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#grid-align">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#collapsed-track">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#grid-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#collapsed-track">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#content-distribution">
 <link rel="match" href="../../reference/ref-filled-green-300px-square.html">
 <meta name="assert" content="Content Distribution alignment ignore collapsed grid tracks and render correctly with a value of 'stretch'.">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-001.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-002.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-003.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-003.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-004.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-004.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-005.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-006.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-007.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-008.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-009.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-009.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-010.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-010.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-011.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-011.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-012.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-012.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-013.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-013.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-014.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-014.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-015.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-015.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-016.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-016.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-001.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-002.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-003.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-003.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-004.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-004.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-005.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-006.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-007.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-008.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-009.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-009.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-010.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-010.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-011.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-011.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-012.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-012.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-013.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-013.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-014.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-014.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-015.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-015.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-016.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-lr-016.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-001.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-001.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-002.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-002.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-003.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-003.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-003.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-004.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-004.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-004.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-005.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-005.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-006.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-006.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-007.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-007.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-008.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-008.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on fixed-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-009.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-009.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-009.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-010.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-010.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-010.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-011.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-011.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-011.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-012.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-012.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-012.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-013.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-013.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-013.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-014.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-014.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-014.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-015.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-015.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-015.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-016.html
@@ -2,9 +2,11 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">
+<link rel="help" href="https://drafts.csswg.org/css-align/#valdef-align-self-stretch">
 <meta name="assert" content="The stretched orthogonal grid items along the column and/or row axis include their defined padding-box.">
 <style>
 .grid {

--- a/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-016.html
+++ b/css/css-grid-1/alignment/grid-self-alignment-stretch-vertical-rl-016.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Alignment and stretch on auto-sized tracks</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#alignment">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#alignment">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#propdef-justify-self">
 <link rel="help" href="https://drafts.csswg.org/css-align/#valdef-justify-self-stretch">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-001.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-002.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-003.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-004.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-005.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-006.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area height</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#column-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-007.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-007.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-007.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-007.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-008.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-009.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-009.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-009.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-009.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-010.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-010.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-010.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-010.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-011.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-011.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-011.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-011.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-012.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-012.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">

--- a/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-012.html
+++ b/css/css-grid-1/alignment/self-baseline/grid-self-baseline-changes-grid-area-size-012.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Grid Layout Test: Self-Baseline alignment may change grid area width</title>
 <link rel="author" title="Javier Fernandez Garcia-Boente" href="mailto:jfernandez@igalia.com">
-<link rel="help" href="https://drafts.csswg.org/css-grid/#row-align">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1/#row-align">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-align-self">
 <link rel="help" href="https://drafts.csswg.org/css-align-3/#align-by-baseline">
 <link rel="match" href="../../../reference/ref-filled-green-100px-square.xht">


### PR DESCRIPTION
The alignment related tests are not being indexed correctly in the test suite. The reason is that none of these tests refer to the relevant spec section. 

This change adds the meta-data links to refer the appropriated spec section for each group of tests.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
