### PR TITLE
Update domparsing spec links to not point at WHATWG

### DIFF
--- a/domparsing/innerhtml-07.html
+++ b/domparsing/innerhtml-07.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>innerHTML and string conversion</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="http://domparsing.spec.whatwg.org/#extensions-to-the-element-interface">
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>

--- a/domparsing/outerhtml-02.html
+++ b/domparsing/outerhtml-02.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>outerHTML and string conversion</title>
 <link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
-<link rel="help" href="http://domparsing.spec.whatwg.org/#extensions-to-the-element-interface">
+<link rel="help" href="https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>


### PR DESCRIPTION

- Change domparsing spec link from domparsing.spec.whatwg.org to w3c.github.io/DOM-Parsing
- Remove from tidy since it's already covered by w3c.github.io
- Update test manifest

Upstreamed from https://github.com/servo/servo/pull/18869 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7843)
<!-- Reviewable:end -->
