### PR TITLE
Extend assert_computed_timing_for_each_phase to accommodate negative playback rates;

### DIFF
--- a/web-animations/resources/effect-tests.js
+++ b/web-animations/resources/effect-tests.js
@@ -7,33 +7,57 @@
 //
 //   {
 //     before, // value to test during before phase
-//     active, // value to test during at the very beginning of the active phase
-//             // or undefined if the active duration is zero,
+//     activeBoundary, // value to test at the very beginning of the active
+//                     // phase when playing forwards, or the very end of
+//                     // the active phase when playing backwards.
+//                     // This should be undefined if the active duration of
+//                     // the effect is zero.
 //     after,  // value to test during the after phase or undefined if the
 //             // active duration is infinite
 //   }
 //
 function assert_computed_timing_for_each_phase(animation, property, values) {
   const effect = animation.effect;
+  const timing = effect.getComputedTiming();
+
+  // The following calculations are based on the definitions here:
+  // https://w3c.github.io/web-animations/#animation-effect-phases-and-states
+  const beforeActive = Math.max(Math.min(timing.delay, timing.endTime), 0);
+  const activeAfter =
+    Math.max(Math.min(timing.delay + timing.activeDuration, timing.endTime), 0);
+  const direction = animation.playbackRate < 0 ? 'backwards' : 'forwards';
 
   // Before phase
+  if (direction === 'forwards') {
+    animation.currentTime = beforeActive - 1;
+  } else {
+    animation.currentTime = beforeActive;
+  }
   assert_equals(effect.getComputedTiming()[property], values.before,
                 `Value of ${property} in the before phase`);
 
   // Active phase
   if (effect.getComputedTiming().activeDuration > 0) {
-    animation.currentTime = effect.getComputedTiming().delay;
-    assert_equals(effect.getComputedTiming()[property], values.active,
-                  `Value of ${property} in the active phase`);
+    if (direction === 'forwards') {
+      animation.currentTime = beforeActive;
+    } else {
+      animation.currentTime = activeAfter;
+    }
+    assert_equals(effect.getComputedTiming()[property], values.activeBoundary,
+                  `Value of ${property} at the boundary of the active phase`);
   } else {
-    assert_equals(values.active, undefined,
+    assert_equals(values.activeBoundary, undefined,
                   'Test specifies a value to check during the active phase but'
                   + ' the animation has a zero duration');
   }
 
   // After phase
   if (effect.getComputedTiming().activeDuration !== Infinity) {
-    animation.finish();
+    if (direction === 'forwards') {
+      animation.currentTime = activeAfter;
+    } else {
+      animation.currentTime = activeAfter + 1;
+    }
     assert_equals(effect.getComputedTiming()[property], values.after,
                   `Value of ${property} in the after phase`);
   } else {

--- a/web-animations/timing-model/animation-effects/current-iteration.html
+++ b/web-animations/timing-model/animation-effects/current-iteration.html
@@ -13,19 +13,25 @@
 
 function runTests(tests, description) {
   for (const currentTest of tests) {
-    const testParams = Object.entries(currentTest.input)
-                             .map(([attr, value]) => `${attr}:${value}`)
-                             .join(' ');
+    let testParams = Object.entries(currentTest.input)
+                           .map(([attr, value]) => `${attr}:${value}`)
+                           .join(' ');
+    if (currentTest.playbackRate !== undefined) {
+      testParams += ` playbackRate:${currentTest.playbackRate}`;
+    }
 
     test(t => {
       const div = createDiv(t);
       const anim = div.animate({}, currentTest.input);
+      if (currentTest.playbackRate !== undefined) {
+        anim.playbackRate = currentTest.playbackRate;
+      }
 
       assert_computed_timing_for_each_phase(
         anim,
         'currentIteration',
         { before: currentTest.before,
-          active: currentTest.active,
+          activeBoundary: currentTest.active,
           after: currentTest.after },
       );
     }, `${description}: ${testParams}`);

--- a/web-animations/timing-model/animation-effects/simple-iteration-progress.html
+++ b/web-animations/timing-model/animation-effects/simple-iteration-progress.html
@@ -14,19 +14,25 @@
 
 function runTests(tests, description) {
   for (const currentTest of tests) {
-    const testParams = Object.entries(currentTest.input)
-                             .map(([attr, value]) => `${attr}:${value}`)
-                             .join(' ');
+    let testParams = Object.entries(currentTest.input)
+                           .map(([attr, value]) => `${attr}:${value}`)
+                           .join(' ');
+    if (currentTest.playbackRate !== undefined) {
+      testParams += ` playbackRate:${currentTest.playbackRate}`;
+    }
 
     test(t => {
       const div = createDiv(t);
       const anim = div.animate({}, currentTest.input);
+      if (currentTest.playbackRate !== undefined) {
+        anim.playbackRate = currentTest.playbackRate;
+      }
 
       assert_computed_timing_for_each_phase(
         anim,
         'progress',
         { before: currentTest.before,
-          active: currentTest.active,
+          activeBoundary: currentTest.active,
           after: currentTest.after },
       );
     }, `${description}: ${testParams}`);


### PR DESCRIPTION

MozReview-Commit-ID: LpTRS6aMaWw

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1406381 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7835)
<!-- Reviewable:end -->
