### PR TITLE
Remove the testing of Request's type member

### DIFF
--- a/fetch/api/request/request-idl.html
+++ b/fetch/api/request/request-idl.html
@@ -37,7 +37,6 @@
         readonly attribute USVString url;
         [SameObject] readonly attribute Headers headers;
 
-        readonly attribute RequestType type;
         readonly attribute RequestDestination destination;
         readonly attribute USVString referrer;
         readonly attribute ReferrerPolicy referrerPolicy;

--- a/fetch/api/request/request-structure.html
+++ b/fetch/api/request/request-structure.html
@@ -22,7 +22,6 @@
       var attributes = ["method",
                         "url",
                         "headers",
-                        "type",
                         "destination",
                         "referrer",
                         "referrerPolicy",
@@ -54,11 +53,6 @@
             request.headers = new Headers ({"name":"value"});
             assert_false(request.headers.has("name"), "Headers attribute is read only");
             return;
-            break;
-
-          case "type":
-            defaultValue = "";
-            newValue = "style";
             break;
 
           case "destination":

--- a/fetch/api/request/request-type-attribute-historical.html
+++ b/fetch/api/request/request-type-attribute-historical.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Request.type attribute should not exist</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+  var request = new Request("https://domfarolino.com");
+  test(() => {
+      assert_equals(request.type, undefined, "request.type should be undefined");
+  }, "'type' getter should not exist on Request objects");
+</script>


### PR DESCRIPTION
 - Remove the testing of Request's type member as per https://github.com/whatwg/fetch/pull/582/
 - Add historical test asserting the non-existence of `Request.type`
 - Opened [bug on webkit](https://bugs.webkit.org/show_bug.cgi?id=177798) for the removal of the Request.type attribute

<!-- Reviewable:start -->

<!-- Reviewable:end -->
