### PR TITLE
webdriver: Add tests to check alerts happening in a script execution

### DIFF
--- a/webdriver/tests/execute_async_script/user_prompts.py
+++ b/webdriver/tests/execute_async_script/user_prompts.py
@@ -1,0 +1,60 @@
+import pytest
+
+from webdriver import error
+
+
+# 15.2 Executing Script
+
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
+    session.execute_async_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.accept()
+
+
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
+    session.execute_async_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_dismiss_and_notify(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss and notify"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_async_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept and notify"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_async_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.accept()
+
+
+def test_handle_prompt_ignore(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "ignore"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_async_script("window.alert('Hello');")
+    session.alert.dismiss()
+
+
+def test_handle_prompt_default(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_async_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_twice(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
+    session.execute_async_script("window.alert('Hello');window.alert('Bye');")
+    # The first alert has been accepted by the user prompt handler, the second one remains.
+    # FIXME: this is how browsers currently work, but the spec should clarify if this is the
+    #        expected behavior, see https://github.com/w3c/webdriver/issues/1153.
+    assert session.alert.text == "Bye"
+    session.alert.dismiss()

--- a/webdriver/tests/execute_script/user_prompts.py
+++ b/webdriver/tests/execute_script/user_prompts.py
@@ -1,0 +1,60 @@
+import pytest
+
+from webdriver import error
+
+
+# 15.2 Executing Script
+
+def test_handle_prompt_accept(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
+    session.execute_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.accept()
+
+
+def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
+    session.execute_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_dismiss_and_notify(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss and notify"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept and notify"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.accept()
+
+
+def test_handle_prompt_ignore(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "ignore"})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_script("window.alert('Hello');")
+    session.alert.dismiss()
+
+
+def test_handle_prompt_default(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        session.execute_script("window.alert('Hello');")
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
+
+
+def test_handle_prompt_twice(new_session, add_browser_capabilites):
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
+    session.execute_script("window.alert('Hello');window.alert('Bye');")
+    # The first alert has been accepted by the user prompt handler, the second one remains.
+    # FIXME: this is how browsers currently work, but the spec should clarify if this is the
+    #        expected behavior, see https://github.com/w3c/webdriver/issues/1153.
+    assert session.alert.text == "Bye"
+    session.alert.dismiss()


### PR DESCRIPTION
15.2 Executing Script

The rules to execute a function body are as follows. The algorithm
will return success with the JSON representation of the function’s
return value, or an error if the evaluation of the function results
in a JavaScript exception being thrown or at any point during its
execution an unhandled user prompt appears.

If at any point during the algorithm a user prompt appears, the user
prompt handler must be invoked. If its return value is an error, it
must immediately return with that error and abort all subsequent
substeps of this algorithm.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
