### PR TITLE
Change callback-timeout-with-raf to use setTimeout.

### DIFF
--- a/requestidlecallback/callback-timeout-when-busy.html
+++ b/requestidlecallback/callback-timeout-when-busy.html
@@ -8,27 +8,27 @@
 async_test(function() {
   // Check whether requestIdleCallback with a timeout works when the event loop
   // is busy.
-  var busy_raf_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
+  var busy_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
   var idle_callback_scheduled;
   var idle_callback = this.step_func_done(function(deadline) {
     assert_false(deadline.didTimeout, "IdleDeadline.didTimeout MUST be false if requestIdleCallback wasn't scheduled due to a timeout");
-    assert_equals(busy_raf_loop_iterations_remaining, 0, "Busy rAF loop should be finished by the time we get scheduled");
+    assert_equals(busy_loop_iterations_remaining, 0, "Busy event loop should be finished by the time we get scheduled");
   });
 
-  var busy_raf_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
-  requestAnimationFrame(this.step_func(function busyRAFLoop() {
+  var busy_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
+  setTimeout(this.step_func(function busyLoop() {
     var start_time = performance.now();
     if (!idle_callback_scheduled) {
       idle_callback_scheduled = start_time;
       requestIdleCallback(idle_callback);
     }
 
-    // Use up the whole frame budget.
+    // Use up more than a frames worth of budget.
     while (performance.now() - start_time < 40) {
     }
-    if (busy_raf_loop_iterations_remaining > 0) {
-      busy_raf_loop_iterations_remaining--;
-      requestAnimationFrame(busyRAFLoop);
+    if (busy_loop_iterations_remaining > 0) {
+      busy_loop_iterations_remaining--;
+      setTimeout(busyLoop);
     }
   }));
 }, 'requestIdleCallback not scheduled when event loop is busy.');
@@ -36,7 +36,7 @@ async_test(function() {
 async_test(function() {
   // Check whether requestIdleCallback with a timeout works when the event loop
   // is busy.
-  var busy_raf_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
+  var busy_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
   var timeout = 200;
   var idle_callback_scheduled;
   var idle_callback = this.step_func_done(function(deadline) {
@@ -44,22 +44,22 @@ async_test(function() {
     assert_true(time_delta >= timeout, "Should only have been run after timeout");
     assert_true(deadline.timeRemaining() == 0, "IdleDeadline.timeRemaining MUST be equal to zero if requestIdleCallback was scheduled due to a timeout");
     assert_true(deadline.didTimeout, "IdleDeadline.didTimeout MUST be true if requestIdleCallback was scheduled due to a timeout");
-    assert_true(busy_raf_loop_iterations_remaining > 0, "Busy rAF loop should still be going");
+    assert_true(busy_loop_iterations_remaining > 0, "Busy event loop should still be going");
   });
 
-  requestAnimationFrame(this.step_func(function busyRAFLoop() {
+  setTimeout(this.step_func(function busyLoop() {
     var start_time = performance.now();
     if (!idle_callback_scheduled) {
       idle_callback_scheduled = start_time;
       requestIdleCallback(idle_callback, { timeout: timeout });
     }
 
-    // Use up the whole frame budget.
+    // Use up more than a frames worth of budget.
     while (performance.now() - start_time < 40) {
     }
-    if (busy_raf_loop_iterations_remaining > 0) {
-      busy_raf_loop_iterations_remaining--;
-      requestAnimationFrame(busyRAFLoop);
+    if (busy_loop_iterations_remaining > 0) {
+      busy_loop_iterations_remaining--;
+      setTimeout(busyLoop);
     }
   }));
 }, 'requestIdleCallback scheduled with timeout when event loop is busy.');

--- a/requestidlecallback/callback-timeout-when-busy.html
+++ b/requestidlecallback/callback-timeout-when-busy.html
@@ -16,7 +16,7 @@ async_test(function() {
   });
 
   var busy_loop_iterations_remaining = 10;  // Should take 20 * 40 = 400ms
-  setTimeout(this.step_func(function busyLoop() {
+  step_timeout(this.step_func(function busyLoop() {
     var start_time = performance.now();
     if (!idle_callback_scheduled) {
       idle_callback_scheduled = start_time;
@@ -28,7 +28,7 @@ async_test(function() {
     }
     if (busy_loop_iterations_remaining > 0) {
       busy_loop_iterations_remaining--;
-      setTimeout(busyLoop);
+      step_timeout(busyLoop);
     }
   }));
 }, 'requestIdleCallback not scheduled when event loop is busy.');
@@ -47,7 +47,7 @@ async_test(function() {
     assert_true(busy_loop_iterations_remaining > 0, "Busy event loop should still be going");
   });
 
-  setTimeout(this.step_func(function busyLoop() {
+  step_timeout(this.step_func(function busyLoop() {
     var start_time = performance.now();
     if (!idle_callback_scheduled) {
       idle_callback_scheduled = start_time;
@@ -59,7 +59,7 @@ async_test(function() {
     }
     if (busy_loop_iterations_remaining > 0) {
       busy_loop_iterations_remaining--;
-      setTimeout(busyLoop);
+      step_timeout(busyLoop);
     }
   }));
 }, 'requestIdleCallback scheduled with timeout when event loop is busy.');


### PR DESCRIPTION
Use setTimeout instead of rAF to create a busy loop for the
callback-timeout-with-raf test. Since the user-agent can decide to
throttle frame rate, the rAF approach didn't guarantee a busy event loop,
so instead use setTimeout.

Addresses #7589

<!-- Reviewable:start -->

<!-- Reviewable:end -->
