### PR TITLE
Consistently use KeyframeEffect constructor for testing in processing-a-keyframes-argument.html;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -12,8 +12,8 @@
 <script>
 'use strict';
 
-// This file only tests the KeyframeEffectReadOnly constructor since it is
-// assumed that the implementation of the KeyframeEffect constructor,
+// This file only tests the KeyframeEffect constructor since it is
+// assumed that the implementation of the KeyframeEffectReadOnly constructor,
 // Animatable.animate() method, and KeyframeEffect.setKeyframes() method will
 // all share common machinery and it is not necessary to test each method.
 
@@ -61,7 +61,7 @@ gNonAnimatableProps.forEach(function(prop) {
   test(function(t) {
     var testKeyframe = new TestKeyframe(prop);
 
-    new KeyframeEffectReadOnly(null, testKeyframe);
+    new KeyframeEffect(null, testKeyframe);
 
     assert_equals(testKeyframe.propAccessCount, 0, 'Accessor not called');
   }, 'non-animatable property \'' + prop + '\' is not accessed when using'
@@ -72,7 +72,7 @@ gNonAnimatableProps.forEach(function(prop) {
   test(function(t) {
     var testKeyframes = GetTestKeyframeSequence(prop);
 
-    new KeyframeEffectReadOnly(null, testKeyframes);
+    new KeyframeEffect(null, testKeyframes);
 
     assert_equals(testKeyframes[0].propAccessCount, 0, 'Accessor not called');
   }, 'non-animatable property \'' + prop + '\' is not accessed when using'
@@ -82,8 +82,8 @@ gNonAnimatableProps.forEach(function(prop) {
 // Test equivalent forms of property indexed and sequenced keyframe syntax
 
 function assertEquivalentKeyframeSyntax(keyframesA, keyframesB) {
-  var processedKeyframesA = new KeyframeEffectReadOnly(null, keyframesA).getKeyframes();
-  var processedKeyframesB = new KeyframeEffectReadOnly(null, keyframesB).getKeyframes();
+  var processedKeyframesA = new KeyframeEffect(null, keyframesA).getKeyframes();
+  var processedKeyframesB = new KeyframeEffect(null, keyframesB).getKeyframes();
   assert_frame_lists_equal(processedKeyframesA, processedKeyframesB);
 }
 
@@ -269,10 +269,12 @@ test(function(t) {
     enumerable: true});
   assert_equals(keyframe.width, '200px', 'width of keyframe is readable');
   assert_equals(keyframe.height, '100px', 'height of keyframe is readable');
-  var anim = createDiv(t).animate([keyframe, {height: '200px'}], 1);
-  assert_frame_lists_equal(anim.effect.getKeyframes(), [
-      {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
-      {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
+
+  const effect = new KeyframeEffect(null, [keyframe, {height: '200px'}]);
+
+  assert_frame_lists_equal(effect.getKeyframes(), [
+    {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
+    {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
   ]);
 }, 'Only enumerable properties on keyframes are considered');
 
@@ -285,10 +287,12 @@ test(function(t) {
     value: '100px',
     enumerable: 'true'});
   var keyframe = new Keyframe();
-  var anim = createDiv(t).animate([keyframe, {top: '200px'}], 1);
-  assert_frame_lists_equal(anim.effect.getKeyframes(), [
-      {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
-      {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
+
+  const effect = new KeyframeEffect(null, [keyframe, {top: '200px'}]);
+
+  assert_frame_lists_equal(effect.getKeyframes(), [
+    {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
+    {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
   ]);
 }, 'Only properties defined directly on keyframes are considered');
 
@@ -298,10 +302,12 @@ test(function(t) {
   Object.defineProperty(keyframes, 'height', {
     value: ['100px', '200px'],
     enumerable: true});
-  var anim = createDiv(t).animate(keyframes, 1);
-  assert_frame_lists_equal(anim.effect.getKeyframes(), [
-      {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
-      {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
+
+  const effect = new KeyframeEffect(null, keyframes);
+
+  assert_frame_lists_equal(effect.getKeyframes(), [
+    {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
+    {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
   ]);
 }, 'Only enumerable properties on property indexed keyframes are considered');
 
@@ -314,10 +320,12 @@ test(function(t) {
     value: ['100px', '200px'],
     enumerable: 'true'});
   var keyframes = new Keyframes();
-  var anim = createDiv(t).animate(keyframes, 1);
-  assert_frame_lists_equal(anim.effect.getKeyframes(), [
-      {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
-      {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
+
+  const effect = new KeyframeEffect(null, keyframes);
+
+  assert_frame_lists_equal(effect.getKeyframes(), [
+    {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
+    {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
   ]);
 }, 'Only properties defined directly on property indexed keyframes are considered');
 


### PR DESCRIPTION

KeyframeEffectReadOnly may disappear (see [1]) and is only needed for CSS
Animations and CSS Transitions so in that sense KeyframeEffect is more basic
(despite being a subclass of KeyframeEffectReadOnly) so we should prefer it to
KeyframeEffectReadOnly.

Furthermore, as the comment at the start of the file suggests, we should
consistently use the same method for testing these procedures. We currently use
the KeyframeEffect constructor because it is more direct and basic.

[1] https://github.com/w3c/web-animations/issues/185

MozReview-Commit-ID: LBrlfzyn2Ch

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7799)
<!-- Reviewable:end -->
