### PR TITLE
setup onnegotiationneeded before checking it

### DIFF
--- a/webrtc/RTCPeerConnection-onnegotiationneeded.html
+++ b/webrtc/RTCPeerConnection-onnegotiationneeded.html
@@ -82,25 +82,18 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const promise = awaitNegotiation(pc);
-    pc.createDataChannel('test');
-    return promise;
-  }, 'Creating first data channel should fire negotiationneeded event');
+    const negotiated = awaitNegotiation(pc);
 
-  promise_test(t => {
-    const pc = new RTCPeerConnection();
     pc.createDataChannel('test');
-    // Attaching the event handler after the negotiation-needed steps
-    // are performed should still receive the event, because the event
-    // firing is queued as a task
-    return awaitNegotiation(pc);
-  }, 'task for negotiationneeded event should be enqueued for next tick');
+    return negotiated;
+  }, 'Creating first data channel should fire negotiationneeded event');
 
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
-    pc.createDataChannel('foo');
+    const negotiated = awaitNegotiation(pc);
 
-    return awaitNegotiation(pc)
+    pc.createDataChannel('foo');
+    return negotiated
       .then(({nextPromise}) => {
       pc.createDataChannel('bar');
       return nextPromise;
@@ -121,8 +114,10 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    const negotiated = awaitNegotiation(pc);
+
     pc.addTransceiver('audio');
-    return awaitNegotiation(pc);
+    return negotiated;
   }, 'addTransceiver() should fire negotiationneeded event');
 
   /*
@@ -132,8 +127,10 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    const negotiated = awaitNegotiation(pc);
+
     pc.addTransceiver('audio');
-    return awaitNegotiation(pc)
+    return negotiated
     .then(({nextPromise}) => {
       pc.addTransceiver('video');
       return nextPromise;
@@ -147,8 +144,10 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    const negotiated = awaitNegotiation(pc);
+
     pc.createDataChannel('test');
-    return awaitNegotiation(pc)
+    return negotiated
     .then(({nextPromise}) => {
       pc.addTransceiver('video');
       return nextPromise;
@@ -162,19 +161,20 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
-    const promise = awaitNegotiation(pc);
+    const negotiated = awaitNegotiation(pc);
 
-    return pc.createOffer()
+    return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer => pc.setLocalDescription(offer))
-    .then(() => {
+    .then(() => negotiated)
+    .then(({nextPromise}) => {
       assert_equals(pc.signalingState, 'have-local-offer');
       pc.createDataChannel('test');
-      return promise;
+      return nextPromise;
     });
   }, 'negotiationneeded event should not fire if signaling state is not stable');
 
   /*
-    4.3.1.6.  Set the RTCSessionSessionDescription
+    4.4.1.6.  Set the RTCSessionSessionDescription
       2.2.10. If connection's signaling state is now stable, update the negotiation-needed
               flag. If connection's [[NegotiationNeeded]] slot was true both before and after
               this update, queue a task that runs the following steps:
@@ -186,7 +186,7 @@
 
     return assert_first_promise_fulfill_after_second(
       awaitNegotiation(pc),
-      pc.createOffer()
+      pc.createOffer({ offerToReceiveAudio: true })
       .then(offer =>
         pc.setLocalDescription(offer)
         .then(() => {


### PR DESCRIPTION
It look like @soareschen had a little misconception here: browsers do not store events for ever until the JS application adds a callback function. If there is no callback function registered at time of the event the event goes to void.

The other problem this fixes is that if you just call CreateOffer() without attaching any track/stream and without any options it results in the browser refusing to anything with an empty offer.

The current tests are causing intermittent test failures in Firefox Ci system, see https://bugzilla.mozilla.org/show_bug.cgi?id=1386143

The last test "negotiationneeded event should fire only after signaling state go back to stable" in here is still causing failures on Firefox although it should pass. I gave up trying to fix it.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
