### PR TITLE
Remove redundant test aspect (closes #7300)

### DIFF
--- a/payment-request/payment-request-constructor.https.html
+++ b/payment-request/payment-request-constructor.https.html
@@ -350,14 +350,6 @@ test(() => {
     const details = Object.assign({}, defaultDetails, {
       shippingOptions: [invalidShippingOption],
     });
-    const request = new PaymentRequest(defaultMethods, details, {
-      requestShipping: false,
-    });
-    assert_equals(
-      request.shippingOption,
-      null,
-      "shippingOption must be null, because requestShipping is false"
-    );
     assert_throws(
       new TypeError(),
       () => {


### PR DESCRIPTION
This part of the test was causing confusion because it didn't match the test description. Thus, it's best to remove this little bit. Also, checking if `request.shippingOption` is `null` by default is tested in the proceeding test, so it doesn't need to be here.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
