### PR TITLE
Make Event-timestamp-high-resolution.html more robust.

### DIFF
--- a/dom/events/Event-timestamp-high-resolution.html
+++ b/dom/events/Event-timestamp-high-resolution.html
@@ -4,13 +4,13 @@
 <script src="/resources/testharnessreport.js"></script>
 <script type="text/javascript">
 'use strict';
-for (let eventType of [MouseEvent, KeyboardEvent, WheelEvent, GamepadEvent, FocusEvent]) {
+for (let eventType of ["MouseEvent", "KeyboardEvent", "WheelEvent", "GamepadEvent", "FocusEvent"]) {
     test(function() {
         let before = performance.now();
-        let e = new eventType('test');
+        let e = new window[eventType]('test');
         let after = performance.now();
         assert_greater_than_equal(e.timeStamp, before, "Event timestamp should be greater than performance.now() timestamp taken before its creation");
         assert_less_than_equal(e.timeStamp, after, "Event timestamp should be less than performance.now() timestamp taken after its creation");
-    }, `Constructed ${eventType.prototype.constructor.name} timestamp should be high resolution and have the same time origin as performance.now()`);
+    }, `Constructed ${eventType} timestamp should be high resolution and have the same time origin as performance.now()`);
 }
 </script>


### PR DESCRIPTION
After this change, if one of the event constructors is not implemented or
exposed, only the relevant subtest will fail, rather than the entire test.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
