### PR TITLE
IndexedDB: Add tests that verify the source of IDBRequests 

### DIFF
--- a/IndexedDB/idbcursor-request-source.html
+++ b/IndexedDB/idbcursor-request-source.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: The source of requests made against cursors</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbrequest-source">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+[
+  'cursor.update(0)',
+  'cursor.delete()'
+].forEach(expr => indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const store = tx.objectStore('store');
+    store.put('value');
+    store.openCursor().onsuccess = t.step_func(e => {
+      const cursor = e.target.result;
+      assert_equals(eval(expr).source, cursor,
+                    `${expr}.source should be the cursor itself`);
+      t.done();
+    });
+  },
+  `The source of the request from ${expr} is the cursor itself`
+));
+
+</script>

--- a/IndexedDB/idbcursor-request-source.html
+++ b/IndexedDB/idbcursor-request-source.html
@@ -8,9 +8,9 @@
 <script>
 
 [
-  'cursor.update(0)',
-  'cursor.delete()'
-].forEach(expr => indexeddb_test(
+  cursor => cursor.update(0),
+  cursor => cursor.delete()
+].forEach(func => indexeddb_test(
   (t, db) => {
     db.createObjectStore('store', {autoIncrement: true});
   },
@@ -20,12 +20,12 @@
     store.put('value');
     store.openCursor().onsuccess = t.step_func(e => {
       const cursor = e.target.result;
-      assert_equals(eval(expr).source, cursor,
-                    `${expr}.source should be the cursor itself`);
+      assert_equals(func(cursor).source, cursor,
+                    `${func}.source should be the cursor itself`);
       t.done();
     });
   },
-  `The source of the request from ${expr} is the cursor itself`
+  `The source of the request from ${func} is the cursor itself`
 ));
 
 </script>

--- a/IndexedDB/idbindex-request-source.html
+++ b/IndexedDB/idbindex-request-source.html
@@ -8,15 +8,15 @@
 <script>
 
 [
-  'index.get(0)',
-  'index.getKey(0)',
-  'index.getAll()',
-  'index.getAllKeys()',
-  'index.count()',
+  index => index.get(0),
+  index => index.getKey(0),
+  index => index.getAll(),
+  index => index.getAllKeys(),
+  index => index.count(),
 
-  'index.openCursor()',
-  'index.openKeyCursor()'
-].forEach(expr => indexeddb_test(
+  index => index.openCursor(),
+  index => index.openKeyCursor()
+].forEach(func => indexeddb_test(
   (t, db) => {
     const store = db.createObjectStore('store', {autoIncrement: true});
     store.createIndex('index', 'kp');
@@ -24,11 +24,11 @@
   (t, db) => {
     const tx = db.transaction('store', 'readwrite');
     const index = tx.objectStore('store').index('index');
-    assert_equals(eval(expr).source, index,
-                  `${expr}.source should be the index itself`);
+    assert_equals(func(index).source, index,
+                  `${func}.source should be the index itself`);
     t.done();
   },
-  `The source of the request from ${expr} is the index itself`
+  `The source of the request from ${func} is the index itself`
 ));
 
 </script>

--- a/IndexedDB/idbindex-request-source.html
+++ b/IndexedDB/idbindex-request-source.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: The source of requests made against indexes</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbrequest-source">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+[
+  'index.get(0)',
+  'index.getKey(0)',
+  'index.getAll()',
+  'index.getAllKeys()',
+  'index.count()',
+
+  'index.openCursor()',
+  'index.openKeyCursor()'
+].forEach(expr => indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store', {autoIncrement: true});
+    store.createIndex('index', 'kp');
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const index = tx.objectStore('store').index('index');
+    assert_equals(eval(expr).source, index,
+                  `${expr}.source should be the index itself`);
+    t.done();
+  },
+  `The source of the request from ${expr} is the index itself`
+));
+
+</script>

--- a/IndexedDB/idbobjectstore-request-source.html
+++ b/IndexedDB/idbobjectstore-request-source.html
@@ -8,20 +8,20 @@
 <script>
 
 [
-  'store.put(0)',
-  'store.add(0)',
-  'store.delete(0)',
-  'store.clear()',
+  store => store.put(0),
+  store => store.add(0),
+  store => store.delete(0),
+  store => store.clear(),
 
-  'store.get(0)',
-  'store.getKey(0)',
-  'store.getAll()',
-  'store.getAllKeys()',
-  'store.count()',
+  store => store.get(0),
+  store => store.getKey(0),
+  store => store.getAll(),
+  store => store.getAllKeys(),
+  store => store.count(),
 
-  'store.openCursor()',
-  'store.openKeyCursor()'
-].forEach(expr => indexeddb_test(
+  store => store.openCursor(),
+  store => store.openKeyCursor()
+].forEach(func => indexeddb_test(
   (t, db) => {
     db.createObjectStore('store', {autoIncrement: true});
   },
@@ -29,11 +29,11 @@
     const tx = db.transaction('store', 'readwrite');
     const store = tx.objectStore('store');
 
-    assert_equals(eval(expr).source, store,
-                  `${expr}.source should be the object store itself`);
+    assert_equals(func(store).source, store,
+                  `${func}.source should be the object store itself`);
     t.done();
   },
-  `The source of the request from ${expr} is the object store itself`
+  `The source of the request from ${func} is the object store itself`
 ));
 
 </script>

--- a/IndexedDB/idbobjectstore-request-source.html
+++ b/IndexedDB/idbobjectstore-request-source.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: The source of requests made against object stores</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbrequest-source">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+[
+  'store.put(0)',
+  'store.add(0)',
+  'store.delete(0)',
+  'store.clear()',
+
+  'store.get(0)',
+  'store.getKey(0)',
+  'store.getAll()',
+  'store.getAllKeys()',
+  'store.count()',
+
+  'store.openCursor()',
+  'store.openKeyCursor()'
+].forEach(expr => indexeddb_test(
+  (t, db) => {
+    db.createObjectStore('store', {autoIncrement: true});
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readwrite');
+    const store = tx.objectStore('store');
+
+    assert_equals(eval(expr).source, store,
+                  `${expr}.source should be the object store itself`);
+    t.done();
+  },
+  `The source of the request from ${expr} is the object store itself`
+));
+
+</script>


### PR DESCRIPTION
Missing coverage noted in https://github.com/w3c/IndexedDB/issues/213

Verify the source property of requests returned by operations made against stores, indexes, and cursors.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
