### PR TITLE
[css-ui-3] Mark support for non fixed size svg as optional

### DIFF
--- a/css/css-ui-3/cursor-image-005-nfs.html
+++ b/css/css-ui-3/cursor-image-005-nfs.html
@@ -4,7 +4,7 @@
 <link rel="reviewer" title="Florian Rivoal" href="http://florian.rivoal.net/"> <!-- 2015-04-12 -->
 <link rel="help" href="http://www.w3.org/TR/css3-ui/#cursor">
 <link rel="help" href="http://www.w3.org/TR/css3-images/#default-object-size">
-<meta name="flags" content="interact svg">
+<meta name="flags" content="interact svg may">
 <meta charset="UTF-8">
 <meta name="assert" content="Test checks that an SVG image with no fixed size is supported as a custom cursor at the default object size for cursor images.">
 <style>


### PR DESCRIPTION
This is to match the following spec change: https://github.com/w3c/csswg-drafts/commit/5dcad3014735dbe9828273d952e2eb3115f33d5b

<!-- Reviewable:start -->

<!-- Reviewable:end -->
