### PR TITLE
Improve module loader mochitests and re-enable failing WPT tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/errorhandling.html
+++ b/html/semantics/scripting-1/the-script-element/module/errorhandling.html
@@ -55,7 +55,6 @@
             assert_unreached("This script should not have loaded!");
         }));
         document.body.appendChild(script_wrongMimetype_import);
-
     </script>
 </body>
 </html>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1388728 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7082)
<!-- Reviewable:end -->
