### PR TITLE
Drop invalid test for offsets;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -125,17 +125,6 @@ const gEquivalentSyntaxTests = [
     ],
   },
   {
-    description: 'same offset applied to all keyframes',
-    indexedKeyframes: {
-      left: ['0px', '100px'],
-      offset: 0.5,
-    },
-    sequencedKeyframes: [
-      {left: '0px', offset: 0.5},
-      {left: '100px', offset: 0.5},
-    ],
-  },
-  {
     description: 'same easing applied to all keyframes',
     indexedKeyframes: {
       left: ['10px', '100px', '150px'],


### PR DESCRIPTION

There is a test that assumes that an offset specified on a property-indexed
keyframe is applied to all generated keyframes but that behavior is not (yet)
specified.

This behavior will be specified in [1] but until that happens it seems invalid
to test for it. Furthermore, when that is specified we will need much more
thorough tests than this one.

[1] https://github.com/w3c/web-animations/issues/148

MozReview-Commit-ID: HUUw88dg2P7

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7803)
<!-- Reviewable:end -->
