### PR TITLE
Update the simple iteration progress calculation to match recent changes to the Web Animations specification;

### DIFF
--- a/web-animations/timing-model/animation-effects/current-iteration.html
+++ b/web-animations/timing-model/animation-effects/current-iteration.html
@@ -517,7 +517,7 @@ runTests([
                 endDelay: -50 },
     before: 0,
     active: 0,
-    after: 0
+    after: 1
   },
 
   {
@@ -539,7 +539,7 @@ runTests([
                 endDelay: -100 },
     before: 0,
     active: 0,
-    after: 0
+    after: 1
   },
 
   {

--- a/web-animations/timing-model/animation-effects/simple-iteration-progress.html
+++ b/web-animations/timing-model/animation-effects/simple-iteration-progress.html
@@ -508,7 +508,7 @@ runTests([
                 endDelay: -50 },
     before: 0.5,
     active: 0.5,
-    after: 1
+    after: 0
   },
 
   {
@@ -530,7 +530,7 @@ runTests([
                 endDelay: -100 },
     before: 0,
     active: 0,
-    after: 1
+    after: 0
   },
 
   {


### PR DESCRIPTION

This implements the following change to the Web Animations specification:

  https://github.com/w3c/web-animations/pull/202/commits/19b6c33cee533dde34b67ac9e416d93ecf4cb1d0

The background to that change is described in the corresponding spec issue:

  https://github.com/w3c/web-animations/issues/201

MozReview-Commit-ID: GGA64LG5vT

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1406381 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7837)
<!-- Reviewable:end -->
