### PR TITLE
Add ref test for linear gradient with transparent

### DIFF
--- a/css/css-images-3/gradients-with-transparent-ref.html
+++ b/css/css-images-3/gradients-with-transparent-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Linear gradient with transparent reference</title>
+<style>
+    .test {
+        width: 200px;
+        height: 100px;
+        margin-left: 90px;
+    }
+    .gradient {
+        background-image: linear-gradient(to left, blue 0%, blue 20%, rgba(0,0,255,0));
+    }
+</style>
+
+<body>
+    <p>Gradient using 'transparent'</p>
+    <div id="gradient1" class="test gradient"></div>
+    <br />
+    <p>Gradient using rgba(0,0,255,0)</p>
+    <div id="gradient2" class="test gradient"></div>
+</body>

--- a/css/css-images-3/gradients-with-transparent.html
+++ b/css/css-images-3/gradients-with-transparent.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Gradients with transparent</title>
+<link rel="help" href="https://www.w3.org/TR/css3-images/#linear-gradients">
+<link rel="match" href="gradients-with-transparent-ref.html">
+<meta name="assert" content="The blue gradients to 'transparent' keyword, and rgba(0,0,0,0), match the gradient to rgba(0,0,255,0)">
+<style>
+    .test {
+        width: 200px;
+        height: 100px;
+        margin-left: 90px;
+    }
+    #gradient1 {
+        background-image: linear-gradient(to left, blue 0%, blue 20%, transparent);
+    }
+    #gradient2 {
+        background-image: linear-gradient(to left, blue 0%, blue 20%, rgba(0,0,0,0));
+    }
+</style>
+<body>
+	<p>Gradient using 'transparent'</p>
+    <div id="gradient1" class="test"></div>
+    <br />
+	<p>Gradient using rgba(0,0,255,0)</p>
+    <div id="gradient2" class="test"></div>
+</body>


### PR DESCRIPTION
Re-attempt at #7527, which was reverted due to mistakenly including a change to Travis CI.

This test passes in chrome + firefox, which premultiply sRGBA, and fails in safari (which does not).

cc/ @sideshowbarker

<!-- Reviewable:start -->

<!-- Reviewable:end -->
