### PR TITLE
Update web-platform-tests to test new pending member;

### DIFF
--- a/web-animations/interfaces/Animatable/animate-no-browsing-context.html
+++ b/web-animations/interfaces/Animatable/animate-no-browsing-context.html
@@ -76,16 +76,15 @@ promise_test(t => {
     const div = xhrdoc.getElementById('test');
     anim = div.animate(null);
     anim.timeline = document.timeline;
-    assert_equals(anim.playState, 'pending',
-                  'The animation should be initially pending');
+    assert_true(anim.pending, 'The animation should be initially pending');
     return waitForAnimationFrames(2);
   }).then(() => {
     // Because the element is in a document without a browsing context, it will
     // not be rendered and hence the user agent will never deem it ready to
     // animate.
-    assert_equals(anim.playState, 'pending',
-                  'The animation should still be pending after replacing'
-                  + ' the document timeline');
+    assert_true(anim.pending,
+                'The animation should still be pending after replacing'
+                + ' the document timeline');
   });
 }, 'Replacing the timeline of an animation targetting an element in a'
    + ' document without a browsing context leaves it in the pending state');

--- a/web-animations/interfaces/Animatable/animate.html
+++ b/web-animations/interfaces/Animatable/animate.html
@@ -170,7 +170,7 @@ async_test(t => {
 test(t => {
   const div = createDiv(t);
   const anim = div.animate({ opacity: [ 0, 1 ] }, 2000);
-  assert_equals(anim.playState, 'pending');
+  assert_equals(anim.playState, 'running');
 }, 'Element.animate() calls play on the Animation');
 
 // Tests on CSSPseudoElement

--- a/web-animations/interfaces/Animation/idlharness.html
+++ b/web-animations/interfaces/Animation/idlharness.html
@@ -20,6 +20,7 @@ interface Animation : EventTarget {
              attribute double?                  currentTime;
              attribute double                   playbackRate;
     readonly attribute AnimationPlayState       playState;
+    readonly attribute boolean                  pending;
     readonly attribute Promise<Animation>       ready;
     readonly attribute Promise<Animation>       finished;
              attribute EventHandler             onfinish;

--- a/web-animations/interfaces/Animation/pause.html
+++ b/web-animations/interfaces/Animation/pause.html
@@ -39,12 +39,12 @@ promise_test(t => {
 
   assert_equals(animation.currentTime, 0, 'currentTime is set to 0');
   assert_equals(animation.startTime, null, 'startTime is not set');
-  assert_equals(animation.playState, 'pending', 'initially pause-pending');
+  assert_equals(animation.playState, 'paused', 'in paused play state');
+  assert_true(animation.pending, 'initially pause-pending');
 
   // Check it still resolves as expected
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'paused',
-                  'resolves to paused state asynchronously');
+    assert_false(animation.pending, 'no longer pending');
     assert_equals(animation.currentTime, 0,
                   'keeps the initially set currentTime');
   });

--- a/web-animations/interfaces/Animation/pending.html
+++ b/web-animations/interfaces/Animation/pending.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Animation.pending</title>
+<link rel="help" href="https://w3c.github.io/web-animations/#dom-animation-pending">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../../testcommon.js"></script>
+<body>
+<div id="log"></div>
+<script>
+'use strict';
+
+promise_test(t => {
+  const div = createDiv(t);
+  const animation = div.animate({}, 100 * MS_PER_SEC);
+
+  assert_true(animation.pending);
+  return animation.ready.then(() => {
+    assert_false(animation.pending);
+  });
+}, 'reports true -> false when initially played');
+
+promise_test(t => {
+  const div = createDiv(t);
+  const animation = div.animate({}, 100 * MS_PER_SEC);
+  animation.pause();
+
+  assert_true(animation.pending);
+  return animation.ready.then(() => {
+    assert_false(animation.pending);
+  });
+}, 'reports true -> false when paused');
+
+</script>
+</body>

--- a/web-animations/timing-model/animations/pausing-an-animation.html
+++ b/web-animations/timing-model/animations/pausing-an-animation.html
@@ -18,7 +18,7 @@ promise_test(t => {
   return promise.then(p => {
     assert_equals(p, animation);
     assert_equals(animation.ready, promise);
-    assert_equals(animation.playState, 'paused');
+    assert_false(animation.pending, 'No longer pause-pending');
   });
 }, 'A pending ready promise should be resolved and not replaced when the'
    + ' animation is paused');

--- a/web-animations/timing-model/animations/play-states.html
+++ b/web-animations/timing-model/animations/play-states.html
@@ -11,23 +11,6 @@
 'use strict';
 
 test(t => {
-  const div = createDiv(t);
-
-  const animation = div.animate({}, 100 * MS_PER_SEC);
-
-  assert_equals(animation.playState, 'pending');
-}, 'reports \'pending\' for an animation with a pending play task');
-
-test(t => {
-  const div = createDiv(t);
-  const animation = div.animate({}, 100 * MS_PER_SEC);
-
-  animation.pause();
-
-  assert_equals(animation.playState, 'pending');
-}, 'reports \'pending\' for an animation with a pending pause task');
-
-test(t => {
   const animation = new Animation(
     new KeyframeEffect(null, {}, 100 * MS_PER_SEC)
   );
@@ -35,7 +18,17 @@ test(t => {
                 'Current time should be initially unresolved');
 
   assert_equals(animation.playState, 'idle');
-}, 'reports \'idle\' for an animation with an unresolved current time')
+}, 'reports \'idle\' for an animation with an unresolved current time'
+   + ' and no pending tasks')
+
+test(t => {
+  const div = createDiv(t);
+  const animation = div.animate({}, 100 * MS_PER_SEC);
+
+  animation.pause();
+
+  assert_equals(animation.playState, 'paused');
+}, 'reports \'paused\' for an animation with a pending pause task');
 
 test(t => {
   const animation = new Animation(
@@ -143,10 +136,22 @@ test(t => {
 test(t => {
   const div = createDiv(t);
   const animation = div.animate({}, 0);
+  assert_equals(animation.startTime, null,
+                'Sanity check: start time should be unresolved');
 
-  assert_equals(animation.playState, 'pending');
-}, 'reports \'pending\' when there is a pending play task even though the'
-   + ' animation will be finished when the pending task completes');
+  assert_equals(animation.playState, 'finished');
+}, 'reports \'finished\' when playback rate > 0 and'
+   + ' current time = target effect end and there is a pending play task');
+
+test(t => {
+  const div = createDiv(t);
+  const animation = div.animate({}, 100 * MS_PER_SEC);
+  assert_equals(animation.startTime, null,
+                'Sanity check: start time should be unresolved');
+
+  assert_equals(animation.playState, 'running');
+}, 'reports \'running\' when playback rate > 0 and'
+   + ' current time < target effect end and there is a pending play task');
 
 </script>
 </body>

--- a/web-animations/timing-model/animations/reversing-an-animation.html
+++ b/web-animations/timing-model/animations/reversing-an-animation.html
@@ -60,13 +60,13 @@ test(t => {
   const div = createDiv(t);
   const animation = div.animate({}, { duration: 200 * MS_PER_SEC,
                                       delay: -100 * MS_PER_SEC });
-  assert_equals(animation.playState, 'pending',
-    'The playState is pending before we call reverse');
+  assert_true(animation.pending,
+              'The animation is pending before we call reverse');
 
   animation.reverse();
 
-  assert_equals(animation.playState, 'pending',
-    'The playState is still pending after calling reverse');
+  assert_true(animation.pending,
+              'The animation is still pending after calling reverse');
 }, 'Reversing an animation does not cause it to leave the pending state');
 
 promise_test(t => {

--- a/web-animations/timing-model/animations/set-the-animation-start-time.html
+++ b/web-animations/timing-model/animations/set-the-animation-start-time.html
@@ -123,8 +123,8 @@ promise_test(t => {
   animation.play();
 
   // Sanity check
-  assert_equals(animation.playState, 'pending',
-                'Animation is in play-pending state');
+  assert_true(animation.pending && animation.playState === 'running',
+              'Animation is in play-pending state');
 
   // Setting the start time should resolve the 'ready' promise, i.e.
   // it should schedule a microtask to run the promise callbacks.
@@ -153,8 +153,8 @@ promise_test(t => {
   animation.pause();
 
   // Sanity check
-  assert_equals(animation.playState, 'pending',
-                'Animation is in pause-pending state');
+  assert_true(animation.pending && animation.playState === 'paused',
+              'Animation is in pause-pending state');
 
   // Setting the start time should resolve the 'ready' promise although
   // the resolution callbacks when be run in a separate microtask.

--- a/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-target-effect-of-an-animation.html
@@ -13,7 +13,7 @@
 promise_test(t => {
   const anim = createDiv(t).animate({ marginLeft: [ '0px', '100px' ] },
                                     100 * MS_PER_SEC);
-  assert_equals(anim.playState, 'pending');
+  assert_true(anim.pending);
 
   const retPromise = anim.ready.then(() => {
     assert_unreached('ready promise is fulfilled');
@@ -23,7 +23,9 @@ promise_test(t => {
   });
 
   anim.effect = null;
+  // This is a bit odd, see: https://github.com/w3c/web-animations/issues/207
   assert_equals(anim.playState, 'paused');
+  assert_false(anim.pending);
 
   return retPromise;
 }, 'If new effect is null and old effect is not null, we reset the pending ' +
@@ -32,14 +34,15 @@ promise_test(t => {
 promise_test(t => {
   const anim = new Animation();
   anim.pause();
-  assert_equals(anim.playState, 'pending');
+  assert_true(anim.pending);
 
   anim.effect = new KeyframeEffectReadOnly(createDiv(t),
                                            { marginLeft: [ '0px', '100px' ] },
                                            100 * MS_PER_SEC);
-  assert_equals(anim.playState, 'pending');
+  assert_true(anim.pending);
 
   return anim.ready.then(() => {
+    assert_false(anim.pending);
     assert_equals(anim.playState, 'paused');
   });
 }, 'If animation has a pending pause task, reschedule that task to run ' +
@@ -48,14 +51,15 @@ promise_test(t => {
 promise_test(t => {
   const anim = new Animation();
   anim.play();
-  assert_equals(anim.playState, 'pending');
+  assert_true(anim.pending);
 
   anim.effect = new KeyframeEffectReadOnly(createDiv(t),
                                            { marginLeft: [ '0px', '100px' ] },
                                            100 * MS_PER_SEC);
-  assert_equals(anim.playState, 'pending');
+  assert_true(anim.pending);
 
   return anim.ready.then(() => {
+    assert_false(anim.pending);
     assert_equals(anim.playState, 'running');
   });
 }, 'If animation has a pending play task, reschedule that task to run ' +

--- a/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
+++ b/web-animations/timing-model/animations/set-the-timeline-of-an-animation.html
@@ -81,47 +81,26 @@ test(t => {
 }, 'After setting timeline on an idle animation with a sufficiently ancient'
    + ' start time it is finished');
 
-test(t => {
-  const animation =
-    new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
-                  null);
-  animation.play();
-  assert_equals(animation.playState, 'pending');
-
-  animation.timeline = document.timeline;
-
-  assert_equals(animation.playState, 'pending');
-}, 'After setting timeline on a play-pending animation it is still pending');
-
 promise_test(t => {
   const animation =
     new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
                   null);
   animation.play();
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'running',
+              'Animation is initially play-pending');
 
   animation.timeline = document.timeline;
 
+  assert_true(animation.pending && animation.playState === 'running',
+              'Animation is still play-pending after setting timeline');
+
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'running');
+    assert_true(!animation.pending && animation.playState === 'running',
+                'Animation plays after it finishes pending');
   });
 }, 'After setting timeline on a play-pending animation it begins playing'
    + ' after pending');
 
-test(t => {
-  const animation =
-    new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
-                  null);
-  animation.startTime = document.timeline.currentTime;
-  animation.pause();
-  animation.timeline = null;
-  assert_equals(animation.playState, 'pending');
-
-  animation.timeline = document.timeline;
-
-  assert_equals(animation.playState, 'pending');
-}, 'After setting timeline on a pause-pending animation it is still pending');
-
 promise_test(t => {
   const animation =
     new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
@@ -129,12 +108,17 @@ promise_test(t => {
   animation.startTime = document.timeline.currentTime;
   animation.pause();
   animation.timeline = null;
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'paused',
+              'Animation is initially pause-pending');
 
   animation.timeline = document.timeline;
 
+  assert_true(animation.pending && animation.playState === 'paused',
+              'Animation is still pause-pending after setting timeline');
+
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'paused');
+    assert_true(!animation.pending && animation.playState === 'paused',
+                'Animation pauses after it finishes pending');
   });
 }, 'After setting timeline on a pause-pending animation it becomes paused'
    + ' after pending');
@@ -150,10 +134,12 @@ test(t => {
     new Animation(new KeyframeEffect(createDiv(t), null, 100 * MS_PER_SEC),
                   document.timeline);
   animation.currentTime = 50 * MS_PER_SEC;
+  assert_false(animation.pending);
   assert_equals(animation.playState, 'paused');
 
   animation.timeline = null;
 
+  assert_false(animation.pending);
   assert_equals(animation.playState, 'paused');
   assert_times_equal(animation.currentTime, 50 * MS_PER_SEC);
 }, 'After clearing timeline on paused animation it is still paused');
@@ -200,23 +186,23 @@ test(t => {
 
 test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'running');
 
   animation.timeline = null;
 
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'running');
 }, 'After clearing timeline on play-pending animation it is still pending');
 
 promise_test(t => {
   const animation = createDiv(t).animate(null, 100 * MS_PER_SEC);
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'running');
 
   animation.timeline = null;
   animation.timeline = document.timeline;
 
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'running');
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'running');
+    assert_true(!animation.pending && animation.playState === 'running');
   });
 }, 'After clearing and re-setting timeline on play-pending animation it'
    + ' begins to play');
@@ -227,11 +213,11 @@ test(t => {
                   document.timeline);
   animation.startTime = document.timeline.currentTime;
   animation.pause();
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'paused');
 
   animation.timeline = null;
 
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'paused');
 }, 'After clearing timeline on a pause-pending animation it is still pending');
 
 promise_test(t => {
@@ -240,17 +226,17 @@ promise_test(t => {
                   document.timeline);
   animation.startTime = document.timeline.currentTime;
   animation.pause();
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'paused');
 
   animation.timeline = null;
   animation.timeline = document.timeline;
 
-  assert_equals(animation.playState, 'pending');
+  assert_true(animation.pending && animation.playState === 'paused');
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'paused');
+    assert_true(!animation.pending && animation.playState === 'paused');
   });
 }, 'After clearing and re-setting timeline on a pause-pending animation it'
-   + ' becomes paused');
+   + ' completes pausing');
 
 promise_test(t => {
   const animation =
@@ -263,10 +249,8 @@ promise_test(t => {
 
   animation.timeline = null;
   animation.timeline = document.timeline;
-  assert_equals(animation.playState, 'pending');
 
   return animation.ready.then(() => {
-    assert_equals(animation.playState, 'running');
     assert_times_equal(animation.startTime, initialStartTime);
   });
 }, 'After clearing and re-setting timeline on an animation in the middle of'


### PR DESCRIPTION

Hopefully most of these changes are self-explanatory however a few notes follow.

* In timing-model/animations/play-states.html, as well as making the tests match
  the updated spec, one or two tests have also been moved to better reflect the
  order in the spec (to make it obvious which branch of the algorithm is being
  tested).

* In timing-model/animations/set-the-timeline-of-an-animation.html we previously
  had two tests that check:
  a) That the playState was 'pending' before and after setting the timeline.
  b) That the playState was 'pending' before setting the timeline and then,
     after setting the timeline and waiting on the ready promise, would become
     'running'.
  Likewise we had the same test for pausing.

  Since these are basically the same test--(b) just adds the wait on the ready
  promise--we combine them here into one test that covers both (a) and (b).

MozReview-Commit-ID: CLoDJvsdwmF

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1412765 [ci skip]