### PR TITLE
Fix document.write()/writeln() tests for custom elements

### DIFF
--- a/custom-elements/parser/parser-uses-registry-of-owner-document.html
+++ b/custom-elements/parser/parser-uses-registry-of-owner-document.html
@@ -8,6 +8,7 @@
 <link rel="help" href="https://dom.spec.whatwg.org/#concept-create-element">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
 </head>
 <body>
 <div id="log"></div>
@@ -120,6 +121,34 @@ promise_test(function () {
         assert_false(instance instanceof MyCustomElement);        
     });
 }, 'HTML parser must use the registry of window.document in a document created by XMLHttpRequest');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'my-custom-element', []);
+    // document-open-steps spec doesn't match most browsers; see https://github.com/whatwg/html/issues/1698.
+    // However, as explained in https://github.com/whatwg/html/issues/1698#issuecomment-298748641
+    // the custom element registry will be replaced after document-open-steps.
+    contentDocument.write('<my-custom-element></my-custom-element>');
+
+    var instance = contentDocument.querySelector('my-custom-element');
+
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof element.class);
+
+}, 'Document.write() must not instantiate a custom element without a defined insertion point');
+
+test_with_window(function (contentWindow, contentDocument) {
+    const element = define_custom_element_in_window(contentWindow, 'my-custom-element', []);
+    // document-open-steps spec doesn't match most browsers; see https://github.com/whatwg/html/issues/1698.
+    // However, as explained in https://github.com/whatwg/html/issues/1698#issuecomment-298748641
+    // the custom element registry will be replaced after document-open-steps.
+    contentDocument.writeln('<my-custom-element></my-custom-element>');
+
+    var instance = contentDocument.querySelector('my-custom-element');
+
+    assert_true(instance instanceof HTMLElement);
+    assert_false(instance instanceof element.class);
+
+}, 'Document.writeln() must not instantiate a custom element without a defined insertion point');
 
 </script>
 </body>

--- a/custom-elements/parser/parser-uses-registry-of-owner-document.html
+++ b/custom-elements/parser/parser-uses-registry-of-owner-document.html
@@ -131,10 +131,10 @@ test_with_window(function (contentWindow, contentDocument) {
 
     var instance = contentDocument.querySelector('my-custom-element');
 
-    assert_true(instance instanceof HTMLElement);
+    assert_true(instance instanceof contentWindow.HTMLElement);
     assert_false(instance instanceof element.class);
 
-}, 'Document.write() must not instantiate a custom element without a defined insertion point');
+}, 'document.write() must not instantiate a custom element without a defined insertion point');
 
 test_with_window(function (contentWindow, contentDocument) {
     const element = define_custom_element_in_window(contentWindow, 'my-custom-element', []);
@@ -145,10 +145,10 @@ test_with_window(function (contentWindow, contentDocument) {
 
     var instance = contentDocument.querySelector('my-custom-element');
 
-    assert_true(instance instanceof HTMLElement);
+    assert_true(instance instanceof contentWindow.HTMLElement);
     assert_false(instance instanceof element.class);
 
-}, 'Document.writeln() must not instantiate a custom element without a defined insertion point');
+}, 'document.writeln() must not instantiate a custom element without a defined insertion point');
 
 </script>
 </body>

--- a/custom-elements/reactions/Document.html
+++ b/custom-elements/reactions/Document.html
@@ -129,6 +129,12 @@ test_with_window(function (contentWindow, contentDocument) {
 }, 'write on Document must enqueue disconnectedCallback when removing a custom element');
 
 test_with_window(function (contentWindow, contentDocument) {
+    contentWindow.document.open();
+    // document.open()'s spec doesn't match most browsers; see https://github.com/whatwg/html/issues/1698.
+    // However, as explained in https://github.com/whatwg/html/issues/1698#issuecomment-298748641
+    // the custom element registry will be replaced after document.open() call,
+    // So call customElements.define() after that in order to register defintion
+    // to correct custom elements registry.
     const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
     contentWindow.document.write('<custom-element></custom-element>');
     assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
@@ -144,6 +150,12 @@ test_with_window(function (contentWindow, contentDocument) {
 }, 'writeln on Document must enqueue disconnectedCallback when removing a custom element');
 
 test_with_window(function (contentWindow) {
+    contentWindow.document.open();
+    // document.open()'s spec doesn't match most browsers; see https://github.com/whatwg/html/issues/1698.
+    // However, as explained in https://github.com/whatwg/html/issues/1698#issuecomment-298748641
+    // the custom element registry will be replaced after document.open() call,
+    // So call customElements.define() after that in order to register defintion
+    // to correct custom elements registry.
     const element = define_custom_element_in_window(contentWindow, 'custom-element', []);
     contentWindow.document.writeln('<custom-element></custom-element>');
     assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);


### PR DESCRIPTION
Fix #8528.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
