### PR TITLE
Remove print statement that fails the lint check

### DIFF
--- a/webdriver/tests/state/get_element_attribute.py
+++ b/webdriver/tests/state/get_element_attribute.py
@@ -160,7 +160,6 @@ def test_normal(session):
 def test_boolean_attribute(session, tag, attrs):
     # 13.2 Step 5
     for attr in attrs:
-        print("testing boolean attribute <{0} {1}>".format(tag, attr))
         session.url = inline("<{0} {1}>".format(tag, attr))
 
         element = session.find.css(tag, all=False)


### PR DESCRIPTION
Introduced by https://github.com/w3c/web-platform-tests/pull/7095

<!-- Reviewable:start -->

<!-- Reviewable:end -->
