### PR TITLE
PaymentAddress organization name.

### DIFF
--- a/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
+++ b/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
@@ -75,7 +75,7 @@ function runManualTest(button, expected = {}) {
       postalCode: '1001',
       sortingCode: '',
       languageCode: 'fa',
-      organization: '',
+      organization: 'w3c',
       recipient: 'web platform test',
       phone: '+93555555555',
     };


### PR DESCRIPTION
The PaymentAddress test instructs the user to specify "w3c" as the
organization of the address under test, but the test expects an empty
organization name instead. This patch updates the PaymentAddress test to
match the user instructions.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
