### PR TITLE
Remove EventSource tests for DNS failures

### DIFF
--- a/eventsource/eventsource-constructor-non-same-origin.htm
+++ b/eventsource/eventsource-constructor-non-same-origin.htm
@@ -7,7 +7,6 @@
     <script src="/resources/testharnessreport.js"></script>
   </head>
   <body>
-    <div id="log"></div>
     <script>
       function fetchFail(url) {
         var test = async_test(document.title + " (" + url + ")", { timeout: 20000 })
@@ -22,8 +21,6 @@
           }
         })
       }
-      fetchFail("http://example.not/")
-      fetchFail("https://example.not/test")
       fetchFail("ftp://example.not/")
       fetchFail("about:blank")
       fetchFail("mailto:whatwg@awesome.example")


### PR DESCRIPTION
The spec says:

> Network errors that prevents the connection from being established in the first place (e.g. DNS errors), should cause the user agent to reestablish the connection in parallel, unless the user agent knows that to be futile, in which case the user agent may fail the connection.

Hence the readyState expectation for http://example.not/ and https://example.not/test is not correct.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
