### PR TITLE
Add more tests for FileReader.result.

### DIFF
--- a/FileAPI/reading-data-section/filereader_events.any.js
+++ b/FileAPI/reading-data-section/filereader_events.any.js
@@ -1,0 +1,19 @@
+promise_test(async t => {
+  var reader = new FileReader();
+  var eventWatcher = new EventWatcher(t, reader, ['loadstart', 'progress', 'abort', 'error', 'load', 'loadend']);
+  reader.readAsText(new Blob([]));
+  await eventWatcher.wait_for('loadstart');
+  // No progress event for an empty blob, as no data is loaded.
+  await eventWatcher.wait_for('load');
+  await eventWatcher.wait_for('loadend');
+}, 'events are dispatched in the correct order for an empty blob');
+
+promise_test(async t => {
+  var reader = new FileReader();
+  var eventWatcher = new EventWatcher(t, reader, ['loadstart', 'progress', 'abort', 'error', 'load', 'loadend']);
+  reader.readAsText(new Blob(['a']));
+  await eventWatcher.wait_for('loadstart');
+  await eventWatcher.wait_for('progress');
+  await eventWatcher.wait_for('load');
+  await eventWatcher.wait_for('loadend');
+}, 'events are dispatched in the correct order for a non-empty blob');

--- a/FileAPI/reading-data-section/filereader_result.html
+++ b/FileAPI/reading-data-section/filereader_result.html
@@ -12,9 +12,10 @@
     <div id="log"></div>
 
     <script>
-    var blob;
+    var blob, blob2;
     setup(function() {
       blob = new Blob(["This test the result attribute"]);
+      blob2 = new Blob(["This is a second blob"]);
     });
 
     async_test(function() {
@@ -54,6 +55,61 @@
 
       readArrayBuffer.readAsArrayBuffer(blob);
     }, "readAsArrayBuffer");
+
+    async_test(function() {
+      var readBinaryString = new FileReader();
+      assert_equals(readBinaryString.result, null);
+
+      readBinaryString.onloadend = this.step_func(function(evt) {
+        assert_equals(typeof readBinaryString.result, "string", "The result type is string");
+        assert_equals(readBinaryString.result, "This test the result attribute", "The result is correct");
+        console.log(readBinaryString.result);
+        this.done();
+      });
+
+      readBinaryString.readAsBinaryString(blob);
+    }, "readAsBinaryString");
+
+
+    function resultDuringLoadTest(readMethod, event) {
+      async_test(function() {
+        var reader = new FileReader();
+        assert_equals(reader.result, null);
+
+        reader.addEventListener(event, this.step_func_done(function(evt) {
+          assert_equals(reader.result, null);
+        }));
+
+        reader[readMethod](blob);
+      }, 'result is null during "' + event + '" event for ' + readMethod);
+
+      async_test(function() {
+        var reader = new FileReader();
+        reader.onloadend = this.step_func(function(evt) {
+          assert_not_equals(reader.result, null);
+          var first_result = reader.result;
+
+          reader.addEventListener(event, this.step_func_done(function(evt) {
+            assert_equals(reader.result, first_result);
+          }));
+
+          reader[readMethod](blob2);
+        });
+
+        reader[readMethod](blob);
+      }, 'result keeps old value during "' + event + '" event for ' + readMethod);
+    }
+
+    function resultDuringLoadTests(readMethod) {
+      resultDuringLoadTest(readMethod, 'loadstart');
+      resultDuringLoadTest(readMethod, 'progress');
+    }
+
+    resultDuringLoadTests('readAsText');
+    resultDuringLoadTests('readAsDataURL');
+    resultDuringLoadTests('readAsArrayBuffer');
+    resultDuringLoadTests('readAsBinaryString');
+
     </script>
   </body>
 </html>

--- a/FileAPI/reading-data-section/filereader_result.html
+++ b/FileAPI/reading-data-section/filereader_result.html
@@ -63,7 +63,6 @@
       readBinaryString.onloadend = this.step_func(function(evt) {
         assert_equals(typeof readBinaryString.result, "string", "The result type is string");
         assert_equals(readBinaryString.result, "This test the result attribute", "The result is correct");
-        console.log(readBinaryString.result);
         this.done();
       });
 

--- a/FileAPI/reading-data-section/filereader_result.html
+++ b/FileAPI/reading-data-section/filereader_result.html
@@ -71,45 +71,28 @@
     }, "readAsBinaryString");
 
 
-    function resultDuringLoadTest(readMethod, event) {
-      async_test(function() {
-        var reader = new FileReader();
-        assert_equals(reader.result, null);
+    for (let event of ['loadstart', 'progress']) {
+      for (let method of ['readAsText', 'readAsDataURL', 'readAsArrayBuffer', 'readAsBinaryString']) {
+        promise_test(async function(t) {
+          var reader = new FileReader();
+          assert_equals(reader.result, null, 'result is null before read');
 
-        reader.addEventListener(event, this.step_func_done(function(evt) {
-          assert_equals(reader.result, null);
-        }));
+          var eventWatcher = new EventWatcher(t, reader,
+              [event, 'loadend']);
 
-        reader[readMethod](blob);
-      }, 'result is null during "' + event + '" event for ' + readMethod);
-
-      async_test(function() {
-        var reader = new FileReader();
-        reader.onloadend = this.step_func(function(evt) {
+          reader[method](blob);
+          assert_equals(reader.result, null, 'result is null after first read call');
+          await eventWatcher.wait_for(event);
+          assert_equals(reader.result, null, 'result is null during event');
+          await eventWatcher.wait_for('loadend');
           assert_not_equals(reader.result, null);
-          var first_result = reader.result;
-
-          reader.addEventListener(event, this.step_func_done(function(evt) {
-            assert_equals(reader.result, first_result);
-          }));
-
-          reader[readMethod](blob2);
-        });
-
-        reader[readMethod](blob);
-      }, 'result keeps old value during "' + event + '" event for ' + readMethod);
+          reader[method](blob);
+          assert_equals(reader.result, null, 'result is null after second read call');
+          await eventWatcher.wait_for(event);
+          assert_equals(reader.result, null, 'result is null during second read event');
+        }, 'result is null during "' + event + '" event for ' + method);
+      }
     }
-
-    function resultDuringLoadTests(readMethod) {
-      resultDuringLoadTest(readMethod, 'loadstart');
-      resultDuringLoadTest(readMethod, 'progress');
-    }
-
-    resultDuringLoadTests('readAsText');
-    resultDuringLoadTests('readAsDataURL');
-    resultDuringLoadTests('readAsArrayBuffer');
-    resultDuringLoadTests('readAsBinaryString');
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
In particular this adds tests to verify the value of the attribute
during progress and loadstart events.

I think this matches what the spec currently says, but there are some open questions in https://github.com/w3c/FileAPI/issues/79 about what the spec should actually say, so we should probably not merge this until we figure out what the desired behavior actually is.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
