### PR TITLE
Run default jobs in CI even if there aren't any changes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         provider: releases
         api_key:
           secure: "EljDx50oNpDLs7rzwIv+z1PxIgB5KMnx1W0OQkpNvltR0rBW9g/aQaE+Z/c8M/sPqN1bkvKPybKzGKjb6j9Dw3/EJhah4SskH78r3yMAe2DU/ngxqqjjfXcCc2t5MKxzHAILTAxqScPj2z+lG1jeK1Z+K5hTbSP9lk+AvS0D16w="
-        file: "~/meta/MANIFEST.json.gz"
+        file: $HOME/meta/MANIFEST.json.gz
         skip_cleanup: true
     - os: linux
       python: "2.7"

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -100,6 +100,12 @@ def get_jobs(paths, **kwargs):
         if not rules:
             break
 
+    # Default jobs shuld run even if there were no changes
+    if not paths:
+        for job, path_re in iteritems(job_path_map):
+            if ".*" in path_re:
+                jobs.add(job)
+
     return jobs
 
 


### PR DESCRIPTION
This means that manifest_upload and lint run on master. Although the
lint is not going to do anything at the moment since it only runs on
changed files. In the future we could make it pass --all in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7904)
<!-- Reviewable:end -->
