### PR TITLE
Move Sauce Connect metrics address to 9876

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -150,6 +150,7 @@ class SauceConnect():
             "--api-key=%s" % self.sauce_key,
             "--no-remove-colliding-tunnels",
             "--tunnel-identifier=%s" % self.sauce_tunnel_id,
+            "--metrics-address=0.0.0.0:9876",
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
             "web-platform.test",


### PR DESCRIPTION
By default the address is localhost:8888, which conflicts with one of the WPT URLs.

(This is part of https://github.com/w3c/wptdashboard/issues/142)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7679)
<!-- Reviewable:end -->
