### PR TITLE
Force HTMLStyleElement to create a new CSSStyleSheet when re-parsing.

### DIFF
--- a/cssom/style-sheet-interfaces-001.html
+++ b/cssom/style-sheet-interfaces-001.html
@@ -61,6 +61,17 @@
       assert: [ "styleElement.sheet exists", "styleElement.sheet is a CSSStyleSheet",
                 "linkElement.sheet exists", "linkElement.sheet is a CSSStyleSheet"] });
 
+    test(function () {
+      var style = document.createElement("style");
+      document.querySelector("head").appendChild(style);
+      var sheet1 = style.sheet;
+      assert_equals(sheet1.cssRules.length, 0);
+      style.appendChild(document.createTextNode("a { color: green; }"));
+      assert_equals(style.sheet.cssRules.length, 1);
+    }, "sheet_property_updates",
+    { help: "https://www.w3.org/TR/cssom-1/#the-linkstyle-interface",
+      assert: "The sheet property on LinkStyle should always return the current associated style sheet." });
+
     test(function() {
         assert_own_property(styleSheet, "ownerRule");
         assert_own_property(styleSheet, "cssRules");


### PR DESCRIPTION

We already call Document::invalidate_style_sheets and set
the stylesheet member to a new Stylesheet. This matches the behavior of
Firefox, and means the new CSSStyleSheet you get from accessing .sheet
from JS will be correct instead of stale.

(::get_cssom_stylesheet already tries to use the new Stylesheet, but
MutNullableJS::or_init is called, so if we already created a
CSSStyleSheet we will continue to return that one).

Upstreamed from https://github.com/servo/servo/pull/17259 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7697)
<!-- Reviewable:end -->
