### PR TITLE
Move document timeline tests to files corresponding to the sections in the spec they test;

### DIFF
--- a/web-animations/interfaces/Document/timeline.html
+++ b/web-animations/interfaces/Document/timeline.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Document.timeline</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-document-timeline">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<div id="log"></div>
+<iframe width="10" height="10" id="iframe"></iframe>
+<script>
+'use strict';
+
+test(function() {
+  assert_equals(document.timeline, document.timeline,
+    'document.timeline returns the same object every time');
+  const iframe = document.getElementById('iframe');
+  assert_not_equals(document.timeline, iframe.contentDocument.timeline,
+    'document.timeline returns a different object for each document');
+  assert_not_equals(iframe.contentDocument.timeline, null,
+    'document.timeline on an iframe is not null');
+}, 'document.timeline identity tests');
+
+</script>

--- a/web-animations/timing-model/timelines/document-timelines.html
+++ b/web-animations/timing-model/timelines/document-timelines.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Document timelines</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#document-timelines">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<div id="log"></div>
+<script>
+'use strict';
+
+async_test(function(t) {
+  assert_true(document.timeline.currentTime > 0,
+    'document.timeline.currentTime is positive');
+  // document.timeline.currentTime should be set even before document
+  // load fires. We expect this code to be run before document load and hence
+  // the above assertion is sufficient.
+  // If the following assertion fails, this test needs to be redesigned.
+  assert_true(document.readyState !== 'complete',
+    'Test is running prior to document load');
+
+  // Test that the document timeline's current time is measured from
+  // navigationStart.
+  //
+  // We can't just compare document.timeline.currentTime to
+  // window.performance.now() because currentTime is only updated on a sample
+  // so we use requestAnimationFrame instead.
+  window.requestAnimationFrame(function(rafTime) {
+    t.step(function() {
+      assert_equals(document.timeline.currentTime, rafTime,
+                    'document.timeline.currentTime matches' +
+                    ' requestAnimationFrame time');
+    });
+    t.done();
+  });
+}, 'document.timeline.currentTime value tests');
+
+</script>

--- a/web-animations/timing-model/timelines/timelines.html
+++ b/web-animations/timing-model/timelines/timelines.html
@@ -1,54 +1,17 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Default document timeline tests</title>
-<link rel="help" href="https://w3c.github.io/web-animations/#the-documents-default-timeline">
+<title>Timelines</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#timelines">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
 <div id="log"></div>
-<iframe width="10" height="10" id="iframe"></iframe>
 <script>
 'use strict';
 
-test(function() {
-  assert_equals(document.timeline, document.timeline,
-    'document.timeline returns the same object every time');
-  var iframe = document.getElementById('iframe');
-  assert_not_equals(document.timeline, iframe.contentDocument.timeline,
-    'document.timeline returns a different object for each document');
-  assert_not_equals(iframe.contentDocument.timeline, null,
-    'document.timeline on an iframe is not null');
-}, 'document.timeline identity tests');
-
-async_test(function(t) {
-  assert_true(document.timeline.currentTime > 0,
-    'document.timeline.currentTime is positive');
-  // document.timeline.currentTime should be set even before document
-  // load fires. We expect this code to be run before document load and hence
-  // the above assertion is sufficient.
-  // If the following assertion fails, this test needs to be redesigned.
-  assert_true(document.readyState !== 'complete',
-    'Test is running prior to document load');
-
-  // Test that the document timeline's current time is measured from
-  // navigationStart.
-  //
-  // We can't just compare document.timeline.currentTime to
-  // window.performance.now() because currentTime is only updated on a sample
-  // so we use requestAnimationFrame instead.
-  window.requestAnimationFrame(function(rafTime) {
-    t.step(function() {
-      assert_equals(document.timeline.currentTime, rafTime,
-                    'document.timeline.currentTime matches' +
-                    ' requestAnimationFrame time');
-    });
-    t.done();
-  });
-}, 'document.timeline.currentTime value tests');
-
 promise_test(function(t) {
-  var valueAtStart = document.timeline.currentTime;
-  var timeAtStart = window.performance.now();
+  const valueAtStart = document.timeline.currentTime;
+  const timeAtStart = window.performance.now();
   while (window.performance.now() - timeAtStart < 50) {
     // Wait 50ms
   }
@@ -87,8 +50,8 @@ async_test(function(t) {
 }, 'iframe document.timeline.currentTime liveness tests');
 
 async_test(function(t) {
-  var startTime = document.timeline.currentTime;
-  var firstRafTime;
+  const startTime = document.timeline.currentTime;
+  let firstRafTime;
 
   requestAnimationFrame(function() {
     t.step(function() {


### PR DESCRIPTION

I replaced a couple instances of 'var' with 'const' or 'let' but otherwise the
test content is untouched. I will update a few test descriptions in the next
patch.

MozReview-Commit-ID: ASVp54dzQUL

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411806 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8238)
<!-- Reviewable:end -->
