### PR TITLE
Verify WritableStream behaviour when both parts of strategy are bad

### DIFF
--- a/streams/writable-streams/bad-strategies.js
+++ b/streams/writable-streams/bad-strategies.js
@@ -90,4 +90,11 @@ promise_test(() => {
   }));
 }, 'Writable stream: invalid strategy.size return value');
 
+test(() => {
+  assert_throws(new TypeError(), () => new WritableStream(undefined, {
+    size: 'not a function',
+    highWaterMark: NaN
+  }), 'WritableStream constructor should throw a TypeError');
+}, 'Writable stream: invalid size beats invalid highWaterMark');
+
 done();


### PR DESCRIPTION
When both the size and highWaterMark parts of the strategy are bad, a TypeError
should be thrown indicating that the size function was checked first.

Verify that it is.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
