### PR TITLE
move to fixed sauce connect binary version - "latest" URL deprecated by Sauce

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -138,7 +138,7 @@ class SauceConnect():
     def __enter__(self, options):
         if not self.sauce_connect_binary:
             self.temp_dir = tempfile.mkdtemp()
-            get_tar("https://saucelabs.com/downloads/sc-latest-linux.tar.gz", self.temp_dir)
+            get_tar("https://saucelabs.com/downloads/sc-4.4.9-linux.tar.gz", self.temp_dir)
             self.sauce_connect_binary = glob.glob(os.path.join(self.temp_dir, "sc-*-linux/bin/sc"))[0]
 
         self.upload_prerun_exec('edge-prerun.bat')


### PR DESCRIPTION
cc @foolip 

From Sauce Labs Support: 

> I've received confirmation from the Sauce Connect team that the latest links have been deprecated, so please use the link I provided earlier to get the latest version of the Sauce Connect binary:
> 
> https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy

Fixes #7553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7557)
<!-- Reviewable:end -->
