### PR TITLE
Drop unnecessary test for KeyframeEffect.timing now that idlharness.html covers the same content;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -197,12 +197,6 @@ test(function(t) {
 }, "a KeyframeEffectReadOnly constructed with null target");
 
 test(function(t) {
-  var effect = new KeyframeEffect(target, null);
-  assert_class_string(effect, "KeyframeEffect");
-  assert_class_string(effect.timing, "AnimationEffectTiming");
-}, "KeyframeEffect constructor creates an AnimationEffectTiming timing object");
-
-test(function(t) {
   var test_error = { name: "test" };
 
   assert_throws(test_error, function() {


### PR DESCRIPTION

MozReview-Commit-ID: LZRx0mU48Id

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411806 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8244)
<!-- Reviewable:end -->
