### PR TITLE
Removing unneeded initial capabilities for IE

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -31,8 +31,6 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     ieOptions = {}
     ieOptions["requireWindowFocus"] = True
     capabilities = {}
-    capabilities["browserName"] = "internet explorer"
-    capabilities["platformName"] = "windows"
     capabilities["se:ieOptions"] = ieOptions
     executor_kwargs = base_executor_kwargs(test_type, server_config,
                                            cache_manager, **kwargs)


### PR DESCRIPTION
When the initial work was done to allow use of IE with WPT WebDriver tests, initial capabilities were added that are not needed, and that cause failures in the tests that exercise WebDriver's new session command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8157)
<!-- Reviewable:end -->
