### PR TITLE
Set up check_stability logging at root level

### DIFF
--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -28,12 +28,13 @@ wptrunner = None
 def setup_logging():
     """Set up basic debug logger."""
     global logger
-    logger = logging.getLogger(here)
+    logger = logging.getLogger(wpt_root)
     handler = logging.StreamHandler(sys.stdout)
     formatter = logging.Formatter(logging.BASIC_FORMAT, None)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
+    logger.propagate = False
 
 
 def do_delayed_imports():

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -10,7 +10,7 @@ from ..manifest import manifest, update
 here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
-logger = logging.getLogger()
+logger = logging.getLogger(wpt_root)
 
 
 def get_git_cmd(repo_path):


### PR DESCRIPTION
When the command `git fetch https://github.com/w3c/web-platform-tests.git master:master` fails (because of local branch state), logging is attempted (with the default/root logger), which is not set up. This causes the output to be:

> No handlers could be found for logger "root"

instead of something like

> ERROR: [...]/web-platform-tests: Git command exited with status 1

cc/ @jgraham

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7768)
<!-- Reviewable:end -->
