### PR TITLE
Improve assert_array_equals message for non-arrays

### DIFF
--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -68,6 +68,36 @@
     }
     test(basicAssertArrayEquals, "basic assert_array_equals test");
 
+    function assertArrayEqualsUndefined()
+    {
+        assert_array_equals(undefined, [1], "undefined equals [1]?");
+    }
+    test(assertArrayEqualsUndefined, "assert_array_equals with first param undefined");
+
+    function assertArrayEqualsTrue()
+    {
+        assert_array_equals(true, [1], "true equals [1]?");
+    }
+    test(assertArrayEqualsTrue, "assert_array_equals with first param true");
+
+    function assertArrayEqualsFalse()
+    {
+        assert_array_equals(false, [1], "false equals [1]?");
+    }
+    test(assertArrayEqualsFalse, "assert_array_equals with first param false");
+
+    function assertArrayEqualsNull()
+    {
+        assert_array_equals(null, [1], "null equals [1]?");
+    }
+    test(assertArrayEqualsNull, "assert_array_equals with first param null");
+
+    function assertArrayEqualsNumeric()
+    {
+        assert_array_equals(1, [1], "1 equals [1]?");
+    }
+    test(assertArrayEqualsNumeric, "assert_array_equals with first param 1");
+
     function basicAssertObjectEquals()
     {
         assert_object_equals([1, 2, [1, 2]], { 0: 1, 1: 2, 2: { 0: 1, 1: 2} }, "array is equal to object")
@@ -322,6 +352,41 @@
       "name": "basic assert_array_equals test", 
       "stack": null, 
       "message": null, 
+      "properties": {}
+    }, 
+    {
+      "status_string": "FAIL", 
+      "name": "assert_array_equals with first param undefined", 
+      "stack": "(implementation-defined)", 
+      "message": "assert_array_equals: value is undefined, expected array", 
+      "properties": {}
+    }, 
+    {
+      "status_string": "FAIL", 
+      "name": "assert_array_equals with first param true", 
+      "stack": "(implementation-defined)", 
+      "message": "assert_array_equals: value is true, expected array", 
+      "properties": {}
+    }, 
+    {
+      "status_string": "FAIL", 
+      "name": "assert_array_equals with first param false", 
+      "stack": "(implementation-defined)", 
+      "message": "assert_array_equals: value is false, expected array", 
+      "properties": {}
+    }, 
+    {
+      "status_string": "FAIL", 
+      "name": "assert_array_equals with first param null", 
+      "stack": "(implementation-defined)", 
+      "message": "assert_array_equals: value is null, expected array", 
+      "properties": {}
+    }, 
+    {
+      "status_string": "FAIL", 
+      "name": "assert_array_equals with first param 1", 
+      "stack": "(implementation-defined)", 
+      "message": "assert_array_equals: value is 1, expected array", 
       "properties": {}
     }, 
     {

--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -358,35 +358,35 @@
       "status_string": "FAIL", 
       "name": "assert_array_equals with first param undefined", 
       "stack": "(implementation-defined)", 
-      "message": "assert_array_equals: value is undefined, expected array", 
+      "message": "assert_array_equals: undefined equals [1]? value is undefined, expected array", 
       "properties": {}
     }, 
     {
       "status_string": "FAIL", 
       "name": "assert_array_equals with first param true", 
       "stack": "(implementation-defined)", 
-      "message": "assert_array_equals: value is true, expected array", 
+      "message": "assert_array_equals: true equals [1]? value is true, expected array", 
       "properties": {}
     }, 
     {
       "status_string": "FAIL", 
       "name": "assert_array_equals with first param false", 
       "stack": "(implementation-defined)", 
-      "message": "assert_array_equals: value is false, expected array", 
+      "message": "assert_array_equals: false equals [1]? value is false, expected array", 
       "properties": {}
     }, 
     {
       "status_string": "FAIL", 
       "name": "assert_array_equals with first param null", 
       "stack": "(implementation-defined)", 
-      "message": "assert_array_equals: value is null, expected array", 
+      "message": "assert_array_equals: null equals [1]? value is null, expected array", 
       "properties": {}
     }, 
     {
       "status_string": "FAIL", 
       "name": "assert_array_equals with first param 1", 
       "stack": "(implementation-defined)", 
-      "message": "assert_array_equals: value is 1, expected array", 
+      "message": "assert_array_equals: 1 equals [1]? value is 1, expected array", 
       "properties": {}
     }, 
     {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -962,7 +962,7 @@ policies and contribution forms [3].
 
     function assert_array_equals(actual, expected, description)
     {
-        assert(actual && "length" in actual,
+        assert(typeof actual === "object" && actual !== null && "length" in actual,
                "assert_array_equals", description,
                "value is ${actual}, expected array",
                {actual:actual});

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -962,6 +962,10 @@ policies and contribution forms [3].
 
     function assert_array_equals(actual, expected, description)
     {
+        assert(actual && "length" in actual,
+               "assert_array_equals", description,
+               "value is ${actual}, expected array",
+               {actual:actual});
         assert(actual.length === expected.length,
                "assert_array_equals", description,
                "lengths differ, expected ${expected} got ${actual}",


### PR DESCRIPTION
Previously, if the "actual" parameter was not an object (e.g.,
undefined), the assert function would throw an error like "actual has no
property length", with no further details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6921)
<!-- Reviewable:end -->
