### PR TITLE
Consistently use single quotes for string literals in web-platform-tests/web-animations;

### DIFF
--- a/web-animations/interfaces/Animation/constructor.html
+++ b/web-animations/interfaces/Animation/constructor.html
@@ -9,9 +9,9 @@
 <div id="log"></div>
 <div id="target"></div>
 <script>
-"use strict";
+'use strict';
 
-const gTarget = document.getElementById("target");
+const gTarget = document.getElementById('target');
 
 function createEffect() {
   return new KeyframeEffectReadOnly(gTarget, { opacity: [0, 1] });
@@ -26,41 +26,41 @@ const gTestArguments = [
     createEffect: createNull,
     timeline: null,
     expectedTimeline: null,
-    expectedTimelineDescription: "null",
-    description: "with null effect and null timeline"
+    expectedTimelineDescription: 'null',
+    description: 'with null effect and null timeline'
   },
   {
     createEffect: createNull,
     timeline: document.timeline,
     expectedTimeline: document.timeline,
-    expectedTimelineDescription: "document.timeline",
-    description: "with null effect and non-null timeline"
+    expectedTimelineDescription: 'document.timeline',
+    description: 'with null effect and non-null timeline'
   },
   {
     createEffect: createNull,
     expectedTimeline: document.timeline,
-    expectedTimelineDescription: "document.timeline",
-    description: "with null effect and no timeline parameter"
+    expectedTimelineDescription: 'document.timeline',
+    description: 'with null effect and no timeline parameter'
   },
   {
     createEffect: createEffect,
     timeline: null,
     expectedTimeline: null,
-    expectedTimelineDescription: "null",
-    description: "with non-null effect and null timeline"
+    expectedTimelineDescription: 'null',
+    description: 'with non-null effect and null timeline'
   },
   {
     createEffect: createEffect,
     timeline: document.timeline,
     expectedTimeline: document.timeline,
-    expectedTimelineDescription: "document.timeline",
-    description: "with non-null effect and non-null timeline"
+    expectedTimelineDescription: 'document.timeline',
+    description: 'with non-null effect and non-null timeline'
   },
   {
     createEffect: createEffect,
     expectedTimeline: document.timeline,
-    expectedTimelineDescription: "document.timeline",
-    description: "with non-null effect and no timeline parameter"
+    expectedTimelineDescription: 'document.timeline',
+    description: 'with non-null effect and no timeline parameter'
   },
 ];
 
@@ -70,22 +70,22 @@ gTestArguments.forEach(args => {
     const animation = new Animation(effect, args.timeline);
 
     assert_not_equals(animation, null,
-                      "An animation sohuld be created");
+                      'An animation sohuld be created');
     assert_equals(animation.effect, effect,
-                  "Animation returns the same effect passed to " +
-                  "the Constructor");
+                  'Animation returns the same effect passed to ' +
+                  'the Constructor');
     assert_equals(animation.timeline, args.expectedTimeline,
-                  "Animation timeline should be " + args.expectedTimelineDescription);
-    assert_equals(animation.playState, "idle",
-                  "Animation.playState should be initially 'idle'");
-  }, "Animation can be constructed " + args.description);
+                  'Animation timeline should be ' + args.expectedTimelineDescription);
+    assert_equals(animation.playState, 'idle',
+                  'Animation.playState should be initially \'idle\'');
+  }, 'Animation can be constructed ' + args.description);
 });
 
 test(t => {
   const effect = new KeyframeEffectReadOnly(null,
-                                            { left: ["10px", "20px"] },
+                                            { left: ['10px', '20px'] },
                                             { duration: 10000,
-                                              fill: "forwards" });
+                                              fill: 'forwards' });
   const anim = new Animation(effect, document.timeline);
   anim.pause();
   assert_equals(effect.getComputedTiming().progress, 0.0);
@@ -93,7 +93,7 @@ test(t => {
   assert_equals(effect.getComputedTiming().progress, 0.5);
   anim.finish();
   assert_equals(effect.getComputedTiming().progress, 1.0);
-}, "Animation constructed by an effect with null target runs normally");
+}, 'Animation constructed by an effect with null target runs normally');
 
 async_test(t => {
   const iframe = document.createElement('iframe');
@@ -108,7 +108,7 @@ async_test(t => {
   }));
 
   document.body.appendChild(iframe);
-}, "Animation constructed with a keyframe that target element is in iframe");
+}, 'Animation constructed with a keyframe that target element is in iframe');
 
 </script>
 </body>

--- a/web-animations/interfaces/Animation/effect.html
+++ b/web-animations/interfaces/Animation/effect.html
@@ -8,16 +8,16 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 test(t => {
   const anim = new Animation();
-  assert_equals(anim.effect, null, "initial effect is null");
+  assert_equals(anim.effect, null, 'initial effect is null');
 
   const newEffect = new KeyframeEffectReadOnly(createDiv(t), null);
   anim.effect = newEffect;
-  assert_equals(anim.effect, newEffect, "new effect is set");
-}, "effect is set correctly.");
+  assert_equals(anim.effect, newEffect, 'new effect is set');
+}, 'effect is set correctly.');
 
 test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/finished.html
+++ b/web-animations/interfaces/Animation/finished.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 promise_test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/id.html
+++ b/web-animations/interfaces/Animation/id.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/oncancel.html
+++ b/web-animations/interfaces/Animation/oncancel.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 async_test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/onfinish.html
+++ b/web-animations/interfaces/Animation/onfinish.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 async_test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/pause.html
+++ b/web-animations/interfaces/Animation/pause.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 promise_test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/Animation/playbackRate.html
+++ b/web-animations/interfaces/Animation/playbackRate.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 function assert_playbackrate(animation,
                              previousAnimationCurrentTime,

--- a/web-animations/interfaces/Animation/ready.html
+++ b/web-animations/interfaces/Animation/ready.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 promise_test(t => {
   const div = createDiv(t);

--- a/web-animations/interfaces/AnimationEffectTiming/endDelay.html
+++ b/web-animations/interfaces/AnimationEffectTiming/endDelay.html
@@ -37,7 +37,7 @@ test(t => {
 test(t => {
   const div = createDiv(t);
   const anim = div.animate({ opacity: [ 0, 1 ] }, 2000);
-  assert_throws({name: "TypeError"}, () => {
+  assert_throws({ name: 'TypeError' }, () => {
     anim.effect.timing.endDelay = Infinity;
   }, 'we can not assign Infinity to timing.endDelay');
 }, 'Throws when setting infinity');
@@ -45,7 +45,7 @@ test(t => {
 test(t => {
   const div = createDiv(t);
   const anim = div.animate({ opacity: [ 0, 1 ] }, 2000);
-  assert_throws({name: "TypeError"}, () => {
+  assert_throws({ name: 'TypeError' }, () => {
     anim.effect.timing.endDelay = -Infinity;
   }, 'we can not assign negative Infinity to timing.endDelay');
 }, 'Throws when setting negative infinity');

--- a/web-animations/interfaces/AnimationEffectTiming/fill.html
+++ b/web-animations/interfaces/AnimationEffectTiming/fill.html
@@ -15,7 +15,7 @@ test(t => {
   assert_equals(anim.effect.timing.fill, 'auto');
 }, 'Has the default value \'auto\'');
 
-["none", "forwards", "backwards", "both", ].forEach(fill => {
+['none', 'forwards', 'backwards', 'both', ].forEach(fill => {
   test(t => {
     const div = createDiv(t);
     const anim = div.animate({ opacity: [ 0, 1 ] }, 100);

--- a/web-animations/interfaces/Document/getAnimations.html
+++ b/web-animations/interfaces/Document/getAnimations.html
@@ -9,7 +9,7 @@
 <div id="log"></div>
 <div id="target"></div>
 <script>
-"use strict";
+'use strict';
 
 const gKeyFrames = { 'marginLeft': ['100px', '200px'] };
 

--- a/web-animations/interfaces/DocumentTimeline/constructor.html
+++ b/web-animations/interfaces/DocumentTimeline/constructor.html
@@ -8,7 +8,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 test(t => {
   const timeline = new DocumentTimeline();

--- a/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
+++ b/web-animations/interfaces/KeyframeEffect/getComputedTiming.html
@@ -9,70 +9,70 @@
 <div id="log"></div>
 <div id="target"></div>
 <script>
-"use strict";
+'use strict';
 
-const target = document.getElementById("target");
+const target = document.getElementById('target');
 
 test(t => {
   const effect = new KeyframeEffectReadOnly(target,
-                                            { left: ["10px", "20px"] });
+                                            { left: ['10px', '20px'] });
 
   const ct = effect.getComputedTiming();
-  assert_equals(ct.delay, 0, "computed delay");
-  assert_equals(ct.fill, "none", "computed fill");
-  assert_equals(ct.iterations, 1.0, "computed iterations");
-  assert_equals(ct.duration, 0, "computed duration");
-  assert_equals(ct.direction, "normal", "computed direction");
-}, "values of getComputedTiming() when a KeyframeEffectReadOnly is " +
-   "constructed without any KeyframeEffectOptions object");
+  assert_equals(ct.delay, 0, 'computed delay');
+  assert_equals(ct.fill, 'none', 'computed fill');
+  assert_equals(ct.iterations, 1.0, 'computed iterations');
+  assert_equals(ct.duration, 0, 'computed duration');
+  assert_equals(ct.direction, 'normal', 'computed direction');
+}, 'values of getComputedTiming() when a KeyframeEffectReadOnly is ' +
+   'constructed without any KeyframeEffectOptions object');
 
 const gGetComputedTimingTests = [
-  { desc:     "an empty KeyframeEffectOptions object",
+  { desc:     'an empty KeyframeEffectOptions object',
     input:    { },
     expected: { } },
-  { desc:     "a normal KeyframeEffectOptions object",
+  { desc:     'a normal KeyframeEffectOptions object',
     input:    { delay: 1000,
-                fill: "auto",
+                fill: 'auto',
                 iterations: 5.5,
-                duration: "auto",
-                direction: "alternate" },
+                duration: 'auto',
+                direction: 'alternate' },
     expected: { delay: 1000,
-                fill: "none",
+                fill: 'none',
                 iterations: 5.5,
                 duration: 0,
-                direction: "alternate" } },
-  { desc:     "a double value",
+                direction: 'alternate' } },
+  { desc:     'a double value',
     input:    3000,
     timing:   { duration: 3000 },
     expected: { delay: 0,
-                fill: "none",
+                fill: 'none',
                 iterations: 1,
                 duration: 3000,
-                direction: "normal" } },
-  { desc:     "+Infinity",
+                direction: 'normal' } },
+  { desc:     '+Infinity',
     input:    Infinity,
     expected: { duration: Infinity } },
-  { desc:     "an Infinity duration",
+  { desc:     'an Infinity duration',
     input:    { duration: Infinity },
     expected: { duration: Infinity } },
-  { desc:     "an auto duration",
-    input:    { duration: "auto" },
+  { desc:     'an auto duration',
+    input:    { duration: 'auto' },
     expected: { duration: 0 } },
-  { desc:     "an Infinity iterations",
+  { desc:     'an Infinity iterations',
     input:    { iterations: Infinity },
     expected: { iterations: Infinity } },
-  { desc:     "an auto fill",
-    input:    { fill: "auto" },
-    expected: { fill: "none" } },
-  { desc:     "a forwards fill",
-    input:    { fill: "forwards" },
-    expected: { fill: "forwards" } }
+  { desc:     'an auto fill',
+    input:    { fill: 'auto' },
+    expected: { fill: 'none' } },
+  { desc:     'a forwards fill',
+    input:    { fill: 'forwards' },
+    expected: { fill: 'forwards' } }
 ];
 
 gGetComputedTimingTests.forEach(stest => {
   test(t => {
     const effect = new KeyframeEffectReadOnly(target,
-                                              { left: ["10px", "20px"] },
+                                              { left: ['10px', '20px'] },
                                               stest.input);
 
     // Helper function to provide default expected values when the test does
@@ -82,62 +82,62 @@ gGetComputedTimingTests.forEach(stest => {
     };
 
     const ct = effect.getComputedTiming();
-    assert_equals(ct.delay, expected("delay", 0),
-                  "computed delay");
-    assert_equals(ct.fill, expected("fill", "none"),
-                  "computed fill");
-    assert_equals(ct.iterations, expected("iterations", 1),
-                  "computed iterations");
-    assert_equals(ct.duration, expected("duration", 0),
-                  "computed duration");
-    assert_equals(ct.direction, expected("direction", "normal"),
-                  "computed direction");
+    assert_equals(ct.delay, expected('delay', 0),
+                  'computed delay');
+    assert_equals(ct.fill, expected('fill', 'none'),
+                  'computed fill');
+    assert_equals(ct.iterations, expected('iterations', 1),
+                  'computed iterations');
+    assert_equals(ct.duration, expected('duration', 0),
+                  'computed duration');
+    assert_equals(ct.direction, expected('direction', 'normal'),
+                  'computed direction');
 
-  }, "values of getComputedTiming() when a KeyframeEffectReadOnly is " +
-     "constructed by " + stest.desc);
+  }, 'values of getComputedTiming() when a KeyframeEffectReadOnly is ' +
+     'constructed by ' + stest.desc);
 });
 
 const gActiveDurationTests = [
-  { desc:     "an empty KeyframeEffectOptions object",
+  { desc:     'an empty KeyframeEffectOptions object',
     input:    { },
     expected: 0 },
-  { desc:     "a non-zero duration and default iteration count",
+  { desc:     'a non-zero duration and default iteration count',
     input:    { duration: 1000 },
     expected: 1000 },
-  { desc:     "a non-zero duration and integral iteration count",
+  { desc:     'a non-zero duration and integral iteration count',
     input:    { duration: 1000, iterations: 7 },
     expected: 7000 },
-  { desc:     "a non-zero duration and fractional iteration count",
+  { desc:     'a non-zero duration and fractional iteration count',
     input:    { duration: 1000, iterations: 2.5 },
     expected: 2500 },
-  { desc:     "an non-zero duration and infinite iteration count",
+  { desc:     'an non-zero duration and infinite iteration count',
     input:    { duration: 1000, iterations: Infinity },
     expected: Infinity },
-  { desc:     "an non-zero duration and zero iteration count",
+  { desc:     'an non-zero duration and zero iteration count',
     input:    { duration: 1000, iterations: 0 },
     expected: 0 },
-  { desc:     "a zero duration and default iteration count",
+  { desc:     'a zero duration and default iteration count',
     input:    { duration: 0 },
     expected: 0 },
-  { desc:     "a zero duration and fractional iteration count",
+  { desc:     'a zero duration and fractional iteration count',
     input:    { duration: 0, iterations: 2.5 },
     expected: 0 },
-  { desc:     "a zero duration and infinite iteration count",
+  { desc:     'a zero duration and infinite iteration count',
     input:    { duration: 0, iterations: Infinity },
     expected: 0 },
-  { desc:     "a zero duration and zero iteration count",
+  { desc:     'a zero duration and zero iteration count',
     input:    { duration: 0, iterations: 0 },
     expected: 0 },
-  { desc:     "an infinite duration and default iteration count",
+  { desc:     'an infinite duration and default iteration count',
     input:    { duration: Infinity },
     expected: Infinity },
-  { desc:     "an infinite duration and zero iteration count",
+  { desc:     'an infinite duration and zero iteration count',
     input:    { duration: Infinity, iterations: 0 },
     expected: 0 },
-  { desc:     "an infinite duration and fractional iteration count",
+  { desc:     'an infinite duration and fractional iteration count',
     input:    { duration: Infinity, iterations: 2.5 },
     expected: Infinity },
-  { desc:     "an infinite duration and infinite iteration count",
+  { desc:     'an infinite duration and infinite iteration count',
     input:    { duration: Infinity, iterations: Infinity },
     expected: Infinity },
 ];
@@ -145,51 +145,51 @@ const gActiveDurationTests = [
 gActiveDurationTests.forEach(stest => {
   test(t => {
     const effect = new KeyframeEffectReadOnly(target,
-                                              { left: ["10px", "20px"] },
+                                              { left: ['10px', '20px'] },
                                               stest.input);
 
     assert_equals(effect.getComputedTiming().activeDuration,
                   stest.expected);
 
-  }, "getComputedTiming().activeDuration for " + stest.desc);
+  }, 'getComputedTiming().activeDuration for ' + stest.desc);
 });
 
 const gEndTimeTests = [
-  { desc:     "an empty KeyframeEffectOptions object",
+  { desc:     'an empty KeyframeEffectOptions object',
     input:    { },
     expected: 0 },
-  { desc:     "a non-zero duration and default iteration count",
+  { desc:     'a non-zero duration and default iteration count',
     input:    { duration: 1000 },
     expected: 1000 },
-  { desc:     "a non-zero duration and non-default iteration count",
+  { desc:     'a non-zero duration and non-default iteration count',
     input:    { duration: 1000, iterations: 2.5 },
     expected: 2500 },
-  { desc:     "a non-zero duration and non-zero delay",
+  { desc:     'a non-zero duration and non-zero delay',
     input:    { duration: 1000, delay: 1500 },
     expected: 2500 },
-  { desc:     "a non-zero duration, non-zero delay and non-default iteration",
+  { desc:     'a non-zero duration, non-zero delay and non-default iteration',
     input:    { duration: 1000, delay: 1500, iterations: 2 },
     expected: 3500 },
-  { desc:     "an infinite iteration count",
+  { desc:     'an infinite iteration count',
     input:    { duration: 1000, iterations: Infinity },
     expected: Infinity },
-  { desc:     "an infinite duration",
+  { desc:     'an infinite duration',
     input:    { duration: Infinity, iterations: 10 },
     expected: Infinity },
-  { desc:     "an infinite duration and delay",
+  { desc:     'an infinite duration and delay',
     input:    { duration: Infinity, iterations: 10, delay: 1000 },
     expected: Infinity },
-  { desc:     "an infinite duration and negative delay",
+  { desc:     'an infinite duration and negative delay',
     input:    { duration: Infinity, iterations: 10, delay: -1000 },
     expected: Infinity },
-  { desc:     "an non-zero duration and negative delay",
+  { desc:     'an non-zero duration and negative delay',
     input:    { duration: 1000, iterations: 2, delay: -1000 },
     expected: 1000 },
-  { desc:     "an non-zero duration and negative delay greater than active " +
-              "duration",
+  { desc:     'an non-zero duration and negative delay greater than active ' +
+              'duration',
     input:    { duration: 1000, iterations: 2, delay: -3000 },
     expected: 0 },
-  { desc:     "a zero duration and negative delay",
+  { desc:     'a zero duration and negative delay',
     input:    { duration: 0, iterations: 2, delay: -1000 },
     expected: 0 }
 ];
@@ -197,13 +197,13 @@ const gEndTimeTests = [
 gEndTimeTests.forEach(stest => {
   test(t => {
     const effect = new KeyframeEffectReadOnly(target,
-                                              { left: ["10px", "20px"] },
+                                              { left: ['10px', '20px'] },
                                               stest.input);
 
     assert_equals(effect.getComputedTiming().endTime,
                   stest.expected);
 
-  }, "getComputedTiming().endTime for " + stest.desc);
+  }, 'getComputedTiming().endTime for ' + stest.desc);
 });
 
 done();

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -201,7 +201,7 @@ test(() => {
     { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
     { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
   ]);
-}, "'easing' and 'offset' are ignored on iterable objects");
+}, '\'easing\' and \'offset\' are ignored on iterable objects');
 
 test(() => {
   const effect = new KeyframeEffect(null, createIterable([

--- a/web-animations/interfaces/KeyframeEffect/target.html
+++ b/web-animations/interfaces/KeyframeEffect/target.html
@@ -9,7 +9,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 const gKeyFrames = { 'marginLeft': ['0px', '100px'] };
 

--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -237,6 +237,6 @@ function assert_matrix_equals(actual, expected, description) {
     'dimension of the matrix: ' + description);
   for (let i = 0; i < actualMatrixArray.length; i++) {
     assert_approx_equals(actualMatrixArray[i], expectedMatrixArray[i], 0.0001,
-      'expected ' + expected + ' but got ' + actual + ": " + description);
+      'expected ' + expected + ' but got ' + actual + ': ' + description);
   }
 }

--- a/web-animations/timing-model/animations/canceling-an-animation.html
+++ b/web-animations/timing-model/animations/canceling-an-animation.html
@@ -9,7 +9,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 promise_test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);

--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -9,7 +9,7 @@
 <body>
 <div id="log"></div>
 <script>
-"use strict";
+'use strict';
 
 promise_test(t => {
   const div = createDiv(t);


### PR DESCRIPTION

We will introduce template literals in the next patch in this series.

MozReview-Commit-ID: H0cF0SjI1U5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415448 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
