### PR TITLE
Handle spaces in path in |wpt test-files|

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -152,7 +152,7 @@ def repo_files_changed(revish, include_uncommitted=False, include_new=False):
         assert not entries[-1]
         entries = entries[:-1]
         for item in entries:
-            status, path = item.split()
+            status, path = item.split(" ", 1)
             if status == "??" and not include_new:
                 continue
             else:


### PR DESCRIPTION
Previously spaces in path would produce ValueError: too many values to
unpack. Explicitly only split on the first space to account for this.