### PR TITLE
Add equality test for webdriver.Element

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -634,6 +634,10 @@ class Element(object):
         assert id not in self.session._element_cache
         self.session._element_cache[self.id] = self
 
+    def __eq__(self, other):
+        return isinstance(other, Element) and self.id == other.id \
+                and self.session == other.session
+
     def send_element_command(self, method, uri, body=None):
         url = "element/%s/%s" % (self.id, uri)
         return self.session.send_session_command(method, url, body)


### PR DESCRIPTION

When comparing two instances of webdriver.Element we want to first
check the type, to make sure the "id" attribute is present, then
compare the web element reference UUIDs.  These are supposed to be
unique across all browsing contexts.

MozReview-Commit-ID: 68PUBQxPdQ5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411281 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8257)
<!-- Reviewable:end -->
