### PR TITLE
Skip needless assertion.

### DIFF
--- a/webdriver/tests/set_window_rect.py
+++ b/webdriver/tests/set_window_rect.py
@@ -104,7 +104,6 @@ def test_minimized(session):
     assert session.window.state == "minimized"
 
     response = set_window_rect(session, {"width": 400, "height": 400})
-    assert session.window.state != "minimized"
     rect = assert_success(response)
     assert rect["width"] == 400
     assert rect["height"] == 400


### PR DESCRIPTION

The window rect's state is already tested a few lines down.

MozReview-Commit-ID: BLDufKrl8ey

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1391691 [ci skip]