### PR TITLE
Tidy up KeyframeEffect(ReadOnly) constructor tests;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffectReadOnly constructor tests</title>
-<link rel="help" href="https://w3c.github.io/web-animations/#the-keyframeeffect-interfaces">
+<title>KeyframeEffect and KeyframeEffectReadOnly constructor</title>
+<link rel="help"
+      href="https://w3c.github.io/web-animations/#dom-keyframeeffect-keyframeeffect">
+<link rel="help"
+      href="https://w3c.github.io/web-animations/#dom-keyframeeffectreadonly-keyframeeffectreadonly">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>
@@ -11,36 +14,31 @@
 <body>
 <div id="log"></div>
 <div id="target"></div>
-<style>
-#target {
-  border-style: solid;  /* so border-*-width values don't compute to 0 */
-}
-</style>
 <script>
-"use strict";
+'use strict';
 
-var target = document.getElementById("target");
+const target = document.getElementById('target');
 
 test(function(t) {
   gEmptyKeyframeListTests.forEach(function(frames) {
     assert_equals(new KeyframeEffectReadOnly(target, frames)
                         .getKeyframes().length,
-                  0, "number of frames for " + JSON.stringify(frames));
+                  0, 'number of frames for ' + JSON.stringify(frames));
   });
-}, "a KeyframeEffectReadOnly can be constructed with no frames");
+}, 'A KeyframeEffectReadOnly can be constructed with no frames');
 
 test(function(t) {
   gEasingParsingTests.forEach(function(subtest) {
-    var easing = subtest[0];
-    var expected = subtest[1];
-    var effect = new KeyframeEffectReadOnly(target, {
-      left: ["10px", "20px"]
+    const easing = subtest[0];
+    const expected = subtest[1];
+    const effect = new KeyframeEffectReadOnly(target, {
+      left: ['10px', '20px']
     }, { easing: easing });
     assert_equals(effect.timing.easing, expected,
-                  "resulting easing for '" + easing + "'");
+                  `resulting easing for '${easing}'`);
   });
-}, "easing values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in KeyframeEffectOptions");
+}, 'easing values are parsed correctly when passed to the ' +
+   'KeyframeEffectReadOnly constructor in KeyframeEffectOptions');
 
 test(function(t) {
   gInvalidEasings.forEach(invalidEasing => {
@@ -48,78 +46,77 @@ test(function(t) {
       new KeyframeEffectReadOnly(target, null, { easing: invalidEasing });
     }, `TypeError is thrown for easing '${invalidEasing}'`);
   });
-}, 'invalid easing values are correctly rejected when passed to the ' +
+}, 'Invalid easing values are correctly rejected when passed to the ' +
    'KeyframeEffectReadOnly constructor in KeyframeEffectOptions');
 
 test(function(t) {
-  var getKeyframe = function(composite) {
-    return { left: [ "10px", "20px" ], composite: composite };
+  const getKeyframe = function(composite) {
+    return { left: [ '10px', '20px' ], composite: composite };
   };
   gGoodKeyframeCompositeValueTests.forEach(function(composite) {
-    var effect = new KeyframeEffectReadOnly(target, getKeyframe(composite));
+    const effect = new KeyframeEffectReadOnly(target, getKeyframe(composite));
     assert_equals(effect.getKeyframes()[0].composite, composite,
-                  "resulting composite for '" + composite + "'");
+                  `resulting composite for '${composite}'`);
   });
   gBadCompositeValueTests.forEach(function(composite) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target, getKeyframe(composite));
     });
   });
-}, "composite values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in property-indexed keyframes");
+}, 'composite values are parsed correctly when passed to the ' +
+   'KeyframeEffectReadOnly constructor in property-indexed keyframes');
 
 test(function(t) {
-  var getKeyframes = function(composite) {
+  const getKeyframes = function(composite) {
     return [
-      { offset: 0, left: "10px", composite: composite },
-      { offset: 1, left: "20px" }
+      { offset: 0, left: '10px', composite: composite },
+      { offset: 1, left: '20px' }
     ];
   };
   gGoodKeyframeCompositeValueTests.forEach(function(composite) {
-    var effect = new KeyframeEffectReadOnly(target, getKeyframes(composite));
+    const effect = new KeyframeEffectReadOnly(target, getKeyframes(composite));
     assert_equals(effect.getKeyframes()[0].composite, composite,
-                  "resulting composite for '" + composite + "'");
+                  `resulting composite for '${composite}'`);
   });
   gBadCompositeValueTests.forEach(function(composite) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target, getKeyframes(composite));
     });
   });
-}, "composite values are parsed correctly when passed to the " +
-   "KeyframeEffectReadOnly constructor in regular keyframes");
+}, 'composite values are parsed correctly when passed to the ' +
+   'KeyframeEffectReadOnly constructor in regular keyframes');
 
 test(function(t) {
   gGoodOptionsCompositeValueTests.forEach(function(composite) {
-    var effect = new KeyframeEffectReadOnly(target, {
-      left: ["10px", "20px"]
+    const effect = new KeyframeEffectReadOnly(target, {
+      left: ['10px', '20px']
     }, { composite: composite });
     assert_equals(effect.getKeyframes()[0].composite, undefined,
-                  "resulting composite for '" + composite + "'");
+                  `resulting composite for '${composite}'`);
   });
   gBadCompositeValueTests.forEach(function(composite) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target, {
-        left: ["10px", "20px"]
+        left: ['10px', '20px']
       }, { composite: composite });
     });
   });
-}, "composite value is absent if the composite operation specified on the " +
-   "keyframe effect is being used");
+}, 'composite value is absent if the composite operation specified on the ' +
+   'keyframe effect is being used');
 
 gKeyframesTests.forEach(function(subtest) {
   test(function(t) {
-    var effect = new KeyframeEffectReadOnly(target, subtest.input);
+    const effect = new KeyframeEffectReadOnly(target, subtest.input);
     assert_frame_lists_equal(effect.getKeyframes(), subtest.output);
-  }, "a KeyframeEffectReadOnly can be constructed with " + subtest.desc);
+  }, `A KeyframeEffectReadOnly can be constructed with ${subtest.desc}`);
 
   test(function(t) {
-    var effect = new KeyframeEffectReadOnly(target, subtest.input);
-    var secondEffect =
+    const effect = new KeyframeEffectReadOnly(target, subtest.input);
+    const secondEffect =
       new KeyframeEffectReadOnly(target, effect.getKeyframes());
     assert_frame_lists_equal(secondEffect.getKeyframes(),
                              effect.getKeyframes());
-  }, "a KeyframeEffectReadOnly constructed with " + subtest.desc +
-     " roundtrips");
+  }, `A KeyframeEffectReadOnly constructed with ${subtest.desc} roundtrips`);
 });
 
 gInvalidKeyframesTests.forEach(function(subtest) {
@@ -127,82 +124,82 @@ gInvalidKeyframesTests.forEach(function(subtest) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target, subtest.input);
     });
-  }, "KeyframeEffectReadOnly constructor throws with " + subtest.desc);
+  }, `KeyframeEffectReadOnly constructor throws with ${subtest.desc}`);
 });
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(target,
-                                          { left: ["10px", "20px"] });
+  const effect = new KeyframeEffectReadOnly(target,
+                                            { left: ['10px', '20px'] });
 
-  var timing = effect.timing;
-  assert_equals(timing.delay, 0, "default delay");
-  assert_equals(timing.endDelay, 0, "default endDelay");
-  assert_equals(timing.fill, "auto", "default fill");
-  assert_equals(timing.iterations, 1.0, "default iterations");
-  assert_equals(timing.iterationStart, 0.0, "default iterationStart");
-  assert_equals(timing.duration, "auto", "default duration");
-  assert_equals(timing.direction, "normal", "default direction");
-  assert_equals(timing.easing, "linear", "default easing");
+  const timing = effect.timing;
+  assert_equals(timing.delay, 0, 'default delay');
+  assert_equals(timing.endDelay, 0, 'default endDelay');
+  assert_equals(timing.fill, 'auto', 'default fill');
+  assert_equals(timing.iterations, 1.0, 'default iterations');
+  assert_equals(timing.iterationStart, 0.0, 'default iterationStart');
+  assert_equals(timing.duration, 'auto', 'default duration');
+  assert_equals(timing.direction, 'normal', 'default direction');
+  assert_equals(timing.easing, 'linear', 'default easing');
 
-  assert_equals(effect.composite, "replace", "default composite");
-  assert_equals(effect.iterationComposite, "replace",
-                "default iterationComposite");
-}, "a KeyframeEffectReadOnly constructed without any " +
-   "KeyframeEffectOptions object");
+  assert_equals(effect.composite, 'replace', 'default composite');
+  assert_equals(effect.iterationComposite, 'replace',
+                'default iterationComposite');
+}, 'A KeyframeEffectReadOnly constructed without any ' +
+   'KeyframeEffectOptions object');
 
-gKeyframeEffectOptionTests.forEach(function(stest) {
+gKeyframeEffectOptionTests.forEach(function(subtest) {
   test(function(t) {
-    var effect = new KeyframeEffectReadOnly(target,
-                                            { left: ["10px", "20px"] },
-                                            stest.input);
+    const effect = new KeyframeEffectReadOnly(target,
+                                              { left: ['10px', '20px'] },
+                                              subtest.input);
 
     // Helper function to provide default expected values when the test does
     // not supply them.
-    var expected = function(field, defaultValue) {
-      return field in stest.expected ? stest.expected[field] : defaultValue;
+    const expected = (field, defaultValue) => {
+      return field in subtest.expected ? subtest.expected[field] : defaultValue;
     };
 
-    var timing = effect.timing;
-    assert_equals(timing.delay, expected("delay", 0),
-                  "timing delay");
-    assert_equals(timing.fill, expected("fill", "auto"),
-                  "timing fill");
-    assert_equals(timing.iterations, expected("iterations", 1),
-                  "timing iterations");
-    assert_equals(timing.duration, expected("duration", "auto"),
-                  "timing duration");
-    assert_equals(timing.direction, expected("direction", "normal"),
-                  "timing direction");
+    const timing = effect.timing;
+    assert_equals(timing.delay, expected('delay', 0),
+                  'timing delay');
+    assert_equals(timing.fill, expected('fill', 'auto'),
+                  'timing fill');
+    assert_equals(timing.iterations, expected('iterations', 1),
+                  'timing iterations');
+    assert_equals(timing.duration, expected('duration', 'auto'),
+                  'timing duration');
+    assert_equals(timing.direction, expected('direction', 'normal'),
+                  'timing direction');
 
-  }, "a KeyframeEffectReadOnly constructed by " + stest.desc);
+  }, `A KeyframeEffectReadOnly constructed by ${subtest.desc}`);
 });
 
-gInvalidKeyframeEffectOptionTests.forEach(function(stest) {
+gInvalidKeyframeEffectOptionTests.forEach(function(subtest) {
   test(function(t) {
     assert_throws(new TypeError, function() {
       new KeyframeEffectReadOnly(target,
-                                 { left: ["10px", "20px"] },
-                                 stest.input);
+                                 { left: ['10px', '20px'] },
+                                 subtest.input);
     });
-  }, "Invalid KeyframeEffectReadOnly option by " + stest.desc);
+  }, `Invalid KeyframeEffectReadOnly option by ${subtest.desc}`);
 });
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(null,
-                                          { left: ["10px", "20px"] },
-                                          { duration: 100 * MS_PER_SEC,
-                                            fill: "forwards" });
+  const effect = new KeyframeEffectReadOnly(null,
+                                            { left: ['10px', '20px'] },
+                                            { duration: 100 * MS_PER_SEC,
+                                              fill: 'forwards' });
   assert_equals(effect.target, null,
-                "Effect created with null target has correct target");
-}, "a KeyframeEffectReadOnly constructed with null target");
+                'Effect created with null target has correct target');
+}, 'A KeyframeEffectReadOnly constructed with null target');
 
 test(function(t) {
-  var test_error = { name: "test" };
+  const test_error = { name: 'test' };
 
   assert_throws(test_error, function() {
     new KeyframeEffect(target, { get left() { throw test_error }})
   });
-}, "KeyframeEffect constructor propagates exceptions generated by accessing"
-   + " the options object");
+}, 'KeyframeEffect constructor propagates exceptions generated by accessing'
+   + ' the options object');
 </script>
 </body>

--- a/web-animations/interfaces/KeyframeEffect/copy-constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/copy-constructor.html
@@ -14,13 +14,13 @@
 'use strict';
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(createDiv(t), null);
-  var copiedEffect = new KeyframeEffectReadOnly(effect);
+  const effect = new KeyframeEffectReadOnly(createDiv(t), null);
+  const copiedEffect = new KeyframeEffectReadOnly(effect);
   assert_equals(copiedEffect.target, effect.target, 'same target');
-}, 'Test copied keyframeEffectReadOnly has the same target');
+}, 'Copied KeyframeEffectReadOnly has the same target');
 
 test(function(t) {
-  var effect =
+  const effect =
     new KeyframeEffectReadOnly(null,
                                [ { marginLeft: '0px' },
                                  { marginLeft: '-20px', easing: 'ease-in',
@@ -29,57 +29,58 @@ test(function(t) {
                                  { marginLeft: '50px' } ],
                                { spacing: 'paced(margin-left)' });
 
-  var copiedEffect = new KeyframeEffectReadOnly(effect);
-  var KeyframesA = effect.getKeyframes();
-  var KeyframesB = copiedEffect.getKeyframes();
-  assert_equals(KeyframesA.length, KeyframesB.length, 'same keyframes length');
+  const copiedEffect = new KeyframeEffectReadOnly(effect);
+  const keyframesA = effect.getKeyframes();
+  const keyframesB = copiedEffect.getKeyframes();
+  assert_equals(keyframesA.length, keyframesB.length, 'same keyframes length');
 
-  for (var i = 0; i < KeyframesA.length; ++i) {
-    assert_equals(KeyframesA[i].offset, KeyframesB[i].offset,
-                  'Keyframe ' + i + ' has the same offset');
-    assert_equals(KeyframesA[i].computedOffset, KeyframesB[i].computedOffset,
-                  'keyframe ' + i + ' has the same computedOffset');
-    assert_equals(KeyframesA[i].easing, KeyframesB[i].easing,
-                  'keyframe ' + i + ' has the same easing');
-    assert_equals(KeyframesA[i].composite, KeyframesB[i].composite,
-                  'keyframe ' + i + ' has the same composite');
+  for (let i = 0; i < keyframesA.length; ++i) {
+    assert_equals(keyframesA[i].offset, keyframesB[i].offset,
+                  `Keyframe ${i} has the same offset`);
+    assert_equals(keyframesA[i].computedOffset, keyframesB[i].computedOffset,
+                  `Keyframe ${i} has the same computedOffset`);
+    assert_equals(keyframesA[i].easing, keyframesB[i].easing,
+                  `Keyframe ${i} has the same easing`);
+    assert_equals(keyframesA[i].composite, keyframesB[i].composite,
+                  `Keyframe ${i} has the same composite`);
 
-    assert_true(!!KeyframesA[i].marginLeft,
-                'original keyframe ' + i + ' has the valid property value');
-    assert_true(!!KeyframesB[i].marginLeft,
-                'new keyframe ' + i + ' has the valid property value');
-    assert_equals(KeyframesA[i].marginLeft, KeyframesB[i].marginLeft,
-                  'keyframe ' + i + ' has the same property value pair');
+    assert_true(!!keyframesA[i].marginLeft,
+                `Original keyframe ${i} has a valid property value`);
+    assert_true(!!keyframesB[i].marginLeft,
+                `New keyframe ${i} has a valid property value`);
+    assert_equals(keyframesA[i].marginLeft, keyframesB[i].marginLeft,
+                  `Keyframe ${i} has the same property value pair`);
   }
-}, 'Test copied keyframeEffectReadOnly has the same keyframes');
+}, 'Copied KeyframeEffectReadOnly has the same keyframes');
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(null, null,
-                                          { spacing: 'paced(margin-left)',
-                                            iterationComposite: 'accumulate' });
+  const effect =
+    new KeyframeEffectReadOnly(null, null,
+                               { spacing: 'paced(margin-left)',
+                                 iterationComposite: 'accumulate' });
 
-  var copiedEffect = new KeyframeEffectReadOnly(effect);
+  const copiedEffect = new KeyframeEffectReadOnly(effect);
   assert_equals(copiedEffect.spacing, effect.spacing, 'same spacing');
   assert_equals(copiedEffect.iterationComposite, effect.iterationComposite,
                 'same iterationCompositeOperation');
   assert_equals(copiedEffect.composite, effect.composite,
                 'same compositeOperation');
-}, 'Test copied keyframeEffectReadOnly has the same keyframeEffectOptions');
+}, 'Copied KeyframeEffectReadOnly has the same KeyframeEffectOptions');
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(null, null,
-                                          { duration: 100 * MS_PER_SEC,
-                                            delay: -1 * MS_PER_SEC,
-                                            endDelay: 2 * MS_PER_SEC,
-                                            fill: 'forwards',
-                                            iterationStart: 2,
-                                            iterations: 20,
-                                            easing: 'ease-out',
-                                            direction: 'alternate' } );
+  const effect = new KeyframeEffectReadOnly(null, null,
+                                            { duration: 100 * MS_PER_SEC,
+                                              delay: -1 * MS_PER_SEC,
+                                              endDelay: 2 * MS_PER_SEC,
+                                              fill: 'forwards',
+                                              iterationStart: 2,
+                                              iterations: 20,
+                                              easing: 'ease-out',
+                                              direction: 'alternate' } );
 
-  var copiedEffect = new KeyframeEffectReadOnly(effect);
-  var timingA = effect.timing;
-  var timingB = copiedEffect.timing;
+  const copiedEffect = new KeyframeEffectReadOnly(effect);
+  const timingA = effect.timing;
+  const timingB = copiedEffect.timing;
   assert_not_equals(timingA, timingB, 'different timing objects');
   assert_equals(timingA.delay, timingB.delay, 'same delay');
   assert_equals(timingA.endDelay, timingB.endDelay, 'same endDelay');
@@ -90,19 +91,19 @@ test(function(t) {
   assert_equals(timingA.duration, timingB.duration, 'same duration');
   assert_equals(timingA.direction, timingB.direction, 'same direction');
   assert_equals(timingA.easing, timingB.easing, 'same easing');
-}, 'Test copied keyframeEffectReadOnly has the same timing content');
+}, 'Copied KeyframeEffectReadOnly has the same timing content');
 
 test(function(t) {
-  var effect = new KeyframeEffectReadOnly(createDiv(t), null);
+  const effect = new KeyframeEffectReadOnly(createDiv(t), null);
   assert_equals(effect.constructor.name, 'KeyframeEffectReadOnly');
   assert_equals(effect.timing.constructor.name,
                 'AnimationEffectTimingReadOnly');
 
   // Make a mutable copy
-  var copiedEffect = new KeyframeEffect(effect);
+  const copiedEffect = new KeyframeEffect(effect);
   assert_equals(copiedEffect.constructor.name, 'KeyframeEffect');
   assert_equals(copiedEffect.timing.constructor.name, 'AnimationEffectTiming');
-}, 'Test mutable copy from a KeyframeEffectReadOnly source');
+}, 'KeyframeEffect constructed from a KeyframeEffectReadOnly is mutable');
 
 </script>
 </body>


### PR DESCRIPTION

These are non-functional changes to:

* Use ES6 const/let
* Use ES6 template strings in various places
* Capitalize/fix test descriptions

MozReview-Commit-ID: CcEl42yVIQx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411806 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8246)
<!-- Reviewable:end -->
