### PR TITLE
Make background gradient cover padding

### DIFF
--- a/css/css-images-3/gradient-button-ref.html
+++ b/css/css-images-3/gradient-button-ref.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Big button with gradient (without padding)</title>
+<style>
+    #button {
+        width: calc(300px + 2 * 30px);
+        height: calc(80px + 2 * 20px);
+        background: linear-gradient(blue, green);
+        border-width: 5px;
+        border-style: solid;
+        border-color: red;
+        border-radius: 10px;
+    }
+</style>
+<div id="button"></div>

--- a/css/css-images-3/gradient-button.html
+++ b/css/css-images-3/gradient-button.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Gradients with padding</title>
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#gradients">
+<meta name="assert" content="gradients cover element padding">
+<link rel="match" href="gradient-button-ref.html">
+<style>
+#button {
+    width: 300px;
+    height: 80px;
+    padding: 20px 30px;
+    background: linear-gradient(blue, green);
+    border-width: 5px;
+    border-style: solid;
+    border-color: red;
+    border-radius: 10px;
+}
+</style>
+<div id="button"></div>


### PR DESCRIPTION

CSS-gradients should not only cover the content of an
element but also the padding (but not the border).

Add a reftest.

Upstreamed from https://github.com/servo/servo/pull/17395 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7694)
<!-- Reviewable:end -->
