### PR TITLE
Wrap a function in test.step_func to avoid harness error

### DIFF
--- a/webrtc/simplecall.html
+++ b/webrtc/simplecall.html
@@ -108,15 +108,13 @@ property to true in Firefox.
 
   // Returns a suitable error callback.
   function failed(function_name) {
-    return test.step_func(function() {
-      assert_unreached('WebRTC called error callback for ' + function_name);
-    });
+    return test.unreached_func('WebRTC called error callback for ' + function_name);
   }
 
   // This function starts the test.
   test.step(function() {
     navigator.mediaDevices.getUserMedia({ video: true, audio: true })
-      .then(getUserMediaOkCallback, failed('getUserMedia'));
+      .then(test.step_func(getUserMediaOkCallback), failed('getUserMedia'));
   });
 </script>
 


### PR DESCRIPTION
Drive-by: simplify the failed() helper a bit.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
