### PR TITLE
Swap webdriver.Element ctor arguments

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -557,7 +557,7 @@ class Session(object):
         assert elem_id
         if elem_id in self._element_cache:
             return self._element_cache[elem_id]
-        return Element(self, elem_id)
+        return Element(elem_id, self)
 
     @command
     def cookies(self, name=None):
@@ -628,9 +628,17 @@ class Element(object):
     """
     identifier = "element-6066-11e4-a52e-4f735466cecf"
 
-    def __init__(self, session, id):
-        self.session = session
+    def __init__(self, id, session):
+        """
+        Construct a new web element representation.
+
+        :param id: Web element UUID which must be unique across
+            all browsing contexts.
+        :param session: Current ``webdriver.Session``.
+        """
         self.id = id
+        self.session = session
+
         assert id not in self.session._element_cache
         self.session._element_cache[self.id] = self
 


### PR DESCRIPTION

It is more natural for the web element UUID to come first, followed
by the associated session state.

The patch also adds ctor documentation.

MozReview-Commit-ID: 5iV4SZzMeKS

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411281 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8258)
<!-- Reviewable:end -->
