### PR TITLE
Port readable stream disturbed tests to WPT

### DIFF
--- a/fetch/api/response/response-stream-disturbed-6.html
+++ b/fetch/api/response/response-stream-disturbed-6.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>ReadableStream disturbed tests, via Response's bodyUsed property</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<link rel="author" title="Takeshi Yoshino" href="mailto:tyoshino@chromium.org">
+
+<link rel="help" href="https://streams.spec.whatwg.org/#is-readable-stream-disturbed">
+<link rel="help" href="https://fetch.spec.whatwg.org/#dom-body-bodyused">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+"use strict";
+
+test(() => {
+  const stream = new ReadableStream();
+  const response = new Response(stream);
+  assert_false(response.bodyUsed, "On construction");
+
+  const reader = stream.getReader();
+  assert_false(response.bodyUsed, "After getting a reader");
+
+  reader.read();
+  assert_true(response.bodyUsed, "After calling stream.read()");
+}, "A non-closed stream on which read() has been called");
+
+test(() => {
+  const stream = new ReadableStream();
+  const response = new Response(stream);
+  assert_false(response.bodyUsed, "On construction");
+
+  const reader = stream.getReader();
+  assert_false(response.bodyUsed, "After getting a reader");
+
+  reader.cancel();
+  assert_true(response.bodyUsed, "After calling stream.cancel()");
+}, "A non-closed stream on which cancel() has been called");
+
+test(() => {
+  const stream = new ReadableStream({
+    start(c) {
+      c.close();
+    }
+  });
+  const response = new Response(stream);
+  assert_false(response.bodyUsed, "On construction");
+
+  const reader = stream.getReader();
+  assert_false(response.bodyUsed, "After getting a reader");
+
+  reader.read();
+  assert_true(response.bodyUsed, "After calling stream.read()");
+}, "A closed stream on which read() has been called");
+
+test(() => {
+  const stream = new ReadableStream({
+    start(c) {
+      c.error(new Error("some error"));
+    }
+  });
+  const response = new Response(stream);
+  assert_false(response.bodyUsed, "On construction");
+
+  const reader = stream.getReader();
+  assert_false(response.bodyUsed, "After getting a reader");
+
+  reader.read();
+  assert_true(response.bodyUsed, "After calling stream.read()");
+}, "An errored stream on which read() has been called");
+
+test(() => {
+  const stream = new ReadableStream({
+    start(c) {
+      c.error(new Error("some error"));
+    }
+  });
+  const response = new Response(stream);
+  assert_false(response.bodyUsed, "On construction");
+
+  const reader = stream.getReader();
+  assert_false(response.bodyUsed, "After getting a reader");
+
+  reader.cancel();
+  assert_true(response.bodyUsed, "After calling stream.cancel()");
+}, "An errored stream on which cancel() has been called");
+
+</script>


### PR DESCRIPTION
These tests previously existed, sort of, in https://github.com/whatwg/streams/blob/232262a/reference-implementation/test/abstract-ops.js . That tested the reference implementation of the corresponding abstract operation in the Streams Standard repository, but did not test the web-exposed effects, since those were only testable via Fetch.

https://github.com/whatwg/streams/pull/832 removes those tests from the Streams Standard repository; to replace them, we port them to web platform tests, using the Fetch API to make the system under test observable.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
