### PR TITLE
Change the string repr for ExecutorBrowser

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/base.py
+++ b/tools/wptrunner/wptrunner/browsers/base.py
@@ -164,3 +164,6 @@ class ExecutorBrowser(object):
         """
         for k, v in kwargs.iteritems():
             setattr(self, k, v)
+
+    def __repr__(self):
+        return str(self.__dict__)


### PR DESCRIPTION
This makes it spit out its dictionary, instead of a useless class name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7932)
<!-- Reviewable:end -->
