### PR TITLE
Wait for the img load event in a File API reftest

### DIFF
--- a/FileAPI/url/url_xmlhttprequest_img.html
+++ b/FileAPI/url/url_xmlhttprequest_img.html
@@ -20,9 +20,8 @@
   http.onloadend = function() {
     var fileDisplay = document.querySelector("#fileDisplay");
     fileDisplay.src = window.URL.createObjectURL(http.response);
-    takeScreenshot();
+    fileDisplay.onload = takeScreenshot;
   };
   http.send();
 </script>
 </html>
-


### PR DESCRIPTION
In https://html.spec.whatwg.org/#update-the-image-data there does not
appear to be anything that guarantees that a blob: URL should load
synchronously.

When attempting to enable this test in Chromium, it was failing
because the screenshot was taken too early.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
