### PR TITLE
Revert "[mediacapture-fromelement] Support Firefox moz-prefixed implementation in tests (#6614)"

### DIFF
--- a/mediacapture-fromelement/capture.html
+++ b/mediacapture-fromelement/capture.html
@@ -3,10 +3,6 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js"
-        data-prefixed-prototypes=
-        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
-</script>
 </head>
 <body>
 <script>

--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -3,10 +3,6 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js"
-        data-prefixed-prototypes=
-        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
-</script>
 </head>
 <body>
 <script>
@@ -19,6 +15,8 @@ var makeAsyncTest = function(filename, numTracks) {
     video.src = "/media/" + filename;
     video.onerror = this.unreached_func("<video> error");
     video.play();
+
+    assert_true('captureStream' in video);
 
     var stream = video.captureStream();
     assert_not_equals(stream, null, "error generating stream");

--- a/mediacapture-fromelement/ended.html
+++ b/mediacapture-fromelement/ended.html
@@ -3,10 +3,6 @@
 <head>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<script src="/common/vendor-prefix.js"
-        data-prefixed-prototypes=
-        '[{"ancestors":["HTMLMediaElement"],"name":"captureStream"}]'>
-</script>
 </head>
 <body>
 <script>
@@ -20,6 +16,8 @@ var makeAsyncTest = function(filename) {
     video.src = "/media/" + filename;
     video.onerror = this.unreached_func("<video> error");
     video.play();
+
+    assert_true('captureStream' in video);
 
     var stream = video.captureStream();
 


### PR DESCRIPTION
This reverts commit cf876359e469cb67664f8a5dfd06056ec3a07650, reversing changes made to bb42139e15be87ea07347a9d6ec3bdc4a80a67d8. Fixes #8414.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
