### PR TITLE
Add geolocation sensor testing constant declaratio and modify geolocation idl test case

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -5,7 +5,9 @@ const properties = {
   'Gyroscope' : ['timestamp', 'x', 'y', 'z'],
   'Magnetometer' : ['timestamp', 'x', 'y', 'z'],
   'AbsoluteOrientationSensor' : ['timestamp', 'quaternion'],
-  'RelativeOrientationSensor' : ['timestamp', 'quaternion']
+  'RelativeOrientationSensor' : ['timestamp', 'quaternion'],
+  'GeolocationSensor' : ['timestamp', 'latitude', 'longitude', 'altitude',
+                         'accuracy', 'altitudeAccuracy', 'heading', 'speed']
 };
 
 function assert_reading_not_null(sensor) {

--- a/geolocation-sensor/idlharness.https.html
+++ b/geolocation-sensor/idlharness.https.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Geolocation Sensor IDL tests</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
 <link rel="help" href="https://wicg.github.io/geolocation-sensor/">
 <link rel="help" href="https://w3c.github.io/sensors/">
 <script src="/resources/testharness.js"></script>

--- a/geolocation-sensor/idlharness.https.html
+++ b/geolocation-sensor/idlharness.https.html
@@ -1,15 +1,20 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>Geolocation Sensor IDL tests</title>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<script src=/resources/WebIDLParser.js></script>
-<script src=/resources/idlharness.js></script>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://wicg.github.io/geolocation-sensor/">
+<link rel="help" href="https://w3c.github.io/sensors/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
 <script>
 "use strict";
 
 function doTest([generic_sensor, geolocation_sensor]) {
-  var idl_array = new IdlArray();
+  const idl_array = new IdlArray();
   idl_array.add_untested_idls('interface EventTarget {};');
+  idl_array.add_untested_idls('interface EventHandler {};');
   idl_array.add_idls(generic_sensor, { only: ['Sensor'] });
   idl_array.add_idls(geolocation_sensor);
   idl_array.add_objects({
@@ -23,8 +28,9 @@ function fetchText(url) {
 }
 
 promise_test(() => {
-  return Promise.all(["/interfaces/generic-sensor.idl",
-                      "/interfaces/geolocation-sensor.idl"].map(fetchText))
-    .then(doTest);
-}, "Test driver");
+  return Promise.all([
+    "/interfaces/generic-sensor.idl",
+    "/interfaces/geolocation-sensor.idl"
+  ].map(fetchText)).then(doTest);
+}, "Test IDL implementation of Geolocation Sensor");
 </script>

--- a/interfaces/geolocation-sensor.idl
+++ b/interfaces/geolocation-sensor.idl
@@ -1,4 +1,4 @@
-[Constructor(optional SensorOptions options), Exposed=Window]
+[Constructor(optional SensorOptions options), SecureContext, Exposed=Window]
 interface GeolocationSensor : Sensor {
   readonly attribute unrestricted double? latitude;
   readonly attribute unrestricted double? longitude;


### PR DESCRIPTION
Add geolocation sensor testing constant declaratio in generic-sensor-tests.js.
Add untest EventHandler in geolocation sensor idl test case.
Following the latest spec, add SecureContext in geolocation sensor idl test case.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
