### PR TITLE
Tidy up test descriptions for AnimationEffectTiming tests;

### DIFF
--- a/web-animations/interfaces/AnimationEffectTiming/delay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/delay.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.delay, 0);
-}, 'Test default value');
+}, 'Has the default value 0');
 
 test(function(t) {
   var div = createDiv(t);
@@ -22,7 +22,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.delay, 100, 'set delay 100');
   assert_equals(anim.effect.getComputedTiming().delay, 100,
                   'getComputedTiming() after set delay 100');
-}, 'set delay 100');
+}, 'Can be set to a positive number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -31,7 +31,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.delay, -100, 'set delay -100');
   assert_equals(anim.effect.getComputedTiming().delay, -100,
                 'getComputedTiming() after set delay -100');
-}, 'set delay -100');
+}, 'Can be set to a negative number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -39,8 +39,8 @@ test(function(t) {
   anim.effect.timing.delay = 100;
   assert_equals(anim.effect.getComputedTiming().progress, null);
   assert_equals(anim.effect.getComputedTiming().currentIteration, null);
-}, 'Test adding a positive delay to an animation without a backwards fill ' +
-   'makes it no longer active');
+}, 'Can set a positive delay on an animation without a backwards fill to'
+   + ' make it no longer active');
 
 test(function(t) {
   var div = createDiv(t);
@@ -49,7 +49,7 @@ test(function(t) {
                            duration: 100 });
   anim.effect.timing.delay = -50;
   assert_equals(anim.effect.getComputedTiming().progress, 0.5);
-}, 'Test seeking an animation by setting a negative delay');
+}, 'Can set a negative delay to seek into the active interval');
 
 test(function(t) {
   var div = createDiv(t);
@@ -59,7 +59,7 @@ test(function(t) {
   anim.effect.timing.delay = -100;
   assert_equals(anim.effect.getComputedTiming().progress, 1);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 0);
-}, 'Test finishing an animation using a large negative delay');
+}, 'Can set a large negative delay to finishing an animation');
 
 test(function(t) {
   var div = createDiv(t);
@@ -72,7 +72,7 @@ test(function(t) {
       div.animate({}, { delay: invalid });
     }, 'animate() with ' + invalid);
   }
-}, 'Setting invalid values should throw TypeError');
+}, 'Throws when setting invalid values');
 
 </script>
 </body>

--- a/web-animations/interfaces/AnimationEffectTiming/direction.html
+++ b/web-animations/interfaces/AnimationEffectTiming/direction.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.direction, 'normal');
-}, 'Test default value');
+}, 'Has the default value \'normal\'');
 
 test(function(t) {
   var div = createDiv(t);
@@ -25,7 +25,7 @@ test(function(t) {
     assert_equals(anim.effect.timing.direction, direction,
                   'set direction to ' + direction);
   });
-}, 'set direction to a valid keyword');
+}, 'Can be set to each of the possible keywords');
 
 </script>
 </body>

--- a/web-animations/interfaces/AnimationEffectTiming/duration.html
+++ b/web-animations/interfaces/AnimationEffectTiming/duration.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.duration, 'auto');
-}, 'Test default value');
+}, 'Has the default value \'auto\'');
 
 test(function(t) {
   var div = createDiv(t);
@@ -23,7 +23,7 @@ test(function(t) {
                      'set duration 123.45');
   assert_times_equal(anim.effect.getComputedTiming().duration, 123.45,
                      'getComputedTiming() after set duration 123.45');
-}, 'set duration 123.45');
+}, 'Can be set to a double value');
 
 test(function(t) {
   var div = createDiv(t);
@@ -32,7 +32,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.duration, 'auto', 'set duration \'auto\'');
   assert_equals(anim.effect.getComputedTiming().duration, 0,
                 'getComputedTiming() after set duration \'auto\'');
-}, 'set duration auto');
+}, 'Can be set to the string \'auto\'');
 
 test(function(t) {
   var div = createDiv(t);
@@ -40,7 +40,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.duration, 'auto', 'set duration \'auto\'');
   assert_equals(anim.effect.getComputedTiming().duration, 0,
                 'getComputedTiming() after set duration \'auto\'');
-}, 'set auto duration in animate as object');
+}, 'Can be set to \'auto\' using a dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
@@ -49,63 +49,65 @@ test(function(t) {
   assert_equals(anim.effect.timing.duration, Infinity, 'set duration Infinity');
   assert_equals(anim.effect.getComputedTiming().duration, Infinity,
                 'getComputedTiming() after set duration Infinity');
-}, 'set duration Infinity');
+}, 'Can be set to Infinity');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, -1);
   });
-}, 'set negative duration in animate using a duration parameter');
+}, 'animate() throws when passed a negative number');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, -Infinity);
   });
-}, 'set negative Infinity duration in animate using a duration parameter');
+}, 'animate() throws when passed negative Infinity');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, NaN);
   });
-}, 'set NaN duration in animate using a duration parameter');
+}, 'animate() throws when passed a NaN value');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, { duration: -1 });
   });
-}, 'set negative duration in animate using an options object');
+}, 'animate() throws when passed a negative number using a dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, { duration: -Infinity });
   });
-}, 'set negative Infinity duration in animate using an options object');
+}, 'animate() throws when passed negative Infinity using a dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, { duration: NaN });
   });
-}, 'set NaN duration in animate using an options object');
+}, 'animate() throws when passed a NaN value using a dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, { duration: 'abc' });
   });
-}, 'set abc string duration in animate using an options object');
+}, 'animate() throws when passed a string other than \'auto\' using a'
+   + ' dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
   assert_throws({ name: 'TypeError' }, function() {
     div.animate({ opacity: [ 0, 1 ] }, { duration: '100' });
   });
-}, 'set 100 string duration in animate using an options object');
+}, 'animate() throws when passed a string containing a number using a'
+   + ' dictionary object');
 
 test(function(t) {
   var div = createDiv(t);
@@ -113,7 +115,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.duration = -1;
   });
-}, 'set negative duration');
+}, 'Throws when setting a negative number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -121,7 +123,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.duration = -Infinity;
   });
-}, 'set negative Infinity duration');
+}, 'Throws when setting negative infinity');
 
 test(function(t) {
   var div = createDiv(t);
@@ -129,7 +131,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.duration = NaN;
   });
-}, 'set NaN duration');
+}, 'Throws when setting a NaN value');
 
 test(function(t) {
   var div = createDiv(t);
@@ -137,7 +139,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.duration = 'abc';
   });
-}, 'set duration abc');
+}, 'Throws when setting a string other than \'auto\'');
 
 test(function(t) {
   var div = createDiv(t);
@@ -145,7 +147,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.duration = '100';
   });
-}, 'set duration string 100');
+}, 'Throws when setting a string containing a number');
 
 promise_test(function(t) {
   var anim = createDiv(t).animate(null, 100 * MS_PER_SEC);

--- a/web-animations/interfaces/AnimationEffectTiming/easing.html
+++ b/web-animations/interfaces/AnimationEffectTiming/easing.html
@@ -14,7 +14,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.easing, 'linear');
-}, 'Test default value');
+}, 'Has the default value \'linear\'');
 
 function assert_progress(animation, currentTime, easingFunction) {
   animation.currentTime = currentTime;
@@ -53,7 +53,7 @@ gInvalidEasings.forEach(function(invalidEasing) {
                   function() {
                     anim.effect.timing.easing = invalidEasing;
                   });
-  }, 'Invalid effect easing value test: \'' + invalidEasing + '\'');
+  }, 'Throws on invalid easing: \'' + invalidEasing + '\'');
 });
 
 gRoundtripEasings.forEach(easing => {
@@ -90,7 +90,7 @@ test(function(t) {
   anim.effect.timing.easing = 'steps(2, end)';
   assert_equals(anim.effect.getComputedTiming().progress, 1,
                 'easing replace to steps(2, end) again at after phase');
-}, 'Change the easing while the animation is running');
+}, 'Allows the easing to be changed while the animation is in progress');
 
 </script>
 </body>

--- a/web-animations/interfaces/AnimationEffectTiming/endDelay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/endDelay.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.endDelay, 0);
-}, 'Test default value');
+}, 'Has the default value 0');
 
 test(function(t) {
   var div = createDiv(t);
@@ -23,7 +23,7 @@ test(function(t) {
                      'set endDelay 123.45');
   assert_times_equal(anim.effect.getComputedTiming().endDelay, 123.45,
                      'getComputedTiming() after set endDelay 123.45');
-}, 'set endDelay 123.45');
+}, 'Can be set to a positive number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -32,7 +32,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.endDelay, -1000, 'set endDelay -1000');
   assert_equals(anim.effect.getComputedTiming().endDelay, -1000,
                 'getComputedTiming() after set endDelay -1000');
-}, 'set endDelay -1000');
+}, 'Can be set to a negative number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -40,7 +40,7 @@ test(function(t) {
   assert_throws({name: "TypeError"}, function() {
     anim.effect.timing.endDelay = Infinity;
   }, 'we can not assign Infinity to timing.endDelay');
-}, 'set endDelay Infinity');
+}, 'Throws when setting infinity');
 
 test(function(t) {
   var div = createDiv(t);
@@ -48,14 +48,14 @@ test(function(t) {
   assert_throws({name: "TypeError"}, function() {
     anim.effect.timing.endDelay = -Infinity;
   }, 'we can not assign negative Infinity to timing.endDelay');
-}, 'set endDelay negative Infinity');
+}, 'Throws when setting negative infinity');
 
 async_test(function(t) {
   var div = createDiv(t);
   var anim = div.animate({ opacity: [ 0, 1 ] },
                          { duration: 100000, endDelay: 50000 });
   anim.onfinish = t.step_func(function(event) {
-    assert_unreached('onfinish event should not be fired');
+    assert_unreached('finish event should not be fired');
   });
 
   anim.ready.then(function() {
@@ -64,7 +64,8 @@ async_test(function(t) {
   }).then(t.step_func(function() {
     t.done();
   }));
-}, 'onfinish event is not fired duration endDelay');
+}, 'finish event is not fired at the end of the active interval when the'
+   + ' endDelay has not expired');
 
 async_test(function(t) {
   var div = createDiv(t);
@@ -82,7 +83,7 @@ async_test(function(t) {
     });
     anim.currentTime = 130000; // after endTime
   }));
-}, 'onfinish event is fired currentTime is after endTime');
+}, 'finish event is fired after the endDelay has expired');
 
 </script>
 </body>

--- a/web-animations/interfaces/AnimationEffectTiming/fill.html
+++ b/web-animations/interfaces/AnimationEffectTiming/fill.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.fill, 'auto');
-}, 'Test default value');
+}, 'Has the default value \'auto\'');
 
 ["none", "forwards", "backwards", "both", ].forEach(function(fill){
   test(function(t) {
@@ -21,8 +21,9 @@ test(function(t) {
     var anim = div.animate({ opacity: [ 0, 1 ] }, 100);
     anim.effect.timing.fill = fill;
     assert_equals(anim.effect.timing.fill, fill, 'set fill ' + fill);
-    assert_equals(anim.effect.getComputedTiming().fill, fill, 'getComputedTiming() after set fill ' + fill);
-  }, 'set fill ' + fill);
+    assert_equals(anim.effect.getComputedTiming().fill, fill,
+                  'getComputedTiming() after set fill ' + fill);
+  }, 'Can set fill to ' + fill);
 });
 
 </script>

--- a/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterationStart.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.iterationStart, 0);
-}, 'Test default value');
+}, 'Has the default value 0');
 
 test(function(t) {
   var div = createDiv(t);
@@ -26,8 +26,7 @@ test(function(t) {
   anim.effect.timing.iterationStart = 2.5;
   assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
-}, 'Test that changing the iterationStart affects computed timing ' +
-   'when backwards-filling');
+}, 'Changing the value updates computed timing when backwards-filling');
 
 test(function(t) {
   var div = createDiv(t);
@@ -40,8 +39,7 @@ test(function(t) {
   anim.effect.timing.iterationStart = 2.5;
   assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 2);
-}, 'Test that changing the iterationStart affects computed timing ' +
-   'during the active phase');
+}, 'Changing the value updates computed timing during the active phase');
 
 test(function(t) {
   var div = createDiv(t);
@@ -55,8 +53,7 @@ test(function(t) {
   anim.effect.timing.iterationStart = 2.5;
   assert_times_equal(anim.effect.getComputedTiming().progress, 0.5);
   assert_equals(anim.effect.getComputedTiming().currentIteration, 3);
-}, 'Test that changing the iterationStart affects computed timing ' +
-   'when forwards-filling');
+}, 'Changing the value updates computed timing when forwards-filling');
 
 test(function(t) {
   var div = createDiv(t);
@@ -69,7 +66,7 @@ test(function(t) {
       div.animate({}, { iterationStart: invalid });
     }, 'animate() with ' + invalid);
   }
-}, 'Using invalid values should throw TypeError');
+}, 'Throws when setting invalid values');
 
 </script>
 </body>

--- a/web-animations/interfaces/AnimationEffectTiming/iterations.html
+++ b/web-animations/interfaces/AnimationEffectTiming/iterations.html
@@ -13,7 +13,7 @@
 test(function(t) {
   var anim = createDiv(t).animate(null);
   assert_equals(anim.effect.timing.iterations, 1);
-}, 'Test default value');
+}, 'Has the default value 1');
 
 test(function(t) {
   var div = createDiv(t);
@@ -22,7 +22,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.iterations, 2, 'set duration 2');
   assert_equals(anim.effect.getComputedTiming().iterations, 2,
                        'getComputedTiming() after set iterations 2');
-}, 'set iterations 2');
+}, 'Can be set to a double value');
 
 test(function(t) {
   var div = createDiv(t);
@@ -31,7 +31,7 @@ test(function(t) {
   assert_equals(anim.effect.timing.iterations, Infinity, 'set duration Infinity');
   assert_equals(anim.effect.getComputedTiming().iterations, Infinity,
                        'getComputedTiming() after set iterations Infinity');
-}, 'set iterations Infinity');
+}, 'Can be set to infinity');
 
 test(function(t) {
   var div = createDiv(t);
@@ -39,7 +39,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.iterations = -1;
   });
-}, 'set negative iterations');
+}, 'Throws when setting a negative number');
 
 test(function(t) {
   var div = createDiv(t);
@@ -47,7 +47,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.iterations = -Infinity;
   });
-}, 'set negative infinity iterations ');
+}, 'Throws when setting negative infinity');
 
 test(function(t) {
   var div = createDiv(t);
@@ -55,7 +55,7 @@ test(function(t) {
   assert_throws({ name: 'TypeError' }, function() {
     anim.effect.timing.iterations = NaN;
   });
-}, 'set NaN iterations');
+}, 'Throws when setting a NaN value');
 
 </script>
 </body>


### PR DESCRIPTION

The test descriptions should generally be testable statements. I'm following the
convention of BDD-style naming where the subject is implied (e.g. 'Has the
default value 0' should be read as '<test subject> has the default value 0').

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415448 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8330)
<!-- Reviewable:end -->
