### PR TITLE
Fix two duplicate callback definitions in Web Audio IDL

### DIFF
--- a/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-delaynode-interface/idl-test.html
@@ -32,7 +32,7 @@ callback interface EventListener {
 interface EventListener {};
 </pre>
 
-   <pre id="base-audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
+   <pre id="base-audio-context-idl">callback DecodeErrorCallback = void (DOMException error);
 
 callback DecodeSuccessCallback = void (AudioBuffer decodedData);
 

--- a/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
+++ b/webaudio/the-audio-api/the-gainnode-interface/idl-test.html
@@ -32,7 +32,7 @@ callback interface EventListener {
 interface EventListener {};
 </pre>
 
-   <pre id="base-audio-context-idl">callback DecodeSuccessCallback = void (AudioBuffer decodedData);
+   <pre id="base-audio-context-idl">callback DecodeErrorCallback = void (DOMException error);
 callback DecodeSuccessCallback = void (AudioBuffer decodedData);
 
 interface BaseAudioContext : EventTarget {


### PR DESCRIPTION
This is causing a parse error with upgraded webidl2.js:
https://github.com/w3c/web-platform-tests/pull/8063

<!-- Reviewable:start -->

<!-- Reviewable:end -->
