### PR TITLE
[css-writing-modes-3] Make background-position-vrl-018 more robust.

### DIFF
--- a/css/css-writing-modes-3/background-position-vrl-018-ref.xht
+++ b/css/css-writing-modes-3/background-position-vrl-018-ref.xht
@@ -11,6 +11,11 @@
   <meta content="image" name="flags" />
 
   <style type="text/css"><![CDATA[
+  html
+    {
+      line-height: 1;
+    }
+
   div#expected
     {
       text-align: right;


### PR DESCRIPTION
Explicitly setting line-height:1 on the reference file avoids the vertical position
of the image varying if the UA's default font has a large 'normal' line-height.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
