### PR TITLE
Fix "passess" typo in css-color causing test failures

### DIFF
--- a/css/css-color/blacktext-ref.html
+++ b/css/css-color/blacktext-ref.html
@@ -5,5 +5,5 @@
     .test { color: #000000}
 </style>
 <body>
-    <p class="test">Test passess if this text is black</p>
+    <p class="test">Test passes if this text is black</p>
 </body>

--- a/css/css-color/color-001.html
+++ b/css/css-color/color-001.html
@@ -9,5 +9,5 @@
     .test {color: green}
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 </body>

--- a/css/css-color/color-002.html
+++ b/css/css-color/color-002.html
@@ -9,5 +9,5 @@
     .test {color: initial}
 </style>
 <body>
-    <p class="test">Test passess if this text is black</p>
+    <p class="test">Test passes if this text is black</p>
 </body>

--- a/css/css-color/color-003.html
+++ b/css/css-color/color-003.html
@@ -10,5 +10,5 @@
 	.inner {color: currentcolor;}
 </style>
 <body>
-    <p class="outer"><span class="inner">Test passess if this text is green</span></p>
+    <p class="outer"><span class="inner">Test passes if this text is green</span></p>
 </body>

--- a/css/css-color/hex-001.html
+++ b/css/css-color/hex-001.html
@@ -9,5 +9,5 @@
     .test {color: #008000}
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 </body>

--- a/css/css-color/hex-002.html
+++ b/css/css-color/hex-002.html
@@ -9,5 +9,5 @@
     .test {color: #008000FF}
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 </body>

--- a/css/css-color/hex-003.html
+++ b/css/css-color/hex-003.html
@@ -8,6 +8,6 @@
     .test {color: #070}
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 	<!-- #007700, not #008000, but visually similar. Thus, no reftest -->
 </body>

--- a/css/css-color/hex-004.html
+++ b/css/css-color/hex-004.html
@@ -8,6 +8,6 @@
     .test {color: #070F}
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 	<!-- #007700, not #008000, but visually similar. Thus, no reftest -->
 </body>

--- a/css/css-color/lab-001.html
+++ b/css/css-color/lab-001.html
@@ -9,5 +9,5 @@
     .test {color: lab(46.277 -47.562 48.583)} 	// green (sRGB #008000) converted to Lab
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 </body>

--- a/css/css-color/lab-002.html
+++ b/css/css-color/lab-002.html
@@ -10,5 +10,5 @@
     .test { color: lab(0 0 0)} 	// black (sRGB #000000) converted to Lab
 </style>
 <body>
-    <p class="test">Test passess if this text is black</p>
+    <p class="test">Test passes if this text is black</p>
 </body>

--- a/css/css-color/lab-003.html
+++ b/css/css-color/lab-003.html
@@ -10,5 +10,5 @@
     .test {	color: lab(100 0 0);} 	// white (sRGB #FFFFFF) converted to Lab
 </style>
 <body>
-    <p class="test">Test passess if this text is white</p>
+    <p class="test">Test passes if this text is white</p>
 </body>

--- a/css/css-color/lch-001.html
+++ b/css/css-color/lch-001.html
@@ -9,5 +9,5 @@
     .test {color: lab(46.277 -67.989 134.391)} 	// green (sRGB #008000) converted to LCH
 </style>
 <body>
-    <p class="test">Test passess if this text is green</p>
+    <p class="test">Test passes if this text is green</p>
 </body>

--- a/css/css-color/lch-002.html
+++ b/css/css-color/lch-002.html
@@ -10,5 +10,5 @@
     .test { color: lch(0 0 0)} 	// black (sRGB #000000) converted to LCH
 </style>
 <body>
-    <p class="test">Test passess if this text is black</p>
+    <p class="test">Test passes if this text is black</p>
 </body>

--- a/css/css-color/lch-003.html
+++ b/css/css-color/lch-003.html
@@ -10,5 +10,5 @@
     .test {	color: lch(100 0 0);} 	// white (sRGB #FFFFFF) converted to LCH
 </style>
 <body>
-    <p class="test">Test passess if this text is white</p>
+    <p class="test">Test passes if this text is white</p>
 </body>

--- a/css/css-color/whitetext-ref.html
+++ b/css/css-color/whitetext-ref.html
@@ -5,5 +5,5 @@
     .test { color: #FFFFFF; background-color: #333; padding: 3px}
 </style>
 <body>
-    <p class="test">Test passess if this text is white</p>
+    <p class="test">Test passes if this text is white</p>
 </body>


### PR DESCRIPTION
Because greentext-ref.html did not have this typo, a number of tests
were failing because of this, discovered when trying to import when into
Chromium. Fix the typo everywhere.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
