### PR TITLE
Enable Set Window Rect from minimized window state test.

### DIFF
--- a/webdriver/tests/set_window_rect.py
+++ b/webdriver/tests/set_window_rect.py
@@ -120,12 +120,16 @@ def test_set_window_fullscreen(session):
 def test_set_window_rect_window_minimized(session):
     # step 11
     session.window.minimize()
-    assert session.execute_script("return document.hidden")
+    assert session.window.state == "minimized"
+
     result = session.transport.send("POST",
                                     "session/%s/window/rect" % session.session_id,
                                     {"width": 400, "height": 400})
     assert not session.execute_script("return document.hidden")
-    assert_success(result, {"width": 400, "height": 400})
+    rect = assert_success(result)
+    assert rect["width"] == 400
+    assert rect["height"] == 400
+    assert rect["state"] == "normal"
 
 
 def test_set_window_height_width(session):


### PR DESCRIPTION

Now that geckodriver has support for window state in the window rect
object, we can enable the test_set_window_rect_window_minimized test
from testing/web-platform/tests/webdriver/tests/set_window_rect.py.

MozReview-Commit-ID: FY6EZTxMUbE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1390520 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7093)
<!-- Reviewable:end -->
