### PR TITLE
Correctly apply the display fixup for ::before and ::after pseudo-elements.

### DIFF
--- a/cssom/getComputedStyle-pseudo.html
+++ b/cssom/getComputedStyle-pseudo.html
@@ -17,7 +17,9 @@
 #test::before,
 #test::after,
 #contents::before,
-#contents::after {
+#contents::after,
+#flex::before,
+#flex::after {
   content: " ";
   width: 50%;
   height: 10px;
@@ -30,10 +32,18 @@
 #none::after {
   content: "Foo";
 }
+#flex {
+  display: flex;
+}
+#flex-no-pseudo {
+  display: flex;
+}
 </style>
 <div id="test">
   <div id="contents"></div>
   <div id="none"></div>
+  <div id="flex"></div>
+  <div id="flex-no-pseudo"></div>
 </div>
 <script>
 test(function() {
@@ -67,4 +77,18 @@ test(function() {
                   "Pseudo-styles of display: none elements should be correct");
   });
 }, "Resolution of pseudo-element styles in display: none elements");
+test(function() {
+  var flex = document.getElementById('flex');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(flex, pseudo).display, "block",
+                  "Pseudo-styles of display: flex elements should get blockified");
+  });
+}, "Item-based blockification of pseudo-elements");
+test(function() {
+  var flexNoPseudo = document.getElementById('flex-no-pseudo');
+  [":before", ":after"].forEach(function(pseudo) {
+    assert_equals(getComputedStyle(flexNoPseudo, pseudo).display, "block",
+                  "Pseudo-styles of display: flex elements should get blockified");
+  });
+}, "Item-based blockification of nonexistent pseudo-elements");
 </script>


### PR DESCRIPTION

MozReview-Commit-ID: G0bcZmn0mP

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1393861 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7393)
<!-- Reviewable:end -->
