### PR TITLE
Test shippingOption set correctly

### DIFF
--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -350,10 +350,18 @@ test(() => {
     const details = Object.assign({}, defaultDetails, {
       shippingOptions: [invalidShippingOption],
     });
+    const request = new PaymentRequest(defaultMethods, details, {
+      requestShipping: false,
+    });
+    assert_equals(
+      request.shippingOption,
+      null,
+      "As no shipping is requested, shippingOption is null"
+    );
     assert_throws(
       new TypeError(),
       () => {
-        new PaymentRequest(defaultMethods, details);
+        new PaymentRequest(defaultMethods, details, { requestShipping: true });
       },
       `Expected TypeError for option.amount.value: "${amount}"`
     );
@@ -376,13 +384,38 @@ test(() => {
   smokeTest();
   const selectedOption = Object.assign({}, defaultShippingOption, {
     selected: true,
-    id: "PASS",
+    id: "the-id",
   });
   const shippingOptions = [selectedOption];
   const details = Object.assign({}, defaultDetails, { shippingOptions });
-  const request = new PaymentRequest(defaultMethods, details);
-  assert_equals(request.shippingOption, "PASS", "selected option must be PASS");
-}, "If there is a selected shipping option, then it becomes synchronously selected");
+  const requestNoShippingRequested1 = new PaymentRequest(
+    defaultMethods,
+    details
+  );
+  assert_equals(
+    requestNoShippingRequested1.shippingOption,
+    null,
+    "Must be null when no shipping is requested (defaults to false)"
+  );
+  const requestNoShippingRequested2 = new PaymentRequest(
+    defaultMethods,
+    details,
+    { requestShipping: false }
+  );
+  assert_equals(
+    requestNoShippingRequested2.shippingOption,
+    null,
+    "Must be null when requestShipping is false"
+  );
+  const requestWithShipping = new PaymentRequest(defaultMethods, details, {
+    requestShipping: "truthy value",
+  });
+  assert_equals(
+    requestWithShipping.shippingOption,
+    "the-id",
+    "Selected option must be 'the-id'"
+  );
+}, "If there is a selected shipping option, and requestShipping is set, then that option becomes synchronously selected");
 
 test(() => {
   smokeTest();
@@ -396,13 +429,27 @@ test(() => {
   });
   const passOption = Object.assign({}, defaultShippingOption, {
     selected: true,
-    id: "PASS",
+    id: "the-id",
   });
   const shippingOptions = [failOption1, failOption2, passOption];
   const details = Object.assign({}, defaultDetails, { shippingOptions });
-  const request = new PaymentRequest(defaultMethods, details);
-  assert_equals(request.shippingOption, "PASS", "selected option must PASS");
-}, "If there is a multiple selected shipping options, only the last is selected");
+  const requestNoShipping = new PaymentRequest(defaultMethods, details, {
+    requestShipping: false,
+  });
+  assert_equals(
+    requestNoShipping.shippingOption,
+    null,
+    "selected option must null, as requestShipping is false"
+  );
+  const requestWithShipping = new PaymentRequest(defaultMethods, details, {
+    requestShipping: true,
+  });
+  assert_equals(
+    requestWithShipping.shippingOption,
+    "the-id",
+    "selected option must 'the-id"
+  );
+}, "If requestShipping is set, and if there is a multiple selected shipping options, only the last is selected.");
 
 test(() => {
   smokeTest();
@@ -414,9 +461,18 @@ test(() => {
   });
   const shippingOptions = [selectedOption, unselectedOption];
   const details = Object.assign({}, defaultDetails, { shippingOptions });
-  const request = new PaymentRequest(defaultMethods, details);
-  assert_equals(request.shippingOption, null, "selected option must be null");
-}, "If there are any duplicate shipping option ids, then there are no shipping options");
+  const requestNoShipping = new PaymentRequest(defaultMethods, details);
+  assert_equals(
+    requestNoShipping.shippingOption,
+    null,
+    "selected option must null, because no shipping requested"
+  );
+  assert_throws(() => {
+    const request = new PaymentRequest(defaultMethods, details, {
+      requestShipping: true,
+    });
+  });
+}, "If there are any duplicate shipping option ids, and shipping is requested, then throw a TypeError");
 
 test(() => {
   smokeTest();
@@ -428,13 +484,23 @@ test(() => {
   const dupShipping2 = Object.assign({}, defaultShippingOption, {
     selected: false,
     id: "DUPLICATE",
-    label: "Fail 2"
+    label: "Fail 2",
   });
   const shippingOptions = [dupShipping1, defaultShippingOption, dupShipping2];
   const details = Object.assign({}, defaultDetails, { shippingOptions });
-  assert_throws(new TypeError(), () => {
-    new PaymentRequest(defaultMethods, details);
-  }, "Expected to throw a TypeError because duplicate IDs");
+  const requestNoShipping = new PaymentRequest(defaultMethods, details);
+  assert_equals(
+    requestNoShipping.shippingOption,
+    null,
+    "selected option must null, because no shipping requested"
+  );
+  assert_throws(
+    new TypeError(),
+    () => {
+      new PaymentRequest(defaultMethods, details, { requestShipping: true });
+    },
+    "Expected to throw a TypeError because duplicate IDs"
+  );
 }, "Throw when there are duplicate shippingOption ids, even if other values are different");
 
 // Process payment details modifiers:

--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -356,7 +356,7 @@ test(() => {
     assert_equals(
       request.shippingOption,
       null,
-      "As no shipping is requested, shippingOption is null"
+      "shippingOption must be null, because requestShipping is false"
     );
     assert_throws(
       new TypeError(),
@@ -376,7 +376,7 @@ test(() => {
   assert_equals(
     request.shippingOption,
     null,
-    "request.shippingOption must be null"
+    "shippingOption must be null, as requestShipping is missing"
   );
 }, "If there is no selected shipping option, then PaymentRequest.shippingOption remains null");
 
@@ -439,7 +439,7 @@ test(() => {
   assert_equals(
     requestNoShipping.shippingOption,
     null,
-    "selected option must null, as requestShipping is false"
+    "shippingOption must be null, as requestShipping is false"
   );
   const requestWithShipping = new PaymentRequest(defaultMethods, details, {
     requestShipping: true,
@@ -465,7 +465,7 @@ test(() => {
   assert_equals(
     requestNoShipping.shippingOption,
     null,
-    "selected option must null, because no shipping requested"
+    "shippingOption must be null, because requestShipping is false"
   );
   assert_throws(() => {
     const request = new PaymentRequest(defaultMethods, details, {
@@ -492,7 +492,7 @@ test(() => {
   assert_equals(
     requestNoShipping.shippingOption,
     null,
-    "selected option must null, because no shipping requested"
+    "shippingOption must be null, because requestShipping is false"
   );
   assert_throws(
     new TypeError(),

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -108,5 +108,24 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
         `Expected response ${attribute} attribute to be ${value}`
       );
     }
+    // Special handling for option.requestShipping
+    assert_equals(
+      request.shippingOption,
+      "pass",
+      "request.shippingOption must be 'pass'"
+    );
+    if (options && options.requestShipping) {
+      assert_equals(
+        response.shippingOption,
+        "pass",
+        "request.shippingOption must be 'pass'"
+      );
+    } else {
+      assert_equals(
+        response.shippingOption,
+        null,
+        "request.shippingOption must be 'pass'"
+      );
+    }
   }, button.textContent.trim());
 }

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -108,12 +108,6 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
         `Expected response ${attribute} attribute to be ${value}`
       );
     }
-    // Special handling for option.requestShipping
-    assert_equals(
-      request.shippingOption,
-      "pass",
-      "request.shippingOption must be 'pass'"
-    );
     if (options && options.requestShipping) {
       assert_equals(
         response.shippingOption,
@@ -121,6 +115,11 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
         "request.shippingOption must be 'pass'"
       );
     } else {
+      assert_equals(
+        request.shippingOption,
+        null,
+        "If requestShipping is falsy, request.shippingOption must be null"
+      );
       assert_equals(
         response.shippingOption,
         null,


### PR DESCRIPTION
The spec does a weird thing that if `requestShipping` is false, but shipping options are given, the request returns the selected shipping option, but the response.shippingOption will be null.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
