### PR TITLE
Fix lint errors introduced in #8261

### DIFF
--- a/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload_form-submission-2.tentative.html
+++ b/html/browsers/history/the-session-history-of-browsing-contexts/navigation-in-onload_form-submission-2.tentative.html
@@ -9,10 +9,10 @@
       function verify() {
         // Navigation in onload handler through form submission should not
         // increse history length.
-        var testRunner = window.top.opener;
-        testRunner.verify(history.length, 1,
+        var runner = window.top.opener;
+        runner.verify(history.length, 1,
           "history.length of subtest '" + top.document.title + "'.");
-        testRunner.scheduleNextTest();
+        runner.scheduleNextTest();
         setTimeout(window.close.bind(top), 0);
       }
     </script>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -155,6 +155,7 @@ SET TIMEOUT: html/browsers/browsing-the-web/scroll-to-fragid/*
 SET TIMEOUT: html/browsers/browsing-the-web/unloading-documents/*
 SET TIMEOUT: html/browsers/history/the-history-interface/*
 SET TIMEOUT: html/browsers/history/the-location-interface/*
+SET TIMEOUT: html/browsers/history/the-session-history-of-browsing-contexts/*
 SET TIMEOUT: html/browsers/offline/*
 SET TIMEOUT: html/browsers/the-window-object/*
 SET TIMEOUT: html/dom/dynamic-markup-insertion/opening-the-input-stream/*


### PR DESCRIPTION
* A new exception for SET TIMEOUT is added to lint.whitelist.
* Rename a variable called `testRunner` to avoid confusing the linter.

This fixes the immediate problem of issue #8271 and unblocks the chromium importer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8272)
<!-- Reviewable:end -->
