### PR TITLE
Regression fix: remove redundant and incorrect array length assert

### DIFF
--- a/html/browsers/the-window-object/named-access-on-the-window-object/named-objects.html
+++ b/html/browsers/the-window-object/named-access-on-the-window-object/named-objects.html
@@ -32,7 +32,6 @@ test(function() {
 }, "Check if the first nested browsing context is returned by window['c']");
 
 test(function() {
-  assert_equals(window['a'].length, 5, "The length should be 5.");
   assert_true(window['a'] instanceof HTMLCollection);
   assert_array_equals(window['a'],
                       [ document.getElementById('embed1'),


### PR DESCRIPTION
Came up in https://github.com/whatwg/html/pull/3013. Regressed in 208fa49afa6e6cbd22ef26c9211fb1060f31ef00.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
