### PR TITLE
tests for gutters in grid layout

### DIFF
--- a/css/css-grid/alignment/grid-gutters-001.html
+++ b/css/css-grid/alignment/grid-gutters-001.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for gap shorthand property of row-gap and column-gap</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="match" href="../reference/grid-equal-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        gap: 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-002.html
+++ b/css/css-grid/alignment/grid-gutters-002.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for grid-gap shorthand property as an alias for gap</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-legacy">
+<link rel="match" href="../reference/grid-equal-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        grid-gap: 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-003.html
+++ b/css/css-grid/alignment/grid-gutters-003.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for gap shorthand property of row-gap and column-gap setting both to different values</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="match" href="../reference/grid-different-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        gap: 40px 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-004.html
+++ b/css/css-grid/alignment/grid-gutters-004.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for grid-gap shorthand property as an alias for gap setting both to different values</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-legacy">
+<link rel="match" href="../reference/grid-different-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        grid-gap: 40px 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-005.html
+++ b/css/css-grid/alignment/grid-gutters-005.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for row-gap and column-gap properties</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#column-row-gap">
+<link rel="match" href="../reference/grid-different-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        row-gap: 40px;
+        column-gap: 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-006.html
+++ b/css/css-grid/alignment/grid-gutters-006.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for grid-row-gap alias for row-gap and grid-column-gap for column-gap</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#column-row-gap">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-legacy">
+<link rel="match" href="../reference/grid-different-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        grid-row-gap: 40px;
+        grid-column-gap: 20px;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-007.html
+++ b/css/css-grid/alignment/grid-gutters-007.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for percentage values for gap with definite height and width for grid</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="match" href="../reference/grid-equal-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        height: 200px;
+        gap: 10%;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-008.html
+++ b/css/css-grid/alignment/grid-gutters-008.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for aliased support to gap of percentage values for grid-gap</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-legacy">
+<link rel="match" href="../reference/grid-equal-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width:200px;
+        height: 200px;
+        grid-gap: 10%;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-009.html
+++ b/css/css-grid/alignment/grid-gutters-009.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for percentage values for gap with no defined height for the grid</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="match" href="../reference/grid-collapsed-row-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width: 200px;
+        gap: 10%;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference. Column gap should be percentage of width. Row gap should resolve to auto, and therefore collapse to 0 height.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/alignment/grid-gutters-010.html
+++ b/css/css-grid/alignment/grid-gutters-010.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Test: Support for percentage values for grid-gap with no defined height for the grid as alias for gap</title>
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#gutters">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#gap-shorthand">
+<link rel="match" href="../reference/grid-collapsed-row-gutters-ref.html">
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk">
+<style>
+    #grid {
+        display: grid;
+        width: 200px;
+        grid-gap: 10%;
+        grid-template-columns: 90px 90px;
+        grid-template-rows: 90px 90px;
+        background-color: green;
+    }
+
+    #grid > div {
+        background-color: silver;
+    }
+</style>
+
+<p>The test passes if it has the same visual effect as reference. Column gap should be percentage of width. Row gap should resolve to auto, and therefore collapse to 0 height.</p>
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/reference/grid-collapsed-row-gutters-ref.html
+++ b/css/css-grid/reference/grid-collapsed-row-gutters-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: a square with a green bar</title>
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk" />
+<style>
+    #grid {
+        width:200px;
+        height: 180px;
+        background-color: green;
+        position: relative;
+    }
+
+    #grid > div {
+        background-color: silver;
+        width: 90px;
+        height: 90px;
+        position: absolute;
+    }
+
+    #grid :nth-child(1) {
+        top: 0;
+        left: 0;
+    }
+
+    #grid :nth-child(2) {
+        top: 0;
+        left: 110px;
+    }
+
+    #grid :nth-child(3) {
+        top: 90px;
+        left: 0;
+    }
+
+    #grid :nth-child(4) {
+        top: 90px;
+        left: 110px;
+    }
+</style>
+
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/reference/grid-different-gutters-ref.html
+++ b/css/css-grid/reference/grid-different-gutters-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: a square with a green cross</title>
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk" />
+<style>
+    #grid {
+        width:200px;
+        height: 220px;
+        background-color: green;
+        position: relative;
+    }
+
+    #grid > div {
+        background-color: silver;
+        width: 90px;
+        height: 90px;
+        position: absolute;
+    }
+
+    #grid :nth-child(1) {
+        top: 0;
+        left: 0;
+    }
+
+    #grid :nth-child(2) {
+        top: 0;
+        left: 110px;
+    }
+
+    #grid :nth-child(3) {
+        top: 130px;
+        left: 0;
+    }
+
+    #grid :nth-child(4) {
+        top: 130px;
+        left: 110px;
+    }
+</style>
+
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>

--- a/css/css-grid/reference/grid-equal-gutters-ref.html
+++ b/css/css-grid/reference/grid-equal-gutters-ref.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Layout Reference: a square with a green cross</title>
+<link rel="author" title="Rachel Andrew" href="mailto:me@rachelandrew.co.uk" />
+<style>
+    #grid {
+        width:200px;
+        height: 200px;
+        background-color: green;
+        position: relative;
+    }
+
+    #grid > div {
+        background-color: silver;
+        width: 90px;
+        height: 90px;
+        position: absolute;
+    }
+
+    #grid :nth-child(1) {
+        top: 0;
+        left: 0;
+    }
+
+    #grid :nth-child(2) {
+        top: 0;
+        left: 110px;
+    }
+
+    #grid :nth-child(3) {
+        top: 110px;
+        left: 0;
+    }
+
+    #grid :nth-child(4) {
+        top: 110px;
+        left: 110px;
+    }
+</style>
+
+<div id="grid">
+    <div></div>
+    <div></div>
+    <div></div>
+    <div></div>
+</div>


### PR DESCRIPTION
I wanted to add tests for issues [6](https://github.com/rachelandrew/gridbugs#6-the-grid-gap-property-should-accept-percentage-values) and [7](https://github.com/rachelandrew/gridbugs#7-grid-gaps-should-behave-as-auto-sized-tracks) on GridBugs. I couldn't find any gutter tests so made some.

With the CSS WG resolving to change `grid-gap` to `gap`, `grid-row-gap` to `row-gap` and `grid-column-gap` to `column-gap` it seemed sensible to have duplicates of each test testing the required aliases for the gutter implementation in Grid layout.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
