### PR TITLE
Part5 - Fix cross origin test failure. r=bz,jgraham

### DIFF
--- a/encrypted-media/scripts/unique-origin.js
+++ b/encrypted-media/scripts/unique-origin.js
@@ -10,7 +10,7 @@ function runTest(config) {
                 resolve(iframe);
             };
             iframe.sandbox = sandbox;
-            iframe.src = src;
+            iframe.srcdoc = src;
             document.documentElement.appendChild(iframe);
         });
     }
@@ -25,7 +25,7 @@ function runTest(config) {
     }
 
     promise_test(function (test) {
-        var script = 'data:text/html,' +
+        var script =
           '<script>' +
           '    window.onmessage = function(e) {' +
           '        navigator.requestMediaKeySystemAccess("' + config.keysystem + '", [{' +
@@ -53,7 +53,7 @@ function runTest(config) {
             return access.createMediaKeys();
         }).then(function (mediaKeys) {
             // Success, so now create the iframe and try there.
-            return load_iframe(script, 'allow-scripts');
+            return load_iframe(script, 'allow-scripts allow-secure-context');
         }).then(function (iframe) {
             iframe.contentWindow.postMessage({}, '*');
             return wait_for_message();


### PR DESCRIPTION

Bug 1322517 will make the EME APIs only run on secure context.
This bug will try to make WPT test run with https.
According to the spec https://www.w3.org/TR/secure-contexts/#is-url-trustworthy
I got "TypeError: navigator.requestMediaKeySystemAccess is not a function" by the original code.
So I need this patch to make the test work as expected.

MozReview-Commit-ID: Gp23IcscXHE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1413427 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8324)
<!-- Reviewable:end -->
