### PR TITLE
ReadableStream: Verify that .tee() uses original constructor

### DIFF
--- a/streams/readable-streams/tee.js
+++ b/streams/readable-streams/tee.js
@@ -251,4 +251,29 @@ promise_test(t => {
 
 }, 'ReadableStream teeing: erroring the original should immediately error the branches');
 
+test(t => {
+
+  // Copy original global.
+  const oldReadableStream = ReadableStream;
+  const getReader = ReadableStream.prototype.getReader;
+
+  const origRS = new ReadableStream();
+
+  // Replace the global ReadableStream constructor with one that doesn't work.
+  ReadableStream = function() {
+    throw new Error('global ReadableStream constructor called');
+  };
+  t.add_cleanup(() => {
+    ReadableStream = oldReadableStream;
+  });
+
+  // This will probably fail if the global ReadableStream constructor was used.
+  const [rs1, rs2] = origRS.tee();
+
+  // These will definitely fail if the global ReadableStream constructor was used.
+  assert_not_equals(getReader.call(rs1), undefined, 'getReader should work on rs1');
+  assert_not_equals(getReader.call(rs2), undefined, 'getReader should work on rs2');
+
+}, 'ReadableStreamTee should not use a modified ReadableStream constructor from the global object');
+
 done();


### PR DESCRIPTION
ReadableStream.prototype.tee should use the original value of the
ReadableStream constructor, not a modified version that may exist on the
global object. Verify that it does.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
