### PR TITLE
Fixed variable name typo

### DIFF
--- a/webdriver/tests/get_window_rect.py
+++ b/webdriver/tests/get_window_rect.py
@@ -102,7 +102,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     response = get_window_rect(session)
 
-    assert_error(result, "unexpected alert open")
+    assert_error(response, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog("confirm", text="dismiss #2", result_var="dismiss2")


### PR DESCRIPTION
Always throws an error because the variable 'result' doesn't exist

<!-- Reviewable:start -->

<!-- Reviewable:end -->
