### PR TITLE
Use Blob URLs instead of data URLs for WebVTT tests

### DIFF
--- a/webvtt/api/VTTCue/align.html
+++ b/webvtt/api/VTTCue/align.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-align">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
 <div id=log></div>
 <script>
 test(function(){
@@ -56,10 +57,10 @@ t_parsed.step(function(){
     t.onerror = this.step_func(function() {
       assert_unreached('got error event');
     });
-    t.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 align:start\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 align:center\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 align:end\ntest');
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:start\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:center\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 align:end\ntest', this);
     t.track.mode = 'showing';
     video.appendChild(t);
 });

--- a/webvtt/api/VTTCue/common.js
+++ b/webvtt/api/VTTCue/common.js
@@ -1,0 +1,8 @@
+function make_vtt_track(contents, test) {
+    var track_blob = new Blob([contents], { type: 'text/vtt' });
+    var track_url = URL.createObjectURL(track_blob);
+    test.add_cleanup(function() {
+        URL.revokeObjectURL(track_url);
+    });
+    return track_url;
+}

--- a/webvtt/api/VTTCue/line.html
+++ b/webvtt/api/VTTCue/line.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-line">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
 <div id=log></div>
 <script>
 test(function(){
@@ -55,9 +56,9 @@ t_parsed.step(function(){
     t.onerror = this.step_func(function() {
       assert_unreached('got error event');
     });
-    t.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 line:0%\ntest');
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0%\ntest', this);
     t.track.mode = 'showing';
     video.appendChild(t);
 });

--- a/webvtt/api/VTTCue/snapToLines.html
+++ b/webvtt/api/VTTCue/snapToLines.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-snaptolines">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
 <div id=log></div>
 <script>
 setup(function(){
@@ -90,9 +91,9 @@ t_parsed.step(function(){
     t.onerror = this.step_func(function() {
       assert_unreached('got error event');
     });
-    t.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 line:0%\ntest');
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 line:0%\ntest', this);
     t.track.mode = 'showing';
     video.appendChild(t);
 });

--- a/webvtt/api/VTTCue/text.html
+++ b/webvtt/api/VTTCue/text.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-text">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
 <div id=log></div>
 <script>
 setup(function(){
@@ -32,8 +33,8 @@ t_parsed.step(function(){
     t.onerror = this.step_func(function() {
       assert_unreached('got error event');
     });
-    t.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\n'+
-                                                      '\n\nfoobar\n00:00:00.000 --> 00:00:00.001\ntest');
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\n'+
+                           '\n\nfoobar\n00:00:00.000 --> 00:00:00.001\ntest', this);
     t.track.mode = 'showing';
     video.appendChild(t);
 });

--- a/webvtt/api/VTTCue/vertical.html
+++ b/webvtt/api/VTTCue/vertical.html
@@ -3,6 +3,7 @@
 <link rel="help" href="https://w3c.github.io/webvtt/#dom-vttcue-vertical">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src=common.js></script>
 <div id=log></div>
 <script>
 setup(function(){
@@ -47,9 +48,9 @@ t_parsed.step(function(){
     t.onerror = this.step_func(function() {
       assert_unreached('got error event');
     });
-    t.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 vertical:rl\ntest\n\n'+
-                                                '00:00:00.000 --> 00:00:00.001 vertical:lr\ntest');
+    t.src = make_vtt_track('WEBVTT\n\n00:00:00.000 --> 00:00:00.001\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 vertical:rl\ntest\n\n'+
+                           '00:00:00.000 --> 00:00:00.001 vertical:lr\ntest', this);
     t.track.mode = 'showing';
     video.appendChild(t);
 });

--- a/webvtt/parsing/cue-text-parsing/common.js
+++ b/webvtt/parsing/cue-text-parsing/common.js
@@ -154,7 +154,14 @@ function runTests(tests) {
             t.test_id = test.name;
             t.url_encoded_input = test.input;
             t.expected = expected;
-            track.src = 'data:text/vtt,'+encodeURIComponent('WEBVTT\n\n00:00.000 --> 00:01.000\n')+test.input;
+            var track_blob = new Blob(['WEBVTT\n\n00:00.000 --> 00:01.000\n',
+                                       decodeURIComponent(test.input)],
+                                      { type: 'text/vtt' });
+            var track_url = URL.createObjectURL(track_blob);;
+            track.src = track_url;
+            t.add_cleanup(function() {
+                URL.revokeObjectURL(track_url);
+            });
             track['default'] = true;
             track.kind = 'subtitles';
             track.onload = t.step_func(trackLoaded);


### PR DESCRIPTION
Avoids issues with unique origins around data URLs.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
