### PR TITLE
Remove vendor prefix support in webaudio/; assert their absense

### DIFF
--- a/webaudio/historical.html
+++ b/webaudio/historical.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>Historical Web Audio API features</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+[
+  "webkitAudioContext",
+  "webkitAudioPannerNode",
+  "webkitOfflineAudioContext",
+].forEach(name => {
+  test(function() {
+    assert_false(name in window);
+  }, name + " interface should not exist");
+});
+</script>

--- a/webaudio/js/vendor-prefixes.js
+++ b/webaudio/js/vendor-prefixes.js
@@ -1,2 +1,0 @@
-window.AudioContext = window.AudioContext || window.webkitAudioContext;
-window.OfflineAudioContext = window.OfflineAudioContext || window.webkitOfflineAudioContext;

--- a/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiobuffer-interface/idl-test.html
@@ -2,7 +2,13 @@
 <html class="a">
 <head>
 <title>AudioBuffer IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/webaudio/js/lodash.js"></script>
+<script src="/webaudio/js/helpers.js"></script>
+<style type="text/css">
     #event-target-idl,
     #base-audio-context-idl
     { visibility:hidden; height: 0px;}

--- a/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audiodestinationnode-interface/idl-test.html
@@ -2,7 +2,13 @@
 <html class="a">
 <head>
 <title>AudioDestinationNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/webaudio/js/lodash.js"></script>
+<script src="/webaudio/js/helpers.js"></script>
+<style type="text/css">
     #event-target-idl,
     #base-audio-context-idl,
     #audio-node-idl

--- a/webaudio/the-audio-api/the-audioparam-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-audioparam-interface/idl-test.html
@@ -2,7 +2,13 @@
 <html class="a">
 <head>
 <title>AudioParam IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/webaudio/js/lodash.js"></script>
+<script src="/webaudio/js/helpers.js"></script>
+<style type="text/css">
     #audio-param-idl
     { visibility:hidden; height: 0px;}
   </style>

--- a/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
@@ -2,7 +2,13 @@
 <html class="a">
 <head>
 <title>DelayNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/webaudio/js/lodash.js"></script>
+<script src="/webaudio/js/helpers.js"></script>
+<style type="text/css">
     #event-target-idl,
     #base-audio-context-idl,
     #audio-node-idl,

--- a/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
@@ -2,7 +2,13 @@
 <html class="a">
 <head>
 <title>GainNode IDL Test</title>
-<script src="/resources/testharness.js"></script><script src="/resources/testharnessreport.js"></script><script src="/resources/idlharness.js"></script><script src="/resources/WebIDLParser.js"></script><script src="/webaudio/js/lodash.js"></script><script src="/webaudio/js/vendor-prefixes.js"></script><script src="/webaudio/js/helpers.js"></script><style type="text/css">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/webaudio/js/lodash.js"></script>
+<script src="/webaudio/js/helpers.js"></script>
+<style type="text/css">
     #event-target-idl,
     #base-audio-context-idl,
     #audio-node-idl,

--- a/webaudio/the-audio-api/the-gainnode-interface/test-gainnode.html
+++ b/webaudio/the-audio-api/the-gainnode-interface/test-gainnode.html
@@ -15,7 +15,6 @@ Based on a test from the WebKit test suite
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/webaudio/js/lodash.js"></script>
-  <script src="/webaudio/js/vendor-prefixes.js"></script>
   <script src="/webaudio/js/helpers.js"></script>
   <script src="/webaudio/js/buffer-loader.js"></script>
  </head>

--- a/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
+++ b/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSourceToScriptProcessorTest.html
@@ -17,7 +17,6 @@ Somewhat similiar to a test from Mozilla:
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/webaudio/js/lodash.js"></script>
-  <script src="/webaudio/js/vendor-prefixes.js"></script>
   <script src="/webaudio/js/helpers.js"></script>
   <script src="/webaudio/js/buffer-loader.js"></script>
  </head>

--- a/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
+++ b/webaudio/the-audio-api/the-waveshapernode-interface/curve-tests.html
@@ -5,7 +5,6 @@
 
 	<script type="text/javascript" src="/resources/testharness.js"></script>
 	<script type="text/javascript" src="/resources/testharnessreport.js"></script>
-	<script type="text/javascript" src="../../js/vendor-prefixes.js"></script>
 </head>
 <body>
 	<div id="log">


### PR DESCRIPTION
See the many other historical.html in the repo for precedence. Of
course, if they are added to some standard, then it would be
appropriate to instead assert that they exist. (Prefixes are not the
problem, lack of standardization is.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
