### PR TITLE
Add urllib3[secure] requirement

### DIFF
--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -2,3 +2,4 @@ html5lib >= 0.99
 mozinfo >= 0.7
 mozlog >= 3.5
 mozdebug >= 0.1
+urllib3[secure]


### PR DESCRIPTION
Installs urllib3[secure] which is needed in python 2.7 to avoid SSL connection errors when running tests with sauce.

cc/ @bobholt  @JKereliuk

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7655)
<!-- Reviewable:end -->
