### PR TITLE
Intermittent pointerevent_touch-action-button-test_touch-manual.html. r=kats.

### DIFF
--- a/pointerevents/pointerevent_support.js
+++ b/pointerevents/pointerevent_support.js
@@ -161,10 +161,13 @@ function updateDescriptionSecondStepTouchActionElement(target, scrollReturnInter
     document.getElementById('desc').innerHTML = "Test Description: Try to scroll element RIGHT moving your outside of the red border";
 }
 
-function updateDescriptionThirdStepTouchActionElement(target, scrollReturnInterval) {
+function updateDescriptionThirdStepTouchActionElement(target, scrollReturnInterval, callback = null) {
     window.step_timeout(function() {
-    objectScroller(target, 'left', 0);}
-    , scrollReturnInterval);
+        objectScroller(target, 'left', 0);
+        if (callback) {
+            callback();
+        }
+    }, scrollReturnInterval);
     document.getElementById('desc').innerHTML = "Test Description: Try to scroll element DOWN then RIGHT starting your touch inside of the element. Then tap complete button";
 }
 

--- a/pointerevents/pointerevent_touch-action-button-test_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-button-test_touch-manual.html
@@ -88,10 +88,11 @@
 
                         if(xScrollIsReceived && yScrollIsReceived) {
                             test_touchaction_div.done();
-                            updateDescriptionThirdStepTouchActionElement(target0, scrollReturnInterval);
-                            setTimeout(function() {
-                                isFirstPart = false;
-                            }, 2 * scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            updateDescriptionThirdStepTouchActionElement(target0, scrollReturnInterval, function () {
+                                setTimeout(function() {
+                                    isFirstPart = false;
+                                }, scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            });
                         }
                     }
                     else {

--- a/pointerevents/pointerevent_touch-action-span-test_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-span-test_touch-manual.html
@@ -91,14 +91,15 @@
 
                         if(xScrollIsReceived && yScrollIsReceived) {
                             test_touchaction_div.done();
-                            updateDescriptionThirdStepTouchActionElement(target0, scrollReturnInterval);
-                            setTimeout(function() {
-                                isFirstPart = false;
-                                xScr0 = target0.scrollLeft;
-                                xScr0 = target0.scrollLeft;
-                                xScrollIsReceived = false;
-                                yScrollIsReceived = false;
-                            }, 2 * scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            updateDescriptionThirdStepTouchActionElement(target0, scrollReturnInterval, function () {
+                                setTimeout(function() {
+                                    isFirstPart = false;
+                                    xScr0 = target0.scrollLeft;
+                                    xScr0 = target0.scrollLeft;
+                                    xScrollIsReceived = false;
+                                    yScrollIsReceived = false;
+                                }, scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            });
                         }
                     }
                 });

--- a/pointerevents/pointerevent_touch-action-table-test_touch-manual.html
+++ b/pointerevents/pointerevent_touch-action-table-test_touch-manual.html
@@ -103,10 +103,11 @@
 
                         if(xScrollIsReceived && yScrollIsReceived) {
                             test_touchaction_row.done();
-                            updateDescriptionThirdStepTable(target0, scrollReturnInterval);
-                            setTimeout(function() {
-                                isFirstPart = false;
-                            }, 2 * scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            updateDescriptionThirdStepTable(target0, scrollReturnInterval, function() {
+                                setTimeout(function() {
+                                    isFirstPart = false;
+                                }, scrollReturnInterval); // avoid immediate triggering while scroll is still being performed
+                            });
                         }
                     }
                     else {
@@ -123,9 +124,12 @@
                 document.getElementById('desc').innerHTML = "Test Description: Try to scroll element RIGHT staring your touch over the Row 1";
             }
 
-            function updateDescriptionThirdStepTable(target, scrollReturnInterval) {
+            function updateDescriptionThirdStepTable(target, scrollReturnInterval, callback = null) {
                 window.setTimeout(function() {
                     objectScroller(target, 'left', 0);
+                    if (callback) {
+                        callback();
+                    }
                 }
                 , scrollReturnInterval);
                 document.getElementById('desc').innerHTML = "Test Description: Try to scroll element DOWN then RIGHT starting your touch inside of the Cell 3";


### PR DESCRIPTION

The test case uses double intervals to make sure there is enough time to wait for the scroll event before continuing the testing. However, it doesn't work while the first timeout is delayed and the second one isn't. Tweaked the test case to start the second timer when the first one timeout.

MozReview-Commit-ID: gvhtIpzauE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1347689 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
