### PR TITLE
Add a test for a Window object being serialized

### DIFF
--- a/webdriver/tests/contexts/json_serialize_windowproxy.py
+++ b/webdriver/tests/contexts/json_serialize_windowproxy.py
@@ -1,0 +1,13 @@
+# META: timeout=long
+
+import json
+
+
+def test_window(session):
+    session.execute_script("window.foo = window.open()")
+    raw_json = session.execute_script("return window.foo;")
+    obj = json.loads(raw_json)
+    assert len(obj) == 1
+    assert "window-fcc6-11e5-b4f8-330a88ab9d7f" in obj
+    handle = obj["window-fcc6-11e5-b4f8-330a88ab9d7f"]
+    assert handle in session.window_handles


### PR DESCRIPTION
Should also add a test for a frame being serialised, but I'm not sure I'm using the webdriver module API right given nothing says what the webdriver module actually is here (is it actually just the Selenium one?).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
