### PR TITLE
observing an empty sequence of entryTypes is a no-op

### DIFF
--- a/performance-timeline/po-observe.any.js
+++ b/performance-timeline/po-observe.any.js
@@ -14,16 +14,18 @@
     assert_throws(new TypeError(), function () {
       obs.observe({entryTypes: "mark"});
     });
-    assert_throws(new TypeError(), function () {
-      obs.observe({entryTypes: []});
-    });
-    assert_throws(new TypeError(), function () {
-      obs.observe({entryTypes: ["this-cannot-match-an-entryType"]});
-    });
-    assert_throws(new TypeError(), function () {
-      obs.observe({entryTypes: ["marks","navigate", "resources"]});
-    });
-  }, "Empty sequence entryTypes throws a TypeError");
+  }, "entryTypes must be a sequence or throw a TypeError");
+
+  test(function () {
+    var obs = new PerformanceObserver(function () { return true; });
+    obs.observe({entryTypes: []});
+  }, "Empty sequence entryTypes is a no-op");
+
+  test(function () {
+    var obs = new PerformanceObserver(function () { return true; });
+    obs.observe({entryTypes: ["this-cannot-match-an-entryType"]});
+    obs.observe({entryTypes: ["marks","navigate", "resources"]});
+  }, "Unknown entryTypes are no-op");
 
   test(function () {
     var obs = new PerformanceObserver(function () { return true; });


### PR DESCRIPTION
This reflects spec change proposed at
 https://github.com/w3c/performance-timeline/pull/88

<!-- Reviewable:start -->

<!-- Reviewable:end -->
