### PR TITLE
Fix a typo (stray [0]) in the RTCCertificate test

### DIFF
--- a/webrtc/RTCCertificate.html
+++ b/webrtc/RTCCertificate.html
@@ -168,7 +168,7 @@
       assert_greater_than_equal(fingerprints.length, 1,
         'Expect at last one fingerprint in array');
 
-      for(const fingerprint of fingerprints[0]) {
+      for(const fingerprint of fingerprints) {
         assert_true(fingerprint instanceof RTCDtlsFingerprint,
           'Expect fingerprint to be instance of RTCDtlsFingerprint');
 


### PR DESCRIPTION
This caused the test to fail in Chrome:
https://wpt.fyi/webrtc/RTCCertificate.html?sha=6ed1ba18d0

<!-- Reviewable:start -->

<!-- Reviewable:end -->
