### PR TITLE
Align WebDriver:DeleteCookie with specification.

### DIFF
--- a/webdriver/tests/cookies/delete_cookie.py
+++ b/webdriver/tests/cookies/delete_cookie.py
@@ -1,0 +1,123 @@
+from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
+from tests.support.fixtures import create_dialog
+from tests.support.inline import inline
+
+
+def delete_cookie(session, name):
+    return session.transport.send("DELETE", "/session/%s/cookie/%s" % (session.session_id, name))
+
+
+# 16.4 Delete Cookie
+
+
+def test_no_browsing_context(session, create_window):
+    """
+    1. If the current top-level browsing context is no longer open,
+    return error with error code no such window.
+
+    """
+    session.window_handle = create_window()
+    session.close()
+    response = delete_cookie(session, "foo")
+    assert_error(response, "no such window")
+
+
+def test_handle_prompt_dismiss_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_accept_and_notify():
+    """TODO"""
+
+
+def test_handle_prompt_ignore():
+    """TODO"""
+
+
+def test_handle_prompt_accept(new_session):
+    """
+    2. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - accept state
+           Accept the current user prompt.
+
+    """
+    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    session.url = inline("<title>WD doc title</title>")
+
+    create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
+    response = delete_cookie(session, "foo")
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #1")
+
+    create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
+    response = delete_cookie(session, "foo")
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #2")
+
+    create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
+    response = delete_cookie(session, "foo")
+    assert response.status == 200
+    assert_dialog_handled(session, "dismiss #3")
+
+
+def test_handle_prompt_missing_value(session, create_dialog):
+    """
+    2. Handle any user prompts and return its value if it is an error.
+
+    [...]
+
+    In order to handle any user prompts a remote end must take the
+    following steps:
+
+      [...]
+
+      2. Perform the following substeps based on the current session's
+      user prompt handler:
+
+        [...]
+
+        - missing value default state
+           1. Dismiss the current user prompt.
+           2. Return error with error code unexpected alert open.
+
+    """
+    session.url = inline("<title>WD doc title</title>")
+    create_dialog("alert", text="dismiss #1", result_var="dismiss1")
+
+    response = delete_cookie(session, "foo")
+
+    assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #1")
+
+    create_dialog("confirm", text="dismiss #2", result_var="dismiss2")
+
+    response = delete_cookie(session, "foo")
+    assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #2")
+
+    create_dialog("prompt", text="dismiss #3", result_var="dismiss3")
+
+    response = delete_cookie(session, "foo")
+    assert_error(response, "unexpected alert open")
+    assert_dialog_handled(session, "dismiss #3")
+
+
+def test_unknown_cookie(session):
+    response = delete_cookie(session, "stilton")
+    assert response.status == 200
+    assert "value" in response.body
+    assert isinstance(response.body["value"], dict)
+    assert response.body["value"] == {}


### PR DESCRIPTION

The Delete Cookie command should not return an error if the cookie
does not exist.

The variable names "toDelete" and "candidateName" was also
juxtapositioned and wrong.  Here I am using the approximate names
used in the specification prose for clarity.

Fixes: https://github.com/mozilla/geckodriver/issues/989
MozReview-Commit-ID: 6IIGGpB1JWn

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1405325 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7831)
<!-- Reviewable:end -->
