### PR TITLE
Don't copy testharnessreport in sync, a=testonly

### DIFF
--- a/tools/wptrunner/wptrunner/testdriver-vendor.js
+++ b/tools/wptrunner/wptrunner/testdriver-vendor.js
@@ -1,0 +1,1 @@
+// This file intentionally left blank

--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -81,7 +81,6 @@ def copy_wpt_tree(tree, dest, excludes=None, includes=None):
             shutil.copy2(source_path, dest_path)
 
     for source, destination in [("testharness_runner.html", ""),
-                                ("testharnessreport.js", "resources/"),
                                 ("testdriver-vendor.js", "resources/")]:
         source_path = os.path.join(here, os.pardir, source)
         dest_path = os.path.join(dest, destination, os.path.split(source)[1])


### PR DESCRIPTION

This is already provided by wptrunner, so copying it isn't necessary.

MozReview-Commit-ID: GETZ5OALk5j

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1397356 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8461)
<!-- Reviewable:end -->
