### PR TITLE
Remove use of testRunner in ruby test

### DIFF
--- a/css/css-ruby-1/line-break-around-ruby-001.html
+++ b/css/css-ruby-1/line-break-around-ruby-001.html
@@ -32,8 +32,5 @@ function runTests() {
             assert_approx_equals(lineCount, 3, 0.1);
         }, element.title);
     });
-
-    if (window.testRunner)
-        container.style.display = "none";
 }
 </script>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -867,8 +867,6 @@ WEBIDL2.JS:.gitmodules
 CONSOLE:payment-request/payment-request-response-id.html
 
 # Tests that use WebKit/Blink testing APIs
-LAYOUTTESTS APIS: content-security-policy/blink-contrib/*
 LAYOUTTESTS APIS: css/css-regions-1/interactivity/*
-LAYOUTTESTS APIS: css/css-ruby-1/line-break-around-ruby-001.html
 LAYOUTTESTS APIS: css/work-in-progress/opera/css-device-adapt/template.blink.html
 LAYOUTTESTS APIS: webgl/conformance-1.0.3/*


### PR DESCRIPTION
This test isn't imported into Blink or WebKit:
https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/external/wpt/css/
https://trac.webkit.org/browser/webkit/trunk/LayoutTests/imported/w3c/web-platform-tests/css

Also clean up after https://github.com/w3c/web-platform-tests/pull/7547

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7658)
<!-- Reviewable:end -->
