### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=179144

### DIFF
--- a/service-workers/service-worker/resources/test-helpers.sub.js
+++ b/service-workers/service-worker/resources/test-helpers.sub.js
@@ -201,20 +201,12 @@ function test_websocket(test, frame, url) {
     });
 }
 
-function login(test) {
-  return test_login(test, 'http://{{domains[www1]}}:{{ports[http][0]}}',
-                    'username1', 'password1', 'cookie1')
-    .then(function() {
-        return test_login(test, 'http://{{host}}:{{ports[http][0]}}',
-                          'username2', 'password2', 'cookie2');
-      });
-}
-
 function login_https(test) {
-  return test_login(test, 'https://{{domains[www1]}}:{{ports[https][0]}}',
+  var host_info = get_host_info();
+  return test_login(test, host_info.HTTPS_REMOTE_ORIGIN,
                     'username1s', 'password1s', 'cookie1')
     .then(function() {
-        return test_login(test, 'https://{{host}}:{{ports[https][0]}}',
+        return test_login(test, host_info.HTTPS_ORIGIN,
                           'username2s', 'password2s', 'cookie2');
       });
 }


### PR DESCRIPTION
Fixing test-helpers.sub.js to use get_host_info() instead of www1.
Removing login(test) as it does not seem to be used anywhere.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
