### PR TITLE
Add safety check for missing kwargs

### DIFF
--- a/tools/wpt/utils.py
+++ b/tools/wpt/utils.py
@@ -14,7 +14,7 @@ class Kwargs(dict):
         if desc is None:
             desc = name
 
-        if self[name] is None:
+        if name not in self or self[name] is None:
             if extra_cond is not None and not extra_cond(self):
                 return
             if callable(value):


### PR DESCRIPTION
Prevents KeyError, which isn't important when intending to set the value anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7960)
<!-- Reviewable:end -->
