### PR TITLE
File/Directory Entries API: Make tests Edge friendly

### DIFF
--- a/entries-api/filesystem-manual.html
+++ b/entries-api/filesystem-manual.html
@@ -28,13 +28,13 @@ entry_test((t, entry) => {
 entry_test((t, entry) => {
   const fs = entry.filesystem;
 
-  entry.getParent(t.step_func(parent => {
-    const pfs = parent.filesystem;
-    assert_not_equals(fs, pfs.filesystem, 'FileSystem objects do not have object identity');
-    assert_equals(fs.name, pfs.name, 'FileSystem names match');
+  getChildEntry(entry, 'file.txt', t.step_func(child => {
+    const cfs = child.filesystem;
+    assert_not_equals(fs, cfs.filesystem, 'FileSystem objects do not have object identity');
+    assert_equals(fs.name, cfs.name, 'FileSystem names match');
 
     t.done();
-  }), t.unreached_func('getParent() should not fail'));
+  }), t.unreached_func('child entry file.txt should be present'));
 
 }, 'FileSystem - name consistency and object identity');
 </script>

--- a/entries-api/filesystemdirectoryentry-attributes-manual.html
+++ b/entries-api/filesystemdirectoryentry-attributes-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Entries API: FileSystemDirectoryEntry manual test</title>
+<title>Entries API: FileSystemDirectoryEntry attributes manual test</title>
 <link rel=help href="https://wicg.github.io/entries-api/#api-directoryentry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -8,8 +8,6 @@
 
 <script>
 entry_test((t, entry) => {
-  // FileSystemEntry ----------
-
   assert_idl_attribute(entry, 'isFile', 'FileSystemDirectoryEntry has isFile attribute');
   assert_equals(typeof entry.isFile, 'boolean', 'isFile is boolean');
 
@@ -23,26 +21,10 @@ entry_test((t, entry) => {
   assert_equals(typeof entry.fullPath, 'string', 'fullPath is a string');
 
   assert_idl_attribute(entry, 'filesystem', 'FileSystemDirectoryEntry has filesystem attribute');
-
-  assert_idl_attribute(entry, 'getParent', 'FileSystemDirectoryEntry has getParent');
-  assert_equals(typeof entry.getParent, 'function', 'getParent() is a method');
-
-  // FileSystemDirectoryEntry  ----------
-
-  assert_idl_attribute(entry, 'getFile', 'FileSystemDirectoryEntry has getFile');
-  assert_equals(typeof entry.getFile, 'function',
-                'getFile() is a method');
-
-  assert_idl_attribute(entry, 'getDirectory', 'FileSystemDirectoryEntry has getDirectory');
-  assert_equals(typeof entry.getDirectory, 'function',
-                'getDirectory() is a method');
-
-  assert_idl_attribute(entry, 'createReader', 'FileSystemDirectoryEntry has createReader');
-  assert_equals(typeof entry.createReader, 'function',
-                'createReader() is a method');
+  assert_equals(typeof entry.filesystem, 'object', 'filesystem is an object');
 
   t.done();
-}, 'FileSystemDirectoryEntry - interface');
+}, 'FileSystemDirectoryEntry - attribute types');
 
 entry_test((t, entry) => {
   assert_false(entry.isFile, 'isFile is false');
@@ -50,5 +32,6 @@ entry_test((t, entry) => {
   assert_equals(entry.name, 'upload', 'expected directory was uploaded');
   assert_equals(entry.fullPath, '/upload', 'directory is child of root directory');
   t.done();
-}, 'FileSystemDirectoryEntry - attributes');
+}, 'FileSystemDirectoryEntry - attribute values');
+
 </script>

--- a/entries-api/filesystemdirectoryentry-createReader-manual.html
+++ b/entries-api/filesystemdirectoryentry-createReader-manual.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemDirectoryEntry createReader() manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#api-directoryentry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+entry_test((t, entry) => {
+
+  assert_idl_attribute(entry, 'createReader', 'FileSystemDirectoryEntry has createReader');
+  assert_equals(typeof entry.createReader, 'function', 'createReader() is a method');
+
+  t.done();
+}, 'FileSystemDirectoryEntry - createReader()');
+
+entry_test((t, entry) => {
+  assert_not_equals(entry.createReader(), entry.createReader(),
+                    'createReader() returns a new object each time');
+  t.done();
+}, 'FileSystemDirectoryEntry - createReader() distinct objects');
+</script>

--- a/entries-api/filesystemdirectoryentry-getDirectory-manual.html
+++ b/entries-api/filesystemdirectoryentry-getDirectory-manual.html
@@ -7,6 +7,13 @@
 <script src="support.js"></script>
 
 <script>
+entry_test((t, entry) => {
+  assert_idl_attribute(entry, 'getDirectory', 'FileSystemDirectoryEntry has getDirectory');
+  assert_equals(typeof entry.getDirectory, 'function', 'getDirectory() is a method');
+
+  t.done();
+}, 'FileSystemDirectoryEntry - getDirectory()');
+
 INVALID_PATHS.forEach(path => {
   entry_test((t, entry) => {
     entry.getDirectory(

--- a/entries-api/filesystemdirectoryentry-getFile-manual.html
+++ b/entries-api/filesystemdirectoryentry-getFile-manual.html
@@ -7,6 +7,13 @@
 <script src="support.js"></script>
 
 <script>
+entry_test((t, entry) => {
+  assert_idl_attribute(entry, 'getFile', 'FileSystemDirectoryEntry has getFile');
+  assert_equals(typeof entry.getFile, 'function', 'getFile() is a method');
+
+  t.done();
+}, 'FileSystemDirectoryEntry - getFile()');
+
 INVALID_PATHS.forEach(path => {
   entry_test((t, entry) => {
     entry.getFile(

--- a/entries-api/filesystemdirectoryentry-getParent-manual.html
+++ b/entries-api/filesystemdirectoryentry-getParent-manual.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemDirectoryEntry getParent() manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#api-directoryentry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+entry_test((t, entry) => {
+
+  assert_idl_attribute(entry, 'getParent', 'FileSystemDirectoryEntry has getParent');
+  assert_equals(typeof entry.getParent, 'function', 'getParent() is a method');
+
+  t.done();
+}, 'FileSystemDirectoryEntry - getParent()');
+</script>

--- a/entries-api/filesystemdirectoryreader-manual.html
+++ b/entries-api/filesystemdirectoryreader-manual.html
@@ -18,7 +18,7 @@ entry_test((t, entry) => {
 
 
 entry_test((t, entry) => {
-  entry.getDirectory('subdir', {}, t.step_func(dir => {
+  getChildEntry(entry, 'subdir', t.step_func(dir => {
     const reader = dir.createReader();
     assert_equals(typeof reader.readEntries, 'function');
 
@@ -39,7 +39,7 @@ entry_test((t, entry) => {
       })));
 
     do_chunk();
-  }), t.unreached_func('getDirectory should not fail'));
+  }));
 }, 'FileSystemDirectoryReader - basic enumeration');
 
 entry_test((t, entry) => {

--- a/entries-api/filesystemdirectoryreader-manual.html
+++ b/entries-api/filesystemdirectoryreader-manual.html
@@ -39,7 +39,7 @@ entry_test((t, entry) => {
       })));
 
     do_chunk();
-  }));
+  }), t.unreached_func('A child entry should be found'));
 }, 'FileSystemDirectoryReader - basic enumeration');
 
 entry_test((t, entry) => {

--- a/entries-api/filesystementry-attributes-manual.html
+++ b/entries-api/filesystementry-attributes-manual.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemEntry attributes manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#api-entry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+entry_test((t, entry) => {
+  assert_idl_attribute(entry, 'isFile', 'FileSystemEntry has isFile attribute');
+  assert_equals(typeof entry.isFile, 'boolean', 'isFile is boolean');
+
+  assert_idl_attribute(entry, 'isDirectory', 'FileSystemEntry has isDirectory attribute');
+  assert_equals(typeof entry.isDirectory, 'boolean', 'isFile is boolean');
+
+  assert_idl_attribute(entry, 'name', 'FileSystemEntry has name attribute');
+  assert_equals(typeof entry.name, 'string', 'name is a string');
+
+  assert_idl_attribute(entry, 'fullPath', 'FileSystemEntry has fullPath attribute');
+  assert_equals(typeof entry.fullPath, 'string', 'fullPath is a string');
+
+  assert_idl_attribute(entry, 'filesystem', 'FileSystemEntry has filesystem attribute');
+  assert_equals(typeof entry.filesystem, 'object', 'filesystem is an object');
+
+  t.done();
+}, 'FileSystemEntry - attribute types');
+
+</script>

--- a/entries-api/filesystementry-getParent-manual.html
+++ b/entries-api/filesystementry-getParent-manual.html
@@ -1,34 +1,16 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Entries API: FileSystemEntry manual test</title>
-<link rel=help href="https://wicg.github.io/entries-api/#api-entry">
+<title>Entries API: FileSystemEntry getParent() manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#dom-filesystementry-getparentapi-entry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support.js"></script>
 
 <script>
 entry_test((t, entry) => {
-  assert_idl_attribute(entry, 'isFile', 'FileSystemEntry has isFile attribute');
-  assert_equals(typeof entry.isFile, 'boolean', 'isFile is boolean');
-
-  assert_idl_attribute(entry, 'isDirectory', 'FileSystemEntry has isDirectory attribute');
-  assert_equals(typeof entry.isDirectory, 'boolean', 'isFile is boolean');
-
-  assert_idl_attribute(entry, 'name', 'FileSystemEntry has name attribute');
-  assert_equals(typeof entry.name, 'string', 'name is a string');
-
-  assert_idl_attribute(entry, 'fullPath', 'FileSystemEntry has fullPath attribute');
-  assert_equals(typeof entry.fullPath, 'string', 'fullPath is a string');
-
-  assert_idl_attribute(entry, 'filesystem', 'FileSystemEntry has filesystem attribute');
-
   assert_idl_attribute(entry, 'getParent', 'FileSystemEntry has filesystem attribute');
   assert_equals(typeof entry.getParent, 'function', 'FileSystemEntry has a getParent() method');
 
-  t.done();
-}, 'FileSystemEntry - interface');
-
-entry_test((t, entry) => {
   assert_equals(entry.getParent(), void 0, 'getParent() arguments are optional');
 
   entry.getParent(t.step_func(parent => {

--- a/entries-api/filesystementry-getParent-manual.html
+++ b/entries-api/filesystementry-getParent-manual.html
@@ -8,7 +8,7 @@
 
 <script>
 entry_test((t, entry) => {
-  assert_idl_attribute(entry, 'getParent', 'FileSystemEntry has filesystem attribute');
+  assert_idl_attribute(entry, 'getParent', 'FileSystemEntry has getParent method');
   assert_equals(typeof entry.getParent, 'function', 'FileSystemEntry has a getParent() method');
 
   assert_equals(entry.getParent(), void 0, 'getParent() arguments are optional');

--- a/entries-api/filesystemfileentry-attributes-manual.html
+++ b/entries-api/filesystemfileentry-attributes-manual.html
@@ -8,7 +8,6 @@
 
 <script>
 file_entry_test('file.txt', (t, entry) => {
-  // FileSystemEntry ----------
 
   assert_idl_attribute(entry, 'isFile', 'FileSystemEntry has isFile attribute');
   assert_equals(typeof entry.isFile, 'boolean', 'isFile is boolean');
@@ -24,14 +23,8 @@ file_entry_test('file.txt', (t, entry) => {
 
   assert_idl_attribute(entry, 'filesystem', 'FileSystemEntry has filesystem attribute');
 
-  assert_idl_attribute(entry, 'getParent', 'FileSystemEntry has filesystem attribute');
-  assert_equals(typeof entry.getParent, 'function', 'FileSystemEntry has a getParent() method');
-
-  // FileSystemFileEntry ----------
-
-  assert_equals(typeof entry.file, 'function', 'FileSystemFileEntry has a file() method');
   t.done();
-}, 'FileSystemFileEntry - interface');
+}, 'FileSystemFileEntry - attribute types');
 
 file_entry_test('file.txt', (t, entry) => {
   assert_true(entry.isFile);
@@ -39,18 +32,6 @@ file_entry_test('file.txt', (t, entry) => {
   assert_equals(entry.name, 'file.txt');
   assert_equals(entry.fullPath, '/upload/file.txt');
   t.done();
-}, 'FileSystemFileEntry - attributes');
+}, 'FileSystemFileEntry - attribute values');
 
-file_entry_test('file.txt', (t, entry) => {
-  assert_throws(TypeError(), () => entry.file(), 'file() has a required argument');
-  entry.file(t.step_func(file => {
-
-    assert_class_string(file, 'File', 'file() should yield a File');
-    assert_equals(entry.name, file.name, 'entry and file names should match');
-    t.done();
-
-  }), t.unreached_func('file() should not fail'));
-}, 'FileSystemFileEntry - file()');
-
-// TODO: Manual test where file is replaced with directory before file() called
 </script>

--- a/entries-api/filesystemfileentry-attributes-manual.html
+++ b/entries-api/filesystemfileentry-attributes-manual.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Entries API: FileSystemFileEntry manual test</title>
+<title>Entries API: FileSystemFileEntry attributes manual test</title>
 <link rel=help href="https://wicg.github.io/entries-api/#api-entry">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/entries-api/filesystemfileentry-file-manual.html
+++ b/entries-api/filesystemfileentry-file-manual.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemFileEntry file() manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#api-entry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+
+file_entry_test('file.txt', (t, entry) => {
+  assert_idl_attribute(entry, 'file', 'FileSystemFileEntry has a file() method');
+  assert_equals(typeof entry.file, 'function', 'FileSystemFileEntry has a file() method');
+
+  assert_throws(TypeError(), () => entry.file(), 'file() has a required argument');
+  entry.file(t.step_func(file => {
+
+    assert_class_string(file, 'File', 'file() should yield a File');
+    assert_equals(entry.name, file.name, 'entry and file names should match');
+    t.done();
+
+  }), t.unreached_func('file() should not fail'));
+}, 'FileSystemFileEntry - file()');
+
+// TODO: Manual test where file is replaced with directory before file() called
+</script>

--- a/entries-api/filesystemfileentry-getParent-manual.html
+++ b/entries-api/filesystemfileentry-getParent-manual.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Entries API: FileSystemFileEntry getParent() manual test</title>
+<link rel=help href="https://wicg.github.io/entries-api/#api-entry">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+
+file_entry_test('file.txt', (t, entry) => {
+  assert_idl_attribute(entry, 'getParent', 'FileSystemFileEntry has a getParent method');
+  assert_equals(typeof entry.getParent, 'function', 'FileSystemFileEntry has a getParent() method');
+  t.done();
+}, 'FileSystemFileEntry - getParent() method');
+
+</script>

--- a/entries-api/interfaces-manual.html
+++ b/entries-api/interfaces-manual.html
@@ -18,8 +18,8 @@ entry_test((t, entry, item) => {
   ]).then(t.step_func(([entries, idls]) => {
     window.samples = {
       item: item,
-      dirEntry: entries.filter(function(entry) { return entry.isDirectory; })[0],
-      fileEntry: entries.filter(function(entry) { return entry.isFile; })[0],
+      dirEntry: entries.filter(entry => entry.isDirectory)[0],
+      fileEntry: entries.filter(entry => entry.isFile)[0],
       fileSystem: entry.filesystem,
     };
 

--- a/entries-api/interfaces-manual.html
+++ b/entries-api/interfaces-manual.html
@@ -10,28 +10,16 @@
 <script>
 'use strict';
 
-function getFileAsPromise(dirEntry, path) {
-  return new Promise((resolve, reject) => {
-    dirEntry.getFile(path, {}, resolve, reject);
-  });
-}
-
-function getDirectoryAsPromise(dirEntry, path) {
-  return new Promise((resolve, reject) => {
-    dirEntry.getDirectory(path, {}, resolve, reject);
-  });
-}
-
 entry_test((t, entry, item) => {
+  assert_true(entry.isDirectory);
   Promise.all([
-    getFileAsPromise(entry, FILE_PATHS[0]),
-    getDirectoryAsPromise(entry, DIR_PATHS[0]),
+    getEntriesAsPromise(entry),
     fetch('interfaces.idl').then(r => r.text())
-  ]).then(t.step_func(([fileEntry, dirEntry, idls]) => {
+  ]).then(t.step_func(([entries, idls]) => {
     window.samples = {
       item: item,
-      dirEntry: dirEntry,
-      fileEntry: fileEntry,
+      dirEntry: entries.filter(function(entry) { return entry.isDirectory; })[0],
+      fileEntry: entries.filter(function(entry) { return entry.isFile; })[0],
       fileSystem: entry.filesystem,
     };
 

--- a/entries-api/interfaces.html
+++ b/entries-api/interfaces.html
@@ -14,7 +14,7 @@ promise_test(t => {
     .then(r => r.text())
     .then(idls => {
 
-      var idl_array = new IdlArray();
+      const idl_array = new IdlArray();
 
       // https://w3c.github.io/FileAPI/#dfn-file
       idl_array.add_untested_idls('[Exposed=(Window,Worker)] interface File {};');


### PR DESCRIPTION
Edge doesn't yet implement getFile()/getDirectory()/getParent() so don't make unrelated tests assume the existence of those methods. Add a helper to get child entries via enumeration (supported everywhere) and also split up the test files by method.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
