### PR TITLE
[cssom][cssom-view] Update IDL tests for CSSOM and CSSOM View

### DIFF
--- a/cssom-view/interfaces.html
+++ b/cssom-view/interfaces.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<meta charset=utf-8>
+<!-- WARNING: These tests are preliminary and probably partly incorrect.  -->
+<title>CSSOM View automated IDL tests</title>
+<link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-1/#idl-index">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+
+<input id="caretPositionInput" style="position: absolute; top: 0; left: 0; border: 0;">
+
+<h1>CSSOM View IDL tests</h1>
+<div id=log></div>
+
+<script>
+"use strict";
+
+function doTest([html, dom, cssom, geometry, cssom_view]) {
+
+  var idlArray = new IdlArray();
+  var svg = "interface SVGElement : Element {};";
+  idlArray.add_untested_idls(html + dom + svg + cssom + geometry);
+  idlArray.add_idls(cssom_view);
+
+  idlArray.add_objects({
+    "Window": ["window"],
+    "MediaQueryList": ["matchMedia('all')"],
+    "MediaQueryListEvent": ["new MediaQueryListEvent('change')"],
+    "Screen": ["screen"],
+    "Document": ["document"],
+    "CaretPosition": ["document.caretPositionFromPoint(5, 5)"],
+    "Element": ["document.createElementNS('x', 'y')"],
+    "HTMLElement": ["document.createElement('div')"],
+    "HTMLImageElement": ["document.createElement('img')"],
+    "Range": ["new Range()"],
+    // "MouseEvent": ["new MouseEvent('foo')"],
+    "Text": ["document.createTextNode('x')"],
+    // "CSSPseudoElement": [],
+    "Document": ["document"],
+  });
+  idlArray.test();
+};
+
+function fetchData(url) {
+  return fetch(url).then((response) => response.text());
+}
+
+function waitForLoad() {
+  return new Promise(function(resolve) {
+    addEventListener("load", resolve);
+  });
+}
+
+promise_test(function() {
+  // Have to wait for onload
+  return Promise.all([fetchData("/interfaces/html.idl"),
+                      fetchData("/interfaces/dom.idl"),
+                      fetchData("/interfaces/cssom.idl"),
+                      fetchData("/interfaces/geometry.idl"),
+                      fetchData("/interfaces/cssom-view.idl"),
+                      waitForLoad()])
+                .then(doTest);
+}, "Test driver");
+
+</script>

--- a/cssom/interfaces.html
+++ b/cssom/interfaces.html
@@ -1,174 +1,85 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
+<!doctype html>
+<meta charset=utf-8>
+<!-- WARNING: These tests are preliminary and probably partly incorrect.  -->
 <title>CSSOM automated IDL tests</title>
 <link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-1/#idl-index">
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/WebIDLParser.js"></script>
-<script src="/resources/idlharness.js"></script>
-<style id="styleElement">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/resources/WebIDLParser.js></script>
+<script src=/resources/idlharness.js></script>
+<style id="styleElement" style="z-index: 0;">
+@import url("data:text/css,");
+@namespace x "y";
+@page { @top-left {} }
+@media all {}
 #test { color: green; }
 </style>
-<div id="log"></div>
-<script type=text/plain id=untested_idl>
-interface EventTarget {};
-interface Node : EventTarget {};
-interface Document : Node {};
-interface ProcessingInstruction : Node {};
-interface Element : Node {};
-interface HTMLElement : Element {};
-interface SVGElement : Element {};
-[PrimaryGlobal] interface Window {};
-</script>
-<script type=text/plain id=idl>
-[LegacyArrayClass]
-interface MediaList {
-  [TreatNullAs=EmptyString] stringifier attribute DOMString mediaText;
-  readonly attribute unsigned long length;
-  getter DOMString? item(unsigned long index);
-  void appendMedium(DOMString medium);
-  void deleteMedium(DOMString medium);
-};
 
-interface StyleSheet {
-  readonly attribute DOMString type;
-  readonly attribute DOMString? href;
-  readonly attribute (Element or ProcessingInstruction)? ownerNode;
-  readonly attribute StyleSheet? parentStyleSheet;
-  readonly attribute DOMString? title;
-  [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-  attribute boolean disabled;
-};
+<svg id="svgElement" style="height: 0;"></svg>
 
-interface CSSStyleSheet : StyleSheet {
-  readonly attribute CSSRule? ownerRule;
-  [SameObject] readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, unsigned long index);
-  void deleteRule(unsigned long index);
-};
+<iframe id="xmlssPiIframe" src="support/xmlss-pi.xhtml" style="display: none;"></iframe>
 
-[LegacyArrayClass]
-interface StyleSheetList {
-  getter StyleSheet? item(unsigned long index);
-  readonly attribute unsigned long length;
-};
+<h1>CSSOM IDL tests</h1>
+<div id=log></div>
 
-partial interface Document {
-  [SameObject] readonly attribute StyleSheetList styleSheets;
-};
-
-[NoInterfaceObject]
-interface LinkStyle {
-  readonly attribute StyleSheet? sheet;
-};
-
-ProcessingInstruction implements LinkStyle;
-[LegacyArrayClass]
-interface CSSRuleList {
-  getter CSSRule? item(unsigned long index);
-  readonly attribute unsigned long length;
-};
-
-interface CSSRule {
-  const unsigned short STYLE_RULE = 1;
-  const unsigned short CHARSET_RULE = 2; // historical
-  const unsigned short IMPORT_RULE = 3;
-  const unsigned short MEDIA_RULE = 4;
-  const unsigned short FONT_FACE_RULE = 5;
-  const unsigned short PAGE_RULE = 6;
-  const unsigned short MARGIN_RULE = 9;
-  const unsigned short NAMESPACE_RULE = 10;
-  readonly attribute unsigned short type;
-  attribute DOMString cssText;
-  readonly attribute CSSRule? parentRule;
-  readonly attribute CSSStyleSheet? parentStyleSheet;
-};
-
-interface CSSStyleRule : CSSRule {
-  attribute DOMString selectorText;
-  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
-};
-
-interface CSSImportRule : CSSRule {
-  readonly attribute DOMString href;
-  [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-  [SameObject] readonly attribute CSSStyleSheet styleSheet;
-};
-
-interface CSSGroupingRule : CSSRule {
-  [SameObject] readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, unsigned long index);
-  void deleteRule(unsigned long index);
-};
-
-interface CSSMediaRule : CSSGroupingRule {
-  [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
-};
-
-interface CSSPageRule : CSSGroupingRule {
-           attribute DOMString selectorText;
-  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
-};
-
-interface CSSMarginRule : CSSRule {
-  readonly attribute DOMString name;
-  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
-};
-
-interface CSSNamespaceRule : CSSRule {
-  readonly attribute DOMString namespaceURI;
-  readonly attribute DOMString prefix;
-};
-
-interface CSSStyleDeclaration {
-  [CEReactions] attribute DOMString cssText;
-  readonly attribute unsigned long length;
-  getter DOMString item(unsigned long index);
-  DOMString getPropertyValue(DOMString property);
-  DOMString getPropertyPriority(DOMString property);
-  [CEReactions] void setProperty(DOMString property, [TreatNullAs=EmptyString] DOMString value, [TreatNullAs=EmptyString] optional DOMString priority = "");
-  [CEReactions] void setPropertyValue(DOMString property, [TreatNullAs=EmptyString] DOMString value);
-  [CEReactions] void setPropertyPriority(DOMString property, [TreatNullAs=EmptyString] DOMString priority);
-  [CEReactions] DOMString removeProperty(DOMString property);
-  readonly attribute CSSRule? parentRule;
-  [CEReactions, TreatNullAs=EmptyString] attribute DOMString cssFloat;
-};
-
-[NoInterfaceObject]
-interface ElementCSSInlineStyle {
-  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
-};
-
-HTMLElement implements ElementCSSInlineStyle;
-
-SVGElement implements ElementCSSInlineStyle;
-
-partial interface Window {
-  [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional DOMString? pseudoElt);
-};
-
-interface CSS {
-  static DOMString escape(DOMString ident);
-};
-</script>
 <script>
-var idl_array, style_element;
-setup(function() {
-  idl_array = new IdlArray();
-  var idls = document.getElementById("idl").textContent;
-  var untested_idls = document.getElementById("untested_idl").textContent;
-  idl_array.add_untested_idls(untested_idls);
-  idl_array.add_idls(idls);
+"use strict";
+var style_element, svg_element, xmlss_pi;
 
+function doTest([html, dom, cssom]) {
   style_element = document.getElementById('styleElement');
-  idl_array.add_objects({
+  svg_element = document.getElementById('svgElement');
+  xmlss_pi = document.getElementById('xmlssPiIframe').contentDocument.firstChild;
+
+  var idlArray = new IdlArray();
+  var svg = "interface SVGElement : Element {};";
+  idlArray.add_untested_idls(html + dom + svg);
+  idlArray.add_idls(cssom);
+
+  idlArray.add_objects({
     "Document": ["document", "new Document()"],
     "StyleSheetList": ["document.styleSheets"],
     "CSSStyleSheet": ["style_element.sheet"],
+    "MediaList": ["style_element.sheet.media"],
     "CSSRuleList": ["style_element.sheet.cssRules"],
-    "CSSStyleRule": ["style_element.sheet.cssRules[0]"],
+    "CSSImportRule": ["style_element.sheet.cssRules[0]"],
+    "CSSNamespaceRule": ["style_element.sheet.cssRules[1]"],
+    "CSSPageRule": ["style_element.sheet.cssRules[2]"],
+    "CSSMarginRule": ["style_element.sheet.cssRules[2].cssRules[0]"],
+    "CSSMediaRule": ["style_element.sheet.cssRules[3]"],
+    "CSSStyleRule": ["style_element.sheet.cssRules[4]"],
+    "CSSStyleDeclaration": ["style_element.sheet.cssRules[4].style", // CSSStyleRule
+                            "style_element.sheet.cssRules[2].style", // CSSPageRule
+                            "style_element.sheet.cssRules[2].cssRules[0].style", // CSSMarginRule
+                            "style_element.style", // ElementCSSInlineStyle for HTMLElement
+                            "svg_element.style", // ElementCSSInlineStyle for SVGElement
+                            "getComputedStyle(svg_element)"],
+    "ProcessingInstruction": ["xmlss_pi"],
+    "Window": ["window"],
+    "HTMLElement": ["style_element", "document.createElement('unknownelement')"],
+    "SVGElement": ["svg_element"],
   });
-});
-idl_array.test();
+  idlArray.test();
+};
+
+function fetchData(url) {
+  return fetch(url).then((response) => response.text());
+}
+
+function waitForLoad() {
+  return new Promise(function(resolve) {
+    addEventListener("load", resolve);
+  });
+}
+
+promise_test(function() {
+  // Have to wait for onload
+  return Promise.all([fetchData("/interfaces/html.idl"),
+                      fetchData("/interfaces/dom.idl"),
+                      fetchData("/interfaces/cssom.idl"),
+                      waitForLoad()])
+                .then(doTest);
+}, "Test driver");
+
 </script>

--- a/cssom/interfaces.html
+++ b/cssom/interfaces.html
@@ -8,6 +8,10 @@
 <script src=/resources/testharnessreport.js></script>
 <script src=/resources/WebIDLParser.js></script>
 <script src=/resources/idlharness.js></script>
+<!--
+Provide some objects to test.
+Use a non-empty style attribute to get a non-empty CSSStyleDeclaration.
+-->
 <style id="styleElement" style="z-index: 0;">
 @import url("data:text/css,");
 @namespace x "y";

--- a/cssom/support/xmlss-pi.xhtml
+++ b/cssom/support/xmlss-pi.xhtml
@@ -1,0 +1,1 @@
+<?xml-stylesheet href='data:text/css,'?><html xmlns='http://www.w3.org/1999/xhtml'/>

--- a/interfaces/cssom-view.idl
+++ b/interfaces/cssom-view.idl
@@ -165,7 +165,8 @@ dictionary ConvertCoordinateOptions {
   CSSBoxType toBox = "border";
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface GeometryUtils {
   sequence<DOMQuad> getBoxQuads(optional BoxQuadOptions options);
   DOMQuad convertQuadFromNode(DOMQuadInit quad, GeometryNode from, optional ConvertCoordinateOptions options);

--- a/interfaces/cssom-view.idl
+++ b/interfaces/cssom-view.idl
@@ -1,0 +1,183 @@
+enum ScrollBehavior { "auto", "instant", "smooth" };
+
+dictionary ScrollOptions {
+    ScrollBehavior behavior = "auto";
+};
+dictionary ScrollToOptions : ScrollOptions {
+    unrestricted double left;
+    unrestricted double top;
+};
+
+partial interface Window {
+    [NewObject] MediaQueryList matchMedia(CSSOMString query);
+    [SameObject, Replaceable] readonly attribute Screen screen;
+
+    // browsing context
+    void moveTo(long x, long y);
+    void moveBy(long x, long y);
+    void resizeTo(long x, long y);
+    void resizeBy(long x, long y);
+
+    // viewport
+    [Replaceable] readonly attribute long innerWidth;
+    [Replaceable] readonly attribute long innerHeight;
+
+    // viewport scrolling
+    [Replaceable] readonly attribute double scrollX;
+    [Replaceable] readonly attribute double pageXOffset;
+    [Replaceable] readonly attribute double scrollY;
+    [Replaceable] readonly attribute double pageYOffset;
+    void scroll(optional ScrollToOptions options);
+    void scroll(unrestricted double x, unrestricted double y);
+    void scrollTo(optional ScrollToOptions options);
+    void scrollTo(unrestricted double x, unrestricted double y);
+    void scrollBy(optional ScrollToOptions options);
+    void scrollBy(unrestricted double x, unrestricted double y);
+
+    // client
+    [Replaceable] readonly attribute long screenX;
+    [Replaceable] readonly attribute long screenY;
+    [Replaceable] readonly attribute long outerWidth;
+    [Replaceable] readonly attribute long outerHeight;
+    [Replaceable] readonly attribute double devicePixelRatio;
+};
+
+[Exposed=Window]
+interface MediaQueryList : EventTarget {
+  readonly attribute CSSOMString media;
+  readonly attribute boolean matches;
+  void addListener(EventListener? listener);
+  void removeListener(EventListener? listener);
+           attribute EventHandler onchange;
+};
+
+[Exposed=Window,
+ Constructor(CSSOMString type, optional MediaQueryListEventInit eventInitDict)]
+interface MediaQueryListEvent : Event {
+  readonly attribute CSSOMString media;
+  readonly attribute boolean matches;
+};
+
+dictionary MediaQueryListEventInit : EventInit {
+  CSSOMString media = "";
+  boolean matches = false;
+};
+
+[Exposed=Window]
+interface Screen {
+  readonly attribute long availWidth;
+  readonly attribute long availHeight;
+  readonly attribute long width;
+  readonly attribute long height;
+  readonly attribute unsigned long colorDepth;
+  readonly attribute unsigned long pixelDepth;
+};
+
+partial interface Document {
+  Element? elementFromPoint(double x, double y);
+  sequence<Element> elementsFromPoint(double x, double y);
+  CaretPosition? caretPositionFromPoint(double x, double y);
+  readonly attribute Element? scrollingElement;
+};
+
+[Exposed=Window]
+interface CaretPosition {
+  readonly attribute Node offsetNode;
+  readonly attribute unsigned long offset;
+  [NewObject] DOMRect? getClientRect();
+};
+
+enum ScrollLogicalPosition { "start", "center", "end", "nearest" };
+dictionary ScrollIntoViewOptions : ScrollOptions {
+  ScrollLogicalPosition block = "center";
+  ScrollLogicalPosition inline = "center";
+};
+
+partial interface Element {
+  DOMRectList getClientRects();
+  [NewObject] DOMRect getBoundingClientRect();
+  void scrollIntoView();
+  void scrollIntoView((boolean or object) arg);
+  void scroll(optional ScrollToOptions options);
+  void scroll(unrestricted double x, unrestricted double y);
+  void scrollTo(optional ScrollToOptions options);
+  void scrollTo(unrestricted double x, unrestricted double y);
+  void scrollBy(optional ScrollToOptions options);
+  void scrollBy(unrestricted double x, unrestricted double y);
+  attribute unrestricted double scrollTop;
+  attribute unrestricted double scrollLeft;
+  readonly attribute long scrollWidth;
+  readonly attribute long scrollHeight;
+  readonly attribute long clientTop;
+  readonly attribute long clientLeft;
+  readonly attribute long clientWidth;
+  readonly attribute long clientHeight;
+};
+
+partial interface HTMLElement {
+  readonly attribute Element? offsetParent;
+  readonly attribute long offsetTop;
+  readonly attribute long offsetLeft;
+  readonly attribute long offsetWidth;
+  readonly attribute long offsetHeight;
+};
+
+partial interface HTMLImageElement {
+  readonly attribute long x;
+  readonly attribute long y;
+};
+
+partial interface Range {
+  DOMRectList getClientRects();
+  [NewObject] DOMRect getBoundingClientRect();
+};
+
+/* TODO This is commented out because: "Partial interface MouseEvent with no original interface"
+partial interface MouseEvent {
+  readonly attribute double screenX;
+  readonly attribute double screenY;
+  readonly attribute double pageX;
+  readonly attribute double pageY;
+  readonly attribute double clientX;
+  readonly attribute double clientY;
+  readonly attribute double x;
+  readonly attribute double y;
+  readonly attribute double offsetX;
+  readonly attribute double offsetY;
+};
+
+partial dictionary MouseEventInit {
+  double screenX = 0.0;
+  double screenY = 0.0;
+  double clientX = 0.0;
+  double clientY = 0.0;
+};
+*/
+
+enum CSSBoxType { "margin", "border", "padding", "content" };
+dictionary BoxQuadOptions {
+  CSSBoxType box = "border";
+  GeometryNode relativeTo; // XXX default document (i.e. viewport)
+};
+
+dictionary ConvertCoordinateOptions {
+  CSSBoxType fromBox = "border";
+  CSSBoxType toBox = "border";
+};
+
+[NoInterfaceObject]
+interface GeometryUtils {
+  sequence<DOMQuad> getBoxQuads(optional BoxQuadOptions options);
+  DOMQuad convertQuadFromNode(DOMQuadInit quad, GeometryNode from, optional ConvertCoordinateOptions options);
+  DOMQuad convertRectFromNode(DOMRectReadOnly rect, GeometryNode from, optional ConvertCoordinateOptions options);
+  DOMPoint convertPointFromNode(DOMPointInit point, GeometryNode from, optional ConvertCoordinateOptions options); // XXX z,w turns into 0
+};
+
+Text implements GeometryUtils; // like Range
+Element implements GeometryUtils;
+/* TODO Commented out because: "CSSPseudoElement implements GeometryUtils, but CSSPseudoElement is undefined."
+CSSPseudoElement implements GeometryUtils;
+*/
+Document implements GeometryUtils;
+
+typedef (Text or Element or CSSPseudoElement or Document) GeometryNode;

--- a/interfaces/cssom.idl
+++ b/interfaces/cssom.idl
@@ -40,7 +40,8 @@ partial interface Document {
   [SameObject] readonly attribute StyleSheetList styleSheets;
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface LinkStyle {
   readonly attribute StyleSheet? sheet;
 };
@@ -122,7 +123,8 @@ interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString cssFloat;
 };
 
-[NoInterfaceObject]
+[Exposed=Window,
+ NoInterfaceObject]
 interface ElementCSSInlineStyle {
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };

--- a/interfaces/cssom.idl
+++ b/interfaces/cssom.idl
@@ -1,294 +1,141 @@
+typedef USVString CSSOMString;
+
+[Exposed=Window,
+ LegacyArrayClass]
 interface MediaList {
-  stringifier attribute DOMString mediaText;
+  stringifier attribute [TreatNullAs=EmptyString] CSSOMString mediaText;
   readonly attribute unsigned long length;
-  getter DOMString item(unsigned long index);
-  void appendMedium(DOMString medium);
-  void deleteMedium(DOMString medium);
+  getter CSSOMString? item(unsigned long index);
+  void appendMedium(CSSOMString medium);
+  void deleteMedium(CSSOMString medium);
 };
 
+[Exposed=Window]
 interface StyleSheet {
-  readonly attribute DOMString type;
-  readonly attribute DOMString href;
-  readonly attribute Node ownerNode;
-  readonly attribute StyleSheet parentStyleSheet;
-  readonly attribute DOMString title;
-  [PutForwards=mediaText] readonly attribute MediaList media;
-           attribute boolean disabled;
+  readonly attribute CSSOMString type;
+  readonly attribute USVString? href;
+  readonly attribute (Element or ProcessingInstruction)? ownerNode;
+  readonly attribute StyleSheet? parentStyleSheet;
+  readonly attribute DOMString? title;
+  [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+  attribute boolean disabled;
 };
 
+[Exposed=Window]
 interface CSSStyleSheet : StyleSheet {
-  readonly attribute CSSRule ownerRule;
-  readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, unsigned long index);
+  readonly attribute CSSRule? ownerRule;
+  [SameObject] readonly attribute CSSRuleList cssRules;
+  unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
   void deleteRule(unsigned long index);
 };
 
-typedef sequence<StyleSheet> StyleSheetList;
+[Exposed=Window,
+ LegacyArrayClass]
+interface StyleSheetList {
+  getter StyleSheet? item(unsigned long index);
+  readonly attribute unsigned long length;
+};
 
 partial interface Document {
   [SameObject] readonly attribute StyleSheetList styleSheets;
 };
 
-[NoInterfaceObject] interface LinkStyle {
-  readonly attribute StyleSheet sheet;
+[NoInterfaceObject]
+interface LinkStyle {
+  readonly attribute StyleSheet? sheet;
 };
 
 ProcessingInstruction implements LinkStyle;
+[Exposed=Window,
+ LegacyArrayClass]
+interface CSSRuleList {
+  getter CSSRule? item(unsigned long index);
+  readonly attribute unsigned long length;
+};
 
-typedef sequence<CSSRule> CSSRuleList;
-
+[Exposed=Window]
 interface CSSRule {
-  // Types
   const unsigned short STYLE_RULE = 1;
+  const unsigned short CHARSET_RULE = 2; // historical
   const unsigned short IMPORT_RULE = 3;
   const unsigned short MEDIA_RULE = 4;
   const unsigned short FONT_FACE_RULE = 5;
   const unsigned short PAGE_RULE = 6;
+  const unsigned short MARGIN_RULE = 9;
   const unsigned short NAMESPACE_RULE = 10;
   readonly attribute unsigned short type;
-
-  // Parsing and serialization
-           attribute DOMString cssText;
-
-  // Context
-  readonly attribute CSSRule parentRule;
-  readonly attribute CSSStyleSheet parentStyleSheet;
+  attribute CSSOMString cssText;
+  readonly attribute CSSRule? parentRule;
+  readonly attribute CSSStyleSheet? parentStyleSheet;
 };
 
+[Exposed=Window]
 interface CSSStyleRule : CSSRule {
-           attribute DOMString selectorText;
-  readonly attribute CSSStyleDeclaration style;
+  attribute CSSOMString selectorText;
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
+[Exposed=Window]
 interface CSSImportRule : CSSRule {
-  readonly attribute DOMString href;
-  [PutForwards=mediaText] readonly attribute MediaList media;
-  readonly attribute CSSStyleSheet styleSheet;
+  readonly attribute USVString href;
+  [SameObject, PutForwards=mediaText] readonly attribute MediaList media;
+  [SameObject] readonly attribute CSSStyleSheet styleSheet;
 };
 
-interface CSSMediaRule : CSSRule {
-  [PutForwards=mediaText] readonly attribute MediaList media;
-  readonly attribute CSSRuleList cssRules;
-  unsigned long insertRule(DOMString rule, unsigned long index);
+[Exposed=Window]
+interface CSSGroupingRule : CSSRule {
+  [SameObject] readonly attribute CSSRuleList cssRules;
+  unsigned long insertRule(CSSOMString rule, optional unsigned long index = 0);
   void deleteRule(unsigned long index);
 };
 
-interface CSSFontFaceRule : CSSRule {
-  readonly attribute CSSStyleDeclaration style;
+[Exposed=Window]
+interface CSSPageRule : CSSGroupingRule {
+           attribute CSSOMString selectorText;
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
-interface CSSPageRule : CSSRule {
-           attribute DOMString selectorText;
-  readonly attribute CSSStyleDeclaration style;
+[Exposed=Window]
+interface CSSMarginRule : CSSRule {
+  readonly attribute CSSOMString name;
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
+[Exposed=Window]
 interface CSSNamespaceRule : CSSRule {
-  readonly attribute DOMString namespaceURI;
-  readonly attribute DOMString? prefix;
+  readonly attribute CSSOMString namespaceURI;
+  readonly attribute CSSOMString prefix;
 };
 
+[Exposed=Window]
 interface CSSStyleDeclaration {
-           attribute DOMString cssText;
-
+  [CEReactions] attribute CSSOMString cssText;
   readonly attribute unsigned long length;
-  DOMString item(unsigned long index);
-
-  DOMString getPropertyValue(DOMString property);
-  DOMString getPropertyPriority(DOMString property);
-  void setProperty(DOMString property, DOMString value, optional DOMString priority);
-  DOMString removeProperty(DOMString property);
-
-  readonly attribute CSSStyleDeclarationValue values;
-
-  readonly attribute CSSRule parentRule;
-
-  // CSS Properties
-           attribute DOMString azimuth;
-           attribute DOMString background;
-           attribute DOMString backgroundAttachment;
-           attribute DOMString backgroundColor;
-           attribute DOMString backgroundImage;
-           attribute DOMString backgroundPosition;
-           attribute DOMString backgroundRepeat;
-           attribute DOMString border;
-           attribute DOMString borderCollapse;
-           attribute DOMString borderColor;
-           attribute DOMString borderSpacing;
-           attribute DOMString borderStyle;
-           attribute DOMString borderTop;
-           attribute DOMString borderRight;
-           attribute DOMString borderBottom;
-           attribute DOMString borderLeft;
-           attribute DOMString borderTopColor;
-           attribute DOMString borderRightColor;
-           attribute DOMString borderBottomColor;
-           attribute DOMString borderLeftColor;
-           attribute DOMString borderTopStyle;
-           attribute DOMString borderRightStyle;
-           attribute DOMString borderBottomStyle;
-           attribute DOMString borderLeftStyle;
-           attribute DOMString borderTopWidth;
-           attribute DOMString borderRightWidth;
-           attribute DOMString borderBottomWidth;
-           attribute DOMString borderLeftWidth;
-           attribute DOMString borderWidth;
-           attribute DOMString bottom;
-           attribute DOMString captionSide;
-           attribute DOMString clear;
-           attribute DOMString clip;
-           attribute DOMString color;
-           attribute DOMString content;
-           attribute DOMString counterIncrement;
-           attribute DOMString counterReset;
-           attribute DOMString cue;
-           attribute DOMString cueAfter;
-           attribute DOMString cueBefore;
-           attribute DOMString cursor;
-           attribute DOMString direction;
-           attribute DOMString display;
-           attribute DOMString elevation;
-           attribute DOMString emptyCells;
-           attribute DOMString cssFloat;
-           attribute DOMString font;
-           attribute DOMString fontFamily;
-           attribute DOMString fontSize;
-           attribute DOMString fontSizeAdjust;
-           attribute DOMString fontStretch;
-           attribute DOMString fontStyle;
-           attribute DOMString fontVariant;
-           attribute DOMString fontWeight;
-           attribute DOMString height;
-           attribute DOMString left;
-           attribute DOMString letterSpacing;
-           attribute DOMString lineHeight;
-           attribute DOMString listStyle;
-           attribute DOMString listStyleImage;
-           attribute DOMString listStylePosition;
-           attribute DOMString listStyleType;
-           attribute DOMString margin;
-           attribute DOMString marginTop;
-           attribute DOMString marginRight;
-           attribute DOMString marginBottom;
-           attribute DOMString marginLeft;
-           attribute DOMString marks;
-           attribute DOMString maxHeight;
-           attribute DOMString maxWidth;
-           attribute DOMString minHeight;
-           attribute DOMString minWidth;
-           attribute DOMString orphans;
-           attribute DOMString outline;
-           attribute DOMString outlineColor;
-           attribute DOMString outlineStyle;
-           attribute DOMString outlineWidth;
-           attribute DOMString overflow;
-           attribute DOMString padding;
-           attribute DOMString paddingTop;
-           attribute DOMString paddingRight;
-           attribute DOMString paddingBottom;
-           attribute DOMString paddingLeft;
-           attribute DOMString page;
-           attribute DOMString pageBreakAfter;
-           attribute DOMString pageBreakBefore;
-           attribute DOMString pageBreakInside;
-           attribute DOMString pause;
-           attribute DOMString pauseAfter;
-           attribute DOMString pauseBefore;
-           attribute DOMString pitch;
-           attribute DOMString pitchRange;
-           attribute DOMString playDuring;
-           attribute DOMString position;
-           attribute DOMString quotes;
-           attribute DOMString richness;
-           attribute DOMString right;
-           attribute DOMString size;
-           attribute DOMString speak;
-           attribute DOMString speakHeader;
-           attribute DOMString speakNumeral;
-           attribute DOMString speakPunctuation;
-           attribute DOMString speechRate;
-           attribute DOMString stress;
-           attribute DOMString tableLayout;
-           attribute DOMString textAlign;
-           attribute DOMString textDecoration;
-           attribute DOMString textIndent;
-           attribute DOMString textShadow;
-           attribute DOMString textTransform;
-           attribute DOMString top;
-           attribute DOMString unicodeBidi;
-           attribute DOMString verticalAlign;
-           attribute DOMString visibility;
-           attribute DOMString voiceFamily;
-           attribute DOMString volume;
-           attribute DOMString whiteSpace;
-           attribute DOMString widows;
-           attribute DOMString width;
-           attribute DOMString wordSpacing;
-           attribute DOMString zIndex;
+  getter CSSOMString item(unsigned long index);
+  CSSOMString getPropertyValue(CSSOMString property);
+  CSSOMString getPropertyPriority(CSSOMString property);
+  [CEReactions] void setProperty(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value, [TreatNullAs=EmptyString] optional CSSOMString priority = "");
+  [CEReactions] void setPropertyValue(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value);
+  [CEReactions] void setPropertyPriority(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString priority);
+  [CEReactions] CSSOMString removeProperty(CSSOMString property);
+  readonly attribute CSSRule? parentRule;
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString cssFloat;
 };
 
-interface CSSStyleDeclarationValue {
-  // ...
-
-  // CSS Properties
-
+[NoInterfaceObject]
+interface ElementCSSInlineStyle {
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
-interface CSSPropertyValue {
-           attribute DOMString cssText;
+HTMLElement implements ElementCSSInlineStyle;
+
+SVGElement implements ElementCSSInlineStyle;
+
+partial interface Window {
+  [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
 };
 
-[NoInterfaceObject] interface CSSMapValue {
-  getter CSSValue (DOMString name);
+[Exposed=Window]
+interface CSS {
+  static CSSOMString escape(CSSOMString ident);
 };
-
-[NoInterfaceObject] interface CSSPropertyValueList {
-  readonly attribute CSSValue[] list;
-};
-
-[NoInterfaceObject] interface CSSComponentValue {
-  readonly attribute DOMString type;
-           attribute any value;
-};
-
-[NoInterfaceObject] interface CSSStringComponentValue {
-           attribute DOMString string;
-};
-
-[NoInterfaceObject] interface CSSKeywordComponentValue {
-           attribute DOMString keyword;
-};
-
-[NoInterfaceObject] interface CSSIdentifierComponentValue {
-           attribute DOMString identifier;
-};
-
-[NoInterfaceObject] interface CSSColorComponentValue {
-           attribute short red;
-           attribute short green;
-           attribute short blue;
-           attribute float alpha;
-};
-
-[NoInterfaceObject] interface CSSLengthComponentValue {
-           attribute float em;
-           attribute float ex;
-           attribute float px;
-           // figure out what to do with absolute lengths
-};
-
-[NoInterfaceObject] interface CSSPercentageComponentValue {
-           attribute float percent;
-};
-
-[NoInterfaceObject] interface CSSURLComponentValue {
-           attribute DOMString? url;
-};
-
-[NoInterfaceObject] interface ElementCSSInlineStyle {
-  readonly attribute CSSStyleDeclaration style;
-};
-
-//partial interface Window {
-//  CSSStyleDeclaration getComputedStyle(Element elt);
-//  CSSStyleDeclaration getComputedStyle(Element elt, DOMString pseudoElt);
-//};


### PR DESCRIPTION
CSSOM's IDL was duplicated in interfaces/cssom.idl and
cssom/interfaces.html, and both were out of date. CSSOM View did
not have any IDL tests.

Fix CSSOM IDL test, add more objects to be tested, and add IDL
tests for CSSOM View.

Includes [Exposed=Window] per https://github.com/w3c/csswg-drafts/pull/1749.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
