### PR TITLE
Properly fail in autoplay-overrides-preload.html

### DIFF
--- a/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html
+++ b/html/semantics/embedded-content/media-elements/loading-the-media-resource/autoplay-overrides-preload.html
@@ -17,6 +17,7 @@
         a.preload = preload;
         a.autoplay = true;
       }
+      a.addEventListener('error', t.unreached_func());
       a.addEventListener('playing', t.step_func(function() {
         assert_equals(a.readyState, a.HAVE_ENOUGH_DATA);
         assert_false(a.paused);


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/18678 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7727)
<!-- Reviewable:end -->
