### PR TITLE
[eme] Fix tests to run with EME Logger enabled

### DIFF
--- a/encrypted-media/resources/clearkey-retrieve-destroy-persistent-license.html
+++ b/encrypted-media/resources/clearkey-retrieve-destroy-persistent-license.html
@@ -40,7 +40,7 @@
             config.messagehandler = (new MessageHandler( 'org.w3.clearkey')).messagehandler;
 
         function onComplete() {
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
         }
 
         function onFailure(error) {

--- a/encrypted-media/resources/clearkey-retrieve-persistent-license.html
+++ b/encrypted-media/resources/clearkey-retrieve-persistent-license.html
@@ -35,7 +35,7 @@
         config.video = document.getElementById('videoelement');
 
         function onComplete() {
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
         }
 
         function onFailure(error) {

--- a/encrypted-media/resources/drm-retrieve-destroy-persistent-license.html
+++ b/encrypted-media/resources/drm-retrieve-destroy-persistent-license.html
@@ -40,7 +40,7 @@
         config.messagehandler = (new MessageHandler(config.keysystem, config.content, 'persistent-license')).messagehandler;
 
         function onComplete() {
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
         }
 
         function onFailure(error) {

--- a/encrypted-media/resources/drm-retrieve-persistent-license.html
+++ b/encrypted-media/resources/drm-retrieve-persistent-license.html
@@ -33,7 +33,7 @@
         config.video = document.getElementById('videoelement');
 
         function onComplete() {
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
         }
 
         function onFailure(error) {

--- a/encrypted-media/resources/drm-retrieve-persistent-usage-record.html
+++ b/encrypted-media/resources/drm-retrieve-persistent-usage-record.html
@@ -33,7 +33,7 @@
 
         function onFailure(error) {
             assertions.push( { actual: false, expected: true, message: error } );
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
         }
 
         function onMessage( event )
@@ -56,13 +56,13 @@
             _mediaKeySession = _mediaKeys.createSession( 'persistent-usage-record' );
             _mediaKeySession.addEventListener( 'message', onMessage );
             _mediaKeySession.closed.then( function() {
-                window.opener.postMessage(assertions, '*');
+                window.opener.postMessage({ testResult: assertions }, '*');
             });
             return _mediaKeySession.load( event.data.sessionId );
         }).then(function( success ) {
             if ( !success ) {
                 assertions.push( { actual: success, expected: true, message: "Error loading session" } );
-                window.opener.postMessage(assertions, '*');
+                window.opener.postMessage({ testResult: assertions }, '*');
             }
         }).catch( onFailure );
     });

--- a/encrypted-media/resources/retrieve-persistent-usage-record.html
+++ b/encrypted-media/resources/retrieve-persistent-usage-record.html
@@ -55,7 +55,7 @@
 
                     assertions.push( { actual: false, expected: true, message: error } );
 
-                    window.opener.postMessage(assertions, '*');
+                    window.opener.postMessage({ testResult: assertions }, '*');
                 });
             });
         }
@@ -71,7 +71,7 @@
             mediaKeySession.addEventListener( 'message', onMessage );
             mediaKeySession.closed.then( function() {
 
-                window.opener.postMessage(assertions, '*');
+                window.opener.postMessage({ testResult: assertions }, '*');
 
             });
 
@@ -81,7 +81,7 @@
 
             assertions.push( { actual: false, expected: true, message: error.toString() } );
 
-            window.opener.postMessage(assertions, '*');
+            window.opener.postMessage({ testResult: assertions }, '*');
 
         });
 

--- a/encrypted-media/scripts/playback-retrieve-persistent-license.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-license.js
@@ -74,12 +74,14 @@ function runTest(config,qualifier) {
 
             // Lisen for an event from the new window containing its test assertions
             window.addEventListener('message', test.step_func(function(messageEvent) {
-                messageEvent.data.forEach(test.step_func(function(assertion) {
-                    assert_equals(assertion.actual, assertion.expected, assertion.message);
-                }));
+                if (messageEvent.data.testResult) {
+                    messageEvent.data.testResult.forEach(test.step_func(function(assertion) {
+                        assert_equals(assertion.actual, assertion.expected, assertion.message);
+                    }));
 
-                win.close();
-                test.done();
+                    win.close();
+                    test.done();
+                }
             }));
 
             // Delete things which can't be cloned and posted over to the new window

--- a/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
+++ b/encrypted-media/scripts/playback-retrieve-persistent-usage-record.js
@@ -70,13 +70,17 @@ function runTest(config,qualifier) {
             _video.setMediaKeys( null );
 
             var win = window.open(config.windowscript);
-            window.addEventListener('message', test.step_func(function(event) {
-                event.data.forEach(test.step_func(function(assertion) {
-                    assert_equals(assertion.actual, assertion.expected, assertion.message);
-                }));
+            assert_not_equals(win, null, "Popup windows not allowed?");
 
-                win.close();
-                test.done();
+            window.addEventListener('message', test.step_func(function(event) {
+                if (event.data.testResult) {
+                    event.data.testResult.forEach(test.step_func(function(assertion) {
+                        assert_equals(assertion.actual, assertion.expected, assertion.message);
+                    }));
+
+                    win.close();
+                    test.done();
+                }
             }));
 
             delete config.video;


### PR DESCRIPTION
Updates the tests that use a popup window to report results back using the struct { testResult: ... } instead of an array and have the original window only check 'message' events that match. This avoids crashing when EME Logger is used at the same time. Fixes #8486.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
