### PR TITLE
RTCTrackEvent: fix typo naming event => trackEvent. Fixes gh-7056

### DIFF
--- a/webrtc/RTCTrackEvent-constructor.html
+++ b/webrtc/RTCTrackEvent-constructor.html
@@ -43,9 +43,9 @@
     assert_array_equals(trackEvent.streams, []);
     assert_equals(trackEvent.transceiver, transceiver);
 
-    assert_equals(event.type, 'track');
-    assert_false(event.bubbles);
-    assert_false(event.cancelable);
+    assert_equals(trackEvent.type, 'track');
+    assert_false(trackEvent.bubbles);
+    assert_false(trackEvent.cancelable);
 
   }, `new RTCTrackEvent() with valid receiver, track, transceiver should succeed`);
 


### PR DESCRIPTION


<!-- Reviewable:start -->

<!-- Reviewable:end -->
