### PR TITLE
Look for NoSuchWindowException when waiting for manual browser close in wpt,

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -175,6 +175,9 @@ class MarionetteProtocol(Protocol):
         while True:
             try:
                 self.marionette.execute_async_script("")
+            except errors.NoSuchWindowException:
+                # The window closed
+                break
             except errors.ScriptTimeoutException:
                 self.logger.debug("Script timed out")
                 pass
@@ -182,7 +185,7 @@ class MarionetteProtocol(Protocol):
                 self.logger.debug("Socket closed")
                 break
             except Exception as e:
-                self.logger.error(traceback.format_exc(e))
+                self.logger.warning(traceback.format_exc(e))
                 break
 
     def on_environment_change(self, old_environment, new_environment):


### PR DESCRIPTION

This method works by running a long-running script and catching the exception when
it is interrupted. But the exception changed so we must make a corresponding change here.

MozReview-Commit-ID: EdZZAOVZ0Sw

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1373444 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7392)
<!-- Reviewable:end -->
