### PR TITLE
Updating WebDriver element state tests for handling user prompts

### DIFF
--- a/webdriver/tests/state/get_element_attribute.py
+++ b/webdriver/tests/state/get_element_attribute.py
@@ -28,24 +28,25 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.2 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #3")
@@ -55,50 +56,52 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.2 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_missing_value(session, create_dialog):
+def test_handle_prompt_missing_value(session):
     # 13.2 step 2
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
-    result = get_attribute(session, "foo", "id")
+    result = get_attribute(session, element.id, "id")
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #3")

--- a/webdriver/tests/state/get_element_property.py
+++ b/webdriver/tests/state/get_element_property.py
@@ -23,12 +23,13 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.3 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #1")
@@ -37,7 +38,7 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #2")
@@ -46,7 +47,7 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #3")
@@ -57,12 +58,13 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.3 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #1")
@@ -71,7 +73,7 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #2")
@@ -80,21 +82,22 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_success(result, "foo")
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_missing_value(session, create_dialog):
+def test_handle_prompt_missing_value(session):
     # 13.3 step 2
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
@@ -103,7 +106,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #2")
@@ -112,7 +115,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/property/id"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #3")

--- a/webdriver/tests/state/get_element_tag_name.py
+++ b/webdriver/tests/state/get_element_tag_name.py
@@ -21,32 +21,33 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.6 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #3")
 
 
@@ -54,44 +55,46 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.6 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, "input")
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_missing_value(session, create_dialog):
+def test_handle_prompt_missing_value(session):
     # 13.6 step 2
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
@@ -100,7 +103,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #2")
@@ -109,7 +112,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/name"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #3")

--- a/webdriver/tests/state/is_element_selected.py
+++ b/webdriver/tests/state/is_element_selected.py
@@ -30,32 +30,33 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     # 13.1 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #3")
 
 
@@ -63,44 +64,46 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     # 13.1 step 2
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #1")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #2")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
-    assert_success(result, "foo")
+    assert_success(result, False)
     assert_dialog_handled(session, "dismiss #3")
 
 
-def test_handle_prompt_missing_value(session, create_dialog):
+def test_handle_prompt_missing_value(session):
     # 13.1 step 2
     session.url = inline("<input id=foo>")
+    element = session.find.css("#foo", all=False)
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
@@ -109,7 +112,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #2")
@@ -118,7 +121,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     result = session.transport.send("GET", "session/{session_id}/element/{element_id}/selected"
                                     .format(session_id=session.session_id,
-                                            element_id="foo"))
+                                            element_id=element.id))
 
     assert_error(result, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #3")


### PR DESCRIPTION
The tests for element state were asserting a success after handling a user
prompt. However, the way the URL end point was formatted in the test, an
error response was being returned. This commit corrects that.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
