### PR TITLE
Test element retrieval from XHTML namespace.

### DIFF
--- a/webdriver/tests/retrieval/find_element.py
+++ b/webdriver/tests/retrieval/find_element.py
@@ -1,7 +1,6 @@
 import pytest
 
-
-from tests.support.asserts import assert_error, assert_success
+from tests.support.asserts import assert_error, assert_same_element, assert_success
 from tests.support.inline import inline
 
 
@@ -57,3 +56,18 @@ def test_no_element(session, using, value):
     # Step 8 - 9
     response = find_element(session, using, value)
     assert_error(response, "no such element")
+
+
+@pytest.mark.parametrize("using,value",
+                         [("css selector", "#linkText"),
+                          ("link text", "full link text"),
+                          ("partial link text", "link text"),
+                          ("tag name", "a"),
+                          ("xpath", "//*[name()='a']")])
+def test_xhtml_namespace(session, using, value):
+    session.url = inline("""<a href="#" id="linkText">full link text</a>""", doctype="xhtml")
+    expected = session.execute_script("return document.links[0]")
+
+    response = find_element(session, using, value)
+    value = assert_success(response)
+    assert_same_element(session, value, expected)

--- a/webdriver/tests/retrieval/find_element_from_element.py
+++ b/webdriver/tests/retrieval/find_element_from_element.py
@@ -1,7 +1,6 @@
 import pytest
 
-
-from tests.support.asserts import assert_error, assert_success
+from tests.support.asserts import assert_error, assert_same_element, assert_success
 from tests.support.inline import inline
 
 
@@ -57,3 +56,19 @@ def test_no_element(session, using, value):
     element = session.find.css("div", all=False)
     response = find_element(session, element.id, using, value)
     assert_error(response, "no such element")
+
+
+@pytest.mark.parametrize("using,value",
+                         [("css selector", "#linkText"),
+                          ("link text", "full link text"),
+                          ("partial link text", "link text"),
+                          ("tag name", "a"),
+                          ("xpath", "//*[name()='a']")])
+def test_xhtml_namespace(session, using, value):
+    session.url = inline("""<p><a href="#" id="linkText">full link text</a></p>""", doctype="xhtml")
+    from_element = session.execute_script("""return document.querySelector("p")""")
+    expected = session.execute_script("return document.links[0]")
+
+    response = find_element(session, from_element.id, using, value)
+    value = assert_success(response)
+    assert_same_element(session, value, expected)

--- a/webdriver/tests/retrieval/find_elements.py
+++ b/webdriver/tests/retrieval/find_elements.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.support.asserts import assert_error, assert_success
+from tests.support.asserts import assert_error, assert_same_element, assert_success
 from tests.support.inline import inline
 
 
@@ -58,3 +58,22 @@ def test_no_element(session, using, value):
     response = find_elements(session, using, value)
     assert_success(response)
     assert response.body["value"] == []
+
+
+@pytest.mark.parametrize("using,value",
+                         [("css selector", "#linkText"),
+                          ("link text", "full link text"),
+                          ("partial link text", "link text"),
+                          ("tag name", "a"),
+                          ("xpath", "//*[name()='a']")])
+def test_xhtml_namespace(session, using, value):
+    session.url = inline("""<p><a href="#" id="linkText">full link text</a></p>""", doctype="xhtml")
+    expected = session.execute_script("return document.links[0]")
+
+    response = find_elements(session, using, value)
+    value = assert_success(response)
+    assert isinstance(value, list)
+    assert len(value) == 1
+
+    found_element = value[0]
+    assert_same_element(session, found_element, expected)


### PR DESCRIPTION

Finding elements in the XHTML namespace will fail unless
element.isDOMElement is fixed so that it does not look at a
particular namespaceURI.

It is worth noting that, generally, the WPT element retrieval tests
are pretty awful and the new tests don't exactly match the style of
the preceding tests.  This intended, because the other tests are bad.
This should be addessed individually.

MozReview-Commit-ID: 8I3VwhJirSb

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1410796 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8263)
<!-- Reviewable:end -->
