### PR TITLE
Update the getGamepads() IDL syntax to match the spec

### DIFF
--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -52,7 +52,7 @@ dictionary GamepadEventInit : EventInit
 };
 
 partial interface Navigator {
-    Gamepad[] getGamepads();
+    sequence<Gamepad?> getGamepads();
 };
 </pre>
 <script>


### PR DESCRIPTION
https://w3c.github.io/gamepad/#navigator-interface-extension

<!-- Reviewable:start -->

<!-- Reviewable:end -->
