### PR TITLE
Properly fail on error event in event_timeupdate_noautoplay.html

### DIFF
--- a/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
+++ b/html/semantics/embedded-content/media-elements/event_timeupdate_noautoplay.html
@@ -17,10 +17,11 @@
 test(function() {
   var t = async_test("calling play() on a sufficiently long audio should trigger timeupdate event", {timeout:5000});
   var a = document.getElementById("a");
-  a.addEventListener("timeupdate", function() {
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("timeupdate", t.step_func(function() {
     t.done();
     a.pause();
-  }, false);
+  }), false);
   a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
   a.play();
 }, "audio events - timeupdate");
@@ -28,10 +29,11 @@ test(function() {
 test(function() {
   var t = async_test("calling play() on a sufficiently long video should trigger timeupdate event", {timeout:5000});
   var v = document.getElementById("v");
-  v.addEventListener("timeupdate", function() {
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("timeupdate", t.step_func(function() {
     t.done();
     v.pause();
-  }, false);
+  }), false);
   v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
   v.play();
 }, "video events - timeupdate");


### PR DESCRIPTION

The tests still time out when the browser doesn't fire a timeupdate event
at all.

Upstreamed from https://github.com/servo/servo/pull/18678 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7726)
<!-- Reviewable:end -->
