### PR TITLE
Restore window state on maximizing, minimizing, and fullscreening.

### DIFF
--- a/webdriver/tests/contexts/maximize_window.py
+++ b/webdriver/tests/contexts/maximize_window.py
@@ -1,5 +1,8 @@
+# META: timeout=long
+
+from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
+from tests.support.fixtures import create_dialog
 from tests.support.inline import inline
-from tests.support.asserts import assert_error, assert_success
 
 
 alert_doc = inline("<script>window.alert()</script>")
@@ -13,24 +16,174 @@ def maximize(session):
 
 
 def test_no_browsing_context(session, create_window):
-    # step 1
+    """
+    2. If the current top-level browsing context is no longer open,
+    return error with error code no such window.
+
+    """
     session.window_handle = create_window()
     session.close()
     response = maximize(session)
     assert_error(response, "no such window")
 
 
-def test_handle_user_prompt(session):
-    # step 2
-    session.url = alert_doc
+def test_handle_prompt_dismiss_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_accept_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_ignore():
+    """TODO"""
+
+
+def test_handle_prompt_accept(new_session):
+    """
+    3. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - accept state
+           Accept the current user prompt.
+
+    """
+    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    session.url = inline("<title>WD doc title</title>")
+
+    create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
+    response = maximize(session)
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #1")
+
+    create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
+    response = maximize(session)
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #2")
+
+    create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
+    response = maximize(session)
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #3")
+
+
+def test_handle_prompt_missing_value(session, create_dialog):
+    """
+    3. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - missing value default state
+           1. Dismiss the current user prompt.
+           2. Return error with error code unexpected alert open.
+
+    """
+    session.url = inline("<title>WD doc title</title>")
+    create_dialog("alert", text="dismiss #1", result_var="dismiss1")
+
+    response = maximize(session)
+
+    assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #1")
+
+    create_dialog("confirm", text="dismiss #2", result_var="dismiss2")
+
     response = maximize(session)
     assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #2")
+
+    create_dialog("prompt", text="dismiss #3", result_var="dismiss3")
+
+    response = maximize(session)
+    assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #3")
+
+
+def test_fully_exit_fullscreen(session):
+    """
+    4. Fully exit fullscreen.
+
+    [...]
+
+    To fully exit fullscreen a document document, run these steps:
+
+      1. If document's fullscreen element is null, terminate these steps.
+
+      2. Unfullscreen elements whose fullscreen flag is set, within
+      document's top layer, except for document's fullscreen element.
+
+      3. Exit fullscreen document.
+
+    """
+    session.window.fullscreen()
+    assert session.execute_script("return window.fullScreen") is True
+
+    response = maximize(session)
+    assert_success(response)
+    assert session.execute_script("return window.fullScreen") is False
+
+
+def test_restore_the_window(session):
+    """
+    5. Restore the window.
+
+    [...]
+
+    To restore the window, given an operating system level window with
+    an associated top-level browsing context, run implementation-specific
+    steps to restore or unhide the window to the visible screen.  Do not
+    return from this operation until the visibility state of the top-level
+    browsing context's active document has reached the visible state,
+    or until the operation times out.
+
+    """
+    session.window.minimize()
+    assert session.execute_script("return document.hidden") is True
+
+    response = maximize(session)
+    assert_success(response)
 
 
 def test_maximize(session):
+    """
+    6. Maximize the window of the current browsing context.
+
+    [...]
+
+    To maximize the window, given an operating system level window with an
+    associated top-level browsing context, run the implementation-specific
+    steps to transition the operating system level window into the
+    maximized window state.  If the window manager supports window
+    resizing but does not have a concept of window maximation, the window
+    dimensions must be increased to the maximum available size permitted
+    by the window manager for the current screen.  Return when the window
+    has completed the transition, or within an implementation-defined
+    timeout.
+
+    """
     before_size = session.window.size
 
-    # step 4
     response = maximize(session)
     assert_success(response)
 

--- a/webdriver/tests/fullscreen_window.py
+++ b/webdriver/tests/fullscreen_window.py
@@ -1,8 +1,8 @@
 # META: timeout=long
 
-from tests.support.inline import inline
 from tests.support.asserts import assert_error, assert_success, assert_dialog_handled
 from tests.support.fixtures import create_dialog
+from tests.support.inline import inline
 
 
 alert_doc = inline("<script>window.alert()</script>")
@@ -19,30 +19,50 @@ def fullscreen(session):
 # 10.7.5 Fullscreen Window
 
 
-# 1. If the current top-level browsing context is no longer open, return error
-#    with error code no such window.
 def test_no_browsing_context(session, create_window):
-    # step 1
+    """
+    1. If the current top-level browsing context is no longer open,
+    return error with error code no such window.
+
+    """
     session.window_handle = create_window()
     session.close()
     response = fullscreen(session)
     assert_error(response, "no such window")
 
 
-# [...]
-# 2. Handle any user prompts and return its value if it is an error.
-# [...]
-# In order to handle any user prompts a remote end must take the following
-# steps:
-# 2. Run the substeps of the first matching user prompt handler:
-#
-#    [...]
-#    - accept state
-#      1. Accept the current user prompt.
-#    [...]
-#
-# 3. Return success.
+def test_handle_prompt_dismiss_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_accept_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_ignore():
+    """TODO"""
+
+
 def test_handle_prompt_accept(new_session):
+    """
+    2. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - accept state
+           Accept the current user prompt.
+
+    """
     _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
     session.url = inline("<title>WD doc title</title>")
     create_dialog(session)("alert", text="accept #1", result_var="accept1")
@@ -73,19 +93,27 @@ def test_handle_prompt_accept(new_session):
     assert read_global(session, "accept3") == ""
 
 
-# [...]
-# 2. Handle any user prompts and return its value if it is an error.
-# [...]
-# In order to handle any user prompts a remote end must take the following
-# steps:
-# 2. Run the substeps of the first matching user prompt handler:
-#
-#    [...]
-#    - missing value default state
-#    - not in the table of simple dialogs
-#      1. Dismiss the current user prompt.
-#      2. Return error with error code unexpected alert open.
 def test_handle_prompt_missing_value(session, create_dialog):
+    """
+    2. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - missing value default state
+           1. Dismiss the current user prompt.
+           2. Return error with error code unexpected alert open.
+
+    """
     session.url = inline("<title>WD doc title</title>")
     create_dialog("alert", text="dismiss #1", result_var="dismiss1")
 
@@ -112,13 +140,15 @@ def test_handle_prompt_missing_value(session, create_dialog):
     assert read_global(session, "dismiss3") == None
 
 
-# 4. Call fullscreen an element with the current top-level browsing
-# context's active document's document element.
 def test_fullscreen(session):
-    # step 4
+    """
+    4. Call fullscreen an element with the current top-level browsing
+    context's active document's document element.
+
+    """
     response = fullscreen(session)
     assert_success(response)
-    assert session.execute_script("return window.fullScreen") == True
+    assert session.execute_script("return window.fullScreen") is True
 
 
 # 5. Return success with the JSON serialization of the current top-level

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -55,12 +55,11 @@ def _dismiss_user_prompts(session):
 
 @ignore_exceptions
 def _restore_window_state(session):
-    """If the window is maximized, minimized, or fullscreened it will
-    be returned to normal state.
+    """Reset window to an acceptable size, bringing it out of maximized,
+    minimized, or fullscreened state
 
     """
-    if session.window.state in ("maximized", "minimized", "fullscreen"):
-        session.window.size = (800, 600)
+    session.window.size = (800, 600)
 
 
 @ignore_exceptions


### PR DESCRIPTION

When maximizing the window we must restore it from iconified state or
exit fullscreen first.  Likewise for minimizing the window, we must
exit fullscreen.  For fullscreening the window we need to also restore
the window.

MozReview-Commit-ID: AOQX2cV2C75

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1396866 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7404)
<!-- Reviewable:end -->
