### PR TITLE
Fix all non-zero delays in transform stream tests

### DIFF
--- a/streams/transform-streams/flush.js
+++ b/streams/transform-streams/flush.js
@@ -19,7 +19,6 @@ promise_test(() => {
   });
 }, 'TransformStream flush is called immediately when the writable is closed, if no writes are queued');
 
-// TODO
 promise_test(() => {
   let flushCalled = false;
   let resolveTransform;

--- a/streams/transform-streams/flush.js
+++ b/streams/transform-streams/flush.js
@@ -20,17 +20,20 @@ promise_test(() => {
 }, 'TransformStream flush is called immediately when the writable is closed, if no writes are queued');
 
 // TODO
-test(() => {
+promise_test(() => {
   let flushCalled = false;
+  let resolveTransform;
   const ts = new TransformStream({
     transform() {
-      return delay(10);
+      return new Promise(resolve => {
+        resolveTransform = resolve;
+      });
     },
     flush() {
       flushCalled = true;
       return new Promise(() => {}); // never resolves
     }
-  });
+  }, undefined, { highWaterMark: 1 });
 
   const writer = ts.writable.getWriter();
   writer.write('a');
@@ -42,7 +45,11 @@ test(() => {
     rsClosed = true;
   });
 
-  return delay(50).then(() => {
+  return delay(0).then(() => {
+    assert_false(flushCalled, 'closing the writable does not asynchronously call flush if writes are not finished');
+    resolveTransform();
+    return delay(0);
+  }).then(() => {
     assert_true(flushCalled, 'flush is eventually called');
     assert_false(rsClosed, 'if flushPromise does not resolve, the readable does not become closed');
   });


### PR DESCRIPTION
Some tests for TransformStream used the delay() function with non-zero
delays. Mostly this was done to make things happen asynchronously in a
particular order, and has been replaced with equivalent code using
promise chains.

The test "TransformStream flush is called after all queued writes
finish, once the writable is closed" was passing accidentally as it was
using test() where it should have been using promise_test(). In addition
to removing non-zero delays from the test, also fix it to use
promise_test() and remove the backpressure that was causing transform()
to never be called.

See https://github.com/whatwg/streams/issues/548 for background on this
clean-up.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
