### PR TITLE
Fix error.get argument name.

### DIFF
--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -145,11 +145,12 @@ class UnsupportedOperationException(WebDriverException):
     status_code = "unsupported operation"
 
 
-def get(status_code):
-    """Gets exception from `status_code`, falling back to
+def get(error_code):
+    """
+    Gets exception from `error_code`, falling back to
     ``WebDriverException`` if it is not found.
     """
-    return _errors.get(status_code, WebDriverException)
+    return _errors.get(error_code, WebDriverException)
 
 
 _errors = collections.defaultdict()


### PR DESCRIPTION

We talk about "error codes", not "status codes", for WebDriver errors.

This is a non-functional change.

MozReview-Commit-ID: Bl8zT8lZvzK

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411045 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8222)
<!-- Reviewable:end -->
