### PR TITLE
Update test criteria of ExtendableEvent.waitUntil() called from microtasks.

### DIFF
--- a/service-workers/service-worker/extendable-event-async-waituntil.https.html
+++ b/service-workers/service-worker/extendable-event-async-waituntil.https.html
@@ -56,8 +56,11 @@ function msg_event_test(scope, test) {
 async_test(msg_event_test.bind(this, 'no-current-extension-different-task'),
   'Test calling waitUntil in a different task without an existing extension throws');
 
-async_test(msg_event_test.bind(this, 'no-current-extension-different-microtask'),
-  'Test calling waitUntil in a different microtask without an existing extension throws');
+async_test(msg_event_test.bind(this, 'no-current-extension-in-a-microtask-of-different-task'),
+  'Test calling waitUntil in a microtask of a different task without an existing extension throws');
+
+async_test(msg_event_test.bind(this, 'extended-in-a-microtask-of-the-same-task'),
+  'Test calling waitUntil in a microtask of the same task without an existing extension succeeds');
 
 async_test(msg_event_test.bind(this, 'current-extension-different-task'),
   'Test calling waitUntil in a different task with an existing extension succeeds');


### PR DESCRIPTION
To update test critieria suggested in 
https://github.com/w3c/ServiceWorker/issues/1213#issuecomment-338304564

Note: Functions names of async_task_waituntil() and async_microtask_waituntil() are revised accordingly for better understanding.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
