### PR TITLE
Expand request-headers-case.any.js.

### DIFF
--- a/fetch/api/basic/request-headers-case.any.js
+++ b/fetch/api/basic/request-headers-case.any.js
@@ -2,5 +2,10 @@ promise_test(() => {
   return fetch("/XMLHttpRequest/resources/echo-headers.py", {headers: [["THIS-is-A-test", 1], ["THIS-IS-A-TEST", 2]] }).then(res => res.text()).then(body => {
     assert_regexp_match(body, /THIS-is-A-test: 1, 2/)
   })
-}, "Multiple headers with the same name, different case")
+}, "Multiple headers with the same name, different case (THIS-is-A-test first)")
 
+promise_test(() => {
+  return fetch("/XMLHttpRequest/resources/echo-headers.py", {headers: [["THIS-IS-A-TEST", 1], ["THIS-is-A-test", 2]] }).then(res => res.text()).then(body => {
+    assert_regexp_match(body, /THIS-IS-A-TEST: 1, 2/)
+  })
+}, "Multiple headers with the same name, different case (THIS-IS-A-TEST first)")


### PR DESCRIPTION
In particular, this catches a bug in libsoup (used by WebKitGTK), where the
casing of headers depends on global state.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
