### PR TITLE
Use template strings in processing-a-keyframes-argument.html;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -64,7 +64,7 @@ for (const prop of gNonAnimatableProps) {
     new KeyframeEffect(null, testKeyframe);
 
     assert_equals(testKeyframe.propAccessCount, 0, 'Accessor not called');
-  }, 'non-animatable property \'' + prop + '\' is not accessed when using'
+  }, `non-animatable property '${prop}' is not accessed when using`
      + ' a property-indexed keyframe object');
 }
 
@@ -75,7 +75,7 @@ for (const prop of gNonAnimatableProps) {
     new KeyframeEffect(null, testKeyframes);
 
     assert_equals(testKeyframes[0].propAccessCount, 0, 'Accessor not called');
-  }, 'non-animatable property \'' + prop + '\' is not accessed when using'
+  }, `non-animatable property '${prop}' is not accessed when using`
      + ' a keyframe sequence');
 }
 


### PR DESCRIPTION

But only in a couple of places where it makes the test more readable.

MozReview-Commit-ID: 6zVJ6h7Zb3k

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7802)
<!-- Reviewable:end -->
