### PR TITLE
Fix wdspec tests using new_session fixture

### DIFF
--- a/webdriver/tests/conftest.py
+++ b/webdriver/tests/conftest.py
@@ -1,8 +1,9 @@
 import pytest
 from tests.support.fixtures import (
-    configuration, create_dialog, create_frame, create_window, http,
-    new_session, server_config, session, url)
+    add_browser_capabilites, configuration, create_dialog, create_frame,
+    create_window, http, new_session, server_config, session, url)
 
+pytest.fixture()(add_browser_capabilites)
 pytest.fixture(scope="session")(configuration)
 pytest.fixture()(create_dialog)
 pytest.fixture()(create_frame)

--- a/webdriver/tests/contexts/maximize_window.py
+++ b/webdriver/tests/contexts/maximize_window.py
@@ -39,7 +39,7 @@ def test_handle_prompt_ignore():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     3. Handle any user prompts and return its value if it is an error.
 
@@ -59,7 +59,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/cookies/delete_cookie.py
+++ b/webdriver/tests/cookies/delete_cookie.py
@@ -34,7 +34,7 @@ def test_handle_prompt_ignore():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     2. Handle any user prompts and return its value if it is an error.
 
@@ -54,7 +54,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/element_retrieval/get_active_element.py
+++ b/webdriver/tests/element_retrieval/get_active_element.py
@@ -43,8 +43,8 @@ def test_closed_context(session, create_window):
 #    [...]
 #
 # 3. Return success.
-def test_handle_prompt_dismiss(new_session):
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<body><p>Hello, World!</p></body>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
@@ -87,8 +87,8 @@ def test_handle_prompt_dismiss(new_session):
 #    [...]
 #
 # 3. Return success.
-def test_handle_prompt_accept(new_session):
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<body><p>Hello, World!</p></body>")
     create_dialog(session)("alert", text="accept #1", result_var="accept1")
 

--- a/webdriver/tests/fullscreen_window.py
+++ b/webdriver/tests/fullscreen_window.py
@@ -43,7 +43,7 @@ def test_handle_prompt_ignore():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     2. Handle any user prompts and return its value if it is an error.
 
@@ -63,7 +63,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
     create_dialog(session)("alert", text="accept #1", result_var="accept1")
 

--- a/webdriver/tests/get_window_rect.py
+++ b/webdriver/tests/get_window_rect.py
@@ -37,7 +37,7 @@ def test_handle_prompt_ignore():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     2. Handle any user prompts and return its value if it is an error.
 
@@ -57,7 +57,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/minimize_window.py
+++ b/webdriver/tests/minimize_window.py
@@ -37,7 +37,7 @@ def test_handle_prompt_ignore():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     2. Handle any user prompts and return its value if it is an error.
 
@@ -57,7 +57,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session({"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/navigation/get_title.py
+++ b/webdriver/tests/navigation/get_title.py
@@ -33,8 +33,8 @@ def test_title_from_closed_context(session, create_window):
 #    [...]
 #
 # 3. Return success.
-def test_title_handle_prompt_dismiss(new_session):
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+def test_title_handle_prompt_dismiss(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<title>WD doc title</title>")
 
     expected_title = read_global(session, "document.title")
@@ -80,8 +80,8 @@ def test_title_handle_prompt_dismiss(new_session):
 #    [...]
 #
 # 3. Return success.
-def test_title_handle_prompt_accept(new_session):
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+def test_title_handle_prompt_accept(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<title>WD doc title</title>")
     create_dialog(session)("alert", text="accept #1", result_var="accept1")
 

--- a/webdriver/tests/sessions/new_session/create_alwaysMatch.py
+++ b/webdriver/tests/sessions/new_session/create_alwaysMatch.py
@@ -8,6 +8,6 @@ from support.create import valid_data
 
 
 @pytest.mark.parametrize("key,value", flatten(product(*item) for item in valid_data))
-def test_valid(new_session, key, value):
-    resp = new_session({"capabilities": {"alwaysMatch": {key: value}}})
+def test_valid(new_session, add_browser_capabilites, key, value):
+    resp = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({key: value})}})
 

--- a/webdriver/tests/sessions/new_session/create_firstMatch.py
+++ b/webdriver/tests/sessions/new_session/create_firstMatch.py
@@ -8,5 +8,5 @@ from support.create import valid_data
 
 
 @pytest.mark.parametrize("key,value", flatten(product(*item) for item in valid_data))
-def test_valid(new_session, key, value):
-    resp = new_session({"capabilities": {"firstMatch": [{key: value}]}})
+def test_valid(new_session, add_browser_capabilites, key, value):
+    resp = new_session({"capabilities": {"firstMatch": [add_browser_capabilites({key: value})]}})

--- a/webdriver/tests/sessions/new_session/default_values.py
+++ b/webdriver/tests/sessions/new_session/default_values.py
@@ -7,15 +7,15 @@ import pytest
 from webdriver import error
 
 
-def test_basic(new_session):
-    resp, _ = new_session({"capabilities": {}})
+def test_basic(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     assert set(resp.keys()) == {"sessionId", "capabilities"}
 
 
-def test_repeat_new_session(new_session):
-    resp, _ = new_session({"capabilities": {}})
+def test_repeat_new_session(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     with pytest.raises(error.SessionNotCreatedException):
-        new_session({"capabilities": {}})
+        new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
 
 
 def test_no_capabilites(new_session):
@@ -23,26 +23,26 @@ def test_no_capabilites(new_session):
         new_session({})
 
 
-def test_missing_first_match(new_session):
-    resp, _ = new_session({"capabilities": {"alwaysMatch": {}}})
+def test_missing_first_match(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
 
 
-def test_missing_always_match(new_session):
-    resp, _ = new_session({"capabilities": {"firstMatch": [{}]}})
+def test_missing_always_match(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"firstMatch": [add_browser_capabilites({})]}})
 
 
-def test_desired(new_session):
+def test_desired(new_session, add_browser_capabilites):
     with pytest.raises(error.InvalidArgumentException):
-        resp, _ = new_session({"desiredCapbilities": {}})
+        resp, _ = new_session({"desiredCapbilities": add_browser_capabilites({})})
 
 
-def test_ignore_non_spec_fields_in_capabilities(new_session):
-    resp, _ = new_session({"capabilities": {"desiredCapbilities": {"pageLoadStrategy": "eager"}}})
+def test_ignore_non_spec_fields_in_capabilities(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({}), "desiredCapbilities": {"pageLoadStrategy": "eager"}}})
     assert resp["capabilities"]["pageLoadStrategy"] == "normal"
 
 
-def test_valid_but_unmatchable_key(new_session):
+def test_valid_but_unmatchable_key(new_session, add_browser_capabilites):
     resp, _ = new_session({"capabilities": {
-      "firstMatch": [{"pageLoadStrategy": "eager", "foo:unmatchable": True},
+      "firstMatch": [add_browser_capabilites({"pageLoadStrategy": "eager", "foo:unmatchable": True}),
                      {"pageLoadStrategy": "none"}]}})
     assert resp["capabilities"]["pageLoadStrategy"] == "none"

--- a/webdriver/tests/sessions/new_session/invalid_capabilities.py
+++ b/webdriver/tests/sessions/new_session/invalid_capabilities.py
@@ -13,15 +13,15 @@ def test_invalid_capabilites(new_session, value):
 
 
 @pytest.mark.parametrize("value", [None, 1, "{}", []])
-def test_invalid_always_match(new_session, value):
+def test_invalid_always_match(new_session, add_browser_capabilites, value):
     with pytest.raises(error.InvalidArgumentException):
-        new_session({"capabilities": {"alwaysMatch": value}})
+        new_session({"capabilities": {"alwaysMatch": value, "firstMatch": [add_browser_capabilites({})]}})
 
 
 @pytest.mark.parametrize("value", [None, 1, "[]", {}])
-def test_invalid_first_match(new_session, value):
+def test_invalid_first_match(new_session, add_browser_capabilites, value):
     with pytest.raises(error.InvalidArgumentException):
-        new_session({"capabilities": {"firstMatch": value}})
+        new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({}), "firstMatch": value}})
 
 
 invalid_data = [
@@ -49,9 +49,14 @@ invalid_data = [
 @pytest.mark.parametrize("body", [lambda key, value: {"alwaysMatch": {key: value}},
                                   lambda key, value: {"firstMatch": [{key: value}]}])
 @pytest.mark.parametrize("key,value", flatten(product(*item) for item in invalid_data))
-def test_invalid_values(new_session, body, key, value):
+def test_invalid_values(new_session, add_browser_capabilites, body, key, value):
+    capabilities = body(key, value)
+    if "alwaysMatch" in capabilities:
+        capabilities["alwaysMatch"] = add_browser_capabilites(capabilities["alwaysMatch"])
+    else:
+        capabilities["firstMatch"][0] = add_browser_capabilites(capabilities["firstMatch"][0])
     with pytest.raises(error.InvalidArgumentException):
-        resp = new_session({"capabilities": body(key, value)})
+        resp = new_session({"capabilities": capabilities})
 
 
 invalid_extensions = [
@@ -82,7 +87,12 @@ invalid_extensions = [
 @pytest.mark.parametrize("body", [lambda key, value: {"alwaysMatch": {key: value}},
                                   lambda key, value: {"firstMatch": [{key: value}]}])
 @pytest.mark.parametrize("key", invalid_extensions)
-def test_invalid_extensions(new_session, body, key):
+def test_invalid_extensions(new_session, add_browser_capabilites, body, key):
+    capabilities = body(key, {})
+    if "alwaysMatch" in capabilities:
+        capabilities["alwaysMatch"] = add_browser_capabilites(capabilities["alwaysMatch"])
+    else:
+        capabilities["firstMatch"][0] = add_browser_capabilites(capabilities["firstMatch"][0])
     with pytest.raises(error.InvalidArgumentException):
-        resp = new_session({"capabilities": body(key, {})})
+        resp = new_session({"capabilities": capabilities})
 

--- a/webdriver/tests/sessions/new_session/merge.py
+++ b/webdriver/tests/sessions/new_session/merge.py
@@ -9,8 +9,13 @@ from conftest import platform_name
 @pytest.mark.skipif(platform_name() is None, reason="Unsupported platform")
 @pytest.mark.parametrize("body", [lambda key, value: {"alwaysMatch": {key: value}},
                                   lambda key, value: {"firstMatch": [{key: value}]}])
-def test_platform_name(new_session, platform_name, body):
-    resp, _ = new_session({"capabilities": body("platformName", platform_name)})
+def test_platform_name(new_session, add_browser_capabilites, platform_name, body):
+    capabilities = body("platformName", platform_name)
+    if "alwaysMatch" in capabilities:
+        capabilities["alwaysMatch"] = add_browser_capabilites(capabilities["alwaysMatch"])
+    else:
+        capabilities["firstMatch"][0] = add_browser_capabilites(capabilities["firstMatch"][0])
+    resp, _ = new_session({"capabilities": capabilities})
     assert resp["capabilities"]["platformName"] == platform_name
 
 
@@ -24,17 +29,17 @@ invalid_merge = [
 
 
 @pytest.mark.parametrize("key,value", invalid_merge)
-def test_merge_invalid(new_session, key, value):
+def test_merge_invalid(new_session, add_browser_capabilites, key, value):
     with pytest.raises(error.InvalidArgumentException):
          new_session({"capabilities":
-                      {"alwaysMatch": {key: value[0]},
+                      {"alwaysMatch": add_browser_capabilites({key: value[0]}),
                        "firstMatch": [{}, {key: value[1]}]}})
 
 
 @pytest.mark.skipif(platform_name() is None, reason="Unsupported platform")
-def test_merge_platformName(new_session, platform_name):
+def test_merge_platformName(new_session, add_browser_capabilites, platform_name):
     resp, _ = new_session({"capabilities":
-                        {"alwaysMatch": {"timeouts": {"script": 10}},
+                        {"alwaysMatch": add_browser_capabilites({"timeouts": {"script": 10}}),
                         "firstMatch": [
                             {
                                 "platformName": platform_name.upper(),
@@ -50,8 +55,8 @@ def test_merge_platformName(new_session, platform_name):
     assert resp["capabilities"]["pageLoadStrategy"] == "eager"
 
 
-def test_merge_browserName(new_session):
-    resp, session = new_session({"capabilities": {}})
+def test_merge_browserName(new_session, add_browser_capabilites):
+    resp, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     browser_settings = {
         "browserName": resp["capabilities"]["browserName"],
         "browserVersion": resp["capabilities"]["browserVersion"],
@@ -60,7 +65,7 @@ def test_merge_browserName(new_session):
     session.end()
 
     resp, _ = new_session({"capabilities":
-                        {"alwaysMatch": {"timeouts": {"script": 10}},
+                        {"alwaysMatch": add_browser_capabilites({"timeouts": {"script": 10}}),
                         "firstMatch": [
                             {
                                 "browserName": browser_settings["browserName"] + "invalid",

--- a/webdriver/tests/sessions/new_session/response.py
+++ b/webdriver/tests/sessions/new_session/response.py
@@ -2,14 +2,14 @@
 
 import uuid
 
-def test_resp_sessionid(new_session):
-    resp, _ = new_session({"capabilities": {}})
+def test_resp_sessionid(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     assert isinstance(resp["sessionId"], unicode)
     uuid.UUID(hex=resp["sessionId"])
 
 
-def test_resp_capabilites(new_session):
-    resp, _ = new_session({"capabilities": {}})
+def test_resp_capabilites(new_session, add_browser_capabilites):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     assert isinstance(resp["sessionId"], unicode)
     assert isinstance(resp["capabilities"], dict)
     assert {"browserName",
@@ -23,8 +23,8 @@ def test_resp_capabilites(new_session):
                 set(resp["capabilities"].keys()))
 
 
-def test_resp_data(new_session, platform_name):
-    resp, _ = new_session({"capabilities": {}})
+def test_resp_data(new_session, add_browser_capabilites, platform_name):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
 
     assert isinstance(resp["capabilities"]["browserName"], unicode)
     assert isinstance(resp["capabilities"]["browserVersion"], unicode)
@@ -41,14 +41,14 @@ def test_resp_data(new_session, platform_name):
     assert resp["capabilities"]["pageLoadStrategy"] == "normal"
 
 
-def test_timeouts(new_session, platform_name):
-    resp, _ = new_session({"capabilities": {"alwaysMatch": {"timeouts": {"implicit": 1000}}}})
+def test_timeouts(new_session, add_browser_capabilites, platform_name):
+    resp, _ = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"timeouts": {"implicit": 1000}})}})
     assert resp["capabilities"]["timeouts"] == {
         "implicit": 1000,
         "pageLoad": 300000,
         "script": 30000
     }
 
-def test_pageLoadStrategy(new_session, platform_name):
-    resp, _ = new_session({"capabilities": {"alwaysMatch": {"pageLoadStrategy": "eager"}}})
+def test_pageLoadStrategy(new_session, add_browser_capabilites, platform_name):
+    resp, _ = new_session({"capabilities": add_browser_capabilites({"alwaysMatch": {"pageLoadStrategy": "eager"}})})
     assert resp["capabilities"]["pageLoadStrategy"] == "eager"

--- a/webdriver/tests/set_window_rect.py
+++ b/webdriver/tests/set_window_rect.py
@@ -33,7 +33,7 @@ def test_handle_prompt_dismiss():
     """TODO"""
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     """
     2. Handle any user prompts and return its value if it is an error.
 
@@ -53,8 +53,7 @@ def test_handle_prompt_accept(new_session):
            Accept the current user prompt.
 
     """
-    _, session = new_session(
-        {"alwaysMatch": {"unhandledPromptBehavior": "accept"}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     original = session.window.rect
 
     # step 2

--- a/webdriver/tests/state/get_element_attribute.py
+++ b/webdriver/tests/state/get_element_attribute.py
@@ -24,9 +24,9 @@ def test_no_browsing_context(session, create_window):
     assert_error(result, "no such window")
 
 
-def test_handle_prompt_dismiss(new_session):
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.2 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
@@ -51,9 +51,9 @@ def test_handle_prompt_dismiss(new_session):
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.2 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/state/get_element_property.py
+++ b/webdriver/tests/state/get_element_property.py
@@ -19,9 +19,9 @@ def test_no_browsing_context(session, create_window):
     assert_error(result, "no such window")
 
 
-def test_handle_prompt_dismiss(new_session):
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.3 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
@@ -53,9 +53,9 @@ def test_handle_prompt_dismiss(new_session):
 
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.3 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/state/get_element_tag_name.py
+++ b/webdriver/tests/state/get_element_tag_name.py
@@ -17,9 +17,9 @@ def test_no_browsing_context(session, create_window):
     assert_error(result, "no such window")
 
 
-def test_handle_prompt_dismiss(new_session):
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.6 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
@@ -50,9 +50,9 @@ def test_handle_prompt_dismiss(new_session):
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.6 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/state/is_element_selected.py
+++ b/webdriver/tests/state/is_element_selected.py
@@ -26,9 +26,9 @@ def test_no_browsing_context(session, create_window):
     assert_error(result, "no such window")
 
 
-def test_handle_prompt_dismiss(new_session):
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.1 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "dismiss"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
@@ -59,9 +59,9 @@ def test_handle_prompt_dismiss(new_session):
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_accept(new_session):
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.1 step 2
-    _, session = new_session({"capabilities": {"alwaysMatch": {"unhandledPromptBehavior": "accept"}}})
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -188,8 +188,6 @@ def new_session(configuration, request):
         _session = webdriver.Session(configuration["host"],
                                      configuration["port"],
                                      capabilities=None)
-        # TODO: merge in some capabilities from the confguration capabilities
-        # since these might be needed to start the browser
         value = _session.send_command("POST", "session", body=body)
         # Don't set the global session until we are sure this succeeded
         _current_session = _session
@@ -201,6 +199,16 @@ def new_session(configuration, request):
     request.addfinalizer(end)
 
     return create_session
+
+
+def add_browser_capabilites(configuration):
+    def update_capabilities(capabilities):
+        # Make sure there aren't keys in common.
+        assert not set(configuration["capabilities"]).intersection(set(capabilities))
+        result = dict(configuration["capabilities"])
+        result.update(capabilities)
+        return result
+    return update_capabilities
 
 
 def url(server_config):


### PR DESCRIPTION
Tests are passing capabilities that should be used when creating the
session, but they are passed directly as body of new session command,
without adding them to a capabilities object. This is also ignoring all
other configuration capabilities, preventing the browser from being
launched in cases where the browser binary is passed to the driver as a
capability. This patch adds a new fixture add_browser_capabilites, that
is used by tests using new_session to provide the browser capabilities
and optionally add others.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
