### PR TITLE
Force HTMLStyleElement to create a new CSSStyleSheet when re-parsing.

### DIFF
--- a/css/css-images-3/gradient-button-ref.html
+++ b/css/css-images-3/gradient-button-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Big button with gradient (without padding)</title>
+<style>
+    #button {
+        width: calc(300px + 2 * 30px);
+        height: calc(80px + 2 * 20px);
+        background: linear-gradient(blue, green);
+        border-width: 5px;
+        border-style: solid;
+        border-color: red;
+        border-radius: 10px;
+    }
+</style>
+<div id="button"></div>

--- a/css/css-images-3/gradient-button.html
+++ b/css/css-images-3/gradient-button.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Gradients with padding</title>
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#gradients">
+<meta name="assert" content="gradients cover element padding">
+<link rel="match" href="gradient-button-ref.html">
+<style>
+#button {
+    width: 300px;
+    height: 80px;
+    padding: 20px 30px;
+    background: linear-gradient(blue, green);
+    border-width: 5px;
+    border-style: solid;
+    border-color: red;
+    border-radius: 10px;
+}
+</style>
+<div id="button"></div>

--- a/css/css-images-3/gradient-move-stops-ref.html
+++ b/css/css-images-3/gradient-move-stops-ref.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        #gradient {
+            width: 400px;
+            height: 300px;
+            background-image: linear-gradient(to right, yellow 0%, blue 70%, green 70%, green 100%);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="gradient"></div>
+</body>
+
+</html>

--- a/css/css-images-3/gradient-move-stops.html
+++ b/css/css-images-3/gradient-move-stops.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Linear gradient which needs some positions changed and inferred.</title>
+    <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-color-stops">
+    <link rel="match" href="gradient-move-stops-ref.html">
+    <style>
+        #gradient {
+            width: 400px;
+            height: 300px;
+            background-image: linear-gradient(to right, yellow, blue 70%, green 0);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="gradient"></div>
+</body>
+
+</html>

--- a/css/css-images-3/linear-gradient-1.html
+++ b/css/css-images-3/linear-gradient-1.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Linear gradient with some inferred positions</title>
+    <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-color-stops">
+    <meta name="assert" content="Calculation of implicit gradient stops.">
+    <link rel="match" href="linear-gradient-ref.html">
+    <style>
+        #gradient {
+            width: 400px;
+            height: 300px;
+            background-image: linear-gradient(to right, black 0%, red, gold);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="gradient"></div>
+</body>
+
+</html>

--- a/css/css-images-3/linear-gradient-2.html
+++ b/css/css-images-3/linear-gradient-2.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <title>Linear gradient with all inferred positions</title>
+    <link rel="help" href="https://drafts.csswg.org/css-images-3/#radial-color-stops">
+    <meta name="assert" content="Calculation of implicit gradient stops.">
+    <link rel="match" href="linear-gradient-ref.html">
+    <style>
+        #gradient {
+            width: 400px;
+            height: 300px;
+            background-image: linear-gradient(to right, black, red, gold);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="gradient"></div>
+</body>
+
+</html>

--- a/css/css-images-3/linear-gradient-ref.html
+++ b/css/css-images-3/linear-gradient-ref.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <style>
+        #gradient {
+            width: 400px;
+            height: 300px;
+            background-image: linear-gradient(to right, black 0%, red 50%, gold 100%);
+        }
+    </style>
+</head>
+
+<body>
+    <div id="gradient"></div>
+</body>
+
+</html>

--- a/cssom/style-sheet-interfaces-001.html
+++ b/cssom/style-sheet-interfaces-001.html
@@ -61,6 +61,17 @@
       assert: [ "styleElement.sheet exists", "styleElement.sheet is a CSSStyleSheet",
                 "linkElement.sheet exists", "linkElement.sheet is a CSSStyleSheet"] });
 
+    test(function () {
+      var style = document.createElement("style");
+      document.querySelector("head").appendChild(style);
+      var sheet1 = style.sheet;
+      assert_equals(sheet1.cssRules.length, 0);
+      style.appendChild(document.createTextNode("a { color: green; }"));
+      assert_equals(style.sheet.cssRules.length, 1);
+    }, "sheet_property_updates",
+    { help: "https://www.w3.org/TR/cssom-1/#the-linkstyle-interface",
+      assert: "The sheet property on LinkStyle should always return the current associated style sheet." });
+
     test(function() {
         assert_own_property(styleSheet, "ownerRule");
         assert_own_property(styleSheet, "cssRules");

--- a/workers/Worker_ErrorEvent_error.htm
+++ b/workers/Worker_ErrorEvent_error.htm
@@ -4,6 +4,10 @@
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script>
+// The worker events races with the window's load event; if the worker events
+// arrive first, the harness will detect the error event and fail the test.
+setup({ allow_uncaught_exception: true });
+
 var t1 = async_test("Error handler outside the worker should not see the error value");
 var t2 = async_test("Error handlers inside a worker should see the error value");
 

--- a/workers/data-url.html
+++ b/workers/data-url.html
@@ -27,6 +27,8 @@ function assert_worker_construction_fails(test_desc, mime_type, worker_code) {
     });
     w.onerror = t.step_func_done(function(e) {
       assert_true(true, 'Should throw ' + e.message);
+      // Stop the error from being propagated to the WPT test harness
+      e.preventDefault();
     });
   }, test_desc);
 }


### PR DESCRIPTION

We already call Document::invalidate_style_sheets and set
the stylesheet member to a new Stylesheet. This matches the behavior of
Firefox, and means the new CSSStyleSheet you get from accessing .sheet
from JS will be correct instead of stale.

(::get_cssom_stylesheet already tries to use the new Stylesheet, but
MutNullableJS::or_init is called, so if we already created a
CSSStyleSheet we will continue to return that one).

Upstreamed from https://github.com/servo/servo/pull/17259 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
