### PR TITLE
Drop unnecessary navigation in user prompt tests.

### DIFF
--- a/webdriver/tests/set_window_rect.py
+++ b/webdriver/tests/set_window_rect.py
@@ -54,7 +54,6 @@ def test_handle_prompt_accept(new_session):
 
     _, session = new_session(
         {"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
-    session.url = inline("<title>WD doc title</title>")
     original = session.window.rect
 
     # step 2
@@ -114,7 +113,6 @@ def test_handle_prompt_missing_value(session, create_dialog):
     original = session.window.rect
 
     # step 2
-    session.url = inline("<title>WD doc title</title>")
     create_dialog("alert", text="dismiss #1", result_var="dismiss1")
 
     result = set_window_rect(session, {"x": int(original["x"]),


### PR DESCRIPTION

The browsing context always has a document.

MozReview-Commit-ID: FU0T2LcUBJq

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1392368 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7113)
<!-- Reviewable:end -->
