### PR TITLE
Fix bad uses of assert_array_equals() in html/semantics/forms/the-pro…

### DIFF
--- a/html/semantics/forms/the-progress-element/progress.html
+++ b/html/semantics/forms/the-progress-element/progress.html
@@ -42,7 +42,7 @@
       }, "Indeterminate progress bar should have value 0");
 
       test(function() {
-        assert_array_equals(largerthanmax.value, 1);
+        assert_equals(largerthanmax.value, 1);
       }, "Value must equal max if the parsed value is larger than max");
 
       test(function() {
@@ -50,7 +50,7 @@
       }, "Max must be 1 by default");
 
       test(function() {
-        assert_array_equals(largerthanmax.max, 1);
+        assert_equals(largerthanmax.max, 1);
       }, "Max must be 1 by default, even if value is specified");
 
       test(function() {


### PR DESCRIPTION
…gress-element/progress.html

progress.value is not an array but a double.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
