### PR TITLE
Load document with a script instead of using execute_script in wdspec…

### DIFF
--- a/webdriver/tests/user_prompts/accept_alert.py
+++ b/webdriver/tests/user_prompts/accept_alert.py
@@ -1,4 +1,5 @@
 from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
 
 
 def accept_alert(session):
@@ -25,14 +26,14 @@ def test_no_user_prompt(session):
 
 def test_accept_alert(session):
     # 18.2 step 3
-    session.execute_script("window.alert(\"Hello\");")
+    session.url = inline("<script>window.alert('Hello');</script>")
     response = accept_alert(session)
     assert_success(response)
 
 
 def test_accept_confirm(session):
     # 18.2 step 3
-    session.execute_script("window.result = window.confirm(\"Hello\");")
+    session.url = inline("<script>window.result = window.confirm('Hello');</script>")
     response = accept_alert(session)
     assert_success(response)
     assert session.execute_script("return window.result") is True
@@ -40,7 +41,7 @@ def test_accept_confirm(session):
 
 def test_accept_prompt(session):
     # 18.2 step 3
-    session.execute_script("window.result = window.prompt(\"Enter Your Name: \", \"Federer\");")
+    session.url = inline("<script>window.result = window.prompt('Enter Your Name: ', 'Federer');</script>")
     response = accept_alert(session)
     assert_success(response)
     assert session.execute_script("return window.result") == "Federer"

--- a/webdriver/tests/user_prompts/dismiss_alert.py
+++ b/webdriver/tests/user_prompts/dismiss_alert.py
@@ -1,4 +1,5 @@
 from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
 
 
 def dismiss_alert(session):
@@ -25,14 +26,14 @@ def test_no_user_prompt(session):
 
 def test_dismiss_alert(session):
     # 18.1 step 3
-    session.execute_script("window.alert(\"Hello\");")
+    session.url = inline("<script>window.alert('Hello');</script>")
     response = dismiss_alert(session)
     assert_success(response)
 
 
 def test_dismiss_confirm(session):
     # 18.1 step 3
-    session.execute_script("window.result = window.confirm(\"Hello\");")
+    session.url = inline("<script>window.result = window.confirm('Hello');</script>")
     response = dismiss_alert(session)
     assert_success(response)
     assert session.execute_script("return window.result;") is False
@@ -40,7 +41,7 @@ def test_dismiss_confirm(session):
 
 def test_dismiss_prompt(session):
     # 18.1 step 3
-    session.execute_script("window.result = window.prompt(\"Enter Your Name: \", \"Federer\");")
+    session.url = inline("<script>window.result = window.prompt('Enter Your Name: ', 'Federer');</script>")
     response = dismiss_alert(session)
     assert_success(response)
     assert session.execute_script("return window.result") is None

--- a/webdriver/tests/user_prompts/get_alert_text.py
+++ b/webdriver/tests/user_prompts/get_alert_text.py
@@ -1,4 +1,5 @@
 from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
 
 
 def get_dialog_text(session):
@@ -25,7 +26,7 @@ def test_no_user_prompt(session):
 
 def test_get_alert_text(session):
     # 18.3 step 3
-    session.execute_script("window.alert(\"Hello\");")
+    session.url = inline("<script>window.alert('Hello');</script>")
     response = get_dialog_text(session)
     assert_success(response)
     assert isinstance(response.body, dict)
@@ -37,7 +38,7 @@ def test_get_alert_text(session):
 
 def test_get_confirm_text(session):
     # 18.3 step 3
-    session.execute_script("window.confirm(\"Hello\");")
+    session.url = inline("<script>window.confirm('Hello');</script>")
     response = get_dialog_text(session)
     assert_success(response)
     assert isinstance(response.body, dict)
@@ -49,7 +50,7 @@ def test_get_confirm_text(session):
 
 def test_get_prompt_text(session):
     # 18.3 step 3
-    session.execute_script("window.prompt(\"Enter Your Name: \", \"Federer\");")
+    session.url = inline("<script>window.prompt('Enter Your Name: ', 'Federer');</script>")
     response = get_dialog_text(session)
     assert_success(response)
     assert isinstance(response.body, dict)

--- a/webdriver/tests/user_prompts/send_alert_text.py
+++ b/webdriver/tests/user_prompts/send_alert_text.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.support.asserts import assert_error, assert_success
+from tests.support.inline import inline
 
 def send_alert_text(session, body=None):
     return session.transport.send("POST", "session/{session_id}/alert/text"
@@ -12,7 +13,7 @@ def send_alert_text(session, body=None):
 @pytest.mark.parametrize("text", [None, {}, [], 42, True])
 def test_invalid_input(session, text):
     # 18.4 step 2
-    session.execute_script("window.result = window.prompt(\"Enter Your Name: \", \"Name\");")
+    session.url = inline("<script>window.result = window.prompt('Enter Your Name: ', 'Name');</script>")
     response = send_alert_text(session, {"text": text})
     assert_error(response, "invalid argument")
 
@@ -35,7 +36,7 @@ def test_no_user_prompt(session):
 
 def test_alert_element_not_interactable(session):
     # 18.4 step 5
-    session.execute_script("window.alert(\"Hello\");")
+    session.url = inline("<script>window.alert('Hello');</script>")
     body = {"text": "Federer"}
     response = send_alert_text(session, body)
     assert_error(response, "element not interactable")
@@ -43,7 +44,7 @@ def test_alert_element_not_interactable(session):
 
 def test_confirm_element_not_interactable(session):
     # 18.4 step 5
-    session.execute_script("window.confirm(\"Hello\");")
+    session.url = inline("<script>window.confirm('Hello');</script>")
     body = {"text": "Federer"}
     response = send_alert_text(session, body)
     assert_error(response, "element not interactable")
@@ -51,7 +52,7 @@ def test_confirm_element_not_interactable(session):
 
 def test_send_alert_text(session):
     # 18.4 step 6
-    session.execute_script("window.result = window.prompt(\"Enter Your Name: \", \"Name\");")
+    session.url = inline("<script>window.result = window.prompt('Enter Your Name: ', 'Name');</script>")
     body = {"text": "Federer"}
     send_response = send_alert_text(session, body)
     assert_success(send_response)
@@ -63,7 +64,7 @@ def test_send_alert_text(session):
 
 def test_send_alert_text_with_whitespace(session):
     # 18.4 step 6
-    session.execute_script("window.result = window.prompt(\"Enter Your Name: \", \"Name\");")
+    session.url = inline("<script>window.result = window.prompt('Enter Your Name: ', 'Name');</script>")
     body = {"text": " Fed erer "}
     send_response = send_alert_text(session, body)
     assert_success(send_response)


### PR DESCRIPTION
… user prompts tests

The tests are expecting that after execute_script() the dialog is still
present and no error is returned. This can't happen according to the
spec, because in case of user prompt in the middle of a script
execution, the user prompt handler should be invoked. The result of the
handler will depend on the unhandled prompt behavior, but in any case
the result should be that either the dialog is no longer present (accept
or dismiss) or unexpected alert error is returned.
To avoid this, we could simply use the inline fixture to load a document
containing the script, instead of using execute_script().

<!-- Reviewable:start -->

<!-- Reviewable:end -->
