### PR TITLE
Adds for XMLHttpRequest's documentXML and responseType in a worker

### DIFF
--- a/XMLHttpRequest/resources/responseType-document-in-worker.js
+++ b/XMLHttpRequest/resources/responseType-document-in-worker.js
@@ -1,0 +1,9 @@
+self.importScripts('/resources/testharness.js');
+
+test(function() {
+    let xhr = new XMLHttpRequest();
+    xhr.responseType = "document";
+    assert_not_equals(xhr.responseType, "document");
+}, "Setting XMLHttpRequest responseType to 'document' in a worker should have no effect.");
+
+done();

--- a/XMLHttpRequest/resources/responseXML-unavailable-in-worker.js
+++ b/XMLHttpRequest/resources/responseXML-unavailable-in-worker.js
@@ -1,0 +1,9 @@
+self.importScripts('/resources/testharness.js');
+
+test(function() {
+    let xhr = new XMLHttpRequest();
+    assert_not_exists(xhr, "responseXML", "responseXML should not be available on instances.");
+    assert_not_exists(XMLHttpRequest.prototype, "responseXML", "responseXML should not be on the prototype.");
+}, "XMLHttpRequest's responseXML property should not be exposed in workers.");
+
+done();

--- a/XMLHttpRequest/responseType-document-in-worker.html
+++ b/XMLHttpRequest/responseType-document-in-worker.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    fetch_tests_from_worker(new Worker("resources/responseType-document-in-worker.js"));
+</script>
+</body>
+</html>

--- a/XMLHttpRequest/responseXML-unavailable-in-worker.html
+++ b/XMLHttpRequest/responseXML-unavailable-in-worker.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+    fetch_tests_from_worker(new Worker("resources/responseXML-unavailable-in-worker.js"));
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds tests that ensure that XMLHttpRequest's documentXML is not available in a worker and that setting responseType to 'document' is no-op in a worker.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
