### PR TITLE
More dynamic import() string compilation tests

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/Function.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/Function.js
@@ -1,0 +1,1 @@
+Function(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`)();

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/eval.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/eval.js
@@ -1,0 +1,1 @@
+eval(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/inline-event-handlers-UA-code.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/inline-event-handlers-UA-code.js
@@ -1,0 +1,2 @@
+window.dummyDiv.setAttribute("onclick", `import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
+window.dummyDiv.click(); // different from **on**click()

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/reflected-inline-event-handlers.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/reflected-inline-event-handlers.js
@@ -1,0 +1,2 @@
+window.dummyDiv.setAttribute("onclick", `import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`);
+window.dummyDiv.onclick();

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/setTimeout.js
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/scripts/setTimeout.js
@@ -1,0 +1,1 @@
+setTimeout(`import('../../imports-a.js?label=' + window.label).then(window.continueTest, window.errorTest)`, 0);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-external-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-external-classic.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() inside compiled strings uses the script base URL inside a classic script that is loaded from a file</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="dummy"></div>
+
+<script>
+function load(scriptSrc) {
+  const el = document.createElement("script");
+  el.src = scriptSrc;
+  document.body.appendChild(el);
+}
+
+function createTestPromise() {
+  return new Promise((resolve, reject) => {
+    window.dummyDiv.removeAttribute("onclick");
+    delete window.evaluated_imports_a;
+    delete window.label;
+
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+window.dummyDiv = document.querySelector("#dummy");
+
+const evaluators = [
+  "setTimeout",
+  "eval",
+  "Function",
+  "reflected-inline-event-handlers",
+  "inline-event-handlers-UA-code"
+];
+
+for (const label of evaluators) {
+  promise_test(() => {
+    const promise = createTestPromise();
+
+    window.label = label;
+    load(`scripts/${label}.js`);
+
+    return promise.then(module => {
+      assert_true(window.evaluated_imports_a, "The module must have been evaluated");
+      assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+    });
+  }, label + " should successfully import");
+};
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-external-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-external-module.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() inside compiled strings uses the script base URL inside a module script that is loaded from a file</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="dummy"></div>
+
+<script type="module">
+function load(scriptSrc) {
+  const el = document.createElement("script");
+  el.type = "module";
+  el.src = scriptSrc;
+  document.body.appendChild(el);
+}
+
+function createTestPromise() {
+  return new Promise((resolve, reject) => {
+    window.dummyDiv.removeAttribute("onclick");
+    delete window.evaluated_imports_a;
+    delete window.label;
+
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+window.dummyDiv = document.querySelector("#dummy");
+
+const evaluators = [
+  "setTimeout",
+  "eval",
+  "Function",
+  "reflected-inline-event-handlers",
+  "inline-event-handlers-UA-code"
+];
+
+for (const label of evaluators) {
+  promise_test(() => {
+    const promise = createTestPromise();
+
+    window.label = label;
+    load(`scripts/${label}.js`);
+
+    return promise.then(module => {
+      assert_true(window.evaluated_imports_a, "The module must have been evaluated");
+      assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+    });
+  }, label + " should successfully import");
+};
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-inline-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-inline-classic.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>import() inside compiled strings uses the document base URL inside a classic script</title>
+<title>import() inside compiled strings uses the script base URL (= document base URL) inside an inline classic script</title>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 
 <base href="..">
@@ -21,8 +21,8 @@ function createTestPromise() {
 const dummyDiv = document.querySelector("#dummy");
 
 const evaluators = {
-  eval,
   setTimeout,
+  eval,
   "the Function constructor"(x) {
     Function(x)();
   },

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-inline-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-base-url-inline-module.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() inside compiled strings uses the script base URL (= document base URL) inside an inline module script</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<base href="..">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="dummy"></div>
+
+<script type="module">
+function createTestPromise() {
+  return new Promise((resolve, reject) => {
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+const dummyDiv = document.querySelector("#dummy");
+
+const evaluators = {
+  setTimeout,
+  eval,
+  "the Function constructor"(x) {
+    Function(x)();
+  },
+  "reflected inline event handlers"(x) {
+    dummyDiv.setAttribute("onclick", x);
+    dummyDiv.onclick();
+  },
+  "inline event handlers triggered via UA code"(x) {
+    dummyDiv.setAttribute("onclick", x);
+    dummyDiv.click(); // different from .**on**click()
+  }
+};
+
+for (const [label, evaluator] of Object.entries(evaluators)) {
+  promise_test(t => {
+    t.add_cleanup(() => {
+      dummyDiv.removeAttribute("onclick");
+      delete window.evaluated_imports_a;
+    });
+
+    const promise = createTestPromise();
+
+    evaluator(`import('./imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
+
+    return promise.then(module => {
+      assert_true(window.evaluated_imports_a, "The module must have been evaluated");
+      assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+    });
+  }, label + " should successfully import");
+};
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-classic.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a classic script</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<meta http-equiv="Content-Security-Policy" content="require-sri-for script">
+
+<script src="/resources/testharness.js" integrity="sha384-4Nybydhnr3tOpv1yrTkDxu3RFpnxWAxlU5kGn7c8ebKvh1iUdfVMjqP6jf0dacrV"></script>
+<script src="/resources/testharnessreport.js" integrity="sha384-GOnHxuyo+nnsFAe4enY+RAl4/+w5NPMJPCQiDroTjxtR7ndRz7Uan8vNbM2qWKmU"></script>
+
+<div id="dummy"></div>
+
+<script>
+function createTestPromise() {
+  return new Promise((resolve, reject) => {
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+const dummyDiv = document.querySelector("#dummy");
+
+const evaluators = {
+  eval,
+  setTimeout,
+  "the Function constructor"(x) {
+    Function(x)();
+  },
+  "reflected inline event handlers"(x) {
+    dummyDiv.setAttribute("onclick", x);
+    dummyDiv.onclick();
+  },
+  "inline event handlers triggered via UA code"(x) {
+    dummyDiv.setAttribute("onclick", x);
+    dummyDiv.click(); // different from .**on**click()
+  }
+};
+
+for (const [label, evaluator] of Object.entries(evaluators)) {
+  promise_test(t => {
+    t.add_cleanup(() => {
+      dummyDiv.removeAttribute("onclick");
+      delete window.evaluated_imports_a;
+    });
+
+    const promise = createTestPromise();
+
+    evaluator(`import('../imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
+
+    return promise_rejects(t, new TypeError(), promise);
+  }, label + " should fail to import");
+};
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-module.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>import() inside compiled strings uses the document base URL inside a module script</title>
+<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a module script</title>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+<meta http-equiv="Content-Security-Policy" content="require-sri-for script">
 
-<base href="..">
-
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js" integrity="sha384-4Nybydhnr3tOpv1yrTkDxu3RFpnxWAxlU5kGn7c8ebKvh1iUdfVMjqP6jf0dacrV"></script>
+<script src="/resources/testharnessreport.js" integrity="sha384-GOnHxuyo+nnsFAe4enY+RAl4/+w5NPMJPCQiDroTjxtR7ndRz7Uan8vNbM2qWKmU"></script>
 
 <div id="dummy"></div>
 
@@ -45,12 +44,9 @@ for (const [label, evaluator] of Object.entries(evaluators)) {
 
     const promise = createTestPromise();
 
-    evaluator(`import('./imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
+    evaluator(`import('../imports-a.js?label=${label}').then(window.continueTest, window.errorTest);`);
 
-    return promise.then(module => {
-      assert_true(window.evaluated_imports_a, "The module must have been evaluated");
-      assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
-    });
-  }, label + " should successfully import");
+    return promise_rejects(t, new TypeError(), promise);
+  }, label + " should fail to import");
 };
 </script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() inside compiled strings uses the appropriate nonce inside a classic script</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<meta http-equiv="content-security-policy" content="script-src 'nonce-correct' 'unsafe-eval' 'unsafe-hashed-attributes' 'sha256-cAMzxBL19bKt4KwKGbxy/ZOFIIjH5AmRjlVbsD5pvNw=' 'sha256-3VjoJYNK/9HJMS8rrZHlqSZgUssDY+GPyc7AU8lNM3k='">
+
+<script nonce="correct" src="/resources/testharness.js"></script>
+<script nonce="correct" src="/resources/testharnessreport.js"></script>
+
+<div id="dummy"></div>
+
+<script nonce="correct">
+"use strict";
+const dummyDiv = document.querySelector("#dummy");
+
+function createTestPromise(t) {
+  t.add_cleanup(() => {
+    delete window.evaluated_imports_a;
+    delete window.unreached;
+    delete window.continueTest;
+    delete window.errorTest;
+  });
+
+  return new Promise((resolve, reject) => {
+    window.unreached = t.unreached_func("Must not reach this");
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+function assertSuccessful(module) {
+  assert_true(window.evaluated_imports_a, "The module must have been evaluated");
+  assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+}
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.unreached, window.continueTest)`, 0);
+
+  return promise.then(assertSuccessful);
+}, "setTimeout must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  eval(`import('../imports-a.js?label=direct eval').then(window.continueTest, window.errorTest)`);
+
+  return promise.then(assertSuccessful);
+}, "direct eval must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  const evalAlias = eval;
+  evalAlias(`import('../imports-a.js?label=indirect eval').then(window.continueTest, window.errorTest)`);
+
+  return promise.then(assertSuccessful);
+}, "indirect eval must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  Function(`import('../imports-a.js?label=the Function constructor').then(window.continueTest, window.errorTest)`)();
+
+  return promise.then(assertSuccessful);
+}, "the Function constructor must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  t.add_cleanup(() => {
+    dummyDiv.removeAttribute("onclick");
+  });
+
+  const promise = createTestPromise(t);
+
+  // This only works because of the 'unsafe-hashed-attributes' and the hash in the CSP policy
+  dummyDiv.setAttribute(
+    "onclick",
+    `import('../imports-a.js?label=reflected inline event handlers').then(window.continueTest, window.errorTest)`
+  );
+  dummyDiv.onclick();
+
+  return promise.then(assertSuccessful);
+}, "reflected inline event handlers must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  t.add_cleanup(() => {
+    dummyDiv.removeAttribute("onclick");
+  });
+
+  const promise = createTestPromise(t);
+
+  // This only works because of the 'unsafe-hashed-attributes' and the hash in the CSP policy
+  dummyDiv.setAttribute(
+    "onclick",
+    `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
+  );
+  dummyDiv.click(); // different from **on**click()
+
+  return promise.then(assertSuccessful);
+}, "inline event handlers triggered via UA code must inherit the nonce from the triggering script, thus execute");
+</script>

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>import() inside compiled strings uses the appropriate nonce inside a module script</title>
+<link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
+
+<meta http-equiv="content-security-policy" content="script-src 'nonce-correct' 'unsafe-eval' 'unsafe-hashed-attributes' 'sha256-cAMzxBL19bKt4KwKGbxy/ZOFIIjH5AmRjlVbsD5pvNw=' 'sha256-3VjoJYNK/9HJMS8rrZHlqSZgUssDY+GPyc7AU8lNM3k='">
+
+<script nonce="correct" src="/resources/testharness.js"></script>
+<script nonce="correct" src="/resources/testharnessreport.js"></script>
+
+<div id="dummy"></div>
+
+<script type="module" nonce="correct">
+const dummyDiv = document.querySelector("#dummy");
+
+function createTestPromise(t) {
+  t.add_cleanup(() => {
+    delete window.evaluated_imports_a;
+    delete window.unreached;
+    delete window.continueTest;
+    delete window.errorTest;
+  });
+
+  return new Promise((resolve, reject) => {
+    window.unreached = t.unreached_func("Must not reach this");
+    window.continueTest = resolve;
+    window.errorTest = reject;
+  });
+}
+
+function assertSuccessful(module) {
+  assert_true(window.evaluated_imports_a, "The module must have been evaluated");
+  assert_equals(module.A.from, "imports-a.js", "The module namespace object must be correct");
+}
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  setTimeout(`import('../imports-a.js?label=setTimeout').then(window.unreached, window.continueTest)`, 0);
+
+  return promise.then(assertSuccessful);
+}, "setTimeout must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  eval(`import('../imports-a.js?label=direct eval').then(window.continueTest, window.errorTest)`);
+
+  return promise.then(assertSuccessful);
+}, "direct eval must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  const evalAlias = eval;
+  evalAlias(`import('../imports-a.js?label=indirect eval').then(window.continueTest, window.errorTest)`);
+
+  return promise.then(assertSuccessful);
+}, "indirect eval must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  const promise = createTestPromise(t);
+
+  Function(`import('../imports-a.js?label=the Function constructor').then(window.continueTest, window.errorTest)`)();
+
+  return promise.then(assertSuccessful);
+}, "the Function constructor must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  t.add_cleanup(() => {
+    dummyDiv.removeAttribute("onclick");
+  });
+
+  const promise = createTestPromise(t);
+
+  // This only works because of the 'unsafe-hashed-attributes' and the hash in the CSP policy
+  dummyDiv.setAttribute(
+    "onclick",
+    `import('../imports-a.js?label=reflected inline event handlers').then(window.continueTest, window.errorTest)`
+  );
+  dummyDiv.onclick();
+
+  return promise.then(assertSuccessful);
+}, "reflected inline event handlers must inherit the nonce from the triggering script, thus execute");
+
+promise_test(t => {
+  t.add_cleanup(() => {
+    dummyDiv.removeAttribute("onclick");
+  });
+
+  const promise = createTestPromise(t);
+
+  // This only works because of the 'unsafe-hashed-attributes' and the hash in the CSP policy
+  dummyDiv.setAttribute(
+    "onclick",
+    `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
+  );
+  dummyDiv.click(); // different from **on**click()
+
+  return promise.then(assertSuccessful);
+}, "inline event handlers triggered via UA code must inherit the nonce from the triggering script, thus execute");
+</script>


### PR DESCRIPTION
More dynamic import() string compilation tests

Follows https://github.com/whatwg/html/pull/3117. Parser state is implicitly tested because lots of tests would otherwise fail.

Referrer policy tests omitted for now since you can only set that via modulepreload at the moment.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
