### PR TITLE
Add tests to confirm document's location getter returns null outside of a browsing context.

### DIFF
--- a/dom/nodes/DOMImplementation-createDocument.html
+++ b/dom/nodes/DOMImplementation-createDocument.html
@@ -131,6 +131,7 @@ test(function() {
     if (expected === null) {
       test(function() {
         var doc = document.implementation.createDocument(namespace, qualifiedName, doctype)
+        assert_equals(doc.location, null)
         assert_equals(doc.compatMode, "CSS1Compat")
         assert_equals(doc.characterSet, "UTF-8")
         assert_equals(doc.contentType, namespace == htmlNamespace ? "application/xhtml+xml"

--- a/dom/nodes/DOMImplementation-createHTMLDocument.html
+++ b/dom/nodes/DOMImplementation-createHTMLDocument.html
@@ -87,4 +87,10 @@ test(function() {
   a.href = "http://example.org/?\u00E4";
   assert_equals(a.href, "http://example.org/?%C3%A4");
 }, "createHTMLDocument(): URL parsing")
+
+// Test the document location getter is null outside of browser context
+test(function() {
+  var doc = document.implementation.createHTMLDocument();
+  assert_equals(doc.location, null);
+}, "createHTMLDocument(): document location getter is null")
 </script>

--- a/dom/nodes/Document-constructor.html
+++ b/dom/nodes/Document-constructor.html
@@ -28,6 +28,7 @@ test(function() {
 
 test(function() {
   var doc = new Document();
+  assert_equals(doc.location, null);
   assert_equals(doc.URL, "about:blank");
   assert_equals(doc.documentURI, "about:blank");
   assert_equals(doc.compatMode, "CSS1Compat");


### PR DESCRIPTION
Rebased from #1757.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
