### PR TITLE
Rewrite open-url-{redirected-,}worker-origin.htm using fetch_tests_from_worker.

### DIFF
--- a/XMLHttpRequest/open-url-redirected-worker-origin.htm
+++ b/XMLHttpRequest/open-url-redirected-worker-origin.htm
@@ -1,43 +1,11 @@
- <!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8" />
-    <title>XMLHttpRequest: redirected worker scripts, origin and referrer</title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-</head>
-<body>
-    <div id="log"></div>
-    <script type="text/javascript">
-        var test = async_test() // This "test" does not actually do any assertations. It's just there to have multiple, separate, asyncronous sub-tests.
-        var expectations = {
-            'Referer header': 'Referer: '+(location.href.replace(/[^/]*$/, ''))+"resources/workerxhr-origin-referrer.js\n",
-            'Origin header': 'Origin: '+location.protocol+'//'+location.hostname+((location.port === "")?"":":"+location.port)+'\n',
-            'Request URL test' : (location.href.replace(/[^/]*$/, ''))+'resources/requri.py?full'
-        }
-        // now start the worker
-        var finalWorkerURL = "workerxhr-origin-referrer.js";
-        var url = "resources/redirect.py?location=" + encodeURIComponent(finalWorkerURL);
-        var worker = new Worker(url)
-        worker.onmessage = function (e) {
-            var subtest = async_test(e.data.test)
-            subtest.step(function(){
-                var thisExpectation = expectations[e.data.test]
-                delete expectations[e.data.test]
-                assert_equals(e.data.result, thisExpectation)
-                subtest.done()
-            })
-            var allDone = true
-            for(var prop in expectations){
-                  allDone = false
-            }
-            if(allDone){
-                test.step(function(){
-                    test.done()
-                })
-            }
-        }
-
-    </script>
-</body>
-</html>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>XMLHttpRequest: redirected worker scripts, origin and referrer</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+var finalWorkerURL = "workerxhr-origin-referrer.js";
+var url = "resources/redirect.py?location=" + encodeURIComponent(finalWorkerURL);
+fetch_tests_from_worker(new Worker(url));
+</script>

--- a/XMLHttpRequest/open-url-worker-origin.htm
+++ b/XMLHttpRequest/open-url-worker-origin.htm
@@ -1,43 +1,9 @@
- <!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8" />
-    <title>XMLHttpRequest: worker scripts, origin and referrer</title>
-    <script src="/resources/testharness.js"></script>
-    <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::OL[1]/LI[3] following::OL[1]/LI[3]/ol[1]/li[1] following::OL[1]/LI[3]/ol[1]/li[2] following::OL[1]/LI[3]/ol[1]/li[3]" />
-</head>
-<body>
-    <div id="log"></div>
-    <script type="text/javascript">
-        var test = async_test() // This "test" does not actually do any assertations. It's just there to have multiple, separate, asyncronous sub-tests.
-        var expectations = {
-            'Referer header': 'Referer: '+(location.href.replace(/[^/]*$/, ''))+"resources/workerxhr-origin-referrer.js\n",
-            'Origin header': 'Origin: '+location.protocol+'//'+location.hostname+((location.port === "")?"":":"+location.port)+'\n',
-            'Request URL test' : (location.href.replace(/[^/]*$/, ''))+'resources/requri.py?full'
-        }
-        // now start the worker
-        var worker = new Worker("resources/workerxhr-origin-referrer.js")
-        worker.onmessage = function (e) {
-            var subtest = async_test(e.data.test)
-            subtest.step(function(){
-                var thisExpectation = expectations[e.data.test]
-                delete expectations[e.data.test]
-                assert_equals(e.data.result, thisExpectation)
-                subtest.done()
-            })
-            var allDone = true
-            for(var prop in expectations){
-                  allDone = false
-            }
-            if(allDone){
-                test.step(function(){
-                    test.done()
-                })
-            }
-        }
-
-    </script>
-</body>
-</html>
-
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>XMLHttpRequest: worker scripts, origin and referrer</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+fetch_tests_from_worker(new Worker("resources/workerxhr-origin-referrer.js"));
+</script>


### PR DESCRIPTION
This produces much more readable tests, with less duplicated code, and has the additional benefit of reporting the subtests in a consistent order. (This helps with the integration of this test in WebKit, which relies on the order of subtests in its format for storing the expected results.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
