### PR TITLE
IndexedDB: Tests for [SameObject] assertions in spec WebIDL

### DIFF
--- a/IndexedDB/globalscope-indexedDB-SameObject.html
+++ b/IndexedDB/globalscope-indexedDB-SameObject.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Verify [SameObject] behavior of the global scope's indexedDB attribute</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-windoworworkerglobalscope-indexeddb">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+test(t => {
+  assert_equals(self.indexedDB, self.indexedDB,
+                'Attribute should yield the same object each time');
+
+}, 'indexedDB is [SameObject]');
+
+</script>

--- a/IndexedDB/idbindex-objectStore-SameObject.html
+++ b/IndexedDB/idbindex-objectStore-SameObject.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Verify [SameObject] behavior of IDBIndex's objectStore attribute</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbindex-objectstore">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store');
+    const index = store.createIndex('index', 'keyPath');
+    assert_equals(index.objectStore, index.objectStore,
+                  'Attribute should yield the same object each time');
+
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const store = tx.objectStore('store');
+    const index = store.index('index');
+    assert_equals(index.objectStore, index.objectStore,
+                  'Attribute should yield the same object each time');
+    t.done();
+  },
+  'IDBIndex.objectStore [SameObject]'
+);
+</script>

--- a/IndexedDB/idbobjectstore-transaction-SameObject.html
+++ b/IndexedDB/idbobjectstore-transaction-SameObject.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Verify [SameObject] behavior of IDBObjectStore's transaction attribute</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbobjectstore-transaction">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store');
+    assert_equals(store.transaction, store.transaction,
+                  'Attribute should yield the same object each time');
+
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    const store = tx.objectStore('store');
+    assert_equals(store.transaction, store.transaction,
+                  'Attribute should yield the same object each time');
+    t.done();
+  },
+  'IDBObjectStore.transaction [SameObject]'
+);
+</script>

--- a/IndexedDB/idbtransaction-db-SameObject.html
+++ b/IndexedDB/idbtransaction-db-SameObject.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IndexedDB: Verify [SameObject] behavior of IDBTransaction's db attribute</title>
+<meta name="help" href="https://w3c.github.io/IndexedDB/#dom-idbtransaction-db">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+<script>
+
+indexeddb_test(
+  (t, db, tx) => {
+    const store = db.createObjectStore('store');
+    assert_equals(tx.db, tx.db,
+                  'Attribute should yield the same object each time');
+  },
+  (t, db) => {
+    const tx = db.transaction('store');
+    assert_equals(tx.db, tx.db,
+                  'Attribute should yield the same object each time');
+    t.done();
+  },
+  'IDBTransaction.db [SameObject]'
+);
+</script>


### PR DESCRIPTION
Add tests to verify the [SameObject] assertions made for some readonly attributes in the spec.

Noted as missing coverage in: https://github.com/w3c/IndexedDB/issues/213

<!-- Reviewable:start -->

<!-- Reviewable:end -->
