### PR TITLE
The descriptive text was missing the word "filled" with respect to the reference file

### DIFF
--- a/css/CSS2/visufx/visibility-005.xht
+++ b/css/CSS2/visufx/visibility-005.xht
@@ -34,7 +34,7 @@
 
  <body>
 
-  <p>Test passes if there is a green square and <strong>no red</strong>.</p>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
   <div>
       <span id="testpassed">X</span> <span>X</span>


### PR DESCRIPTION


<!-- Reviewable:start -->

<!-- Reviewable:end -->
