### PR TITLE
Move the tests for the type of the 'visibility' property to the animation-types section;

### DIFF
--- a/web-animations/animation-model/animation-types/visibility.html
+++ b/web-animations/animation-model/animation-types/visibility.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Effect value for 'visibility' property</title>
-<link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
+<title>Animation type for the 'visibility' property</title>
+<!-- FIXME: The following spec link should be updated once this definition has
+  been moved to CSS Values & Units. -->
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#animtype-visibility">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="../../testcommon.js"></script>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415448 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8328)
<!-- Reviewable:end -->
