### PR TITLE
[css-text-3] Add tests for line-break:anywhere

### DIFF
--- a/css/css-text-3/line-break/line-break-anywhere-001.html
+++ b/css/css-text-3/line-break/line-break-anywhere-001.html
@@ -1,0 +1,32 @@
+﻿<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: line-break: anywhere</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-line-break-anywhere">
+<link rel="match" href="reference/line-break-anywhere-001-ref.html">
+<meta name="flags" content="">
+<meta name="assert" content="line-break:anywhere puts a soft wrap opportunity around every typographic character unit,
+                             including around punctuation or in the middle of words,
+                             disregarding any prohibition against line breaks introduced by characters with the GL, JW, or ZJW character class.">
+<style>
+#green {
+  position: absolute;
+  background: green;
+  font-family: monospace;
+  width: 1ch;
+  height: 20em;
+}
+#test {
+  width: 1ch;
+  line-height: 1;
+  color: red;
+  font-family: monospace;
+  line-break: anywhere;
+}
+</style>
+
+<p>Test passes if there is a green rectangle below and no red.</p>
+<div id=green></div>
+<!-- with line breaks everywhere, none of the following characters should stick out from under the green div -->
+<div id=test>aa-a.a)a,a）a&nbsp;a&#xfeff;a&#x2060;a&#x200d;a･a</div>

--- a/css/css-text-3/line-break/line-break-anywhere-002.html
+++ b/css/css-text-3/line-break/line-break-anywhere-002.html
@@ -1,0 +1,32 @@
+﻿<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test: line-break: anywhere</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-line-break-anywhere">
+<link rel="match" href="reference/line-break-anywhere-001-ref.html">
+<meta name="flags" content="">
+<meta name="assert" content="line-break:anywhere puts a soft wrap opportunity betwwen letters in the middle of words and hyphenation is not applied.">
+<style>
+#green {
+  position: absolute;
+  background: green;
+  font-family: monospace;
+  width: 1ch;
+  height: 20em;
+}
+#test {
+  width: 1ch;
+  line-height: 1;
+  color: red;
+  font-family: monospace;
+  line-break: anywhere;
+  hyphens: auto;
+}
+</style>
+
+<p>Test passes if there is a green rectangle below and no red.</p>
+<div id=green></div>
+<!-- Hyphenation, if it occurs, will produce a hyphen that sticks out from under the green rectangle.
+     Also, if the words fails to be wrapped between all letters, letters will also stick out from under the green rectangle -->
+<div id=test>no hyphenation</div>

--- a/css/css-text-3/line-break/reference/line-break-anywhere-001-ref.html
+++ b/css/css-text-3/line-break/reference/line-break-anywhere-001-ref.html
@@ -1,0 +1,17 @@
+﻿<!DOCTYPE html>
+<html lang=en>
+<meta charset="utf-8">
+<title>CSS Text Test Reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+#green {
+  position: absolute;
+  background: green;
+  font-family: monospace;
+  width: 1ch;
+  height: 20em;
+}
+</style>
+
+<p>Test passes if there is a green rectangle below and no red.</p>
+<div id=green></div>


### PR DESCRIPTION
Tests for https://drafts.csswg.org/css-text-3/#valdef-line-break-anywhere, as added in https://github.com/w3c/csswg-drafts/issues/1171 / https://github.com/w3c/csswg-drafts/issues/1561 / https://github.com/w3c/csswg-drafts/commit/c2beab13bcc63aa8597ad5d97ab7faee1cc5182f

<!-- Reviewable:start -->

<!-- Reviewable:end -->
