### PR TITLE
Fix service-workers/service-worker/getregistrations.https.html

### DIFF
--- a/service-workers/service-worker/getregistrations.https.html
+++ b/service-workers/service-worker/getregistrations.https.html
@@ -61,10 +61,9 @@ promise_test(function(t) {
           return navigator.serviceWorker.getRegistrations();
         })
       .then(function(value) {
-          assert_array_equals(
-            value,
-            registrations,
-            'getRegistrations should resolve with array of registrations.');
+          assert_equals(value.length, registrations.length, "Should return the right number of registrations");
+          for (let registration of registrations)
+              assert_in_array(registration, value, "Should return the right registrations");
           return service_worker_unregister(t, scope1);
         })
       .then(function() {


### PR DESCRIPTION
The test expected the registrations returned by getRegistrations() to be
in a specific order but nothing seems the guarantee a given order in the
specification.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
