### PR TITLE
Ignore exceptions during wpt test teardown,

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -452,10 +452,14 @@ class MarionetteRefTestExecutor(RefTestExecutor):
         self.implementation.setup(**self.implementation_kwargs)
 
     def teardown(self):
-        self.implementation.teardown()
-        handle = self.protocol.marionette.window_handles[0]
-        self.protocol.marionette.switch_to_window(handle)
-        super(self.__class__, self).teardown()
+        try:
+            self.implementation.teardown()
+            handle = self.protocol.marionette.window_handles[0]
+            self.protocol.marionette.switch_to_window(handle)
+            super(self.__class__, self).teardown()
+        except Exception as e:
+            # Ignore errors during teardown
+            self.logger.warning(traceback.traceback.format_exc(e))
 
     def is_alive(self):
         return self.protocol.is_alive
@@ -489,10 +493,10 @@ class MarionetteRefTestExecutor(RefTestExecutor):
         test_url = self.test_url(test)
 
         return ExecuteAsyncScriptRun(self.logger,
-                             self._screenshot,
-                             self.protocol,
-                             test_url,
-                             timeout).run()
+                                     self._screenshot,
+                                     self.protocol,
+                                     test_url,
+                                     timeout).run()
 
     def _screenshot(self, marionette, url, timeout):
         marionette.navigate(url)
@@ -547,8 +551,10 @@ class InternalRefTestImplementation(object):
         try:
             self.executor.protocol.marionette._send_message("reftest:teardown", {})
             self.executor.protocol.marionette.set_context(self.executor.protocol.marionette.CONTEXT_CONTENT)
-        except socket.error:
-            pass
+        except Exception as e:
+            # Ignore errors during teardown
+            self.logger.warning(traceback.traceback.format_exc(e))
+
 
 
 class GeckoDriverProtocol(WebDriverProtocol):


### PR DESCRIPTION

In general these exceptions are the result of something unexpected in
the environment, but shouldn't themseslves cause the test to error.

MozReview-Commit-ID: 5XjJoT4UwnC

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1373444 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7391)
<!-- Reviewable:end -->
