### PR TITLE
Consistently use arrow syntax for functions in processing-a-keyframes-argument-*.html tests;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -44,12 +44,12 @@ function TestKeyframe(testProp) {
   let _propAccessCount = 0;
 
   Object.defineProperty(this, testProp, {
-    get: function() { _propAccessCount++; },
+    get: () => { _propAccessCount++; },
     enumerable: true,
   });
 
   Object.defineProperty(this, 'propAccessCount', {
-    get: function() { return _propAccessCount; }
+    get: () => _propAccessCount
   });
 }
 
@@ -58,7 +58,7 @@ function GetTestKeyframeSequence(testProp) {
 }
 
 for (const prop of gNonAnimatableProps) {
-  test(function(t) {
+  test(() => {
     const testKeyframe = new TestKeyframe(prop);
 
     new KeyframeEffect(null, testKeyframe);
@@ -69,7 +69,7 @@ for (const prop of gNonAnimatableProps) {
 }
 
 for (const prop of gNonAnimatableProps) {
-  test(function(t) {
+  test(() => {
     const testKeyframes = GetTestKeyframeSequence(prop);
 
     new KeyframeEffect(null, testKeyframes);
@@ -152,7 +152,7 @@ const gEquivalentSyntaxTests = [
 
 for (const {description, indexedKeyframes, sequencedKeyframes} of
      gEquivalentSyntaxTests) {
-  test(function(t) {
+  test(() => {
     assertEquivalentKeyframeSyntax(indexedKeyframes, sequencedKeyframes);
   }, `Equivalent property-indexed and sequenced keyframes: ${description}`);
 }
@@ -236,7 +236,7 @@ test(() => {
    + ' specified');
 
 test(() => {
-  assert_throws({ name: 'TypeError' }, function() {
+  assert_throws({ name: 'TypeError' }, () => {
     new KeyframeEffect(null, createIterable([
       { done: false, value: { left: '100px' } },
       { done: false, value: 1234 },
@@ -257,7 +257,7 @@ test(() => {
   ]);
 }, 'A list of values returned from a custom iterator should be ignored');
 
-test(function(t) {
+test(() => {
   const keyframe = {};
   Object.defineProperty(keyframe, 'width', { value: '200px' });
   Object.defineProperty(keyframe, 'height', {
@@ -275,7 +275,7 @@ test(function(t) {
   ]);
 }, 'Only enumerable properties on keyframes are read');
 
-test(function(t) {
+test(() => {
   const KeyframeParent = function() { this.width = '100px'; };
   KeyframeParent.prototype = { height: '100px' };
   const Keyframe = function() { this.top = '100px'; };
@@ -294,7 +294,7 @@ test(function(t) {
   ]);
 }, 'Only properties defined directly on keyframes are read');
 
-test(function(t) {
+test(() => {
   const keyframes = {};
   Object.defineProperty(keyframes, 'width', ['100px', '200px']);
   Object.defineProperty(keyframes, 'height', {
@@ -310,7 +310,7 @@ test(function(t) {
   ]);
 }, 'Only enumerable properties on property-indexed keyframes are read');
 
-test(function(t) {
+test(() => {
   const KeyframesParent = function() { this.width = '100px'; };
   KeyframesParent.prototype = { height: '100px' };
   const Keyframes = function() { this.top = ['100px', '200px']; };
@@ -329,7 +329,7 @@ test(function(t) {
   ]);
 }, 'Only properties defined directly on property-indexed keyframes are read');
 
-test(function(t) {
+test(() => {
   const expectedOrder = ['composite', 'easing', 'offset', 'left', 'marginLeft'];
   const actualOrder = [];
   const kf1 = {};
@@ -340,7 +340,7 @@ test(function(t) {
                                { prop: 'composite',  value: 'replace' }]) {
     Object.defineProperty(kf1, prop, {
       enumerable: true,
-      get: function() { actualOrder.push(prop); return value; }
+      get: () => { actualOrder.push(prop); return value; }
     });
   }
   const kf2 = { marginLeft: '10px', left: '20px', offset: 1 };

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
@@ -12,7 +12,7 @@
 <script>
 'use strict';
 
-test(function() {
+test(() => {
   for (const [easing, expected] of gEasingParsingTests) {
     const effect = new KeyframeEffect(target, {
       left: ['10px', '20px'],
@@ -24,7 +24,7 @@ test(function() {
 }, 'easing values are parsed correctly when set on a property-indexed'
    + ' keyframe');
 
-test(function() {
+test(() => {
   for (const [easing, expected] of gEasingParsingTests) {
     const effect = new KeyframeEffect(target, [
       { offset: 0, left: '10px', easing: easing },
@@ -35,7 +35,7 @@ test(function() {
   }
 }, 'easing values are parsed correctly when using a keyframe sequence');
 
-test(function() {
+test(() => {
   for (const invalidEasing of gInvalidEasings) {
     assert_throws(new TypeError, () => {
       new KeyframeEffect(target, { easing: invalidEasing });
@@ -44,7 +44,7 @@ test(function() {
 }, 'Invalid easing values are correctly rejected when set on a property-'
    + 'indexed keyframe');
 
-test(function() {
+test(() => {
   for (const invalidEasing of gInvalidEasings) {
     assert_throws(new TypeError, () => {
       new KeyframeEffect(target, [{ easing: invalidEasing }]);
@@ -53,7 +53,7 @@ test(function() {
 }, 'Invalid easing values are correctly rejected when using a keyframe'
    + ' sequence');
 
-test(function(t) {
+test(() => {
   let propAccessCount = 0;
   const keyframe = {};
   const addProp = prop => {
@@ -73,7 +73,7 @@ test(function(t) {
     'All properties were read before throwing the easing error');
 }, 'Errors from invalid easings on a property-indexed keyframe are thrown after reading all properties');
 
-test(function(t) {
+test(() => {
   let propAccessCount = 0;
 
   const addProp = (keyframe, prop) => {


### PR DESCRIPTION

We don't however, use arrow syntax for local functions that act as class
constructors since they don't want the lexical this that arrow functions use.

MozReview-Commit-ID: FuVhHIBFZrE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402170 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7818)
<!-- Reviewable:end -->
