### PR TITLE
Upstream transform streams tests

### DIFF
--- a/streams/resources/recording-streams.js
+++ b/streams/resources/recording-streams.js
@@ -86,3 +86,45 @@ self.recordingWritableStream = (extras = {}, strategy) => {
 
   return stream;
 };
+
+self.recordingTransformStream = (extras = {}, writableStrategy, readableStrategy) => {
+  let controllerToCopyOver;
+  const stream = new TransformStream({
+    start(controller) {
+      controllerToCopyOver = controller;
+
+      if (extras.start) {
+        return extras.start(controller);
+      }
+
+      return undefined;
+    },
+
+    transform(chunk, controller) {
+      stream.events.push('transform', chunk);
+
+      if (extras.transform) {
+        return extras.transform(chunk, controller);
+      }
+
+      controller.enqueue(chunk);
+
+      return undefined;
+    },
+
+    flush(controller) {
+      stream.events.push('flush');
+
+      if (extras.flush) {
+        return extras.flush(controller);
+      }
+
+      return undefined;
+    }
+  }, writableStrategy, readableStrategy);
+
+  stream.controller = controllerToCopyOver;
+  stream.events = [];
+
+  return stream;
+};

--- a/streams/resources/test-utils.js
+++ b/streams/resources/test-utils.js
@@ -7,7 +7,7 @@ self.getterRejects = (t, obj, getterName, target) => {
 };
 
 self.getterRejectsForAll = (t, obj, getterName, targets) => {
-  return Promise.all(targets.map(target => getterRejects(t, obj, getterName, target)));
+  return Promise.all(targets.map(target => self.getterRejects(t, obj, getterName, target)));
 };
 
 self.methodRejects = (t, obj, methodName, target, args) => {
@@ -17,8 +17,8 @@ self.methodRejects = (t, obj, methodName, target, args) => {
                          methodName + ' should reject with a TypeError');
 };
 
-self.methodRejectsForAll =  (t, obj, methodName, targets, args) => {
-  return Promise.all(targets.map(target => methodRejects(t, obj, methodName, target, args)));
+self.methodRejectsForAll = (t, obj, methodName, targets, args) => {
+  return Promise.all(targets.map(target => self.methodRejects(t, obj, methodName, target, args)));
 };
 
 self.getterThrows = (obj, getterName, target) => {
@@ -28,8 +28,8 @@ self.getterThrows = (obj, getterName, target) => {
 };
 
 self.getterThrowsForAll = (obj, getterName, targets) => {
-  targets.forEach(target => getterThrows(obj, getterName, target));
-}
+  targets.forEach(target => self.getterThrows(obj, getterName, target));
+};
 
 self.methodThrows = (obj, methodName, target, args) => {
   const method = obj[methodName];
@@ -39,8 +39,13 @@ self.methodThrows = (obj, methodName, target, args) => {
 };
 
 self.methodThrowsForAll = (obj, methodName, targets, args) => {
-  targets.forEach(target => methodThrows(obj, methodName, target, args));
-}
+  targets.forEach(target => self.methodThrows(obj, methodName, target, args));
+};
+
+self.constructorThrowsForAll = (constructor, firstArgs) => {
+  firstArgs.forEach(firstArg => assert_throws(new TypeError(), () => new constructor(firstArg),
+                                              'constructor should throw a TypeError'));
+};
 
 self.garbageCollect = () => {
   if (self.gc) {

--- a/streams/transform-streams/backpressure.dedicatedworker.html
+++ b/streams/transform-streams/backpressure.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backpressure.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('backpressure.js'));
+</script>

--- a/streams/transform-streams/backpressure.html
+++ b/streams/transform-streams/backpressure.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backpressure.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="backpressure.js"></script>

--- a/streams/transform-streams/backpressure.js
+++ b/streams/transform-streams/backpressure.js
@@ -1,0 +1,200 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/recording-streams.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+const error1 = new Error('error1 message');
+error1.name = 'error1';
+
+promise_test(() => {
+  const ts = recordingTransformStream();
+  const writer = ts.writable.getWriter();
+  // This call never resolves.
+  writer.write('a');
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(ts.events, [], 'transform should not be called');
+  });
+}, 'backpressure allows no transforms with a default identity transform and no reader');
+
+promise_test(() => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  // This call to write() resolves asynchronously.
+  writer.write('a');
+  // This call to write() waits for backpressure that is never relieved and never calls transform().
+  writer.write('b');
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(ts.events, ['transform', 'a'], 'transform should be called once');
+  });
+}, 'backpressure only allows one transform() with a identity transform with a readable HWM of 1 and no reader');
+
+promise_test(() => {
+  // Without a transform() implementation, recordingTransformStream() never enqueues anything.
+  const ts = recordingTransformStream({
+    transform() {
+      // Discard all chunks. As a result, the readable side is never full enough to exert backpressure and transform()
+      // keeps being called.
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  const writePromises = [];
+  for (let i = 0; i < 4; ++i) {
+    writePromises.push(writer.write(i));
+  }
+  return Promise.all(writePromises).then(() => {
+    assert_array_equals(ts.events, ['transform', 0, 'transform', 1, 'transform', 2, 'transform', 3],
+                        'all 4 events should be transformed');
+  });
+}, 'transform() should keep being called as long as there is no backpressure');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const events = [];
+  const writerPromises = [
+    writer.write('a').then(() => events.push('a')),
+    writer.write('b').then(() => events.push('b')),
+    writer.close().then(() => events.push('closed'))];
+  return delay(0).then(() => {
+    assert_array_equals(events, ['a'], 'the first write should have resolved');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should not be true');
+    assert_equals('a', value, 'value should be "a"');
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(events, ['a', 'b', 'closed'], 'both writes and close() should have resolved');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should still not be true');
+    assert_equals('b', value, 'value should be "b"');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+    return writerPromises;
+  });
+}, 'writes should resolve as soon as transform completes');
+
+promise_test(() => {
+  const ts = new TransformStream(undefined, undefined, { highWaterMark: 0 });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const readPromise = reader.read();
+  writer.write('a');
+  return readPromise.then(({ value, done }) => {
+    assert_false(done, 'not done');
+    assert_equals(value, 'a', 'value should be "a"');
+  });
+}, 'calling pull() before the first write() with backpressure should work');
+
+promise_test(() => {
+  let reader;
+  const ts = recordingTransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      return reader.read();
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  reader = ts.readable.getReader();
+  return writer.write('a');
+}, 'transform() should be able to read the chunk it just enqueued');
+
+promise_test(() => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = recordingTransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, new CountQueuingStrategy({ highWaterMark: Infinity }));
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  return delay(0).then(() => {
+    writer.write('a');
+    assert_array_equals(ts.events, ['transform', 'a']);
+    assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+    return flushAsyncEvents();
+  }).then(() => {
+    assert_equals(writer.desiredSize, 0, 'desiredSize should still be 0');
+    resolveTransform();
+    return delay(0);
+  }).then(() => {
+    assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  });
+}, 'blocking transform() should cause backpressure');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  ts.readable.cancel(error1);
+  return promise_rejects(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+}, 'writer.closed should resolve after readable is canceled during start');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+  });
+}, 'writer.closed should resolve after readable is canceled with backpressure');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+  });
+}, 'writer.closed should resolve after readable is canceled with no backpressure');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  return delay(0).then(() => {
+    const writePromise = writer.write('a');
+    ts.readable.cancel(error1);
+    return writePromise;
+  });
+}, 'cancelling the readable should cause a pending write to resolve');
+
+promise_test(t => {
+  const rs = new ReadableStream();
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  ts.readable.cancel(error1);
+  return promise_rejects(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+}, 'cancelling the readable side of a TransformStream should abort an empty pipe');
+
+promise_test(t => {
+  const rs = new ReadableStream();
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+  });
+}, 'cancelling the readable side of a TransformStream should abort an empty pipe after startup');
+
+promise_test(t => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.enqueue('b');
+      controller.enqueue('c');
+    }
+  });
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  // Allow data to flow into the pipe.
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+  });
+}, 'cancelling the readable side of a TransformStream should abort a full pipe');
+
+done();

--- a/streams/transform-streams/backpressure.serviceworker.https.html
+++ b/streams/transform-streams/backpressure.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backpressure.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('backpressure.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/backpressure.sharedworker.html
+++ b/streams/transform-streams/backpressure.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>backpressure.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('backpressure.js'));
+</script>

--- a/streams/transform-streams/brand-checks.dedicatedworker.html
+++ b/streams/transform-streams/brand-checks.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>brand-checks.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('brand-checks.js'));
+</script>

--- a/streams/transform-streams/brand-checks.html
+++ b/streams/transform-streams/brand-checks.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>brand-checks.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+
+<script src="brand-checks.js"></script>

--- a/streams/transform-streams/brand-checks.js
+++ b/streams/transform-streams/brand-checks.js
@@ -1,0 +1,79 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+const TransformStreamDefaultController = getTransformStreamDefaultControllerConstructor();
+
+function getTransformStreamDefaultControllerConstructor() {
+  return realTSDefaultController().constructor;
+}
+
+function fakeTS() {
+  return Object.setPrototypeOf({
+    get readable() { return new ReadableStream(); },
+    get writable() { return new WritableStream(); }
+  }, TransformStream.prototype);
+}
+
+function realTS() {
+  return new TransformStream();
+}
+
+function fakeTSDefaultController() {
+  return Object.setPrototypeOf({
+    get desiredSize() { return 1; },
+    enqueue() { },
+    close() { },
+    error() { }
+  }, TransformStreamDefaultController.prototype);
+}
+
+function realTSDefaultController() {
+  let controller;
+  new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return controller;
+}
+
+test(() => {
+  getterThrowsForAll(TransformStream.prototype, 'readable',
+                     [fakeTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStream.prototype.readable enforces a brand check');
+
+test(() => {
+  getterThrowsForAll(TransformStream.prototype, 'writable',
+                     [fakeTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStream.prototype.writable enforces a brand check');
+
+test(() => {
+  constructorThrowsForAll(TransformStreamDefaultController,
+                          [fakeTS(), realTS(), realTSDefaultController(), undefined, null]);
+}, 'TransformStreamDefaultConstructor enforces a brand check and doesn\'t permit independent construction');
+
+test(() => {
+  getterThrowsForAll(TransformStreamDefaultController.prototype, 'desiredSize',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.desiredSize enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'enqueue',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.enqueue enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'terminate',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.terminate enforces a brand check');
+
+test(() => {
+  methodThrowsForAll(TransformStreamDefaultController.prototype, 'error',
+                     [fakeTSDefaultController(), realTS(), undefined, null]);
+}, 'TransformStreamDefaultController.prototype.error enforces a brand check');
+
+done();

--- a/streams/transform-streams/brand-checks.serviceworker.https.html
+++ b/streams/transform-streams/brand-checks.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>brand-checks.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('brand-checks.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/brand-checks.sharedworker.html
+++ b/streams/transform-streams/brand-checks.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>brand-checks.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('brand-checks.js'));
+</script>

--- a/streams/transform-streams/errors.dedicatedworker.html
+++ b/streams/transform-streams/errors.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>errors.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('errors.js'));
+</script>

--- a/streams/transform-streams/errors.html
+++ b/streams/transform-streams/errors.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>errors.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+
+<script src="errors.js"></script>

--- a/streams/transform-streams/errors.js
+++ b/streams/transform-streams/errors.js
@@ -1,0 +1,339 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+const thrownError = new Error('bad things are happening!');
+thrownError.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+      throw thrownError;
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    promise_rejects(t, thrownError, writer.write('a'),
+                    'writable\'s write should reject with the thrown error'),
+    promise_rejects(t, thrownError, reader.read(),
+                    'readable\'s read should reject with the thrown error'),
+    promise_rejects(t, thrownError, reader.closed,
+                    'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects(t, thrownError, writer.closed,
+                    'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in transform put the writable and readable in an errored state');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+    },
+    flush() {
+      throw thrownError;
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    writer.write('a'),
+    promise_rejects(t, thrownError, writer.close(),
+                    'writable\'s close should reject with the thrown error'),
+    promise_rejects(t, thrownError, reader.read(),
+                    'readable\'s read should reject with the thrown error'),
+    promise_rejects(t, thrownError, reader.closed,
+                    'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects(t, thrownError, writer.closed,
+                    'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in flush put the writable and readable in an errored state');
+
+test(() => {
+  new TransformStream({
+    start(c) {
+      c.enqueue('a');
+      c.error(new Error('generic error'));
+      assert_throws(new TypeError(), () => c.enqueue('b'), 'enqueue() should throw');
+    }
+  });
+}, 'errored TransformStream should not enqueue new chunks');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start() {
+      return flushAsyncEvents().then(() => {
+        throw thrownError;
+      });
+    },
+    transform: t.unreached_func('transform should not be called'),
+    flush: t.unreached_func('flush should not be called')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects(t, thrownError, writer.write('a'), 'writer should reject with thrownError'),
+    promise_rejects(t, thrownError, writer.close(), 'close() should reject with thrownError'),
+    promise_rejects(t, thrownError, reader.read(), 'reader should reject with thrownError')
+  ]);
+}, 'TransformStream transformer.start() rejected promise should error the stream');
+
+promise_test(t => {
+  const controllerError = new Error('start failure');
+  controllerError.name = 'controllerError';
+  const ts = new TransformStream({
+    start(c) {
+      return flushAsyncEvents()
+        .then(() => {
+          c.error(controllerError);
+          throw new Error('ignored error');
+        });
+    },
+    transform: t.unreached_func('transform should never be called if start() fails'),
+    flush: t.unreached_func('flush should never be called if start() fails')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects(t, controllerError, writer.write('a'), 'writer should reject with controllerError'),
+    promise_rejects(t, controllerError, writer.close(), 'close should reject with same error'),
+    promise_rejects(t, controllerError, reader.read(), 'reader should reject with same error')
+  ]);
+}, 'when controller.error is followed by a rejection, the error reason should come from controller.error');
+
+test(() => {
+  assert_throws(new URIError(), () => new TransformStream({
+    start() { throw new URIError('start thrown error'); },
+    transform() {}
+  }), 'constructor should throw');
+}, 'TransformStream constructor should throw when start does');
+
+test(() => {
+  const strategy = {
+    size() { throw new URIError('size thrown error'); }
+  };
+
+  assert_throws(new URIError(), () => new TransformStream({
+    start(c) {
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'constructor should throw the same error strategy.size throws');
+}, 'when strategy.size throws inside start(), the constructor should throw the same error');
+
+test(() => {
+  const controllerError = new URIError('controller.error');
+
+  let controller;
+  const strategy = {
+    size() {
+      controller.error(controllerError);
+      throw new Error('redundant error');
+    }
+  };
+
+  assert_throws(new URIError(), () => new TransformStream({
+    start(c) {
+      controller = c;
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'the first error should be thrown');
+}, 'when strategy.size calls controller.error() then throws, the constructor should throw the first error');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  const closedPromise = writer.closed;
+  return Promise.all([
+    ts.readable.cancel(thrownError),
+    promise_rejects(t, thrownError, closedPromise, 'closed should throw a TypeError')
+  ]);
+}, 'cancelling the readable side should error the writable');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const writePromise = writer.write('a');
+  const closePromise = writer.close();
+  controller.error(thrownError);
+  return Promise.all([
+    promise_rejects(t, thrownError, reader.closed, 'reader.closed should reject'),
+    promise_rejects(t, thrownError, writePromise, 'writePromise should reject'),
+    promise_rejects(t, thrownError, closePromise, 'closePromise should reject')]);
+}, 'it should be possible to error the readable between close requested and complete');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      controller.terminate();
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writePromise = ts.writable.getWriter().write('a');
+  const closedPromise = ts.readable.getReader().closed;
+  return Promise.all([
+    promise_rejects(t, thrownError, writePromise, 'write() should reject'),
+    promise_rejects(t, thrownError, closedPromise, 'reader.closed should reject')
+  ]);
+}, 'an exception from transform() should error the stream if terminate has been requested but not completed');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  // The microtask following transformer.start() hasn't completed yet, so the abort is queued and not notified to the
+  // TransformStream yet.
+  const abortPromise = writer.abort(thrownError);
+  const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+  return Promise.all([
+    abortPromise,
+    cancelPromise,
+    promise_rejects(t, new TypeError(), writer.closed, 'writer.closed should reject with a TypeError')]);
+}, 'abort should set the close reason for the writable when it happens before cancel during start, but cancel should ' +
+             'still succeed');
+
+promise_test(t => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = new TransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, { highWaterMark: 2 });
+  const writer = ts.writable.getWriter();
+  return delay(0).then(() => {
+    const writePromise = writer.write();
+    const abortPromise = writer.abort(thrownError);
+    const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+    resolveTransform();
+    return Promise.all([
+      writePromise,
+      abortPromise,
+      cancelPromise,
+      promise_rejects(t, new TypeError(), writer.closed, 'writer.closed should reject with a TypeError')]);
+  });
+}, 'abort should set the close reason for the writable when it happens before cancel during underlying sink write, ' +
+             'but cancel should still succeed');
+
+const ignoredError = new Error('ignoredError');
+ignoredError.name = 'ignoredError';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.error(thrownError);
+      controller.error(ignoredError);
+    }
+  });
+  return promise_rejects(t, thrownError, ts.writable.abort(), 'abort() should reject with thrownError');
+}, 'controller.error() should do nothing the second time it is called');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelPromise = ts.readable.cancel(thrownError);
+  controller.error(ignoredError);
+  return Promise.all([
+    cancelPromise,
+    promise_rejects(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError')
+  ]);
+}, 'controller.error() should do nothing after readable.cancel()');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ts.writable.abort().then(() => {
+    controller.error(ignoredError);
+    return promise_rejects(t, new TypeError(), ts.writable.getWriter().closed, 'closed should reject with a TypeError');
+  });
+}, 'controller.error() should do nothing after writable.abort() has completed');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  const writer = ts.writable.getWriter();
+  return promise_rejects(t, thrownError, writer.write(), 'write() should reject').then(() => {
+    controller.error();
+    return promise_rejects(t, thrownError, writer.closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after a transformer method has thrown an exception');
+
+promise_test(t => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      ++calls;
+    }
+  }, undefined, { highWaterMark: 1 });
+  return delay(0).then(() => {
+    // Create backpressure.
+    controller.enqueue('a');
+    const writer = ts.writable.getWriter();
+    // transform() will not be called until backpressure is relieved.
+    const writePromise = writer.write('b');
+    assert_equals(calls, 0, 'transform() should not have been called');
+    controller.error(thrownError);
+    // Now backpressure has been relieved and the write can proceed.
+    return promise_rejects(t, thrownError, writePromise, 'write() should reject').then(() => {
+      assert_equals(calls, 0, 'transform() should not be called');
+    });
+  });
+}, 'erroring during write with backpressure should result in the write failing');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    const writer = ts.writable.getWriter();
+    // write should start synchronously
+    const writePromise = writer.write(0);
+    // The underlying sink's abort() is not called until the write() completes.
+    const abortPromise = writer.abort();
+    // Perform a read to relieve backpressure and permit the write() to complete.
+    const readPromise = ts.readable.getReader().read();
+    return Promise.all([
+      promise_rejects(t, new TypeError(), readPromise, 'read() should reject'),
+      promise_rejects(t, new TypeError(), writePromise, 'write() should reject'),
+      abortPromise
+    ]);
+  });
+}, 'a write() that was waiting for backpressure should reject if the writable is aborted');
+
+done();

--- a/streams/transform-streams/errors.serviceworker.https.html
+++ b/streams/transform-streams/errors.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>errors.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('errors.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/errors.sharedworker.html
+++ b/streams/transform-streams/errors.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>errors.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('errors.js'));
+</script>

--- a/streams/transform-streams/flush.dedicatedworker.html
+++ b/streams/transform-streams/flush.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>flush.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('flush.js'));
+</script>

--- a/streams/transform-streams/flush.html
+++ b/streams/transform-streams/flush.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>flush.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+
+<script src="flush.js"></script>

--- a/streams/transform-streams/flush.js
+++ b/streams/transform-streams/flush.js
@@ -1,0 +1,130 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('../resources/test-utils.js');
+  self.importScripts('/resources/testharness.js');
+}
+
+promise_test(() => {
+  let flushCalled = false;
+  const ts = new TransformStream({
+    transform() { },
+    flush() {
+      flushCalled = true;
+    }
+  });
+
+  return ts.writable.getWriter().close().then(() => {
+    return assert_true(flushCalled, 'closing the writable triggers the transform flush immediately');
+  });
+}, 'TransformStream flush is called immediately when the writable is closed, if no writes are queued');
+
+// TODO
+test(() => {
+  let flushCalled = false;
+  const ts = new TransformStream({
+    transform() {
+      return delay(10);
+    },
+    flush() {
+      flushCalled = true;
+      return new Promise(() => {}); // never resolves
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+  assert_false(flushCalled, 'closing the writable does not immediately call flush if writes are not finished');
+
+  let rsClosed = false;
+  ts.readable.getReader().closed.then(() => {
+    rsClosed = true;
+  });
+
+  return delay(50).then(() => {
+    assert_true(flushCalled, 'flush is eventually called');
+    assert_false(rsClosed, 'if flushPromise does not resolve, the readable does not become closed');
+  });
+}, 'TransformStream flush is called after all queued writes finish, once the writable is closed');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+    },
+    flush() {
+      c.enqueue('x');
+      c.enqueue('y');
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'x', 'the first chunk read is the first one enqueued in flush');
+    assert_equals(result1.done, false, 'the first chunk read is the first one enqueued in flush');
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'y', 'the second chunk read is the second one enqueued in flush');
+      assert_equals(result2.done, false, 'the second chunk read is the second one enqueued in flush');
+    });
+  });
+}, 'TransformStream flush gets a chance to enqueue more into the readable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+    },
+    flush() {
+      c.enqueue('x');
+      c.enqueue('y');
+      return delay(0);
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  return Promise.all([
+    reader.read().then(result1 => {
+      assert_equals(result1.value, 'x', 'the first chunk read is the first one enqueued in flush');
+      assert_equals(result1.done, false, 'the first chunk read is the first one enqueued in flush');
+
+      return reader.read().then(result2 => {
+        assert_equals(result2.value, 'y', 'the second chunk read is the second one enqueued in flush');
+        assert_equals(result2.done, false, 'the second chunk read is the second one enqueued in flush');
+      });
+    }),
+    reader.closed.then(() => {
+      assert_true(true, 'readable reader becomes closed');
+    })
+  ]);
+}, 'TransformStream flush gets a chance to enqueue more into the readable, and can then async close');
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.error(error1);
+    }
+  });
+  return promise_rejects(t, error1, ts.writable.getWriter().close(), 'close() should reject');
+}, 'error() during flush should cause writer.close() to reject');
+
+done();

--- a/streams/transform-streams/flush.serviceworker.https.html
+++ b/streams/transform-streams/flush.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>flush.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('flush.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/flush.sharedworker.html
+++ b/streams/transform-streams/flush.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>flush.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('flush.js'));
+</script>

--- a/streams/transform-streams/general.dedicatedworker.html
+++ b/streams/transform-streams/general.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>general.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('general.js'));
+</script>

--- a/streams/transform-streams/general.html
+++ b/streams/transform-streams/general.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>general.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/rs-utils.js"></script>
+
+<script src="general.js"></script>

--- a/streams/transform-streams/general.js
+++ b/streams/transform-streams/general.js
@@ -1,0 +1,442 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+  self.importScripts('../resources/rs-utils.js');
+}
+
+test(() => {
+  new TransformStream({ transform() { } });
+}, 'TransformStream can be constructed with a transform function');
+
+test(() => {
+  new TransformStream();
+  new TransformStream({});
+}, 'TransformStream can be constructed with no transform function');
+
+test(() => {
+  const ts = new TransformStream({ transform() { } });
+  const proto = Object.getPrototypeOf(ts);
+
+  const writableStream = Object.getOwnPropertyDescriptor(proto, 'writable');
+  assert_true(writableStream !== undefined, 'it has a writable property');
+  assert_false(writableStream.enumerable, 'writable should be non-enumerable');
+  assert_equals(typeof writableStream.get, 'function', 'writable should have a getter');
+  assert_equals(writableStream.set, undefined, 'writable should not have a setter');
+  assert_true(writableStream.configurable, 'writable should be configurable');
+  assert_true(ts.writable instanceof WritableStream, 'writable is an instance of WritableStream');
+  assert_not_equals(WritableStream.prototype.getWriter.call(ts.writable), undefined,
+                    'writable should pass WritableStream brand check');
+
+  const readableStream = Object.getOwnPropertyDescriptor(proto, 'readable');
+  assert_true(readableStream !== undefined, 'it has a readable property');
+  assert_false(readableStream.enumerable, 'readable should be non-enumerable');
+  assert_equals(typeof readableStream.get, 'function', 'readable should have a getter');
+  assert_equals(readableStream.set, undefined, 'readable should not have a setter');
+  assert_true(readableStream.configurable, 'readable should be configurable');
+  assert_true(ts.readable instanceof ReadableStream, 'readable is an instance of ReadableStream');
+  assert_not_equals(ReadableStream.prototype.getReader.call(ts.readable), undefined,
+                    'readable should pass ReadableStream brand check');
+}, 'TransformStream instances must have writable and readable properties of the correct types');
+
+test(() => {
+  const ts = new TransformStream({ transform() { } });
+
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'writer.desiredSize should be 1');
+}, 'TransformStream writable starts in the writable state');
+
+
+promise_test(() => {
+  const ts = new TransformStream();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  assert_equals(writer.desiredSize, 0, 'writer.desiredSize should be 0 after write()');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'a',
+      'result from reading the readable is the same as was written to writable');
+    assert_false(result.done, 'stream should not be done');
+
+    return delay(0).then(() => assert_equals(writer.desiredSize, 1, 'desiredSize should be 1 again'));
+  });
+}, 'Identity TransformStream: can read from readable what is put into writable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      c.enqueue(chunk.toUpperCase());
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'A',
+      'result from reading the readable is the transformation of what was written to writable');
+    assert_false(result.done, 'stream should not be done');
+  });
+}, 'Uppercaser sync TransformStream: can read from readable transformed version of what is put into writable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      c.enqueue(chunk.toUpperCase());
+      c.enqueue(chunk.toUpperCase());
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  const reader = ts.readable.getReader();
+
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'A',
+      'the first chunk read is the transformation of the single chunk written');
+    assert_false(result1.done, 'stream should not be done');
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'A',
+        'the second chunk read is also the transformation of the single chunk written');
+      assert_false(result2.done, 'stream should not be done');
+    });
+  });
+}, 'Uppercaser-doubler sync TransformStream: can read both chunks put into the readable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      setTimeout(() => c.enqueue(chunk.toUpperCase()), 10);
+      return delay(50);
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'A',
+      'result from reading the readable is the transformation of what was written to writable');
+    assert_false(result.done, 'stream should not be done');
+  });
+}, 'Uppercaser async TransformStream: can read from readable transformed version of what is put into writable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      setTimeout(() => c.enqueue(chunk.toUpperCase()), 10);
+      setTimeout(() => c.enqueue(chunk.toUpperCase()), 50);
+      return delay(90);
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'A',
+      'the first chunk read is the transformation of the single chunk written');
+    assert_false(result1.done, 'stream should not be done');
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'A',
+        'the second chunk read is also the transformation of the single chunk written');
+      assert_false(result2.done, 'stream should not be done');
+    });
+  });
+}, 'Uppercaser-doubler async TransformStream: can read both chunks put into the readable');
+
+promise_test(() => {
+  const ts = new TransformStream({ transform() { } });
+
+  const writer = ts.writable.getWriter();
+  writer.close();
+
+  return Promise.all([writer.closed, ts.readable.getReader().closed]);
+}, 'TransformStream: by default, closing the writable closes the readable (when there are no queued writes)');
+
+promise_test(() => {
+  let transformResolve;
+  const transformPromise = new Promise(resolve => {
+    transformResolve = resolve;
+  });
+  const ts = new TransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, { highWaterMark: 1 });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  let rsClosed = false;
+  ts.readable.getReader().closed.then(() => {
+    rsClosed = true;
+  });
+
+  return delay(0).then(() => {
+    assert_equals(rsClosed, false, 'readable is not closed after a tick');
+    transformResolve();
+
+    return writer.closed.then(() => {
+      // TODO: Is this expectation correct?
+      assert_equals(rsClosed, true, 'readable is closed at that point');
+    });
+  });
+}, 'TransformStream: by default, closing the writable waits for transforms to finish before closing both');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+      c.enqueue('x');
+      c.enqueue('y');
+      return delay(50);
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
+    });
+  });
+}, 'TransformStream: by default, closing the writable closes the readable after sync enqueues and async done');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+      setTimeout(() => c.enqueue('x'), 10);
+      setTimeout(() => c.enqueue('y'), 50);
+      return new Promise(resolve => setTimeout(resolve, 50));
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
+    });
+  });
+}, 'TransformStream: by default, closing the writable closes the readable after async enqueues and async done');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    suffix: '-suffix',
+
+    start(controller) {
+      c = controller;
+      c.enqueue('start' + this.suffix);
+    },
+
+    transform(chunk) {
+      c.enqueue(chunk + this.suffix);
+    },
+
+    flush() {
+      c.enqueue('flushed' + this.suffix);
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['start-suffix', 'a-suffix', 'flushed-suffix'], 'all enqueued chunks have suffixes');
+    });
+  });
+}, 'Transform stream should call transformer methods as methods');
+
+promise_test(() => {
+  function functionWithOverloads() {}
+  functionWithOverloads.apply = () => assert_unreached('apply() should not be called');
+  functionWithOverloads.call = () => assert_unreached('call() should not be called');
+  const ts = new TransformStream({
+    start: functionWithOverloads,
+    transform: functionWithOverloads,
+    flush: functionWithOverloads
+  });
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  return readableStreamToArray(ts.readable);
+}, 'methods should not not have .apply() or .call() called');
+
+promise_test(t => {
+  let startCalled = false;
+  let startDone = false;
+  let transformDone = false;
+  let flushDone = false;
+  const ts = new TransformStream({
+    start() {
+      startCalled = true;
+      return flushAsyncEvents().then(() => {
+        startDone = true;
+      });
+    },
+    transform() {
+      return t.step(() => {
+        assert_true(startDone, 'transform() should not be called until the promise returned from start() has resolved');
+        return flushAsyncEvents().then(() => {
+          transformDone = true;
+        });
+      });
+    },
+    flush() {
+      return t.step(() => {
+        assert_true(transformDone,
+                    'flush() should not be called until the promise returned from transform() has resolved');
+        return flushAsyncEvents().then(() => {
+          flushDone = true;
+        });
+      });
+    }
+  }, undefined, { highWaterMark: 1 });
+
+  assert_true(startCalled, 'start() should be called synchronously');
+
+  const writer = ts.writable.getWriter();
+  const writePromise = writer.write('a');
+  return writer.close().then(() => {
+    assert_true(flushDone, 'promise returned from flush() should have resolved');
+    return writePromise;
+  });
+}, 'TransformStream start, transform, and flush should be strictly ordered');
+
+promise_test(() => {
+  let transformCalled = false;
+  const ts = new TransformStream({
+    transform() {
+      transformCalled = true;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  // transform() is only called synchronously when there is no backpressure and all microtasks have run.
+  return delay(0).then(() => {
+    const writePromise = ts.writable.getWriter().write();
+    assert_true(transformCalled, 'transform() should have been called');
+    return writePromise;
+  });
+}, 'it should be possible to call transform() synchronously');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+
+  const writer = ts.writable.getWriter();
+  writer.close();
+
+  return Promise.all([writer.closed, ts.readable.getReader().closed]);
+}, 'closing the writable should close the readable when there are no queued chunks, even with backpressure');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.terminate();
+      assert_throws(new TypeError(), () => controller.enqueue(), 'enqueue should throw');
+    }
+  });
+}, 'enqueue() should throw after controller.terminate()');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelPromise = ts.readable.cancel();
+  assert_throws(new TypeError(), () => controller.enqueue(), 'enqueue should throw');
+  return cancelPromise;
+}, 'enqueue() should throw after readable.cancel()');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.terminate();
+      controller.terminate();
+    }
+  });
+}, 'controller.terminate() should do nothing the second time it is called');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelReason = { name: 'cancelReason' };
+  const cancelPromise = ts.readable.cancel(cancelReason);
+  controller.terminate();
+  return Promise.all([
+    cancelPromise,
+    promise_rejects(t, cancelReason, ts.writable.getWriter().closed, 'closed should reject with cancelReason')
+  ]);
+}, 'terminate() should do nothing after readable.cancel()');
+
+promise_test(() => {
+  let calls = 0;
+  new TransformStream({
+    start() {
+      ++calls;
+    }
+  });
+  return flushAsyncEvents().then(() => {
+    assert_equals(calls, 1, 'start() should have been called exactly once');
+  });
+}, 'start() should not be called twice');
+
+test(() => {
+  assert_throws(new RangeError(), () => new TransformStream({ readableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined readableType should throw');
+
+test(() => {
+  assert_throws(new RangeError(), () => new TransformStream({ writableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined writableType should throw');
+
+done();

--- a/streams/transform-streams/general.js
+++ b/streams/transform-streams/general.js
@@ -122,7 +122,7 @@ promise_test(() => {
       c = controller;
     },
     transform(chunk) {
-      setTimeout(() => c.enqueue(chunk.toUpperCase()), 10);
+      delay(10).then(() => c.enqueue(chunk.toUpperCase()));
       return delay(50);
     }
   });
@@ -144,8 +144,8 @@ promise_test(() => {
       c = controller;
     },
     transform(chunk) {
-      setTimeout(() => c.enqueue(chunk.toUpperCase()), 10);
-      setTimeout(() => c.enqueue(chunk.toUpperCase()), 50);
+      delay(10).then(() => c.enqueue(chunk.toUpperCase()));
+      delay(50).then(() => c.enqueue(chunk.toUpperCase()));
       return delay(90);
     }
   });
@@ -241,9 +241,9 @@ promise_test(() => {
       c = controller;
     },
     transform() {
-      setTimeout(() => c.enqueue('x'), 10);
-      setTimeout(() => c.enqueue('y'), 50);
-      return new Promise(resolve => setTimeout(resolve, 50));
+      delay(10).then(() => c.enqueue('x'));
+      delay(50).then(() => c.enqueue('y'));
+      return delay(50);
     }
   });
 

--- a/streams/transform-streams/general.serviceworker.https.html
+++ b/streams/transform-streams/general.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>general.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('general.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/general.sharedworker.html
+++ b/streams/transform-streams/general.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>general.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('general.js'));
+</script>

--- a/streams/transform-streams/lipfuzz.dedicatedworker.html
+++ b/streams/transform-streams/lipfuzz.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lipfuzz.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('lipfuzz.js'));
+</script>

--- a/streams/transform-streams/lipfuzz.html
+++ b/streams/transform-streams/lipfuzz.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lipfuzz.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+
+
+<script src="lipfuzz.js"></script>

--- a/streams/transform-streams/lipfuzz.js
+++ b/streams/transform-streams/lipfuzz.js
@@ -1,0 +1,168 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+class LipFuzzTransformer {
+  constructor(substitutions) {
+    this.substitutions = substitutions;
+    this.partialChunk = '';
+    this.lastIndex = undefined;
+  }
+
+  transform(chunk, controller) {
+    chunk = this.partialChunk + chunk;
+    this.partialChunk = '';
+    // lastIndex is the index of the first character after the last substitution.
+    this.lastIndex = 0;
+    chunk = chunk.replace(/\{\{([a-zA-Z0-9_-]+)\}\}/g, this.replaceTag.bind(this));
+    // Regular expression for an incomplete template at the end of a string.
+    const partialAtEndRegexp = /\{(\{([a-zA-Z0-9_-]+(\})?)?)?$/g;
+    // Avoid looking at any characters that have already been substituted.
+    partialAtEndRegexp.lastIndex = this.lastIndex;
+    this.lastIndex = undefined;
+    const match = partialAtEndRegexp.exec(chunk);
+    if (match) {
+      this.partialChunk = chunk.substring(match.index);
+      chunk = chunk.substring(0, match.index);
+    }
+    controller.enqueue(chunk);
+  }
+
+  flush(controller) {
+    if (this.partialChunk.length > 0) {
+      controller.enqueue(this.partialChunk);
+    }
+  }
+
+  replaceTag(match, p1, offset) {
+    let replacement = this.substitutions[p1];
+    if (replacement === undefined) {
+      replacement = '';
+    }
+    this.lastIndex = offset + replacement.length;
+    return replacement;
+  }
+}
+
+const substitutions = {
+  in1: 'out1',
+  in2: 'out2',
+  quine: '{{quine}}',
+  bogusPartial: '{{incompleteResult}'
+};
+
+const cases = [
+  {
+    input: [''],
+    output: ['']
+  },
+  {
+    input: [],
+    output: []
+  },
+  {
+    input: ['{{in1}}'],
+    output: ['out1']
+  },
+  {
+    input: ['z{{in1}}'],
+    output: ['zout1']
+  },
+  {
+    input: ['{{in1}}q'],
+    output: ['out1q']
+  },
+  {
+    input: ['{{in1}}{{in1}'],
+    output: ['out1', '{{in1}']
+  },
+  {
+    input: ['{{in1}}{{in1}', '}'],
+    output: ['out1', 'out1']
+  },
+  {
+    input: ['{{in1', '}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{', '{in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}'],
+    output: ['', '', '{{in1}']
+  },
+  {
+    input: ['{'],
+    output: ['', '{']
+  },
+  {
+    input: ['{', ''],
+    output: ['', '', '{']
+  },
+  {
+    input: ['{', '{', 'i', 'n', '1', '}', '}'],
+    output: ['', '', '', '', '', '', 'out1']
+  },
+  {
+    input: ['{{in1}}{{in2}}{{in1}}'],
+    output: ['out1out2out1']
+  },
+  {
+    input: ['{{wrong}}'],
+    output: ['']
+  },
+  {
+    input: ['{{wron', 'g}}'],
+    output: ['', '']
+  },
+  {
+    input: ['{{quine}}'],
+    output: ['{{quine}}']
+  },
+  {
+    input: ['{{bogusPartial}}'],
+    output: ['{{incompleteResult}']
+  },
+  {
+    input: ['{{bogusPartial}}}'],
+    output: ['{{incompleteResult}}']
+  }
+];
+
+for (const testCase of cases) {
+  const inputChunks = testCase.input;
+  const outputChunks = testCase.output;
+  promise_test(() => {
+    const lft = new TransformStream(new LipFuzzTransformer(substitutions));
+    const writer = lft.writable.getWriter();
+    const promises = [];
+    for (const inputChunk of inputChunks) {
+      promises.push(writer.write(inputChunk));
+    }
+    promises.push(writer.close());
+    const reader = lft.readable.getReader();
+    let readerChain = Promise.resolve();
+    for (const outputChunk of outputChunks) {
+      readerChain = readerChain.then(() => {
+        return reader.read().then(({ value, done }) => {
+          assert_false(done, `done should be false when reading ${outputChunk}`);
+          assert_equals(value, outputChunk, `value should match outputChunk`);
+        });
+      });
+    }
+    readerChain = readerChain.then(() => {
+      return reader.read().then(({ done }) => assert_true(done, `done should be true`));
+    });
+    promises.push(readerChain);
+    return Promise.all(promises);
+  }, `testing "${inputChunks}"`);
+}
+
+done();

--- a/streams/transform-streams/lipfuzz.js
+++ b/streams/transform-streams/lipfuzz.js
@@ -162,7 +162,7 @@ for (const testCase of cases) {
     });
     promises.push(readerChain);
     return Promise.all(promises);
-  }, `testing "${inputChunks}"`);
+  }, `testing "${inputChunks}" (length ${inputChunks.length})`);
 }
 
 done();

--- a/streams/transform-streams/lipfuzz.serviceworker.https.html
+++ b/streams/transform-streams/lipfuzz.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lipfuzz.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('lipfuzz.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/lipfuzz.sharedworker.html
+++ b/streams/transform-streams/lipfuzz.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>lipfuzz.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('lipfuzz.js'));
+</script>

--- a/streams/transform-streams/patched-global.dedicatedworker.html
+++ b/streams/transform-streams/patched-global.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>patched-global.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('patched-global.js'));
+</script>

--- a/streams/transform-streams/patched-global.html
+++ b/streams/transform-streams/patched-global.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>patched-global.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+
+
+<script src="patched-global.js"></script>

--- a/streams/transform-streams/patched-global.js
+++ b/streams/transform-streams/patched-global.js
@@ -20,4 +20,34 @@ test(() => {
   assert_not_equals(new TransformStream(), null, 'constructor should work');
 }, 'TransformStream constructor should not call setters for highWaterMark or size');
 
+test(t => {
+  /* eslint-disable no-native-reassign */
+
+  const oldReadableStream = ReadableStream;
+  const oldWritableStream = WritableStream;
+  const getReader = ReadableStream.prototype.getReader;
+  const getWriter = WritableStream.prototype.getWriter;
+
+  // Replace ReadableStream and WritableStream with broken versions.
+  ReadableStream = function () {
+    throw new Error('Called the global ReadableStream constructor');
+  };
+  WritableStream = function () {
+    throw new Error('Called the global WritableStream constructor');
+  };
+  t.add_cleanup(() => {
+    ReadableStream = oldReadableStream;
+    WritableStream = oldWritableStream;
+  });
+
+  const ts = new TransformStream();
+
+  // Just to be sure, ensure the readable and writable pass brand checks.
+  assert_not_equals(getReader.call(ts.readable), undefined,
+                    'getReader should work when called on ts.readable');
+  assert_not_equals(getWriter.call(ts.writable), undefined,
+                    'getWriter should work when called on ts.writable');
+  /* eslint-enable no-native-reassign */
+}, 'TransformStream should use the original value of ReadableStream and WritableStream');
+
 done();

--- a/streams/transform-streams/patched-global.js
+++ b/streams/transform-streams/patched-global.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Tests which patch the global environment are kept separate to avoid interfering with other tests.
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+// eslint-disable-next-line no-extend-native, accessor-pairs
+Object.defineProperty(Object.prototype, 'highWaterMark', {
+  set() { throw new Error('highWaterMark setter called'); }
+});
+
+// eslint-disable-next-line no-extend-native, accessor-pairs
+Object.defineProperty(Object.prototype, 'size', {
+  set() { throw new Error('size setter called'); }
+});
+
+test(() => {
+  assert_not_equals(new TransformStream(), null, 'constructor should work');
+}, 'TransformStream constructor should not call setters for highWaterMark or size');
+
+done();

--- a/streams/transform-streams/patched-global.serviceworker.https.html
+++ b/streams/transform-streams/patched-global.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>patched-global.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('patched-global.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/patched-global.sharedworker.html
+++ b/streams/transform-streams/patched-global.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>patched-global.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('patched-global.js'));
+</script>

--- a/streams/transform-streams/reentrant-strategies.dedicatedworker.html
+++ b/streams/transform-streams/reentrant-strategies.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategies.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('reentrant-strategies.js'));
+</script>

--- a/streams/transform-streams/reentrant-strategies.html
+++ b/streams/transform-streams/reentrant-strategies.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategies.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/rs-utils.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="reentrant-strategies.js"></script>

--- a/streams/transform-streams/reentrant-strategies.js
+++ b/streams/transform-streams/reentrant-strategies.js
@@ -1,0 +1,316 @@
+'use strict';
+
+// The size() function of readableStrategy can re-entrantly call back into the TransformStream implementation. This
+// makes it risky to cache state across the call to ReadableStreamDefaultControllerEnqueue. These tests attempt to catch
+// such errors. They are separated from the other strategy tests because no real user code should ever do anything like
+// this.
+//
+// There is no such issue with writableStrategy size() because it is never called from within TransformStream
+// algorithms.
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/recording-streams.js');
+  self.importScripts('../resources/rs-utils.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(() => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        controller.enqueue('b');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['b', 'a'], 'array should contain two chunks'));
+}, 'enqueue() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // The readable queue is empty.
+      controller.terminate();
+      // The readable state has gone from "readable" to "closed".
+      return 1;
+      // This chunk will be enqueued, but will be impossible to read because the state is already "closed".
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, [], 'array should contain no chunks'));
+  // The chunk 'a' is still in readable's queue. readable is closed so 'a' cannot be read. writable's queue is empty and
+  // it is still writable.
+}, 'terminate() inside size() should work');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      controller.error(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => promise_rejects(t, error1, ts.readable.getReader().read(), 'read() should reject'));
+}, 'error() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      assert_equals(controller.desiredSize, 1, 'desiredSize should be 1');
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['a'], 'array should contain one chunk'));
+}, 'desiredSize inside size() should work');
+
+promise_test(t => {
+  let cancelPromise;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      cancelPromise = ts.readable.cancel(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => {
+        promise_rejects(t, error1, writer.closed, 'writer.closed should reject');
+        return cancelPromise;
+      });
+}, 'readable cancel() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let pipeToPromise;
+  const ws = recordingWritableStream();
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      pipeToPromise = ts.readable.pipeTo(ws);
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  // Allow promise returned by start() to resolve so that enqueue() will happen synchronously.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    // Allow pipeTo() to move the 'a' to the writable.
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a'], 'first chunk should have been written');
+    controller.terminate();
+    return pipeToPromise;
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'close'], 'target should have been closed');
+  });
+}, 'pipeTo() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let readPromise;
+  let calls = 0;
+  let reader;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // This is triggered by controller.enqueue(). The queue is empty and there are no pending reads. pull() is called
+      // synchronously, allowing transform() to proceed asynchronously. This results in a second call to enqueue(),
+      // which resolves this pending read() without calling size() again.
+      readPromise = reader.read();
+      ++calls;
+      return 1;
+    },
+    highWaterMark: 0
+  });
+  reader = ts.readable.getReader();
+  const writer = ts.writable.getWriter();
+  let writeResolved = false;
+  const writePromise = writer.write('b').then(() => {
+    writeResolved = true;
+  });
+  return flushAsyncEvents().then(() => {
+    assert_false(writeResolved);
+    controller.enqueue('a');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return delay(0);
+  }).then(() => {
+    assert_true(writeResolved);
+    assert_equals(calls, 1, 'size() should only be called once');
+    return readPromise;
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    // See https://github.com/whatwg/streams/issues/794 for why this chunk is not 'a'.
+    assert_equals(value, 'b', 'chunk should have been read');
+    assert_equals(calls, 1, 'calls should still be 1');
+    return writePromise;
+  });
+}, 'read() inside of size() should work');
+
+promise_test(() => {
+  let writer;
+  let writePromise1;
+  let calls = 0;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise1 = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This write results in a synchronous call to transform(), enqueue(), and size().
+    const writePromise2 = writer.write('b');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return Promise.all([writePromise1, writePromise2, writer.close()]);
+  }).then(() => {
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    assert_array_equals(array, ['b', 'a'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'writer.write() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let writer;
+  let writePromise;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This enqueue results in synchronous calls to size(), write(), transform() and enqueue().
+    controller.enqueue('b');
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return Promise.all([writePromise, writer.close()]);
+  }).then(() => {
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    // Because one call to enqueue() is nested inside the other, they finish in the opposite order that they were
+    // called, so the chunks end up reverse order.
+    assert_array_equals(array, ['a', 'b'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'synchronous writer.write() inside size() should work');
+
+promise_test(() => {
+  let writer;
+  let closePromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      closePromise = writer.close();
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to close() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be correct');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+    return closePromise;
+  });
+}, 'writer.close() inside size() should work');
+
+promise_test(t => {
+  let abortPromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      abortPromise = ts.writable.abort(error1);
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to abort() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return Promise.all([promise_rejects(t, new TypeError(), reader.read(), 'read() should reject'), abortPromise]);
+  });
+}, 'writer.abort() inside size() should work');
+
+done();

--- a/streams/transform-streams/reentrant-strategies.serviceworker.https.html
+++ b/streams/transform-streams/reentrant-strategies.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategies.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('reentrant-strategies.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/reentrant-strategies.sharedworker.html
+++ b/streams/transform-streams/reentrant-strategies.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>reentrant-strategies.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('reentrant-strategies.js'));
+</script>

--- a/streams/transform-streams/strategies.dedicatedworker.html
+++ b/streams/transform-streams/strategies.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>strategies.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('strategies.js'));
+</script>

--- a/streams/transform-streams/strategies.html
+++ b/streams/transform-streams/strategies.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>strategies.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="strategies.js"></script>

--- a/streams/transform-streams/strategies.js
+++ b/streams/transform-streams/strategies.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Here we just test that the strategies are correctly passed to the readable and writable sides. We assume that
+// ReadableStream and WritableStream will correctly apply the strategies when they are being used by a TransformStream
+// and so it isn't necessary to repeat their tests here.
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/recording-streams.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+test(() => {
+  const ts = new TransformStream({}, { highWaterMark: 17 });
+  assert_equals(ts.writable.getWriter().desiredSize, 17, 'desiredSize should be 17');
+}, 'writableStrategy highWaterMark should work');
+
+promise_test(() => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 9 });
+  const writer = ts.writable.getWriter();
+  for (let i = 0; i < 10; ++i) {
+    writer.write(i);
+  }
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, [
+      'transform', 0, 'transform', 1, 'transform', 2, 'transform', 3, 'transform', 4,
+      'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
+                        'transform() should have been called 9 times');
+  });
+}, 'readableStrategy highWaterMark should work');
+
+promise_test(t => {
+  let writableSizeCalled = false;
+  let readableSizeCalled = false;
+  let transformCalled = false;
+  const ts = new TransformStream(
+    {
+      transform(chunk, controller) {
+        t.step(() => {
+          transformCalled = true;
+          assert_true(writableSizeCalled, 'writableStrategy.size() should have been called');
+          assert_false(readableSizeCalled, 'readableStrategy.size() should not have been called');
+          controller.enqueue(chunk);
+          assert_true(readableSizeCalled, 'readableStrategy.size() should have been called');
+        });
+      }
+    },
+    {
+      size() {
+        writableSizeCalled = true;
+        return 1;
+      }
+    },
+    {
+      size() {
+        readableSizeCalled = true;
+        return 1;
+      },
+      highWaterMark: Infinity
+    });
+  return ts.writable.getWriter().write().then(() => {
+    assert_true(transformCalled, 'transform() should be called');
+  });
+}, 'writable should have the correct size() function');
+
+test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'default writable HWM is 1');
+  // There should be no size function, but a size function that always returns 1 is indistinguishable.
+  writer.write(undefined);
+  assert_equals(writer.desiredSize, 0, 'default chunk size is 1');
+}, 'default writable strategy should be equivalent to { highWaterMark: 1 }');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      return t.step(() => {
+        assert_equals(controller.desiredSize, 0, 'desiredSize should be 0');
+        controller.enqueue(undefined);
+        // The first chunk enqueued is consumed by the pending read().
+        assert_equals(controller.desiredSize, 0, 'desiredSize should still be 0');
+        controller.enqueue(undefined);
+        assert_equals(controller.desiredSize, -1, 'desiredSize should be -1');
+      });
+    }
+  });
+  const writePromise = ts.writable.getWriter().write();
+  return ts.readable.getReader().read().then(() => writePromise);
+}, 'default readable strategy should be equivalent to { highWaterMark: 0 }');
+
+done();

--- a/streams/transform-streams/strategies.serviceworker.https.html
+++ b/streams/transform-streams/strategies.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>strategies.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('strategies.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/strategies.sharedworker.html
+++ b/streams/transform-streams/strategies.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>strategies.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('strategies.js'));
+</script>

--- a/streams/transform-streams/terminate.dedicatedworker.html
+++ b/streams/transform-streams/terminate.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>terminate.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('terminate.js'));
+</script>

--- a/streams/transform-streams/terminate.html
+++ b/streams/transform-streams/terminate.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>terminate.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/recording-streams.js"></script>
+<script src="../resources/test-utils.js"></script>
+
+<script src="terminate.js"></script>

--- a/streams/transform-streams/terminate.js
+++ b/streams/transform-streams/terminate.js
@@ -1,0 +1,105 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/recording-streams.js');
+  self.importScripts('../resources/test-utils.js');
+}
+
+promise_test(t => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 0 });
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(0);
+    }
+  });
+  let pipeToRejected = false;
+  const pipeToPromise = promise_rejects(t, new TypeError(), rs.pipeTo(ts.writable), 'pipeTo should reject').then(() => {
+    pipeToRejected = true;
+  });
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, [], 'transform() should have seen no chunks');
+    assert_false(pipeToRejected, 'pipeTo() should not have rejected yet');
+    ts.controller.terminate();
+    return pipeToPromise;
+  }).then(() => {
+    assert_array_equals(ts.events, [], 'transform() should still have seen no chunks');
+    assert_true(pipeToRejected, 'pipeToRejected must be true');
+  });
+}, 'controller.terminate() should error pipeTo()');
+
+promise_test(t => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 1 });
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.enqueue(1);
+    }
+  });
+  const pipeToPromise = rs.pipeTo(ts.writable);
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, ['transform', 0], 'transform() should have seen one chunk');
+    ts.controller.terminate();
+    return promise_rejects(t, new TypeError(), pipeToPromise, 'pipeTo() should reject');
+  }).then(() => {
+    assert_array_equals(ts.events, ['transform', 0], 'transform() should still have seen only one chunk');
+  });
+}, 'controller.terminate() should prevent remaining chunks from being processed');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.terminate();
+      assert_throws(new TypeError(), () => controller.enqueue(1), 'enqueue should throw');
+    }
+  });
+}, 'controller.enqueue() should throw after controller.terminate()');
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.terminate();
+      controller.error(error1);
+    }
+  });
+  return Promise.all([
+    promise_rejects(t, new TypeError(), ts.writable.abort(), 'abort() should reject with a TypeError'),
+    promise_rejects(t, error1, ts.readable.cancel(), 'cancel() should reject with error1'),
+    promise_rejects(t, error1, ts.readable.getReader().closed, 'closed should reject with error1')
+  ]);
+}, 'controller.error() after controller.terminate() with queued chunk should error the readable');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.terminate();
+      controller.error(error1);
+    }
+  });
+  return Promise.all([
+    promise_rejects(t, new TypeError(), ts.writable.abort(), 'abort() should reject with a TypeError'),
+    ts.readable.cancel(),
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.error() after controller.terminate() without queued chunk should do nothing');
+
+promise_test(() => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.terminate();
+    }
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([
+    writer.close(),
+    writer.closed,
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.terminate() inside flush() should not prevent writer.close() from succeeding');
+
+done();

--- a/streams/transform-streams/terminate.serviceworker.https.html
+++ b/streams/transform-streams/terminate.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>terminate.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('terminate.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/terminate.sharedworker.html
+++ b/streams/transform-streams/terminate.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>terminate.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('terminate.js'));
+</script>


### PR DESCRIPTION
Copy the tests for transform streams from the whatwg/streams repository.

TransformStream has now been added to the Streams Standard so it seems
reasonable to move these tests to the web-platform-tests repository. A follow-on
change will remove them from the whatwg/streams repository.

See https://github.com/whatwg/streams/issues/851.

There are no changes to the test Javascript files. They have all been
reviewed in their old location. All the HTML files have been regenerated by
generate-test-wrappers.js.

recording-streams.js has an additional "recordingTransformStream" function which
is used in some of the new tests. test-utils.js has an additional
"constructorThrowsForAll" test helper.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
