### PR TITLE
[css-shapes] Fix shape-image-treshold-003.html

### DIFF
--- a/css/css-shapes/shape-outside/values/shape-image-threshold-003.html
+++ b/css/css-shapes/shape-outside/values/shape-image-threshold-003.html
@@ -42,7 +42,7 @@
 
         test(function() {
             var results = setUpTest("0.3", null);
-            assert_equals(results[0], null);
+            assert_equals(results[0], "");
             assert_equals(results[1], "0");
         }, "shape-image-threshold is not inherited and defaults to 0");
 


### PR DESCRIPTION
CSSStyleDeclaration.getPropertyValue can't return null per:

  https://drafts.csswg.org/cssom/#the-cssstyledeclaration-interface

And it's supposed to return the empty string when the property is missing.

Implementations do this, and this makes the test pass in Blink and in Gecko once
the patches at https://bugzil.la/1265343 land.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
