### PR TITLE
Fix #8095: give a better error message when elementsFromPoint is unsupported

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -28,9 +28,11 @@
 
         if ("elementsFromPoint" in document) {
             return document.elementsFromPoint(centerPoint[0], centerPoint[1]);
-        } else {
+        } else if ("msElementsFromPoint" in document) {
             var rv = document.msElementsFromPoint(centerPoint[0], centerPoint[1]);
             return Array.prototype.slice.call(rv ? rv : []);
+        } else {
+            throw new Error("document.elementsFromPoint unsupported");
         }
     }
 


### PR DESCRIPTION
MDN lied to me, Safari doesn't support document.elementsFromPoint 😞

fixes #8095

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8101)
<!-- Reviewable:end -->
