### PR TITLE
Implement CSSStyleRule.selectorText.

### DIFF
--- a/cssom/selectorText-modification-restyle-001-ref.html
+++ b/cssom/selectorText-modification-restyle-001-ref.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>(Ref #1) CSSOM - CSSStyleRule.selectorText Modification Restyle - Reference #1</title>
+
+<style>
+div {
+  color: green;
+}
+</style>
+
+<body>
+<div>I should be green.</div>
+</body>

--- a/cssom/selectorText-modification-restyle-001.html
+++ b/cssom/selectorText-modification-restyle-001.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>(Test #1) CSSOM - CSSStyleRule.selectorText Modification Restyle - Test #1</title>
+<link rel="match" href="selectorText-modification-restyle-001-ref.html">
+
+<style>
+@namespace bogus url(http://example.com/bogus);
+
+bogus|div {
+  color: green;
+}
+</style>
+
+<body>
+<div>I should be green.</div>
+<script>
+// Remove the "bogus" namespace--now it should apply to the div above.
+// We also expect to see a restyle.
+document.querySelector("style").sheet.cssRules[1].selectorText = "div";
+</script>
+</body>


### PR DESCRIPTION

We parse when assigning using the namespaces of the stylesheet. It isn't
clear if the spec says to do that (Firefox doesn't support the setter at
all, Chrome does, Safari doesn't); the spec issue is here:
https://github.com/w3c/csswg-drafts/issues/1511

Also fix ToCss implementation of AttrSelectorOperator to not pad with
spaces, to conform with CSSOM. This means we have to update some unit
tests that expect operators with spaces around them in attribute
selectors to roundtrip.

See the "attribute selector" section of "Serializing Selectors" here:
https://drafts.csswg.org/cssom/#serializing-selectors

CSSStyleRule.selectorText is specified here:
https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext

Upstreamed from https://github.com/servo/servo/pull/17538 [ci skip]