### PR TITLE
Use string representation of http_status.

### DIFF
--- a/tools/webdriver/webdriver/error.py
+++ b/tools/webdriver/webdriver/error.py
@@ -11,10 +11,10 @@ class WebDriverException(Exception):
         self.stacktrace = stacktrace
 
     def __repr__(self):
-        return "<%s http_status=%d>" % (self.__class__.__name__, self.http_status)
+        return "<%s http_status=%s>" % (self.__class__.__name__, self.http_status)
 
     def __str__(self):
-        return ("%s (%d)\n"
+        return ("%s (%s)\n"
             "\n"
             "Remote-end stacktrace:\n"
             "\n"


### PR DESCRIPTION

The WebDriverException.http_status can be None if it falls back to
the WebDriverException abstract class.

MozReview-Commit-ID: mgWKfDtTYO

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1417821 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8470)
<!-- Reviewable:end -->
