### PR TITLE
[wptrunner] Fix crash caused by passing None to os.path.exists

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -163,7 +163,7 @@ class SauceConnect():
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.sc_process.terminate()
-        if os.path.exists(self.temp_dir):
+        if self.temp_dir and os.path.exists(self.temp_dir):
             try:
                 shutil.rmtree(self.temp_dir)
             except OSError:


### PR DESCRIPTION
If sauce_connect_binary is passed, then SauceConnect.temp_dir will
be None and will cause a crash when passed to os.path.exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7635)
<!-- Reviewable:end -->
