### PR TITLE
Implement wdpec support for Edge

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -438,7 +438,7 @@ class Session(object):
             bug:
             https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14641972
             """
-            if url == "session" and method == "POST" and "sessionId" in response.body:
+            if url == "session" and method == "POST" and "sessionId" in response.body and "sessionId" not in value:
                 value["sessionId"] = response.body["sessionId"]
         else:
             raise error.UnknownErrorException("No 'value' key in response body:\n%s" %

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -432,7 +432,7 @@ class Session(object):
         if "value" in response.body:
             value = response.body["value"]
             """
-            Edge does not yet return the w3c session ID. 
+            Edge does not yet return the w3c session ID.
             We want the tests to run in Edge anyway to help with REC.
             In order to run the tests in Edge, we need to hack around
             bug:

--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -431,6 +431,15 @@ class Session(object):
 
         if "value" in response.body:
             value = response.body["value"]
+            """
+            Edge does not yet return the w3c session ID. 
+            We want the tests to run in Edge anyway to help with REC.
+            In order to run the tests in Edge, we need to hack around
+            bug:
+            https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/14641972
+            """
+            if url == "session" and method == "POST" and "sessionId" in response.body:
+                value["sessionId"] = response.body["sessionId"]
         else:
             raise error.UnknownErrorException("No 'value' key in response body:\n%s" %
                                               json.dumps(response.body))

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -3,12 +3,14 @@ from ..webdriver_server import EdgeDriverServer
 from ..executors import executor_kwargs as base_executor_kwargs
 from ..executors.executorselenium import (SeleniumTestharnessExecutor,
                                           SeleniumRefTestExecutor)
+from ..executors.executoredge import EdgeDriverWdspecExecutor
 
 __wptrunner__ = {"product": "edge",
                  "check_args": "check_args",
                  "browser": "EdgeBrowser",
                  "executor": {"testharness": "SeleniumTestharnessExecutor",
-                              "reftest": "SeleniumRefTestExecutor"},
+                              "reftest": "SeleniumRefTestExecutor",
+                              "wdspec": "EdgeDriverWdspecExecutor"},
                  "browser_kwargs": "browser_kwargs",
                  "executor_kwargs": "executor_kwargs",
                  "env_extras": "env_extras",

--- a/tools/wptrunner/wptrunner/executors/executoredge.py
+++ b/tools/wptrunner/wptrunner/executors/executoredge.py
@@ -1,0 +1,10 @@
+from ..webdriver_server import EdgeDriverServer
+from .base import WdspecExecutor, WebDriverProtocol
+
+
+class EdgeDriverProtocol(WebDriverProtocol):
+    server_cls = EdgeDriverServer
+
+
+class EdgeDriverWdspecExecutor(WdspecExecutor):
+    protocol_cls = EdgeDriverProtocol

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -12,7 +12,7 @@ import mozprocess
 
 
 __all__ = ["SeleniumServer", "ChromeDriverServer", "OperaDriverServer",
-           "GeckoDriverServer", "InternetExplorerDriverServer",
+           "GeckoDriverServer", "InternetExplorerDriverServer", "EdgeDriverServer",
            "ServoDriverServer", "WebDriverServer"]
 
 
@@ -137,6 +137,18 @@ class ChromeDriverServer(WebDriverServer):
                 cmd_arg("port", str(self.port)),
                 cmd_arg("url-base", self.base_path) if self.base_path else ""] + self._args
 
+class EdgeDriverServer(WebDriverServer):
+    default_base_path = "/"
+
+    def __init__(self, logger, binary="microsoftwebdriver.exe", port=None,
+                 base_path="", args=None):
+        WebDriverServer.__init__(
+            self, logger, binary, port=port, base_path=base_path, args=args)
+
+    def make_command(self):
+        return [self.binary,
+                cmd_arg("port", str(self.port)),
+                cmd_arg("url-base", self.base_path) if self.base_path else ""] + self._args
 
 class OperaDriverServer(ChromeDriverServer):
     def __init__(self, logger, binary="operadriver", port=None,


### PR DESCRIPTION
In order to run the wdspec tests in Edge, we need to implement the WdspecExecutor.

Included in this change is a hack to run the tests even though we do not return a valid w3c session ID yet.

@jgraham - I removed the lines where we Printed the session Id for debugging. You mentioned making the change a little cleaner, but I'm not sure if you wanted something different from what I have here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8167)
<!-- Reviewable:end -->
