### PR TITLE
Streams: Check constructor and method names

### DIFF
--- a/streams/byte-length-queuing-strategy.js
+++ b/streams/byte-length-queuing-strategy.js
@@ -104,4 +104,11 @@ test(() => {
 
 }, 'ByteLengthQueuingStrategy\'s highWaterMark property can be set to anything');
 
+test(() => {
+
+  assert_equals(ByteLengthQueuingStrategy.name, 'ByteLengthQueuingStrategy',
+                'ByteLengthQueuingStrategy.name must be "ByteLengthQueuingStrategy"');
+
+}, 'ByteLengthQueuingStrategy.name is correct');
+
 done();

--- a/streams/count-queuing-strategy.js
+++ b/streams/count-queuing-strategy.js
@@ -103,4 +103,11 @@ test(() => {
 
 }, 'CountQueuingStrategy\'s highWaterMark property can be set to anything');
 
+test(() => {
+
+  assert_equals(CountQueuingStrategy.name, 'CountQueuingStrategy',
+                'CountQueuingStrategy.name must be "CountQueuingStrategy"');
+
+}, 'CountQueuingStrategy.name is correct');
+
 done();

--- a/streams/readable-byte-streams/properties.dedicatedworker.html
+++ b/streams/readable-byte-streams/properties.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('properties.js'));
+</script>

--- a/streams/readable-byte-streams/properties.html
+++ b/streams/readable-byte-streams/properties.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/rs-utils.js"></script>
+
+<script src="properties.js"></script>

--- a/streams/readable-byte-streams/properties.js
+++ b/streams/readable-byte-streams/properties.js
@@ -1,0 +1,147 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('../resources/rs-utils.js');
+  self.importScripts('/resources/testharness.js');
+}
+
+let ReadableStreamBYOBReader;
+
+test(() => {
+
+  // It's not exposed globally, but we test a few of its properties here.
+  ReadableStreamBYOBReader = (new ReadableStream({ type: 'bytes' }))
+      .getReader({ mode: 'byob' }).constructor;
+
+}, 'Can get the ReadableStreamBYOBReader constructor indirectly');
+
+test(() => {
+
+  assert_throws(new TypeError(), () => new ReadableStreamBYOBReader('potato'));
+  assert_throws(new TypeError(), () => new ReadableStreamBYOBReader({}));
+  assert_throws(new TypeError(), () => new ReadableStreamBYOBReader());
+
+}, 'ReadableStreamBYOBReader constructor should get a ReadableStream object as argument');
+
+test(() => {
+
+  const methods = ['cancel', 'constructor', 'read', 'releaseLock'];
+  const properties = methods.concat(['closed']).sort();
+
+  const rsReader = new ReadableStreamBYOBReader(new ReadableStream({ type: 'bytes' }));
+  const proto = Object.getPrototypeOf(rsReader);
+
+  assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties);
+
+  for (const m of methods) {
+    const propDesc = Object.getOwnPropertyDescriptor(proto, m);
+    assert_equals(propDesc.enumerable, false, 'method should be non-enumerable');
+    assert_equals(propDesc.configurable, true, 'method should be configurable');
+    assert_equals(propDesc.writable, true, 'method should be writable');
+    assert_equals(typeof rsReader[m], 'function', 'should have be a method');
+    const expectedName = m === 'constructor' ? 'ReadableStreamBYOBReader' : m;
+    assert_equals(rsReader[m].name, expectedName, 'method should have the correct name');
+  }
+
+  const closedPropDesc = Object.getOwnPropertyDescriptor(proto, 'closed');
+  assert_equals(closedPropDesc.enumerable, false, 'closed should be non-enumerable');
+  assert_equals(closedPropDesc.configurable, true, 'closed should be configurable');
+  assert_not_equals(closedPropDesc.get, undefined, 'closed should have a getter');
+  assert_equals(closedPropDesc.set, undefined, 'closed should not have a setter');
+
+  assert_equals(rsReader.cancel.length, 1, 'cancel has 1 parameter');
+  assert_not_equals(rsReader.closed, undefined, 'has a non-undefined closed property');
+  assert_equals(typeof rsReader.closed.then, 'function', 'closed property is thenable');
+  assert_equals(rsReader.constructor.length, 1, 'constructor has 1 parameter');
+  assert_equals(rsReader.read.length, 1, 'read has 1 parameter');
+  assert_equals(rsReader.releaseLock.length, 0, 'releaseLock has no parameters');
+
+}, 'ReadableStreamBYOBReader instances should have the correct list of properties');
+
+promise_test(t => {
+
+  const rs = new ReadableStream({
+    pull(controller) {
+      return t.step(() => {
+        const byobRequest = controller.byobRequest;
+
+        const methods = ['constructor', 'respond', 'respondWithNewView'];
+        const properties = methods.concat(['view']).sort();
+
+        const proto = Object.getPrototypeOf(byobRequest);
+
+        assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties);
+
+        for (const m of methods) {
+          const propDesc = Object.getOwnPropertyDescriptor(proto, m);
+          assert_equals(propDesc.enumerable, false, 'method should be non-enumerable');
+          assert_equals(propDesc.configurable, true, 'method should be configurable');
+          assert_equals(propDesc.writable, true, 'method should be writable');
+          assert_equals(typeof byobRequest[m], 'function', 'should have a method');
+          const expectedName = m === 'constructor' ? 'ReadableStreamBYOBRequest' : m;
+          assert_equals(byobRequest[m].name, expectedName, 'method should have the correct name');
+        }
+
+        const viewPropDesc = Object.getOwnPropertyDescriptor(proto, 'view');
+        assert_equals(viewPropDesc.enumerable, false, 'view should be non-enumerable');
+        assert_equals(viewPropDesc.configurable, true, 'view should be configurable');
+        assert_not_equals(viewPropDesc.get, undefined, 'view should have a getter');
+        assert_equals(viewPropDesc.set, undefined, 'view should not have a setter');
+        assert_not_equals(byobRequest.view, undefined, 'has a non-undefined view property');
+        assert_equals(byobRequest.constructor.length, 2, 'constructor has 1 parameter');
+        assert_equals(byobRequest.respond.length, 1, 'respond has 1 parameter');
+        assert_equals(byobRequest.respondWithNewView.length, 1, 'releaseLock has 1 parameter');
+
+        byobRequest.respond(1);
+
+      });
+    },
+    type: 'bytes' });
+  const reader = rs.getReader({ mode: 'byob' });
+  return reader.read(new Uint8Array(1));
+
+}, 'ReadableStreamBYOBRequest instances should have the correct list of properties');
+
+test(() => {
+
+  const methods = ['close', 'constructor', 'enqueue', 'error'];
+  const accessors = ['byobRequest', 'desiredSize'];
+  const properties = methods.concat(accessors).sort();
+
+  let controller;
+  new ReadableStream({
+    start(c) {
+      controller = c;
+    },
+    type: 'bytes'
+  });
+  const proto = Object.getPrototypeOf(controller);
+
+  assert_array_equals(Object.getOwnPropertyNames(proto).sort(), properties);
+
+  for (const m of methods) {
+    const propDesc = Object.getOwnPropertyDescriptor(proto, m);
+    assert_equals(propDesc.enumerable, false, 'method should be non-enumerable');
+    assert_equals(propDesc.configurable, true, 'method should be configurable');
+    assert_equals(propDesc.writable, true, 'method should be writable');
+    assert_equals(typeof controller[m], 'function', 'should have be a method');
+    const expectedName = m === 'constructor' ? 'ReadableByteStreamController' : m;
+    assert_equals(controller[m].name, expectedName, 'method should have the correct name');
+  }
+
+  for (const a of accessors) {
+    const propDesc = Object.getOwnPropertyDescriptor(proto, a);
+    assert_equals(propDesc.enumerable, false, `${a} should be non-enumerable`);
+    assert_equals(propDesc.configurable, true, `${a} should be configurable`);
+    assert_not_equals(propDesc.get, undefined, `${a} should have a getter`);
+    assert_equals(propDesc.set, undefined, `${a} should not have a setter`);
+  }
+
+  assert_equals(controller.close.length, 0, 'cancel has no parameters');
+  assert_equals(controller.constructor.length, 3, 'constructor has 3 parameters');
+  assert_equals(controller.enqueue.length, 1, 'enqueue has 1 parameter');
+  assert_equals(controller.error.length, 1, 'releaseLock has 1 parameter');
+
+}, 'ReadableByteStreamController instances should have the correct list of properties');
+
+done();

--- a/streams/readable-byte-streams/properties.serviceworker.https.html
+++ b/streams/readable-byte-streams/properties.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('properties.js', 'Service worker test setup');
+</script>

--- a/streams/readable-byte-streams/properties.sharedworker.html
+++ b/streams/readable-byte-streams/properties.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('properties.js'));
+</script>

--- a/streams/readable-streams/default-reader.js
+++ b/streams/readable-streams/default-reader.js
@@ -38,6 +38,8 @@ test(() => {
     assert_equals(propDesc.configurable, true, 'method should be configurable');
     assert_equals(propDesc.writable, true, 'method should be writable');
     assert_equals(typeof rsReader[m], 'function', 'should have be a method');
+    const expectedName = m === 'constructor' ? 'ReadableStreamDefaultReader' : m;
+    assert_equals(rsReader[m].name, expectedName, 'method should have the correct name');
   }
 
   const closedPropDesc = Object.getOwnPropertyDescriptor(proto, 'closed');

--- a/streams/readable-streams/general.js
+++ b/streams/readable-streams/general.js
@@ -56,6 +56,8 @@ test(() => {
     assert_true(propDesc.configurable, 'method should be configurable');
     assert_true(propDesc.writable, 'method should be writable');
     assert_equals(typeof rs[m], 'function', 'method should be a function');
+    const expectedName = m === 'constructor' ? 'ReadableStream' : m;
+    assert_equals(rs[m].name, expectedName, 'method should have the correct name');
   }
 
   const lockedPropDesc = Object.getOwnPropertyDescriptor(proto, 'locked');
@@ -115,6 +117,8 @@ test(() => {
         assert_false(propDesc.enumerable, m + ' should be non-enumerable');
         assert_true(propDesc.configurable, m + ' should be configurable');
         assert_true(propDesc.writable, m + ' should be writable');
+        const expectedName = m === 'constructor' ? 'ReadableStreamDefaultController' : m;
+        assert_equals(controller[m].name, expectedName, 'method should have the correct name');
       }
 
       const desiredSizePropDesc = Object.getOwnPropertyDescriptor(proto, 'desiredSize');

--- a/streams/writable-streams/properties.js
+++ b/streams/writable-streams/properties.js
@@ -127,8 +127,10 @@ for (const c in expected) {
                         `${name} should take ${properties[name].length} arguments`);
           if (type === 'constructor') {
             assert_true(IsConstructor(prototype[name]), `${name} should be a constructor`);
+            assert_equals(prototype[name].name, c, `${name}.name should be '${c}'`);
           } else {
             assert_false(IsConstructor(prototype[name]), `${name} should not be a constructor`);
+            assert_equals(prototype[name].name, name, `${name}.name should be '${name}`);
           }
         }, `${fullName} should be a ${type}`);
         break;


### PR DESCRIPTION
Check the .name properties of constructors and methods for the Streams API.

Also add properties tests for ReadableByteStreamController,
ReadableStreamBYOBReader and ReadableStreamBYOBRequest.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
