### PR TITLE
webdriver: fix new_session in test_status_with_session_running_on_end…

### DIFF
--- a/webdriver/tests/sessions/status.py
+++ b/webdriver/tests/sessions/status.py
@@ -21,13 +21,13 @@ def test_get_status_no_session(http):
         assert isinstance(value["message"], basestring)
 
 
-def test_status_with_session_running_on_endpoint_node(new_session):
+def test_status_with_session_running_on_endpoint_node(new_session, add_browser_capabilites):
     # For an endpoint node, the maximum number of active
     # sessions is 1: https://www.w3.org/TR/webdriver/#dfn-maximum-active-sessions
     # A session is open, so we expect `ready` to be False
     # 8.3 step 1.
 
-    _, session = new_session("{}")  # we don't care what we're using
+    _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
     value = session.send_command("GET", "status")
 
     assert value["ready"] == False


### PR DESCRIPTION
…point_node

Use add_browser_capabilites fixture to ensure we use valid
capabilities.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
