### PR TITLE
Consistently use spaces in object notation;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument.html
@@ -45,7 +45,7 @@ function TestKeyframe(testProp) {
 
   Object.defineProperty(this, testProp, {
     get: function() { _propAccessCount++; },
-    enumerable: true
+    enumerable: true,
   });
 
   Object.defineProperty(this, 'propAccessCount', {
@@ -97,7 +97,7 @@ const gEquivalentSyntaxTests = [
       opacity: ['1'],
     },
     sequencedKeyframes: [
-      {left: '100px', opacity: '1'},
+      { left: '100px', opacity: '1' },
     ],
   },
   {
@@ -107,9 +107,9 @@ const gEquivalentSyntaxTests = [
       opacity: ['1', '0', '1'],
     },
     sequencedKeyframes: [
-      {left: '10px', opacity: '1'},
-      {left: '100px', opacity: '0'},
-      {left: '150px', opacity: '1'},
+      { left: '10px', opacity: '1' },
+      { left: '100px', opacity: '0' },
+      { left: '150px', opacity: '1' },
     ],
   },
   {
@@ -119,9 +119,9 @@ const gEquivalentSyntaxTests = [
       opacity: ['0', '1']
     },
     sequencedKeyframes: [
-      {left: '0px', opacity: '0'},
-      {left: '100px'},
-      {left: '200px', opacity: '1'},
+      { left: '0px', opacity: '0' },
+      { left: '100px' },
+      { left: '200px', opacity: '1' },
     ],
   },
   {
@@ -132,9 +132,9 @@ const gEquivalentSyntaxTests = [
       easing: 'ease',
     },
     sequencedKeyframes: [
-      {left: '10px', opacity: '1', easing: 'ease'},
-      {left: '100px', opacity: '0', easing: 'ease'},
-      {left: '150px', opacity: '1', easing: 'ease'},
+      { left: '10px', opacity: '1', easing: 'ease' },
+      { left: '100px', opacity: '0', easing: 'ease' },
+      { left: '150px', opacity: '1', easing: 'ease' },
     ],
   },
   {
@@ -144,8 +144,8 @@ const gEquivalentSyntaxTests = [
       composite: 'add',
     },
     sequencedKeyframes: [
-      {left: '0px', composite: 'add'},
-      {left: '100px', composite: 'add'},
+      { left: '0px', composite: 'add' },
+      { left: '100px', composite: 'add' },
     ],
   },
 ];
@@ -174,72 +174,74 @@ function createIterable(iterations) {
 
 test(() => {
   const effect = new KeyframeEffect(null, createIterable([
-    {done: false, value: {left: '100px'}},
-    {done: false, value: {left: '300px'}},
-    {done: false, value: {left: '200px'}},
-    {done: true},
+    { done: false, value: { left: '100px' } },
+    { done: false, value: { left: '300px' } },
+    { done: false, value: { left: '200px' } },
+    { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', left: '100px'},
-    {offset: null, computedOffset: 0.5, easing: 'linear', left: '300px'},
-    {offset: null, computedOffset: 1, easing: 'linear', left: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
+    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
+    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
   ]);
 }, 'Keyframes are read from a custom iterator');
 
 test(() => {
   const keyframes = createIterable([
-    {done: false, value: {left: '100px'}},
-    {done: false, value: {left: '300px'}},
-    {done: false, value: {left: '200px'}},
-    {done: true},
+    { done: false, value: { left: '100px' } },
+    { done: false, value: { left: '300px' } },
+    { done: false, value: { left: '200px' } },
+    { done: true },
   ]);
   keyframes.easing = 'ease-in-out';
   keyframes.offset = '0.1';
   const effect = new KeyframeEffect(null, keyframes);
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', left: '100px'},
-    {offset: null, computedOffset: 0.5, easing: 'linear', left: '300px'},
-    {offset: null, computedOffset: 1, easing: 'linear', left: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
+    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
+    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
   ]);
 }, "'easing' and 'offset' are ignored on iterable objects");
 
 test(() => {
   const effect = new KeyframeEffect(null, createIterable([
-    {done: false, value: {left: '100px', top: '200px'}},
-    {done: false, value: {left: '300px'}},
-    {done: false, value: {left: '200px', top: '100px'}},
-    {done: true},
+    { done: false, value: { left: '100px', top: '200px' } },
+    { done: false, value: { left: '300px' } },
+    { done: false, value: { left: '200px', top: '100px' } },
+    { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', left: '100px', top: '200px'},
-    {offset: null, computedOffset: 0.5, easing: 'linear', left: '300px'},
-    {offset: null, computedOffset: 1, easing: 'linear', left: '200px', top: '100px'},
+    { offset: null, computedOffset: 0, easing: 'linear', left: '100px',
+      top: '200px' },
+    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
+    { offset: null, computedOffset: 1, easing: 'linear', left: '200px',
+      top: '100px' },
   ]);
 }, 'Keyframes are read from a custom iterator with multiple properties'
    + ' specified');
 
 test(() => {
   const effect = new KeyframeEffect(null, createIterable([
-    {done: false, value: {left: '100px'}},
-    {done: false, value: {left: '250px', offset: 0.75}},
-    {done: false, value: {left: '200px'}},
-    {done: true},
+    { done: false, value: { left: '100px' } },
+    { done: false, value: { left: '250px', offset: 0.75 } },
+    { done: false, value: { left: '200px' } },
+    { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', left: '100px'},
-    {offset: 0.75, computedOffset: 0.75, easing: 'linear', left: '250px'},
-    {offset: null, computedOffset: 1, easing: 'linear', left: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
+    { offset: 0.75, computedOffset: 0.75, easing: 'linear', left: '250px' },
+    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
   ]);
 }, 'Keyframes are read from a custom iterator with where an offset is'
    + ' specified');
 
 test(() => {
-  assert_throws({name: 'TypeError'}, function() {
+  assert_throws({ name: 'TypeError' }, function() {
     new KeyframeEffect(null, createIterable([
-      {done: false, value: {left: '100px'}},
-      {done: false, value: 1234},
-      {done: false, value: {left: '200px'}},
-      {done: true},
+      { done: false, value: { left: '100px' } },
+      { done: false, value: 1234 },
+      { done: false, value: { left: '200px' } },
+      { done: true },
     ]));
   });
 }, 'Reading from a custom iterator that returns a non-object keyframe'
@@ -247,28 +249,29 @@ test(() => {
 
 test(() => {
   const effect = new KeyframeEffect(null, createIterable([
-    {done: false, value: {left: ['100px', '200px']}},
-    {done: true},
+    { done: false, value: { left: ['100px', '200px'] } },
+    { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 1, easing: 'linear'}
+    { offset: null, computedOffset: 1, easing: 'linear' }
   ]);
 }, 'A list of values returned from a custom iterator should be ignored');
 
 test(function(t) {
   const keyframe = {};
-  Object.defineProperty(keyframe, 'width', {value: '200px'});
+  Object.defineProperty(keyframe, 'width', { value: '200px' });
   Object.defineProperty(keyframe, 'height', {
     value: '100px',
-    enumerable: true});
+    enumerable: true,
+  });
   assert_equals(keyframe.width, '200px', 'width of keyframe is readable');
   assert_equals(keyframe.height, '100px', 'height of keyframe is readable');
 
-  const effect = new KeyframeEffect(null, [keyframe, {height: '200px'}]);
+  const effect = new KeyframeEffect(null, [keyframe, { height: '200px' }]);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
-    {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', height: '100px' },
+    { offset: null, computedOffset: 1, easing: 'linear', height: '200px' },
   ]);
 }, 'Only enumerable properties on keyframes are read');
 
@@ -279,14 +282,15 @@ test(function(t) {
   Keyframe.prototype = Object.create(KeyframeParent.prototype);
   Object.defineProperty(Keyframe.prototype, 'left', {
     value: '100px',
-    enumerable: 'true'});
+    enumerable: true,
+  });
   const keyframe = new Keyframe();
 
-  const effect = new KeyframeEffect(null, [keyframe, {top: '200px'}]);
+  const effect = new KeyframeEffect(null, [keyframe, { top: '200px' }]);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
-    {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', top: '100px' },
+    { offset: null, computedOffset: 1, easing: 'linear', top: '200px' },
   ]);
 }, 'Only properties defined directly on keyframes are read');
 
@@ -295,13 +299,14 @@ test(function(t) {
   Object.defineProperty(keyframes, 'width', ['100px', '200px']);
   Object.defineProperty(keyframes, 'height', {
     value: ['100px', '200px'],
-    enumerable: true});
+    enumerable: true,
+  });
 
   const effect = new KeyframeEffect(null, keyframes);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', height: '100px'},
-    {offset: null, computedOffset: 1, easing: 'linear', height: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', height: '100px' },
+    { offset: null, computedOffset: 1, easing: 'linear', height: '200px' },
   ]);
 }, 'Only enumerable properties on property-indexed keyframes are read');
 
@@ -312,14 +317,15 @@ test(function(t) {
   Keyframes.prototype = Object.create(KeyframesParent.prototype);
   Object.defineProperty(Keyframes.prototype, 'left', {
     value: ['100px', '200px'],
-    enumerable: 'true'});
+    enumerable: true,
+  });
   const keyframes = new Keyframes();
 
   const effect = new KeyframeEffect(null, keyframes);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    {offset: null, computedOffset: 0, easing: 'linear', top: '100px'},
-    {offset: null, computedOffset: 1, easing: 'linear', top: '200px'},
+    { offset: null, computedOffset: 0, easing: 'linear', top: '100px' },
+    { offset: null, computedOffset: 1, easing: 'linear', top: '200px' },
   ]);
 }, 'Only properties defined directly on property-indexed keyframes are read');
 


### PR DESCRIPTION

This seems to be standard JS style recently (as used in prettier etc.): Use
spaces to separate the { and } from the properties (but not for arrays).

MozReview-Commit-ID: FRkFRwwcJJh

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
