### PR TITLE
Fix incorrect marquee scrollDelay test

### DIFF
--- a/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html
+++ b/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html
@@ -23,7 +23,9 @@
 
   test(function() {
     var mq = document.getElementById("test3");
-    assert_equals(mq.scrollDelay, 60, "The delay time should be 60ms.");
+    assert_equals(mq.scrollDelay, 1,
+                  "The delay time should be 1ms (although this doesn't " +
+                  "match rendering).");
   }, "The scrolldelay attribute is less than 60");
 
   test(function() {


### PR DESCRIPTION
The spec says simply that scrollDelay must reflect the scrolldelay
content attribute with no extra processing beyond default value:

  https://html.spec.whatwg.org/#dom-marquee-scrolldelay

Even though for rendering values below 60 are clamped to 60, this is not
reflected in the IDL property per spec.  All browsers match the spec:

  http://wpt.fyi/html/obsolete/requirements-for-implementations/the-marquee-element-0/marquee-scrolldelay.html

Firefox doesn't register properly on that page because of its weird
<marquee> implementation, but this shows that it also doesn't clamp:

  data:text/html,<!doctype html>
  <body onload="alert(m.scrollDelay)">
  <marquee id=m scrolldelay=1></marquee>

alerts "1".

<!-- Reviewable:start -->

<!-- Reviewable:end -->
