### PR TITLE
Fix idle-callbacks/callback-suspended for non-bfcache browsers.

### DIFF
--- a/html/webappapis/idle-callbacks/callback-suspended.html
+++ b/html/webappapis/idle-callbacks/callback-suspended.html
@@ -80,7 +80,7 @@
                 running = false;
               }),
             // ... or not. If not, we expect a load event.
-            waitForMessage("foo")
+            waitForMessage("foo", _ => win)
           ]))
           .then(_ => win.close())
           .catch(e => {


### PR DESCRIPTION
Fixes an issue with idle-callbacks/callback-suspended for browsers that don't have a bfcache (e.g., Chrome).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
