### PR TITLE
add note about pipes applying to static files only

### DIFF
--- a/tools/wptserve/docs/pipes.rst
+++ b/tools/wptserve/docs/pipes.rst
@@ -11,6 +11,10 @@ functions are applied to the response from left to right. For example::
 This would serve bytes 1 to 199, inclusive, of foo.txt with the HTTP status
 code 404.
 
+.. note::
+   Pipes are only applied to static files, and will not work if applied to
+   other types of handlers, such as Python File Handlers.
+
 There are several built-in pipe functions, and it is possible to add
 more using the `@pipe` decorator on a function, if required.
 


### PR DESCRIPTION
I tried transforming the response coming from a python file handler, and it didn't seem to work, digging into the code seemed to confirm that the pipes are only applied to the response of `FileHandlers`, see https://github.com/w3c/web-platform-tests/blob/master/tools/wptserve/wptserve/handlers.py#L150.

If this is correct, a note in the docs is helpful from my point of view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8415)
<!-- Reviewable:end -->
