### PR TITLE
Make assert_same_element accept webdriver.Element

### DIFF
--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -102,12 +102,23 @@ def assert_dialog_handled(session, expected_text):
 
 def assert_same_element(session, a, b):
     """Verify that two element references describe the same element."""
-    assert isinstance(a, dict), "Actual value is not a dictionary"
-    assert isinstance(b, dict), "Expected value is not a dictionary"
-    assert Element.identifier in a, "Actual value does not describe an element"
-    assert Element.identifier in b, "Expected value does not describe an element"
+    if isinstance(a, dict):
+        assert Element.identifier in a, "Actual value does not describe an element"
+        a_id = a[Element.identifier]
+    elif isinstance(a, Element):
+        a_id = a.id
+    else:
+        raise AssertionError("Actual value is not a dictionary or web element")
 
-    if a[Element.identifier] == b[Element.identifier]:
+    if isinstance(b, dict):
+        assert Element.identifier in b, "Expected value does not describe an element"
+        b_id = b[Element.identifier]
+    elif isinstance(b, Element):
+        b_id = b.id
+    else:
+        raise AssertionError("Expected value is not a dictionary or web element")
+
+    if a_id == b_id:
         return
 
     message = ("Expected element references to describe the same element, " +
@@ -116,8 +127,8 @@ def assert_same_element(session, a, b):
     # Attempt to provide more information, accounting for possible errors such
     # as stale element references or not visible elements.
     try:
-        a_markup = session.execute_script("return arguments[0].outerHTML;", args=[a])
-        b_markup = session.execute_script("return arguments[0].outerHTML;", args=[b])
+        a_markup = session.execute_script("return arguments[0].outerHTML;", args=(a,))
+        b_markup = session.execute_script("return arguments[0].outerHTML;", args=(b,))
         message += " Actual: `%s`. Expected: `%s`." % (a_markup, b_markup)
     except WebDriverException:
         pass


### PR DESCRIPTION

Allow assert_same_element to compare web element references (JSON
Objects) with webdriver.Element and vice versa.

Tests will typically look up some element using traditional means
and use that as the trusted comparison when retrieving the same
element using the session.transport.send primitive that returns
the plain JSON Object.

MozReview-Commit-ID: 2DScnviOevb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1411281 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8260)
<!-- Reviewable:end -->
