### PR TITLE
Display error when response is unsuccessful.

### DIFF
--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -68,6 +68,7 @@ def assert_error(response, error_code):
     assert isinstance(response.body["value"]["message"], basestring)
     assert isinstance(response.body["value"]["stacktrace"], basestring)
 
+
 def assert_success(response, value=None):
     """Verify that the provided wdclient.Response instance described a valid
     error response as defined by `dfn-send-an-error` and the provided error
@@ -77,10 +78,12 @@ def assert_success(response, value=None):
     :param value: Expected value of the response body, if any.
 
     """
-    assert response.status == 200
+    assert response.status == 200, str(response.error)
+
     if value is not None:
         assert response.body["value"] == value
     return response.body.get("value")
+
 
 def assert_dialog_handled(session, expected_text):
     result = session.transport.send("GET",
@@ -96,6 +99,7 @@ def assert_dialog_handled(session, expected_text):
         assert (result.status == 200 and
                 result.body["value"] != expected_text), (
                "Dialog with text '%s' was not handled." % expected_text)
+
 
 def assert_same_element(session, a, b):
     """Verify that two element references describe the same element."""


### PR DESCRIPTION

Instead of the default pytest error message when the assertion
fails, which is rather pointless because we know we did not match
the 200 HTTP status code, display the string representation of
wdclient.error.WebDriverException.

This string representation includes the remote end's stacktrace,
which is infinitely more useful in this context.

MozReview-Commit-ID: 6XUgEEc9Qoj

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411045 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8224)
<!-- Reviewable:end -->
