### PR TITLE
Add equality test for webdriver.Session

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -354,8 +354,13 @@ class UserPrompt(object):
 
 
 class Session(object):
-    def __init__(self, host, port, url_prefix="/", capabilities=None,
-                 timeout=None, extension=None):
+    def __init__(self,
+                 host,
+                 port,
+                 url_prefix="/",
+                 capabilities=None,
+                 timeout=None,
+                 extension=None):
         self.transport = transport.HTTPWireProtocol(
             host, port, url_prefix, timeout=timeout)
         self.capabilities = capabilities
@@ -372,6 +377,10 @@ class Session(object):
         self.find = Find(self)
         self.alert = UserPrompt(self)
         self.actions = Actions(self)
+
+    def __eq__(self, other):
+        return (self.session_id is not None and isinstance(other, Session)
+                and self.session_Id == other.session_id)
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION

When comparing two instances of webdriver.Session we want to first
check that there is a current session, then the type of the object
to compare with to make sure the "session_id" attribute is present,
then finally we compare the session IDs.

MozReview-Commit-ID: 6Ch4Uy2MEhB

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411281 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8256)
<!-- Reviewable:end -->
