### PR TITLE
[geometry] Replace serializers with "[Default] toJSON()".

### DIFF
--- a/interfaces/geometry.idl
+++ b/interfaces/geometry.idl
@@ -12,7 +12,7 @@ interface DOMPointReadOnly {
 
     DOMPoint matrixTransform(optional DOMMatrixInit matrix);
 
-    serializer = { attribute };
+    [Default] toJSON();
 };
 
 [Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
@@ -52,7 +52,7 @@ interface DOMRectReadOnly {
     readonly attribute unrestricted double bottom;
     readonly attribute unrestricted double left;
 
-    serializer = { attribute };
+    [Default] toJSON();
 };
 
 [Constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
@@ -97,7 +97,7 @@ interface DOMQuad {
     [SameObject] readonly attribute DOMPoint p4;
     [NewObject] DOMRect getBounds();
 
-    serializer = { attribute };
+    [Default] toJSON();
 };
 
 dictionary DOMQuadInit {
@@ -178,7 +178,7 @@ interface DOMMatrixReadOnly {
     [NewObject] Float64Array toFloat64Array();
 
     [Exposed=Window] stringifier;
-    serializer = { attribute };
+    [Default] toJSON();
 };
 
 [Constructor(optional (DOMString or sequence<unrestricted double>) init),


### PR DESCRIPTION
Match latest WebIDL spec[1].

[1] https://heycam.github.io/webidl/#Default

<!-- Reviewable:start -->

<!-- Reviewable:end -->
