### PR TITLE
Return no such element error when on no active element.

### DIFF
--- a/webdriver/tests/element_retrieval/get_active_element.py
+++ b/webdriver/tests/element_retrieval/get_active_element.py
@@ -2,8 +2,10 @@ from tests.support.asserts import assert_error, assert_dialog_handled, assert_sa
 from tests.support.fixtures import create_dialog
 from tests.support.inline import inline
 
+
 def read_global(session, name):
     return session.execute_script("return %s;" % name)
+
 
 def get_active_element(session):
     return session.transport.send("GET", "session/%s/element/active" % session.session_id)
@@ -244,7 +246,7 @@ def test_success_iframe_content(session):
     assert_is_active_element(session, response)
 
 
-def test_sucess_without_body(session):
+def test_missing_document_element(session):
     session.url = inline("<body></body>")
     session.execute_script("""
         if (document.body.remove) {
@@ -254,4 +256,4 @@ def test_sucess_without_body(session):
         }""")
 
     response = get_active_element(session)
-    assert_is_active_element(session, response)
+    assert_error(response, "no such element")


### PR DESCRIPTION

document.activeElement will return null if there is no document
element.  This may happen if, for example, in an HTML document the
<body> element is removed.

The WPT test test_sucess_without_body in get_active_element.py
is wrong.  It expects Get Active Element to return null if there
is no document element, but following a recent specification change
we want it to return a no such element error.

Specification change: https://github.com/w3c/webdriver/pull/1157

MozReview-Commit-ID: LQJ3slV9aty

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1420431 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8475)
<!-- Reviewable:end -->
