### PR TITLE
Don't allow Selection in nodes not in the document;

### DIFF
--- a/selection/removeAllRanges.html
+++ b/selection/removeAllRanges.html
@@ -13,8 +13,13 @@ testRanges.unshift("[]");
 var range = rangeFromEndpoints([paras[0].firstChild, 0, paras[0].firstChild, 1]);
 
 function testRange(rangeDesc, method) {
+    var endpoints = eval(testRanges[i]);
+    if (endpoints.length && (!isSelectableNode(endpoints[0]) ||
+                             !isSelectableNode(endpoints[2]))) {
+      return;
+    }
     test(function() {
-        setSelectionForwards(eval(rangeDesc));
+        setSelectionForwards(endpoints);
         selection[method]();
         assert_equals(selection.rangeCount, 0,
             "After " + method + "(), rangeCount must be 0");
@@ -28,7 +33,7 @@ function testRange(rangeDesc, method) {
 
     // Copy-pasted from above
     test(function() {
-        setSelectionBackwards(eval(rangeDesc));
+        setSelectionBackwards(endpoints);
         selection[method]();
         assert_equals(selection.rangeCount, 0,
             "After " + method + "(), rangeCount must be 0");


### PR DESCRIPTION

This matches the spec and Chrome, and seems to bring us closer to Edge
and WebKit as well.  It also matches our own behavior for addRange(),
which was changed in bug 1341137.

For collapse and selectAllChildren, we match the tests and browsers, but
the spec is incorrect at the time of this writing:
https://github.com/w3c/selection-api/pull/86

The removeAllRanges test hadn't been updated for the spec change.

MozReview-Commit-ID: DTK8283k5IP

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1359397 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7087)
<!-- Reviewable:end -->
