### PR TITLE
entries-api: Don't assume file is first item in dropped data

### DIFF
--- a/entries-api/support.js
+++ b/entries-api/support.js
@@ -18,12 +18,14 @@ window.addEventListener('DOMContentLoaded', e => {
   });
   elem.addEventListener('drop', e => {
     e.preventDefault();
-    const item = e.dataTransfer.items[0];
-    const entry = item.webkitGetAsEntry();
-    window.entry = entry;
-    elem.parentElement.removeChild(elem);
-
-    tests.forEach(f => f(entry, item));
+    for (const item of e.dataTransfer.items) {
+      if (item.kind !== 'file')
+        continue;
+      const entry = item.webkitGetAsEntry();
+      elem.parentElement.removeChild(elem);
+      tests.forEach(f => f(entry, item));
+      break;
+    }
   });
 });
 


### PR DESCRIPTION
This gets the entries-api manual tests mostly passing in Safari TP 41.

Safari tends to include a string entry before the file entries. Let the tests account for that.

@cdumez - can you review?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
