### PR TITLE
Add test to ensure UA conditionally blocks rendering on link's media attr

### DIFF
--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -7,19 +7,34 @@
 <link rel=stylesheet media="screen and (max-width:10px)" href=stylesheet.py?stylesNotMatchingEnvironment&delay=2>
 <h1>Dominic Farolino</h1>
 <script>
+  function styleExists(styleText) {
+    for (let key in document.styleSheets) {
+      if (!document.styleSheets.hasOwnProperty(key) || key == "length") continue;
+
+      let currentStyleText = document.styleSheets[key].cssRules["0"].cssText;
+      if (currentStyleText == styleText) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   test(() => {
     const h1 = document.querySelector('h1');
     const computedColor = getComputedStyle(h1).color;
     const expectedColor = "rgb(128, 0, 128)";
 
     assert_equals(computedColor, expectedColor);
-    assert_equals(document.styleSheets.length, 1);
+    assert_true(styleExists("h1 { color: purple; }")); // first style sheet
+    assert_false(styleExists("h1 { color: brown; }")); // second style sheet (should not be loaded yet)
   }, "Only the style sheet loaded via a link element whose media attribute matches the environment should block following script execution");
 
-  const secondStylesheetTest = async_test("Two style sheets should be registered as style sheets for the document after 3 seconds");
+  const secondStylesheetTest = async_test("Both style sheets loaded via the link elements should be registered as style sheets for the document after 2 seconds");
   secondStylesheetTest.step_timeout(() => {
     secondStylesheetTest.step(() => {
-      assert_equals(document.styleSheets.length, 2);
+      assert_true(styleExists("h1 { color: purple; }")); // first style sheet
+      assert_true(styleExists("h1 { color: brown; }")); // second style sheet (loaded now!)
     });
     secondStylesheetTest.done();
   }, 3000);

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -8,6 +8,11 @@
 <h1>Dominic Farolino</h1>
 <script>
   test(() => {
+    const h1 = document.querySelector('h1');
+    const computedColor = getComputedStyle(h1).color;
+    const expectedColor = "rgb(128, 0, 128)";
+
+    assert_equals(computedColor, expectedColor);
     assert_equals(document.styleSheets.length, 1);
   }, "Only the style sheet loaded via a link element whose media attribute matches the environment should be loaded synchronously");
 

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -14,7 +14,7 @@
 
     assert_equals(computedColor, expectedColor);
     assert_equals(document.styleSheets.length, 1);
-  }, "Only the style sheet loaded via a link element whose media attribute matches the environment should be loaded synchronously");
+  }, "Only the style sheet loaded via a link element whose media attribute matches the environment should block following script execution");
 
   const secondStylesheetTest = async_test("Two style sheets should be registered as style sheets for the document after 3 seconds");
   step_timeout(() => {

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -12,7 +12,7 @@
   }, "Only the style sheet loaded via a link element whose media attribute matches the environment should be loaded synchronously");
 
   const secondStylesheetTest = async_test("Two style sheets should be registered as style sheets for the document after 3 seconds");
-  setTimeout(() => {
+  step_timeout(() => {
     secondStylesheetTest.step(() => {
       assert_equals(document.styleSheets.length, 2);
     });

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -8,10 +8,8 @@
 <h1>Dominic Farolino</h1>
 <script>
   function styleExists(styleText) {
-    for (let key in document.styleSheets) {
-      if (!document.styleSheets.hasOwnProperty(key) || key == "length") continue;
-
-      let currentStyleText = document.styleSheets[key].cssRules["0"].cssText;
+    for (let styleRule of document.styleSheets) {
+      let currentStyleText = styleRule.cssRules["0"].cssText;
       if (currentStyleText == styleText) {
         return true;
       }
@@ -32,10 +30,8 @@
 
   const secondStylesheetTest = async_test("Both style sheets loaded via the link elements should be registered as style sheets for the document after 2 seconds");
   secondStylesheetTest.step_timeout(() => {
-    secondStylesheetTest.step(() => {
       assert_true(styleExists("h1 { color: purple; }")); // first style sheet
       assert_true(styleExists("h1 { color: brown; }")); // second style sheet (loaded now!)
-    });
-    secondStylesheetTest.done();
+      secondStylesheetTest.done();
   }, 3000);
 </script>

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -17,7 +17,7 @@
   }, "Only the style sheet loaded via a link element whose media attribute matches the environment should block following script execution");
 
   const secondStylesheetTest = async_test("Two style sheets should be registered as style sheets for the document after 3 seconds");
-  step_timeout(() => {
+  secondStylesheetTest.step_timeout(() => {
     secondStylesheetTest.step(() => {
       assert_equals(document.styleSheets.length, 2);
     });

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/conditionally-block-rendering-on-link-media-attr.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+
+<link rel=stylesheet href=stylesheet.py>
+<link rel=stylesheet media="screen and (max-width:10px)" href=stylesheet.py?stylesNotMatchingEnvironment&delay=2>
+<h1>Dominic Farolino</h1>
+<script>
+  test(() => {
+    assert_equals(document.styleSheets.length, 1);
+  }, "Only the style sheet loaded via a link element whose media attribute matches the environment should be loaded synchronously");
+
+  const secondStylesheetTest = async_test("Two style sheets should be registered as style sheets for the document after 3 seconds");
+  setTimeout(() => {
+    secondStylesheetTest.step(() => {
+      assert_equals(document.styleSheets.length, 2);
+    });
+    secondStylesheetTest.done();
+  }, 3000);
+</script>

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
@@ -1,0 +1,10 @@
+from time import sleep
+def main(request, response):
+  if "delay" in request.GET:
+    delay = int(request.GET["delay"])
+    sleep(delay)
+
+  if "stylesNotMatchingEnvironment" in request.GET:
+    return 'h1 {color: green}'
+  else:
+    return 'h1 {color: red}'

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
@@ -5,6 +5,6 @@ def main(request, response):
     sleep(delay)
 
   if "stylesNotMatchingEnvironment" in request.GET:
-    return 'h1 {color: green}'
+    return 'h1 {color: brown}'
   else:
-    return 'h1 {color: red}'
+    return 'h1 {color: purple}'

--- a/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
+++ b/html/semantics/document-metadata/interactions-of-styling-and-scripting/stylesheet.py
@@ -5,6 +5,6 @@ def main(request, response):
     sleep(delay)
 
   if "stylesNotMatchingEnvironment" in request.GET:
-    return 'h1 {color: brown}'
+    return 'h1 {color: brown;}'
   else:
-    return 'h1 {color: purple}'
+    return 'h1 {color: purple;}'


### PR DESCRIPTION
This addresses the need for a test case in https://github.com/whatwg/html/pull/2984.

At the very least it is a start, as I'm not sure if it is written the best way since it has potential to be a tad racy I think, but seems to do the trick. Basically we load two stylesheets, one via a link element whose media attribute matches the environment, and one whose media attribute doesn't*. The style sheet that is supposedly non-matching is loaded with a 2 second delay to avoid racy-ness in the following tests.

Then I run two tests, one immediately that blocks the rendering of the page, and another that runs a few seconds later. The former tests to ensure that we've only blocked rendering on a single style sheet (since at this point only one should appear in `document.styleSheets`), and the latter checks to see that the other one was loaded a few seconds after, as it would then asynchronously appear in `document.styleSheets`

----

Things to consider:

 - \* I don't actually verify in code that the media attribute which supposedly doesn't match the environment, truly doesn't match the environment. If it did, the test would incorrectly fail. Should I verify this in another test perhaps?
 - Boris mentioned a better way would be to test the computed styles as the stylesheets loaded, however I'm not sure if this is the best way since the style sheets that we're testing the loading of are supposed to fail to match the environment, so the styles of the page should never change really, we're just looking at which style sheets are loaded sync vs async.

/cc @annevk

<!-- Reviewable:start -->

<!-- Reviewable:end -->
