### PR TITLE
Fix setTimeout lint errors around media elements

### DIFF
--- a/html/semantics/embedded-content/media-elements/interfaces/TextTrack/activeCues.html
+++ b/html/semantics/embedded-content/media-elements/interfaces/TextTrack/activeCues.html
@@ -78,10 +78,10 @@ test1.step(function(){
                 var c3 = new VTTCue(0, 2, "text3");
                 t1.addCue(c3);
                 assert_equals(t1.activeCues.length, 1, "t1.activeCues.length after adding a cue in the same script");
-                setTimeout(test3.step_func(function(){
+                test3.step_timeout(function(){
                     assert_equals(t1.activeCues.length, 2, "t1.activeCues.length after the event loop has spun");
                     test3.done();
-                }, 0));
+                }, 0);
             });
             test2.done();
         });

--- a/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
+++ b/html/semantics/embedded-content/media-elements/location-of-the-media-resource/currentSrc.html
@@ -14,14 +14,14 @@
       var e = document.createElement(tagName);
       e.src = src;
       assert_equals(e.currentSrc, '');
-      setTimeout(t.step_func(function() {
+      t.step_timeout(function() {
         if (src == '') {
           assert_equals(e.currentSrc, '');
         } else {
           assert_equals(e.currentSrc, e.src);
         }
         t.done();
-      }), 0);
+      }, 0);
     }, tagName + '.currentSrc after setting src attribute "' + src + '"');
 
     async_test(function(t) {
@@ -30,14 +30,14 @@
       s.src = src;
       e.appendChild(s);
       assert_equals(e.currentSrc, '');
-      setTimeout(t.step_func(function() {
+      t.step_timeout(function() {
         if (src == '') {
           assert_equals(e.currentSrc, '');
         } else {
           assert_equals(e.currentSrc, s.src);
         }
         t.done();
-      }), 0);
+      }, 0);
     }, tagName + '.currentSrc after adding source element with src attribute "' + src + '"');
   });
 });

--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-to-other-document.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-to-other-document.html
@@ -15,10 +15,10 @@ async_test(function(t) {
     assert_false(v.paused, 'paused after playing');
     document.querySelector('iframe').contentDocument.body.appendChild(v);
     assert_false(v.paused, 'paused after moving');
-    setTimeout(t.step_func(function() {
+    t.step_timeout(function() {
       assert_false(v.paused, 'paused after stable state')
       t.done();
-    }), 0);
+    }, 0);
   });
   v.onpause = t.step_func(function() { assert_unreached(); });
 });

--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-within-document.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-move-within-document.html
@@ -15,10 +15,10 @@ async_test(function(t) {
     assert_false(v.paused, 'paused after playing');
     document.getElementById('elsewhere').appendChild(v);
     assert_false(v.paused, 'paused after moving');
-    setTimeout(t.step_func(function() {
+    t.step_timeout(function() {
       assert_false(v.paused, 'paused after stable state')
       t.done();
-    }), 0);
+    }, 0);
   });
   v.onpause = t.step_func(function() { assert_unreached(); });
 });

--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-networkState.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document-networkState.html
@@ -9,13 +9,13 @@
 async_test(function(t) {
   var v = document.querySelector('video');
   v.play();
-  setTimeout(t.step_func(function() {
+  t.step_timeout(function() {
     assert_equals(v.networkState, v.NETWORK_EMPTY,
                   'networkState after stable state');
     assert_false(v.paused, 'paused after stable state');
     v.parentNode.removeChild(v);
     assert_false(v.paused, 'paused after removing');
-    v.onpause = t.step_func(function() { t.done(); });
-  }), 0);
+    v.onpause = t.step_func_done();
+  }, 0);
 });
 </script>

--- a/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document.html
+++ b/html/semantics/embedded-content/media-elements/playing-the-media-resource/pause-remove-from-document.html
@@ -26,10 +26,10 @@ async_test(function(t) {
         assert_true(v.paused, 'paused in pause event');
         // re-insert and verify that it stays paused
         document.body.appendChild(v);
-        setTimeout(t.step_func(function() {
+        t.step_timeout(function() {
           assert_true(v.paused, 'paused after re-inserting');
           t.done();
-        }), 0);
+        }, 0);
       });
     }));
   });

--- a/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html
+++ b/html/semantics/embedded-content/media-elements/track/track-element/cloneNode.html
@@ -20,7 +20,7 @@ async_test(function(t) {
     assert_equals(elm.readyState, elm.NONE, 'elm.readyState after appening to video setting mode');
     elm.src = 'resources/track.vtt?pipe=trickle(d1)';
     assert_equals(elm.readyState, elm.NONE, 'elm.readyState after setting src');
-    setTimeout(t.step_func_done(function() {
+    t.step_timeout(function() {
       assert_equals(elm.readyState, elm.LOADING, 'elm.readyState in setTimeout');
       var clone = elm.cloneNode(true);
       assert_equals(clone.readyState, clone.NONE, 'clone.readyState after element creation');
@@ -28,7 +28,8 @@ async_test(function(t) {
       clone.track.mode = 'showing';
       assert_equals(clone.readyState, clone.NONE, 'clone.readyState after appending to video and setting mode');
       assert_not_equals(clone.track, elm.track, 'clone.track and elm.track');
-    }), 0);
+      t.done();
+    }, 0);
 }, document.title+', loading');
 
 async_test(function(t) {

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -188,7 +188,6 @@ SET TIMEOUT: html/dom/documents/resource-metadata-management/document-lastModifi
 SET TIMEOUT: html/dom/dynamic-markup-insertion/opening-the-input-stream/*
 SET TIMEOUT: html/editing/dnd/*
 SET TIMEOUT: html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
-SET TIMEOUT: html/semantics/embedded-content/media-elements/*
 SET TIMEOUT: html/semantics/embedded-content/the-iframe-element/*
 SET TIMEOUT: html/semantics/embedded-content/the-img-element/*
 SET TIMEOUT: html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html


### PR DESCRIPTION
In activeCues.html, the parenthesis were originally in the wrong place,
causing the function to be called with 0 as this. Fortunately, this
didn't matter. Fixed nonetheless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8026)
<!-- Reviewable:end -->
