### PR TITLE
Move tests for easing values on keyframes to processing-a-keyframes-argument-002.html;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -33,34 +33,6 @@ test(function(t) {
     var easing = subtest[0];
     var expected = subtest[1];
     var effect = new KeyframeEffectReadOnly(target, {
-      left: ["10px", "20px"],
-      easing: easing
-    });
-    assert_equals(effect.getKeyframes()[0].easing, expected,
-                  "resulting easing for '" + easing + "'");
-  });
-}, "easing values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in a property-indexed keyframe");
-
-test(function(t) {
-  gEasingValueTests.forEach(function(subtest) {
-    var easing = subtest[0];
-    var expected = subtest[1];
-    var effect = new KeyframeEffectReadOnly(target, [
-      { offset: 0, left: "10px", easing: easing },
-      { offset: 1, left: "20px" }
-    ]);
-    assert_equals(effect.getKeyframes()[0].easing, expected,
-                  "resulting easing for '" + easing + "'");
-  });
-}, "easing values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in regular keyframes");
-
-test(function(t) {
-  gEasingValueTests.forEach(function(subtest) {
-    var easing = subtest[0];
-    var expected = subtest[1];
-    var effect = new KeyframeEffectReadOnly(target, {
       left: ["10px", "20px"]
     }, { easing: easing });
     assert_equals(effect.timing.easing, expected,
@@ -68,24 +40,6 @@ test(function(t) {
   });
 }, "easing values are parsed correctly when passed to the " +
    "KeyframeEffectReadOnly constructor in KeyframeEffectOptions");
-
-test(function(t) {
-  gInvalidEasings.forEach(invalidEasing => {
-    assert_throws(new TypeError, () => {
-      new KeyframeEffectReadOnly(target, { easing: invalidEasing });
-    }, `TypeError is thrown for easing '${invalidEasing}'`);
-  });
-}, 'invalid easing values are correctly rejected when passed to the ' +
-   'KeyframeEffectReadOnly constructor in regular keyframes');
-
-test(function(t) {
-  gInvalidEasings.forEach(invalidEasing => {
-    assert_throws(new TypeError, () => {
-      new KeyframeEffectReadOnly(target, [{ easing: invalidEasing }]);
-    }, `TypeError is thrown for easing '${invalidEasing}'`);
-  });
-}, 'invalid easing values are correctly rejected when passed to the ' +
-   'KeyframeEffectReadOnly constructor in a keyframe sequence');
 
 test(function(t) {
   gInvalidEasings.forEach(invalidEasing => {

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Tests for processing a keyframes argument (easing)</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#processing-a-keyframes-argument">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<script src="../../resources/keyframe-utils.js"></script>
+<script src="../../resources/easing-tests.js"></script>
+<body>
+<div id="log"></div>
+<div id="target"></div>
+<script>
+'use strict';
+
+test(function(t) {
+  gEasingValueTests.forEach(function(subtest) {
+    var easing = subtest[0];
+    var expected = subtest[1];
+    var effect = new KeyframeEffectReadOnly(target, {
+      left: ["10px", "20px"],
+      easing: easing
+    });
+    assert_equals(effect.getKeyframes()[0].easing, expected,
+                  "resulting easing for '" + easing + "'");
+  });
+}, "easing values are parsed correctly when passed to the " +
+   "KeyframeEffectReadOnly constructor in a property-indexed keyframe");
+
+test(function(t) {
+  gEasingValueTests.forEach(function(subtest) {
+    var easing = subtest[0];
+    var expected = subtest[1];
+    var effect = new KeyframeEffectReadOnly(target, [
+      { offset: 0, left: "10px", easing: easing },
+      { offset: 1, left: "20px" }
+    ]);
+    assert_equals(effect.getKeyframes()[0].easing, expected,
+                  "resulting easing for '" + easing + "'");
+  });
+}, "easing values are parsed correctly when passed to the " +
+   "KeyframeEffectReadOnly constructor in regular keyframes");
+
+test(function(t) {
+  gInvalidEasings.forEach(invalidEasing => {
+    assert_throws(new TypeError, () => {
+      new KeyframeEffectReadOnly(target, { easing: invalidEasing });
+    }, `TypeError is thrown for easing '${invalidEasing}'`);
+  });
+}, 'invalid easing values are correctly rejected when passed to the ' +
+   'KeyframeEffectReadOnly constructor in regular keyframes');
+
+test(function(t) {
+  gInvalidEasings.forEach(invalidEasing => {
+    assert_throws(new TypeError, () => {
+      new KeyframeEffectReadOnly(target, [{ easing: invalidEasing }]);
+    }, `TypeError is thrown for easing '${invalidEasing}'`);
+  });
+}, 'invalid easing values are correctly rejected when passed to the ' +
+   'KeyframeEffectReadOnly constructor in a keyframe sequence');
+
+</script>


### PR DESCRIPTION

MozReview-Commit-ID: LEydYxdMoay

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7811)
<!-- Reviewable:end -->
