### PR TITLE
Drop references to no-longer-existent 'spacing' property in KeyframeEffect(ReadOny) constructor tests;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/copy-constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/copy-constructor.html
@@ -26,8 +26,7 @@ test(function(t) {
                                  { marginLeft: '-20px', easing: 'ease-in',
                                    offset: 0.1 },
                                  { marginLeft: '100px', easing: 'ease-out' },
-                                 { marginLeft: '50px' } ],
-                               { spacing: 'paced(margin-left)' });
+                                 { marginLeft: '50px' } ]);
 
   const copiedEffect = new KeyframeEffectReadOnly(effect);
   const keyframesA = effect.getKeyframes();
@@ -56,11 +55,9 @@ test(function(t) {
 test(function(t) {
   const effect =
     new KeyframeEffectReadOnly(null, null,
-                               { spacing: 'paced(margin-left)',
-                                 iterationComposite: 'accumulate' });
+                               { iterationComposite: 'accumulate' });
 
   const copiedEffect = new KeyframeEffectReadOnly(effect);
-  assert_equals(copiedEffect.spacing, effect.spacing, 'same spacing');
   assert_equals(copiedEffect.iterationComposite, effect.iterationComposite,
                 'same iterationCompositeOperation');
   assert_equals(copiedEffect.composite, effect.composite,


### PR DESCRIPTION

MozReview-Commit-ID: XN1pQRvPJg

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411806 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8247)
<!-- Reviewable:end -->
