### PR TITLE
Properly remove display: contents pseudo-frames.

### DIFF
--- a/css/css-display-3/display-contents-dynamic-generated-content-fieldset-001-ref.html
+++ b/css/css-display-3/display-contents-dynamic-generated-content-fieldset-001-ref.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+div {
+  display: contents;
+  border: 10px solid red;
+}
+</style>
+<p>
+  Test passes if there is no red text and no red border.
+</p>
+<fieldset>
+  <div></div>
+</fieldset>

--- a/css/css-display-3/display-contents-dynamic-generated-content-fieldset-001.html
+++ b/css/css-display-3/display-contents-dynamic-generated-content-fieldset-001.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Dynamic changes to display: contents generated content in fieldsets.</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel="match" href="display-contents-dynamic-generated-content-fieldset-001-ref.html">
+<style>
+.after::after {
+  content: "FAIL";
+  color: red;
+}
+div {
+  display: contents;
+  border: 10px solid red;
+}
+</style>
+<p>
+  Test passes if there is no red text and no red border.
+</p>
+<fieldset>
+  <div class="after"></div>
+</fieldset>
+<script>
+document.body.offsetHeight;
+document.querySelector("div").classList.remove("after");
+</script>


### PR DESCRIPTION

MozReview-Commit-ID: 4pjVLQfv3YR
Signed-off-by: Emilio Cobos Álvarez <emilio@crisal.io>

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1402442 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7820)
<!-- Reviewable:end -->
