### PR TITLE
Add option to disable unstable tests with wpt-update;

### DIFF
--- a/tools/wptrunner/wptrunner/manifestupdate.py
+++ b/tools/wptrunner/wptrunner/manifestupdate.py
@@ -29,8 +29,11 @@ set of results and conditionals. The AST of the underlying parsed manifest
 is updated with the changes, and the result is serialised to a file.
 """
 
+
 class ConditionError(Exception):
-    pass
+    def __init__(self, cond=None):
+        self.cond = cond
+
 
 Result = namedtuple("Result", ["run_info", "status"])
 
@@ -102,6 +105,7 @@ class ExpectedManifest(ManifestItem):
         return urlparse.urljoin(self.url_base,
                                 "/".join(self.test_path.split(os.path.sep)))
 
+
 class TestNode(ManifestItem):
     def __init__(self, node):
         """Tree node associated with a particular test in a manifest
@@ -111,6 +115,7 @@ class TestNode(ManifestItem):
         ManifestItem.__init__(self, node)
         self.updated_expected = []
         self.new_expected = []
+        self.new_disabled = False
         self.subtests = {}
         self.default_status = None
         self._from_file = True
@@ -181,7 +186,7 @@ class TestNode(ManifestItem):
             self.new_expected.append(Result(run_info, result.status))
             self.root.modified = True
 
-    def coalesce_expected(self):
+    def coalesce_expected(self, stability=None):
         """Update the underlying manifest AST for this test based on all the
         added results.
 
@@ -190,9 +195,11 @@ class TestNode(ManifestItem):
         that get more than one different result in the updated run, and add new
         conditionals for anything that doesn't match an existing conditional.
 
-        Conditionals not matched by any added result are not changed."""
+        Conditionals not matched by any added result are not changed.
 
-        final_conditionals = []
+        When `stability` is not None, disable any test that shows multiple
+        unexpected results for the same set of parameters.
+        """
 
         try:
             unconditional_status = self.get("expected")
@@ -202,7 +209,7 @@ class TestNode(ManifestItem):
         for conditional_value, results in self.updated_expected:
             if not results:
                 # The conditional didn't match anything in these runs so leave it alone
-                final_conditionals.append(conditional_value)
+                pass
             elif all(results[0].status == result.status for result in results):
                 # All the new values for this conditional matched, so update the node
                 result = results[0]
@@ -212,7 +219,6 @@ class TestNode(ManifestItem):
                         self.remove_value("expected", conditional_value)
                 else:
                     conditional_value.value = result.status
-                    final_conditionals.append(conditional_value)
             elif conditional_value.condition_node is not None:
                 # Blow away the existing condition and rebuild from scratch
                 # This isn't sure to work if we have a conditional later that matches
@@ -233,20 +239,22 @@ class TestNode(ManifestItem):
                 status = self.new_expected[0].status
                 if status != self.default_status:
                     self.set("expected", status, condition=None)
-                    final_conditionals.append(self._data["expected"][-1])
             else:
                 try:
                     conditionals = group_conditionals(
                         self.new_expected,
                         property_order=self.root.property_order,
                         boolean_properties=self.root.boolean_properties)
-                except ConditionError:
-                    print "Conflicting test results for %s, cannot update" % self.root.test_path
+                except ConditionError as e:
+                    if stability is not None:
+                       self.set("disabled", stability or "unstable", e.cond.children[0])
+                       self.new_disabled = True
+                    else:
+                        print "Conflicting test results for %s, cannot update" % self.root.test_path
                     return
                 for conditional_node, status in conditionals:
                     if status != unconditional_status:
                         self.set("expected", status, condition=conditional_node.children[0])
-                        final_conditionals.append(self._data["expected"][-1])
 
         if ("expected" in self._data and
             len(self._data["expected"]) > 0 and
@@ -367,6 +375,9 @@ def group_conditionals(values, property_order=None, boolean_properties=None):
     for run_info, status in values:
         prop_set = tuple((prop, run_info[prop]) for prop in include_props)
         if prop_set in conditions:
+            if conditions[prop_set][1] != status:
+                # A prop_set contains contradictory results
+                raise ConditionError(make_expr(prop_set, status, boolean_properties))
             continue
 
         expr = make_expr(prop_set, status, boolean_properties=boolean_properties)

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -29,9 +29,13 @@ def load_test_manifests(serve_root, test_paths):
 
 def update_expected(test_paths, serve_root, log_file_names,
                     rev_old=None, rev_new="HEAD", ignore_existing=False,
-                    sync_root=None, property_order=None, boolean_properties=None):
+                    sync_root=None, property_order=None, boolean_properties=None,
+                    stability=None):
     """Update the metadata files for web-platform-tests based on
-    the results obtained in a previous run"""
+    the results obtained in a previous run or runs
+
+    If stability is not None, assume log_file_names refers to logs from repeated
+    test jobs, disable tests that don't behave as expected on all runs"""
 
     manifests = load_test_manifests(serve_root, test_paths)
 
@@ -45,17 +49,25 @@ def update_expected(test_paths, serve_root, log_file_names,
         if rev_old is not None:
             change_data = load_change_data(rev_old, rev_new, repo=sync_root)
 
-
     expected_map_by_manifest = update_from_logs(manifests,
                                                 *log_file_names,
                                                 ignore_existing=ignore_existing,
                                                 property_order=property_order,
-                                                boolean_properties=boolean_properties)
+                                                boolean_properties=boolean_properties,
+                                                stability=stability)
 
     for test_manifest, expected_map in expected_map_by_manifest.iteritems():
         url_base = manifests[test_manifest]["url_base"]
         metadata_path = test_paths[url_base]["metadata_path"]
         write_changes(metadata_path, expected_map)
+        if stability is not None:
+            for tree in expected_map.itervalues():
+                for test in tree.iterchildren():
+                    for subtest in test.iterchildren():
+                        if subtest.new_disabled:
+                            print os.path.dirname(subtest.root.test_path) + "/" + subtest.name
+                    if test.new_disabled:
+                        print test.root.test_path
 
     results_changed = [item.test_path for item in expected_map.itervalues() if item.modified]
 
@@ -121,7 +133,9 @@ def unexpected_changes(manifests, change_data, files_changed):
 # For each test in the list of tests:
 #   for each conditional:
 #      If all the new values match (or there aren't any) retain that conditional
-#      If any new values mismatch mark the test as needing human attention
+#      If any new values mismatch:
+#           If stability and any repeated values don't match, disable the test
+#           else mark the test as needing human attention
 #   Check if all the RHS values are the same; if so collapse the conditionals
 
 
@@ -129,6 +143,7 @@ def update_from_logs(manifests, *log_filenames, **kwargs):
     ignore_existing = kwargs.get("ignore_existing", False)
     property_order = kwargs.get("property_order")
     boolean_properties = kwargs.get("boolean_properties")
+    stability = kwargs.get("stability")
 
     expected_map = {}
     id_test_map = {}
@@ -152,8 +167,8 @@ def update_from_logs(manifests, *log_filenames, **kwargs):
         for tree in manifest_expected.itervalues():
             for test in tree.iterchildren():
                 for subtest in test.iterchildren():
-                    subtest.coalesce_expected()
-                test.coalesce_expected()
+                    subtest.coalesce_expected(stability=stability)
+                test.coalesce_expected(stability=stability)
 
     return expected_map
 
@@ -284,7 +299,6 @@ class ExpectedUpdater(object):
         result = test_cls.result_cls(
             data["status"],
             data.get("message"))
-
         test.set_result(self.run_info, result)
         del self.test_cache[test_id]
 

--- a/tools/wptrunner/wptrunner/update/metadata.py
+++ b/tools/wptrunner/wptrunner/update/metadata.py
@@ -33,7 +33,8 @@ class UpdateExpected(Step):
                                                      ignore_existing=state.ignore_existing,
                                                      sync_root=sync_root,
                                                      property_order=state.property_order,
-                                                     boolean_properties=state.boolean_properties)
+                                                     boolean_properties=state.boolean_properties,
+                                                     stability=state.stability)
 
 
 class CreateMetadataPatch(Step):

--- a/tools/wptrunner/wptrunner/update/update.py
+++ b/tools/wptrunner/wptrunner/update/update.py
@@ -90,6 +90,7 @@ class UpdateMetadata(Step):
         with state.push(["local_tree", "sync_tree", "paths", "serve_root"]):
             state.run_log = kwargs["run_log"]
             state.ignore_existing = kwargs["ignore_existing"]
+            state.stability = kwargs["stability"]
             state.patch = kwargs["patch"]
             state.suite_name = kwargs["suite_name"]
             state.product = kwargs["product"]

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -463,6 +463,9 @@ def create_parser_update(product_choices=None):
     parser.add_argument("--sync", dest="sync", action="store_true", default=False,
                         help="Sync the tests with the latest from upstream (implies --patch)")
     parser.add_argument("--ignore-existing", action="store_true", help="When updating test results only consider results from the logfiles provided, not existing expectations.")
+    parser.add_argument("--stability", nargs="?", action="store", const="unstable", default=None,
+        help=("Reason for disabling tests. When updating test results, disable tests that have "
+              "inconsistent results across many runs with the given reason."))
     parser.add_argument("--continue", action="store_true", help="Continue a previously started run of the update script")
     parser.add_argument("--abort", action="store_true", help="Clear state from a previous incomplete run of the update script")
     parser.add_argument("--exclude", action="store", nargs="*",


### PR DESCRIPTION

Add a --stability option to wpt-update. If test results are inconsistent
across many runs, the test is disabled for the condition(s) indicated by
the corresponding log files. The --stability option is used to specify
a reason for disabling the tests (typically a bug number), which is
recorded in metadata. Disabled test paths are printed to stdout.

MozReview-Commit-ID: DEIqRkN7NzR

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1401684 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7793)
<!-- Reviewable:end -->
