### PR TITLE
Show details after each test finish in text-orientation.js

### DIFF
--- a/css/css-writing-modes-3/support/text-orientation.js
+++ b/css/css-writing-modes-3/support/text-orientation.js
@@ -69,13 +69,12 @@
         }});
 
     function Results(name) {
-        var block = document.createElement("details");
-        this.summary = appendChildElement(block, "summary");
+        this.details = document.createElement("details");
+        this.summary = appendChildElement(this.details, "summary");
         this.summary.textContent = name;
-        var typeList = appendChildElement(block, "ul");
+        var typeList = appendChildElement(this.details, "ul");
         this.failList = appendChildElement(appendChildElement(typeList, "li", "Failures"), "ol");
         this.inconclusiveList = appendChildElement(appendChildElement(typeList, "li", "Inconclusives"), "ol");
-        details.appendChild(block);
         this.passCount = 0;
         this.failCount = 0;
         this.inconclusiveCount = 0;
@@ -101,6 +100,7 @@
             this.summary.textContent += " (" + this.passCount + " passes, " +
                 this.failCount + " fails, " +
                 this.inconclusiveCount + " inconclusives)";
+            details.appendChild(this.details);
             assert_equals(this.failCount, 0, "Fail count");
             assert_greater_than(this.passCount, 0, "Pass count");
             test.done();


### PR DESCRIPTION
This change makes the details be added to the page after each test is done. This can improve the performance of this test significantly when we don't get expected result for many characters.

This is because `getBoundingClientRect` basically need a synchronous flush on the document. If we add some element into the document every time before calling that, we are flushing the document for each character, which can be really slow. By collecting the failure info on a detached element, we can avoid such synchronous flush.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
