### PR TITLE
Updating WebDriver actions tests to be IE-friendly

### DIFF
--- a/webdriver/tests/actions/conftest.py
+++ b/webdriver/tests/actions/conftest.py
@@ -26,6 +26,7 @@ def key_reporter(session, test_actions_page, request):
     """Represents focused input element from `test_keys_page` fixture."""
     input_el = session.find.css("#keys", all=False)
     input_el.click()
+    session.execute_script("resetEvents();")
     return input_el
 
 

--- a/webdriver/tests/actions/key.py
+++ b/webdriver/tests/actions/key.py
@@ -34,11 +34,15 @@ def test_single_printable_key_sends_correct_events(session,
         .key_up(value) \
         .perform()
     expected = [
-        {"key": value, "type": "keydown"},
-        {"key": value, "type": "keypress"},
-        {"key": value, "type": "keyup"},
+        {"code": code, "key": value, "type": "keydown"},
+        {"code": code, "key": value, "type": "keypress"},
+        {"code": code, "key": value, "type": "keyup"},
     ]
-    events = [filter_dict(e, expected[0]) for e in get_events(session)]
+    all_events = get_events(session)
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+    events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
     assert get_keys(key_reporter) == value
 
@@ -76,9 +80,12 @@ def test_single_modifier_key_sends_correct_events(session,
         .perform()
     all_events = get_events(session)
     expected = [
-        {"key": key, "type": "keydown"},
-        {"key": key, "type": "keyup"},
+        {"code": code, "key": key, "type": "keydown"},
+        {"code": code, "key": key, "type": "keyup"},
     ]
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
     events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
     assert len(get_keys(key_reporter)) == 0
@@ -99,11 +106,15 @@ def test_single_nonprintable_key_sends_events(session,
         .key_up(value) \
         .perform()
     expected = [
-        {"key": key, "type": "keydown"},
-        {"key": key, "type": "keypress"},
-        {"key": key, "type": "keyup"},
+        {"code": code, "key": key, "type": "keydown"},
+        {"code": code, "key": key, "type": "keypress"},
+        {"code": code, "key": key, "type": "keyup"},
     ]
-    events = [filter_dict(e, expected[0]) for e in get_events(session)]
+    all_events = get_events(session)
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+    events = [filter_dict(e, expected[0]) for e in all_events]
     if len(events) == 2:
         # most browsers don't send a keypress for non-printable keys
         assert events == [expected[0], expected[2]]
@@ -120,12 +131,16 @@ def test_sequence_of_keydown_printable_keys_sends_events(session,
         .key_down("b") \
         .perform()
     expected = [
-        {"key": "a", "type": "keydown"},
-        {"key": "a", "type": "keypress"},
-        {"key": "b", "type": "keydown"},
-        {"key": "b", "type": "keypress"},
+        {"code": "KeyA", "key": "a", "type": "keydown"},
+        {"code": "KeyA", "key": "a", "type": "keypress"},
+        {"code": "KeyB", "key": "b", "type": "keydown"},
+        {"code": "KeyB", "key": "b", "type": "keypress"},
     ]
-    events = [filter_dict(e, expected[0]) for e in get_events(session)]
+    all_events = get_events(session)
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+    events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
     assert get_keys(key_reporter) == "ab"
 
@@ -133,14 +148,18 @@ def test_sequence_of_keydown_printable_keys_sends_events(session,
 def test_sequence_of_keydown_character_keys(session, key_reporter, key_chain):
     key_chain.send_keys("ef").perform()
     expected = [
-        {"key": "e", "type": "keydown"},
-        {"key": "e", "type": "keypress"},
-        {"key": "e", "type": "keyup"},
-        {"key": "f", "type": "keydown"},
-        {"key": "f", "type": "keypress"},
-        {"key": "f", "type": "keyup"},
+        {"code": "KeyE", "key": "e", "type": "keydown"},
+        {"code": "KeyE", "key": "e", "type": "keypress"},
+        {"code": "KeyE", "key": "e", "type": "keyup"},
+        {"code": "KeyF", "key": "f", "type": "keydown"},
+        {"code": "KeyF", "key": "f", "type": "keypress"},
+        {"code": "KeyF", "key": "f", "type": "keyup"},
     ]
-    events = [filter_dict(e, expected[0]) for e in get_events(session)]
+    all_events = get_events(session)
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+    events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
     assert get_keys(key_reporter) == "ef"
 

--- a/webdriver/tests/actions/key.py
+++ b/webdriver/tests/actions/key.py
@@ -39,10 +39,11 @@ def test_single_printable_key_sends_correct_events(session,
         {"code": code, "key": value, "type": "keyup"},
     ]
     all_events = get_events(session)
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     assert events == expected
     assert get_keys(key_reporter) == value
 
@@ -83,10 +84,11 @@ def test_single_modifier_key_sends_correct_events(session,
         {"code": code, "key": key, "type": "keydown"},
         {"code": code, "key": key, "type": "keyup"},
     ]
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     assert events == expected
     assert len(get_keys(key_reporter)) == 0
 
@@ -111,10 +113,11 @@ def test_single_nonprintable_key_sends_events(session,
         {"code": code, "key": key, "type": "keyup"},
     ]
     all_events = get_events(session)
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     if len(events) == 2:
         # most browsers don't send a keypress for non-printable keys
         assert events == [expected[0], expected[2]]
@@ -137,10 +140,11 @@ def test_sequence_of_keydown_printable_keys_sends_events(session,
         {"code": "KeyB", "key": "b", "type": "keypress"},
     ]
     all_events = get_events(session)
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     assert events == expected
     assert get_keys(key_reporter) == "ab"
 
@@ -156,10 +160,11 @@ def test_sequence_of_keydown_character_keys(session, key_reporter, key_chain):
         {"code": "KeyF", "key": "f", "type": "keyup"},
     ]
     all_events = get_events(session)
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     assert events == expected
     assert get_keys(key_reporter) == "ef"
 

--- a/webdriver/tests/actions/key.py
+++ b/webdriver/tests/actions/key.py
@@ -34,9 +34,9 @@ def test_single_printable_key_sends_correct_events(session,
         .key_up(value) \
         .perform()
     expected = [
-        {"code": code, "key": value, "type": "keydown"},
-        {"code": code, "key": value, "type": "keypress"},
-        {"code": code, "key": value, "type": "keyup"},
+        {"key": value, "type": "keydown"},
+        {"key": value, "type": "keypress"},
+        {"key": value, "type": "keyup"},
     ]
     events = [filter_dict(e, expected[0]) for e in get_events(session)]
     assert events == expected
@@ -76,8 +76,8 @@ def test_single_modifier_key_sends_correct_events(session,
         .perform()
     all_events = get_events(session)
     expected = [
-        {"code": code, "key": key, "type": "keydown"},
-        {"code": code, "key": key, "type": "keyup"},
+        {"key": key, "type": "keydown"},
+        {"key": key, "type": "keyup"},
     ]
     events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
@@ -99,9 +99,9 @@ def test_single_nonprintable_key_sends_events(session,
         .key_up(value) \
         .perform()
     expected = [
-        {"code": code, "key": key, "type": "keydown"},
-        {"code": code, "key": key, "type": "keypress"},
-        {"code": code, "key": key, "type": "keyup"},
+        {"key": key, "type": "keydown"},
+        {"key": key, "type": "keypress"},
+        {"key": key, "type": "keyup"},
     ]
     events = [filter_dict(e, expected[0]) for e in get_events(session)]
     if len(events) == 2:
@@ -120,10 +120,10 @@ def test_sequence_of_keydown_printable_keys_sends_events(session,
         .key_down("b") \
         .perform()
     expected = [
-        {"code": "KeyA", "key": "a", "type": "keydown"},
-        {"code": "KeyA", "key": "a", "type": "keypress"},
-        {"code": "KeyB", "key": "b", "type": "keydown"},
-        {"code": "KeyB", "key": "b", "type": "keypress"},
+        {"key": "a", "type": "keydown"},
+        {"key": "a", "type": "keypress"},
+        {"key": "b", "type": "keydown"},
+        {"key": "b", "type": "keypress"},
     ]
     events = [filter_dict(e, expected[0]) for e in get_events(session)]
     assert events == expected
@@ -133,12 +133,12 @@ def test_sequence_of_keydown_printable_keys_sends_events(session,
 def test_sequence_of_keydown_character_keys(session, key_reporter, key_chain):
     key_chain.send_keys("ef").perform()
     expected = [
-        {"code": "KeyE", "key": "e", "type": "keydown"},
-        {"code": "KeyE", "key": "e", "type": "keypress"},
-        {"code": "KeyE", "key": "e", "type": "keyup"},
-        {"code": "KeyF", "key": "f", "type": "keydown"},
-        {"code": "KeyF", "key": "f", "type": "keypress"},
-        {"code": "KeyF", "key": "f", "type": "keyup"},
+        {"key": "e", "type": "keydown"},
+        {"key": "e", "type": "keypress"},
+        {"key": "e", "type": "keyup"},
+        {"key": "f", "type": "keydown"},
+        {"key": "f", "type": "keypress"},
+        {"key": "f", "type": "keyup"},
     ]
     events = [filter_dict(e, expected[0]) for e in get_events(session)]
     assert events == expected

--- a/webdriver/tests/actions/mouse.py
+++ b/webdriver/tests/actions/mouse.py
@@ -19,7 +19,7 @@ def get_center(rect):
 
 # TODO use pytest.approx once we upgrade to pytest > 3.0
 def approx(n, m, tolerance=1):
-    return abs(n - m) < tolerance
+    return abs(n - m) <= tolerance
 
 
 def test_click_at_coordinates(session, test_actions_page, mouse_chain):

--- a/webdriver/tests/actions/sequence.py
+++ b/webdriver/tests/actions/sequence.py
@@ -27,10 +27,11 @@ def test_release_char_sequence_sends_keyup_events_in_reverse(session,
         {"code": "KeyA", "key": "a", "type": "keyup"},
     ]
     all_events = get_events(session)
-    if len(all_events) > 0 and all_events[0]["code"] == None:
+    events = [filter_dict(e, expected[0]) for e in all_events]
+    if len(events) > 0 and events[0]["code"] == None:
         # Remove 'code' entry if browser doesn't support it
         expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
-    events = [filter_dict(e, expected[0]) for e in all_events]
+        events = [filter_dict(e, expected[0]) for e in events]
     assert events == expected
 
 

--- a/webdriver/tests/actions/sequence.py
+++ b/webdriver/tests/actions/sequence.py
@@ -23,10 +23,14 @@ def test_release_char_sequence_sends_keyup_events_in_reverse(session,
     session.execute_script("resetEvents();")
     session.actions.release()
     expected = [
-        {"key": "b", "type": "keyup"},
-        {"key": "a", "type": "keyup"},
+        {"code": "KeyB", "key": "b", "type": "keyup"},
+        {"code": "KeyA", "key": "a", "type": "keyup"},
     ]
-    events = [filter_dict(e, expected[0]) for e in get_events(session)]
+    all_events = get_events(session)
+    if len(all_events) > 0 and all_events[0]["code"] == None:
+        # Remove 'code' entry if browser doesn't support it
+        expected = [filter_dict(e, {"key": "", "type": ""}) for e in expected]
+    events = [filter_dict(e, expected[0]) for e in all_events]
     assert events == expected
 
 

--- a/webdriver/tests/actions/sequence.py
+++ b/webdriver/tests/actions/sequence.py
@@ -23,8 +23,8 @@ def test_release_char_sequence_sends_keyup_events_in_reverse(session,
     session.execute_script("resetEvents();")
     session.actions.release()
     expected = [
-        {"code": "KeyB", "key": "b", "type": "keyup"},
-        {"code": "KeyA", "key": "a", "type": "keyup"},
+        {"key": "b", "type": "keyup"},
+        {"key": "a", "type": "keyup"},
     ]
     events = [filter_dict(e, expected[0]) for e in get_events(session)]
     assert events == expected
@@ -90,9 +90,8 @@ def test_release_control_click(session, key_reporter, key_chain, mouse_chain):
     session.actions.perform([key_chain.dict, mouse_chain.dict])
     session.execute_script("""
         var keyReporter = document.getElementById("keys");
-        ["mousedown", "mouseup"].forEach((e) => {
-            keyReporter.addEventListener(e, recordPointerEvent);
-          });
+        keyReporter.addEventListener("mousedown", recordPointerEvent);
+        keyReporter.addEventListener("mouseup", recordPointerEvent);
         resetEvents();
     """)
     session.actions.release()

--- a/webdriver/tests/actions/special_keys.py
+++ b/webdriver/tests/actions/special_keys.py
@@ -1,6 +1,7 @@
 # META: timeout=long
 
 import pytest
+import time
 from tests.actions.support.keys import ALL_EVENTS, Keys
 from tests.actions.support.refine import filter_dict, get_keys, get_events
 
@@ -20,13 +21,16 @@ def test_webdriver_special_key_sends_keydown(session,
                     function(e) { e.preventDefault() });
         """)
     key_chain.key_down(getattr(Keys, name)).perform()
+
     # only interested in keydown
     first_event = get_events(session)[0]
     # make a copy so we can throw out irrelevant keys and compare to events
     expected = dict(expected)
 
     del expected["value"]
-    del expected["code"]
+    if first_event["code"] == None:
+        del expected["code"]
+
     # check and remove keys that aren't in expected
     assert first_event["type"] == "keydown"
     assert first_event["repeat"] == False

--- a/webdriver/tests/actions/special_keys.py
+++ b/webdriver/tests/actions/special_keys.py
@@ -17,7 +17,7 @@ def test_webdriver_special_key_sends_keydown(session,
         # may interfere with subsequent tests.)
         session.execute_script("""
             document.body.addEventListener("keydown",
-                    (e) => e.preventDefault());
+                    function(e) { e.preventDefault() });
         """)
     key_chain.key_down(getattr(Keys, name)).perform()
     # only interested in keydown
@@ -26,6 +26,7 @@ def test_webdriver_special_key_sends_keydown(session,
     expected = dict(expected)
 
     del expected["value"]
+    del expected["code"]
     # check and remove keys that aren't in expected
     assert first_event["type"] == "keydown"
     assert first_event["repeat"] == False

--- a/webdriver/tests/actions/special_keys.py
+++ b/webdriver/tests/actions/special_keys.py
@@ -28,13 +28,14 @@ def test_webdriver_special_key_sends_keydown(session,
     expected = dict(expected)
 
     del expected["value"]
-    if first_event["code"] == None:
-        del expected["code"]
 
     # check and remove keys that aren't in expected
     assert first_event["type"] == "keydown"
     assert first_event["repeat"] == False
     first_event = filter_dict(first_event, expected)
+    if first_event["code"] == None:
+        del first_event["code"]
+        del expected["code"]
     assert first_event == expected
     # only printable characters should be recorded in input field
     entered_keys = get_keys(key_reporter)

--- a/webdriver/tests/actions/support/test_actions_wdspec.html
+++ b/webdriver/tests/actions/support/test_actions_wdspec.html
@@ -16,7 +16,6 @@
         "use strict";
         var els = {};
         var allEvents = { events: [] };
-        var initialMoveHandler;
         function displayMessage(message) {
             document.getElementById("events").innerHTML = "<p>" + message + "</p>";
         }
@@ -104,10 +103,11 @@
           els.dragTarget.removeEventListener("mousedown", grabOnce);
         }
 
-        function dropOnce(event) {
-          initialMoveHandler(event);
-          els.dragArea.removeEventListener("mouseup", dropOnce);
-          initialMoveHandler = null;
+        function dropOnce(moveHandler) {
+          return function (event) {
+            moveHandler(event);
+            els.dragArea.removeEventListener("mouseup", dropOnce);
+          }
         }
 
         function resetEvents() {
@@ -145,8 +145,7 @@
               -(areaRect.top + (event.clientY - boxRect.top)),
               20);
           els.dragArea.addEventListener("mousemove", moveHandler);
-          initialMoveHandler = drop(moveHandler);
-          els.dragArea.addEventListener("mouseup", dropOnce);
+          els.dragArea.addEventListener("mouseup", dropOnce(drop(moveHandler)));
         }
 
         document.addEventListener("DOMContentLoaded", function() {

--- a/webdriver/tests/actions/support/test_actions_wdspec.html
+++ b/webdriver/tests/actions/support/test_actions_wdspec.html
@@ -1,5 +1,6 @@
-<!doctype html>
+﻿<!doctype html>
 <meta charset=utf-8>
+<html>
 <head>
     <title>Test Actions</title>
     <style>
@@ -14,7 +15,8 @@
     <script>
         "use strict";
         var els = {};
-        var allEvents = {events: []};
+        var allEvents = { events: [] };
+        var initialMoveHandler;
         function displayMessage(message) {
             document.getElementById("events").innerHTML = "<p>" + message + "</p>";
         }
@@ -56,11 +58,11 @@
             "repeat": event.repeat,
             "type": event.type
           });
-          appendMessage(`${event.type}(` +
-              `code: ${event.code}, ` +
-              `key: ${key}, ` +
-              `which: ${event.which}, ` +
-              `keyCode: ${event.keyCode})`);
+          appendMessage(event.type + " " +
+              "code: " + event.code + ", " +
+              "key: " + key + ", " +
+              "which: " + event.which + ", " +
+              "keyCode: " + event.keyCode);
         }
 
         function recordPointerEvent(event) {
@@ -79,17 +81,17 @@
             "shiftKey": event.shiftKey,
             "target": event.target.id
           });
-          appendMessage(`${event.type}(` +
-              `button: ${event.button}, ` +
-              `pageX: ${event.pageX}, ` +
-              `pageY: ${event.pageY}, ` +
-              `button: ${event.button}, ` +
-              `buttons: ${event.buttons}, ` +
-              `ctrlKey: ${event.ctrlKey}, ` +
-              `altKey: ${event.altKey}, ` +
-              `metaKey: ${event.metaKey}, ` +
-              `shiftKey: ${event.shiftKey}, ` +
-              `target id: ${event.target.id})`);
+          appendMessage(event.type + " " +
+              "button: " + event.button + ", " +
+              "pageX: " + event.pageX + ", " +
+              "pageY: " + event.pageY + ", " +
+              "button: " + event.button + ", " +
+              "buttons: " + event.buttons + ", " +
+              "ctrlKey: " + event.ctrlKey + ", " +
+              "altKey: " + event.altKey + ", " +
+              "metaKey: " + event.metaKey + ", " +
+              "shiftKey: " + event.shiftKey + ", " +
+              "target id: " + event.target.id);
         }
 
         function recordFirstPointerMove(event) {
@@ -97,9 +99,20 @@
           window.removeEventListener("mousemove", recordFirstPointerMove);
         }
 
+        function grabOnce(event) {
+          grab(event);
+          els.dragTarget.removeEventListener("mousedown", grabOnce);
+        }
+
+        function dropOnce(event) {
+          initialMoveHandler(event);
+          els.dragArea.removeEventListener("mouseup", dropOnce);
+          initialMoveHandler = null;
+        }
+
         function resetEvents() {
-            allEvents.events.length = 0;
-            displayMessage("");
+          allEvents.events.length = 0;
+          displayMessage("");
         }
 
         function drop(moveHandler) {
@@ -112,8 +125,8 @@
         }
 
         function move(el, offsetX, offsetY, timeout) {
-          return (event) => {
-            setTimeout(() => {
+          return function(event) {
+            setTimeout(function() {
               el.style.top = event.clientY + offsetY + "px";
               el.style.left = event.clientX + offsetX + "px";
             }, timeout);
@@ -132,27 +145,31 @@
               -(areaRect.top + (event.clientY - boxRect.top)),
               20);
           els.dragArea.addEventListener("mousemove", moveHandler);
-          els.dragArea.addEventListener("mouseup", drop(moveHandler), {once: true});
+          initialMoveHandler = drop(moveHandler);
+          els.dragArea.addEventListener("mouseup", dropOnce);
         }
 
-        document.addEventListener("DOMContentLoaded", () => {
+        document.addEventListener("DOMContentLoaded", function() {
           var keyReporter = document.getElementById("keys");
-          ["keyup", "keypress", "keydown"].forEach((e) => {
-            keyReporter.addEventListener(e, recordKeyboardEvent);
-          });
+          keyReporter.addEventListener("keyup", recordKeyboardEvent);
+          keyReporter.addEventListener("keypress", recordKeyboardEvent);
+          keyReporter.addEventListener("keydown", recordKeyboardEvent);
+
           var outer = document.getElementById("outer");
-          ["click", "dblclick", "mousedown",
-              "mouseup", "contextmenu"].forEach((e) => {
-            outer.addEventListener(e, recordPointerEvent);
-          });
-          window.addEventListener("mousemove", recordPointerEvent, {once: true});
+          outer.addEventListener("click", recordPointerEvent);
+          outer.addEventListener("dblclick", recordPointerEvent);
+          outer.addEventListener("mousedown", recordPointerEvent);
+          outer.addEventListener("mouseup", recordPointerEvent);
+          outer.addEventListener("contextmenu", recordPointerEvent);
+
+          window.addEventListener("mousemove", recordFirstPointerMove);
           //visual cue for mousemove
           var pointer = document.getElementById("trackPointer");
           window.addEventListener("mousemove", move(pointer, 15, 15, 30));
           // drag and drop
           els.dragArea = document.getElementById("dragArea");
           els.dragTarget = document.getElementById("dragTarget");
-          els.dragTarget.addEventListener("mousedown", grab, {once: true});
+          els.dragTarget.addEventListener("mousedown", grabOnce);
         });
     </script>
 </head>


### PR DESCRIPTION
Removing ES6 constructs from tests and supporting test page. Also removing
validation of keyboard event `code` property, as IE (and Edge) do not
support it.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
