### PR TITLE
Fix title in processing-a-keyframes-argument.html test;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffectReadOnly constructor tests</title>
+<title>Tests for processing a keyframes argument</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#processing-a-keyframes-argument">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
@@ -12,8 +12,6 @@
 <script>
 'use strict';
 
-// Test the "process a keyframe-like object" procedure.
-//
 // This file only tests the KeyframeEffectReadOnly constructor since it is
 // assumed that the implementation of the KeyframeEffect constructor,
 // Animatable.animate() method, and KeyframeEffect.setKeyframes() method will


### PR DESCRIPTION

And also drop the slightly misleading and redundant comment about the procedure
that this test covers (it covers *both* the "process a keyframes argument"
procedure and the "process a keyframe-like object" subprocedure).

MozReview-Commit-ID: 9lzx4rCj20o

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7798)
<!-- Reviewable:end -->
