### PR TITLE
Make Ambient Light Sensor IDL tests use a standalone IDL file

### DIFF
--- a/ambient-light/idlharness.https.html
+++ b/ambient-light/idlharness.https.html
@@ -15,7 +15,7 @@ function doTest([dom, generic_sensor, ambient_light]) {
   const idl_array = new IdlArray();
   idl_array.add_untested_idls(dom);
   idl_array.add_untested_idls('interface EventHandler {};');
-  idl_array.add_idls(generic_sensor, { include: ['Sensor'] });
+  idl_array.add_idls(generic_sensor, { only: ['Sensor'] });
   idl_array.add_idls(ambient_light);
   idl_array.add_objects({
     AmbientLightSensor: ['new AmbientLightSensor()']

--- a/ambient-light/idlharness.https.html
+++ b/ambient-light/idlharness.https.html
@@ -8,48 +8,30 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
-<div id="log"></div>
-
-<script id="idl" type="text/plain">
-interface EventTarget {
-};
-
-interface EventHandler {
-};
-</script>
-
-<script id="ambient-light-idl" type="text/plain">
-// The interface of Sensor is defined in
-// https://www.w3.org/TR/generic-sensor/#idl-index
-[SecureContext, Exposed=Window]
-interface Sensor : EventTarget {
-  readonly attribute boolean activated;
-  readonly attribute boolean hasReading;
-  readonly attribute DOMHighResTimeStamp? timestamp;
-  void start();
-  void stop();
-  attribute EventHandler onreading;
-  attribute EventHandler onactivate;
-  attribute EventHandler onerror;
-};
-
-[Constructor(optional SensorOptions sensorOptions), Exposed=Window]
-interface AmbientLightSensor : Sensor {
-  readonly attribute double? illuminance;
-};
-</script>
-
 <script>
-(() => {
-  "use strict";
-  let idl_array = new IdlArray();
-  idl_array.add_untested_idls(document.getElementById('idl').textContent);
-  idl_array.add_idls(document.getElementById('ambient-light-idl').textContent);
+"use strict";
 
+function doTest([dom, generic_sensor, ambient_light]) {
+  const idl_array = new IdlArray();
+  idl_array.add_untested_idls(dom);
+  idl_array.add_untested_idls('interface EventHandler {};');
+  idl_array.add_idls(generic_sensor, { include: ['Sensor'] });
+  idl_array.add_idls(ambient_light);
   idl_array.add_objects({
-    AmbientLightSensor: ['new AmbientLightSensor();']
+    AmbientLightSensor: ['new AmbientLightSensor()']
   });
-
   idl_array.test();
-})();
+}
+
+function fetchText(url) {
+  return fetch(url).then((response) => response.text());
+}
+
+promise_test(() => {
+  return Promise.all([
+    "/interfaces/dom.idl",
+    "/interfaces/generic-sensor.idl",
+    "/interfaces/ambient-light.idl",
+  ].map(fetchText)).then(doTest);
+}, "Test driver");
 </script>

--- a/interfaces/ambient-light.idl
+++ b/interfaces/ambient-light.idl
@@ -1,0 +1,4 @@
+[Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
+interface AmbientLightSensor : Sensor {
+  readonly attribute double? illuminance;
+};

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -207,24 +207,24 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
      * .members) so that they'll be skipped by test() -- they'll only be
      * used for base interfaces of tested interfaces, return types, etc.
      *
-     * options is a dictionary that can have an include or exclude member which
-     * are arrays. If include is given then only members, partials and interface
-     * targets listed will be added, and if exclude is given only those that
-     * aren't listed will be added. Only one of include and exclude can be used.
+     * options is a dictionary that can have an only or except member which are
+     * arrays. If only is given then only members, partials and interface
+     * targets listed will be added, and if except is given only those that
+     * aren't listed will be added. Only one of only and except can be used.
      */
 
-    if (options && options.include && options.exclude)
+    if (options && options.only && options.except)
     {
-        throw "The include and exclude options can't be used together."
+        throw "The only and except options can't be used together."
     }
 
     function should_skip(name)
     {
-        if (options && options.include && options.include.indexOf(name) == -1)
+        if (options && options.only && options.only.indexOf(name) == -1)
         {
             return true;
         }
-        if (options && options.exclude && options.exclude.indexOf(name) != -1)
+        if (options && options.except && options.except.indexOf(name) != -1)
         {
             return true;
         }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -167,11 +167,11 @@ self.IdlArray = function()
 };
 
 //@}
-IdlArray.prototype.add_idls = function(raw_idls)
+IdlArray.prototype.add_idls = function(raw_idls, options)
 //@{
 {
     /** Entry point.  See documentation at beginning of file. */
-    this.internal_add_idls(WebIDL2.parse(raw_idls));
+    this.internal_add_idls(WebIDL2.parse(raw_idls), options);
 };
 
 //@}
@@ -195,27 +195,60 @@ IdlArray.prototype.add_untested_idls = function(raw_idls)
 };
 
 //@}
-IdlArray.prototype.internal_add_idls = function(parsed_idls)
+IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
 //@{
 {
     /**
      * Internal helper called by add_idls() and add_untested_idls().
+     *
      * parsed_idls is an array of objects that come from WebIDLParser.js's
      * "definitions" production.  The add_untested_idls() entry point
      * additionally sets an .untested property on each object (and its
      * .members) so that they'll be skipped by test() -- they'll only be
      * used for base interfaces of tested interfaces, return types, etc.
+     *
+     * options is a dictionary that can have an include or exclude member which
+     * are arrays. If include is given then only members, partials and interface
+     * targets listed will be added, and if exclude is given only those that
+     * aren't listed will be added. Only one of include and exclude can be used.
      */
+
+    if (options && options.include && options.exclude)
+    {
+        throw "The include and exclude options can't be used together."
+    }
+
+    function should_skip(name)
+    {
+        if (options && options.include && options.include.indexOf(name) == -1)
+        {
+            return true;
+        }
+        if (options && options.exclude && options.exclude.indexOf(name) != -1)
+        {
+            return true;
+        }
+        return false;
+    }
+
     parsed_idls.forEach(function(parsed_idl)
     {
         if (parsed_idl.type == "interface" && parsed_idl.partial)
         {
+            if (should_skip(parsed_idl.name))
+            {
+                return;
+            }
             this.partials.push(parsed_idl);
             return;
         }
 
         if (parsed_idl.type == "implements")
         {
+            if (should_skip(parsed_idl.target))
+            {
+                return;
+            }
             if (!(parsed_idl.target in this["implements"]))
             {
                 this["implements"][parsed_idl.target] = [];
@@ -228,6 +261,10 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls)
         if (parsed_idl.name in this.members)
         {
             throw "Duplicate identifier " + parsed_idl.name;
+        }
+        if (should_skip(parsed_idl.name))
+        {
+            return;
         }
         switch(parsed_idl.type)
         {


### PR DESCRIPTION
This also adds the support to idlharness.js to filter which
members/etc. are added from a chunk of IDL text, fixing
https://github.com/w3c/web-platform-tests/issues/7781.

Before and after the changes, there are 2 failing tests in Chrome Dev,
both due to the hasReading attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7861)
<!-- Reviewable:end -->
