### PR TITLE
Move getComputedTiming test to AnimationEffectTiming;

### DIFF
--- a/web-animations/interfaces/AnimationEffectTiming/getComputedTiming.html
+++ b/web-animations/interfaces/AnimationEffectTiming/getComputedTiming.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>KeyframeEffectReadOnly.getComputedTiming</title>
+<title>AnimationEffectTiming.getComputedTiming</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#dom-animationeffectreadonly-getcomputedtiming">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION

MozReview-Commit-ID: J2ByEQJWv3w

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1417808 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8345)
<!-- Reviewable:end -->
