### PR TITLE
Fix some WebSocket test handlers

### DIFF
--- a/websockets/cookies/002.html
+++ b/websockets/cookies/002.html
@@ -17,6 +17,7 @@ async_test(function(t) {
   ws.onopen = t.step_func(function(e) {
     assert_regexp_match(document.cookie, new RegExp('ws_test_'+cookie_id+'=test'));
     ws.close();
+    ws.onclose = null;
     t.done();
   });
   ws.onerror = ws.onclose = t.step_func(function(e) {assert_unreached(e.type)});

--- a/websockets/cookies/003.html
+++ b/websockets/cookies/003.html
@@ -22,6 +22,7 @@ var t = async_test(function(t) {
     var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/echo-cookie');
     ws.onmessage = t.step_func(function(e) {
       ws.close();
+      ws.onclose = null;
       assert_regexp_match(e.data, new RegExp('ws_test_'+cookie_id+'=test'));
       t.done();
     });

--- a/websockets/cookies/004.html
+++ b/websockets/cookies/004.html
@@ -21,6 +21,7 @@ var t = async_test(function(t) {
   var ws = new WebSocket(url);
   ws.onopen = t.step_func(function(e) {
     ws.close();
+    ws.onclose = null;
     assert_false(new RegExp('ws_test_'+cookie_id+'=test').test(document.cookie));
     t.done();
   });

--- a/websockets/cookies/005.html
+++ b/websockets/cookies/005.html
@@ -23,6 +23,7 @@ var t = async_test(function(t) {
     var ws2 = new WebSocket(SCHEME_DOMAIN_PORT+'/echo-cookie');
     ws2.onmessage = t.step_func(function(e) {
       ws.close();
+      ws.onclose = null;
       ws2.close();
       assert_regexp_match(e.data, new RegExp('ws_test_'+cookie_id+'=test'));
       t.done();

--- a/websockets/cookies/007.html
+++ b/websockets/cookies/007.html
@@ -17,6 +17,7 @@ async_test(function(t) {
   var ws = new WebSocket(SCHEME_DOMAIN_PORT+'/set-cookie?'+cookie_id);
   ws.onopen = t.step_func(function(e) {
     ws.close();
+    ws.onclose = null;
     assert_regexp_match(document.cookie, new RegExp('ws_test_'+cookie_id+'=test'));
     t.done();
   });

--- a/websockets/handlers/handshake_no_protocol_wsh.py
+++ b/websockets/handlers/handshake_no_protocol_wsh.py
@@ -1,12 +1,8 @@
 #!/usr/bin/python
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
-
 def web_socket_do_extra_handshake(request):
-    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    # Trick pywebsocket into believing no subprotocol was requested.
+    request.ws_requested_protocols = None
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    pass

--- a/websockets/handlers/handshake_protocol_wsh.py
+++ b/websockets/handlers/handshake_protocol_wsh.py
@@ -1,12 +1,7 @@
 #!/usr/bin/python
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
-
 def web_socket_do_extra_handshake(request):
-    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASec-WebSocket-Protocol: foobar\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    request.ws_protocol = 'foobar'
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    pass

--- a/websockets/handlers/set-cookie-secure_wsh.py
+++ b/websockets/handlers/set-cookie-secure_wsh.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python
 import urlparse
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
-
 
 def web_socket_do_extra_handshake(request):
     url_parts = urlparse.urlsplit(request.uri)
-    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASet-Cookie: ws_test_'+(url_parts.query or '')+'=test; Secure; Path=/\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Secure; Path=/'))
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    # Expect close() from user agent.
+    request.ws_stream.receive_message()

--- a/websockets/handlers/set-cookie_http_wsh.py
+++ b/websockets/handlers/set-cookie_http_wsh.py
@@ -1,14 +1,11 @@
 #!/usr/bin/python
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
 import urlparse
 
 def web_socket_do_extra_handshake(request):
     url_parts = urlparse.urlsplit(request.uri)
-    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASet-Cookie: ws_test_'+(url_parts.query or '')+'=test; Path=/; HttpOnly\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Path=/; HttpOnly\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin))
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    # Expect close from user agent.
+    request.ws_stream.receive_message()

--- a/websockets/handlers/set-cookie_wsh.py
+++ b/websockets/handlers/set-cookie_wsh.py
@@ -1,15 +1,11 @@
 #!/usr/bin/python
 import urlparse
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
-
 
 def web_socket_do_extra_handshake(request):
     url_parts = urlparse.urlsplit(request.uri)
-    request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASet-Cookie: ws_test_'+(url_parts.query or '')+'=test; Path=/\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Path=/'))
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    # Expect close from user agent.
+    request.ws_stream.receive_message()

--- a/websockets/handlers/simple_handshake_wsh.py
+++ b/websockets/handlers/simple_handshake_wsh.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 
-import struct
-
 from mod_pywebsocket import common, stream
 from mod_pywebsocket.handshake import AbortedByUserException, hybi
 

--- a/websockets/handlers/simple_handshake_wsh.py
+++ b/websockets/handlers/simple_handshake_wsh.py
@@ -1,13 +1,25 @@
 #!/usr/bin/python
 
-from mod_pywebsocket import common, msgutil, util
-from mod_pywebsocket.handshake import hybi
+import struct
+
+from mod_pywebsocket import common, stream
+from mod_pywebsocket.handshake import AbortedByUserException, hybi
 
 
 def web_socket_do_extra_handshake(request):
+    # Send simple response header. This test implements the handshake
+    # manually. It's not clear why.
     request.connection.write('HTTP/1.1 101 Switching Protocols:\x0D\x0AConnection: Upgrade\x0D\x0AUpgrade: WebSocket\x0D\x0ASet-Cookie: ws_test=test\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin+'\x0D\x0ASec-WebSocket-Accept: '+hybi.compute_accept(request.headers_in.get(common.SEC_WEBSOCKET_KEY_HEADER))[0]+'\x0D\x0A\x0D\x0A')
-    return
+    # Send a clean close frame.
+    body = stream.create_closing_handshake_body(1000, '')
+    request.connection.write(stream.create_close_frame(body));
+    # Wait for the responding close frame from the user agent. It's not possible
+    # to use the stream methods at this point because the stream hasn't been
+    # established from pywebsocket's point of view. Instead just read the
+    # appropriate number of bytes and assume they are correct.
+    request.connection.read(8)
+    # Close the socket without pywebsocket sending its own handshake response.
+    raise AbortedByUserException('Abort the connection')
 
 def web_socket_transfer_data(request):
-    while True:
-        return
+    pass


### PR DESCRIPTION
Several of the pywebsocket handlers used in tests had the problem that they
would generate a hand-crafted header and then pywebsocket would add its own
header immediately afterwards, causing unnecessary errors.

In most cases there was no need to generate a hand-crafted header at all, so the
tests have been modified to use pywebsocket APIs to do the same
thing. simple_handshake_wsh.py still generates a hand-crafted header but now
suppresses pywebsocket's own header.

Several tests closed the WebSocket on the client side but the handler didn't
wait to receive the client-side close. These have been modified to wait for the
close frame.

Several tests had expectations that onclose would never be called but then
called close() themselves, causing onclose to be called. In some cases this was
mitigated by calling t.done() before t.unreached_func() was called, but it has
been fixed by disabling the onclose handler after calling close().

This change only fixes a subset of handlers and their affected tests. It is not
intended to be comprehensive, and many issues remain.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
