### PR TITLE
Change tests of calc in media-queries so that the root element style has been resolved first.

### DIFF
--- a/css/mediaqueries/mq-calc-002.html
+++ b/css/mediaqueries/mq-calc-002.html
@@ -19,11 +19,19 @@
 			@media (min-width: calc(1em)){
 				div { background-color: green; }
 			}
-	</style>
+		</style>
 	</head>
 	<body>
 		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1em)){
+				div { background-color: green; }
+			}
+		</style>
 	</body>
 </html>
 

--- a/css/mediaqueries/mq-calc-003.html
+++ b/css/mediaqueries/mq-calc-003.html
@@ -19,11 +19,19 @@
 			@media (min-width: calc(1ex)){
 				div { background-color: green; }
 			}
-	</style>
+		</style>
 	</head>
 	<body>
 		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1ex)){
+				div { background-color: green; }
+			}
+		</style>
 	</body>
 </html>
 

--- a/css/mediaqueries/mq-calc-004.html
+++ b/css/mediaqueries/mq-calc-004.html
@@ -16,14 +16,19 @@
 				height: 100px;
 				background-color: red;
 			}
-			@media (min-width: calc(1ch)){
-				div { background-color: green; }
-			}
 	</style>
 	</head>
 	<body>
 		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1ch)){
+				div { background-color: green; }
+			}
+		</style>
 	</body>
 </html>
 

--- a/css/mediaqueries/mq-calc-005.html
+++ b/css/mediaqueries/mq-calc-005.html
@@ -16,14 +16,19 @@
 				height: 100px;
 				background-color: red;
 			}
-			@media (min-width: calc(1rem)){
-				div { background-color: green; }
-			}
 	</style>
 	</head>
 	<body>
 		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1rem)){
+				div { background-color: green; }
+			}
+		</style>
 	</body>
 </html>
 

--- a/css/mediaqueries/relative-units-001.html
+++ b/css/mediaqueries/relative-units-001.html
@@ -16,11 +16,6 @@
 body {
   background: red;
 }
-@media (min-width: 1rem) {
-  body {
-    background: green;
-  }
-}
 p {
   font-size: 24px;
 }
@@ -28,5 +23,15 @@ p {
 </head>
 <body>
   <p>This should have a green background.</p>
+  <script>
+    document.body.offsetTop;
+  </script>
+  <style>
+    @media (min-width: 1rem) {
+      body {
+        background: green;
+      }
+    }
+  </style>
 </body>
 </html>

--- a/css/mediaqueries/relative-units-002.html
+++ b/css/mediaqueries/relative-units-002.html
@@ -16,11 +16,6 @@
 body {
   background: red;
 }
-@media (min-width: 1em) {
-  body {
-    background: green;
-  }
-}
 p {
   font-size: 24px;
 }
@@ -28,5 +23,15 @@ p {
 </head>
 <body>
   <p>This should have a green background.</p>
+  <script>
+    document.body.offsetTop;
+  </script>
+  <style>
+    @media (min-width: 1em) {
+      body {
+        background: green;
+      }
+    }
+  </style>
 </body>
 </html>

--- a/css/mediaqueries/relative-units-003.html
+++ b/css/mediaqueries/relative-units-003.html
@@ -16,11 +16,6 @@
 body {
   background: red;
 }
-@media (min-width: 1ex) {
-  body {
-    background: green;
-  }
-}
 p {
   font-size: 24px;
 }
@@ -28,5 +23,15 @@ p {
 </head>
 <body>
   <p>This should have a green background.</p>
+  <script>
+    document.body.offsetTop;
+  </script>
+  <style>
+    @media (min-width: 1ex) {
+      body {
+        background: green;
+      }
+    }
+  </style>
 </body>
 </html>

--- a/css/mediaqueries/relative-units-004.html
+++ b/css/mediaqueries/relative-units-004.html
@@ -16,11 +16,6 @@
 body {
   background: red;
 }
-@media (min-width: 1ch) {
-  body {
-    background: green;
-  }
-}
 p {
   font-size: 24px;
 }
@@ -28,5 +23,15 @@ p {
 </head>
 <body>
   <p>This should have a green background.</p>
+  <script>
+    document.body.offsetTop;
+  </script>
+  <style>
+    @media (min-width: 1ch) {
+      body {
+        background: green;
+      }
+    }
+  </style>
 </body>
 </html>


### PR DESCRIPTION

This modify the tests so that the media query evaluation they're testing happens
after style resolution, which would've caught a bug in rem unit evaluation
inside media queries in stylo.

MozReview-Commit-ID: ByaR4ZA995l

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1396057 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8336)
<!-- Reviewable:end -->
