### PR TITLE
WebRTC: increase DTMF timeout range for slow environments

### DIFF
--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -76,7 +76,7 @@ function test_tone_change_events(testFunc, toneChanges, desc) {
         const now = Date.now();
         const duration = now - lastEventTime;
 
-        assert_approx_equals(duration, expectedDuration, 50,
+        assert_approx_equals(duration, expectedDuration, 150,
           `Expect tonechange event for "${tone}" to be fired approximately after ${expectedDuration} seconds`);
 
         lastEventTime = now;


### PR DESCRIPTION
The timeout range values in the WebRTC DTMF tests are causing intermittent test failures on debug builds in the Firefox CI system. See
https://bugzilla.mozilla.org/show_bug.cgi?id=1398308
https://bugzilla.mozilla.org/show_bug.cgi?id=1411822

Until we have a better solution it would help to increase the expected timeout values.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
