### PR TITLE
Changes for early fetching of methods

### DIFF
--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -520,27 +520,12 @@ promise_test(() => {
   return promise;
 }, 'ReadableStream with byte source: Push source that doesn\'t understand pull signal');
 
-promise_test(t => {
-  const stream = new ReadableStream({
+test(() => {
+  assert_throws(new TypeError(), () => new ReadableStream({
     pull: 'foo',
     type: 'bytes'
-  });
-
-  const reader = stream.getReader();
-
-  return promise_rejects(t, new TypeError(), reader.read(), 'read() must fail');
-}, 'ReadableStream with byte source: read(), but pull() function is not callable');
-
-promise_test(t => {
-  const stream = new ReadableStream({
-    pull: 'foo',
-    type: 'bytes'
-  });
-
-  const reader = stream.getReader({ mode: 'byob' });
-
-  return promise_rejects(t, new TypeError(), reader.read(new Uint8Array(1)), 'read() must fail');
-}, 'ReadableStream with byte source: read(view), but pull() function is not callable');
+  }), 'constructor should throw');
+}, 'ReadableStream with byte source: pull() function is not callable');
 
 promise_test(() => {
   const stream = new ReadableStream({

--- a/streams/readable-streams/bad-underlying-sources.js
+++ b/streams/readable-streams/bad-underlying-sources.js
@@ -35,16 +35,14 @@ test(() => {
 }, 'Underlying source start: throwing method');
 
 
-promise_test(t => {
+test(() => {
 
   const theError = new Error('a unique string');
-  const rs = new ReadableStream({
+  assert_throws(theError, () => new ReadableStream({
     get pull() {
       throw theError;
     }
-  });
-
-  return promise_rejects(t, theError, rs.getReader().closed);
+  }), 'constructor should throw');
 
 }, 'Underlying source: throwing pull getter (initial pull)');
 
@@ -82,9 +80,11 @@ promise_test(t => {
 
   return Promise.all([
     reader.read().then(r => {
-      assert_object_equals(r, { value: 'a', done: false }, 'the chunk read should be correct');
+      assert_object_equals(r, { value: 'a', done: false }, 'the first chunk read should be correct');
     }),
-    promise_rejects(t, theError, reader.closed)
+    reader.read().then(r => {
+      assert_object_equals(r, { value: 'a', done: false }, 'the second chunk read should be correct');
+    })
   ]);
 
 }, 'Underlying source pull: throwing getter (second pull)');
@@ -117,16 +117,14 @@ promise_test(t => {
 
 }, 'Underlying source pull: throwing method (second pull)');
 
-promise_test(t => {
+test(() => {
 
   const theError = new Error('a unique string');
-  const rs = new ReadableStream({
+  assert_throws(theError, () => new ReadableStream({
     get cancel() {
       throw theError;
     }
-  });
-
-  return promise_rejects(t, theError, rs.cancel());
+  }), 'constructor should throw');
 
 }, 'Underlying source cancel: throwing getter');
 

--- a/streams/readable-streams/bad-underlying-sources.js
+++ b/streams/readable-streams/bad-underlying-sources.js
@@ -84,11 +84,11 @@ promise_test(t => {
     }),
     reader.read().then(r => {
       assert_object_equals(r, { value: 'a', done: false }, 'the second chunk read should be correct');
+      assert_equals(counter, 1, 'counter should be 1');
     })
   ]);
 
-}, 'Underlying source pull: throwing getter (second pull)');
-
+}, 'Underlying source pull: throwing getter (second pull does not result in a second get)');
 
 promise_test(t => {
 

--- a/streams/readable-streams/general.js
+++ b/streams/readable-streams/general.js
@@ -86,15 +86,15 @@ test(() => {
 
 test(() => {
 
-  new ReadableStream({ cancel: '2' });
+  assert_throws(new TypeError(), () => new ReadableStream({ cancel: '2' }), 'constructor should throw');
 
-}, 'ReadableStream constructor can get initial garbage as cancel argument');
+}, 'ReadableStream constructor will not tolerate initial garbage as cancel argument');
 
 test(() => {
 
-  new ReadableStream({ pull: { } });
+  assert_throws(new TypeError(), () => new ReadableStream({ pull: { } }), 'constructor should throw');
 
-}, 'ReadableStream constructor can get initial garbage as pull argument');
+}, 'ReadableStream constructor will not tolerate initial garbage as pull argument');
 
 test(() => {
 

--- a/streams/transform-streams/properties.dedicatedworker.html
+++ b/streams/transform-streams/properties.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('properties.js'));
+</script>

--- a/streams/transform-streams/properties.html
+++ b/streams/transform-streams/properties.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+
+
+<script src="properties.js"></script>

--- a/streams/transform-streams/properties.js
+++ b/streams/transform-streams/properties.js
@@ -1,0 +1,190 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+}
+
+// The purpose of this file is to test for objects, attributes and arguments that should not exist.
+// The test cases are generated from data tables to reduce duplication.
+
+// Courtesy of André Bargull. Source is https://esdiscuss.org/topic/isconstructor#content-11.
+function IsConstructor(o) {
+  try {
+    new new Proxy(o, { construct: () => ({}) })();
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+test(() => {
+  assert_equals(self['TransformStreamDefaultController'], undefined,
+                `TransformStreamDefaultController should not be defined`);
+}, `TransformStreamDefaultController should not be exported on the global object`);
+
+// Now get hold of the symbol so we can test its properties.
+self.TransformStreamDefaultController = (() => {
+  let controller;
+  new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return controller.constructor;
+})();
+
+const expected = {
+  TransformStream: {
+    constructor: {
+      type: 'constructor',
+      length: 0
+    },
+    readable: {
+      type: 'getter'
+    },
+    writable: {
+      type: 'getter'
+    }
+  },
+  TransformStreamDefaultController: {
+    constructor: {
+      type: 'constructor',
+      length: 0
+    },
+    desiredSize: {
+      type: 'getter'
+    },
+    enqueue: {
+      type: 'method',
+      length: 1
+    },
+    error: {
+      type: 'method',
+      length: 1
+    },
+    terminate: {
+      type: 'method',
+      length: 0
+    }
+  }
+};
+
+for (const c in expected) {
+  const properties = expected[c];
+  const prototype = self[c].prototype;
+  for (const name in properties) {
+    const fullName = `${c}.prototype.${name}`;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, name);
+    test(() => {
+      const { configurable, enumerable } = descriptor;
+      assert_true(configurable, `${name} should be configurable`);
+      assert_false(enumerable, `${name} should not be enumerable`);
+    }, `${fullName} should have standard properties`);
+    const type = properties[name].type;
+    switch (type) {
+      case 'getter':
+        test(() => {
+          const { writable, get, set } = descriptor;
+          assert_equals(writable, undefined, `${name} should not be a data descriptor`);
+          assert_equals(typeof get, 'function', `${name} should have a getter`);
+          assert_equals(set, undefined, `${name} should not have a setter`);
+        }, `${fullName} should be a getter`);
+        break;
+
+      case 'constructor':
+      case 'method':
+        test(() => {
+          assert_true(descriptor.writable, `${name} should be writable`);
+          assert_equals(typeof prototype[name], 'function', `${name} should be a function`);
+          assert_equals(prototype[name].length, properties[name].length,
+                        `${name} should take ${properties[name].length} arguments`);
+          if (type === 'constructor') {
+            assert_true(IsConstructor(prototype[name]), `${name} should be a constructor`);
+            assert_equals(prototype[name].name, c, `${name}.name should be '${c}'`);
+          } else {
+            assert_false(IsConstructor(prototype[name]), `${name} should not be a constructor`);
+            assert_equals(prototype[name].name, name, `${name}.name should be '${name}`);
+          }
+        }, `${fullName} should be a ${type}`);
+        break;
+    }
+  }
+  test(() => {
+    const expectedPropertyNames = Object.keys(properties).sort();
+    const actualPropertyNames = Object.getOwnPropertyNames(prototype).sort();
+    assert_array_equals(actualPropertyNames, expectedPropertyNames,
+                        `${c} properties should match expected properties`);
+  }, `${c}.prototype should have exactly the expected properties`);
+}
+
+const transformerMethods = {
+  start: {
+    length: 1,
+    trigger: () => {}
+  },
+  transform: {
+    length: 2,
+    trigger: ts => ts.writable.getWriter().write()
+  },
+  flush: {
+    length: 1,
+    trigger: ts => ts.writable.getWriter().close()
+  }
+};
+
+for (const method in transformerMethods) {
+  const { length, trigger } = transformerMethods[method];
+
+  // Some semantic tests of how transformer methods are called can be found in general.js, as well as in the test files
+  // specific to each method.
+  promise_test(() => {
+    let argCount;
+    const ts = new TransformStream({
+      [method](...args) {
+        argCount = args.length;
+      }
+    }, undefined, { highWaterMark: Infinity });
+    return Promise.resolve(trigger(ts)).then(() => {
+      assert_equals(argCount, length, `${method} should be called with ${length} arguments`);
+    });
+  }, `transformer method ${method} should be called with the right number of arguments`);
+
+  promise_test(() => {
+    let methodWasCalled = false;
+    function Transformer() {}
+    Transformer.prototype = {
+      [method]() {
+        methodWasCalled = true;
+      }
+    };
+    const ts = new TransformStream(new Transformer(), undefined, { highWaterMark: Infinity });
+    return Promise.resolve(trigger(ts)).then(() => {
+      assert_true(methodWasCalled, `${method} should be called`);
+    });
+  }, `transformer method ${method} should be called even when it's located on the prototype chain`);
+
+  if (method !== 'start') {
+    promise_test(t => {
+      const unreachedTraps = ['getPrototypeOf', 'setPrototypeOf', 'isExtensible', 'preventExtensions',
+                              'getOwnPropertyDescriptor', 'defineProperty', 'has', 'set', 'deleteProperty', 'ownKeys',
+                              'apply', 'construct'];
+      const handler = {
+        get: t.step_func((target, property) => {
+          if (property === 'readableType' || property === 'writableType') {
+            return undefined;
+          }
+          assert_in_array(property, ['start', method], `only start() and ${method}() should be called`);
+          return () => Promise.resolve();
+        })
+      };
+      for (const trap of unreachedTraps) {
+        handler[trap] = t.unreached_func(`${trap} should not be trapped`);
+      }
+      const transformer = new Proxy({}, handler);
+      const ts = new TransformStream(transformer, undefined, { highWaterMark: Infinity });
+      return trigger(ts);
+    }, `unexpected properties should not be accessed when calling transformer method ${method}`);
+  }
+}
+
+done();

--- a/streams/transform-streams/properties.serviceworker.https.html
+++ b/streams/transform-streams/properties.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('properties.js', 'Service worker test setup');
+</script>

--- a/streams/transform-streams/properties.sharedworker.html
+++ b/streams/transform-streams/properties.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>properties.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('properties.js'));
+</script>

--- a/streams/writable-streams/bad-underlying-sinks.js
+++ b/streams/writable-streams/bad-underlying-sinks.js
@@ -74,29 +74,20 @@ promise_test(t => {
 
 }, 'close: returning a rejected promise should cause writer close() and ready to reject');
 
-promise_test(t => {
-  const ws = new WritableStream({
+test(() => {
+  assert_throws(error1, () => new WritableStream({
     get close() {
       throw error1;
     }
-  });
+  }), 'constructor should throw');
+}, 'close: throwing getter should cause constructor to throw');
 
-  const writer = ws.getWriter();
-
-  return promise_rejects(t, error1, writer.close(), 'close should reject with the thrown error');
-}, 'close: throwing getter should cause writer close() to reject');
-
-promise_test(t => {
-  const ws = new WritableStream({
+test(() => {
+  assert_throws(error1, () => new WritableStream({
     get write() {
       throw error1;
     }
-  });
-
-  const writer = ws.getWriter();
-
-  return promise_rejects(t, error1, writer.write('a'), 'write should reject with the thrown error')
-  .then(() => promise_rejects(t, error1, writer.closed, 'closed should reject with the thrown error'));
+  }), 'constructor should throw');
 }, 'write: throwing getter should cause write() and closed to reject');
 
 promise_test(t => {
@@ -173,29 +164,18 @@ promise_test(t => {
 
 }, 'write: returning a rejected promise (second write) should cause writer write() and ready to reject');
 
-promise_test(t => {
-  const ws = new WritableStream({
+test(() => {
+  assert_throws(new TypeError(), () => new WritableStream({
     abort: { apply() {} }
-  });
-
-  return promise_rejects(t, new TypeError(), ws.abort(error1), 'abort should reject with TypeError').then(() => {
-    const writer = ws.getWriter();
-    return promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError');
-  });
+  }), 'constructor should throw');
 }, 'abort: non-function abort method with .apply');
 
-promise_test(t => {
-  const abortReason = new Error('different string');
-  const ws = new WritableStream({
+test(() => {
+  assert_throws(error1, () => new WritableStream({
     get abort() {
       throw error1;
     }
-  });
-
-  const writer = ws.getWriter();
-
-  return promise_rejects(t, error1, writer.abort(abortReason), 'abort should reject with the thrown error')
-  .then(() => promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError'));
+  }), 'constructor should throw');
 }, 'abort: throwing getter should cause abort() and closed to reject');
 
 promise_test(t => {

--- a/streams/writable-streams/properties.js
+++ b/streams/writable-streams/properties.js
@@ -147,7 +147,7 @@ for (const c in expected) {
 const sinkMethods = {
   start: {
     length: 1,
-    trigger: () => {}
+    trigger: () => Promise.resolve()
   },
   write: {
     length: 2,
@@ -194,28 +194,32 @@ for (const method in sinkMethods) {
     });
   }, `sink method ${method} should be called even when it's located on the prototype chain`);
 
-  if (method !== 'start') {
-    promise_test(t => {
-      const unreachedTraps = ['getPrototypeOf', 'setPrototypeOf', 'isExtensible', 'preventExtensions',
-                              'getOwnPropertyDescriptor', 'defineProperty', 'has', 'set', 'deleteProperty', 'ownKeys',
-                              'apply', 'construct'];
-      const handler = {
-        get: t.step_func((target, property) => {
-          if (property === 'type') {
-            return undefined;
-          }
-          assert_in_array(property, ['start', method], `only start() and ${method}() should be called`);
-          return () => Promise.resolve();
-        })
-      };
-      for (const trap of unreachedTraps) {
-        handler[trap] = t.unreached_func(`${trap} should not be trapped`);
-      }
-      const sink = new Proxy({}, handler);
-      const ws = new WritableStream(sink);
-      return trigger(ws.getWriter());
-    }, `unexpected properties should not be accessed when calling sink method ${method}`);
-  }
+  promise_test(t => {
+    const unreachedTraps = ['getPrototypeOf', 'setPrototypeOf', 'isExtensible', 'preventExtensions',
+                            'getOwnPropertyDescriptor', 'defineProperty', 'has', 'set', 'deleteProperty', 'ownKeys',
+                            'apply', 'construct'];
+    const touchedProperties = [];
+    const handler = {
+      get: t.step_func((target, property) => {
+        touchedProperties.push(property);
+        if (property === 'type') {
+          return undefined;
+        }
+        return () => Promise.resolve();
+      })
+    };
+    for (const trap of unreachedTraps) {
+      handler[trap] = t.unreached_func(`${trap} should not be trapped`);
+    }
+    const sink = new Proxy({}, handler);
+    const ws = new WritableStream(sink);
+    assert_array_equals(touchedProperties, ['type', 'write', 'close', 'abort', 'start'],
+                        'expected properties should be got');
+    return trigger(ws.getWriter()).then(() => {
+      assert_array_equals(touchedProperties, ['type', 'write', 'close', 'abort', 'start'],
+                          'no properties should be accessed on method call');
+    });
+  }, `unexpected properties should not be accessed when calling sink method ${method}`);
 }
 
 done();


### PR DESCRIPTION
Stream classes are changing to get methods from the underlying object
during construction rather than when the methods are called.

Change expectations of when method lookup happens.

See https://github.com/whatwg/streams/issues/691 for background.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
