### PR TITLE
Add tests for the behavior of `<iterator>.return === document.all` in the iterator protocol

### DIFF
--- a/js/behaviours/iterator-close-return-emulates-undefined-throws-when-called.html
+++ b/js/behaviours/iterator-close-return-emulates-undefined-throws-when-called.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Test for document.all as the value of &lt;iterator&gt;.return</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(function() {
+  var iter = {
+    [Symbol.iterator]() { return this; },
+    next() { return {}; },
+    return: document.all,
+  };
+
+  assert_throws(new TypeError, function() {
+    for (var x of iter)
+      break;
+  });
+}, "When <iterator>.return is document.all, it should be invoked by the " +
+   "iterator protocol (and then throw a TypeError)");
+</script>
+</body>
+</html>

--- a/js/behaviours/star-iterable-return-emulates-undefined-throws-when-called.html
+++ b/js/behaviours/star-iterable-return-emulates-undefined-throws-when-called.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Test for document.all as the value of &lt;iterator&gt;.return</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(function() {
+  var iter = {
+    [Symbol.iterator]() { return this; },
+    next() { return {}; },
+    return: document.all,
+  };
+
+  var outer = (function*() { yield* iter; })();
+
+  outer.next();
+
+  assert_throws(new TypeError, function() {
+    outer.return();
+  });
+}, "When <iterator>.return is document.all, it should be invoked by the " +
+   "iterator protocol (and then throw a TypeError)");
+</script>
+</body>
+</html>


### PR DESCRIPTION
test262 peoples want this sort of test in w-p-t, notwithstanding that basically all the testing is of ECMA-262 algorithm -- see https://github.com/tc39/test262/pull/1287 for the first attempt on getting these test in an upstream.

Dunno who you want reviewing this patch, because realistically you want someone JS-ful to review it, given that.  :-\  The test262 PR has links to where in ECMA-262 is being tested, but presumably you want someone with prior familiarity with this spec reviewing it.  Maybe @anba knows who can?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
