### PR TITLE
Add a state file existence check

### DIFF
--- a/tools/wptrunner/wptrunner/update/state.py
+++ b/tools/wptrunner/wptrunner/update/state.py
@@ -44,6 +44,8 @@ class State(object):
     def load(cls, logger):
         """Load saved state from a file"""
         try:
+            if not os.path.isfile(cls.filename):
+                return None
             with open(cls.filename) as f:
                 try:
                     rv = pickle.load(f)


### PR DESCRIPTION
This prevents 
`LOG: MainThread DEBUG IOError loading stored state`

Which is a little misleading (and the next log line is `No existing state found`, which is the expected message)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/7982)
<!-- Reviewable:end -->
