### PR TITLE
Tentatively test removal of `<meta http-equiv="set-cookie">`

### DIFF
--- a/cookies/meta-blocked.tentative.html
+++ b/cookies/meta-blocked.tentative.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<head>
+  <meta http-equiv="set-cookie" content="meta-set-cookie=1">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <script>
+    test(t => {
+      assert_equals(document.cookie.indexOf('meta-set-cookie'), -1);
+    }, "Cookie is not set from `<meta>`.");
+  </script>
+</body>


### PR DESCRIPTION
`<meta http-equiv="set-cookie" ...>` is an attack vector, and doesn't
seem to be used widely enough to justify keeping it in the platform.
This patch contains a tentative test for removing that functionality,
as discussed in whatwg/html#3076.

Chrome has approved an [intent to deprecate][1], and [Edge][2] and
[Firefox][3] have both expressed support.

[1]: https://groups.google.com/a/chromium.org/d/msg/blink-dev/0sJ8GUJO0Dw/iMmcXLIGBAAJ
[2]: https://twitter.com/patrickkettner/status/911282308337983489
[3]: https://github.com/whatwg/html/pull/3011#issuecomment-331181807

<!-- Reviewable:start -->

<!-- Reviewable:end -->
