### PR TITLE
Remove SpecialPowers from css parsing tests

### DIFF
--- a/css/css-fonts-3/test_font_family_parsing.html
+++ b/css/css-fonts-3/test_font_family_parsing.html
@@ -135,18 +135,15 @@ var testFontFamilyLists = [
   { namelist: "icon", single: true },
   { namelist: "menu", single: true }
 
+  /* Unset */
+  { namelist: "unset", invalid: true, fontonly: true, single: true },
+  { namelist: "unset, simple", invalid: true },
+  { namelist: "simple, unset", invalid: true },
+  { namelist: "simple, unset bongo" },
+  { namelist: "simple, bongo unset" },
+  { namelist: "simple unset", single: true },
+  { namelist: "unset simple", single: true },
 ];
-
-if (SpecialPowers.getBoolPref("layout.css.unset-value.enabled")) {
-  testFontFamilyLists.push(
-    { namelist: "unset", invalid: true, fontonly: true, single: true },
-    { namelist: "unset, simple", invalid: true },
-    { namelist: "simple, unset", invalid: true },
-    { namelist: "simple, unset bongo" },
-    { namelist: "simple, bongo unset" },
-    { namelist: "simple unset", single: true },
-    { namelist: "unset simple", single: true });
-}
 
 var gTest = 0;
 

--- a/css/css-fonts-3/test_font_family_parsing.html
+++ b/css/css-fonts-3/test_font_family_parsing.html
@@ -133,7 +133,7 @@ var testFontFamilyLists = [
   { namelist: "normal simple", single: true },
   { namelist: "caption", single: true }, // these are keywords for the 'font' property but only when in the first position
   { namelist: "icon", single: true },
-  { namelist: "menu", single: true }
+  { namelist: "menu", single: true },
 
   /* Unset */
   { namelist: "unset", invalid: true, fontonly: true, single: true },

--- a/css/css-fonts-3/test_font_feature_values_parsing.html
+++ b/css/css-fonts-3/test_font_feature_values_parsing.html
@@ -69,7 +69,6 @@ var testrules = [
   { rule: makeRule("bongo", "@styleset { abc 1 2 3 }"), serializationNoValueDefn: true },
   { rule: makeRule("bongo", "@styleset { abc:, 1 2 3 }"), serializationNoValueDefn: true },
   { rule: makeRule("bongo", "@styleset { abc:; 1 2 3 }"), serializationNoValueDefn: true },
-  { rule: makeRule("bongo", "@styleset { abc:; 1 2 3 }"), serializationNoValueDefn: true },
   { rule: makeRule("bongo", "@styleset { abc: 1 2 3a }"), serializationNoValueDefn: true },
   { rule: makeRule("bongo", "@styleset { abc: 1 2 3, def: 1; }"), serializationNoValueDefn: true },
   { rule: makeRule("bongo", "@blah @styleset { abc: 1 2 3; }"), serializationNoValueDefn: true },
@@ -335,10 +334,6 @@ function testOneRule(testrule) {
 }
 
 function testFontFeatureValuesRuleParsing() {
-  // Gecko-specific check - if pref not set, skip these tests
-  if (window.SpecialPowers && !window.SpecialPowers.getBoolPref("layout.css.font-features.enabled")) {
-    return;
-  }
   var i;
   for (i = 0; i < testrules.length; i++) {
     var testrule = testrules[i];


### PR DESCRIPTION
This is Gecko-specific and doesn't even exist in wpt tests run in
Gecko.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
