### PR TITLE
Use for...of instead of forEach for several tests in processing-a-keyframes-argument.html;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -57,7 +57,7 @@ function GetTestKeyframeSequence(testProp) {
   return [ new TestKeyframe(testProp) ]
 }
 
-gNonAnimatableProps.forEach(function(prop) {
+for (const prop of gNonAnimatableProps) {
   test(function(t) {
     const testKeyframe = new TestKeyframe(prop);
 
@@ -66,9 +66,9 @@ gNonAnimatableProps.forEach(function(prop) {
     assert_equals(testKeyframe.propAccessCount, 0, 'Accessor not called');
   }, 'non-animatable property \'' + prop + '\' is not accessed when using'
      + ' a property-indexed keyframe object');
-});
+}
 
-gNonAnimatableProps.forEach(function(prop) {
+for (const prop of gNonAnimatableProps) {
   test(function(t) {
     const testKeyframes = GetTestKeyframeSequence(prop);
 
@@ -77,7 +77,7 @@ gNonAnimatableProps.forEach(function(prop) {
     assert_equals(testKeyframes[0].propAccessCount, 0, 'Accessor not called');
   }, 'non-animatable property \'' + prop + '\' is not accessed when using'
      + ' a keyframe sequence');
-});
+}
 
 // Test equivalent forms of property indexed and sequenced keyframe syntax
 
@@ -161,11 +161,12 @@ const gEquivalentSyntaxTests = [
   },
 ];
 
-gEquivalentSyntaxTests.forEach(function({description, indexedKeyframes, sequencedKeyframes}) {
+for (const {description, indexedKeyframes, sequencedKeyframes} of
+     gEquivalentSyntaxTests) {
   test(function(t) {
     assertEquivalentKeyframeSyntax(indexedKeyframes, sequencedKeyframes);
-  }, 'Equivalent property indexed and sequenced keyframes: ' + description);
-});
+  }, `Equivalent property indexed and sequenced keyframes: ${description}`);
+}
 
 // Test handling of custom iterable objects.
 


### PR DESCRIPTION

for...of is generally preferred over forEach since it is a little easier to read
and allows using 'break' and 'continue'. Furthermore it is supported in all
major browsers. (It also makes wrapping one of the long lines in this file
easier.)

MozReview-Commit-ID: 1BuoW0QSxaG

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7801)
<!-- Reviewable:end -->
