### PR TITLE
Fix HTTP status for stale element reference error

### DIFF
--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -107,7 +107,7 @@ class SessionNotCreatedException(WebDriverException):
 
 
 class StaleElementReferenceException(WebDriverException):
-    http_status = 400
+    http_status = 404
     status_code = "stale element reference"
 
 

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -21,7 +21,7 @@ errors = {
     "no such window": 404,
     "script timeout": 408,
     "session not created": 500,
-    "stale element reference": 400,
+    "stale element reference": 404,
     "timeout": 408,
     "unable to set cookie": 500,
     "unable to capture screen": 500,


### PR DESCRIPTION

The HTTP status for the "stale element reference" error in WebDriver
should be 404 (Not Found).

MozReview-Commit-ID: CBb7Ds8AEY3

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1410799 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8317)
<!-- Reviewable:end -->
