### PR TITLE
PaymentResponse IDL attribute checks

### DIFF
--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -100,7 +100,11 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
       assert_idl_attribute(
         response,
         attribute,
+<<<<<<< HEAD
         `Expected a ${attribute} IDL attribute`
+=======
+        `Expected ${attribute} to be an IDL attribute.`
+>>>>>>> Check payment response IDL attributes
       );
       assert_equals(
         response[attribute],

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -95,6 +95,11 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
   const { request, response } = await getPaymentRequestResponse(options, id);
   await response.complete();
   test(() => {
+    assert_idl_attribute(
+      response,
+      "requestId",
+      "expect requestId to be an IDL attribute."
+    );
     assert_equals(response.requestId, request.id, `Expected ids to match`);
     for (const [attribute, value] of Object.entries(expected)) {
       assert_idl_attribute(

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -98,7 +98,7 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
     assert_idl_attribute(
       response,
       "requestId",
-      "expect requestId to be an IDL attribute."
+      "Expected requestId to be an IDL attribute."
     );
     assert_equals(response.requestId, request.id, `Expected ids to match`);
     for (const [attribute, value] of Object.entries(expected)) {

--- a/payment-request/payment-response/helpers.js
+++ b/payment-request/payment-response/helpers.js
@@ -105,11 +105,7 @@ async function runManualTest(button, options, expected = {}, id = undefined) {
       assert_idl_attribute(
         response,
         attribute,
-<<<<<<< HEAD
-        `Expected a ${attribute} IDL attribute`
-=======
         `Expected ${attribute} to be an IDL attribute.`
->>>>>>> Check payment response IDL attributes
       );
       assert_equals(
         response[attribute],

--- a/payment-request/payment-response/shippingAddress-attribute-manual.https.html
+++ b/payment-request/payment-response/shippingAddress-attribute-manual.https.html
@@ -13,6 +13,7 @@ async function checkNullShippingAddress(button, options) {
   const { request, response } = await getPaymentRequestResponse(options);
   await response.complete();
   test(() => {
+    assert_idl_attribute(response, "shippingAddress");
     assert_equals(
       response.shippingAddress,
       null,
@@ -32,6 +33,7 @@ async function runManualTest(button, options = {}, expected = {}, id) {
   await response.complete();
   test(() => {
     assert_equals(response.requestId, request.id, `Expected ids to match`);
+    assert_idl_attribute(response, "shippingAddress");
     const { shippingAddress: addr } = request;
     assert_true(
       addr instanceof PaymentAddress,


### PR DESCRIPTION
Applies to PaymentResponse attributes: 

* methodName 
* payerEmail 
* payerName
* payerPhone
* requestId 
* shippingOption
* shippingAddress

<!-- Reviewable:start -->

<!-- Reviewable:end -->
