### PR TITLE
wai-aria: Remove redundant AX API assertions from two aria-modal tests.

### DIFF
--- a/wai-aria/alertdialog_modal_true-manual.html
+++ b/wai-aria/alertdialog_modal_true-manual.html
@@ -31,26 +31,6 @@
                   "STATE_MODAL"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "AXRole",
-                  "is",
-                  "AXGroup"
-               ],
-               [
-                  "property",
-                  "AXSubrole",
-                  "is",
-                  "AXApplicationAlertDialog"
-               ],
-               [
-                  "property",
-                  "AXRoleDescription",
-                  "is",
-                  "web alert dialog"
-               ]
-            ],
             "IAccessible2" : [
                [
                   "property",

--- a/wai-aria/dialog_modal_true-manual.html
+++ b/wai-aria/dialog_modal_true-manual.html
@@ -31,26 +31,6 @@
                   "STATE_MODAL"
                ]
             ],
-            "AXAPI" : [
-               [
-                  "property",
-                  "AXRole",
-                  "is",
-                  "AXGroup"
-               ],
-               [
-                  "property",
-                  "AXSubrole",
-                  "is",
-                  "AXApplicationDialog"
-               ],
-               [
-                  "property",
-                  "AXRoleDescription",
-                  "is",
-                  "web dialog"
-               ]
-            ],
             "IAccessible2" : [
                [
                   "property",


### PR DESCRIPTION
The AXRole, AXSubrole, and AXRoleDescription are already being tested
by the aria-modal="false" tests. In addition, what we really need to
verify for AX API when aria-modal="true" is that the background content
has been removed from the accessibility tree. The role details of other
elements are irrelevant in performing that verification, and their
inclusion introduces noise into the results.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
