### PR TITLE
Enable uploading manifest to GitHub.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ matrix:
   include:
     - os: linux
       python: "2.7"
+      env: JOB=manifest_upload SCRIPT=tools/ci/ci_manifest.sh
+      deploy:
+        provider: releases
+        api_key:
+          secure: "EljDx50oNpDLs7rzwIv+z1PxIgB5KMnx1W0OQkpNvltR0rBW9g/aQaE+Z/c8M/sPqN1bkvKPybKzGKjb6j9Dw3/EJhah4SskH78r3yMAe2DU/ngxqqjjfXcCc2t5MKxzHAILTAxqScPj2z+lG1jeK1Z+K5hTbSP9lk+AvS0D16w="
+        file: "~/meta/MANIFEST.json.gz"
+        skip_cleanup: true
+    - os: linux
+      python: "2.7"
       env: JOB=lint SCRIPT=tools/ci/ci_lint.sh
     - os: linux
       python: "2.7"

--- a/tools/ci/ci_manifest.sh
+++ b/tools/ci/ci_manifest.sh
@@ -1,0 +1,10 @@
+set -ex
+
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+WPT_ROOT=$(readlink -f $SCRIPT_DIR/../..)
+cd $WPT_ROOT
+
+mkdir -p ~/meta
+./wpt manifest -p ~/meta/MANIFEST.json
+# Force overwrite of any existing file
+gzip -f ~/meta/MANIFEST.json

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -21,6 +21,7 @@ job_path_map = {
                   "!.*/README",
                   "!css/[^/]*$"],
     "lint": [".*"],
+    "manifest_upload": [".*"],
     "resources_unittest": ["resources/"],
     "tools_unittest": ["tools/"],
     "wptrunner_unittest": ["tools/wptrunner/*"],

--- a/tools/ci/tests/test_jobs.py
+++ b/tools/ci/tests/test_jobs.py
@@ -1,7 +1,9 @@
 from tools.ci import jobs
 
+default_jobs = set(["lint", "manifest_upload"])
+
 def test_testharness():
-    assert jobs.get_jobs(["resources/testharness.js"]) == set(["lint", "resources_unittest"])
+    assert jobs.get_jobs(["resources/testharness.js"]) == default_jobs | set(["resources_unittest"])
     assert jobs.get_jobs(["resources/testharness.js"],
                          includes=["resources_unittest"]) == set(["resources_unittest"])
     assert jobs.get_jobs(["foo/resources/testharness.js"],
@@ -32,8 +34,10 @@ def test_stability():
                           "css/CSS21/test-001.html"],
                          includes=["stability"]) == set(["stability"])
 
-def test_lint():
-    assert jobs.get_jobs(["README.md"]) == set(["lint"])
+
+def test_default():
+    assert jobs.get_jobs(["README.md"]) == default_jobs
+
 
 def test_tools_unittest():
     assert jobs.get_jobs(["tools/ci/test/test_jobs.py"],
@@ -43,11 +47,13 @@ def test_tools_unittest():
     assert jobs.get_jobs(["dom/historical.html"],
                          includes=["tools_unittest"]) == set()
 
+
 def test_wptrunner_unittest():
     assert jobs.get_jobs(["tools/wptrunner/wptrunner/wptrunner.py"],
                          includes=["wptrunner_unittest"]) == set(["wptrunner_unittest"])
     assert jobs.get_jobs(["tools/example.py"],
                          includes=["wptrunner_unittest"]) == set()
+
 
 def test_build_css():
     assert jobs.get_jobs(["css/css-build-testsuites.sh"],


### PR DESCRIPTION
This uploads a MANIFEST.json.gz file for every commit to master, so
that we can build tooling that attempts to download that file as an
initial manifest that can then have a rapid update rather than a slow
build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7898)
<!-- Reviewable:end -->
