### PR TITLE
Add tests for time-origin.

### DIFF
--- a/hr-time/resources/unload-a.html
+++ b/hr-time/resources/unload-a.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Helper page for ../unload-manual.html</title>
+</head>
+<body>
+  <script src="./unload.js"></script>
+  <script>
+    setupListeners("a", "./unload-b.html");
+  </script>
+  <button id="proceed">Click me!</button>
+</body>
+</html>

--- a/hr-time/resources/unload-b.html
+++ b/hr-time/resources/unload-b.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Helper page for ../unload-manual.html</title>
+</head>
+<body>
+  <script src="./unload.js"></script>
+  <script>
+    setupListeners("b", "./unload-c.html");
+  </script>
+  <button id="proceed">Click me again!</button>
+</body>
+</html>

--- a/hr-time/resources/unload-c.html
+++ b/hr-time/resources/unload-c.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Helper page for ../unload-manual.html</title>
+</head>
+<body>
+  <script src="./unload.js"></script>
+  <script>
+    setupListeners("c", null);
+  </script>
+  <button id="proceed">Click me, one last time!</button>
+</body>
+</html>

--- a/hr-time/resources/unload.js
+++ b/hr-time/resources/unload.js
@@ -1,0 +1,51 @@
+const syncDelay = ms => {
+  const start = performance.now();
+  let elapsedTime;
+  do {
+    elapsedTime = performance.now() - start;
+  } while (elapsedTime < ms);
+};
+
+const markTime = (docName, lifecycleEventName) => {
+  // Calculating these values before the below `mark` invocation ensures that delays in
+  // reaching across to the other window object doesn't interfere with the correctness
+  // of the test.
+  const dateNow = Date.now();
+  const performanceNow = performance.now();
+
+  window.opener.mark({
+    docName,
+    lifecycleEventName,
+    performanceNow: performanceNow,
+    dateNow: dateNow
+  });
+};
+
+const setupUnloadPrompt = (docName, msg) => {
+  window.addEventListener("beforeunload", ev => {
+    markTime(docName, "beforeunload");
+    return ev.returnValue = msg || "Click OK to continue test."
+  });
+};
+
+const setupListeners = (docName, nextDocument) => {
+  window.addEventListener("load", () => {
+    markTime(docName, "load");
+    document.getElementById("proceed").addEventListener("click", ev => {
+      ev.preventDefault();
+      if (nextDocument) {
+        document.location = nextDocument;
+      } else {
+        window.close();
+      }
+    })
+  });
+
+  setupUnloadPrompt(docName);
+
+  window.addEventListener("unload", () => {
+    markTime(docName, "unload");
+    if (docName !== "c") { syncDelay(1000); }
+  });
+};
+

--- a/hr-time/unload-manual.html
+++ b/hr-time/unload-manual.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>time origin value manual test</title>
+  <link rel="help" href="https://w3c.github.io/hr-time/#time-origin-1">
+  <link rel="prefetch" href="./resources/unload-a.html">
+  <link rel="prefetch" href="./resources/unload-b.html">
+  <link rel="prefetch" href="./resources/unload-c.html">
+</head>
+<body>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script>
+    setup({ explicit_timeout: true });
+
+    const ACCEPTABLE_VARIANCE = 400; // ms
+
+    const isRoughlyEqual = (a, b) => Math.abs(a - b) < ACCEPTABLE_VARIANCE;
+
+    const timings = { a: {}, b: {}, c: {} };
+    const t = async_test("hr-time time origin");
+
+    window.mark = msg => {
+      timings[msg.docName][msg.lifecycleEventName] = {
+        performanceNow: msg.performanceNow,
+        dateNow: msg.dateNow
+      };
+
+      if (msg.docName === "c" && msg.lifecycleEventName === "unload") {
+        setTimeout(makeAssertions, 0);
+      }
+    };
+
+    function makeAssertions () {
+      t.step(() => {
+        const loadTimeBetweenAandB = timings.b.load.dateNow - timings.a.unload.dateNow;
+        const loadTimeBetweenBandC = timings.c.load.dateNow - timings.b.unload.dateNow;
+
+        assert_true(
+          isRoughlyEqual(loadTimeBetweenAandB, timings.b.load.performanceNow),
+          "Document in reused window's time origin should be time of close of pop-up box."
+        );
+        assert_true(
+          isRoughlyEqual(loadTimeBetweenBandC, timings.c.load.performanceNow),
+          "Document in reused window's time origin should be time of close of pop-up box."
+        );
+        assert_true(
+          !isRoughlyEqual(timings.a.unload.performanceNow, 0),
+          "Time origin during unload event should match that of rest of document."
+        );
+        assert_true(
+          !isRoughlyEqual(timings.b.unload.performanceNow, 0),
+          "Time origin during unload event should match that of rest of document."
+        );
+        assert_true(
+          !isRoughlyEqual(timings.c.unload.performanceNow, 0),
+          "Time origin during unload event should match that of rest of document."
+        );
+      });
+      t.done();
+    }
+  </script>
+
+  <h2>Description</h2>
+  <p>This test validates the behavior of <code>performance.now()</code> with respect to its time origin.</p>
+  <div id="log">
+   <h2>Manual Test Steps</h2>
+   <ol>
+    <li><a href="resources/unload-a.html" target="_blank">Click here</a>
+   </ol>
+  </div>
+</body>
+<html>


### PR DESCRIPTION
This adds tests to check HR Time Origin, as refined in the spec PR [here](https://github.com/w3c/hr-time/pull/54).

Closes https://github.com/w3c/hr-time/issues/32.

@toddreifsteck @igrigorik

### Status

- Test passes in Chrome 62.
- Test fails in Firefox 57: looks like a bug in the HR Time implementation.
- Test fails in Safari: the browser won't display a second `Prompt to Unload` message.
- Test fails in Edge: the time origin looks right, but `window.opener.postMessage` fails silently.

Eager for input on how to address these issues.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
