### PR TITLE
fetch: Reduce flakiness in integrity.html.

### DIFF
--- a/fetch/api/basic/integrity.js
+++ b/fetch/api/basic/integrity.js
@@ -8,11 +8,10 @@ function integrity(desc, url, integrity, initRequestMode, shouldPass) {
   if (!!initRequestMode && initRequestMode !== "") {
     fetchRequestInit.mode = initRequestMode;
   }
-  var fetchPromise = fetch(url, fetchRequestInit);
 
   if (shouldPass) {
     promise_test(function(test) {
-      return fetchPromise.then(function(resp) {
+      return fetch(url, fetchRequestInit).then(function(resp) {
         if (initRequestMode !== "no-cors") {
           assert_equals(resp.status, 200, "Response's status is 200");
         } else {
@@ -23,7 +22,7 @@ function integrity(desc, url, integrity, initRequestMode, shouldPass) {
     }, desc);
   } else {
     promise_test(function(test) {
-      return promise_rejects(test, new TypeError(), fetchPromise);
+      return promise_rejects(test, new TypeError(), fetch(url, fetchRequestInit));
     }, desc);
   }
 }


### PR DESCRIPTION
Commit 96adf8a1a0cd ("P4: Modify wpt test to verify only the opaque response
with the empty string will pass the SRI check") stored the promise returned
by fetch() in a separate variable, fetchPromise, which is later used in
calls to promise_test() and promise_rejects().

In the test cases where a fetch failure is expected there is a window
between fetch() returning a rejected promise and promise_rejects() being
called to connect a proper handler for the rejection.

While everything still works correctly, when this happens testharness'
"unhandledrejection" event handler will log a non-existent failure which can be
included in the test's output and cause flakiness (it happens at least with
Blink).

Fix it by dropping fetchPromise in favor of two separate calls to fetch(),
just like the code did in the past.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
