### PR TITLE
add web platform tests coverage for what status/statusText/readyState should be in various abort() edge cases; r=annevk,baku

### DIFF
--- a/XMLHttpRequest/abort-during-done.htm
+++ b/XMLHttpRequest/abort-during-done.htm
@@ -9,20 +9,18 @@
   <body>
     <div id="log"></div>
     <script>
-      var test = async_test()
-      test.step(function() {
+      async_test(test => {
         var client = new XMLHttpRequest(),
             result = [],
             expected = [1, 4] // open() -> 1, send() -> 4
-        client.onreadystatechange = function() {
-          test.step(function() {
-            result.push(client.readyState)
-          })
-        }
+        client.onreadystatechange = test.step_func(function() {
+          result.push(client.readyState)
+        })
         client.open("GET", "resources/well-formed.xml", false)
         client.send(null)
         assert_equals(client.readyState, 4)
         assert_equals(client.status, 200)
+        assert_equals(client.statusText, "OK")
         assert_equals(client.responseXML.documentElement.localName, "html")
         client.abort()
         assert_equals(client.readyState, 0)
@@ -32,7 +30,61 @@
         assert_equals(client.getAllResponseHeaders(), "")
         assert_array_equals(result, expected)
         test.done()
-      })
+      }, document.title + " (sync)")
+
+      async_test(test => {
+        var client = new XMLHttpRequest(),
+            result = [],
+            expected = [1, 4] // open() -> 1, send() -> 4
+        client.onreadystatechange = test.step_func(function() {
+          result.push(client.readyState);
+          if (client.readyState === 4) {
+            assert_equals(client.readyState, 4)
+            assert_equals(client.status, 200)
+            assert_equals(client.statusText, "OK")
+            assert_equals(client.responseXML.documentElement.localName, "html")
+            client.abort();
+            assert_equals(client.readyState, 0)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+            test.done()
+          }
+        })
+        client.open("GET", "resources/well-formed.xml", false)
+        client.send(null)
+        assert_equals(client.readyState, 0)
+        assert_equals(client.status, 200)
+        assert_equals(client.statusText, "OK")
+        assert_equals(client.responseXML.documentElement.localName, "html")
+      }, document.title + " (sync aborted in readystatechange)")
+
+      async_test(test => {
+        var client = new XMLHttpRequest(),
+            result = [],
+            expected = [1, 2, 3, 4]
+        client.onreadystatechange = test.step_func(function() {
+          result.push(client.readyState);
+          if (client.readyState === 4) {
+            assert_equals(client.readyState, 4)
+            assert_equals(client.status, 200)
+            assert_equals(client.responseXML.documentElement.localName, "html")
+            client.abort();
+            assert_equals(client.readyState, 0)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+            setTimeout(function() {
+              assert_array_equals(result, expected)
+              test.done();
+            }, 100); // wait a bit in case XHR timeout causes spurious event
+          }
+        })
+        client.open("GET", "resources/well-formed.xml")
+        client.send(null)
+      }, document.title + " (async)")
     </script>
   </body>
 </html>

--- a/XMLHttpRequest/abort-during-headers-received.htm
+++ b/XMLHttpRequest/abort-during-headers-received.htm
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: abort() during HEADERS_RECEIVED</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-abort()-method" data-tested-assertations="following-sibling::ol/li[4] following-sibling::ol/li[5]" />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      async_test(test => {
+        var client = new XMLHttpRequest(),
+            result = [],
+            expected = [1, 2, 4]
+        client.onreadystatechange = test.step_func(function() {
+          result.push(client.readyState);
+          if (client.readyState === 2) {
+            assert_equals(client.status, 200)
+            assert_equals(client.statusText, "OK")
+            assert_equals(client.responseXML, null)
+            client.abort();
+            assert_equals(client.readyState, 0)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+          }
+          if (client.readyState === 4) {
+            assert_equals(client.readyState, 4)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+          }
+        })
+        client.onloadend = test.step_func(function() {
+          assert_equals(client.readyState, 4)
+          assert_equals(client.status, 0)
+          assert_equals(client.statusText, "")
+          assert_equals(client.responseXML, null)
+          assert_equals(client.getAllResponseHeaders(), "")
+          setTimeout(function() {
+            assert_array_equals(result, expected)
+            test.done();
+          }, 100); // wait a bit in case XHR timeout causes spurious event
+        })
+        client.open("GET", "resources/well-formed.xml")
+        client.send(null)
+      })
+    </script>
+  </body>
+</html>

--- a/XMLHttpRequest/abort-during-loading.htm
+++ b/XMLHttpRequest/abort-during-loading.htm
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: abort() during LOADING</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-abort()-method" data-tested-assertations="following-sibling::ol/li[4] following-sibling::ol/li[5]" />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      async_test(test => {
+        var client = new XMLHttpRequest(),
+            result = [],
+            expected = [1, 2, 3, 4]
+        client.onreadystatechange = test.step_func(function() {
+          result.push(client.readyState);
+          if (client.readyState === 3) {
+            assert_equals(client.status, 200)
+            assert_equals(client.statusText, "OK")
+            assert_equals(client.responseXML, null)
+            client.abort();
+            assert_equals(client.readyState, 0)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+          }
+          if (client.readyState === 4) {
+            assert_equals(client.readyState, 4)
+            assert_equals(client.status, 0)
+            assert_equals(client.statusText, "")
+            assert_equals(client.responseXML, null)
+            assert_equals(client.getAllResponseHeaders(), "")
+          }
+        })
+        client.onloadend = test.step_func(function() {
+          assert_equals(client.readyState, 4)
+          assert_equals(client.status, 0)
+          assert_equals(client.statusText, "")
+          assert_equals(client.responseXML, null)
+          assert_equals(client.getAllResponseHeaders(), "")
+          setTimeout(function() {
+            assert_array_equals(result, expected)
+            test.done();
+          }, 100); // wait a bit in case XHR timeout causes spurious event
+        })
+        client.open("GET", "resources/well-formed.xml")
+        client.send(null)
+      })
+    </script>
+  </body>
+</html>
+

--- a/XMLHttpRequest/abort-during-open.js
+++ b/XMLHttpRequest/abort-during-open.js
@@ -8,7 +8,11 @@ test.step(function() {
     })
   }
   assert_equals(client.readyState, 1, "before abort()")
+  assert_equals(client.status, 0)
+  assert_equals(client.statusText, "")
   client.abort()
   assert_equals(client.readyState, 1, "after abort()")
+  assert_equals(client.status, 0)
+  assert_equals(client.statusText, "")
 })
 test.done()

--- a/XMLHttpRequest/abort-during-unsent.htm
+++ b/XMLHttpRequest/abort-during-unsent.htm
@@ -17,8 +17,13 @@
             assert_unreached()
           })
         }
+        assert_equals(client.readyState, 0)
+        assert_equals(client.status, 0)
+        assert_equals(client.statusText, "")
         client.abort()
         assert_equals(client.readyState, 0)
+        assert_equals(client.status, 0)
+        assert_equals(client.statusText, "")
       })
       test.done()
     </script>


### PR DESCRIPTION

MozReview-Commit-ID: H8oEOoyPhko

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1400748 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7796)
<!-- Reviewable:end -->
