### PR TITLE
Tidy up simple-iteration-progress.html and current-iteration.html somewhat;

### DIFF
--- a/web-animations/timing-model/animation-effects/current-iteration.html
+++ b/web-animations/timing-model/animation-effects/current-iteration.html
@@ -11,26 +11,40 @@
 'use strict';
 
 function runTests(tests, description) {
-  tests.forEach(function(currentTest) {
-    var testParams = '';
-    for (var attr in currentTest.input) {
-      testParams += ' ' + attr + ':' + currentTest.input[attr];
-    }
-    test(function(t) {
-      var div = createDiv(t);
-      var anim = div.animate({ opacity: [ 0, 1 ] }, currentTest.input);
+  for (const currentTest of tests) {
+    const testParams = Object.entries(currentTest.input)
+                             .map(([attr, value]) => `${attr}:${value}`)
+                             .join(' ');
+
+    test(t => {
+      const div = createDiv(t);
+      const anim = div.animate({}, currentTest.input);
+
+      // Before phase
       assert_equals(anim.effect.getComputedTiming().currentIteration,
                     currentTest.before);
-      anim.currentTime = currentTest.input.delay || 0;
-      assert_equals(anim.effect.getComputedTiming().currentIteration,
-                    currentTest.active);
-      if (typeof currentTest.after !== 'undefined') {
+
+      // Active phase
+      if (anim.effect.getComputedTiming().activeDuration > 0) {
+        anim.currentTime = currentTest.input.delay || 0;
+        assert_equals(anim.effect.getComputedTiming().currentIteration,
+                      currentTest.active);
+      } else if (currentTest.active !== undefined) {
+        assert_false('Test specifies an active phase iteration to check but the'
+                     + ' animation has a zero duration');
+      }
+
+      // After phase
+      if (anim.effect.getComputedTiming().activeDuration !== Infinity) {
         anim.finish();
         assert_equals(anim.effect.getComputedTiming().currentIteration,
                       currentTest.after);
+      } else if (currentTest.after !== undefined) {
+        assert_false('Test specifies an after phase iteration to check but the'
+                     + ' animation has an infinite duration');
       }
-    }, description + ':' + testParams);
-  });
+    }, `${description}: ${testParams}`);
+  }
 }
 
 async_test(function(t) {
@@ -58,7 +72,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -69,7 +82,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -80,7 +92,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -91,7 +102,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: 2,
     after: 2
   },
 
@@ -102,7 +112,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: 2,
     after: 2
   },
 
@@ -113,7 +122,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: 2,
     after: 2
   },
 
@@ -124,7 +132,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: 3,
     after: 3
   },
 
@@ -135,7 +142,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: 3,
     after: 3
   },
 
@@ -146,7 +152,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: 3,
     after: 3
   }
 ], 'Test zero iterations');
@@ -166,7 +171,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 2,
     after: 2
   },
 
@@ -198,7 +202,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: 5,
     after: 5
   },
 
@@ -230,7 +233,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: 5,
     after: 5
   },
 
@@ -271,7 +273,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 3,
     after: 3
   },
 
@@ -303,7 +304,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: 5,
     after: 5
   },
 
@@ -335,7 +335,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: 6,
     after: 6
   },
 
@@ -376,7 +375,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: Infinity,
     after: Infinity
   },
 
@@ -407,7 +405,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 2,
-    active: Infinity,
     after: Infinity
   },
 
@@ -438,7 +435,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 3,
-    active: Infinity,
     after: Infinity
   },
 

--- a/web-animations/timing-model/animation-effects/simple-iteration-progress.html
+++ b/web-animations/timing-model/animation-effects/simple-iteration-progress.html
@@ -12,26 +12,40 @@
 'use strict';
 
 function runTests(tests, description) {
-  tests.forEach(function(currentTest) {
-    var testParams = '';
-    for (var attr in currentTest.input) {
-      testParams += ' ' + attr + ':' + currentTest.input[attr];
-    }
-    test(function(t) {
-      var div = createDiv(t);
-      var anim = div.animate({ opacity: [ 0, 1 ] }, currentTest.input);
+  for (const currentTest of tests) {
+    const testParams = Object.entries(currentTest.input)
+                             .map(([attr, value]) => `${attr}:${value}`)
+                             .join(' ');
+
+    test(t => {
+      const div = createDiv(t);
+      const anim = div.animate({}, currentTest.input);
+
+      // Before phase
       assert_equals(anim.effect.getComputedTiming().progress,
                     currentTest.before);
-      anim.currentTime = currentTest.input.delay || 0;
-      assert_equals(anim.effect.getComputedTiming().progress,
-                    currentTest.active);
-      if (typeof currentTest.after !== 'undefined') {
+
+      // Active phase
+      if (anim.effect.getComputedTiming().activeDuration > 0) {
+        anim.currentTime = currentTest.input.delay || 0;
+        assert_equals(anim.effect.getComputedTiming().progress,
+                      currentTest.active);
+      } else if (currentTest.active !== undefined) {
+        assert_false('Test specifies an active progress to check but the'
+                     + ' animation has a zero duration');
+      }
+
+      // After phase
+      if (anim.effect.getComputedTiming().activeDuration !== Infinity) {
         anim.finish();
         assert_equals(anim.effect.getComputedTiming().progress,
                       currentTest.after);
+      } else if (currentTest.after !== undefined) {
+        assert_false('Test specifies an after phase progress to check but the'
+                     + ' animation has an infinite duration');
       }
-    }, description + ':' + testParams);
-  });
+    }, `${description}: ${testParams}`);
+  }
 }
 
 
@@ -49,7 +63,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -60,7 +73,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -71,7 +83,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -82,7 +93,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 0.5,
     after: 0.5
   },
 
@@ -93,7 +103,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 0.5,
     after: 0.5
   },
 
@@ -104,7 +113,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 0.5,
     after: 0.5
   },
 
@@ -115,7 +123,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -126,7 +133,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   },
 
@@ -137,7 +143,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0,
     after: 0
   }
 ], 'Test zero iterations');
@@ -157,7 +162,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 1,
     after: 1
   },
 
@@ -189,7 +193,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 0.5,
     after: 0.5
   },
 
@@ -221,7 +224,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 1,
     after: 1
   },
 
@@ -262,7 +264,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0.5,
     after: 0.5
   },
 
@@ -294,7 +295,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 1,
     after: 1
   },
 
@@ -326,7 +326,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 0.5,
     after: 0.5
   },
 
@@ -367,7 +366,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 1,
     after: 1
   },
 
@@ -398,7 +396,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0.5,
-    active: 0.5,
     after: 0.5
   },
 
@@ -429,7 +426,6 @@ runTests([
                 delay: 1,
                 fill: 'both' },
     before: 0,
-    active: 1,
     after: 1
   },
 


### PR DESCRIPTION

This is in preparation for further changes to these files later in this patch
series.

In particular this patch:

* Moves some code to more modern Javascript that should be easier to read and
  maintain

* Makes the tests more strict about when active/after values are specified
  - If the timing parameters mean there is no active phase, the test should not
    specify a value to test for that phase. If there *is* an active phase, the
    test must provide a value to test (if it does not the test will fails when
    it compares against the undefined value).
  - Likewise for the after phase
  This should make it a little easier to incorporate testing the playbackRate.

MozReview-Commit-ID: 17vihK5RSbu

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1406381 [ci skip]