### PR TITLE
Show local variables in wdspec tracebacks.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -56,6 +56,7 @@ def run(path, server_config, session_config, timeout=0):
                      "--verbose",  # show each individual subtest
                      "--capture", "no",  # enable stdout/stderr from tests
                      "--basetemp", cache,  # temporary directory
+                     "--showlocals",  # display contents of variables in local scope
                      "-p", "no:mozlog",  # use the WPT result recorder
                      "-p", "no:cacheprovider",  # disable state preservation across invocations
                      path],


### PR DESCRIPTION

Using the "--showlocals" pytest flag we can show the values of
variables in the local scope in the pytest tracebacks.  This seems
like a good thing to do to ease debugging.

Thanks-to: Dave Hunt <dave.hunt@gmail.com>

MozReview-Commit-ID: F62untoxEyi

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411052 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8225)
<!-- Reviewable:end -->
