### PR TITLE
Disable test_maximize_when_resized_to_max_size.

### DIFF
--- a/webdriver/tests/contexts/maximize_window.py
+++ b/webdriver/tests/contexts/maximize_window.py
@@ -249,6 +249,12 @@ def test_maximize_twice_is_idempotent(session):
     assert session.window.size == max_size
 
 
+"""
+TODO(ato): Implicit session start does not use configuration passed on
+from wptrunner.  This causes an exception.
+
+See https://bugzil.la/1398459.
+
 def test_maximize_when_resized_to_max_size(session):
     # Determine the largest available window size by first maximising
     # the window and getting the window rect dimensions.
@@ -258,7 +264,7 @@ def test_maximize_when_resized_to_max_size(session):
     available = session.window.maximize()
     session.end()
 
-    session.window.size = (int(available["width"]), int(available["height"]))
+    session.window.size = available
 
     # In certain window managers a window extending to the full available
     # dimensions of the screen may not imply that the window is maximised,
@@ -268,3 +274,4 @@ def test_maximize_when_resized_to_max_size(session):
     before = session.window.size
     session.window.maximize()
     assert session.window.size == before
+"""


### PR DESCRIPTION

This test causes both a failure and an error and we need to investigate
how to reuse the wptrunner session configuration when implicitly starting
a session.

MozReview-Commit-ID: 5k7nfevamZY

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1396866 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7406)
<!-- Reviewable:end -->
