### PR TITLE
Add cookie domain field to WebDriver:AddCookie

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -248,3 +248,8 @@ def create_dialog(session):
                                      {"script": spawn, "args": []})
 
     return create_dialog
+
+def clear_all_cookies(session):
+    """Removes all cookies associated with the current active document"""
+    session.transport.send("DELETE", "session/%s/cookie" % session.session_id)
+


### PR DESCRIPTION

There were two issues with the previous implementation:
* Domain cookies were created as host only cookies (due to lack of
leading '.' characters)
* The cookie domain included in the Marionette request was completely
ignored, which always resulted in host-only cookies

MozReview-Commit-ID: 2JLQ3vwNMrb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402978 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7819)
<!-- Reviewable:end -->
