### PR TITLE
Avoid visual comparisons with lang="ja-jp"

### DIFF
--- a/css/CSS2/selectors/attribute-value-selector-001-ref.xht
+++ b/css/CSS2/selectors/attribute-value-selector-001-ref.xht
@@ -9,9 +9,9 @@
 }
 </style>
 </head>
-<body>
+<body lang="en-us">
 <p>Test passes if the first line of "Filler Text" below is black and the second one is green.</p>
 <div>Filler Text</div>
-<div class="green">Filler Text</div>
+<div class="green" lang="fr-fr">Filler Text</div>
 </body>
 </html>

--- a/css/CSS2/selectors/attribute-value-selector-001.xht
+++ b/css/CSS2/selectors/attribute-value-selector-001.xht
@@ -14,9 +14,9 @@
             }
         </style>
     </head>
-    <body>
+    <body lang="en-us">
         <p>Test passes if the first line of "Filler Text" below is black and the second one is green.</p>
         <div id="div1">Filler Text</div>
-        <div id="div2">Filler Text</div>
+        <div id="div2" lang="fr-fr">Filler Text</div>
     </body>
 </html>

--- a/css/CSS2/selectors/attribute-value-selector-002.xht
+++ b/css/CSS2/selectors/attribute-value-selector-002.xht
@@ -8,15 +8,15 @@
         <meta name="flags" content="" />
         <meta name="assert" content="Selector matches attributes with specific value in a hyphen-separated list." />
         <style type="text/css">
-            [lang|=en]
+            [lang|=fr]
             {
                 color: green;
             }
         </style>
     </head>
-    <body>
+    <body lang="en-us">
         <p>Test passes if the first line of "Filler Text" below is black and the second one is green.</p>
-        <div lang="ja-jp">Filler Text</div>
-        <div lang="en-us">Filler Text</div>
+        <div>Filler Text</div>
+        <div lang="fr-fr">Filler Text</div>
     </body>
 </html>

--- a/css/CSS2/selectors/attribute-value-selector-003.xht
+++ b/css/CSS2/selectors/attribute-value-selector-003.xht
@@ -14,9 +14,9 @@
             }
         </style>
     </head>
-    <body>
+    <body lang="en-us">
         <p>Test passes if the first line of "Filler Text" below is black and the second one is green.</p>
         <div class="t estDiv">Filler Text</div>
-        <div class="t est">Filler Text</div>
+        <div class="t est" lang="fr-fr">Filler Text</div>
     </body>
 </html>


### PR DESCRIPTION
The reference file `attribute-value-selector-001-ref.xht` does not specify `lang="ja-jp"` on the first `div` while this file does. This causes the two pages to look different because a Japanese font is selected in this file. Changing "ja-jp" to a language written in Latin letters, "fr-fr", avoids this problem.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
