### PR TITLE
Marionette executor has to use raise_for_port. r=ato,jgraham

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -63,30 +63,26 @@ class MarionetteProtocol(Protocol):
         self.marionette = marionette.Marionette(host='localhost',
                                                 port=self.marionette_port,
                                                 socket_timeout=None,
-                                                startup_timeout=None)
+                                                startup_timeout=startup_timeout)
+        try:
+            self.logger.debug("Waiting for Marionette connection")
+            while True:
+                try:
+                    self.marionette.raise_for_port()
+                    break
+                except IOError:
+                    # When running in a debugger wait indefinitely for Firefox to start
+                    if self.executor.debug_info is None:
+                        raise
 
-        # XXX Move this timeout somewhere
-        self.logger.debug("Waiting for Marionette connection")
-        while True:
-            success = self.marionette.wait_for_port(startup_timeout)
-            #When running in a debugger wait indefinitely for firefox to start
-            if success or self.executor.debug_info is None:
-                break
+            self.logger.debug("Starting Marionette session")
+            self.marionette.start_session()
+            self.logger.debug("Marionette session started")
 
-        session_started = False
-        if success:
-            try:
-                self.logger.debug("Starting Marionette session")
-                self.marionette.start_session(capabilities=self.capabilities)
-            except Exception as e:
-                self.logger.warning("Starting marionette session failed: %s" % e)
-            else:
-                self.logger.debug("Marionette session started")
-                session_started = True
-
-        if not success or not session_started:
-            self.logger.warning("Failed to connect to Marionette")
+        except Exception as e:
+            self.logger.warning("Failed to start a Marionette session: %s" % e)
             self.executor.runner.send_message("init_failed")
+
         else:
             try:
                 self.after_connect()
@@ -173,7 +169,11 @@ class MarionetteProtocol(Protocol):
             self.load_runner(protocol)
 
     def wait(self):
-        socket_timeout = self.marionette.client.sock.gettimeout()
+        try:
+            socket_timeout = self.marionette.client.socket_timeout
+        except AttributeError:
+            # This can happen if there was a crash
+            return
         if socket_timeout:
             self.marionette.timeout.script = socket_timeout / 2
 


### PR DESCRIPTION

To allow more fine-grained failure details when waiting for
a port, raise_for_port has to be used.

MozReview-Commit-ID: 5Anfd9yRVY0

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1414882 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8314)
<!-- Reviewable:end -->
