### PR TITLE
Add a test for the removal of Event::getPreventDefault.

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -178,4 +178,14 @@ var EventRemoved = [
   "CHANGE"
 ]
 EventRemoved.forEach(isRemovedFromEvent)
+
+var EventPrototypeRemoved = [
+  "getPreventDefault",
+]
+EventPrototypeRemoved.forEach(name => {
+  test(() => {
+    assert_equals(Event.prototype[name], undefined)
+    assert_equals((new Event("test"))[name], undefined)
+  }, "Event.prototype should not have this property: " + name)
+})
 </script>


### PR DESCRIPTION
It was removed from Gecko in <https://bugzilla.mozilla.org/show_bug.cgi?id=691151>.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
