### PR TITLE
Update path to fonts/Ahem.ttf: "../../fonts/Ahem.ttf" => "./fonts/Ahem.ttf"

### DIFF
--- a/infrastructure/assumptions/ahem-ref.html
+++ b/infrastructure/assumptions/ahem-ref.html
@@ -4,7 +4,7 @@
 <style>
 @font-face {
   font-family: Ahem;
-  src: url("../../fonts/Ahem.ttf");
+  src: url("./fonts/Ahem.ttf");
 }
 * {
   padding: 0;


### PR DESCRIPTION
@gsnedders does this make sense to you?

Details originally posted here: https://github.com/w3c/wptdashboard/issues/218#issuecomment-346129172

--------------------------------------------

With the following command:

```
$ ./wpt run chrome infrastructure/assumptions/ahem.html
```

I'm seeing Chrome fail:

```
Summary
=======

Ran 1 tests
Expected results: 0
Unexpected results: 1 (FAIL: 1)

Unexpected Results
==================

FAIL /infrastructure/assumptions/ahem.html
```

And I captured this: 

![](https://i.gyazo.com/b6a376ec510f89275746c976d60c6eb3.png)

I went to the history and the path to `fonts/Ahem.ttf` was changed here: https://github.com/w3c/web-platform-tests/blob/master/infrastructure/assumptions/ahem.html; when I changed it from `../../fonts/Ahem.ttf` to `./fonts/Ahem.ttf`, the test passes:

```
Summary
=======

Ran 1 tests
Expected results: 1
Unexpected results: 0

OK
```

And now ahem-ref.html looks like this:

![](https://i.gyazo.com/362bd16d1d8c44773365106e8f24ed36.png)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
