### PR TITLE
Update the titles of a couple of test files that test part of the "The effect value of a keyframe effect" section of the spec;

### DIFF
--- a/web-animations/animation-model/keyframe-effects/effect-value-context.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-context.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Calculating computed keyframes: Property values that depend on their context (target element)</title>
+<title>The effect value of a keyframe effect: Property values that depend on
+  their context (target element)</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#calculating-computed-keyframes">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-transformed-distance.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<title>Transformed distance when computing an effect value</title>
+<title>The effect value of a keyframe effect: Calculating the transformed
+  distance between keyframes</title>
 <link rel="help" href="https://w3c.github.io/web-animations/#the-effect-value-of-a-keyframe-animation-effect">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>


### PR DESCRIPTION

This makes them consistent with the other two test files in this directory that
begin with effect-value-...

  - The effect value of a keyframe effect: Property values that depend on their
    context (target element)
  - The effect value of a keyframe effect: Applying the iteration composite
    operation

MozReview-Commit-ID: B8pgUPEw9Vq

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1417808 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8349)
<!-- Reviewable:end -->
