### PR TITLE
wai-aria: Update test cases for macOS

### DIFF
--- a/wai-aria/aria-details_pointing_to_details_element-manual.html
+++ b/wai-aria/aria-details_pointing_to_details_element-manual.html
@@ -25,14 +25,6 @@
                   "[details]"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "TBD",
-                  "is",
-                  "TBD"
-               ]
-            ],
             "IAccessible2" : [
                [
                   "property",

--- a/wai-aria/aria-details_pointing_to_div_element-manual.html
+++ b/wai-aria/aria-details_pointing_to_div_element-manual.html
@@ -25,14 +25,6 @@
                   "[details]"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "TBD",
-                  "is",
-                  "TBD"
-               ]
-            ],
             "IAccessible2" : [
                [
                   "property",

--- a/wai-aria/errormessage_object_in_invalid_state-manual.html
+++ b/wai-aria/errormessage_object_in_invalid_state-manual.html
@@ -28,9 +28,9 @@
             "AXAPI" : [
                [
                   "property",
-                  "TBD",
+                  "AXValidationError",
                   "is",
-                  "TBD"
+                  "You did not enter a valid date!"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/errormessage_object_in_valid_state-manual.html
+++ b/wai-aria/errormessage_object_in_valid_state-manual.html
@@ -28,9 +28,9 @@
             "AXAPI" : [
                [
                   "property",
-                  "TBD",
+                  "AXValidationError",
                   "is",
-                  "TBD"
+                  "<nil>"
                ]
             ],
             "IAccessible2" : [

--- a/wai-aria/keyshortcuts_multiple_shortcuts-manual.html
+++ b/wai-aria/keyshortcuts_multiple_shortcuts-manual.html
@@ -31,32 +31,6 @@
                   "keyshortcuts:Shift+Space Alt+Space"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "AXRole",
-                  "is",
-                  "AXButton"
-               ],
-               [
-                  "property",
-                  "AXSubrole",
-                  "is",
-                  "<nil>"
-               ],
-               [
-                  "property",
-                  "AXRoleDescription",
-                  "is",
-                  "button"
-               ],
-               [
-                  "result",
-                  "The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts",
-                  "is",
-                  "true"
-               ]
-            ],
             "MSAA" : [
                [
                   "property",

--- a/wai-aria/keyshortcuts_one_shortcut-manual.html
+++ b/wai-aria/keyshortcuts_one_shortcut-manual.html
@@ -31,32 +31,6 @@
                   "keyshortcuts:Shift+Space"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "AXRole",
-                  "is",
-                  "AXButton"
-               ],
-               [
-                  "property",
-                  "AXSubrole",
-                  "is",
-                  "<nil>"
-               ],
-               [
-                  "property",
-                  "AXRoleDescription",
-                  "is",
-                  "button"
-               ],
-               [
-                  "result",
-                  "The element with role=\"button\" and id=\"test\", does not expose aria-keyshortcuts",
-                  "is",
-                  "true"
-               ]
-            ],
             "MSAA" : [
                [
                   "property",


### PR DESCRIPTION
There is no mapping defined in macOS for aria-details or aria-keyshortcuts.
As a result, we cannot test an undefined and, at least in the case of
Safari, unimplemented feature. There are now mappings in macOS for the
new aria-errormessage feature, so update the test cases accordingly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
