### PR TITLE
Fixed cut/paste errors; added new reftests for lab

### DIFF
--- a/css/css-color/lab-004-ref.html
+++ b/css/css-color/lab-004-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Specifying Lab and LCH</title>
+<style>
+    .match { color: rgb(75.62% 30.45% 47.56%)} /* lab(50 50 0) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if the two lines of filler text are the same color.</p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+</body>

--- a/css/css-color/lab-004.html
+++ b/css/css-color/lab-004.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-004-ref.html">
 <meta name="assert" content="lab() with no alpha, positive a axis">
 <style>
     .test { color: red; }
     .test { color: lab(50 50 0)}
-    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lab(50,0,0) converted to sRGB */
+    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lab(50 50 0) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lab-005-ref.html
+++ b/css/css-color/lab-005-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Specifying Lab and LCH</title>
+<style>
+    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70 -45 0) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if the two lines of filler text are the same color.</p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+</body>

--- a/css/css-color/lab-005.html
+++ b/css/css-color/lab-005.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-005-ref.html">
 <meta name="assert" content="lab() with no alpha, negative a axis">
 <style>
     .test { color: red; }
     .test { color: lab(70 -45 0)}
-    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70,-45,0) converted to sRGB */
+    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lab(70 -45 0) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lab-006-ref.html
+++ b/css/css-color/lab-006-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Specifying Lab and LCH</title>
+<style>
+    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lab(70 0 70) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if the two lines of filler text are the same color.</p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+</body>

--- a/css/css-color/lab-006.html
+++ b/css/css-color/lab-006.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-006-ref.html">
 <meta name="assert" content="lab() with no alpha, positive b axis">
 <style>
     .test { color: red; }
     .test { color: lab(70 0 70)}
-    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lab(70,0,70) converted to sRGB */
+    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lab(70 0 70) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lab-007-ref.html
+++ b/css/css-color/lab-007-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: Specifying Lab and LCH</title>
+<style>
+    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55 0 -60) converted to sRGB */
+</style>
+<body>
+    <p>Test passes if the two lines of filler text are the same color.</p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+    <p class="match">Filler text. Filler text. Filler text. </p>
+</body>

--- a/css/css-color/lab-007.html
+++ b/css/css-color/lab-007.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-007-ref.html">
 <meta name="assert" content="lab() with no alpha, negative b axis">
 <style>
     .test { color: red; }
     .test { color: lab(55 0 -60)}
-    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55,0,-60) converted to sRGB */
+    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lab(55 0 -60) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lch-001.html
+++ b/css/css-color/lch-001.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="lch() with no alpha">
 <style>
-    .test {color: lab(46.277 -67.989 134.391)} /* green (sRGB #008000) converted to LCH */
+    .test {color: lch(46.277 67.945 134.427)} /* green (sRGB #008000) converted to LCH */
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/lch-004.html
+++ b/css/css-color/lch-004.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-004-ref.html">
 <meta name="assert" content="lch() with no alpha, positive a axis">
 <style>
     .test { color: red; }
     .test { color: lch(50 50 0)}
-    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lch(50,0,0) converted to sRGB */
+    .match { color: rgb(75.62%, 30.45%, 47.56%)} /* lch(50 50 0) converted to sRGB (happens to be the same as lab(50 50 0)*/
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lch-005.html
+++ b/css/css-color/lch-005.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-005-ref.html">
 <meta name="assert" content="lch() with no alpha, negative a axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 45 180)}
-    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lch(70,45,180) converted to sRGB */
+    .test { color: lch(70 45 -180)}
+    .match { color: rgb(10.79%, 75.55%, 66.40%)} /* lch(70 45 180) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lch-006.html
+++ b/css/css-color/lch-006.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-006-ref.html">
 <meta name="assert" content="lch() with no alpha, positive b axis">
 <style>
     .test { color: red; }
-    .test { color: lab(70 70 90)}
-    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lch(70,70,90) converted to sRGB */
+    .test { color: lch(70 70 90)}
+    .match { color: rgb(76.62%, 66.36%, 5.58%)} /* lch(70 70 90) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/lch-007.html
+++ b/css/css-color/lch-007.html
@@ -3,12 +3,12 @@
 <title>CSS Color 4: Specifying Lab and LCH</title>
 <link rel="author" title="Chris Lilley" href="mailto:chris@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#specifying-lab-lch">
-<link rel="match" href="blacktext-ref.html">
+<link rel="match" href="lab-007-ref.html">
 <meta name="assert" content="lab() with no alpha, negative b axis">
 <style>
     .test { color: red; }
-    .test { color: lch(55 60 270)}
-    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lch(55,60,270) converted to sRGB */
+    .test { color: lch(56 58 275)}
+    .match { color: rgb(12.81%, 53.10%, 92.76%)} /* lch(56 58 275) converted to sRGB */
 </style>
 <body>
     <p>Test passes if the two lines of filler text are the same color.</p>

--- a/css/css-color/rgb-002.html
+++ b/css/css-color/rgb-002.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="rgb() with 8-bit numbers and no alpha, also no comma">
 <style>
-    .test {color: rgb(0 80.0 0)}
+    .test {color: rgb(0 128.0 0)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgb-004.html
+++ b/css/css-color/rgb-004.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="rgb() with 8-bit numbers and numeric alpha, also no comma">
 <style>
-    .test {color: rgb(0 80.0 0 / 1)}
+    .test {color: rgb(0 128.0 0 / 1)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgb-006.html
+++ b/css/css-color/rgb-006.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="rgb() with 8-bit numbers and percent alpha, also no comma">
 <style>
-    .test {color: rgb(0 80.0 0 / 100%)}
+    .test {color: rgb(0 128.0 0 / 100%)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgb-008.html
+++ b/css/css-color/rgb-008.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="legacy rgb() with 8-bit numbers and percent alpha, with commas">
 <style>
-    .test {color: rgb(0, 80.0, 0, 100%)}
+    .test {color: rgb(0, 128.0, 0, 100%)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgba-002.html
+++ b/css/css-color/rgba-002.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="legacy rgba() with 8-bit numbers and no alpha, also no comma">
 <style>
-    .test {color: rgba(0 80.0 0)}
+    .test {color: rgba(0 128.0 0)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgba-004.html
+++ b/css/css-color/rgba-004.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="legacy rgba() with 8-bit numbers and numeric alpha, also no comma">
 <style>
-    .test {color: rgba(0 80.0 0 / 1)}
+    .test {color: rgba(0 128.0 0 / 1)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgba-006.html
+++ b/css/css-color/rgba-006.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="legacy rgba() with 8-bit numbers and percent alpha, also no comma">
 <style>
-    .test {color: rgba(0 80.0 0 / 100%)}
+    .test {color: rgba(0 128.0 0 / 100%)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>

--- a/css/css-color/rgba-008.html
+++ b/css/css-color/rgba-008.html
@@ -6,7 +6,7 @@
 <link rel="match" href="greentext-ref.html">
 <meta name="assert" content="legacy rgba() with 8-bit numbers and percent alpha, with commas">
 <style>
-    .test {color: rgba(0, 80.0, 0, 100%)}
+    .test {color: rgba(0, 128.0, 0, 100%)}
 </style>
 <body>
     <p class="test">Test passes if this text is green</p>


### PR DESCRIPTION
Some of the tests under css-color had cut-n-paste errors;

* the lab tests were referencing the "blacktest-ref.html" instead of a correct reftest (which I created)
* the rgb hex value 008000 had incorrectly been matched to rgb(0, 80, 0) - should be 128
* several of the lch tests had been copied from lab tests, but had not had the function changed from lab->lch

<!-- Reviewable:start -->

<!-- Reviewable:end -->
