### PR TITLE
Test that font-variant-alternates: historical-forms is parsed case-insensitively.

### DIFF
--- a/css/css-fonts-3/font-variant-alternates-parsing.html
+++ b/css/css-fonts-3/font-variant-alternates-parsing.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Test:  font-variant-alternates: historical-forms; parses case-insensitively</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="emilio@crisal.io">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  let div = document.createElement('div');
+  div.style.fontVariantAlternates = "Historical-Forms";
+  assert_equals(
+    getComputedStyle(div).fontVariantAlternates,
+    "historical-forms",
+    "historical-forms is parsed case-insensitively"
+  );
+});
+</script>


### PR DESCRIPTION

MozReview-Commit-ID: 4qUwqD2pdD8

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415946 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8335)
<!-- Reviewable:end -->
