### PR TITLE
Dismiss alerts when we hit an UnexpectedAlertOpen error.

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -8,6 +8,7 @@ import mozlog
 
 from tests.support.asserts import assert_error
 from tests.support.http_request import HTTPRequest
+from tests.support.wait import wait
 from tests.support import merge_dictionaries
 
 default_host = "http://127.0.0.1"
@@ -254,10 +255,15 @@ def create_dialog(session):
         session.send_session_command("POST",
                                      "execute/async",
                                      {"script": spawn, "args": []})
+        wait(session,
+             lambda s: s.send_session_command("GET", "alert/text") == text,
+             "modal has not appeared",
+             timeout=15,
+             ignored_exceptions=webdriver.NoSuchAlertException)
 
     return create_dialog
+
 
 def clear_all_cookies(session):
     """Removes all cookies associated with the current active document"""
     session.transport.send("DELETE", "session/%s/cookie" % session.session_id)
-


### PR DESCRIPTION

The Browser Testing and Tools group agreed that the webdriver endpoint, when
asserting for a modal, that it clears the modal on the screen and raises an
an Unexpected Alert Open error.

See https://github.com/w3c/webdriver/pull/1145

MozReview-Commit-ID: 1OnT1AMM0tY

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1416284 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8463)
<!-- Reviewable:end -->
