### PR TITLE
Delete an OWNERS accidentally exported from Chromium

### DIFF
--- a/viewport/OWNERS
+++ b/viewport/OWNERS
@@ -1,2 +1,0 @@
-# TEAM: input-dev@chromium.org
-# COMPONENT: Blink>Input


### PR DESCRIPTION
Sorry, but it seems like a recent change in Chromium's wpt bots accidentally exported this OWNERS file. The bug in our bots is being tracked at https://bugs.chromium.org/p/chromium/issues/detail?id=759181 and we are already working on fixing it.

Due to some fortunate coincidences, this is the only accidental "contamination" thus far, and it is unlikely to have new cases even with the bug present. That being said, we will fix the bug ASAP.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
