### PR TITLE
Add test for stale frame element.

### DIFF
--- a/webdriver/tests/switch_to_parent_frame.py
+++ b/webdriver/tests/switch_to_parent_frame.py
@@ -1,0 +1,18 @@
+import pytest
+from webdriver import StaleElementReferenceException
+
+from tests.support.inline import inline, iframe
+
+
+def switch_to_parent_frame(session):
+    return session.transport.send("POST", "session/%s/frame/parent" % session.session_id)
+
+
+def test_stale_element_from_iframe(session):
+    session.url = inline(iframe("<p>foo"))
+    frame_element = session.find.css("iframe", all=False)
+    session.switch_frame(frame_element)
+    stale_element = session.find.css("p", all=False)
+    switch_to_parent_frame(session)
+    with pytest.raises(StaleElementReferenceException):
+        stale_element.text


### PR DESCRIPTION

The <p> element inside the <iframe> should be considered stale when
interacting with it after the current browsing context is switched
back to the top level browsing context.

MozReview-Commit-ID: 1zrnBowSpxt

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1405018 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7825)
<!-- Reviewable:end -->
