### PR TITLE
Delete vendor-prefix.js.headers

### DIFF
--- a/common/vendor-prefix.js.headers
+++ b/common/vendor-prefix.js.headers
@@ -1,1 +1,0 @@
-Content-Type: text/javascript; charset=utf-8


### PR DESCRIPTION
Left over from 4efe9f5bfe0eb84e3f131e7bb1d9bd91ad24c288

Fixes the footnote of #8414 .

<!-- Reviewable:start -->

<!-- Reviewable:end -->
