### PR TITLE
Tidy lint.whitelist a bit without changing any rules

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -70,17 +70,17 @@ TRAILING WHITESPACE, INDENT TABS, CR AT EOL: *.wasm
 
 ## Documentation ##
 
-W3C-TEST.ORG:README.md
-W3C-TEST.ORG:*/README.md
-W3C-TEST.ORG:docs/*
+W3C-TEST.ORG: README.md
+W3C-TEST.ORG: */README.md
+W3C-TEST.ORG: docs/*
 SET TIMEOUT: docs/*
 
 ## Helper scripts ##
 
-W3C-TEST.ORG:tools/*
-PRINT STATEMENT:tools/*
-W3C-TEST.ORG:*/tools/*
-PRINT STATEMENT:*/tools/*
+W3C-TEST.ORG: tools/*
+PRINT STATEMENT: tools/*
+W3C-TEST.ORG: */tools/*
+PRINT STATEMENT: */tools/*
 
 ## Deliberate copies of Ahem ##
 # The allowed copy
@@ -92,42 +92,45 @@ AHEM COPY: css/fonts/ahem-extra/AHEM_*.TTF
 # https://github.com/w3c/web-platform-tests/issues/7437
 AHEM COPY: css/vendor-imports/mozilla/mozilla-central-reftests/*/Ahem.ttf
 
-### Test exclusions ##
+## Test exclusions ##
 
-CR AT EOL:WebIDL/valid/idl/documentation-dos.widl
-CR AT EOL:cors/resources/cors-headers.asis
-CR AT EOL:html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
-INDENT TABS:html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
-CR AT EOL:webvtt/parsing/file-parsing/tests/support/newlines.vtt
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/empty.svg
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/empty.xhtml
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/minimal_html.svg
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/minimal_html.xhtml
+# Intentional use of CRLF
+CR AT EOL: WebIDL/valid/idl/documentation-dos.widl
+CR AT EOL: cors/resources/cors-headers.asis
+CR AT EOL: html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
+CR AT EOL: webvtt/parsing/file-parsing/tests/support/newlines.vtt
+
+# Intentional use of tabs
+INDENT TABS: html/semantics/embedded-content/the-canvas-element/size.attributes.parse.whitespace.html
 
 # Test generation files containing print statements
-PRINT STATEMENT:dom/nodes/Document-createElement-namespace-tests/generate.py
-PRINT STATEMENT:encrypted-media/polyfill/make-polyfill-tests.py
+PRINT STATEMENT: dom/nodes/Document-createElement-namespace-tests/generate.py
+PRINT STATEMENT: encrypted-media/polyfill/make-polyfill-tests.py
 
 # semi-legitimate use of console.*
-CONSOLE:console/*
-CONSOLE:streams/resources/test-utils.js
-CONSOLE:service-workers/service-worker/resources/navigation-redirect-other-origin.html
-CONSOLE:service-workers/service-worker/navigation-redirect.https.html
-CONSOLE:service-workers/service-worker/resources/clients-get-other-origin.html
+CONSOLE: console/*
+CONSOLE: streams/resources/test-utils.js
+CONSOLE: service-workers/service-worker/resources/navigation-redirect-other-origin.html
+CONSOLE: service-workers/service-worker/navigation-redirect.https.html
+CONSOLE: service-workers/service-worker/resources/clients-get-other-origin.html
 
 # use of console in a public library - annotation-model ensures
 # it is not actually used
-CONSOLE:annotation-model/scripts/ajv.min.js
-CONSOLE:annotation-model/scripts/showdown.min.js
+CONSOLE: annotation-model/scripts/ajv.min.js
+CONSOLE: annotation-model/scripts/showdown.min.js
 CR AT EOL: annotation-model/scripts/showdown.min.js
 
 # Lint doesn't know about sub.svg I guess
-PARSE-FAILED:content-security-policy/svg/including.sub.svg
+PARSE-FAILED: content-security-policy/svg/including.sub.svg
 
-#Helper files that aren't valid XML
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/empty.xml
-PARSE-FAILED:dom/nodes/Document-createElement-namespace-tests/minimal_html.xml
-PARSE-FAILED:acid/acid3/empty.xml
+# Helper files that aren't valid XML
+PARSE-FAILED: acid/acid3/empty.xml
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/empty.svg
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/empty.xhtml
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/empty.xml
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/minimal_html.svg
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/minimal_html.xhtml
+PARSE-FAILED: dom/nodes/Document-createElement-namespace-tests/minimal_html.xml
 
 # setTimeout usage (should probably mostly be fixed)
 SET TIMEOUT: *-manual.*
@@ -303,16 +306,16 @@ SET TIMEOUT: html/webappapis/timers/*
 SET TIMEOUT: acid/acid3/test.html
 
 # Travis
-W3C-TEST.ORG:.travis.yml
+W3C-TEST.ORG: .travis.yml
 
 # Git submodules are not currently scanned
-*:tools/*
-*:resources/*
-*:css/tools/apiclient/*
-*:css/tools/w3ctestlib/*
+*: tools/*
+*: resources/*
+*: css/tools/apiclient/*
+*: css/tools/w3ctestlib/*
 
 # Build system virtualenv
-*:css/tools/_virtualenv/*
+*: css/tools/_virtualenv/*
 
 
 ## Third party data files
@@ -931,10 +934,10 @@ CSS-COLLIDING-TEST-NAME: css/cssom/interfaces.html
 # TODO https://github.com/w3c/web-platform-tests/issues/5770
 MISSING-LINK: css/geometry/*.worker.js
 
-WEBIDL2.JS:.gitmodules
+WEBIDL2.JS: .gitmodules
 
 # Manual test that uses console.logs for feedback
-CONSOLE:payment-request/payment-request-response-id.html
+CONSOLE: payment-request/payment-request-response-id.html
 
 # Tests that use WebKit/Blink testing APIs
 LAYOUTTESTS APIS: css/css-regions/interactivity/*

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -56,7 +56,7 @@ For example, to make the lint tool ignore all '%s'
 errors in the %s file,
 you could add the following line to the lint.whitelist file.
 
-%s:%s"""
+%s: %s"""
 
 def all_filesystem_paths(repo_root):
     path_filter = PathFilter(repo_root, extras=[".git/*"])


### PR DESCRIPTION
 * Add two "Intentional use" sections for whitespace
 * Consistently use a space after the colon and change the script that
   suggests lint lines to do the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8444)
<!-- Reviewable:end -->
