### PR TITLE
Fix webdriver.transport.HTTPWireProtocol#url.

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -63,7 +63,7 @@ class HTTPWireProtocol(object):
         self._timeout = timeout
 
     def url(self, suffix):
-        return urlparse.urljoin(self.path_prefix, suffix)
+        return urlparse.urljoin(self.url_prefix, suffix)
 
     def send(self, method, url, body=None, headers=None):
         """Send a command to the remote.


### PR DESCRIPTION

The self.path_prefix attribute does not exist.  It should be
self.url_prefix.

MozReview-Commit-ID: 8LGES8GsTsm

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1405325 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7827)
<!-- Reviewable:end -->
