### PR TITLE
Clean up click-cancel.html a bit

### DIFF
--- a/uievents/order-of-events/mouse-events/click-cancel.html
+++ b/uievents/order-of-events/mouse-events/click-cancel.html
@@ -10,36 +10,28 @@
     <script src="/resources/testdriver-vendor.js"></script>
   </head>
   <body>
-    <ol>
-      <li>Check the following item.</li>
-      <li>Hover over the button.</li>
-    </ol>
     <input type="checkbox" id="checkbox">Check me!<br>
-    <button type="button" id="done">Button</button>
-</body>
-<script>
-var t = async_test("Default event is canceled if the click event is canceled");
+    <button type="button" id="button">Button</button>
+    <script>
+async_test(function(t) {
+  var box_clicked = false;
 
-var box_clicked = false;
+  var box = document.getElementById("checkbox");
+  box.addEventListener("click", function(event) {
+    box_clicked = true;
+    event.preventDefault();
+  });
 
-var box = document.getElementById("checkbox");
-box.addEventListener("click", function(event) {
-  box_clicked = true;
-  event.preventDefault();
-});
-
-var done = document.getElementById("done");
-done.addEventListener("click", t.step_func_done(function () {
-  assert_true(box_clicked);
-  assert_false(box.checked);
-}));
-
-
-t.step(function() {
-  test_driver.click(box).then(t.step_func(function() {
-    test_driver.click(done);
+  var button = document.getElementById("button");
+  button.addEventListener("click", t.step_func_done(function() {
+    assert_true(box_clicked);
+    assert_false(box.checked);
   }));
-});
 
+  test_driver.click(box).then(function() {
+    return test_driver.click(button);
+  }).catch(t.unreached_func("click failed"));
+});
     </script>
+  </body>
 </html>


### PR DESCRIPTION
As the first testdriver.js test, people might look. So:
 * Remove the manual instructions (which were wrong anyway)
 * Don't use a variable called done, that's confusing
 * Make the test fail fast if test_driver.click() rejects
 * Make the indentation a bit more reasonable

<!-- Reviewable:start -->

<!-- Reviewable:end -->
