### PR TITLE
Fixed verification on initial SDP offer

### DIFF
--- a/webrtc/RTCPeerConnection-createOffer.html
+++ b/webrtc/RTCPeerConnection-createOffer.html
@@ -48,7 +48,7 @@
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer =>
       pc.setLocalDescription(offer)
-      .then(offer => {
+      .then(() => {
         assert_equals(pc.signalingState, 'have-local-offer');
         assert_session_desc_equals(pc.localDescription, offer);
         assert_session_desc_equals(pc.pendingLocalDescription, offer);

--- a/webrtc/RTCPeerConnection-helper.js
+++ b/webrtc/RTCPeerConnection-helper.js
@@ -69,7 +69,7 @@ function assert_is_session_description(sessionDesc) {
   assert_true(typeof(sessionDesc.type) === 'string',
     'Expect sessionDescription.type to be a string');
 
-  assert_true(typeof(sessionDesc.type) === 'string',
+  assert_true(typeof(sessionDesc.sdp) === 'string',
     'Expect sessionDescription.sdp to be a string');
 }
 

--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -58,7 +58,7 @@
     return generateOffer({ data: true })
     .then(offer =>
       pc.setRemoteDescription(offer)
-      .then(offer => {
+      .then(() => {
         assert_equals(pc.signalingState, 'have-remote-offer');
         assert_session_desc_equals(pc.remoteDescription, offer);
         assert_session_desc_equals(pc.pendingRemoteDescription, offer);
@@ -127,9 +127,9 @@
     return pc.createOffer()
     .then(offer => pc.setLocalDescription(offer))
     .then(() => generateOffer())
-    .then(offer =>
+    .then(offer2 =>
       promise_rejects(t, 'InvalidStateError',
-        pc.setRemoteDescription(offer)));
+        pc.setRemoteDescription(offer2)));
   }, 'Calling setRemoteDescription(offer) from have-local-offer state should reject with InvalidStateError');
 
 </script>


### PR DESCRIPTION
The additional `offer` argument in line 51 actually gets filled with the return from the setLocalDescription() call.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
