### PR TITLE
Changing set_timeout command to return None

### DIFF
--- a/tools/webdriver/webdriver/client.py
+++ b/tools/webdriver/webdriver/client.py
@@ -42,7 +42,7 @@ class Timeouts(object):
     def _set(self, key, secs):
         body = {key: secs * 1000}
         timeouts = self.session.send_session_command("POST", "timeouts", body)
-        return timeouts[key]
+        return None
 
     @property
     def script(self):


### PR DESCRIPTION
The WebDriver spec says that the setTimeout command should return null.
This updates the client to honor that part of the spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8441)
<!-- Reviewable:end -->
