### PR TITLE
[eme] Always check promise result of setMediaKeys()

### DIFF
--- a/encrypted-media/resources/clearkey-retrieve-persistent-license.html
+++ b/encrypted-media/resources/clearkey-retrieve-persistent-license.html
@@ -54,9 +54,10 @@
         .then(function(access) {
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
-            config.video.setMediaKeys(mediaKeys);
+            return config.video.setMediaKeys(mediaKeys);
+        }).then(function() {
             config.video.addEventListener('timeupdate', onTimeupdate, true);
-            _mediaKeySession = mediaKeys.createSession( 'persistent-license' );
+            _mediaKeySession = config.video.mediaKeys.createSession( 'persistent-license' );
             _mediaKeySession.closed.then(onComplete);
             return _mediaKeySession.load(event.data.sessionId);
         }).then(function( success ) {

--- a/encrypted-media/resources/drm-retrieve-persistent-license.html
+++ b/encrypted-media/resources/drm-retrieve-persistent-license.html
@@ -58,9 +58,10 @@
         .then(function(access) {
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
-            config.video.setMediaKeys(mediaKeys);
+            return config.video.setMediaKeys(mediaKeys);
+        }).then(function() {
             config.video.addEventListener('timeupdate', onTimeupdate);
-            _mediaKeySession = mediaKeys.createSession( 'persistent-license' );
+            _mediaKeySession = config.video.mediaKeys.createSession( 'persistent-license' );
             return _mediaKeySession.load(event.data.sessionId);
         }).then(function( success ) {
             if ( !success ) throw new DOMException( 'Could not load session' );

--- a/encrypted-media/scripts/playback-retrieve-persistent-license.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-license.js
@@ -96,7 +96,8 @@ function runTest(config,qualifier) {
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
             _mediaKeys = mediaKeys;
-            _video.setMediaKeys( mediaKeys );
+            return _video.setMediaKeys( mediaKeys );
+        }).then(function() {
             _mediaKeySession = _mediaKeys.createSession('persistent-license');
             waitForEventAndRunStep('encrypted', _video, onEncrypted, test);
             waitForEventAndRunStep('playing', _video, onPlaying, test);

--- a/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
@@ -45,7 +45,7 @@ function runTest(config,qualifier) {
             config.messagehandler( event.messageType, event.message ).then(function(response) {
                 return _mediaKeySession.update(response);
             }).then(function() {
-                _video.setMediaKeys(_mediaKeys);
+                return _video.setMediaKeys(_mediaKeys);
             }).catch(onFailure);
         }
 


### PR DESCRIPTION
Several of the encrypted-media tests do not check that setMediaKeys() succeeds. As it is an asynchronous operation, it should be checked to catch failures, as well as ensuring that the operation completes before attempting to do things that rely on it being successful.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
