### PR TITLE
Make error messages around /etc/hosts more consistent

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -446,7 +446,8 @@ def check_subdomains(host, paths, bind_hostname, ssl_config, aliases):
             time.sleep(1)
 
     if not connected:
-        logger.critical("Failed to connect to test server on http://%s:%s You may need to edit /etc/hosts or similar" % (host, port))
+        logger.critical("Failed to connect to test server on http://%s:%s. "
+                        "You may need to edit /etc/hosts or similar, see README.md." % (host, port))
         sys.exit(1)
 
     for subdomain, (punycode, host) in subdomains.iteritems():
@@ -454,7 +455,8 @@ def check_subdomains(host, paths, bind_hostname, ssl_config, aliases):
         try:
             urllib2.urlopen("http://%s:%d/" % (domain, port))
         except Exception as e:
-            logger.critical("Failed probing domain %s. You may need to edit /etc/hosts or similar." % domain)
+            logger.critical("Failed probing domain %s. "
+                            "You may need to edit /etc/hosts or similar, see README.md." % domain)
             sys.exit(1)
 
     wrapper.wait()

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -418,7 +418,8 @@ class WebTestHttpd(object):
 
             _host, self.port = self.httpd.socket.getsockname()
         except Exception:
-            self.logger.error('Init failed! You may need to modify your hosts file. Refer to README.md.')
+            self.logger.error("Failed to start HTTP server. "
+                              "You may need to edit /etc/hosts or similar, see README.md.")
             raise
 
     def start(self, block=False):


### PR DESCRIPTION
This is what remains after removing some real changes around
https://github.com/w3c/web-platform-tests/issues/8182, and seems just
as well to make prettier. Make some lines shorter too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8296)
<!-- Reviewable:end -->
