### PR TITLE
Fix --exclude and --include arguments to wptrunner,

### DIFF
--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -341,6 +341,7 @@ class TestFilter(object):
             self.manifest = manifestinclude.get_manifest(manifest_path)
         else:
             self.manifest = manifestinclude.IncludeManifest.create()
+            self.manifest.set_defaults()
 
         if include:
             self.manifest.set("skip", "true")


### PR DESCRIPTION

We need to set_default when creating an empty IncludeManifest so that skip is set.
This is pretty unfortunate.

MozReview-Commit-ID: 43Vwtu2bhvn

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1397215 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7394)
<!-- Reviewable:end -->
