### PR TITLE
Add a --verify-log-full option to wpt;

### DIFF
--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -181,9 +181,10 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     kwargs.update(kwargs_extras)
 
     def wrap_handler(x):
-        return LogActionFilter(
-            LogLevelFilter(x, "WARNING"),
-            ["log", "process_output"])
+        x = LogLevelFilter(x, "WARNING")
+        if not kwargs["verify_log_full"]:
+            x = LogActionFilter(x, ["log", "process_output"])
+        return x
 
     initial_handlers = logger._state.handlers
     logger._state.handlers = [wrap_handler(handler)
@@ -197,6 +198,8 @@ def run_step(logger, iterations, restart_after_iteration, kwargs_extras, **kwarg
     wptrunner.run_tests(**kwargs)
 
     logger._state.handlers = initial_handlers
+    logger._state.running_tests = set()
+    logger._state.suite_started = False
 
     log.seek(0)
     results, inconsistent = process_results(log, iterations)

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -79,6 +79,9 @@ scheme host and port.""")
     mode_group.add_argument("--verify", action="store_true",
                             default=False,
                             help="Run a stability check on the selected tests")
+    mode_group.add_argument("--verify-log-full", action="store_true",
+                            default=False,
+                            help="Output per-iteration test results when running verify")
 
     test_selection_group = parser.add_argument_group("Test Selection")
     test_selection_group.add_argument("--test-types", action="store",


### PR DESCRIPTION

This passes all the logging to the output, which makes it rather verbose,
but also ensures we get the full set of test results

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1413729 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8351)
<!-- Reviewable:end -->
