### PR TITLE
Apply pipes to python handlers

### DIFF
--- a/tools/wptserve/docs/pipes.rst
+++ b/tools/wptserve/docs/pipes.rst
@@ -12,8 +12,7 @@ This would serve bytes 1 to 199, inclusive, of foo.txt with the HTTP status
 code 404.
 
 .. note::
-   Pipes are only applied to static files, and will not work if applied to
-   other types of handlers, such as Python File Handlers.
+   Pipes are only applied to static files, Python file and function handlers, and json handlers.
 
 There are several built-in pipe functions, and it is possible to add
 more using the `@pipe` decorator on a function, if required.

--- a/tools/wptserve/docs/pipes.rst
+++ b/tools/wptserve/docs/pipes.rst
@@ -12,7 +12,8 @@ This would serve bytes 1 to 199, inclusive, of foo.txt with the HTTP status
 code 404.
 
 .. note::
-   Pipes are only applied to static files, Python file and function handlers, and json handlers.
+   If you write directly to the response socket using ResponseWriter,
+   or when using the asis handler, only the trickle pipe will affect the response.
 
 There are several built-in pipe functions, and it is possible to add
 more using the `@pipe` decorator on a function, if required.

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -98,6 +98,27 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         resp = self.request(route[1], query="pipe=slice(null,2)")
         self.assertEqual(resp.read(), "PA")
 
+    def test_with_python_func_handler_using_response_writer(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_content("PASS")
+        route = ("GET", "/test/test_pipes_1/", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1], query="pipe=slice(null,2)")
+        # slice has not been applied to the response, because response.writer was used.
+        self.assertEqual(resp.read(), "PASS")
+
+    def test_header_pipe_with_python_func_using_response_writer(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_content("CONTENT")
+        route = ("GET", "/test/test_pipes_1/", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1], query="pipe=header(X-TEST,FAIL)")
+        # header pipe was ignored, because response.writer was used.
+        self.assertFalse(resp.info().get("X-TEST"))
+        self.assertEqual(resp.read(), "CONTENT")
+
     def test_with_json_handler(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -106,6 +127,29 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         self.server.router.register(*route)
         resp = self.request(route[1], query="pipe=slice(null,2)")
         self.assertEqual(resp.read(), '"{')
+
+    def test_slice_with_as_is_handler(self):
+        resp = self.request("/test.asis", query="pipe=slice(null,2)")
+        self.assertEqual(202, resp.getcode())
+        self.assertEqual("Giraffe", resp.msg)
+        self.assertEqual("PASS", resp.info()["X-Test"])
+        # slice has not been applied to the response, because response.writer was used.
+        self.assertEqual("Content", resp.read())
+
+    def test_headers_with_as_is_handler(self):
+        resp = self.request("/test.asis", query="pipe=header(X-TEST,FAIL)")
+        self.assertEqual(202, resp.getcode())
+        self.assertEqual("Giraffe", resp.msg)
+        # header pipe was ignored.
+        self.assertEqual("PASS", resp.info()["X-TEST"])
+        self.assertEqual("Content", resp.read())
+
+    def test_trickle_with_as_is_handler(self):
+        t0 = time.time()
+        resp = self.request("/test.asis", query="pipe=trickle(1:d2:5:d1:r2)")
+        t1 = time.time()
+        self.assertTrue('Content' in resp.read())
+        self.assertGreater(6, t1-t0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -311,6 +311,7 @@ class AsIsHandler(object):
         try:
             with open(path) as f:
                 response.writer.write_content(f.read())
+            wrap_pipeline(path, request, response)
             response.close_connection = True
         except IOError:
             raise HTTPException(404)

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -237,6 +237,7 @@ class PythonScriptHandler(object):
             if "main" in environ:
                 handler = FunctionHandler(environ["main"])
                 handler(request, response)
+                wrap_pipeline(path, request, response)
             else:
                 raise HTTPException(500, "No main function in script %s" % path)
         except IOError:
@@ -267,6 +268,7 @@ class FunctionHandler(object):
             else:
                 content = rv
             response.content = content
+            wrap_pipeline('', request, response)
 
 
 #The generic name here is so that this can be used as a decorator


### PR DESCRIPTION
Follow-up on https://github.com/w3c/web-platform-tests/pull/8415#issuecomment-348445942

I only added support for applying pipes to Python script and function handlers(which covers the json handler as well),  for the following reason:
1. That was the use case I encountered myself("apply standard pipes on top of the custom logic contained in the python handler, to avoid writing custom code")
2. I'm currently wondering if there is any value in applying pipes to other handlers like directory and as_is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8541)
<!-- Reviewable:end -->
