### PR TITLE
fetch: Remove now-incorrect no-cors, non-empty integrity error test.

### DIFF
--- a/fetch/api/request/request-error.js
+++ b/fetch/api/request/request-error.js
@@ -32,10 +32,6 @@ const badRequestArgTests = [
     testName: "RequestInit's mode is no-cors and method is not simple"
   },
   {
-    args: ["", { "mode": "no-cors", "integrity": "not  an empty string" }],
-    testName: "RequestInit's mode is no-cors and integrity is not empty"
-  },
-  {
     args: ["", { "mode": "cors", "cache": "only-if-cached" }],
     testName: "RequestInit's cache mode is only-if-cached and mode is not same-origin"
   },


### PR DESCRIPTION
Since whatwg/fetch#584 was merged, no-cors, same-origin requests with
non-empty integrity values no longer throw a TypeError.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
