### PR TITLE
Fix insertion point computation when display: contents pseudos are involved. r=mats,bz

### DIFF
--- a/css/css-display-3/display-contents-dynamic-pseudo-insertion-001-ref.html
+++ b/css/css-display-3/display-contents-dynamic-pseudo-insertion-001-ref.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+PASS

--- a/css/css-display-3/display-contents-dynamic-pseudo-insertion-001.html
+++ b/css/css-display-3/display-contents-dynamic-pseudo-insertion-001.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test: Dynamic insertion on empty display: contents element with pseudo-elements</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-display-3/#valdef-display-contents">
+<link rel=match href="display-contents-dynamic-pseudo-insertion-001-ref.html">
+<style>
+.contents {
+  display: contents;
+  border: 10px solid red;
+}
+.contents::before {
+  content: "A";
+}
+.contents::after {
+  content: "SS";
+}
+</style>
+<div class="contents"></div>
+<script>
+document.body.offsetTop;
+let span = document.createElement('span');
+span.innerHTML = "P";
+let contents = document.querySelector('.contents');
+contents.parentNode.insertBefore(span, contents);
+</script>


### PR DESCRIPTION

This is a significant rework of how do we compute the insertion point of a
node.

We handle pseudos in the same function instead of out of band, and also recurse
up when the parent has display: contents, which simplifies the code IMO.

MozReview-Commit-ID: 1rSfv1Tq5gO

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1413619 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8319)
<!-- Reviewable:end -->
