### PR TITLE
entries-api: Don't use const for loop variable

### DIFF
--- a/entries-api/support.js
+++ b/entries-api/support.js
@@ -18,7 +18,7 @@ window.addEventListener('DOMContentLoaded', e => {
   });
   elem.addEventListener('drop', e => {
     e.preventDefault();
-    for (const i = 0; i < e.dataTransfer.items.length; ++i) {
+    for (let i = 0; i < e.dataTransfer.items.length; ++i) {
       const item = e.dataTransfer.items[i];
       if (item.kind !== 'file')
         continue;


### PR DESCRIPTION
Safari throws on `for (const i = 0; ...) { ... }` (assignment to readonly variable). Other browsers are okay with this since the loop never makes it to the next iteration.

@pwnall - can you take a look?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
