### PR TITLE
Fix cookie creation via Marionette using IP address

### DIFF
--- a/webdriver/tests/cookies/add_cookie.py
+++ b/webdriver/tests/cookies/add_cookie.py
@@ -1,36 +1,7 @@
-from tests.support.inline import inline
 from tests.support.fixtures import clear_all_cookies
+from tests.support.fixtures import server_config
 
-def test_get_named_cookie(session, url):
-    session.url = url("/common/blank.html")
-    session.execute_script("document.cookie = 'foo=bar'")
-
-    result = session.transport.send("GET", "session/%s/cookie/foo" % session.session_id)
-    assert result.status == 200
-    assert isinstance(result.body["value"], dict)
-
-    # table for cookie conversion
-    # https://w3c.github.io/webdriver/webdriver-spec.html#dfn-table-for-cookie-conversion
-    cookie = result.body["value"]
-    assert "name" in cookie
-    assert isinstance(cookie["name"], basestring)
-    assert "value" in cookie
-    assert isinstance(cookie["value"], basestring)
-    assert "path" in cookie
-    assert isinstance(cookie["path"], basestring)
-    assert "domain" in cookie
-    assert isinstance(cookie["domain"], basestring)
-    assert "secure" in cookie
-    assert isinstance(cookie["secure"], bool)
-    assert "httpOnly" in cookie
-    assert isinstance(cookie["httpOnly"], bool)
-    assert "expiry" in cookie
-    assert isinstance(cookie["expiry"], (int, long))
-
-    assert cookie["name"] == "foo"
-    assert cookie["value"] == "bar"
-
-def test_duplicated_cookie(session, url):
+def test_add_domain_cookie(session, url):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
     create_cookie_request = {
@@ -48,7 +19,6 @@ def test_duplicated_cookie(session, url):
     assert "value" in result.body
     assert isinstance(result.body["value"], dict)
 
-    session.url = inline("<script>document.cookie = 'hello=newworld; domain=web-platform.test; path=/';</script>")
     result = session.transport.send("GET", "session/%s/cookie" % session.session_id)
     assert result.status == 200
     assert "value" in result.body
@@ -61,7 +31,46 @@ def test_duplicated_cookie(session, url):
     assert isinstance(cookie["name"], basestring)
     assert "value" in cookie
     assert isinstance(cookie["value"], basestring)
+    assert "domain" in cookie
+    assert isinstance(cookie["domain"], basestring)
 
     assert cookie["name"] == "hello"
-    assert cookie["value"] == "newworld"
+    assert cookie["value"] == "world"
+    assert cookie["domain"] == ".web-platform.test"
 
+def test_add_cookie_for_ip(session, url, server_config):
+    session.url = "http://127.0.0.1:%s/404" % (server_config["ports"]["http"][0])
+    clear_all_cookies(session)
+    create_cookie_request = {
+        "cookie": {
+            "name": "hello",
+            "value": "world",
+            "domain": "127.0.0.1",
+            "path": "/",
+            "httpOnly": False,
+            "secure": False
+        }
+    }
+    result = session.transport.send("POST", "session/%s/cookie" % session.session_id, create_cookie_request)
+    assert result.status == 200
+    assert "value" in result.body
+    assert isinstance(result.body["value"], dict)
+
+    result = session.transport.send("GET", "session/%s/cookie" % session.session_id)
+    assert result.status == 200
+    assert "value" in result.body
+    assert isinstance(result.body["value"], list)
+    assert len(result.body["value"]) == 1
+    assert isinstance(result.body["value"][0], dict)
+
+    cookie = result.body["value"][0]
+    assert "name" in cookie
+    assert isinstance(cookie["name"], basestring)
+    assert "value" in cookie
+    assert isinstance(cookie["value"], basestring)
+    assert "domain" in cookie
+    assert isinstance(cookie["domain"], basestring)
+
+    assert cookie["name"] == "hello"
+    assert cookie["value"] == "world"
+    assert cookie["domain"] == "127.0.0.1"


### PR DESCRIPTION

The issue here was that the cookie domain was always prepended with
'.' character. To resolve this edge-case Marionette now first checks
whether the cookie domain is in fact an IP address.

MozReview-Commit-ID: 4xBd4rscXxx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1407675 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7838)
<!-- Reviewable:end -->
