### PR TITLE
Fix undefined variable error with client.Session#position().

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -272,7 +272,7 @@ class Window(object):
     @command
     def position(self, new_position):
         """Set window position by passing a tuple of `(x, y)`."""
-        data = x, y
+        x, y = new_position
         body = {"x": x, "y": y}
         self.session.send_session_command("POST", "window/rect", body)
 


### PR DESCRIPTION

The x and y variables are not defined but needs to be extracted from
new_position.

MozReview-Commit-ID: Ds8cPlufjUa

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1391691 [ci skip]