### PR TITLE
Fix some setTimeout lint errors in html/

### DIFF
--- a/html/dom/documents/resource-metadata-management/document-lastModified-01.html
+++ b/html/dom/documents/resource-metadata-management/document-lastModified-01.html
@@ -39,13 +39,11 @@
   }
   var t = async_test("Date returned by lastModified is current after timeout.");
 
-  setTimeout(function() {
-    t.step(function() {
-      var new_modified = Date.parse(document.lastModified) / 1000;
-      var new_expected = Math.round(new Date() / 1000);
-      assert_approx_equals(new_modified, new_expected, 2.5,
-                           "(initial value was " + initial_modified + ")");
-      t.done();
-    });
+  t.step_timeout(function() {
+    var new_modified = Date.parse(document.lastModified) / 1000;
+    var new_expected = Math.round(new Date() / 1000);
+    assert_approx_equals(new_modified, new_expected, 2.5,
+                         "(initial value was " + initial_modified + ")");
+    t.done();
   }, 4000);
 </script>

--- a/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
+++ b/html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
@@ -112,7 +112,7 @@
       //
       // This is unfortunately racy in that we might _still_ get spurious
       // passes.  I'm not sure how best to handle that.
-      setTimeout(this.step_func(function() {
+      this.step_timeout(function() {
         var q = false;
         element.onselect = this.step_func_done(function(e) {
           assert_true(q, "event should be queued");
@@ -122,7 +122,7 @@
         });
         element.setRangeText("foobar2", 0, 6);
         q = true;
-      }), 10);
+      }, 10);
     }, element.id + " setRangeText fires a select event");
 
   })

--- a/html/semantics/forms/the-input-element/checkbox.html
+++ b/html/semantics/forms/the-input-element/checkbox.html
@@ -102,7 +102,7 @@
     */
     assert_true(checkbox5.checked);
     assert_false(checkbox5.indeterminate);
-    window.setTimeout(t5.step_func(function(e) {
+    t5.step_timeout(function() {
       /*
       The click event has finished being dispatched, so the checkedness and
       determinateness have been toggled back by now because the event
@@ -111,7 +111,7 @@
       assert_false(checkbox5.checked);
       assert_false(checkbox5.indeterminate);
       t5.done();
-    }), 0);
+    }, 0);
   });
 
   t5.step(function(){
@@ -129,7 +129,7 @@
     */
     assert_true(checkbox6.checked);
     assert_true(checkbox6.indeterminate);
-    window.setTimeout(t6.step_func(function(e) {
+    t6.step_timeout(function() {
       /*
       The click event has finished being dispatched, so the checkedness and
       determinateness have been toggled back by now because the event
@@ -138,7 +138,7 @@
       assert_false(checkbox6.checked);
       assert_false(checkbox6.indeterminate);
       t6.done();
-    }), 0);
+    }, 0);
   });
 
   t6.step(function(){

--- a/html/semantics/interactive-elements/the-details-element/toggleEvent.html
+++ b/html/semantics/interactive-elements/the-details-element/toggleEvent.html
@@ -111,10 +111,10 @@
       loop = true;
     }
   });
-  setTimeout(t6.step_func(function() {
+  t6.step_timeout(function() {
     assert_true(loop);
     t6.done();
-  }), 0);
+  }, 0);
 
   details7.ontoggle = t7.step_func_done(function(evt) {
     assert_true(details7.open);
@@ -139,19 +139,19 @@
   // The toggle event should be fired once when declaring details9 with open
   // attribute.
   details9.open = true; // opens details9
-  setTimeout(t9.step_func(function() {
+  t9.step_timeout(function() {
     assert_true(details9.open);
     assert_true(toggleFiredOnDetails9);
     t9.done();
-  }), 0);
+  }, 0);
 
   details10.ontoggle = t10.step_func_done(function(evt) {
     assert_unreached("toggle event fired on closed details element");
   });
   details10.open = false; // closes details10
-  setTimeout(t10.step_func(function() {
+  t10.step_timeout(function() {
     assert_false(details10.open);
     t10.done();
-  }), 0);
+  }, 0);
 
 </script>

--- a/html/syntax/parsing/DOMContentLoaded-defer-support.js
+++ b/html/syntax/parsing/DOMContentLoaded-defer-support.js
@@ -2,12 +2,13 @@ t.step(function() {
   assert_false(dcl, "DOMContentLoaded should not have fired before executing " +
                     "a defer script");
 
-  setTimeout(t.step_func(function() {
+  t.step_timeout(function() {
     assert_false(dcl, "DOMContentLoaded should not have fired before " +
                       "executing a task queued from a defer script");
-    setTimeout(t.step_func_done(function() {
+    t.step_timeout(function() {
       assert_true(dcl, "DOMContentLoaded should have fired in a task that " +
                        "was queued after the DOMContentLoaded task was queued");
-    }), 0);
-  }), 0);
+      t.done();
+    }, 0);
+  }, 0);
 });

--- a/html/webappapis/animation-frames/same-dispatch-time.html
+++ b/html/webappapis/animation-frames/same-dispatch-time.html
@@ -9,7 +9,7 @@
   <body>
     <div id="log"></div>
     <script>
-      test(function (t) {
+      async_test(function (t) {
         var a = 0, b = 0;
 
         /* REASONING:
@@ -17,14 +17,14 @@
         * they execute right after eachother, they're added to the same
         * queue and SHOULD be timestamped with the same value.
         */
-        window.requestAnimationFrame(function() { a = arguments[0]; });
-        window.requestAnimationFrame(function() { b = arguments[0]; });
-
-        setTimeout(function() {
-            assert_true(a != 0);
-            assert_true(b != 0);
-            assert_true(a == b);
-        }, 100);
+        requestAnimationFrame(t.step_func(function() { a = arguments[0]; }));
+        requestAnimationFrame(t.step_func(function() {
+          b = arguments[0];
+          assert_not_equals(a, 0);
+          assert_not_equals(b, 0);
+          assert_equals(a, b);
+          t.done();
+        });
       }, "requestAnimationFrame will timestamp events in the same queue with the same time");
     </script>
   </body>

--- a/html/webappapis/animation-frames/same-dispatch-time.html
+++ b/html/webappapis/animation-frames/same-dispatch-time.html
@@ -24,7 +24,7 @@
           assert_not_equals(b, 0);
           assert_equals(a, b);
           t.done();
-        });
+        }));
       }, "requestAnimationFrame will timestamp events in the same queue with the same time");
     </script>
   </body>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -157,20 +157,11 @@ SET TIMEOUT: html/browsers/history/the-history-interface/*
 SET TIMEOUT: html/browsers/history/the-location-interface/*
 SET TIMEOUT: html/browsers/offline/*
 SET TIMEOUT: html/browsers/the-window-object/*
-SET TIMEOUT: html/browsers/windows/auxiliary-browsing-contexts/resources/close-opener.html
-SET TIMEOUT: html/dom/documents/dom-tree-accessors/Document.currentScript.html
-SET TIMEOUT: html/dom/documents/resource-metadata-management/document-lastModified-01.html
 SET TIMEOUT: html/dom/dynamic-markup-insertion/opening-the-input-stream/*
 SET TIMEOUT: html/editing/dnd/*
-SET TIMEOUT: html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
 SET TIMEOUT: html/semantics/embedded-content/the-iframe-element/*
 SET TIMEOUT: html/semantics/embedded-content/the-img-element/*
-SET TIMEOUT: html/semantics/forms/textfieldselection/textfieldselection-setRangeText.html
-SET TIMEOUT: html/semantics/forms/the-input-element/checkbox.html
-SET TIMEOUT: html/semantics/interactive-elements/the-details-element/toggleEvent.html
 SET TIMEOUT: html/semantics/scripting-1/the-script-element/*
-SET TIMEOUT: html/syntax/parsing/DOMContentLoaded-defer-support.js
-SET TIMEOUT: html/webappapis/animation-frames/same-dispatch-time.html
 SET TIMEOUT: html/webappapis/scripting/event-loops/*
 SET TIMEOUT: html/webappapis/scripting/events/event-handler-processing-algorithm-error/*
 SET TIMEOUT: html/webappapis/scripting/processing-model-2/*
@@ -302,6 +293,8 @@ GENERATE_TESTS: shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/w
 GENERATE_TESTS: shadow-dom/untriaged/shadow-trees/upper-boundary-encapsulation/window-named-properties-003.html
 
 # Intentional use of setTimeout
+SET TIMEOUT: html/browsers/windows/auxiliary-browsing-contexts/resources/close-opener.html
+SET TIMEOUT: html/dom/documents/dom-tree-accessors/Document.currentScript.html
 SET TIMEOUT: html/webappapis/timers/*
 
 # setTimeout use in reftests


### PR DESCRIPTION
same-dispatch-time.html is the most interesting, because it was
previously broken. As a synchronous test, it would pass regardless of
what happened in the callbacks. Fix that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8028)
<!-- Reviewable:end -->
