### PR TITLE
Tidy up titles of Web Animations web-platform-tests;

### DIFF
--- a/web-animations/animation-model/animation-types/accumulation-per-property.html
+++ b/web-animations/animation-model/animation-types/accumulation-per-property.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Tests for animation type of accumulation</title>
+<title>Accumulation for each property</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#animation-types">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/animation-types/addition-per-property.html
+++ b/web-animations/animation-model/animation-types/addition-per-property.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Tests for animation type of addition</title>
+<title>Addition for each property</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#animation-types">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/animation-types/discrete-animation.html
+++ b/web-animations/animation-model/animation-types/discrete-animation.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for discrete animation</title>
-<link rel="help" href="http://w3c.github.io/web-animations/#animatable-as-string-section">
+<title>Discrete animation</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#discrete-animation-type">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/animation-model/animation-types/interpolation-per-property.html
+++ b/web-animations/animation-model/animation-types/interpolation-per-property.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for animation type of interpolation</title>
+<title>Interpolation for each property</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#animation-types">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/combining-effects/effect-composition.html
+++ b/web-animations/animation-model/combining-effects/effect-composition.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Test for effect composition</title>
+<title>Effect composition</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#effect-composition">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>

--- a/web-animations/animation-model/keyframe-effects/effect-value-context.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-context.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests that property values respond to changes to their context</title>
-<link rel="help" href="https://w3c.github.io/web-animations/#keyframes-section">
+<title>Calculating computed keyframes: Property values that depend on their context (target element)</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#calculating-computed-keyframes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Effect value computation tests when keyframes overlap</title>
+<title>The effect value of a keyframe effect: Overlapping keyframes</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for calculation of the transformed distance when computing an effect value</title>
+<title>Transformed distance when computing an effect value</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-visibility.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Effect value computation tests for 'visibility' property</title>
+<title>Effect value for 'visibility' property</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animatable/animate-no-browsing-context.html
+++ b/web-animations/interfaces/Animatable/animate-no-browsing-context.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Animatable.animate tests in combination with elements in documents
+<title>Animatable.animate in combination with elements in documents
        without a browsing context</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animatable-animate">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/interfaces/Animatable/animate.html
+++ b/web-animations/interfaces/Animatable/animate.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animatable.animate tests</title>
+<title>Animatable.animate</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animatable-animate">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animatable/getAnimations.html
+++ b/web-animations/interfaces/Animatable/getAnimations.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animatable.getAnimations tests</title>
+<title>Animatable.getAnimations</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animatable-getanimations">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/cancel.html
+++ b/web-animations/interfaces/Animation/cancel.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.cancel()</title>
+<title>Animation.cancel</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-cancel">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/constructor.html
+++ b/web-animations/interfaces/Animation/constructor.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation constructor tests</title>
-<link rel="help" href="http://w3c.github.io/web-animations/#dom-animation-animation">
-<link rel="author" title="Hiroyuki Ikezoe" href="mailto:hiikezoe@mozilla-japan.org">
+<title>Animation constructor</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-animation">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/Animation/effect.html
+++ b/web-animations/interfaces/Animation/effect.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.effect tests</title>
+<title>Animation.effect</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/finish.html
+++ b/web-animations/interfaces/Animation/finish.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.finish()</title>
+<title>Animation.finish</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-finish">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/pause.html
+++ b/web-animations/interfaces/Animation/pause.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.pause()</title>
+<title>Animation.pause</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-pause">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/play.html
+++ b/web-animations/interfaces/Animation/play.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.play()</title>
+<title>Animation.play</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-play">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Animation/startTime.html
+++ b/web-animations/interfaces/Animation/startTime.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Animation.startTime tests</title>
+<title>Animation.startTime</title>
 <link rel="help"
 href="https://w3c.github.io/web-animations/#dom-animation-starttime">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/delay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/delay.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>delay tests</title>
+<title>AnimationEffectTiming.delay</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-delay">
-<link rel="author" title="Daisuke Akatsuka" href="mailto:daisuke@mozilla-japan.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/direction.html
+++ b/web-animations/interfaces/AnimationEffectTiming/direction.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>direction tests</title>
+<title>AnimationEffectTiming.direction</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-direction">
-<link rel="author" title="Ryo Kato" href="mailto:foobar094@gmail.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/duration.html
+++ b/web-animations/interfaces/AnimationEffectTiming/duration.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>duration tests</title>
-<link rel="help" href="http://w3c.github.io/web-animations/#dom-animationeffecttiming-duration">
-<link rel="author" title="Ryo Motozawa" href="mailto:motozawa@mozilla-japan.org">
+<title>AnimationEffectTiming.duration</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-duration">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/easing.html
+++ b/web-animations/interfaces/AnimationEffectTiming/easing.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>easing tests</title>
+<title>AnimationEffectTiming.easing</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-easing">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/endDelay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/endDelay.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>endDelay tests</title>
-<link rel="help" href="http://w3c.github.io/web-animations/#dom-animationeffecttiming-enddelay">
-<link rel="author" title="Ryo Motozawa" href="mailto:motozawa@mozilla-japan.org">
+<title>AnimationEffectTiming.endDelay</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-enddelay">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/fill.html
+++ b/web-animations/interfaces/AnimationEffectTiming/fill.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>fill tests</title>
+<title>AnimationEffectTiming.fill</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-fill">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/getAnimations.html
+++ b/web-animations/interfaces/AnimationEffectTiming/getAnimations.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Element.getAnimations tests</title>
+<title>Element.getAnimations</title>
 <link rel="help" href="http://w3c.github.io/web-animations/#animationeffecttiming">
-<link rel="author" title="Ryo Motozawa" href="mailto:motozawa@mozilla-japan.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
+++ b/web-animations/interfaces/AnimationEffectTiming/getComputedStyle.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>getComputedStyle tests</title>
+<title>getComputedStyle</title>
 <link rel="help" href="http://w3c.github.io/web-animations/#animationeffecttiming">
-<link rel="author" title="Ryo Motozawa" href="mailto:motozawa@mozilla-japan.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>iterationStart tests</title>
+<title>AnimationEffectTiming.iterationStart</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-iterationstart">
-<link rel="author" title="Daisuke Akatsuka" href="mailto:daisuke@mozilla-japan.org">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/AnimationEffectTiming/iterations.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterations.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>iterations tests</title>
+<title>AnimationEffectTiming.iterations</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffecttiming-iterations">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/Document/getAnimations.html
+++ b/web-animations/interfaces/Document/getAnimations.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>document.getAnimations tests</title>
+<title>Document.getAnimations</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-document-getanimations">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/composite.html
+++ b/web-animations/interfaces/KeyframeEffect/composite.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>KeyframeEffect.composite tests</title>
+<title>KeyframeEffect.composite</title>
 <link rel="help"
       href="https://w3c.github.io/web-animations/#dom-keyframeeffect-composite">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
+++ b/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffectReadOnly getComputedTiming() tests</title>
+<title>KeyframeEffectReadOnly.getComputedTiming</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffectreadonly-getcomputedtiming">
-<link rel="author" title="Boris Chiou" href="mailto:boris.chiou@gmail.com">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/iterationComposite.html
+++ b/web-animations/interfaces/KeyframeEffect/iterationComposite.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>KeyframeEffect.iterationComposite tests</title>
+<title>KeyframeEffect.iterationComposite</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#effect-accumulation-section">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for processing a keyframes argument (property access)</title>
+<title>Processing a keyframes argument (property access)</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#processing-a-keyframes-argument">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-002.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for processing a keyframes argument (easing)</title>
+<title>Processing a keyframes argument (easing)</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#processing-a-keyframes-argument">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/setKeyframes.html
+++ b/web-animations/interfaces/KeyframeEffect/setKeyframes.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffect setKeyframes() tests</title>
+<title>KeyframeEffect.setKeyframes</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-keyframeeffect-setkeyframes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/interfaces/KeyframeEffect/setTarget.html
+++ b/web-animations/interfaces/KeyframeEffect/setTarget.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Writable effect.target tests</title>
+<title>KeyframeEffect.target</title>
 <link rel="help"
   href="https://w3c.github.io/web-animations/#dom-keyframeeffect-target">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/timing-model/animation-effects/active-time.html
+++ b/web-animations/timing-model/animation-effects/active-time.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Active time tests</title>
+<title>Active time</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#calculating-the-active-time">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animation-effects/current-iteration.html
+++ b/web-animations/timing-model/animation-effects/current-iteration.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Current iteration tests</title>
+<title>Current iteration</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#current-iteration">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animation-effects/local-time.html
+++ b/web-animations/timing-model/animation-effects/local-time.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>AnimationEffect local time tests</title>
+<title>Local time</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#local-time">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animation-effects/phases-and-states.html
+++ b/web-animations/timing-model/animation-effects/phases-and-states.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset=utf-8>
-<title>Tests for phases and states</title>
+<title>Phases and states</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#animation-effect-phases-and-states">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animation-effects/simple-iteration-progress.html
+++ b/web-animations/timing-model/animation-effects/simple-iteration-progress.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Simple iteration progress tests</title>
+<title>Simple iteration progress</title>
 <link rel="help"
       href="https://w3c.github.io/web-animations/#simple-iteration-progress">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/timing-model/animations/current-time.html
+++ b/web-animations/timing-model/animations/current-time.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for current time</title>
+<title>Current time</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#current-time">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animations/pausing-an-animation.html
+++ b/web-animations/timing-model/animations/pausing-an-animation.html
@@ -2,7 +2,7 @@
 <meta charset=utf-8>
 <title>Pausing an animation</title>
 <link rel="help"
-  href="https://w3c.github.io/web-animations/#finishing-an-animation-section">
+  href="https://w3c.github.io/web-animations/#pausing-an-animation-section">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>

--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Reversing an animation</title>
+<title>Reverse an animation</title>
 <link rel="help"
       href="https://w3c.github.io/web-animations/#reverse-an-animation">
 <script src="/resources/testharness.js"></script>

--- a/web-animations/timing-model/animations/set-the-animation-start-time.html
+++ b/web-animations/timing-model/animations/set-the-animation-start-time.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Setting the start time tests</title>
+<title>Set the animation start time</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#set-the-animation-start-time">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Setting the target effect tests</title>
+<title>Setting the target effect</title>
 <link rel='help' href='https://w3c.github.io/web-animations/#setting-the-target-effect'>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>

--- a/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Setting the timeline tests</title>
+<title>Setting the timeline</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#setting-the-timeline">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/animations/updating-the-finished-state.html
+++ b/web-animations/timing-model/animations/updating-the-finished-state.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for updating the finished state of an animation</title>
+<title>Updating the finished state</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#updating-the-finished-state">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/timing-model/time-transformations/transformed-progress.html
+++ b/web-animations/timing-model/time-transformations/transformed-progress.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Tests for the transformed progress</title>
+<title>Transformed progress</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#calculating-the-transformed-progress">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION

It's not necessary to say "tests" or "tests for" in the title of these tests.
It's obvious from the context that these are test files.

This patch:

* Remove "Tests for" and "tests" from the titles
* Makes the titles match the spec sections they test more closely where
  practical
* Makes the titles more consistent in general (e.g. not putting () after method
  names)
* Updates a few spec links
* Drops a few author annotations since we decided to no longer use them

There are still some inconsistencies:

- The naming of the setTarget.html test file
- The location of the effect-value-visibility.html file
- The getComputedStyle.html test
- etc.

These will be fixed in subsequent patches in this series.

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415448 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8326)
<!-- Reviewable:end -->
