### PR TITLE
Allow firefox to run ssl tests without certutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ And on macOS with homebrew using:
 brew install nss
 ```
 
+On other platforms, download the firefox archive and common.tests.zip
+archive for your platform from
+[https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/](Mozilla CI)
+
+Then extract `certutil[.exe]` from the tests.zip package and
+`libnss3[.so|.dll|.dynlib]` and put the former on your path and the latter on
+your library path.
+
+
 Command Line Tools
 ==================
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -169,32 +169,12 @@ Install Firefox or use --binary to set the binary path""")
 
             if certutil is None:
                 # Can't download this for now because it's missing the libnss3 library
-                raise WptrunError("""Can't find certutil.
-
-This must be installed using your OS package manager or directly e.g.
-
-Debian/Ubuntu:
-    sudo apt install libnss3-tools
-
-macOS/Homebrew:
-    brew install nss
-
-Others:
-    Download the firefox archive and common.tests.zip archive for your platform
-    from https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/
-
-   Then extract certutil[.exe] from the tests.zip package and
-   libnss3[.so|.dll|.dynlib] and but the former on your path and the latter on
-   your library path.
-""")
+                logger.info("""Can't find certutil, certificates will not be checked.
+Consider installing certutil via your OS package manager or directly.""")
             else:
                 print("Using certutil %s" % certutil)
 
-            if certutil is not None:
-                kwargs["certutil_binary"] = certutil
-            else:
-                print("Unable to find or install certutil, setting ssl-type to none")
-                kwargs["ssl_type"] = "none"
+            kwargs["certutil_binary"] = certutil
 
         if kwargs["webdriver_binary"] is None and "wdspec" in kwargs["test_types"]:
             webdriver_binary = self.browser.find_webdriver()

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -101,7 +101,6 @@ def test_tests_affected(capsys):
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
     assert "html/browsers/offline/appcache/workers/appcache-worker.html" in out
-    assert err == ""
 
 
 def test_serve():

--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -1,4 +1,4 @@
-marionette_driver >= 0.4
+marionette_driver >= 2.4
 mozprofile >= 0.21
 mozprocess >= 0.19
 mozcrash >= 0.13

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -57,8 +57,6 @@ def get_timeout_multiplier(test_type, run_info_data, **kwargs):
 
 def check_args(**kwargs):
     require_arg(kwargs, "binary")
-    if kwargs["ssl_type"] != "none":
-        require_arg(kwargs, "certutil_binary")
 
 
 def browser_kwargs(test_type, run_info_data, **kwargs):
@@ -89,6 +87,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs["timeout_multiplier"] = get_timeout_multiplier(test_type,
                                                                    run_info_data,
                                                                    **kwargs)
+    capabilities = {}
     if test_type == "reftest":
         executor_kwargs["reftest_internal"] = kwargs["reftest_internal"]
         executor_kwargs["reftest_screenshot"] = kwargs["reftest_screenshot"]
@@ -101,7 +100,10 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         fxOptions["prefs"] = {
             "network.dns.localDomains": ",".join(hostnames)
         }
-        capabilities = {"moz:firefoxOptions": fxOptions}
+        capabilities["moz:firefoxOptions"] = fxOptions
+    if kwargs["certutil_binary"] is None:
+        capabilities["acceptInsecureCerts"] = True
+    if capabilities:
         executor_kwargs["capabilities"] = capabilities
     return executor_kwargs
 
@@ -333,6 +335,9 @@ class FirefoxBrowser(Browser):
         """Create a certificate database to use in the test profile. This is configured
         to trust the CA Certificate that has signed the web-platform.test server
         certificate."""
+        if self.certutil_binary is None:
+            self.logger.info("--certutil-binary not supplied; Firefox will not check certificates")
+            return
 
         self.logger.info("Setting up ssl")
 

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -43,12 +43,13 @@ def do_delayed_imports():
 
 
 class MarionetteProtocol(Protocol):
-    def __init__(self, executor, browser, timeout_multiplier=1):
+    def __init__(self, executor, browser, capabilities=None, timeout_multiplier=1):
         do_delayed_imports()
 
         Protocol.__init__(self, executor, browser)
         self.marionette = None
         self.marionette_port = browser.marionette_port
+        self.capabilities = capabilities
         self.timeout_multiplier = timeout_multiplier
         self.timeout = None
         self.runner_handle = None
@@ -76,7 +77,7 @@ class MarionetteProtocol(Protocol):
         if success:
             try:
                 self.logger.debug("Starting Marionette session")
-                self.marionette.start_session()
+                self.marionette.start_session(capabilities=self.capabilities)
             except Exception as e:
                 self.logger.warning("Starting marionette session failed: %s" % e)
             else:
@@ -360,13 +361,14 @@ class ExecuteAsyncScriptRun(object):
 
 class MarionetteTestharnessExecutor(TestharnessExecutor):
     def __init__(self, browser, server_config, timeout_multiplier=1,
-                 close_after_done=True, debug_info=None, **kwargs):
+                 close_after_done=True, debug_info=None, capabilities=None,
+                 **kwargs):
         """Marionette-based executor for testharness.js tests"""
         TestharnessExecutor.__init__(self, browser, server_config,
                                      timeout_multiplier=timeout_multiplier,
                                      debug_info=debug_info)
 
-        self.protocol = MarionetteProtocol(self, browser, timeout_multiplier)
+        self.protocol = MarionetteProtocol(self, browser, capabilities, timeout_multiplier)
         self.script = open(os.path.join(here, "testharness_marionette.js")).read()
         self.close_after_done = close_after_done
         self.window_id = str(uuid.uuid4())
@@ -425,7 +427,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                  screenshot_cache=None, close_after_done=True,
                  debug_info=None, reftest_internal=False,
                  reftest_screenshot="unexpected",
-                 group_metadata=None, **kwargs):
+                 group_metadata=None, capabilities=None, **kwargs):
         """Marionette-based executor for reftests"""
         RefTestExecutor.__init__(self,
                                  browser,
@@ -433,7 +435,8 @@ class MarionetteRefTestExecutor(RefTestExecutor):
                                  screenshot_cache=screenshot_cache,
                                  timeout_multiplier=timeout_multiplier,
                                  debug_info=debug_info)
-        self.protocol = MarionetteProtocol(self, browser)
+        self.protocol = MarionetteProtocol(self, browser, capabilities,
+                                           timeout_multiplier)
         self.implementation = (InternalRefTestImplementation
                                if reftest_internal
                                else RefTestImplementation)(self)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -393,7 +393,7 @@ def check_args(kwargs):
             sys.exit(1)
         kwargs["openssl_binary"] = path
 
-    if kwargs["ssl_type"] != "none" and kwargs["product"] == "firefox":
+    if kwargs["ssl_type"] != "none" and kwargs["product"] == "firefox" and kwargs["certutil_binary"]:
         path = exe_path(kwargs["certutil_binary"])
         if path is None:
             print >> sys.stderr, "certutil-binary argument missing or not a valid executable"


### PR DESCRIPTION
Support for allowInsecureCerts was recently added to marionette, so we
can get similar behaviour to Chrome where certificate validity is not
checked during tests. To enable this we pass acceptInsecureCerts: True
to the marionette session. However we should still use certutil when
possible since that's closer to the standard browser codepath.

This also requires a new release of marionette_driver since something
changed in capability passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7945)
<!-- Reviewable:end -->
