### PR TITLE
Handle a rare error case more gracefully.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -160,8 +160,13 @@ class MarionetteProtocol(Protocol):
             runner_handle = handles.pop(0)
 
         for handle in handles:
-            self.marionette.switch_to_window(handle)
-            self.marionette.close()
+            try:
+                self.marionette.switch_to_window(handle)
+                self.marionette.close()
+            except errors.NoSuchWindowException:
+                # We might have raced with the previous test to close this
+                # window, skip it.
+                pass
 
         self.marionette.switch_to_window(runner_handle)
         if runner_handle != self.runner_handle:


### PR DESCRIPTION

In certain rare cases, it's possible for a previous test to close a window
between the executor getting the window list and trying to close the needed
windows.

MozReview-Commit-ID: GTzoOxBaPwl

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1403428 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8210)
<!-- Reviewable:end -->
