### PR TITLE
Updating WebDriver getActiveElement test for dismissing alerts

### DIFF
--- a/webdriver/tests/element_retrieval/get_active_element.py
+++ b/webdriver/tests/element_retrieval/get_active_element.py
@@ -69,7 +69,7 @@ def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     response = get_active_element(session)
     assert_is_active_element(session, response)
     assert_dialog_handled(session, "dismiss #2")
-    assert read_global(session, "dismiss2") is None
+    assert read_global(session, "dismiss2") is False
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
 


### PR DESCRIPTION
Using the user prompt handler to automatically dismiss an alert should
result in a value of False, not None for the retrieved JavaScript variable
on the page.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
