### PR TITLE
Flag the in-flow frames of kids of various wrapper frames during frame construction, so we know to restyle the wrapper frames.

### DIFF
--- a/css/CSS2/tables/reference/table-anonymous-border-spacing-ref.xht
+++ b/css/CSS2/tables/reference/table-anonymous-border-spacing-ref.xht
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <style><![CDATA[
+    #target { border-spacing: 20px; }
+    #target > * { display: table-cell; border: 1px solid black; }
+    ]]></style>
+  </head>
+<body>
+  <p>There should be 20px border-spacing in the table below.</p>
+  <div id="target">
+    <div>First cell</div>
+    <div>Second cell</div>
+  </div>
+</body>
+</html>

--- a/css/CSS2/tables/reference/table-anonymous-text-indent-ref.xht
+++ b/css/CSS2/tables/reference/table-anonymous-text-indent-ref.xht
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <style><![CDATA[
+    #target { text-indent: 20px; display: table; }
+    #target > * { display: table-cell; border: 1px solid black; }
+    ]]></style>
+  </head>
+<body>
+  <p>There should be 20px text-indent in the table below.</p>
+  <div id="target">
+    <div>First cell</div>
+    Second cell (no element on purpose)
+  </div>
+</body>
+</html>

--- a/css/CSS2/tables/table-anonymous-border-spacing.xht
+++ b/css/CSS2/tables/table-anonymous-border-spacing.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="match" href="reference/table-anonymous-border-spacing-ref.xht"/>
+  <meta name="flags" content='dom'/>
+    <script type="text/javascript"><![CDATA[
+      function doTest() {
+        var t = document.getElementById("target");
+        t.style.borderSpacing = '20px';
+      }
+      ]]></script>
+    <style><![CDATA[
+    #target { border-spacing: 0; }
+    #target > * { display: table-cell; border: 1px solid black; }
+    ]]></style>
+  </head>
+<body onload="doTest()">
+  <p>There should be 20px border-spacing in the table below.</p>
+  <div id="target">
+    <div>First cell</div>
+    <div>Second cell</div>
+  </div>
+</body>
+</html>

--- a/css/CSS2/tables/table-anonymous-text-indent.xht
+++ b/css/CSS2/tables/table-anonymous-text-indent.xht
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="match" href="reference/table-anonymous-text-indent-ref.xht"/>
+  <meta name="flags" content='dom'/>
+  <script type="text/javascript"><![CDATA[
+    function doTest() {
+      var t = document.getElementById("target");
+      t.style.textIndent = '20px';
+    }
+    ]]></script>
+  <style><![CDATA[
+    #target { text-indent: 0; display: table; }
+    #target > * { display: table-cell; border: 1px solid black; }
+  ]]></style>
+</head>
+<body onload="doTest()">
+  <p>There should be 20px text-indent in the table below.</p>
+  <div id="target">
+    <div>First cell</div>
+    Second cell (no element on purpose)
+  </div>
+</body>
+</html>

--- a/cssom-view/elementFromPoint-002.html
+++ b/cssom-view/elementFromPoint-002.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Checking whether dynamic changes to visibility interact correctly with
+  table anonymous boxes</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<style>
+#overlay {
+  display: table;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: white;
+  z-index: 999
+}
+
+#wrapper { position: relative; }
+</style>
+<div id=log></div>
+<div id="wrapper">
+  <div id="overlay"><div></div></div>
+  <div id="target">Some text</div>
+</div>
+<script>
+  test(function() {
+    var t = document.querySelector("#target");
+    var rect = t.getBoundingClientRect();
+    var hit = document.elementFromPoint(rect.x + rect.width/2,
+                                        rect.y + rect.height/2);
+    assert_equals(hit, t.previousElementSibling,
+                  "Should hit the overlay first.");
+    t.previousElementSibling.style.visibility = "hidden";
+    hit = document.elementFromPoint(rect.x + rect.width/2,
+                                    rect.y + rect.height/2);
+    assert_equals(hit, t,
+                  "Should hit our target now that the overlay is hidden.");
+  });
+</script>

--- a/cssom-view/elementFromPoint-003.html
+++ b/cssom-view/elementFromPoint-003.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Checking whether dynamic changes to visibility interact correctly with
+  table anonymous boxes</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<style>
+#overlay {
+  display: table;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: white;
+  z-index: 999
+}
+
+#wrapper { position: relative; }
+</style>
+<div id=log></div>
+<div id="wrapper">
+  <div id="overlay"><div></div></div>
+  <div id="target">Some text</div>
+</div>
+<script>
+  test(function() {
+    // Make sure we have boxes constructed already.
+    document.body.offsetWidth;
+    var overlay = document.querySelector("#overlay");
+    overlay.insertBefore(document.createElement("div"), overlay.firstChild);
+    overlay.appendChild(document.createElement("div"));
+    // Make sure we have boxes constructed for those inserts/appends
+    document.body.offsetWidth;
+    overlay.firstChild.nextSibling.remove();
+    var t = document.querySelector("#target");
+    var rect = t.getBoundingClientRect();
+    var hit = document.elementFromPoint(rect.x + rect.width/2,
+                                        rect.y + rect.height/2);
+    assert_equals(hit, t.previousElementSibling,
+                  "Should hit the overlay first.");
+    t.previousElementSibling.style.visibility = "hidden";
+    hit = document.elementFromPoint(rect.x + rect.width/2,
+                                    rect.y + rect.height/2);
+    assert_equals(hit, t,
+                  "Should hit our target now that the overlay is hidden.");
+  });
+</script>


### PR DESCRIPTION

MozReview-Commit-ID: 8KNug88sGp

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1388625 [ci skip]