### PR TITLE
Fix several bugs related to scrolling

### DIFF
--- a/cssom-view/elementScroll.html
+++ b/cssom-view/elementScroll.html
@@ -25,12 +25,14 @@
 
 <section id="section">
     <div id="scrollable"></div>
+    <div id="unrelated"></div>
 </section>
 
 <script>
     setup({explicit_done:true});
     window.onload = function () {
         var section = document.getElementById("section");
+        var unrelated = document.getElementById("unrelated");
 
         test(function () {
             assert_equals(section.scrollTop, 0, "initial scrollTop should be 0");
@@ -41,6 +43,8 @@
 
             assert_equals(section.scrollTop, 30, "changed scrollTop should be 40");
             assert_equals(section.scrollLeft, 40, "changed scrollLeft should be 40");
+            assert_equals(unrelated.scrollTop, 0, "unrelated element should not scroll");
+            assert_equals(unrelated.scrollLeft, 0, "unrelated element should not scroll");
         },  "Element scrollTop/Left getter/setter test");
 
         test(function () {


### PR DESCRIPTION

* scrollLeft/scrollTop returned values of parent or even document root
   Only the scroll of the node itself is returned. Otherwise 0.0.
* Scrolling via script had set viewport.
   This resulted in other nodes appearing scrolled.
   Now scroll_offsets are updated with correct node id.

These bugs caused other odd behavior like both body and
document.documentElement being scrolled or the view for scrolled
elements jumping.

Upstreamed from https://github.com/servo/servo/pull/18851 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7841)
<!-- Reviewable:end -->
