### PR TITLE
Rename processing-a-keyframes-argument.html to have a 001 extension;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for processing a keyframes argument</title>
+<title>Tests for processing a keyframes argument (property access)</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#processing-a-keyframes-argument">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION

This naming is recommended by [1] and from a random sampling of tests in
web-platform-tests it seems like most test don't use this, only tests that are
split over multiple files.

This "processing a keyframes argument" section is quite large so I intend to
split the tests up into a number of files to cover:

* Tests for property access
* Tests for easing
* Tests for offset
* Tests for composite
* Tests for equivalent forms

[1] http://web-platform-tests.org/writing-tests/general-guidelines.html#file-paths-and-names

MozReview-Commit-ID: JW2m50UnsKv

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7810)
<!-- Reviewable:end -->
