### PR TITLE
wai-aria/tools Have make_tests.pl strip out colons from file names

### DIFF
--- a/wai-aria/tools/make_tests.pl
+++ b/wai-aria/tools/make_tests.pl
@@ -464,7 +464,7 @@ sub build_test() {
   $fileName =~ s/\s*$//;
   $fileName =~ s/\///g;
   $fileName =~ s/\s+/_/g;
-  $fileName =~ s/[,=]/_/g;
+  $fileName =~ s/[,=:]/_/g;
   $fileName =~ s/['"]//g;
 
   my $count = 2;


### PR DESCRIPTION
Replace ":" with "_" when generating tests. See related pull request #7497.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
