### PR TITLE
Added smiley.png.headers.

### DIFF
--- a/images/smiley.png.headers
+++ b/images/smiley.png.headers
@@ -1,0 +1,1 @@
+Timing-Allow-Origin: *


### PR DESCRIPTION

For web-platform-tests imageset.https.sub,html [1], it will fetch smiley.png
and use window.performace to query the download size to determine the image is
actually downloaded or not. [2]

However this test is a mixed-content-blocked test, (https: document to
load some images from http:), and performace API only allows pages with
different origin to use this API if the HTTP header 'Timing-Allow-Origin' is
specified. [3]

So we added a smiley.png.header to specifiy 'Timing-Allow-Origin'.

[1]: http://searchfox.org/mozilla-central/rev/b258e6864ee3e809d40982bc5d0d5aff66a20780/testing/web-platform/tests/mixed-content/imageset.https.sub.html
[2]: http://searchfox.org/mozilla-central/rev/b258e6864ee3e809d40982bc5d0d5aff66a20780/testing/web-platform/tests/preload/resources/preload_helper.js#13
[3]: https://www.w3.org/TR/resource-timing-1/#timing-allow-origin

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1373780 [ci skip]