### PR TITLE
Remove css-color-3 tests for parse failures of values now valid in css-color-4

### DIFF
--- a/css/css3-color/t424-hsl-parsing-f.xht
+++ b/css/css3-color/t424-hsl-parsing-f.xht
@@ -13,8 +13,6 @@
 		p { color: hsl(120, 100%, 25%); }
 		p { color: hsl(0, 255, 128); }
 		p { color: hsl(0%, 100%, 50%); }
-		p { color: hsl(0, 100%, 50%, 1); }
-		p { color: hsl(0deg, 100%, 50%); }
 		p { color: hsl(0px, 100%, 50%); }
 		]]></style>
 	</head>

--- a/css/css3-color/t425-hsla-parsing-f.xht
+++ b/css/css3-color/t425-hsla-parsing-f.xht
@@ -11,14 +11,10 @@
 		<style type="text/css"><![CDATA[
 		html, body { background: white; }
 		p { color: hsla(120, 100%, 25%, 1.0); }
-		p { color: hsla(0, 100%, 25%); }
 		p { color: hsla(0, 100%, 25%, 1.0, 1.0); }
 		p { color: hsla(0, 100%, 25%, 1.0,); }
 		p { color: hsla(0, 255, 128, 1.0); }
 		p { color: hsla(0%, 100%, 50%, 1.0); }
-		p { color: hsla(0, 100%, 50%, 1%); }
-		p { color: hsla(0, 100%, 50%, 0%); }
-		p { color: hsla(0deg, 100%, 50%, 1.0); }
 		p { color: hsla(0px, 100%, 50%, 1.0); }
 		]]></style>
 	</head>


### PR DESCRIPTION
css-color-4 changed the syntax of colors to add a number of new syntax possibilities to the color functions.  Existing tests for css-color-3 tested that some of the newly-accepted values were invalid.  This removes those tests so that implementations that implement the new values (I think Gecko, Chromium and WebKit, although I'm not sure about Chromium) can pass the tests.  (It would be good to add tests for the new functions at some point, but that's beyond the scope of this patch.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
