### PR TITLE
Optimized generic sensor cases by using promise_test  and EventWatcher

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -1,8 +1,8 @@
-let unreached = event => {
+const unreached = event => {
   assert_unreached(event.error.name + ": " + event.error.message);
 };
 
-let properties = {
+const properties = {
   'AmbientLightSensor' : ['timestamp', 'illuminance'],
   'Accelerometer' : ['timestamp', 'x', 'y', 'z'],
   'LinearAccelerationSensor' : ['timestamp', 'x', 'y', 'z'],
@@ -27,7 +27,7 @@ function assert_reading_null(sensor) {
 }
 
 function reading_to_array(sensor) {
-  let arr = new Array();
+  const arr = new Array();
   for (let property in properties[sensor.constructor.name]) {
     let propertyName = properties[sensor.constructor.name][property];
     arr[property] = sensor[propertyName];
@@ -36,84 +36,81 @@ function reading_to_array(sensor) {
 }
 
 function runGenericSensorTests(sensorType) {
-  async_test(t => {
-    let sensor = new sensorType();
-    sensor.onreading = t.step_func_done(() => {
-      assert_reading_not_null(sensor);
-      assert_true(sensor.hasReading);
-      sensor.stop();
-      assert_reading_null(sensor);
-      assert_false(sensor.hasReading);
-    });
-    sensor.onerror = t.step_func_done(unreached);
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     sensor.start();
+
+    await eventWatcher.wait_for("reading");
+    assert_reading_not_null(sensor);
+    assert_true(sensor.hasReading);
+
+    sensor.stop();
+    assert_reading_null(sensor);
+    assert_false(sensor.hasReading);
   }, `${sensorType.name}: Test that 'onreading' is called and sensor reading is valid`);
 
-  async_test(t => {
-    let sensor1 = new sensorType();
-    let sensor2 = new sensorType();
-    sensor1.onreading = t.step_func_done(() => {
-      // Reading values are correct for both sensors.
-      assert_reading_not_null(sensor1);
-      assert_reading_not_null(sensor2);
-
-      //After first sensor stops its reading values are null,
-      //reading values for the second sensor remains
-      sensor1.stop();
-      assert_reading_null(sensor1);
-      assert_reading_not_null(sensor2);
-      sensor2.stop();
-      assert_reading_null(sensor2);
-    });
-    sensor1.onerror = t.step_func_done(unreached);
-    sensor2.onerror = t.step_func_done(unreached);
+  promise_test(async t => {
+    const sensor1 = new sensorType();
+    const sensor2 = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor1, ["reading", "error"]);
     sensor2.start();
     sensor1.start();
+
+    await eventWatcher.wait_for("reading");
+    // Reading values are correct for both sensors.
+    assert_reading_not_null(sensor1);
+    assert_reading_not_null(sensor2);
+
+    //After first sensor stops its reading values are null,
+    //reading values for the second sensor remains
+    sensor1.stop();
+    assert_reading_null(sensor1);
+    assert_reading_not_null(sensor2);
+    sensor2.stop();
+    assert_reading_null(sensor2);
   }, `${sensorType.name}: sensor reading is correct`);
 
-  async_test(t => {
-    let sensor = new sensorType();
-    let cachedTimeStamp1;
-    sensor.onreading = () => {
-      cachedTimeStamp1 = sensor.timestamp;
-    };
-    sensor.onerror = t.step_func_done(unreached);
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     sensor.start();
-    t.step_timeout(() => {
-      sensor.onreading = t.step_func_done(() => {
-        //sensor.timestamp changes.
-        let cachedTimeStamp2 = sensor.timestamp;
-        assert_greater_than(cachedTimeStamp2, cachedTimeStamp1);
-        sensor.stop();
-      });
-    }, 1000);
+
+    await eventWatcher.wait_for("reading");
+    const cachedTimeStamp1 = sensor.timestamp;
+
+    await eventWatcher.wait_for("reading");
+    const cachedTimeStamp2 = sensor.timestamp;
+
+    assert_greater_than(cachedTimeStamp2, cachedTimeStamp1);
+    sensor.stop();
   }, `${sensorType.name}: sensor timestamp is updated when time passes`);
 
-  async_test(t => {
-    let sensor = new sensorType();
-    sensor.onerror = t.step_func_done(unreached);
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     assert_false(sensor.activated);
-    sensor.onreading = t.step_func_done(() => {
-      assert_true(sensor.activated);
-      sensor.stop();
-      assert_false(sensor.activated);
-    });
     sensor.start();
+    assert_false(sensor.activated);
+
+    await eventWatcher.wait_for("reading");
+    assert_true(sensor.activated);
+
+    sensor.stop();
     assert_false(sensor.activated);
   }, `${sensorType.name}: Test that sensor can be successfully created and its states are correct.`);
 
   test(() => {
-    let sensor, start_return;
-    sensor = new sensorType();
+    const sensor = new sensorType();
     sensor.onerror = unreached;
-    start_return = sensor.start();
+    const start_return = sensor.start();
     assert_equals(start_return, undefined);
     sensor.stop();
   }, `${sensorType.name}: sensor.start() returns undefined`);
 
   test(() => {
     try {
-      let sensor = new sensorType();
+      const sensor = new sensorType();
       sensor.onerror = unreached;
       sensor.start();
       sensor.start();
@@ -125,17 +122,16 @@ function runGenericSensorTests(sensorType) {
   }, `${sensorType.name}: no exception is thrown when calling start() on already started sensor`);
 
   test(() => {
-    let sensor, stop_return;
-    sensor = new sensorType();
+    const sensor = new sensorType();
     sensor.onerror = unreached;
     sensor.start();
-    stop_return = sensor.stop();
+    const stop_return = sensor.stop();
     assert_equals(stop_return, undefined);
   }, `${sensorType.name}: sensor.stop() returns undefined`);
 
   test(() => {
     try {
-      let sensor = new sensorType();
+      const sensor = new sensorType();
       sensor.onerror = unreached;
       sensor.start();
       sensor.stop();
@@ -146,49 +142,44 @@ function runGenericSensorTests(sensorType) {
     }
   }, `${sensorType.name}: no exception is thrown when calling stop() on already stopped sensor`);
 
-  promise_test(() => {
-    return new Promise((resolve,reject) => {
-      let iframe = document.createElement('iframe');
-      iframe.srcdoc = '<script>' +
-                      '  window.onmessage = message => {' +
-                      '    if (message.data === "LOADED") {' +
-                      '      try {' +
-                      '        new ' + sensorType.name + '();' +
-                      '        parent.postMessage("FAIL", "*");' +
-                      '      } catch (e) {' +
-                      '        parent.postMessage(e.name, "*");' +
-                      '      }' +
-                      '    }' +
-                      '   };' +
-                      '<\/script>';
-      iframe.onload = () => iframe.contentWindow.postMessage('LOADED', '*');
-      document.body.appendChild(iframe);
-      window.onmessage = message => {
-        if (message.data == 'SecurityError') {
-          resolve();
-        } else {
-          reject();
-        }
-      }
-    });
+  promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = '<script>' +
+                    '  window.onmessage = message => {' +
+                    '    if (message.data === "LOADED") {' +
+                    '      try {' +
+                    '        new ' + sensorType.name + '();' +
+                    '        parent.postMessage("FAIL", "*");' +
+                    '      } catch (e) {' +
+                    '        parent.postMessage(e.name, "*");' +
+                    '      }' +
+                    '    }' +
+                    '   };' +
+                    '<\/script>';
+    iframe.onload = () => iframe.contentWindow.postMessage('LOADED', '*');
+    document.body.appendChild(iframe);
+    const eventWatcher = new EventWatcher(t, window, "message");
+    const message = await eventWatcher.wait_for("message");
+    assert_equals(message.data, 'SecurityError');
   }, `${sensorType.name}: throw a 'SecurityError' when constructing sensor object within iframe`);
 
-  async_test(t => {
-    let sensor = new sensorType();
-    sensor.onreading = t.step_func(() => {
-      assert_reading_not_null(sensor);
-      let cachedSensor1 = reading_to_array(sensor);
-      let win = window.open('', '_blank');
-      t.step_timeout(() => {
-        let cachedSensor2 = reading_to_array(sensor);
-        win.close();
-        sensor.stop();
-        assert_array_equals(cachedSensor1, cachedSensor2);
-        t.done();
-      }, 1000);
-    });
-    sensor.onerror = t.step_func_done(unreached);
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+    const visibilityChangeWatcher = new EventWatcher(t, document, "visibilitychange");
     sensor.start();
+
+    await eventWatcher.wait_for("reading");
+    assert_reading_not_null(sensor);
+    const cachedSensor1 = reading_to_array(sensor);
+
+    const win = window.open('', '_blank');
+    await visibilityChangeWatcher.wait_for("visibilitychange");
+    const cachedSensor2 = reading_to_array(sensor);
+
+    win.close();
+    sensor.stop();
+    assert_array_equals(cachedSensor1, cachedSensor2);
   }, `${sensorType.name}: sensor readings can not be fired on the background tab`);
 }
 
@@ -199,13 +190,13 @@ function runGenericSensorInsecureContext(sensorType) {
 }
 
 function runGenericSensorOnerror(sensorType) {
-  async_test(t => {
-    let sensor = new sensorType();
-    sensor.onactivate = t.step_func_done(assert_unreached);
-    sensor.onerror = t.step_func_done(event => {
-      assert_false(sensor.activated);
-      assert_equals(event.error.name, 'NotReadableError');
-    });
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const eventWatcher = new EventWatcher(t, sensor, ["error", "activate"]);
     sensor.start();
+
+    const event = await eventWatcher.wait_for("error");
+    assert_false(sensor.activated);
+    assert_equals(event.error.name, 'NotReadableError');
   }, `${sensorType.name}: 'onerror' event is fired when sensor is not supported`);
 }

--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -1,7 +1,3 @@
-const unreached = event => {
-  assert_unreached(event.error.name + ": " + event.error.message);
-};
-
 const properties = {
   'AmbientLightSensor' : ['timestamp', 'illuminance'],
   'Accelerometer' : ['timestamp', 'x', 'y', 'z'],
@@ -38,10 +34,10 @@ function reading_to_array(sensor) {
 function runGenericSensorTests(sensorType) {
   promise_test(async t => {
     const sensor = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+    const sensorWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     sensor.start();
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("reading");
     assert_reading_not_null(sensor);
     assert_true(sensor.hasReading);
 
@@ -53,11 +49,11 @@ function runGenericSensorTests(sensorType) {
   promise_test(async t => {
     const sensor1 = new sensorType();
     const sensor2 = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor1, ["reading", "error"]);
+    const sensorWatcher = new EventWatcher(t, sensor1, ["reading", "error"]);
     sensor2.start();
     sensor1.start();
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("reading");
     // Reading values are correct for both sensors.
     assert_reading_not_null(sensor1);
     assert_reading_not_null(sensor2);
@@ -73,13 +69,13 @@ function runGenericSensorTests(sensorType) {
 
   promise_test(async t => {
     const sensor = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+    const sensorWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     sensor.start();
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("reading");
     const cachedTimeStamp1 = sensor.timestamp;
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("reading");
     const cachedTimeStamp2 = sensor.timestamp;
 
     assert_greater_than(cachedTimeStamp2, cachedTimeStamp1);
@@ -88,58 +84,58 @@ function runGenericSensorTests(sensorType) {
 
   promise_test(async t => {
     const sensor = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+    const sensorWatcher = new EventWatcher(t, sensor, ["activate", "error"]);
     assert_false(sensor.activated);
     sensor.start();
     assert_false(sensor.activated);
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("activate");
     assert_true(sensor.activated);
 
     sensor.stop();
     assert_false(sensor.activated);
   }, `${sensorType.name}: Test that sensor can be successfully created and its states are correct.`);
 
-  test(() => {
+  promise_test(async t => {
     const sensor = new sensorType();
-    sensor.onerror = unreached;
+    const sensorWatcher = new EventWatcher(t, sensor, ["activate", "error"]);
     const start_return = sensor.start();
+
+    await sensorWatcher.wait_for("activate");
     assert_equals(start_return, undefined);
     sensor.stop();
   }, `${sensorType.name}: sensor.start() returns undefined`);
 
-  test(() => {
-    try {
-      const sensor = new sensorType();
-      sensor.onerror = unreached;
-      sensor.start();
-      sensor.start();
-      assert_false(sensor.activated);
-      sensor.stop();
-    } catch (e) {
-       assert_unreached(e.name + ": " + e.message);
-    }
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const sensorWatcher = new EventWatcher(t, sensor, ["activate", "error"]);
+    sensor.start();
+    sensor.start();
+
+    await sensorWatcher.wait_for("activate");
+    assert_true(sensor.activated);
+    sensor.stop();
   }, `${sensorType.name}: no exception is thrown when calling start() on already started sensor`);
 
-  test(() => {
+  promise_test(async t => {
     const sensor = new sensorType();
-    sensor.onerror = unreached;
+    const sensorWatcher = new EventWatcher(t, sensor, ["activate", "error"]);
     sensor.start();
+
+    await sensorWatcher.wait_for("activate");
     const stop_return = sensor.stop();
     assert_equals(stop_return, undefined);
   }, `${sensorType.name}: sensor.stop() returns undefined`);
 
-  test(() => {
-    try {
-      const sensor = new sensorType();
-      sensor.onerror = unreached;
-      sensor.start();
-      sensor.stop();
-      sensor.stop();
-      assert_false(sensor.activated);
-    } catch (e) {
-       assert_unreached(e.name + ": " + e.message);
-    }
+  promise_test(async t => {
+    const sensor = new sensorType();
+    const sensorWatcher = new EventWatcher(t, sensor, ["activate", "error"]);
+    sensor.start();
+
+    await sensorWatcher.wait_for("activate");
+    sensor.stop();
+    sensor.stop();
+    assert_false(sensor.activated);
   }, `${sensorType.name}: no exception is thrown when calling stop() on already stopped sensor`);
 
   promise_test(async t => {
@@ -158,18 +154,18 @@ function runGenericSensorTests(sensorType) {
                     '<\/script>';
     iframe.onload = () => iframe.contentWindow.postMessage('LOADED', '*');
     document.body.appendChild(iframe);
-    const eventWatcher = new EventWatcher(t, window, "message");
-    const message = await eventWatcher.wait_for("message");
+    const sensorWatcher = new EventWatcher(t, window, "message");
+    const message = await sensorWatcher.wait_for("message");
     assert_equals(message.data, 'SecurityError');
   }, `${sensorType.name}: throw a 'SecurityError' when constructing sensor object within iframe`);
 
   promise_test(async t => {
     const sensor = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+    const sensorWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
     const visibilityChangeWatcher = new EventWatcher(t, document, "visibilitychange");
     sensor.start();
 
-    await eventWatcher.wait_for("reading");
+    await sensorWatcher.wait_for("reading");
     assert_reading_not_null(sensor);
     const cachedSensor1 = reading_to_array(sensor);
 
@@ -192,10 +188,10 @@ function runGenericSensorInsecureContext(sensorType) {
 function runGenericSensorOnerror(sensorType) {
   promise_test(async t => {
     const sensor = new sensorType();
-    const eventWatcher = new EventWatcher(t, sensor, ["error", "activate"]);
+    const sensorWatcher = new EventWatcher(t, sensor, ["error", "activate"]);
     sensor.start();
 
-    const event = await eventWatcher.wait_for("error");
+    const event = await sensorWatcher.wait_for("error");
     assert_false(sensor.activated);
     assert_equals(event.error.name, 'NotReadableError');
   }, `${sensorType.name}: 'onerror' event is fired when sensor is not supported`);

--- a/orientation-sensor/OrientationSensor.https.html
+++ b/orientation-sensor/OrientationSensor.https.html
@@ -42,7 +42,7 @@ async function checkQuaternion(t, sensorType) {
 async function checkPopulateMatrix(t, sensorType) {
   const sensor = new sensorType();
   const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
-  
+
   //Throws with insufficient buffer space.
   assert_throws({ name: 'TypeError' }, () => sensor.populateMatrix(new Float32Array(15)));
 

--- a/orientation-sensor/OrientationSensor.https.html
+++ b/orientation-sensor/OrientationSensor.https.html
@@ -15,11 +15,11 @@
 const float_precision = 1e-7;
 
 function create_matrix(quat) {
-  let X = quat[0];
-  let Y = quat[1];
-  let Z = quat[2];
-  let W = quat[3];
-  let mat = new Array(
+  const X = quat[0];
+  const Y = quat[1];
+  const Z = quat[2];
+  const W = quat[3];
+  const mat = new Array(
     1-2*Y*Y-2*Z*Z, 2*X*Y-2*Z*W, 2*X*Z+2*Y*W, 0,
     2*X*Y+2*Z*W, 1-2*X*X-2*Z*Z, 2*Y*Z-2*X*W, 0,
     2*X*Z-2*Y*W, 2*Y*Z+2*W*X, 1-2*X*X-2*Y*Y, 0,
@@ -28,21 +28,21 @@ function create_matrix(quat) {
   return mat;
 }
 
-function checkQuaternion(t, sensorType) {
-  let sensor = new sensorType();
-  sensor.onreading = t.step_func_done(() => {
-    assert_equals(sensor.quaternion.length, 4);
-    assert_true(sensor.quaternion instanceof Array);
-    sensor.stop();
-  });
-  sensor.onerror = t.step_func_done(unreached);
+async function checkQuaternion(t, sensorType) {
+  const sensor = new sensorType();
+  const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
   sensor.start();
+
+  await eventWatcher.wait_for("reading");
+  assert_equals(sensor.quaternion.length, 4);
+  assert_true(sensor.quaternion instanceof Array);
+  sensor.stop();
 };
 
-function checkPopulateMatrix(t, sensorType) {
-  let sensor = new sensorType();
-  sensor.onerror = t.step_func_done(unreached);
-
+async function checkPopulateMatrix(t, sensorType) {
+  const sensor = new sensorType();
+  const eventWatcher = new EventWatcher(t, sensor, ["reading", "error"]);
+  
   //Throws with insufficient buffer space.
   assert_throws({ name: 'TypeError' }, () => sensor.populateMatrix(new Float32Array(15)));
 
@@ -54,47 +54,46 @@ function checkPopulateMatrix(t, sensorType) {
     assert_throws({ name: 'TypeError' }, () => sensor.populateMatrix(new Float32Array(new SharedArrayBuffer(16))));
   }
 
-  sensor.onreading = t.step_func_done(() => {
-    let quat = sensor.quaternion;
-    let mat_expect = create_matrix(quat);
-
-    // Works for all supported types.
-    let mat_32 = new Float32Array(16);
-    sensor.populateMatrix(mat_32);
-    assert_array_approx_equals(mat_32, mat_expect, float_precision);
-
-    let mat_64 = new Float64Array(16);
-    sensor.populateMatrix(mat_64);
-    assert_array_equals(mat_64, mat_expect);
-
-    let mat_dom = new DOMMatrix();
-    sensor.populateMatrix(mat_dom);
-    assert_array_equals(mat_dom.toFloat64Array(), mat_expect);
-
-    // Sets every matrix element.
-    mat_64.fill(123);
-    sensor.populateMatrix(mat_64);
-    assert_array_equals(mat_64, mat_expect);
-
-    sensor.stop();
-  });
   sensor.start();
+  await eventWatcher.wait_for("reading");
+  const quat = sensor.quaternion;
+  const mat_expect = create_matrix(quat);
+
+  // Works for all supported types.
+  const mat_32 = new Float32Array(16);
+  sensor.populateMatrix(mat_32);
+  assert_array_approx_equals(mat_32, mat_expect, float_precision);
+
+  const mat_64 = new Float64Array(16);
+  sensor.populateMatrix(mat_64);
+  assert_array_equals(mat_64, mat_expect);
+
+  const mat_dom = new DOMMatrix();
+  sensor.populateMatrix(mat_dom);
+  assert_array_equals(mat_dom.toFloat64Array(), mat_expect);
+
+  // Sets every matrix element.
+  mat_64.fill(123);
+  sensor.populateMatrix(mat_64);
+  assert_array_equals(mat_64, mat_expect);
+
+  sensor.stop();
 }
 
-async_test(t => {
-  checkQuaternion(t, AbsoluteOrientationSensor);
+promise_test(t => {
+  return checkQuaternion(t, AbsoluteOrientationSensor);
 }, "Test AbsoluteOrientationSensor.quaternion return a four-element FrozenArray.");
 
-async_test(t => {
-  checkQuaternion(t, RelativeOrientationSensor);
+promise_test(t => {
+  return checkQuaternion(t, RelativeOrientationSensor);
 }, "Test RelativeOrientationSensor.quaternion return a four-element FrozenArray.");
 
-async_test(t => {
-  checkPopulateMatrix(t, AbsoluteOrientationSensor);
+promise_test(t => {
+  return checkPopulateMatrix(t, AbsoluteOrientationSensor);
 }, "Test AbsoluteOrientationSensor.populateMatrix() method works correctly.");
 
-async_test(t => {
-  checkPopulateMatrix(t, RelativeOrientationSensor);
+promise_test(t => {
+  return checkPopulateMatrix(t, RelativeOrientationSensor);
 }, "Test RelativeOrientationSensor.populateMatrix() method works correctly.");
 
 runGenericSensorTests(AbsoluteOrientationSensor);


### PR DESCRIPTION
Use EventWatcher and promise_test with async/await can make our code easier to understand and simpler to write.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
