### PR TITLE
Preserve the precision of a timestamp when converting it to string.

### DIFF
--- a/service-workers/service-worker/resources/update-max-aged-worker-imported-script.py
+++ b/service-workers/service-worker/resources/update-max-aged-worker-imported-script.py
@@ -6,7 +6,7 @@ def main(request, response):
                ('Last-Modified', time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime()))]
 
     body = '''
-        const importTime = {time};
+        const importTime = {time:8f};
     '''.format(time=time.time())
 
     return headers, body

--- a/service-workers/service-worker/resources/update-max-aged-worker.py
+++ b/service-workers/service-worker/resources/update-max-aged-worker.py
@@ -9,7 +9,7 @@ def main(request, response):
     test = request.GET['test']
 
     body = '''
-        const mainTime = {time};
+        const mainTime = {time:8f};
         const testName = {test};
         importScripts('update-max-aged-worker-imported-script.py');
 


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1391532 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7384)
<!-- Reviewable:end -->
