### PR TITLE
Remove the iframe margin size quirk.

### DIFF
--- a/html/rendering/non-replaced-elements/the-page/body-margin-1-ref.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<iframe src="data:text/html,<!doctype html><body style='margin-left: 100px; margin-right: 100px;'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1a.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1a.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginwidth attribute has the right effect in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe src="data:text/html,<!doctype html><body marginwidth='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1b.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1b.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginwidth attribute has the right effect in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe src="data:text/html,<body marginwidth='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1c.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1c.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's leftmargin/rightmargin attributes have the right effect in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe src="data:text/html,<!doctype html><body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1d.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1d.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's leftmargin/rightmargin attributes have the right effect in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe src="data:text/html,<body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1e.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1e.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that iframe's marginwidth attribute has the right effect in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="100" src="data:text/html,<!doctype html><body>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1f.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1f.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that iframe's marginwidth attribute has the right effect in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="100" src="data:text/html,<body>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1g.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1g.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's style margin takes precedence over everything else in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<!doctype html><body marginwidth='30' leftmargin='40' rightmargin='50' style='margin-left: 100px; margin-right: 100px'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1h.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1h.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's style margin takes precedence over everything else in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<body marginwidth='30' leftmargin='40' rightmargin='50' style='margin-left: 100px; margin-right: 100px'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1i.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1i.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginwidth attribute takes precedence over other body margin presentational attributes in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<!doctype html><body marginwidth='100' leftmargin='40' rightmargin='50'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1j.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1j.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginwidth attribute takes precedence over other body margin presentational attributes in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<body marginwidth='100' leftmargin='40' rightmargin='50'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1k.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1k.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's leftmargin/rightmargin attributes take precedence over iframe marginwidth in standards mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<!doctype html><body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-1l.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-1l.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's leftmargin/rightmargin attributes take precedence over iframe marginwidth in quirks mode</title>
+<link rel=match href="body-margin-1-ref.html">
+<iframe marginwidth="20" src="data:text/html,<body leftmargin='100' rightmargin='100'>100px left/right margins, default top/bottom margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2-ref.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2-ref.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<iframe src="data:text/html,<!doctype html><body style='margin-top: 100px; margin-bottom: 100px;'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2a.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2a.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginheight attribute has the right effect in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe src="data:text/html,<!doctype html><body marginheight='100'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2b.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2b.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginheight attribute has the right effect in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe src="data:text/html,<body marginheight='100'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2c.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2c.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's topmargin/bottommargin attributes have the right effect in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe src="data:text/html,<!doctype html><body topmargin='100' bottommargin='100'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2d.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2d.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's topmargin/bottommargin attributes have the right effect in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe src="data:text/html,<body topmargin='100' bottommargin='100'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2e.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2e.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that iframe's marginheight attribute has the right effect in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="100" src="data:text/html,<!doctype html><body>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2f.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2f.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that iframe's marginheight attribute has the right effect in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="100" src="data:text/html,<body>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2g.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2g.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's style margin takes precedence over everything else in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<!doctype html><body marginheight='30' topmargin='40' bottommargin='50' style='margin-top: 100px; margin-bottom: 100px'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2h.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2h.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's style margin takes precedence over everything else in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<body marginheight='30' topmargin='40' bottommargin='50' style='margin-top: 100px; margin-bottom: 100px'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2i.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2i.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginheight attribute takes precedence over other body margin presentational attributes in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<!doctype html><body marginheight='100' topmargin='40' bottommargin='50'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2j.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2j.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's marginheight attribute takes precedence over other body margin presentational attributes in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<body marginheight='100' topmargin='40' bottommargin='50'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2k.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2k.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's topmargin/bottommargin attributes take precedence over iframe marginheight in standards mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<!doctype html><body topmargin='100' bottommargin='100'>100px top/bottom margins, default left/right margins</body>"></iframe>

--- a/html/rendering/non-replaced-elements/the-page/body-margin-2l.html
+++ b/html/rendering/non-replaced-elements/the-page/body-margin-2l.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that body's topmargin/bottommargin attributes take precedence over iframe marginheight in quirks mode</title>
+<link rel=match href="body-margin-2-ref.html">
+<iframe marginheight="20" src="data:text/html,<body topmargin='100' bottommargin='100'>100px top/bottom margins, default left/right margins</body>"></iframe>


### PR DESCRIPTION

None of the spec, Chrome, or Safari have this quirk.  Edge has our quirks behavior in both modes.

MozReview-Commit-ID: ADyGxeIm3B4

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1352002 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8237)
<!-- Reviewable:end -->
