### PR TITLE
Properly fail in event_loadeddata_noautoplay.html

### DIFF
--- a/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_loadeddata_noautoplay.html
@@ -17,18 +17,16 @@
 test(function() {
   var t = async_test("setting src attribute on non-autoplay audio should trigger loadeddata event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("loadeddata", function() {
-    t.done();
-  }, false);
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("loadeddata", t.step_func_done(), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
 }, "audio events - loadeddata");
 
 test(function() {
   var t = async_test("setting src attribute on non-autoplay video should trigger loadeddata event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("loadeddata", function() {
-    t.done();
-  }, false);
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("loadeddata", t.step_func_done(), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
 }, "video events - loadeddata");
   </script>


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/18675 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7713)
<!-- Reviewable:end -->
