### PR TITLE
Ensure that tests-affected picks up changes to webidl/idlharness

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -91,6 +91,24 @@ html/browsers/offline/appcache/workers/resources/appcache-worker.py
     assert err == ""
 
 
+def test_files_changed_ignore():
+    from tools.wpt.testfiles import exclude_ignored
+    files = ["resources/testharness.js", "resources/webidl2/index.js", "test/test.js"]
+    changed, ignored = exclude_ignored(files, ignore_rules=["resources/testharness*"])
+    assert changed == [os.path.join(wpt.wpt_root, item) for item in
+                       ["resources/webidl2/index.js", "test/test.js"]]
+    assert ignored == [os.path.join(wpt.wpt_root, item) for item in
+                       ["resources/testharness.js"]]
+
+
+def test_files_changed_ignore_rules():
+    from tools.wpt.testfiles import compile_ignore_rule
+    assert compile_ignore_rule("foo*bar*/baz").pattern == "^foo\*bar[^/]*/baz$"
+    assert compile_ignore_rule("foo**bar**/baz").pattern == "^foo\*\*bar.*/baz$"
+    assert compile_ignore_rule("foobar/baz/*").pattern == "^foobar/baz/[^/]*$"
+    assert compile_ignore_rule("foobar/baz/**").pattern == "^foobar/baz/.*$"
+
+
 def test_tests_affected(capsys):
     # This doesn't really work properly for random commits because we test the files in
     # the current working directory for references to the changed files, not the ones at


### PR DESCRIPTION
When checking the tests that are affected by a change we previously
had a rule to ignore all files under reources, so that changes to
testharness.js don't cause the entire repository to be rerun. However
changes to WebIDL2 or idlharness.js probably should cause all
interfaces.html tests to be rerun. That requires two changes:

* Support for the rewrite rule that causes /resources/WebIDLParser.js
  to be interpreted as the resources/webidl2/lib/webidl2.js path

* Support for more precise exclude rules so that we can exclude
  resources/testharness.js without excluding all of the WebIDL stuff.

For the latter --ignore-dirs has been replaced by --ignore-rules,
where the rules can include a * to match anything other than a path
separator or ** to match anything. In either case the patterns are
only valid at the end of a path segment (i.e. before a seperator or
the end of the path).

Further changes may be required if we want to allow changes to webidl2
that don't affect the webidl2.js file itself to be seen as affecting
all idlharness tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8069)
<!-- Reviewable:end -->
