### PR TITLE
Fix lower-case digest algorithm name test

### DIFF
--- a/WebCryptoAPI/digest/digest.js
+++ b/WebCryptoAPI/digest/digest.js
@@ -61,11 +61,11 @@ function run_test() {
             }, upCase + " with " + size + " source data");
 
             promise_test(function(test) {
-                var promise = subtle.digest({name: mixedCase}, sourceData[size])
+                var promise = subtle.digest({name: downCase}, sourceData[size])
                 .then(function(result) {
                     assert_true(equalBuffers(result, digestedData[alg][size]), "digest() yielded expected result for " + alg + ":" + size);
                 }, function(err) {
-                    assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);mixedCase
+                    assert_unreached("digest() threw an error for " + alg + ":" + size + " - " + err.message);
                 });
 
                 return promise;


### PR DESCRIPTION
The surrounding context in WebCryptoAPI/digest/digest.js suggests that the second test was meant to test lower-case algorithm names, not mixed-case, which is tested in the third test.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
