### PR TITLE
[css-ui-3] Avoid test failure unrelated to the object of the test

### DIFF
--- a/css/css-ui-3/caret-color-020.html
+++ b/css/css-ui-3/caret-color-020.html
@@ -33,7 +33,14 @@
         var player = textarea.animate(keyframes, options);
         player.pause();
         player.currentTime = 5;
-        assert_equals(getComputedStyle(textarea).caretColor, 'rgb(128, 128, 128)');
+        var rgb = getComputedStyle(textarea).caretColor.match(/\d+/g);
+        /* Only testing that the rgb value is some intermediary value,
+           but not checking which, as we only care that the value is interpolated,
+           not about the numerical accuracy of interpolation,
+           which is something tests for the animation spec ought to worry about. */
+        assert_true( rgb[0] < 255 && rgb[0] > 0, "the red channel is interpolated");
+        assert_true( rgb[1] < 255 && rgb[1] > 0, "the green channel is interpolated");
+        assert_true( rgb[2] < 255 && rgb[2] > 0, "the blue channel is interpolated");
       }, "caret-color: currentcolor is interpolable");
 </script>
 </body>


### PR DESCRIPTION
At the time of writing, the original version of
css/css-ui-3/caret-color-20 fails in Firefox due to insufficient
precision in its interpolation code. This is unrelated to the object of
this test.

This change avoids this accidental dependency of numerical precision,
making the test more truthful about what it claims to be testing.

The Firefox precision issue discovered by the original version of this
test is tracked here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1366197

<!-- Reviewable:start -->

<!-- Reviewable:end -->
