### PR TITLE
Allow space-separated host names in hosts file.

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -109,8 +109,8 @@ def check_environ(product):
             for line in f:
                 line = line.split("#", 1)[0].strip()
                 parts = line.split()
-                if len(parts) == 2:
-                    host = parts[1]
+                hosts = parts[1:]
+                for host in hosts:
                     missing_hosts.discard(host)
             if missing_hosts:
                 raise WptrunError("""Missing hosts file configuration. Expected entries like:


### PR DESCRIPTION
My new Ubuntu install decided to teach me more about the format of the hosts file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7981)
<!-- Reviewable:end -->
