### PR TITLE
Some service worker tests rely on a document body which might be null

### DIFF
--- a/service-workers/service-worker/activation.https.html
+++ b/service-workers/service-worker/activation.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
+<body>
 <script>
 // Registers, waits for activation, then unregisters on a dummy scope.
 //
@@ -177,3 +178,4 @@ promise_test(t => {
         });
   }, 'finishing a request triggers unregister');
 </script>
+</body>

--- a/service-workers/service-worker/registration-iframe.https.html
+++ b/service-workers/service-worker/registration-iframe.https.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="resources/test-helpers.sub.js"></script>
+<body>
 <script>
 
 // Set script url and scope url relative to the iframe's document's url. Assert
@@ -112,3 +113,4 @@ async_test(function(t) {
   }, 'A scope url should start with the given script url');
 
 </script>
+</body>


### PR DESCRIPTION
On WebKit side, there is a race so that document.body might be null when with_iframe is called.
This makes the tests fail.
Although additional investigation should be done to see whether body should or should not be null in that case, this change allows making the following two tests more robust.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
