### PR TITLE
Sync Mozilla reftests as of 2017-11-08

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/break3/moz-block-fragmentation-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/break3/moz-block-fragmentation-001-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html class="reftest-paged">
+<title>
+  Reference
+</title>
+<style>
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    left: 0; right: 0;
+    height: 100%;
+  }
+  div {
+    border: solid orange 10px;
+  }
+  div + div {
+    border: solid transparent 20px;
+  }
+  div > div {
+    border: solid gray 10px;
+    height: 300%;
+  }
+</style>
+<div></div>
+<div>
+  <div></div>
+</div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/break3/moz-block-fragmentation-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/break3/moz-block-fragmentation-001.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html class="reftest-paged">
+<title>
+  Overflowing content does not affect whether a fixed-height box fits on a page,
+  but does get printed on the next page.
+</title>
+<meta name="flags" content="may print">
+<link rel="match" href="moz-block-fragmentation-001-ref.html">
+<link rel="help" href="https://www.w3.org/TR/css-break-3/#parallel-flows">
+<style>
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+  }
+  body {
+    border: solid orange 10px;
+    padding: 10px;
+  }
+  div {
+    border: solid gray 10px;
+    height: 300%;
+  }
+</style>
+<div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/break3/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/break3/reftest.list
@@ -1,0 +1,1 @@
+== moz-block-fragmentation-001.html moz-block-fragmentation-001-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/masking/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/masking/reftest.list
@@ -87,7 +87,6 @@
 == mask-size-percent-percent.html mask-size-percent-percent-ref.html
 == mask-size-percent-percent-stretch.html mask-size-percent-percent-stretch-ref.html
 
-
 == clip-path-contentBox-1a.html clip-path-geometryBox-1-ref.html
 == clip-path-contentBox-1b.html clip-path-geometryBox-1-ref.html
 == clip-path-contentBox-1c.html clip-path-geometryBox-1-ref.html
@@ -107,8 +106,6 @@
 == clip-path-geometryBox-2.html clip-path-geometryBox-2-ref.html
 
 == clip-path-localRef-1.html clip-path-localRef-1-ref.html
-
-default-preferences
 
 # mask with opacity test cases
 == mask-opacity-1a.html mask-opacity-1-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/reftest.list
@@ -16,6 +16,9 @@ include css21/reftest.list
 # Backgrounds and Borders
 include background/reftest.list
 
+# Fragmentation
+include break3/reftest.list
+
 # Color Level 4
 include color4/reftest.list
 

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001z.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/text-decor-3/text-emphasis-line-height-001z.html
@@ -10,6 +10,8 @@
 textarea {
   all: inherit;
   width: 100%;
+  height: 10em; /* ensure there's plenty of height even if the default font is quite tall,
+                   to avoid risk of a vertical scrollbar showing up inside textarea */
   box-sizing: border-box;
   border: 0 none; margin: 0; padding: 0;
 }


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/f63559d7e6a570e4e73ba367964099394248e18d .

Previously reviewed in [bug 1364714](https://bugzilla.mozilla.org/show_bug.cgi?id=1364714) (text-decor-3 test) and [bug 1141765](https://bugzilla.mozilla.org/show_bug.cgi?id=1411765) (break3 tests).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
