### PR TITLE
Core-AAM: Fix copy-and-paste error in two tests

### DIFF
--- a/core-aam/aria-valuenow_value_changes-manual.html
+++ b/core-aam/aria-valuenow_value_changes-manual.html
@@ -69,7 +69,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-valuenow value changes.</p>
-     <div role='checkbox' id='test'>content</div>
+     <div role='slider' id='test'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>

--- a/core-aam/aria-valuetext_value_changes-manual.html
+++ b/core-aam/aria-valuetext_value_changes-manual.html
@@ -61,7 +61,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for aria-valuetext value changes.</p>
-     <div role='checkbox' id='test'>content</div>
+     <div role='slider' id='test'>content</div>
 
   <div id="manualMode"></div>
   <div id="log"></div>


### PR DESCRIPTION
The wrong role was being used on two tests as a result of an uncaught
copy-and-paste error.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
