### PR TITLE
updateWith() must abort when dup shippingOption ids

### DIFF
--- a/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<meta charset="utf8">
+<link rel="help" href="">
+<title>
+</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+setup({ explicit_done: true, explicit_timeout: true });
+
+const validMethod = Object.freeze({ supportedMethods: "basic-card" });
+const validMethods = [validMethod];
+const validAmount = Object.freeze({
+  currency: "USD",
+  value: "5.00",
+});
+const validShippingOption = Object.freeze({
+  id: "option1",
+  label: "Option 1",
+  amount: validAmount,
+  selected: true,
+});
+const validShippingOptions = Object.freeze([validShippingOption]);
+const validDetails = Object.freeze({
+  total: {
+    label: "Total due",
+    amount: validAmount,
+  },
+  shippingOptions: validShippingOptions,
+});
+const validOptions = Object.freeze({
+  requestShipping: true,
+});
+
+test(() => {
+  try {
+    const request = new PaymentRequest(validMethods, validDetails);
+  } catch (err) {
+    done();
+    throw err;
+  }
+}, "Must construct a PaymentRequest (smoke test)");
+
+function testFireEvents(button) {
+  promise_test(async t => {
+    const request = new PaymentRequest(
+      validMethods,
+      validDetails,
+      validOptions
+    );
+    request.addEventListener("shippingaddresschange", event => {
+      // Same option, so duplicate ids
+      const otherShippingOption = Object.assign({}, validShippingOption, {
+        id: "other",
+      });
+      const shippingOptions = [
+        validShippingOption,
+        otherShippingOption,
+        validShippingOption,
+      ];
+      const newDetails = Object.assign({}, validDetails, { shippingOptions });
+      event.updateWith(newDetails);
+    });
+    const acceptPromise = request.show();
+    await promise_rejects(
+      t,
+      new TypeError(),
+      acceptPromise,
+      "Duplicate shippingOption ids must abort with TypeError"
+    );
+  }, button.textContent.trim());
+}
+</script>
+<h2>updateWith() method - duplicate shippingOptions</h2>
+<p>
+  When the payment sheet is shown, select a different shipping address.
+</p>
+<ol>
+  <li>
+    <button onclick="testFireEvents(this)">
+      If there are duplicate shippingOption ids, then abort payment request.
+    </button>
+  </li>
+</ol>

--- a/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
+++ b/payment-request/PaymentRequestUpdateEvent/updateWith-duplicate-shipping-options-manual.https.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <meta charset="utf8">
-<link rel="help" href="">
+<link rel="help" href="https://w3c.github.io/payment-request/#updatewith()-method">
 <title>
+  updateWith() method - duplicate shippingOption ids
 </title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -42,6 +43,7 @@ test(() => {
 }, "Must construct a PaymentRequest (smoke test)");
 
 function testFireEvents(button) {
+  button.disabled = true;
   promise_test(async t => {
     const request = new PaymentRequest(
       validMethods,
@@ -71,7 +73,7 @@ function testFireEvents(button) {
   }, button.textContent.trim());
 }
 </script>
-<h2>updateWith() method - duplicate shippingOptions</h2>
+<h2>updateWith() method - duplicate shippingOptions ids</h2>
 <p>
   When the payment sheet is shown, select a different shipping address.
 </p>


### PR DESCRIPTION
Test for https://github.com/w3c/payment-request/pull/596

<!-- Reviewable:start -->

<!-- Reviewable:end -->
