### PR TITLE
Link header preload on a subresource triggers a preload

### DIFF
--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/preload/resources/preload_helper.js"></script>
+<script>
+    var t = async_test('Makes sure that Link headers on subresources preload resources');
+</script>
+<link rel=stylesheet href="resources/dummy-preloads-subresource.css?link-header-on-subresource">
+<script src="resources/dummy.js?pipe=trickle(d5)&link-header-on-subresources"></script>
+<script>
+    window.addEventListener("load", t.step_func(function() {
+        verifyPreloadAndRTSupport();
+        verifyNumberOfDownloads("/preload/resources/CanvasTest.ttf?link-header-on-subresource", 1);
+        t.done();
+    }));
+</script>
+

--- a/preload/resources/dummy-preloads-subresource.css
+++ b/preload/resources/dummy-preloads-subresource.css
@@ -1,0 +1,1 @@
+/* This is just a dummy, empty CSS file */

--- a/preload/resources/dummy-preloads-subresource.css.sub.headers
+++ b/preload/resources/dummy-preloads-subresource.css.sub.headers
@@ -1,0 +1,2 @@
+Cache-Control: max-age=1000
+Link: </preload/resources/CanvasTest.ttf?link-header-on-subresource>; rel=preload;as=font;crossorigin


### PR DESCRIPTION
This adds a test to make sure preloads on subresources are triggered as they should.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
