### PR TITLE
Add tests for Algorithms section

### DIFF
--- a/payment-request/algorithms-manual.https.html
+++ b/payment-request/algorithms-manual.https.html
@@ -13,7 +13,7 @@ setup({
 });
 const methods = [
   {
-    supportedMethods: ["basic-card"],
+    supportedMethods: "basic-card",
   },
 ];
 const shippingOptions = {

--- a/payment-request/algorithms-manual.https.html
+++ b/payment-request/algorithms-manual.https.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<meta charset="utf8">
+<link rel="help" href="https://w3c.github.io/payment-request/#algorithms">
+<title>
+  Payment Request algorithms
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({
+  explicit_done: true,
+  explicit_timeout: true,
+});
+const methods = [
+  {
+    supportedMethods: ["basic-card"],
+  },
+];
+const shippingOptions = {
+  shippingOptions: [
+    {
+      id: "fail",
+      label: "Option 1",
+      amount: {
+        currency: "USD",
+        value: "5.00",
+      },
+      selected: true,
+    },
+    {
+      id: "pass",
+      label: "Option 2",
+      amount: {
+        currency: "USD",
+        value: "5.00",
+      },
+    },
+  ],
+};
+
+const detailsNoShippingOptions = {
+  total: {
+    label: "Total due",
+    amount: {
+      currency: "USD",
+      value: "1.0",
+    },
+  },
+};
+
+const detailsWithShippingOptions = Object.assign(
+  {
+    total: {
+      label: "Total due",
+      amount: {
+        currency: "USD",
+        value: "1.0",
+      },
+    },
+  },
+  shippingOptions
+);
+
+const options = {
+  requestShipping: true,
+};
+
+test(() => {
+  const request = new PaymentRequest(
+    methods,
+    detailsNoShippingOptions,
+    options
+  );
+}, "Smoke test");
+
+function testFireEvent(button, details, eventName, expectRequestProps) {
+  button.disabled = true;
+  promise_test(async t => {
+    const request = new PaymentRequest(methods, details, options);
+    const events = [];
+    const p1 = new Promise(resolve => {
+      request[`on${eventName}`] = event => {
+        events.push(event);
+        resolve("handler");
+        event.updateWith(details);
+      };
+    });
+    const p2 = new Promise(resolve => {
+      request.addEventListener(eventName, event => {
+        events.push(event);
+        resolve("listener-1");
+      });
+    });
+    const p3 = new Promise(resolve => {
+      request.addEventListener(eventName, event => {
+        events.push(event);
+        resolve("listener-2");
+      });
+    });
+    try {
+      const response = await request.show();
+      response.complete("success");
+    } catch (err) {
+      await request.abort();
+      assert_unreached("Unexpected exception: " + err.message);
+    }
+    const [handler, listener1, listener2] = await Promise.all([p1, p2, p3]);
+    assert_equals(
+      handler,
+      "handler",
+      "Expected p1 to have resolved with 'handler'"
+    );
+    assert_equals(
+      listener1,
+      "listener-1",
+      "Expected p2 to have resolved with 'listener-1'"
+    );
+    assert_equals(
+      listener2,
+      "listener-2",
+      "Expected p3 to have resolved with 'listener-2'"
+    );
+    const [e1, e2, e3] = events;
+    assert_equals(e1, e2);
+    assert_equals(e2, e3);
+    assert_equals(e1, e3);
+    assert_true(
+      events.every(e => e instanceof window.PaymentRequestUpdateEvent),
+      "Expected instances of PaymentRequestUpdateEvent"
+    );
+  }, button.textContent.trim());
+}
+
+async function runAbortTest(button) {
+  button.disabled = true;
+  const { textContent: testName } = button;
+  promise_test(async t => {
+    const request = new PaymentRequest(methods, detailsNoShippingOptions);
+    // Await the user to abort
+    await promise_rejects(t, "AbortError", request.show());
+    // [[state]] is now closed
+    await promise_rejects(t, "InvalidStateError", request.show());
+  }, testName.trim());
+}
+
+</script>
+<section>
+  <h2 id="abort-algo">
+    User aborts the payment request algorithm
+  </h2>
+  <link rel="help" href="https://w3c.github.io/payment-request/#user-aborts-the-payment-request-algorithm">
+  <p>
+    When presented with the payment sheet, abort the payment request (e.g., by hitting the esc key or pressing a UA provided button).
+  </p>
+  <ol>
+    <li>
+      <button onclick="runAbortTest(this);">
+      If the user aborts, the UA must run the user aborts the payment request algorithm.
+    </button>
+    </li>
+  </ol>
+</section>
+
+<section>
+  <h2 id="shipping-address-changed-algo">Shipping address changed algorithm</h2>
+  <link rel="help" href="https://www.w3.org/TR/payment-request/#shipping-address-changed-algorithm">
+  <p>
+    When prompted, please enter or select "web platform test" as recipient, at address "1 wpt street" in "Kabul, Afghanistan", zip/postal code 1001.
+  </p>
+  <ol>
+    <li>
+      <button onclick="testFireEvent(this, detailsWithShippingOptions, 'shippingaddresschange', {});">
+      The shipping address changed algorithm runs when the user provides a new shipping address.
+    </button>
+    </li>
+  </ol>
+</section>
+
+<section>
+  <h2 id="shipping-option-changed-algo">Shipping option changed algorithm</h2>
+  <link rel="help" href="https://w3c.github.io/payment-request/#shipping-option-changed-algorithm">
+  <p>
+    When prompted, please select "shipping option 2".
+  </p>
+  <ol>
+    <li>
+      <button onclick="testFireEvent(this, detailsWithShippingOptions, 'shippingoptionchange', {}, 'pass'); done();">
+      The shipping option changed algorithm runs when the user chooses a new shipping option.
+    </button>
+    </li>
+  </ol>
+</section>

--- a/payment-request/algorithms-manual.https.html
+++ b/payment-request/algorithms-manual.https.html
@@ -101,7 +101,6 @@ function testFireEvent(button, details, eventName, expectRequestProps) {
       const response = await request.show();
       response.complete("success");
     } catch (err) {
-      await request.abort();
       assert_unreached("Unexpected exception: " + err.message);
     }
     const [handler, listener1, listener2] = await Promise.all([p1, p2, p3]);

--- a/payment-request/user-abort-algorithm-manual.https.html
+++ b/payment-request/user-abort-algorithm-manual.https.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <meta charset="utf8">
-<link rel="help" href="https://w3c.github.io/payment-request/#dom-paymentresponse-complete()">
+<link rel="help" href="https://w3c.github.io/payment-request/#user-aborts-the-payment-request-algorithm">
 <title>
-  PaymentResponse.prototype.complete() method
+  User aborts the payment request algorithm.
 </title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/payment-request/user-abort-algorithm-manual.https.html
+++ b/payment-request/user-abort-algorithm-manual.https.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset="utf8">
+<link rel="help" href="https://w3c.github.io/payment-request/#dom-paymentresponse-complete()">
+<title>
+  PaymentResponse.prototype.complete() method
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ explicit_done: true, explicit_timeout: true });
+
+const validAmount = Object.freeze({
+  currency: "USD",
+  value: "1.0",
+});
+const validTotal = Object.freeze({
+    label: "Total due",
+    amount: validAmount,
+})
+const validMethod = Object.freeze({
+  supportedMethods: "basic-card"
+});
+const validMethods = Object.freeze([validMethod]);
+const validDetails = Object.freeze({
+  total: validTotal,
+});
+
+test(() => {
+  try {
+    new PaymentRequest(validMethods, validDetails)
+  } catch (err) {
+    done();
+    throw err;
+  }
+}, "Can construct a payment request (smoke test).");
+
+async function runAbortTest(button) {
+  button.disabled = true;
+  const { textContent: testName } = button;
+  promise_test(async t => {
+    const request = new PaymentRequest(validMethods, validDetails);
+    // Await the user to abort
+    await promise_rejects(t, "AbortError", request.show());
+    // [[state]] is now closed
+    await promise_rejects(t, "InvalidStateError", request.show());
+  }, testName.trim());
+}
+</script>
+<h2>
+   User aborts the payment request algorithm.
+</h2>
+<p>
+  When presented with the payment sheet, abort the payment request
+  (e.g., by hitting the esc key or pressing a UA provided button).
+</p>
+<ol>
+  <li>
+    <button onclick="runAbortTest(this); done();">
+      If the user aborts, the UA must run the user aborts the payment request algorithm.
+    </button>
+  </li>
+</ol>

--- a/payment-request/user-abort-algorithm-manual.https.html
+++ b/payment-request/user-abort-algorithm-manual.https.html
@@ -14,11 +14,11 @@ const validAmount = Object.freeze({
   value: "1.0",
 });
 const validTotal = Object.freeze({
-    label: "Total due",
-    amount: validAmount,
-})
+  label: "Total due",
+  amount: validAmount,
+});
 const validMethod = Object.freeze({
-  supportedMethods: "basic-card"
+  supportedMethods: "basic-card",
 });
 const validMethods = Object.freeze([validMethod]);
 const validDetails = Object.freeze({
@@ -27,7 +27,7 @@ const validDetails = Object.freeze({
 
 test(() => {
   try {
-    new PaymentRequest(validMethods, validDetails)
+    new PaymentRequest(validMethods, validDetails);
   } catch (err) {
     done();
     throw err;


### PR DESCRIPTION
This covers the [algorithms](https://w3c.github.io/payment-request/#algorithms) section - but excludes the accepts right now. 

*  Shipping address changed algorithm
* Shipping option changed algorithm
* User aborts the payment request algorithm

The following is called indirectly: 

 * PaymentRequest updated algorithm

The "User accepts the payment request algorithm" is tested elsewhere. 

<!-- Reviewable:start -->

<!-- Reviewable:end -->
