### PR TITLE
Assign actual response to variable.

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -100,8 +100,7 @@ class HTTPWireProtocol(object):
         conn.request(method, url, body, headers)
 
         try:
-            response = Response.from_http_response(conn.getresponse())
+            response = conn.getresponse()
+            return Response.from_http_response(response)
         finally:
             conn.close()
-
-        return response


### PR DESCRIPTION

This is a non-functional change, but if anything should be assigned
to the "response" value, it should be the actual response.  I had
to do this because I was debugging a low-level HTTP problem with
geckodriver, so this will be more useful in the future.  In any case,
we can return the webdriver.transport.Response representation directly
because the finally clause is always called.

MozReview-Commit-ID: 8JKNKAEbOAe

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1405325 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7829)
<!-- Reviewable:end -->
