### PR TITLE
Use HTTPWireProtocol#url to build full URL.

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -65,7 +65,7 @@ class HTTPWireProtocol(object):
     def url(self, suffix):
         return urlparse.urljoin(self.url_prefix, suffix)
 
-    def send(self, method, url, body=None, headers=None):
+    def send(self, method, uri, body=None, headers=None):
         """Send a command to the remote.
 
         :param method: "POST" or "GET".
@@ -89,7 +89,7 @@ class HTTPWireProtocol(object):
         if headers is None:
             headers = {}
 
-        url = self.url_prefix + url
+        url = self.url(uri)
 
         kwargs = {}
         if self._timeout is not None:


### PR DESCRIPTION

Instead of using string concatentation for building the command URL,
rely on self.url which internally uses urlparse.urljoin.

MozReview-Commit-ID: DqakZJIgdJF

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1405325 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7828)
<!-- Reviewable:end -->
