### PR TITLE
Change expectation for unexpected WebSocket protocol

### DIFF
--- a/websockets/constructor/010.html
+++ b/websockets/constructor/010.html
@@ -9,14 +9,13 @@
 <script>
 async_test(function(t) {
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/handshake_protocol');
-  ws.onerror = ws.onmessage = ws.onclose = t.step_func(e => assert_unreached(e.type));
-  ws.onopen = t.step_func(function(e) {
+  ws.onopen = ws.onmessage = ws.onclose = t.step_func(e => assert_unreached(e.type));
+  ws.onerror = t.step_func(function(e) {
     ws.onclose = t.step_func(function(e) {
-      ws.onclose = t.step_func(e => assert_unreached(e.type));
-      t.step_timeout(() => t.done(), 50);
-    })
-    ws.close();
+      assert_false(e.wasClean, 'e.wasClean should be false');
+      assert_equals(e.code, 1006, 'e.code should be 1006');
+      t.done();
+    });
   })
 });
 </script>
-


### PR DESCRIPTION
RFC6455 section 4.1 clearly states that it is a hard error for the
server to specify a sub-protocol when the client didn't request it:

```
   6.  If the response includes a |Sec-WebSocket-Protocol| header field
       and this header field indicates the use of a subprotocol that was
       not present in the client's handshake (the server has indicated a
       subprotocol not requested by the client), the client MUST _Fail
       the WebSocket Connection_.
```

However, test websockets/constructor/010.html had the expectation that
the connection would succeed in this case. This doesn't correspond with
the behaviour of any current major browser.

Change the expectation to be connection failure. Also remove the check
for duplicate calls to the onclose handler, as it is unrelated to the
main purpose of the test.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
