### PR TITLE
two corrections to the four font-variant-nn tests

### DIFF
--- a/css/css-fonts/font-variant-01.html
+++ b/css/css-fonts/font-variant-01.html
@@ -23,9 +23,9 @@
   }
   .outer {
     font-variant-ligatures: common-ligatures  discretionary-ligatures historical-ligatures contextual;
-    font-variant-position: sub;
+    font-variant-numeric: oldstyle-nums;
     font-variant-caps: small-caps;
-    font-variant-east-asian: jis04;
+    font-variant-east-asian: jis90;
   }
   .child {
     color: green;
@@ -36,6 +36,6 @@
 <p>Test passes if the two lines below are identical, with (in purple) eight check marks (✓),
 and then (in green) three check marks (✓) followed by five crosses (✗). </p>
 <section class="test">
-	<p class="outer">CDGFEJHa<span class="inner child">CDGFEJHa</span></p>
+	<p class="outer">CDGFEJQa<span class="inner child">CDGFEJQa</span></p>
 	<p class="ref">AAAAAAAA<span class="child">AAABBBBB</span></p>
 </section>

--- a/css/css-fonts/font-variant-02.html
+++ b/css/css-fonts/font-variant-02.html
@@ -23,9 +23,9 @@
   }
   .outer {
     font-variant-ligatures: common-ligatures  discretionary-ligatures historical-ligatures contextual;
-    font-variant-position: sub;
+    font-variant-numeric: oldstyle-nums;
     font-variant-caps: small-caps;
-    font-variant-east-asian: jis04;
+    font-variant-east-asian: jis90;
   }
   .child {
     color: green;
@@ -36,6 +36,6 @@
 <p>Test passes if the two lines below are identical, with (in purple) eight check marks (✓),
 and then (in green) eight crosses (✗). </p>
 <section class="test">
-	<p class="outer">CDGFEJHa<span class="inner child">CDGFEJHa</span></p>
+	<p class="outer">CDGFEJQa<span class="inner child">CDGFEJQa</span></p>
 	<p class="ref">AAAAAAAA<span class="child">BBBBBBBB</span></p>
 </section>

--- a/css/css-fonts/font-variant-03.html
+++ b/css/css-fonts/font-variant-03.html
@@ -22,7 +22,7 @@
 	  font-variant: normal;
   }
   .outer {
-    font-feature-settings: "liga" on, "clig" on, "calt" on, "hlig" on, "dlig" on, "subs" on, "smcp" on, "jp04" on;
+    font-feature-settings: "liga" on, "clig" on, "calt" on, "hlig" on, "dlig" on, "onum" on, "smcp" on, "jp90" on;
   }
   .child {
     color: green;
@@ -33,6 +33,6 @@
 <p>Test passes if the two lines below are identical, with (in purple) eight check marks (✓),
 and then (in green) eight check marks (✓). </p>
 <section class="test">
-	<p class="outer">CDGFEJHa<span class="inner child">CDGFEJHa</span></p>
+	<p class="outer">CDGFEJQa<span class="inner child">CDGFEJQa</span></p>
 	<p class="ref">AAAAAAAA<span class="child">AAAAAAAA</span></p>
 </section>

--- a/css/css-fonts/font-variant-04.html
+++ b/css/css-fonts/font-variant-04.html
@@ -22,7 +22,7 @@
 	  font-variant: none;
   }
   .outer {
-    font-feature-settings: "liga" on, "clig" on, "calt" on, "hlig" on, "dlig" on, "subs" on, "smcp" on, "jp04" on;
+    font-feature-settings: "liga" on, "clig" on, "calt" on, "hlig" on, "dlig" on, "onum" on, "smcp" on, "jp90" on;
   }
   .child {
     color: green;
@@ -33,6 +33,6 @@
 <p>Test passes if the two lines below are identical, with (in purple) eight check marks (✓),
 and then (in green) eight check marks (✓). </p>
 <section class="test">
-	<p class="outer">CDGFEJHa<span class="inner child">CDGFEJHa</span></p>
+	<p class="outer">CDGFEJQa<span class="inner child">CDGFEJQa</span></p>
 	<p class="ref">AAAAAAAA<span class="child">AAAAAAAA</span></p>
 </section>


### PR DESCRIPTION
Firstly, the tests claimed to be testing `font-variant-east-asian: jis04` and `font-feature-settings: "jp04" on`
but used the letter for `font-variant-east-asian: jis90` and `font-feature-settings: "jp90" on`. Now corrected.

Secondly, they were testing the superscript feature but that is a poor choice because the spec allows a lot of wiggle room for superscripts and subscripts, for historical reasons. That made everyone fail the test (separately from the error above). Now changed to use `font-variant-numeric: oldstyle-nums;` and `font-feature-settings: "onum" on` which is a much better test. (So the test letter is Q, instead of J previously. See https://www.w3.org/People/chris/fwf/fancytester.html for explanation of the letter-to-feature mapping in this font).

With those two changes, Firefox and Chrome both pass, so this is no longer at-risk. Win!

<!-- Reviewable:start -->

<!-- Reviewable:end -->
