### PR TITLE
wai-aria: Add charset to test files; fix aria-activedescendant tests

### DIFF
--- a/wai-aria/alertdialog_modal_false-manual.html
+++ b/wai-aria/alertdialog_modal_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>alertdialog modal false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/alertdialog_modal_true-manual.html
+++ b/wai-aria/alertdialog_modal_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>alertdialog modal true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/application_activedescendant-manual.html
+++ b/wai-aria/application_activedescendant-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>application activedescendant</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -161,12 +162,6 @@
                   "states",
                   "contains",
                   "STATE_SYSTEM_FOCUSABLE"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "EVENT_OBJECT_FOCUS"
                ]
             ],
             "UIA" : [
@@ -197,7 +192,7 @@
   <body>
   <p>This test examines the ARIA properties for application activedescendant.</p>
      <div id='test' tabindex="0" aria-activedescendant="bob" role='application'>
-     <div id='bob' class='bobber'>Hello world</div>
+     <div id='bob' role='group'>Hello world</div>
   </div>
  then role:application, aria-activedescendant: bob
 

--- a/wai-aria/application_activedescendant_value_changes-manual.html
+++ b/wai-aria/application_activedescendant_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>application activedescendant value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -79,18 +80,6 @@
                   "AXUIElementIsAttributeSettable(AXFocused)",
                   "is",
                   "true"
-               ],
-               [
-                  "result",
-                  "array",
-                  "isNot",
-                  "true"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "AXSelectedChildrenChanged"
                ]
             ],
             "IAccessible2" : [
@@ -254,7 +243,7 @@
   <body>
   <p>This test examines the ARIA properties for application activedescendant value changes.</p>
      <div id='test' tabindex="0" role='application'>
-     <div id='bob' class='bobber'>Hello world</div>
+     <div id='bob' role='group'>Hello world</div>
   </div>
  then role:application, aria-activedescendant: bob generates a state change event
 

--- a/wai-aria/aria-current_not_declared-manual.html
+++ b/wai-aria/aria-current_not_declared-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current not declared</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_changes-manual.html
+++ b/wai-aria/aria-current_with_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_date-manual.html
+++ b/wai-aria/aria-current_with_value_date-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value date</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_location-manual.html
+++ b/wai-aria/aria-current_with_value_location-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value location</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_page-manual.html
+++ b/wai-aria/aria-current_with_value_page-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value page</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_step-manual.html
+++ b/wai-aria/aria-current_with_value_step-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value step</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_time-manual.html
+++ b/wai-aria/aria-current_with_value_time-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value time</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_true-manual.html
+++ b/wai-aria/aria-current_with_value_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-current_with_value_unspecified-manual.html
+++ b/wai-aria/aria-current_with_value_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-current with value unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-details_pointing_to_details_element-manual.html
+++ b/wai-aria/aria-details_pointing_to_details_element-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-details pointing to details element</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/aria-details_pointing_to_div_element-manual.html
+++ b/wai-aria/aria-details_pointing_to_div_element-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>aria-details pointing to div element</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/article_in_feed_posinset_and_setsize-manual.html
+++ b/wai-aria/article_in_feed_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>article in feed posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/article_in_feed_setsize_-1-manual.html
+++ b/wai-aria/article_in_feed_setsize_-1-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>article in feed setsize -1</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html
+++ b/wai-aria/article_not_in_feed_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>article not in feed posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_dialog-manual.html
+++ b/wai-aria/button_haspopup_dialog-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup dialog</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_emptystring-manual.html
+++ b/wai-aria/button_haspopup_emptystring-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup emptystring</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_false-manual.html
+++ b/wai-aria/button_haspopup_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_foo-manual.html
+++ b/wai-aria/button_haspopup_foo-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup foo</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_grid-manual.html
+++ b/wai-aria/button_haspopup_grid-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup grid</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_listbox-manual.html
+++ b/wai-aria/button_haspopup_listbox-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup listbox</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_menu-manual.html
+++ b/wai-aria/button_haspopup_menu-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup menu</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_tree-manual.html
+++ b/wai-aria/button_haspopup_tree-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup tree</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_true-manual.html
+++ b/wai-aria/button_haspopup_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_haspopup_unspecified-manual.html
+++ b/wai-aria/button_haspopup_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button haspopup unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_roledescription_empty-manual.html
+++ b/wai-aria/button_roledescription_empty-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button roledescription empty</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_roledescription_valid-manual.html
+++ b/wai-aria/button_roledescription_valid-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button roledescription valid</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/button_roledescription_whitespace_only-manual.html
+++ b/wai-aria/button_roledescription_whitespace_only-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>button roledescription whitespace only</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell-manual.html
+++ b/wai-aria/cell-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-colspan_2_on_div-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-colspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-colspan 2 on td html colspan 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_headers_and_border-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-colspan 2 on td html colspan 3 with headers and border</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_html_colspan_3_with_three_actual_columns-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-colspan 2 on td html colspan 3 with three actual columns</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html
+++ b/wai-aria/cell_aria-colspan_2_on_td_with_html_colspan_not_specified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-colspan 2 on td with html colspan not specified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-rowspan_2_on_div-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-rowspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-rowspan 2 on td html rowspan 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_td_html_rowspan_3_with_three_actual_rows-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-rowspan 2 on td html rowspan 3 with three actual rows</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html
+++ b/wai-aria/cell_aria-rowspan_2_on_td_with_html_rowspan_not_specified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell aria-rowspan 2 on td with html rowspan not specified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_colindex_4-manual.html
+++ b/wai-aria/cell_colindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell colindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/cell_rowindex_4-manual.html
+++ b/wai-aria/cell_rowindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>cell rowindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/checkbox_readonly_false-manual.html
+++ b/wai-aria/checkbox_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>checkbox readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/checkbox_readonly_true-manual.html
+++ b/wai-aria/checkbox_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>checkbox readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/checkbox_readonly_unspecified-manual.html
+++ b/wai-aria/checkbox_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>checkbox readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-colspan_2_on_div-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-colspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-colspan 2 on th html colspan 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_th_html_colspan_3_with_three_actual_columns-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-colspan 2 on th html colspan 3 with three actual columns</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html
+++ b/wai-aria/columnheader_aria-colspan_2_on_th_with_html_colspan_not_specified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-colspan 2 on th with html colspan not specified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html
+++ b/wai-aria/columnheader_aria-rowspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-rowspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html
+++ b/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-rowspan 2 on th html rowspan 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html
+++ b/wai-aria/columnheader_aria-rowspan_2_on_th_html_rowspan_3_with_three_actual_rows-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-rowspan 2 on th html rowspan 3 with three actual rows</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html
+++ b/wai-aria/columnheader_aria-rowspan_2_on_th_with_html_rowspan_not_specified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader aria-rowspan 2 on th with html rowspan not specified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_colindex_4-manual.html
+++ b/wai-aria/columnheader_colindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader colindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_rowindex_4-manual.html
+++ b/wai-aria/columnheader_rowindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader rowindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html
+++ b/wai-aria/columnheader_selected_false_not_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader selected false not automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html
+++ b/wai-aria/columnheader_selected_true_not_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>columnheader selected true not automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_controls_an_invalid_id-manual.html
+++ b/wai-aria/combobox_controls_an_invalid_id-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox controls an invalid ID</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_dialog-manual.html
+++ b/wai-aria/combobox_haspopup_dialog-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup dialog</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_false-manual.html
+++ b/wai-aria/combobox_haspopup_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_grid-manual.html
+++ b/wai-aria/combobox_haspopup_grid-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup grid</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_listbox-manual.html
+++ b/wai-aria/combobox_haspopup_listbox-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup listbox</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_menu-manual.html
+++ b/wai-aria/combobox_haspopup_menu-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup menu</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_tree-manual.html
+++ b/wai-aria/combobox_haspopup_tree-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup tree</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_true-manual.html
+++ b/wai-aria/combobox_haspopup_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_haspopup_unspecified-manual.html
+++ b/wai-aria/combobox_haspopup_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox haspopup unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_orientation_horizontal-manual.html
+++ b/wai-aria/combobox_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_orientation_unspecified-manual.html
+++ b/wai-aria/combobox_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_orientation_vertical-manual.html
+++ b/wai-aria/combobox_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_readonly_false-manual.html
+++ b/wai-aria/combobox_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_readonly_true-manual.html
+++ b/wai-aria/combobox_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/combobox_readonly_unspecified-manual.html
+++ b/wai-aria/combobox_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>combobox readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/dialog_modal_false-manual.html
+++ b/wai-aria/dialog_modal_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>dialog modal false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/dialog_modal_true-manual.html
+++ b/wai-aria/dialog_modal_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>dialog modal true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/dialog_modal_unspecified-manual.html
+++ b/wai-aria/dialog_modal_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>dialog modal unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/div_element_without_role_roledescription_valid-manual.html
+++ b/wai-aria/div_element_without_role_roledescription_valid-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>div element without role roledescription valid</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/errormessage_object_in_invalid_state-manual.html
+++ b/wai-aria/errormessage_object_in_invalid_state-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>errormessage object in invalid state</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/errormessage_object_in_valid_state-manual.html
+++ b/wai-aria/errormessage_object_in_valid_state-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>errormessage object in valid state</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/feed-manual.html
+++ b/wai-aria/feed-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>feed</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/figure-manual.html
+++ b/wai-aria/figure-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>figure</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html
+++ b/wai-aria/grid_aria-readonly_false_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid aria-readonly false automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html
+++ b/wai-aria/grid_aria-readonly_true_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid aria-readonly true automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_busy_false-manual.html
+++ b/wai-aria/grid_busy_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid busy false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_busy_true-manual.html
+++ b/wai-aria/grid_busy_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid busy true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_busy_value_changes-manual.html
+++ b/wai-aria/grid_busy_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid busy value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_colcount_8-manual.html
+++ b/wai-aria/grid_colcount_8-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid colcount 8</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_readonly_false-manual.html
+++ b/wai-aria/grid_columnheader_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_readonly_true-manual.html
+++ b/wai-aria/grid_columnheader_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_readonly_unspecified-manual.html
+++ b/wai-aria/grid_columnheader_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_required_false-manual.html
+++ b/wai-aria/grid_columnheader_required_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader required false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_required_true-manual.html
+++ b/wai-aria/grid_columnheader_required_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader required true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_columnheader_required_unspecified-manual.html
+++ b/wai-aria/grid_columnheader_required_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid columnheader required unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowcount_3-manual.html
+++ b/wai-aria/grid_rowcount_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowcount 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_readonly_false-manual.html
+++ b/wai-aria/grid_rowheader_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_readonly_true-manual.html
+++ b/wai-aria/grid_rowheader_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_readonly_unspecified-manual.html
+++ b/wai-aria/grid_rowheader_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_required_false-manual.html
+++ b/wai-aria/grid_rowheader_required_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader required false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_required_true-manual.html
+++ b/wai-aria/grid_rowheader_required_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader required true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/grid_rowheader_required_unspecified-manual.html
+++ b/wai-aria/grid_rowheader_required_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>grid rowheader required unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/gridcell_aria-colspan_2_on_div-manual.html
+++ b/wai-aria/gridcell_aria-colspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>gridcell aria-colspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html
+++ b/wai-aria/gridcell_aria-rowspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>gridcell aria-rowspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/gridcell_colindex_4-manual.html
+++ b/wai-aria/gridcell_colindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>gridcell colindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/gridcell_rowindex_4-manual.html
+++ b/wai-aria/gridcell_rowindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>gridcell rowindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/group_hidden_undefined_element_not_rendered-manual.html
+++ b/wai-aria/group_hidden_undefined_element_not_rendered-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>group hidden undefined element not rendered</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/group_hidden_undefined_element_rendered-manual.html
+++ b/wai-aria/group_hidden_undefined_element_rendered-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>group hidden undefined element rendered</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/heading_level_unspecified-manual.html
+++ b/wai-aria/heading_level_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>heading level unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/keyshortcuts_multiple_shortcuts-manual.html
+++ b/wai-aria/keyshortcuts_multiple_shortcuts-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>keyshortcuts multiple shortcuts</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/keyshortcuts_one_shortcut-manual.html
+++ b/wai-aria/keyshortcuts_one_shortcut-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>keyshortcuts one shortcut</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_busy_false-manual.html
+++ b/wai-aria/listbox_busy_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox busy false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_busy_true-manual.html
+++ b/wai-aria/listbox_busy_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox busy true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_orientation_horizontal-manual.html
+++ b/wai-aria/listbox_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_orientation_unspecified-manual.html
+++ b/wai-aria/listbox_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_orientation_vertical-manual.html
+++ b/wai-aria/listbox_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_readonly_false-manual.html
+++ b/wai-aria/listbox_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_readonly_true-manual.html
+++ b/wai-aria/listbox_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listbox_readonly_unspecified-manual.html
+++ b/wai-aria/listbox_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listbox readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/listitem_setsize_-1-manual.html
+++ b/wai-aria/listitem_setsize_-1-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>listitem setsize -1</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menu_orientation_horizontal-manual.html
+++ b/wai-aria/menu_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menu orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menu_orientation_unspecified-manual.html
+++ b/wai-aria/menu_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menu orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menu_orientation_vertical-manual.html
+++ b/wai-aria/menu_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menu orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menubar_busy_false-manual.html
+++ b/wai-aria/menubar_busy_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menubar busy false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menubar_busy_true-manual.html
+++ b/wai-aria/menubar_busy_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menubar busy true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menubar_orientation_horizontal-manual.html
+++ b/wai-aria/menubar_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menubar orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menubar_orientation_unspecified-manual.html
+++ b/wai-aria/menubar_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menubar orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menubar_orientation_vertical-manual.html
+++ b/wai-aria/menubar_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menubar orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitem_posinset_and_setsize-manual.html
+++ b/wai-aria/menuitem_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitem posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html
+++ b/wai-aria/menuitemcheckbox_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemcheckbox posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemcheckbox_readonly_false-manual.html
+++ b/wai-aria/menuitemcheckbox_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemcheckbox readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemcheckbox_readonly_true-manual.html
+++ b/wai-aria/menuitemcheckbox_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemcheckbox readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html
+++ b/wai-aria/menuitemcheckbox_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemcheckbox readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemradio_posinset_and_setsize-manual.html
+++ b/wai-aria/menuitemradio_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemradio posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemradio_readonly_false-manual.html
+++ b/wai-aria/menuitemradio_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemradio readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemradio_readonly_true-manual.html
+++ b/wai-aria/menuitemradio_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemradio readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/menuitemradio_readonly_unspecified-manual.html
+++ b/wai-aria/menuitemradio_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>menuitemradio readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/none-manual.html
+++ b/wai-aria/none-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>none</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/option_selected_false-manual.html
+++ b/wai-aria/option_selected_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>option selected false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/option_selected_true-manual.html
+++ b/wai-aria/option_selected_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>option selected true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/option_selected_undefined-manual.html
+++ b/wai-aria/option_selected_undefined-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>option selected undefined</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/option_selected_value_changes-manual.html
+++ b/wai-aria/option_selected_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>option selected value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -51,14 +52,6 @@
                   "1"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "AXSelectedChildrenChanged"
-               ]
-            ],
             "MSAA" : [
                [
                   "event",
@@ -96,7 +89,15 @@
                   "object:selection-changed"
                ]
             ],
-            "AXAPI" : []
+            "AXAPI" : [
+               [
+                  "event",
+                  "type",
+                  "is",
+                  "AXSelectedChildrenChanged"
+               ]
+            ],
+            "UIA" : []
          },
          "title" : "step 5",
          "type" : "test"
@@ -117,7 +118,8 @@
                   "is",
                   "0"
                ]
-            ]
+            ],
+            "AXAPI" : []
          },
          "title" : "step 6",
          "type" : "test"

--- a/wai-aria/radiogroup_orientation_horizontal-manual.html
+++ b/wai-aria/radiogroup_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/radiogroup_orientation_unspecified-manual.html
+++ b/wai-aria/radiogroup_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/radiogroup_orientation_vertical-manual.html
+++ b/wai-aria/radiogroup_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/radiogroup_readonly_false-manual.html
+++ b/wai-aria/radiogroup_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/radiogroup_readonly_true-manual.html
+++ b/wai-aria/radiogroup_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/radiogroup_readonly_unspecified-manual.html
+++ b/wai-aria/radiogroup_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>radiogroup readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/region_with_name-manual.html
+++ b/wai-aria/region_with_name-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>region with name</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/region_without_name-manual.html
+++ b/wai-aria/region_without_name-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>region without name</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/row_colindex_4-manual.html
+++ b/wai-aria/row_colindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>row colindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/row_rowindex_4-manual.html
+++ b/wai-aria/row_rowindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>row rowindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_aria-colspan_2_on_div-manual.html
+++ b/wai-aria/rowheader_aria-colspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader aria-colspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html
+++ b/wai-aria/rowheader_aria-rowspan_2_on_div-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader aria-rowspan 2 on div</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_colindex_4-manual.html
+++ b/wai-aria/rowheader_colindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader colindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_rowindex_4-manual.html
+++ b/wai-aria/rowheader_rowindex_4-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader rowindex 4</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html
+++ b/wai-aria/rowheader_selected_false_not_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader selected false not automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html
+++ b/wai-aria/rowheader_selected_true_not_automatically_propagated-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>rowheader selected true not automatically propagated</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/scrollbar_all_values_unspecified-manual.html
+++ b/wai-aria/scrollbar_all_values_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>scrollbar all values unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/scrollbar_only_valuenow_unspecified-manual.html
+++ b/wai-aria/scrollbar_only_valuenow_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>scrollbar only valuenow unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/scrollbar_orientation_unspecified-manual.html
+++ b/wai-aria/scrollbar_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>scrollbar orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox-manual.html
+++ b/wai-aria/searchbox-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_activedescendant-manual.html
+++ b/wai-aria/searchbox_activedescendant-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox activedescendant</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -153,18 +154,6 @@
                   "states",
                   "contains",
                   "STATE_FOCUSABLE"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "object:state-changed:focused"
-               ],
-               [
-                  "event",
-                  "detail1",
-                  "is",
-                  "1"
                ]
             ],
             "AXAPI" : [
@@ -179,12 +168,6 @@
                   "AXUIElementIsAttributeSettable(AXFocused)",
                   "is",
                   "true"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "AXFocusedUIElementChanged"
                ]
             ],
             "MSAA" : [
@@ -199,12 +182,6 @@
                   "states",
                   "contains",
                   "STATE_SYSTEM_FOCUSABLE"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "EVENT_OBJECT_FOCUS"
                ]
             ],
             "UIA" : [
@@ -219,12 +196,6 @@
                   "IUIAutomationElement.UIA_HasKeyboardFocusPropertyId",
                   "is",
                   "true"
-               ],
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "UIA_AutomationFocusChangedEventId"
                ]
             ]
          },
@@ -241,7 +212,7 @@
   <body>
   <p>This test examines the ARIA properties for searchbox activedescendant.</p>
      <div id='test' tabindex="0" aria-activedescendant="bob" role='searchbox'>
-     <div id='bob'>Hello world</div>
+     <div id='bob' role='group'>Hello world</div>
   </div>
  then role:searchbox, aria-activedescendant: bob
 

--- a/wai-aria/searchbox_activedescendant_value_changes-manual.html
+++ b/wai-aria/searchbox_activedescendant_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox activedescendant value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -87,21 +88,9 @@
                   "false"
                ],
                [
-                  "event",
-                  "type",
-                  "is",
-                  "AXSelectedChildrenChanged"
-               ],
-               [
                   "result",
                   "AXUIElementIsAttributeSettable(AXFocused)",
                   "is",
-                  "true"
-               ],
-               [
-                  "result",
-                  "array",
-                  "isNot",
                   "true"
                ]
             ],
@@ -272,7 +261,7 @@
   <body>
   <p>This test examines the ARIA properties for searchbox activedescendant value changes.</p>
      <div id='test' tabindex="0" role='searchbox'>
-     <div id='bob'>Hello world</div>
+     <div id='bob' role='group'>Hello world</div>
   </div>
  then role:searchbox, aria-activedescendant: bob
 

--- a/wai-aria/searchbox_autocomplete_both-manual.html
+++ b/wai-aria/searchbox_autocomplete_both-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox autocomplete both</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_autocomplete_inline-manual.html
+++ b/wai-aria/searchbox_autocomplete_inline-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox autocomplete inline</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_autocomplete_list-manual.html
+++ b/wai-aria/searchbox_autocomplete_list-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox autocomplete list</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_autocomplete_none-manual.html
+++ b/wai-aria/searchbox_autocomplete_none-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox autocomplete none</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_autocomplete_unspecified-manual.html
+++ b/wai-aria/searchbox_autocomplete_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox autocomplete unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_multiline_false-manual.html
+++ b/wai-aria/searchbox_multiline_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox multiline false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_multiline_true-manual.html
+++ b/wai-aria/searchbox_multiline_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox multiline true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_multiline_unspecified-manual.html
+++ b/wai-aria/searchbox_multiline_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox multiline unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_placeholder-manual.html
+++ b/wai-aria/searchbox_placeholder-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox placeholder</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_readonly_false-manual.html
+++ b/wai-aria/searchbox_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_readonly_true-manual.html
+++ b/wai-aria/searchbox_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_readonly_unspecified-manual.html
+++ b/wai-aria/searchbox_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_required_false-manual.html
+++ b/wai-aria/searchbox_required_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox required false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_required_true-manual.html
+++ b/wai-aria/searchbox_required_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox required true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/searchbox_required_unspecified-manual.html
+++ b/wai-aria/searchbox_required_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>searchbox required unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_focusable_all_values_unspecified-manual.html
+++ b/wai-aria/separator_focusable_all_values_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator focusable all values unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html
+++ b/wai-aria/separator_focusable_only_valuenow_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator focusable only valuenow unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_focusable_valuetext-manual.html
+++ b/wai-aria/separator_focusable_valuetext-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator focusable valuetext</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_orientation_unspecified-manual.html
+++ b/wai-aria/separator_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_unfocusable_all_values_unspecified-manual.html
+++ b/wai-aria/separator_unfocusable_all_values_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator unfocusable all values unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/separator_unfocusable_valuetext-manual.html
+++ b/wai-aria/separator_unfocusable_valuetext-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>separator unfocusable valuetext</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_all_values_unspecified-manual.html
+++ b/wai-aria/slider_all_values_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider all values unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_only_valuenow_unspecified-manual.html
+++ b/wai-aria/slider_only_valuenow_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider only valuenow unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_orientation_unspecified-manual.html
+++ b/wai-aria/slider_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_readonly_false-manual.html
+++ b/wai-aria/slider_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_readonly_true-manual.html
+++ b/wai-aria/slider_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/slider_readonly_unspecified-manual.html
+++ b/wai-aria/slider_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>slider readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/spinbutton_all_values_unspecified-manual.html
+++ b/wai-aria/spinbutton_all_values_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>spinbutton all values unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html
+++ b/wai-aria/spinbutton_only_aria-valuenow_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>spinbutton only aria-valuenow unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/spinbutton_readonly_false-manual.html
+++ b/wai-aria/spinbutton_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>spinbutton readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/spinbutton_readonly_true-manual.html
+++ b/wai-aria/spinbutton_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>spinbutton readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/spinbutton_readonly_unspecified-manual.html
+++ b/wai-aria/spinbutton_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>spinbutton readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_checked_false-manual.html
+++ b/wai-aria/switch_checked_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch checked false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_checked_mixed-manual.html
+++ b/wai-aria/switch_checked_mixed-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch checked mixed</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_checked_true-manual.html
+++ b/wai-aria/switch_checked_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch checked true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_checked_undefined-manual.html
+++ b/wai-aria/switch_checked_undefined-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch checked undefined</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_checked_value_changes-manual.html
+++ b/wai-aria/switch_checked_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch checked value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_readonly_false-manual.html
+++ b/wai-aria/switch_readonly_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch readonly false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_readonly_true-manual.html
+++ b/wai-aria/switch_readonly_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch readonly true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/switch_readonly_unspecified-manual.html
+++ b/wai-aria/switch_readonly_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>switch readonly unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tab_posinset_and_setsize-manual.html
+++ b/wai-aria/tab_posinset_and_setsize-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tab posinset and setsize</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/table_colcount_-1-manual.html
+++ b/wai-aria/table_colcount_-1-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>table colcount -1</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/table_colcount_8-manual.html
+++ b/wai-aria/table_colcount_8-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>table colcount 8</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/table_rowcount_-1-manual.html
+++ b/wai-aria/table_rowcount_-1-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>table rowcount -1</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/table_rowcount_3-manual.html
+++ b/wai-aria/table_rowcount_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>table rowcount 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tablist_orientation_horizontal-manual.html
+++ b/wai-aria/tablist_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tablist orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tablist_orientation_unspecified-manual.html
+++ b/wai-aria/tablist_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tablist orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tablist_orientation_vertical-manual.html
+++ b/wai-aria/tablist_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tablist orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/term_role-manual.html
+++ b/wai-aria/term_role-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>term role</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/textbox_placeholder-manual.html
+++ b/wai-aria/textbox_placeholder-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>textbox placeholder</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/toolbar_orientation_horizontal-manual.html
+++ b/wai-aria/toolbar_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>toolbar orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/toolbar_orientation_unspecified-manual.html
+++ b/wai-aria/toolbar_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>toolbar orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/toolbar_orientation_vertical-manual.html
+++ b/wai-aria/toolbar_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>toolbar orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tree_orientation_horizontal-manual.html
+++ b/wai-aria/tree_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tree orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tree_orientation_unspecified-manual.html
+++ b/wai-aria/tree_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tree orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/tree_orientation_vertical-manual.html
+++ b/wai-aria/tree_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>tree orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treegrid_colcount_8-manual.html
+++ b/wai-aria/treegrid_colcount_8-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treegrid colcount 8</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treegrid_orientation_horizontal-manual.html
+++ b/wai-aria/treegrid_orientation_horizontal-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treegrid orientation horizontal</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treegrid_orientation_unspecified-manual.html
+++ b/wai-aria/treegrid_orientation_unspecified-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treegrid orientation unspecified</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treegrid_orientation_vertical-manual.html
+++ b/wai-aria/treegrid_orientation_vertical-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treegrid orientation vertical</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treegrid_rowcount_3-manual.html
+++ b/wai-aria/treegrid_rowcount_3-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treegrid rowcount 3</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treeitem_selected_false-manual.html
+++ b/wai-aria/treeitem_selected_false-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treeitem selected false</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treeitem_selected_true-manual.html
+++ b/wai-aria/treeitem_selected_true-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treeitem selected true</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treeitem_selected_undefined-manual.html
+++ b/wai-aria/treeitem_selected_undefined-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treeitem selected undefined</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>

--- a/wai-aria/treeitem_selected_value_changes-manual.html
+++ b/wai-aria/treeitem_selected_value_changes-manual.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>treeitem selected value changes</title>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
     <script src="/resources/testharness.js"></script>
@@ -51,14 +52,6 @@
                   "1"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "event",
-                  "type",
-                  "is",
-                  "AXSelectedChildrenChanged"
-               ]
-            ],
             "MSAA" : [
                [
                   "event",
@@ -96,7 +89,15 @@
                   "object:selection-changed"
                ]
             ],
-            "AXAPI" : []
+            "AXAPI" : [
+               [
+                  "event",
+                  "type",
+                  "is",
+                  "AXSelectedChildrenChanged"
+               ]
+            ],
+            "UIA" : []
          },
          "title" : "step 5",
          "type" : "test"
@@ -117,7 +118,8 @@
                   "is",
                   "0"
                ]
-            ]
+            ],
+            "AXAPI" : []
          },
          "title" : "step 6",
          "type" : "test"


### PR DESCRIPTION
With respect to the aria-activedescendant tests:
* Remove initial, irrelevant focus-related event assertions
* Remove inexplicable "array" assertions
* Remove AXSelectedChildrenChanged assertion from role which does not
  support selection or selected children
* Move other AXSelectedChildrenChanged assertions from child to parent
* Add role to element which will become the activedescendant (as per spec)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
