### PR TITLE
[webdriver] Element Send Keys puts insertion point at end of contententeditable

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -39,6 +39,11 @@ class Response(object):
         return cls(status, body)
 
 
+class ToJsonEncoder(json.JSONEncoder):
+    def default(self, obj):
+        return getattr(obj.__class__, "json", json.JSONEncoder().default)(obj)
+
+
 class HTTPWireProtocol(object):
     """Transports messages (commands and responses) over the WebDriver
     wire protocol.
@@ -76,7 +81,7 @@ class HTTPWireProtocol(object):
             body = {}
 
         if isinstance(body, dict):
-            body = json.dumps(body)
+            body = json.dumps(body, cls=ToJsonEncoder)
 
         if isinstance(body, unicode):
             body = body.encode("utf-8")

--- a/webdriver/tests/interaction/send_keys_content_editable.py
+++ b/webdriver/tests/interaction/send_keys_content_editable.py
@@ -1,0 +1,23 @@
+import pytest
+
+from tests.support.inline import inline
+
+
+def test_sets_insertion_point_to_end(session):
+    session.url = inline('<div contenteditable=true>Hello,</div>')
+    input = session.find.css("div", all=False)
+    input.send_keys(' world!')
+    text = session.execute_script('return arguments[0].innerText', args=[input])
+    assert "Hello, world!" == text.strip()
+
+
+# 12. Let current text length be the element’s length.
+#
+# 13. Set the text insertion caret using set selection range using current
+#     text length for both the start and end parameters.
+def test_sets_insertion_point_to_after_last_text_node(session):
+    session.url = inline('<div contenteditable=true>Hel<span>lo</span>,</div>')
+    input = session.find.css("div", all=False)
+    input.send_keys(" world!")
+    text = session.execute_script("return arguments[0].innerText", args=[input])
+    assert "Hello, world!" == text.strip()


### PR DESCRIPTION
Adding a test to allow us to verify that the insertion point
of a contenteditable is at the end of any TEXT nodes.

Closes w3c/webdriver#810

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/6965)
<!-- Reviewable:end -->
