### PR TITLE
Fix some mixed whitespace problems in css-color

### DIFF
--- a/css/css-color/color-003.html
+++ b/css/css-color/color-003.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="If the currentcolor keyword is set on the color property itself, it is treated as color: inherit.">
 <style>
     .outer {color: green;}
-	.inner {color: currentcolor;}
+    .inner {color: currentcolor;}
 </style>
 <body>
     <p class="outer"><span class="inner">Test passes if this text is green</span></p>

--- a/css/css-color/currentcolor-001.html
+++ b/css/css-color/currentcolor-001.html
@@ -7,9 +7,9 @@
 <meta name="assert" content="The keyword currentcolor takes its value from the value of the color property on the same element.">
 <style>
     .outer {color: red; background-color: red; font-size: 200%; width: 6em; height: 6em; }
-	.inner {color: green; background-color: currentColor; width: 6em; height: 6em; font-weight: bold;}
+    .inner {color: green; background-color: currentColor; width: 6em; height: 6em; font-weight: bold;}
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>
-	<div class="outer"><div class="inner">FAIL</div></div>
+    <div class="outer"><div class="inner">FAIL</div></div>
 </body>

--- a/css/css-color/currentcolor-002.html
+++ b/css/css-color/currentcolor-002.html
@@ -7,10 +7,10 @@
 <meta name="assert" content="This happens at used-value time, which means that if the value is inherited, it’s inherited as currentcolor, not as the value of the color property, so descendants will use their own color property to resolve it.">
 <style>
     .outer {color: red; background-color: currentColor; font-size: 200%; width: 6em; height: 6em; }
-	.middle {background-color: inherit; width: 6em; height: 6em;}
-	.inner {color: green; background-color: inherit; width: 6em; height: 6em; font-weight: bold;}
+    .middle {background-color: inherit; width: 6em; height: 6em;}
+    .inner {color: green; background-color: inherit; width: 6em; height: 6em; font-weight: bold;}
 </style>
 <body>
     <p>Test passes if you see a green square, and no red.</p>
-	<div class="outer"><div class="middle"><div class="inner">FAIL</div></div></div>
+    <div class="outer"><div class="middle"><div class="inner">FAIL</div></div></div>
 </body>

--- a/css/css-color/hex-003.html
+++ b/css/css-color/hex-003.html
@@ -9,5 +9,5 @@
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>
-	<!-- #007700, not #008000, but visually similar. Thus, no reftest -->
+    <!-- #007700, not #008000, but visually similar. Thus, no reftest -->
 </body>

--- a/css/css-color/hex-004.html
+++ b/css/css-color/hex-004.html
@@ -9,5 +9,5 @@
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>
-	<!-- #007700, not #008000, but visually similar. Thus, no reftest -->
+    <!-- #007700, not #008000, but visually similar. Thus, no reftest -->
 </body>

--- a/css/css-color/lab-001.html
+++ b/css/css-color/lab-001.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="lab() with no alpha">
 <style>
-    .test {color: lab(46.277 -47.562 48.583)} 	// green (sRGB #008000) converted to Lab
+    .test {color: lab(46.277 -47.562 48.583)} /* green (sRGB #008000) converted to Lab */
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/lab-002.html
+++ b/css/css-color/lab-002.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="lab() with no alpha">
 <style>
     .test { color: red; }
-    .test { color: lab(0 0 0)} 	// black (sRGB #000000) converted to Lab
+    .test { color: lab(0 0 0)} /* black (sRGB #000000) converted to Lab */
 </style>
 <body>
     <p class="test">Test passes if this text is black</p>

--- a/css/css-color/lab-003.html
+++ b/css/css-color/lab-003.html
@@ -6,8 +6,8 @@
 <link rel="match" href="whitetext-ref.html">
 <meta name="assert" content="lab() with no alpha">
 <style>
-	.test { color: red; background-color: #333; padding: 3px;}
-    .test {	color: lab(100 0 0);} 	// white (sRGB #FFFFFF) converted to Lab
+    .test { color: red; background-color: #333; padding: 3px;}
+    .test { color: lab(100 0 0);} /* white (sRGB #FFFFFF) converted to Lab */
 </style>
 <body>
     <p class="test">Test passes if this text is white</p>

--- a/css/css-color/lab-004.html
+++ b/css/css-color/lab-004.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lab() with no alpha, positive a axis">
 <style>
     .test { color: red; }
-    .test { color: lab(50 50 0)} 	
-	.match { color: rgb(75.62%, 30.45%, 47.56%)} //lab(50,0,0) converted to sRGB
+    .test { color: lab(50 50 0)}
+    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lab(50,0,0) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lab-005.html
+++ b/css/css-color/lab-005.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lab() with no alpha, negative a axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 -45 0)} 	
-	.match { color: rgb(10.79%, 75.55%, 66.40%)} //lab(70,-45,0) converted to sRGB
+    .test { color: lab(70 -45 0)}
+    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70,-45,0) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lab-006.html
+++ b/css/css-color/lab-006.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lab() with no alpha, positive b axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 0 70)} 	
-	.match { color: rgb(76.62%, 66.36%, 5.58%)} //lab(70,0,70) converted to sRGB
+    .test { color: lab(70 0 70)}
+    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lab(70,0,70) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lab-007.html
+++ b/css/css-color/lab-007.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lab() with no alpha, negative b axis">
 <style>
     .test { color: red; }
-    .test { color: lab(55 0 -60)} 	
-	.match { color: rgb(12.81%, 53.10%, 92.76%)} //lab(55,0,-60) converted to sRGB
+    .test { color: lab(55 0 -60)}
+    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55,0,-60) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lch-001.html
+++ b/css/css-color/lch-001.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-    .test {color: lab(46.277 -67.989 134.391)} 	// green (sRGB #008000) converted to LCH
+    .test {color: lab(46.277 -67.989 134.391)} /* green (sRGB #008000) converted to LCH */
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/lch-002.html
+++ b/css/css-color/lch-002.html
@@ -7,7 +7,7 @@
 <meta name="assert" content="lch() with no alpha">
 <style>
     .test { color: red; }
-    .test { color: lch(0 0 0)} 	// black (sRGB #000000) converted to LCH
+    .test { color: lch(0 0 0)} /* black (sRGB #000000) converted to LCH */
 </style>
 <body>
     <p class="test">Test passes if this text is black</p>

--- a/css/css-color/lch-003.html
+++ b/css/css-color/lch-003.html
@@ -6,8 +6,8 @@
 <link rel="match" href="whitetext-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-	.test { color: red; background-color: #333; padding: 3px;}
-    .test {	color: lch(100 0 0);} 	// white (sRGB #FFFFFF) converted to LCH
+    .test { color: red; background-color: #333; padding: 3px;}
+    .test { color: lch(100 0 0);} /* white (sRGB #FFFFFF) converted to LCH */
 </style>
 <body>
     <p class="test">Test passes if this text is white</p>

--- a/css/css-color/lch-004.html
+++ b/css/css-color/lch-004.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lch() with no alpha, positive a axis">
 <style>
     .test { color: red; }
-    .test { color: lch(50 50 0)} 	
-	.match { color: rgb(75.62%, 30.45%, 47.56%)} //lch(50,0,0) converted to sRGB
+    .test { color: lch(50 50 0)}
+    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lch(50,0,0) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lch-005.html
+++ b/css/css-color/lch-005.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lch() with no alpha, negative a axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 45 180)} 	
-	.match { color: rgb(10.79%, 75.55%, 66.40%)} //lch(70,45,180) converted to sRGB
+    .test { color: lab(70 45 180)}
+    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lch(70,45,180) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lch-006.html
+++ b/css/css-color/lch-006.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lch() with no alpha, positive b axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 70 90)} 	
-	.match { color: rgb(76.62%, 66.36%, 5.58%)} //lch(70,70,90) converted to sRGB
+    .test { color: lab(70 70 90)}
+    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lch(70,70,90) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/lch-007.html
+++ b/css/css-color/lch-007.html
@@ -7,11 +7,11 @@
 <meta name="assert" content="lab() with no alpha, negative b axis">
 <style>
     .test { color: red; }
-    .test { color: lch(55 60 270)} 	
-	.match { color: rgb(12.81%, 53.10%, 92.76%)} //lch(55,60,270) converted to sRGB
+    .test { color: lch(55 60 270)}
+    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lch(55,60,270) converted to sRGB */
 </style>
 <body>
-	<p>Test passes if the two lines of filler text are the same color.</p>
+    <p>Test passes if the two lines of filler text are the same color.</p>
     <p class="test">Filler text. Filler text. Filler text. </p>
-	<p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
 </body>

--- a/css/css-color/named-001.html
+++ b/css/css-color/named-001.html
@@ -7,9 +7,9 @@
 <meta name="assert" content="New named color, rebeccapurple">
 <style>
     .outer {background: red; width: 10em; height: 10em;}
-	.inner {background: rebeccapurple; width: 10em; height: 10em;}
+    .inner {background: rebeccapurple; width: 10em; height: 10em;}
 </style>
 <body>
     <p>Test passes if you see a purple square and no red.</p>
-	<div class="outer"><div class="inner"></div></div>
+    <div class="outer"><div class="inner"></div></div>
 </body>

--- a/css/css-color/rebeccapurple-ref.html
+++ b/css/css-color/rebeccapurple-ref.html
@@ -6,5 +6,5 @@
 </style>
 <body>
     <p>Test passes if you see a purple square and no red.</p>
-	<div class="ref"></div>
+    <div class="ref"></div>
 </body>

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -447,14 +447,6 @@ CONSOLE: css/cssom/index-002.html
 TRAILING WHITESPACE: css/CSS2/generated-content/before-after-positioned-002.html
 TRAILING WHITESPACE: css/CSS2/generated-content/before-after-positioned-003.html
 TRAILING WHITESPACE: css/CSS2/generated-content/before-after-positioned-004.html
-TRAILING WHITESPACE: css/css-color/lab-004.html
-TRAILING WHITESPACE: css/css-color/lab-005.html
-TRAILING WHITESPACE: css/css-color/lab-006.html
-TRAILING WHITESPACE: css/css-color/lab-007.html
-TRAILING WHITESPACE: css/css-color/lch-004.html
-TRAILING WHITESPACE: css/css-color/lch-005.html
-TRAILING WHITESPACE: css/css-color/lch-006.html
-TRAILING WHITESPACE: css/css-color/lch-007.html
 TRAILING WHITESPACE: css/css-fonts/support/fonts/gsubtest-lookup3.ufo/features.fea
 TRAILING WHITESPACE: css/css-scoping/css-scoping-shadow-assigned-node-with-before-after.html
 TRAILING WHITESPACE: css/css-scoping/css-scoping-shadow-assigned-node-with-rules.html


### PR DESCRIPTION
This was found by enabling the INDENT TABS lint for css-color, but not
everything was fixed. What remains uses only tabs for indentation.

In lab-*.html and lch-*.html, also change the // comments to
/* comments */.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8442)
<!-- Reviewable:end -->
