### PR TITLE
Meta: Add preload/OWNERS

### DIFF
--- a/preload/OWNERS
+++ b/preload/OWNERS
@@ -1,0 +1,5 @@
+@sideshowbarker
+@igrigorik
+@zcorpan
+@foolip
+@snuggs

--- a/preload/OWNERS
+++ b/preload/OWNERS
@@ -1,5 +1,2 @@
-@sideshowbarker
-@yoavweiss
-@igrigorik
-@zcorpan
 @snuggs
+@yoavweiss

--- a/preload/OWNERS
+++ b/preload/OWNERS
@@ -1,5 +1,4 @@
 @sideshowbarker
 @igrigorik
 @zcorpan
-@foolip
 @snuggs

--- a/preload/OWNERS
+++ b/preload/OWNERS
@@ -1,4 +1,5 @@
 @sideshowbarker
+@yoavweiss
 @igrigorik
 @zcorpan
 @snuggs


### PR DESCRIPTION
AKA the #ironic PR.

![capture d ecran 2017-11-26 a 01 23 53](https://user-images.githubusercontent.com/38223/33237704-8d19ebd2-d248-11e7-82b9-1e4f30d65203.png)

- Add missing `preload/OWNERS`
- Request to be notified of `preload/**` changes.

Following instructions within http://web-platform-tests.org/introduction.html#github

<!-- Reviewable:start -->

<!-- Reviewable:end -->

@sideshowbarker @igrigorik @zcorpan @foolip Feel free to remove yourself if you would prefer to not have the extra spam. However, interest in `rel=preload` is increasing and `wpt-pr-bot` doesn't lie :-)