### PR TITLE
Test that requestMediaKeySystemAccess sets label

### DIFF
--- a/encrypted-media/scripts/requestmediakeysystemaccess.js
+++ b/encrypted-media/scripts/requestmediakeysystemaccess.js
@@ -91,10 +91,12 @@ function runTest(config, qualifier) {
         initDataTypes: [config.initDataType],
         audioCapabilities: [{contentType: config.audioType}],
         videoCapabilities: [{contentType: config.videoType}],
+        label: 'abcd',
     }], {
         initDataTypes: [config.initDataType],
         audioCapabilities: [{contentType: config.audioType}],
         videoCapabilities: [{contentType: config.videoType}],
+        label: 'abcd',
     }, 'Basic supported configuration');
 
     expect_config(config.keysystem, [{


### PR DESCRIPTION
On Edge, navigator.requestMediaKeySystemAccess ignores the value passed
along to the label configuration field.
This test exposes that bug.
See https://goo.gl/6SgCRb

<!-- Reviewable:start -->

<!-- Reviewable:end -->
