### PR TITLE
Change expectation for WebSocket case-only sub-protocol mismatch

### DIFF
--- a/websockets/constructor/011.html
+++ b/websockets/constructor/011.html
@@ -8,20 +8,20 @@
 <div id=log></div>
 <script>
 async_test(function(t) {
+  // Sub-protocol matching is case-sensitive.
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/handshake_protocol', 'FOOBAR');
   var gotOpen = false;
   var gotError = false;
   ws.onopen = t.step_func(function(e) {
     gotOpen = true;
-  })
+  });
   ws.onerror = t.step_func(function(e) {
     gotError = true;
-  })
+  });
   ws.onclose = t.step_func(function(e) {
-    assert_true(gotOpen, 'got open');
+    assert_false(gotOpen, 'got open');
     assert_true(gotError, 'got error');
-    ws.onclose = t.unreached_func();
-    t.step_timeout(() => t.done(), 50);
-  })
+    t.done();
+  });
 });
 </script>


### PR DESCRIPTION
A sub-protocol mismatch during the WebSocket handshake causes the browser to
fail the WebSocket connection, meaning the onopen event should never fire. Test
websockets/constructor/011.html assumed that the onopen event would fire in this
case. This doesn't match the standard or the behaviour of any current major
browser. Fix it.

Also remove the unrelated check that the onclose event is not fired twice.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
