### PR TITLE
Integrated fixes from core-aam wiki

### DIFF
--- a/core-aam/aria-flowto-manual.html
+++ b/core-aam/aria-flowto-manual.html
@@ -36,7 +36,7 @@
             "IAccessible2" : [
                [
                   "relation",
-                  "IA2_RELATION_FLOW_TO",
+                  "IA2_RELATION_FLOWS_TO",
                   "is",
                   "[next]"
                ]
@@ -67,7 +67,7 @@
             "IAccessible2" : [
                [
                   "relation",
-                  "IA2_RELATION_FLOW_FROM",
+                  "IA2_RELATION_FLOWS_FROM",
                   "is",
                   "[test]"
                ]

--- a/core-aam/progressbar-manual.html
+++ b/core-aam/progressbar-manual.html
@@ -62,7 +62,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ]
             ],
             "MSAA" : [

--- a/core-aam/scrollbar-manual.html
+++ b/core-aam/scrollbar-manual.html
@@ -56,7 +56,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ]
             ],
             "MSAA" : [

--- a/core-aam/slider-manual.html
+++ b/core-aam/slider-manual.html
@@ -56,7 +56,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ]
             ],
             "MSAA" : [

--- a/core-aam/spinbutton-manual.html
+++ b/core-aam/spinbutton-manual.html
@@ -56,7 +56,7 @@
                   "property",
                   "interfaces",
                   "contains",
-                  "IAcesssibleValue"
+                  "IAccessibleValue"
                ]
             ],
             "MSAA" : [

--- a/wai-aria/tools/make_tests.pl
+++ b/wai-aria/tools/make_tests.pl
@@ -21,6 +21,11 @@ my %specs = (
       specURL => "https://www.w3.org/TR/wai-aria11/",
       dir => "aria11"
     },
+    "coreaam" => {
+      title => "Core_AAM_1.1_Testable_Statements",
+      specURL => "https://www.w3.org/wiki/Core_AAM_1.1_Testable_Statements/",
+      dir => "../core-aam"
+    },
     "svg" => {
       title => "SVG_Accessibility/Testing/Test_Assertions_with_Tables_for_ATTA",
       specURL => "https://www.w3.org/TR/svg-aam-1.0/",
@@ -532,8 +537,6 @@ sub usage() {
   -w wiki_title - the TITLE of a wiki page with testable statements
   -f file       - the file from which to read
 
-  -n            - do nothing
-  -v            - be verbose
   -d dir        - put generated tests in directory dir
   );
   exit 1;


### PR DESCRIPTION
These fix typos in some IAccessible2 Testable Statements.

Also adds coreaam as a supported "spec" in the make_tests.pl tool

<!-- Reviewable:start -->

<!-- Reviewable:end -->
