### PR TITLE
Switch to using http URLs for webdriver inline()

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -215,6 +215,7 @@ def url(server_config):
         host = "%s:%s" % (server_config["host"], port)
         return urlparse.urlunsplit((protocol, host, path, query, fragment))
 
+    inner.__name__ = "url"
     return inner
 
 def create_dialog(session):

--- a/webdriver/tests/support/inline.py
+++ b/webdriver/tests/support/inline.py
@@ -1,6 +1,10 @@
 import urllib
 
-def inline(doc, doctype="html", mime="text/html;charset=utf-8"):
+
+def inline(doc, doctype="html", mime="text/html;charset=utf-8", protocol="http"):
+    from .fixtures import server_config, url
+    build_url = url(server_config())
+
     if doctype == "html":
         mime = "text/html;charset=utf-8"
     elif doctype == "xhtml":
@@ -16,4 +20,21 @@ def inline(doc, doctype="html", mime="text/html;charset=utf-8"):
     {}
   </body>
 </html>""".format(doc)
-    return "data:{},{}".format(mime, urllib.quote(doc))
+
+    query = {"doc": doc}
+    if mime != "text/html;charset=utf8":
+        query["content-type"] = mime
+
+    return build_url("/webdriver/tests/support/inline.py",
+                     query=urllib.urlencode(query),
+                     protocol=protocol)
+
+
+def main(request, response):
+    doc = request.GET.first("doc", None)
+    content_type = request.GET.first("content-type", "text/html;charset=utf8")
+    if doc is None:
+        rv = 404, [("Content-Type", "text/plain")], "Missing doc parameter in query"
+    else:
+        rv = [("Content-Type", content_type)], doc
+    return rv


### PR DESCRIPTION
Apparently Edge doesn't like data: urls, so instead use a
server url that returns the passed-in document.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
