### PR TITLE
Fix check for throwing in reflection original harness

### DIFF
--- a/html/dom/original-harness.js
+++ b/html/dom/original-harness.js
@@ -141,7 +141,8 @@ ReflectionHarness.assertThrows = function(exceptionName, fn) {
   try {
     fn();
   } catch (e) {
-    if (e instanceof DOMException && e.code == DOMException[exceptionName]) {
+    if (e instanceof DOMException && (e.code == DOMException[exceptionName] ||
+                                      e.name == exceptionName)) {
       this.increment(this.passed);
       return true;
     }


### PR DESCRIPTION
The original harness was never updated for new-style
"IndexSizeError"-type exception syntax, so it falsely reported all
browsers as failing all "assert throws" checks.

This does not affect the conformance tests, only the old-style harness
at html/dom/reflection-original.html, which possibly no one uses but me
but is considerably more useful for identifying bugs than
testharness.js.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
