### PR TITLE
Fix css/css-shapes-1 test to not have reftest <link>

### DIFF
--- a/css/css-shapes-1/spec-examples/shape-outside-012.html
+++ b/css/css-shapes-1/spec-examples/shape-outside-012.html
@@ -7,7 +7,6 @@
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shapes-from-image"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-outside-property"/>
     <link rel="help" href="http://www.w3.org/TR/css-shapes-1/#shape-image-threshold-property"/>
-    <link rel="match" href="reference/shape-outside-012-ref.html"/>
     <meta name="flags" content="ahem dom"/>
     <meta name="assert" content="This test verifies content flows around a shape that is
                                  defined in the image's alpha channel and adjusted by the

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -374,7 +374,6 @@ SUPPORT-WRONG-DIR: css/WOFF2/manifest.txt
 SUPPORT-WRONG-DIR: css/WOFF2/testcaseindex.xht
 NON-EXISTENT-REF: css/css-masking-1/clip-path-svg-content/clip-path-clip-rule-008.svg
 NON-EXISTENT-REF: css/css-masking-1/clip-path-svg-content/clip-path-precision-001.svg
-NON-EXISTENT-REF: css/css-shapes-1/spec-examples/shape-outside-012.html
 NON-EXISTENT-REF: css/CSS2/tables/border-collapse-005.html
 NON-EXISTENT-REF: css/mediaqueries-3/relative-units-002.html
 NON-EXISTENT-REF: css/mediaqueries-3/relative-units-003.html


### PR DESCRIPTION
This is fallout from 3137b884e178d57919bcada6913d644e669c6624 which removed `<link rel=match>` links from every other test it touched

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7467)
<!-- Reviewable:end -->
