### PR TITLE
Fix setRemoteDescription test to accept offer from same connection

### DIFF
--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -57,7 +57,7 @@
         type: 'bogus',
         sdp: 'bogus'
       }));
-  }, 'setRemoteDescription with invalid type and invalid SDP should reject with TypeError')
+  }, 'setRemoteDescription with invalid type and invalid SDP should reject with TypeError');
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
@@ -68,7 +68,7 @@
         type: 'answer',
         sdp: 'invalid'
       }));
-  }, 'setRemoteDescription() with invalid SDP and stable state should reject with InvalidStateError')
+  }, 'setRemoteDescription() with invalid SDP and stable state should reject with InvalidStateError');
 
   /* Operations after returning to stable state */
 
@@ -79,21 +79,22 @@
     test_state_change_event(t, pc,
       ['have-remote-offer', 'stable', 'have-remote-offer']);
 
-    return generateOffer({ audio: true })
+    return pc2.createOffer({ offerToReceiveAudio: true })
     .then(offer1 =>
       pc.setRemoteDescription(offer1)
       .then(() => pc.createAnswer())
       .then(answer => pc.setLocalDescription(answer))
-      .then(() => generateOffer({ data: true }))
-      .then(offer2 =>
-        pc.setRemoteDescription(offer2)
+      .then(() => pc2.createOffer({ offerToReceiveVideo: true }))
+      .then(offer2 => {
+        return pc.setRemoteDescription(offer2)
         .then(() => {
           assert_equals(pc.signalingState, 'have-remote-offer');
           assert_session_desc_not_equals(offer1, offer2);
           assert_session_desc_equals(pc.remoteDescription, offer2);
           assert_session_desc_equals(pc.currentRemoteDescription, offer1);
           assert_session_desc_equals(pc.pendingRemoteDescription, offer2);
-        })));
+        });
+      }));
   }, 'Calling setRemoteDescription() again after one round of remote-offer/local-answer should succeed');
 
   promise_test(t => {


### PR DESCRIPTION
Fixes #7054. Note that the test still fails Firefox, as it does not persistently save the first m=audio line in subsequent SDPs when `offerToReceiveAudio` is set to true. (The spec requires it to behave as if `addTransceiver('audio')` has been called.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
