### PR TITLE
Move test for accessing keyframe property order to processing-a-keyframes-argument.html;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -158,26 +158,6 @@ gPropertyIndexedKeyframesTests.forEach(function(subtest) {
      " roundtrips");
 });
 
-test(function(t) {
-  var expectedOrder = ["composite", "easing", "offset", "left", "marginLeft"];
-  var actualOrder = [];
-  var kf1 = {};
-  var kf2 = { marginLeft: "10px", left: "20px", offset: 1 };
-  [{ p: "marginLeft", v: "10px" },
-   { p: "left",       v: "20px" },
-   { p: "offset",     v: "0" },
-   { p: "easing",     v: "linear" },
-   { p: "composite",  v: "replace" }].forEach(function(e) {
-    Object.defineProperty(kf1, e.p, {
-      enumerable: true,
-      get: function() { actualOrder.push(e.p); return e.v; }
-    });
-  });
-  new KeyframeEffectReadOnly(target, [kf1, kf2]);
-  assert_array_equals(actualOrder, expectedOrder, "property access order");
-}, "the KeyframeEffectReadOnly constructor reads keyframe properties in the " +
-   "expected order");
-
 gKeyframeSequenceTests.forEach(function(subtest) {
   test(function(t) {
     var effect = new KeyframeEffectReadOnly(target, subtest.input);

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -321,9 +321,23 @@ test(function(t) {
   ]);
 }, 'Only properties defined directly on property-indexed keyframes are read');
 
-// FIXME: Test that properties are accessed in ascending order by Unicode
-//        codepoint
-//        (There is an existing test for this in
-//        keyframe-effect/constructor.html that should be moved here.)
+test(function(t) {
+  var expectedOrder = ['composite', 'easing', 'offset', 'left', 'marginLeft'];
+  var actualOrder = [];
+  var kf1 = {};
+  var kf2 = { marginLeft: '10px', left: '20px', offset: 1 };
+  [ { p: 'marginLeft', v: '10px' },
+    { p: 'left',       v: '20px' },
+    { p: 'offset',     v: '0' },
+    { p: 'easing',     v: 'linear' },
+    { p: 'composite',  v: 'replace' } ].forEach(function(e) {
+    Object.defineProperty(kf1, e.p, {
+      enumerable: true,
+      get: function() { actualOrder.push(e.p); return e.v; }
+    });
+  });
+  new KeyframeEffect(target, [kf1, kf2]);
+  assert_array_equals(actualOrder, expectedOrder, 'property access order');
+}, 'Properties are read in ascending order by Unicode codepoint');
 
 </script>


### PR DESCRIPTION

MozReview-Commit-ID: 3y6SnzAtNZZ

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7805)
<!-- Reviewable:end -->
