### PR TITLE
Increase timeout for tone events in RTCDTMFSender-helper.js;

### DIFF
--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -76,8 +76,8 @@ function test_tone_change_events(testFunc, toneChanges, desc) {
         const now = Date.now();
         const duration = now - lastEventTime;
 
-        assert_approx_equals(duration, expectedDuration, 150,
-          `Expect tonechange event for "${tone}" to be fired approximately after ${expectedDuration} seconds`);
+        assert_approx_equals(duration, expectedDuration, 250,
+          `Expect tonechange event for "${tone}" to be fired approximately after ${expectedDuration} milliseconds`);
 
         lastEventTime = now;
 


### PR DESCRIPTION

With the current value of 150 milliseconds we get intermittent timeouts on our
test infrastructure. We are missing by only a small amount, e.g. 6 milliseconds
in Bug 1415283, but it seems safer to increase the timeout to 250 milliseconds so
that we don't end up revisiting this problem in the future.

This also fixes the error message to say milliseconds rather than seconds.

MozReview-Commit-ID: CqjTKZn33q8

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415283 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8321)
<!-- Reviewable:end -->
