### PR TITLE
EventSource: remove tests for DNS failures

### DIFF
--- a/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm
+++ b/eventsource/dedicated-worker/eventsource-constructor-non-same-origin.htm
@@ -35,8 +35,6 @@ try {
           }
         })
       }
-      fetchFail("http://example.not/")
-      fetchFail("https://example.not/test")
       fetchFail("ftp://example.not/")
       fetchFail("about:blank")
       fetchFail("mailto:whatwg@awesome.example")

--- a/eventsource/shared-worker/eventsource-constructor-non-same-origin.htm
+++ b/eventsource/shared-worker/eventsource-constructor-non-same-origin.htm
@@ -38,8 +38,6 @@ try {
           }
         })
       }
-      fetchFail("http://example.not")
-      fetchFail("https://example.not/test")
       fetchFail("ftp://example.not")
       fetchFail("about:blank")
       fetchFail("mailto:whatwg@awesome.example")


### PR DESCRIPTION
I removed the test cases for the main document in 9bea493fe78a21ce0a4b521c6c2790a0e0b6a28b. This change removes them in workers.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
