### PR TITLE
added a test+reftest for font shorthand using calc()

### DIFF
--- a/css/CSS2/fonts/font-148-ref.xht
+++ b/css/CSS2/fonts/font-148-ref.xht
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+ <head>
+
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Ondřej Žára" href="https://ondras.zarovi.cz/" />
+
+<style type="text/css">
+    div {
+        font: 10px sans-serif;
+    }
+    span {
+        font: 100px sans-serif;
+    }
+</style>
+
+ </head>
+
+    <body>
+        <p>Test passes if letters "def" below are larger than "abc" and "ghi".</p>
+        <div>abc<span class="test">def</span>ghi</div>
+    </body>
+</html>

--- a/css/CSS2/fonts/font-148.xht
+++ b/css/CSS2/fonts/font-148.xht
@@ -3,9 +3,8 @@
     <head>
         <title>CSS Test: Font shorthand using calc() value for font-size</title>
         <link rel="author" title="Ondřej Žára" href="https://ondras.zarovi.cz/" />
-        <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font" />
-        <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-shorthand" />
-        <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-prop"/>
+        <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-prop" />
+        <link rel="help" href="https://www.w3.org/TR/css-values-3/#calc-notation" />
         <link rel="match" href="font-148-ref.html"/>
         <meta name="flags" content="" />
         <meta name="assert" content="The 'font' shorthand property accepts and sets font-variant, font-size and font-family." />

--- a/css/CSS2/fonts/font-148.xht
+++ b/css/CSS2/fonts/font-148.xht
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>CSS Test: Font shorthand using calc() value for font-size</title>
+        <link rel="author" title="Ondřej Žára" href="https://ondras.zarovi.cz/" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font" />
+        <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-shorthand" />
+        <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-prop"/>
+        <link rel="match" href="font-148-ref.html"/>
+        <meta name="flags" content="" />
+        <meta name="assert" content="The 'font' shorthand property accepts and sets font-variant, font-size and font-family." />
+        <style type="text/css">
+            div {
+                font: 10px sans-serif;
+            }
+            span {
+                font: calc(10 * 10px) sans-serif;
+            }
+        </style>
+    </head>
+    <body>
+        <p>Test passes if letters "def" below are larger than "abc" and "ghi".</p>
+        <div>abc<span class="test">def</span>ghi</div>
+    </body>
+</html>

--- a/css/CSS2/fonts/font-148.xht
+++ b/css/CSS2/fonts/font-148.xht
@@ -6,7 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#propdef-font" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-shorthand" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-prop"/>
-        <link rel="match" href="font-148-ref.html"/>
+        <link rel="match" href="font-148-ref.xht"/>
         <meta name="flags" content="" />
         <meta name="assert" content="The 'font' shorthand property accepts and sets font-variant, font-size and font-family." />
         <style type="text/css">


### PR DESCRIPTION
This new test (+reftest) checks support for `calc()` expression in `font` shorthand property.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
