### PR TITLE
Disable pytest cache provider in WPT.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -56,7 +56,8 @@ def run(path, server_config, session_config, timeout=0):
                      "--verbose",  # show each individual subtest
                      "--capture", "no",  # enable stdout/stderr from tests
                      "--basetemp", cache,  # temporary directory
-                     "-p", "no:mozlog",
+                     "-p", "no:mozlog",  # use the WPT result recorder
+                     "-p", "no:cacheprovider",  # disable state preservation across invocations
                      path],
                     plugins=plugins)
 


### PR DESCRIPTION

The pytest cache provider lets you have access to --last-failed and
--failed-first based on a cache file it puts in .cache/v/lastfailed.
This can be useful for iterating on a set of failures, but not a feature
we want to support through wptrunner.

This patch disables the cache provider so that these files are
not generated.  When calling wptrunner with --manifest-update, these
temporary files have had a tedency to be included in MANIFEST.json,
and this change will effectively prevent that from happening.

MozReview-Commit-ID: EU7zXAdxsfY

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1391662 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7084)
<!-- Reviewable:end -->
