### PR TITLE
Add initial payment handler tests.

### DIFF
--- a/interfaces/payment-handler.idl
+++ b/interfaces/payment-handler.idl
@@ -1,0 +1,53 @@
+[SecureContext,
+ Exposed=(Window,Worker)]
+interface PaymentManager {
+    [SameObject]
+    readonly attribute PaymentInstruments instruments;
+    [Exposed=Window] static Promise<PermissionState> requestPermission();
+};
+interface PaymentInstruments {
+    Promise<boolean>             delete(DOMString instrumentKey);
+    Promise<PaymentInstrument>   get(DOMString instrumentKey);
+    Promise<sequence<DOMString>> keys();
+    Promise<boolean>             has(DOMString instrumentKey);
+    Promise<void>                set(DOMString instrumentKey,
+                                     PaymentInstrument details);
+    Promise<void>                clear();
+};
+dictionary PaymentInstrument {
+    required DOMString             name;
+             sequence<ImageObject> icons;
+             sequence<DOMString>   enabledMethods;
+             object                capabilities;
+};
+dictionary ImageObject {
+    required USVString src;
+             DOMString sizes;
+             DOMString type;
+};
+[Constructor(DOMString type, PaymentRequestEventInit eventInitDict),
+ Exposed=ServiceWorker]
+interface PaymentRequestEvent : ExtendableEvent {
+    readonly attribute USVString                           topLevelOrigin;
+    readonly attribute USVString                           paymentRequestOrigin;
+    readonly attribute DOMString                           paymentRequestId;
+    readonly attribute FrozenArray<PaymentMethodData>      methodData;
+    readonly attribute object                              total;
+    readonly attribute FrozenArray<PaymentDetailsModifier> modifiers;
+    readonly attribute DOMString                           instrumentKey;
+    Promise<WindowClient?> openWindow(USVString url);
+    void                   respondWith(Promise<PaymentHandlerResponse> handlerResponse);
+};
+dictionary PaymentRequestEventInit : ExtendableEventInit {
+    USVString                        topLevelOrigin;
+    USVString                        paymentRequestOrigin;
+    DOMString                        paymentRequestId;
+    sequence<PaymentMethodData>      methodData;
+    PaymentCurrencyAmount            total;
+    sequence<PaymentDetailsModifier> modifiers;
+    DOMString                        instrumentKey;
+};
+dictionary PaymentHandlerResponse {
+    DOMString methodName;
+    object    details;
+};

--- a/payment-handler/OWNERS
+++ b/payment-handler/OWNERS
@@ -1,0 +1,2 @@
+@marcoscaceres
+@rsolomakhin

--- a/payment-handler/interfaces.https.any.js
+++ b/payment-handler/interfaces.https.any.js
@@ -1,0 +1,20 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+"use strict";
+
+if (self.importScripts) {
+    importScripts("/resources/testharness.js");
+    importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
+}
+
+// https://w3c.github.io/payment-handler/
+
+promise_test(async() => {
+    const text = await fetch("/interfaces/payment-handler.idl")
+        .then(response => response.text());
+    const idlArray = new IdlArray();
+    idlArray.add_idls(text);
+    idlArray.test();
+    done();
+}, "Payment handler interfaces.");


### PR DESCRIPTION
This patch adds initial WebIDL interface tests for payment handler:

https://w3c.github.io/payment-handler/#idl-index

The partial interfaces for ServiceWorkerRegistration and
ServiceWorkerGlobalScope are omitted.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
