### PR TITLE
URLSearchParam update steps shouldn't run on construction

### DIFF
--- a/url/urlsearchparams-stringifier.html
+++ b/url/urlsearchparams-stringifier.html
@@ -116,6 +116,20 @@ test(function() {
     params = new URLSearchParams('a=&a=b');
     assert_equals(params.toString(), 'a=&a=b');
 }, 'URLSearchParams.toString');
+
+test(() => {
+    const url = new URL('http://www.example.com/?a=b,c');
+    const params = url.searchParams;
+
+    assert_equals(url.toString(), 'http://www.example.com/?a=b,c');
+    assert_equals(params.toString(), 'a=b%2Cc');
+
+    params.append('x', 'y');
+
+    assert_equals(url.toString(), 'http://www.example.com/?a=b%2Cc&x=y');
+    assert_equals(params.toString(), 'a=b%2Cc&x=y');
+}, 'URLSearchParams connected to URL');
+
 </script>
 </head>
 </html>


### PR DESCRIPTION
[The steps](https://url.spec.whatwg.org/#concept-urlsearchparams-update) should run only when updated.

See https://github.com/whatwg/url/issues/350 and https://github.com/whatwg/url/issues/18.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
