### PR TITLE
Increase the marionette connect timeout in wptrunner,

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -62,12 +62,12 @@ class MarionetteProtocol(Protocol):
         self.marionette = marionette.Marionette(host='localhost',
                                                 port=self.marionette_port,
                                                 socket_timeout=None,
-                                                startup_timeout=startup_timeout)
+                                                startup_timeout=None)
 
         # XXX Move this timeout somewhere
         self.logger.debug("Waiting for Marionette connection")
         while True:
-            success = self.marionette.wait_for_port(60 * self.timeout_multiplier)
+            success = self.marionette.wait_for_port(startup_timeout)
             #When running in a debugger wait indefinitely for firefox to start
             if success or self.executor.debug_info is None:
                 break


### PR DESCRIPTION

This switches to using a timeout of 120s * timeout_multplier, which is
twice the current value. The Marionette startup_timout value is
removed because it turns out that's only used when marionette starts
the Firefox instance and therefore is ignored in this case.

MozReview-Commit-ID: 4VA8yB6M1d5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1393366 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7794)
<!-- Reviewable:end -->
