### PR TITLE
Correctly test CSSStyleRule.style.

### DIFF
--- a/cssom/CSSStyleRule.html
+++ b/cssom/CSSStyleRule.html
@@ -67,7 +67,24 @@
             assert_idl_attribute(rule, "selectorText");
             assert_equals(typeof rule.selectorText, "string");
             assert_idl_attribute(rule, "style");
-        }, "Existence, writability and type of CSSStyleRule attributes");
+        }, "Existence and type of CSSStyleRule attributes");
+
+        test(function() {
+            // CSSStyleRule.style has PutForwards=cssText and SameObject.
+            var initial = rule.style.cssText;
+            var style = rule.style;
+
+            rule.style = "";
+            assert_equals(rule.style.cssText, "");
+            assert_equals(rule.style, style);
+
+            rule.style = "margin: 42px;";
+            assert_equals(rule.style.margin, "42px");
+            assert_equals(rule.style, style);
+
+            rule.style = initial;
+            assert_equals(rule.style, style);
+        }, "Assigning to CSSStyleRule.style assigns to cssText; CSSStyleRule.style returns the same object");
 
         test(function() {
             assert_equals(rule.selectorText, "div");


### PR DESCRIPTION

Remove the assert_readonly test and add one to verify that assigning to
CSSStyleRule.style correctly forwards to CSSStyleRule.style.cssText.

We currently test for whether CSSStyleRule.style is read-only by
trying to assign to it; however, the spec has it as actually:

interface CSSStyleRule : CSSRule {
  ...
  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
};

See: https://drafts.csswg.org/cssom/

The `PutForwards=cssText` means that assigning to CSSStyleRule.style
should actually assign to style.cssText.

Upstreamed from https://github.com/servo/servo/pull/18851 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7840)
<!-- Reviewable:end -->
