### PR TITLE
Make it possible to filter the wdspec tests to run for a given file

### DIFF
--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -348,6 +348,7 @@ class WdspecExecutor(TestExecutor):
         success, data = WdspecRun(self.do_wdspec,
                                   self.protocol.session_config,
                                   test.abs_path,
+                                  test.filter,
                                   timeout).run()
 
         if success:
@@ -355,9 +356,10 @@ class WdspecExecutor(TestExecutor):
 
         return (test.result_cls(*data), [])
 
-    def do_wdspec(self, session_config, path, timeout):
+    def do_wdspec(self, session_config, path, filter, timeout):
         harness_result = ("OK", None)
         subtest_results = pytestrunner.run(path,
+                                           filter,
                                            self.server_config,
                                            session_config,
                                            timeout=timeout)
@@ -388,11 +390,12 @@ class Protocol(object):
 
 
 class WdspecRun(object):
-    def __init__(self, func, session, path, timeout):
+    def __init__(self, func, session, path, filter, timeout):
         self.func = func
         self.result = (None, None)
         self.session = session
         self.path = path
+        self.filter = filter
         self.timeout = timeout
         self.result_flag = threading.Event()
 
@@ -414,7 +417,7 @@ class WdspecRun(object):
 
     def _run(self):
         try:
-            self.result = True, self.func(self.session, self.path, self.timeout)
+            self.result = True, self.func(self.session, self.path, self.filter, self.timeout)
         except (socket.timeout, IOError):
             self.result = False, ("CRASH", None)
         except Exception as e:

--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -23,7 +23,7 @@ def do_delayed_imports():
     import pytest
 
 
-def run(path, server_config, session_config, timeout=0):
+def run(path, filter, server_config, session_config, timeout=0):
     """Run Python test at ``path`` in pytest.  The provided ``session``
     is exposed as a fixture available in the scope of the test functions.
 
@@ -52,14 +52,17 @@ def run(path, server_config, session_config, timeout=0):
     # TODO(ato): Deal with timeouts
 
     with TemporaryDirectory() as cache:
-        pytest.main(["--strict",  # turn warnings into errors
-                     "--verbose",  # show each individual subtest
-                     "--capture", "no",  # enable stdout/stderr from tests
-                     "--basetemp", cache,  # temporary directory
-                     "-p", "no:mozlog",  # use the WPT result recorder
-                     "-p", "no:cacheprovider",  # disable state preservation across invocations
-                     path],
-                    plugins=plugins)
+        cmd = ["--strict",  # turn warnings into errors
+               "--verbose",  # show each individual subtest
+               "--capture", "no",  # enable stdout/stderr from tests
+               "--basetemp", cache,  # temporary directory
+               "-p", "no:mozlog",  # use the WPT result recorder
+               "-p", "no:cacheprovider",  # disable state preservation across invocations
+               path]
+        if filter is not None:
+            cmd.extend(["-k", filter])
+
+        pytest.main(cmd, plugins=plugins)
 
     return recorder.results
 


### PR DESCRIPTION
Currently it's only possible to run all the tests for a given test file.
This patch makes it possible to pass an expression to filter which test
to run for a given file, using the pattern test-file.py::expression.
It uses the -k <expression> pytest option, passing the provided
expression to pytest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7923)
<!-- Reviewable:end -->
