### PR TITLE
Close peer connection and tracks after end of each test

### DIFF
--- a/webrtc/RTCConfiguration-bundlePolicy.html
+++ b/webrtc/RTCConfiguration-bundlePolicy.html
@@ -32,67 +32,89 @@
       };
    */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.getConfiguration().bundlePolicy, 'balanced');
   }, 'Default bundlePolicy should be balanced');
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: undefined });
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.getConfiguration().bundlePolicy, 'balanced');
   }, `new RTCPeerConnection({ bundlePolicy: undefined }) should have bundlePolicy balanced`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'balanced' });
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.getConfiguration().bundlePolicy, 'balanced');
   }, `new RTCPeerConnection({ bundlePolicy: 'balanced' }) should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-compat' });
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.getConfiguration().bundlePolicy, 'max-compat');
   }, `new RTCPeerConnection({ bundlePolicy: 'max-compat' }) should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.getConfiguration().bundlePolicy, 'max-bundle');
   }, `new RTCPeerConnection({ bundlePolicy: 'max-bundle' }) should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({});
   }, 'setConfiguration({}) with initial default bundlePolicy balanced should succeed');
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'balanced' });
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({});
   }, 'setConfiguration({}) with initial bundlePolicy balanced should succeed');
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({ bundlePolicy: 'balanced' });
   }, 'setConfiguration({ bundlePolicy: balanced }) with initial default bundlePolicy balanced should succeed');
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'balanced' });
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({ bundlePolicy: 'balanced' });
   }, `setConfiguration({ bundlePolicy: 'balanced' }) with initial bundlePolicy balanced should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-compat' });
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({ bundlePolicy: 'max-compat' });
   }, `setConfiguration({ bundlePolicy: 'max-compat' }) with initial bundlePolicy max-compat should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
+    t.add_cleanup(() => pc.close());
+
     pc.setConfiguration({ bundlePolicy: 'max-bundle' });
   }, `setConfiguration({ bundlePolicy: 'max-bundle' }) with initial bundlePolicy max-bundle should succeed`);
 
-  test(() => {
+  test(t => {
     assert_throws(new TypeError(), () =>
       new RTCPeerConnection({ bundlePolicy: null }));
   }, `new RTCPeerConnection({ bundlePolicy: null }) should throw TypeError`);
 
-  test(() => {
+  test(t => {
     assert_throws(new TypeError(), () =>
       new RTCPeerConnection({ bundlePolicy: 'invalid' }));
   }, `new RTCPeerConnection({ bundlePolicy: 'invalid' }) should throw TypeError`);
@@ -103,16 +125,20 @@
         5.  If configuration.bundlePolicy is set and its value differs from the
             connection's bundle policy, throw an InvalidModificationError.
    */
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
+    t.add_cleanup(() => pc.close());
+
     assert_idl_attribute(pc, 'setConfiguration');
 
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ bundlePolicy: 'max-compat' }));
   }, `setConfiguration({ bundlePolicy: 'max-compat' }) with initial bundlePolicy max-bundle should throw InvalidModificationError`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ bundlePolicy: 'max-bundle' });
+    t.add_cleanup(() => pc.close());
+
     assert_idl_attribute(pc, 'setConfiguration');
 
     // the default value for bundlePolicy is balanced

--- a/webrtc/RTCConfiguration-helper.js
+++ b/webrtc/RTCConfiguration-helper.js
@@ -9,13 +9,18 @@
 // a new instance of RTCPeerConnection with given config,
 // either directly as constructor parameter or through setConfiguration.
 function config_test(test_func, desc) {
-  test(() => {
-    test_func(config => new RTCPeerConnection(config));
+  test(t => {
+    test_func(config => {
+      const pc = new RTCPeerConnection(config)
+      t.add_cleanup(() => pc.close());
+      return pc;
+    });
   }, `new RTCPeerConnection(config) - ${desc}`);
 
-  test(() => {
+  test(t => {
     test_func(config => {
       const pc = new RTCPeerConnection();
+      t.add_cleanup(() => pc.close());
       assert_idl_attribute(pc, 'setConfiguration');
       pc.setConfiguration(config);
       return pc;

--- a/webrtc/RTCConfiguration-iceCandidatePoolSize.html
+++ b/webrtc/RTCConfiguration-iceCandidatePoolSize.html
@@ -24,29 +24,32 @@ dictionary RTCConfiguration {
 
 ... of type octet
 */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   assert_idl_attribute(pc, "getConfiguration");
   assert_equals(pc.getConfiguration().iceCandidatePoolSize, 0);
 }, "Initialize a new RTCPeerConnection with no iceCandidatePoolSize");
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection({
     iceCandidatePoolSize: 0
   });
+  t.add_cleanup(() => pc.close());
   assert_idl_attribute(pc, "getConfiguration");
   assert_equals(pc.getConfiguration().iceCandidatePoolSize, 0);
 }, "Initialize a new RTCPeerConnection with iceCandidatePoolSize: 0");
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection({
     iceCandidatePoolSize: 255
   });
+  t.add_cleanup(() => pc.close());
   assert_idl_attribute(pc, "getConfiguration");
   assert_equals(pc.getConfiguration().iceCandidatePoolSize, 255);
 }, "Initialize a new RTCPeerConnection with iceCandidatePoolSize: 255");
 
-test(() => {
+test(t => {
   assert_throws(new TypeError(), () => {
     new RTCPeerConnection({
       iceCandidatePoolSize: -1
@@ -54,7 +57,7 @@ test(() => {
   });
 }, "Initialize a new RTCPeerConnection with iceCandidatePoolSize: -1 (Out Of Range)");
 
-test(() => {
+test(t => {
   assert_throws(new TypeError(), () => {
     new RTCPeerConnection({
       iceCandidatePoolSize: 256
@@ -67,8 +70,10 @@ test(() => {
 Reconfiguration
 */
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_idl_attribute(pc, "getConfiguration");
   assert_idl_attribute(pc, "setConfiguration");
   pc.setConfiguration({
@@ -77,8 +82,10 @@ test(() => {
   assert_equals(pc.getConfiguration().iceCandidatePoolSize, 0);
 }, "Reconfigure RTCPeerConnection instance iceCandidatePoolSize to 0");
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_idl_attribute(pc, "getConfiguration");
   assert_idl_attribute(pc, "setConfiguration");
   pc.setConfiguration({
@@ -95,8 +102,10 @@ non-existent setConfiguration method (in cases where it has not yet
 been implemented). Without this check, these tests will pass incorrectly.
 */
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_equals(typeof pc.setConfiguration, "function", "RTCPeerConnection.prototype.setConfiguration is not implemented");
   assert_throws(new TypeError(), () => {
     pc.setConfiguration({
@@ -105,8 +114,10 @@ test(() => {
   });
 }, "Reconfigure RTCPeerConnection instance iceCandidatePoolSize to -1 (Out Of Range)");
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_equals(typeof pc.setConfiguration, "function", "RTCPeerConnection.prototype.setConfiguration is not implemented");
   assert_throws(new TypeError(), () => {
     pc.setConfiguration({

--- a/webrtc/RTCConfiguration-iceServers.html
+++ b/webrtc/RTCConfiguration-iceServers.html
@@ -48,8 +48,9 @@
       };
    */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceServers, undefined);
   }, 'new RTCPeerConnection() should have default configuration.iceServers of undefined');
 

--- a/webrtc/RTCConfiguration-iceTransportPolicy.html
+++ b/webrtc/RTCConfiguration-iceTransportPolicy.html
@@ -31,23 +31,27 @@
     };
    */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection() should have default iceTransportPolicy all`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: undefined });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection({ iceTransportPolicy: undefined }) should have default iceTransportPolicy all`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: 'all' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection({ iceTransportPolicy: 'all' }) should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
   }, `new RTCPeerConnection({ iceTransportPolicy: 'relay' }) should succeed`);
 
@@ -59,24 +63,27 @@
           will be taken until the next gathering phase. If a script wants this to
           happen immediately, it should do an ICE restart.
    */
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: 'all' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
 
     pc.setConfiguration({ iceTransportPolicy: 'relay' });
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
   }, `setConfiguration({ iceTransportPolicy: 'relay' }) with initial iceTransportPolicy all should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
 
     pc.setConfiguration({ iceTransportPolicy: 'all' });
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `setConfiguration({ iceTransportPolicy: 'all' }) with initial iceTransportPolicy relay should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransportPolicy: 'relay' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'relay');
 
     // default value for iceTransportPolicy is all
@@ -101,18 +108,21 @@
   }, `with null iceTransportPolicy should throw TypeError`);
 
   // iceTransportPolicy is called iceTransports in Blink.
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransports: 'relay' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection({ iceTransports: 'relay' }) should have no effect`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransports: 'invalid' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection({ iceTransports: 'invalid' }) should have no effect`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ iceTransports: null });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().iceTransportPolicy, 'all');
   }, `new RTCPeerConnection({ iceTransports: null }) should have no effect`);
 

--- a/webrtc/RTCConfiguration-rtcpMuxPolicy.html
+++ b/webrtc/RTCConfiguration-rtcpMuxPolicy.html
@@ -31,18 +31,21 @@
     };
   */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'require');
   }, `new RTCPeerConnection() should have default rtcpMuxPolicy require`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ rtcpMuxPolicy: undefined });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'require');
   }, `new RTCPeerConnection({ rtcpMuxPolicy: undefined }) should have default rtcpMuxPolicy require`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ rtcpMuxPolicy: 'require' });
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'require');
   }, `new RTCPeerConnection({ rtcpMuxPolicy: 'require' }) should succeed`);
 
@@ -51,7 +54,7 @@
       3.  If configuration.rtcpMuxPolicy is negotiate, and the user agent does not
           implement non-muxed RTCP, throw a NotSupportedError.
    */
-  test(() => {
+  test(t => {
     let pc;
     try {
       pc = new RTCPeerConnection({ rtcpMuxPolicy: 'negotiate' });
@@ -65,6 +68,7 @@
       }
     }
 
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.getConfiguration().rtcpMuxPolicy, 'negotiate');
 
   }, `new RTCPeerConnection({ rtcpMuxPolicy: 'negotiate' }) may succeed or throw NotSupportedError`);
@@ -85,15 +89,16 @@
           connection's rtcpMux policy, throw an InvalidModificationError.
    */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection({ rtcpMuxPolicy: 'require' });
+    t.add_cleanup(() => pc.close());
     assert_idl_attribute(pc, 'setConfiguration');
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ rtcpMuxPolicy: 'negotiate' }));
 
   }, `setConfiguration({ rtcpMuxPolicy: 'negotiate' }) with initial rtcpMuxPolicy require should throw InvalidModificationError`);
 
-  test(() => {
+  test(t => {
     let pc;
     try {
       pc = new RTCPeerConnection({ rtcpMuxPolicy: 'negotiate' });
@@ -107,13 +112,14 @@
       }
     }
 
+    t.add_cleanup(() => pc.close());
     assert_idl_attribute(pc, 'setConfiguration');
     assert_throws('InvalidModificationError', () =>
       pc.setConfiguration({ rtcpMuxPolicy: 'require' }));
 
   }, `setConfiguration({ rtcpMuxPolicy: 'require' }) with initial rtcpMuxPolicy negotiate should throw InvalidModificationError`);
 
-  test(() => {
+  test(t => {
     let pc;
     try {
       pc = new RTCPeerConnection({ rtcpMuxPolicy: 'negotiate' });
@@ -127,6 +133,7 @@
       }
     }
 
+    t.add_cleanup(() => pc.close());
     assert_idl_attribute(pc, 'setConfiguration');
     // default value for rtcpMuxPolicy is require
     assert_throws('InvalidModificationError', () =>

--- a/webrtc/RTCDTMFSender-helper.js
+++ b/webrtc/RTCDTMFSender-helper.js
@@ -10,8 +10,13 @@
 //   getTrackFromUserMedia
 
 // Create a RTCDTMFSender using getUserMedia()
-function createDtmfSender(pc = new RTCPeerConnection()) {
-  return getTrackFromUserMedia('audio')
+function createDtmfSender(t, pc) {
+  if (!pc) {
+    pc = new RTCPeerConnection()
+    t.add_cleanup(() => pc.close());
+  }
+
+  return getTrackFromUserMedia(t, 'audio')
   .then(([track, mediaStream]) => {
     const sender = pc.addTrack(track, mediaStream);
     const dtmfSender = sender.dtmf;
@@ -47,8 +52,9 @@ function createDtmfSender(pc = new RTCPeerConnection()) {
 function test_tone_change_events(testFunc, toneChanges, desc) {
   async_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
-    createDtmfSender(pc)
+    createDtmfSender(t, pc)
     .then(dtmfSender => {
       let lastEventTime = Date.now();
 
@@ -88,7 +94,6 @@ function test_tone_change_events(testFunc, toneChanges, desc) {
           t.step_timeout(
             t.step_func(() => {
               t.done();
-              pc.close();
             }), expectedDuration + 100);
         }
       });

--- a/webrtc/RTCDTMFSender-insertDTMF.https.html
+++ b/webrtc/RTCDTMFSender-insertDTMF.https.html
@@ -54,7 +54,7 @@
       unrecognized.
    */
   promise_test(t => {
-    return createDtmfSender()
+    return createDtmfSender(t)
     .then(dtmfSender => {
       dtmfSender.insertDTMF('');
       dtmfSender.insertDTMF('012345689');
@@ -73,7 +73,7 @@
           InvalidCharacterError.
    */
   promise_test(t => {
-    return createDtmfSender()
+    return createDtmfSender(t)
     .then(dtmfSender => {
       assert_throws('InvalidCharacterError', () =>
         // 'F' is invalid
@@ -95,6 +95,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const dtmfSender = transceiver.sender.dtmf;
 
@@ -109,6 +111,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', {
       direction: 'recvonly'
     });
@@ -126,6 +130,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', {
       direction: 'inactive'
     });
@@ -148,8 +154,8 @@
 
       7.  Set the object's toneBuffer attribute to tones.
    */
-  promise_test(() => {
-    return createDtmfSender()
+  promise_test(t => {
+    return createDtmfSender(t)
     .then(dtmfSender => {
       dtmfSender.insertDTMF('123');
       assert_equals(dtmfSender.toneBuffer, '123');

--- a/webrtc/RTCDTMFSender-ontonechange.https.html
+++ b/webrtc/RTCDTMFSender-ontonechange.https.html
@@ -73,7 +73,7 @@
       10. If toneBuffer is an empty string, abort these steps.
    */
   async_test(t => {
-    createDtmfSender()
+    createDtmfSender(t)
     .then(dtmfSender => {
       dtmfSender.addEventListener('tonechange',
         t.unreached_func('Expect no tonechange event to be fired'));
@@ -232,6 +232,8 @@
    */
   async_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', { direction: 'sendrecv' });
     const dtmfSender = transceiver.sender.dtmf;
 

--- a/webrtc/RTCDataChannel-bufferedAmount.html
+++ b/webrtc/RTCDataChannel-bufferedAmount.html
@@ -69,7 +69,7 @@
             by the number of bytes needed to express data as UTF-8.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel1.send(unicodeString);
       assert_equals(channel1.bufferedAmount, unicodeBuffer.byteLength,
@@ -92,7 +92,7 @@
             ArrayBuffer in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel1.send(helloBuffer.buffer);
       assert_equals(channel1.bufferedAmount, helloBuffer.byteLength,
@@ -114,7 +114,7 @@
             the bufferedAmount attribute by the size of data, in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel1.send(helloBlob);
       assert_equals(channel1.bufferedAmount, helloBlob.size,
@@ -132,7 +132,7 @@
   async_test(t => {
     let messageCount = 0;
 
-    createDataChannelPair()
+    createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       const onMessage = t.step_func(event => {
         const { data } = event;

--- a/webrtc/RTCDataChannel-id.html
+++ b/webrtc/RTCDataChannel-id.html
@@ -9,8 +9,10 @@
 // This and the test below verify that after a description is set that
 // negotiates the DTLS role used by SCTP, data channels with unset IDs
 // have IDs set according to the rules in rtcweb-data-channel.
-promise_test(test => {
-  const pc = new RTCPeerConnection;
+promise_test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('');
   return pc.createOffer()
   .then(offer => pc.setLocalDescription(offer))
@@ -33,8 +35,10 @@ promise_test(test => {
   })
 }, "DTLS client uses odd data channel IDs");
 
-promise_test(test => {
-  const pc = new RTCPeerConnection;
+promise_test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('');
   return pc.createOffer()
   .then(offer => pc.setLocalDescription(offer))

--- a/webrtc/RTCDataChannel-send.html
+++ b/webrtc/RTCDataChannel-send.html
@@ -51,6 +51,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close())
+
     const channel = pc.createDataChannel('test');
     assert_equals(channel.readyState, 'connecting');
     assert_throws('InvalidStateError', () => channel.send(helloString));
@@ -71,7 +73,7 @@
             attribute to data.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel1.send(helloString);
       return awaitMessage(channel2)
@@ -84,7 +86,7 @@
   }, 'Data channel should be able to send simple string and receive as string');
 
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel1.send(unicodeString);
       return awaitMessage(channel2)
@@ -96,7 +98,7 @@
     });
   }, 'Data channel should be able to send unicode string and receive as unicode string');
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloString);
@@ -131,7 +133,7 @@
         Float32Array or Float64Array or DataView) ArrayBufferView;
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBuffer);
@@ -153,7 +155,7 @@
             ArrayBuffer in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBuffer.buffer);
@@ -174,7 +176,7 @@
             the bufferedAmount attribute by the size of data, in bytes.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel1.send(helloBlob);
@@ -195,7 +197,7 @@
             to a new Blob object that represents data as its raw data.
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'blob';
       channel1.send(helloBuffer);
@@ -223,7 +225,7 @@
         be initialized to the string "blob".
    */
   promise_test(t => {
-    return createDataChannelPair()
+    return createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       assert_equals(channel2.binaryType, 'blob',
         'Expect initial binaryType value to be blob');
@@ -261,7 +263,7 @@
       }
     });
 
-    createDataChannelPair()
+    createDataChannelPair(t)
     .then(([channel1, channel2]) => {
       channel2.binaryType = 'arraybuffer';
       channel2.addEventListener('message', onMessage);

--- a/webrtc/RTCDataChannelEvent-constructor.html
+++ b/webrtc/RTCDataChannelEvent-constructor.html
@@ -26,8 +26,10 @@ test(function() {
     );
 }, 'RTCDataChannelEvent constructor with a channel passed as undefined.');
 
-test(function() {
+test(t => {
     var pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     var c = pc.createDataChannel('');
     var e = new RTCDataChannelEvent('type', { channel: c });
     assert_true(e instanceof RTCDataChannelEvent);

--- a/webrtc/RTCDtlsTransport-getRemoteCertificates.html
+++ b/webrtc/RTCDtlsTransport-getRemoteCertificates.html
@@ -38,7 +38,9 @@
    */
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close())
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close())
 
     pc1.createDataChannel('test');
     exchangeIceCandidates(pc1, pc2);

--- a/webrtc/RTCIceTransport.html
+++ b/webrtc/RTCIceTransport.html
@@ -118,11 +118,13 @@
     validateCandidateParameter(iceTransport.getRemoteParameters());
   }
 
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close())
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close())
 
-    return createDataChannelPair(pc1, pc2)
+    return createDataChannelPair(t, pc1, pc2)
     .then(([channel1, channel2]) => {
       // Send a ping message and wait for it just to make sure
       // that the connection is fully working before testing
@@ -163,9 +165,12 @@
     });
   }, 'Two connected iceTransports should has matching local/remote candidates returned');
 
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
+
     pc1.createDataChannel('');
 
     // setRemoteDescription(answer) without the other peer

--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -141,6 +141,7 @@ a=rtcp-rsize
   // when null is used to indicate end of candidate
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -156,6 +157,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return promise_rejects(t, 'InvalidStateError',
       pc.addIceCandidate({
@@ -169,6 +171,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -179,6 +182,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate(new RTCIceCandidate({
@@ -189,6 +193,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
       .then(() => pc.addIceCandidate({ sdpMid }));
@@ -196,6 +201,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
       .then(() => pc.addIceCandidate({ sdpMLineIndex }));
@@ -211,6 +217,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -225,6 +232,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -241,6 +249,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -256,6 +265,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -290,6 +300,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -317,6 +328,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -330,6 +342,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -341,6 +354,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -354,6 +368,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -363,6 +378,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -384,6 +400,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -404,6 +421,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -431,6 +449,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() => pc.addIceCandidate({
@@ -454,6 +473,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -474,6 +494,7 @@ a=rtcp-rsize
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
@@ -486,6 +507,7 @@ a=rtcp-rsize
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>

--- a/webrtc/RTCPeerConnection-addTrack.https.html
+++ b/webrtc/RTCPeerConnection-addTrack.https.html
@@ -39,6 +39,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -66,6 +67,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -101,6 +103,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -121,6 +124,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -148,6 +152,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -182,6 +187,7 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const transceiver = pc.addTransceiver('audio', { direction: 'recvonly' });
     assert_equals(transceiver.sender.track, null);
@@ -199,6 +205,7 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const transceiver = pc.addTransceiver('audio');
     assert_equals(transceiver.sender.track, null);
@@ -224,6 +231,7 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const transceiver = pc.addTransceiver('video', { direction: 'recvonly' });
     assert_equals(transceiver.sender.track, null);

--- a/webrtc/RTCPeerConnection-canTrickleIceCandidates.html
+++ b/webrtc/RTCPeerConnection-canTrickleIceCandidates.html
@@ -30,13 +30,15 @@
       'a=ssrc:1001 cname:some\r\n' +
       'a=rtpmap:111 opus/48000/2\r\n';
 
-  test(function() {
+  test(t => {
     var pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.canTrickleIceCandidates, null, 'canTrickleIceCandidates property is null');
   }, 'canTrickleIceCandidates property is null prior to setRemoteDescription');
 
-  promise_test(function() {
+  promise_test(t => {
     var pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(new RTCSessionDescription({type: 'offer', sdp: sdp}))
     .then(function() {
@@ -44,8 +46,9 @@
     })
   }, 'canTrickleIceCandidates property is true after setRemoteDescription with a=ice-options:trickle');
 
-  promise_test(function() {
+  promise_test(t => {
     var pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription(new RTCSessionDescription({type: 'offer', sdp: sdp.replace('a=ice-options:trickle\r\n', '')}))
     .then(function() {

--- a/webrtc/RTCPeerConnection-connectionState.html
+++ b/webrtc/RTCPeerConnection-connectionState.html
@@ -73,6 +73,7 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.connectionState, 'new');
   }, 'Initial connectionState should be new');
 
@@ -107,7 +108,9 @@
    */
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const onConnectionStateChange = t.step_func(() => {
       const { connectionState } = pc1;

--- a/webrtc/RTCPeerConnection-createAnswer.html
+++ b/webrtc/RTCPeerConnection-createAnswer.html
@@ -24,6 +24,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return promise_rejects(t, 'InvalidStateError',
       pc.createAnswer());
   }, 'createAnswer() with null remoteDescription should reject with InvalidStateError');
@@ -35,6 +37,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({ offerToReceiveVideo: true })
     .then(offer => pc.setRemoteDescription(offer))
@@ -50,6 +53,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return generateOffer({ pc, data: true })
     .then(offer => pc.setRemoteDescription(offer))

--- a/webrtc/RTCPeerConnection-createDataChannel.html
+++ b/webrtc/RTCPeerConnection-createDataChannel.html
@@ -53,8 +53,10 @@
     };
  */
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_equals(pc.createDataChannel.length, 1);
   assert_throws(new TypeError(), () => pc.createDataChannel());
 }, 'createDataChannel with no argument should throw TypeError');
@@ -63,7 +65,7 @@ test(() => {
   6.2.  createDataChannel
     2.  If connection's [[isClosed]] slot is true, throw an InvalidStateError.
  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
   pc.close();
   assert_equals(pc.signalingState, 'closed', 'signaling state');
@@ -99,8 +101,10 @@ test(() => {
       When a RTCDataChannel object is created, the binaryType attribute MUST
       be initialized to the string "blob".
  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('');
   assert_true(channel instanceof RTCDataChannel, 'is RTCDataChannel');
   assert_equals(channel.label, '');
@@ -120,8 +124,10 @@ test(() => {
 
 }, 'createDataChannel attribute default values');
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('test', {
     ordered: false,
     maxPacketLifeTime: null,
@@ -164,8 +170,10 @@ const labels = [
   ['lone surrogate', '\uD800', '\uFFFD'],
 ];
 for (const [description, label, expected] of labels) {
-  test(() => {
-    const pc = new RTCPeerConnection;
+  test(t => {
+    const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const channel = pc.createDataChannel(label);
     assert_equals(channel.label, expected);
   }, `createDataChannel with label ${description} should succeed`);
@@ -177,16 +185,20 @@ for (const [description, label, expected] of labels) {
       9.  Let channel have an [[Ordered]] internal slot initialized to option's
           ordered member.
  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('', { ordered: false });
   assert_equals(channel.ordered, false);
 }, 'createDataChannel with ordered false should succeed');
 
 // true as the default value of a boolean is confusing because null is converted
 // to false while undefined is converted to true.
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel1 = pc.createDataChannel('', { ordered: null });
   assert_equals(channel1.ordered, false);
   const channel2 = pc.createDataChannel('', { ordered: undefined });
@@ -199,8 +211,10 @@ test(() => {
       6.  Let channel have an [[MaxPacketLifeTime]] internal slot initialized to
           option's maxPacketLifeTime member, if present, otherwise null.
  */
-test(() => {
-  const pc = new RTCPeerConnection;
+test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('', { maxPacketLifeTime: 0 });
   assert_equals(channel.maxPacketLifeTime, 0);
 }, 'createDataChannel with maxPacketLifeTime 0 should succeed');
@@ -211,8 +225,10 @@ test(() => {
       7.  Let channel have an [[MaxRetransmits]] internal slot initialized to
           option's maxRetransmits member, if present, otherwise null.
  */
-test(() => {
-  const pc = new RTCPeerConnection;
+test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('', { maxRetransmits: 0 });
   assert_equals(channel.maxRetransmits, 0);
 }, 'createDataChannel with maxRetransmits 0 should succeed');
@@ -222,8 +238,10 @@ test(() => {
     15. If both [[MaxPacketLifeTime]] and [[MaxRetransmits]] attributes are set
         (not null), throw a TypeError.
  */
-test(() => {
-  const pc = new RTCPeerConnection;
+test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   assert_throws(new TypeError(), () => pc.createDataChannel('', {
     maxPacketLifeTime: 0,
     maxRetransmits: 0
@@ -243,8 +261,10 @@ const protocols = [
   ['lone surrogate', '\uD800', '\uFFFD'],
 ];
 for (const [description, protocol, expected] of protocols) {
-  test(() => {
-    const pc = new RTCPeerConnection;
+  test(t => {
+    const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const channel = pc.createDataChannel('', { protocol });
     assert_equals(channel.protocol, expected);
   }, `createDataChannel with protocol ${description} should succeed`);
@@ -256,8 +276,10 @@ for (const [description, protocol, expected] of protocols) {
       11. Let channel have an [[Negotiated]] internal slot initialized to option's
           negotiated member.
  */
-test(() => {
-  const pc = new RTCPeerConnection;
+test(t => {
+  const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('', { negotiated: true });
   assert_equals(channel.negotiated, true);
 }, 'createDataChannel with negotiated true should succeed');
@@ -270,16 +292,20 @@ test(() => {
           of 65534 but still qualifies as an unsigned short, throw a TypeError.
  */
 for (const id of [0, 1, 65534]) {
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const channel = pc.createDataChannel('', { id });
     assert_equals(channel.id, id);
   }, `createDataChannel with id ${id} should succeed`);
 }
 
 for (const id of [-1, 65535, 65536]) {
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     assert_throws(new TypeError(), () => pc.createDataChannel('', { id }));
   }, `createDataChannel with id ${id} should throw TypeError`);
 }
@@ -291,14 +317,17 @@ for (const id of [-1, 65535, 65536]) {
           to option's priority member.
 
  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
+
   const channel = pc.createDataChannel('', { priority: 'high' });
   assert_equals(channel.priority, 'high');
 }, 'createDataChannel with priority "high" should succeed');
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   assert_throws(new TypeError(),
     () => pc.createDataChannel('', { priority: 'invalid' }));
 }, 'createDataChannel with invalid priority should throw TypeError');
@@ -307,8 +336,9 @@ test(() => {
   6.2.  createDataChannel
     13. If [[Negotiated]] is false and [[Label]] is longer than 65535 bytes
         long, throw a TypeError.  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   assert_throws(new TypeError(), () =>
     pc.createDataChannel('', {
       label: ' '.repeat(65536),
@@ -321,8 +351,9 @@ test(() => {
     14. If [[Negotiated]] is false and [[Protocol]] is longer than 65535 bytes long,
         throw a TypeError.
  */
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   assert_throws(new TypeError(), () =>
     pc.createDataChannel('', {
       protocol: ' '.repeat(65536),
@@ -330,8 +361,9 @@ test(() => {
     }));
 }, 'createDataChannel with negotiated false and long protocol should throw TypeError');
 
-test(() => {
+test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   const label = ' '.repeat(65536)
 
   const channel = pc.createDataChannel('', {
@@ -362,6 +394,7 @@ test(() => {
  */
 promise_test(t => {
   const pc = new RTCPeerConnection();
+  t.add_cleanup(() => pc.close());
   const channel1 = pc.createDataChannel('channel');
   assert_equals(channel1.id, null,
     'Expect initial id to be null');

--- a/webrtc/RTCPeerConnection-createOffer.html
+++ b/webrtc/RTCPeerConnection-createOffer.html
@@ -30,6 +30,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection()
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer => {
@@ -58,6 +59,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     pc.close();
 
     return promise_rejects(t, 'InvalidStateError',
@@ -78,6 +80,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const promise = pc.createOffer();
 
     pc.addTransceiver('audio');
@@ -121,6 +124,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer1 => {
@@ -148,6 +152,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({ offerToReceiveVideo: true })
     .then(offer1 => {
@@ -164,6 +169,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({
       offerToReceiveAudio: true,

--- a/webrtc/RTCPeerConnection-getDefaultIceServers.html
+++ b/webrtc/RTCPeerConnection-getDefaultIceServers.html
@@ -34,7 +34,7 @@
       };
    */
 
-  test(() => {
+  test(t => {
     const iceServers = RTCPeerConnection.getDefaultIceServers();
 
     assert_true(Array.isArray(iceServers),
@@ -80,6 +80,7 @@
 
     // Expect default ice servers to be accepted as valid configuration
     const pc = new RTCPeerConnection({ iceServers });
+    t.add_cleanup(() => pc.close());
 
     // Only make sure there are same number of ice servers configured
     // and not do any deep equality checking

--- a/webrtc/RTCPeerConnection-getIdentityAssertion.html
+++ b/webrtc/RTCPeerConnection-getIdentityAssertion.html
@@ -36,8 +36,9 @@
         DOMString peerIdentity;
       };
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const port = window.location.port;
 
     const [idpDomain] = getIdpDomains();
@@ -95,8 +96,9 @@
 
   // When generating assertion, the RTCPeerConnection doesn't care if the returned assertion
   // represents identity of different domain
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const port = window.location.port;
 
     const [idpDomain1, idpDomain2] = getIdpDomains();
@@ -138,6 +140,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     assert_equals(pc.idpErrorInfo, null,
       'Expect initial pc.idpErrorInfo to be null');
@@ -167,6 +170,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
@@ -191,6 +195,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
@@ -216,6 +221,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     pc.setIdentityProvider('nonexistent-origin.web-platform.test', {
       protocol: `non-existent`,
@@ -242,6 +248,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     assert_equals(pc.idpLoginUrl, null,
       'Expect initial pc.idpLoginUrl to be null');
@@ -278,10 +285,11 @@
         value is provided for the peerIdentity member of RTCConfiguration, the value from
         RTCConfiguration is used.
   */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection({
       peerIdentity: 'bob@example.net'
     });
+    t.add_cleanup(() => pc.close());
 
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
@@ -302,8 +310,9 @@
     9.6.  setIdentityProvider
       3.  If any identity provider value has changed, discard any stored identity assertion.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
     const idpHost = hostString(idpDomain, port);
@@ -332,6 +341,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
 
@@ -358,6 +368,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
 
@@ -380,6 +391,10 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
+
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
 
@@ -388,8 +403,7 @@
       usernameHint: `alice@${idpDomain}`
     });
 
-    return new RTCPeerConnection()
-    .createOffer()
+    return pc2.createOffer()
     .then(offer => pc.setRemoteDescription(offer))
     .then(() =>
       promise_rejects(t, 'NotReadableError',

--- a/webrtc/RTCPeerConnection-getStats.https.html
+++ b/webrtc/RTCPeerConnection-getStats.https.html
@@ -53,13 +53,15 @@
         2.  Resolve p with the resulting RTCStatsReport object, containing the gathered stats.
    */
 
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     return pc.getStats();
   }, 'getStats() with no argument should succeed');
 
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     return pc.getStats(null);
   }, 'getStats(null) should succeed');
 
@@ -71,7 +73,9 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    return getTrackFromUserMedia('audio')
+    t.add_cleanup(() => pc.close());
+
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       return promise_rejects(t, 'InvalidAccessError', pc.getStats(track));
     });
@@ -79,7 +83,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    return getTrackFromUserMedia('audio')
+    t.add_cleanup(() => pc.close());
+
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       pc.addTrack(track, mediaStream);
       return pc.getStats(track);
@@ -88,6 +94,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack();
     pc.addTransceiver(track);
 
@@ -102,7 +110,9 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    return getTrackFromUserMedia('audio')
+    t.add_cleanup(() => pc.close());
+
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       // addTransceiver allows adding same track multiple times
       const transceiver1 = pc.addTransceiver(track);
@@ -118,6 +128,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver1 = pc.addTransceiver('audio');
 
     // Create another transceiver that resends what
@@ -135,6 +147,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.getStats()
     .then(statsReport => {
       validateStatsReport(statsReport);
@@ -150,9 +164,11 @@
         - All stats objects referenced directly or indirectly by the RTCOutboundRTPStreamStats
           objects added.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
-    return getTrackFromUserMedia('audio')
+    t.add_cleanup(() => pc.close());
+
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       pc.addTrack(track, mediaStream);
 
@@ -173,8 +189,10 @@
         - All stats objects referenced directly or indirectly by the RTCInboundRTPStreamStats
           added.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
 
     return pc.getStats(transceiver.receiver.track)

--- a/webrtc/RTCPeerConnection-getTransceivers.html
+++ b/webrtc/RTCPeerConnection-getTransceivers.html
@@ -21,6 +21,7 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     assert_idl_attribute(pc, 'getSenders');
     const senders = pc.getSenders();

--- a/webrtc/RTCPeerConnection-iceConnectionState.html
+++ b/webrtc/RTCPeerConnection-iceConnectionState.html
@@ -61,6 +61,7 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.iceConnectionState, 'new');
   }, 'Initial iceConnectionState should be new');
 
@@ -104,7 +105,9 @@
    */
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const onIceConnectionStateChange = t.step_func(() => {
       const { iceConnectionState } = pc1;

--- a/webrtc/RTCPeerConnection-iceGatheringState.html
+++ b/webrtc/RTCPeerConnection-iceGatheringState.html
@@ -51,11 +51,13 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.iceGatheringState, 'new');
   }, 'Initial iceGatheringState should be new');
 
   async_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     const onIceGatheringStateChange = t.step_func(() => {
       const { iceGatheringState } = pc;
@@ -97,7 +99,9 @@
    */
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const onIceGatheringStateChange = t.step_func(() => {
       const { iceGatheringState } = pc2;

--- a/webrtc/RTCPeerConnection-ondatachannel.html
+++ b/webrtc/RTCPeerConnection-ondatachannel.html
@@ -36,7 +36,9 @@
    */
   async_test(t => {
     const localPc = new RTCPeerConnection();
+    t.add_cleanup(() => localPc.close());
     const remotePc = new RTCPeerConnection();
+    t.add_cleanup(() => remotePc.close());
 
     let eventCount = 0;
 
@@ -98,7 +100,9 @@
    */
   async_test(t => {
     const localPc = new RTCPeerConnection();
+    t.add_cleanup(() => localPc.close());
     const remotePc = new RTCPeerConnection();
+    t.add_cleanup(() => remotePc.close());
 
     const onDataChannel = t.step_func_done(event => {
       const remoteChannel = event.channel;
@@ -145,7 +149,9 @@
    */
   async_test(t => {
     const localPc = new RTCPeerConnection();
+    t.add_cleanup(() => localPc.close());
     const remotePc = new RTCPeerConnection();
+    t.add_cleanup(() => remotePc.close());
 
     const onDataChannel = t.unreached_func('datachannel event should not be fired');
 

--- a/webrtc/RTCPeerConnection-onnegotiationneeded.html
+++ b/webrtc/RTCPeerConnection-onnegotiationneeded.html
@@ -82,6 +82,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     pc.createDataChannel('test');
@@ -90,6 +91,7 @@
 
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     pc.createDataChannel('foo');
@@ -114,6 +116,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     pc.addTransceiver('audio');
@@ -127,6 +130,7 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     pc.addTransceiver('audio');
@@ -144,6 +148,7 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     pc.createDataChannel('test');
@@ -161,6 +166,7 @@
    */
   test_never_resolve(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const negotiated = awaitNegotiation(pc);
 
     return pc.createOffer({ offerToReceiveAudio: true })
@@ -183,6 +189,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return assert_first_promise_fulfill_after_second(
       awaitNegotiation(pc),

--- a/webrtc/RTCPeerConnection-ontrack.https.html
+++ b/webrtc/RTCPeerConnection-ontrack.https.html
@@ -97,6 +97,7 @@
   // the streams with matching identifiers.
   async_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     // Fail the test if the ontrack event handler is not implemented
     assert_idl_attribute(pc, 'ontrack', 'Expect pc to have ontrack event handler attribute');
@@ -187,7 +188,9 @@ a=ssrc:1001 cname:some
 
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     pc2.ontrack = t.step_func(trackEvent => {
       const { track } = trackEvent;
@@ -200,7 +203,7 @@ a=ssrc:1001 cname:some
       t.done();
     });
 
-    return getTrackFromUserMedia('audio')
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       pc1.addTrack(track, mediaStream);
 
@@ -215,7 +218,9 @@ a=ssrc:1001 cname:some
 
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     pc2.ontrack = t.step_func(trackEvent => {
       const { track } = trackEvent;
@@ -240,7 +245,9 @@ a=ssrc:1001 cname:some
 
   async_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     pc2.ontrack = t.step_func(trackEvent => {
       const { track } = trackEvent;

--- a/webrtc/RTCPeerConnection-peerIdentity.html
+++ b/webrtc/RTCPeerConnection-peerIdentity.html
@@ -54,9 +54,11 @@
       is, there is a current value for peerIdentity ), then this also establishes a
       target peer identity.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();
@@ -92,9 +94,11 @@
     const idpHost = hostString(idpDomain, port);
 
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection({
       peerIdentity: `bob@${idpDomain}`
     });
+    t.add_cleanup(() => pc2.close());
 
     pc1.setIdentityProvider(idpHost, {
       protocol: 'mock-idp.js',
@@ -131,9 +135,11 @@
     const idpHost = hostString(idpDomain, port);
 
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection({
       peerIdentity: `alice@${idpDomain}`
     });
+    t.add_cleanup(() => pc2.close());
 
     // Ask mockidp.js to return custom contents in validation result
     pc1.setIdentityProvider(idpHost, {
@@ -167,9 +173,11 @@
     const idpHost1 = hostString(idpDomain1, port);
 
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection({
       peerIdentity: `alice@${idpDomain2}`
     });
+    t.add_cleanup(() => pc2.close());
 
     // mock-idp.js will return assertion of domain2 identity
     // with domain1 in the idp.domain field
@@ -220,9 +228,11 @@
     const idpHost = hostString(idpDomain, port);
 
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection({
       peerIdentity: `alice@${idpDomain}`
     });
+    t.add_cleanup(() => pc2.close());
 
     // Ask mock-idp.js to throw error during validation,
     // i.e. during pc2.setRemoteDescription()
@@ -263,7 +273,9 @@
    */
   promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const port = window.location.port;
     const [idpDomain] = getIdpDomains();

--- a/webrtc/RTCPeerConnection-removeTrack.https.html
+++ b/webrtc/RTCPeerConnection-removeTrack.https.html
@@ -37,6 +37,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -48,6 +50,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -65,6 +68,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -77,6 +82,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -99,6 +105,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -110,6 +118,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -131,6 +140,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -148,6 +159,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return navigator.mediaDevices.getUserMedia({ audio: true })
     .then(mediaStream => {
@@ -173,6 +185,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -205,6 +219,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track, { direction: 'sendonly' });
     const { sender } = transceiver;
@@ -237,6 +253,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track, { direction: 'recvonly' });
     const { sender } = transceiver;
@@ -268,6 +286,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
     const transceiver = pc.addTransceiver(track, { direction: 'inactive' });
     const { sender } = transceiver;

--- a/webrtc/RTCPeerConnection-setDescription-transceiver.html
+++ b/webrtc/RTCPeerConnection-setDescription-transceiver.html
@@ -64,8 +64,10 @@
         2.  Set transceiver's mid value to the mid of the corresponding media
             description.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     assert_equals(transceiver.mid, null);
 
@@ -97,9 +99,11 @@
               transceiver be the result.
         3.  Set transceiver's mid value to the mid of the corresponding media description.
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const transceiver1 = pc1.addTransceiver('audio');
     assert_array_equals(pc1.getTransceivers(), [transceiver1]);
@@ -137,8 +141,10 @@
             the RTCSessionDescription that is being rolled back, set the mid value
             of that transceiver to null, as described by [JSEP] (section 4.1.8.2.).
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     assert_equals(transceiver.mid, null);
 
@@ -157,8 +163,10 @@
     });
   }, 'setLocalDescription(rollback) should unset transceiver.mid');
 
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver1 = pc.addTransceiver('audio');
     assert_equals(transceiver1.mid, null);
 
@@ -202,9 +210,11 @@
             addTrack, remove that transceiver from connection's set of transceivers,
             as described by [JSEP] (section 4.1.8.2.).
    */
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     pc1.addTransceiver('audio');
 

--- a/webrtc/RTCPeerConnection-setLocalDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-answer.html
@@ -90,6 +90,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({ offerToReceiveVideo: true })
     .then(offer =>
@@ -119,6 +120,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer({ offerToReceiveVideo: true })
     .then(offer =>
@@ -141,6 +143,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>
@@ -151,6 +154,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>

--- a/webrtc/RTCPeerConnection-setLocalDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-offer.html
@@ -79,6 +79,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer =>
       pc.setLocalDescription({ type: 'offer' })
@@ -99,6 +101,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return generateOffer({ pc, data: true })
     .then(offer =>
@@ -112,6 +115,8 @@
     // last offer, setLocalDescription would reject when setting
     // with the first offer
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer1 =>
       pc.createOffer({ offerToReceiveVideo: true })

--- a/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-pranswer.html
@@ -63,6 +63,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>

--- a/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription-rollback.html
@@ -56,9 +56,8 @@
         - If description is of type "rollback", then this is a rollback. Set
           connection.pendingLocalDescription to null and signaling state to stable.
    */
-  promise_test(t=> {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
-
     test_state_change_event(t, pc, ['have-local-offer', 'stable']);
 
     return pc.createOffer()
@@ -94,12 +93,16 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return promise_rejects(t, 'InvalidStateError',
       pc.setLocalDescription({ type: 'rollback' }));
   }, `setLocalDescription(rollback) from stable state should reject with InvalidStateError`);
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer =>
       pc.setRemoteDescription(offer)
@@ -113,6 +116,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer()
     .then(offer => pc.setLocalDescription(offer))
     .then(() => pc.setLocalDescription({

--- a/webrtc/RTCPeerConnection-setRemoteDescription-answer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-answer.html
@@ -94,6 +94,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>
@@ -103,6 +104,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-offer.html
@@ -52,10 +52,10 @@
 
   promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     pc1.createDataChannel('datachannel');
 
     const pc2 = new RTCPeerConnection();
-
     test_state_change_event(t, pc2, ['have-remote-offer']);
 
     return pc1.createOffer()
@@ -72,6 +72,7 @@
 
   promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     pc1.createDataChannel('datachannel');
 
     const pc2 = new RTCPeerConnection();
@@ -94,6 +95,7 @@
 
   promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     pc1.createDataChannel('datachannel');
 
     const pc2 = new RTCPeerConnection();
@@ -131,6 +133,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.setRemoteDescription({
       type: 'offer',
@@ -159,6 +162,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer()
     .then(offer => {
       return pc.setLocalDescription(offer)

--- a/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-pranswer.html
@@ -63,6 +63,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     return pc.createOffer()
     .then(offer =>

--- a/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-rollback.html
@@ -59,7 +59,6 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-
     test_state_change_event(t, pc, ['have-remote-offer', 'stable']);
 
     return generateOffer({ data: true })
@@ -94,12 +93,16 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return promise_rejects(t, 'InvalidStateError',
       pc.setRemoteDescription({ type: 'rollback' }));
   }, `setRemoteDescription(rollback) from stable state should reject with InvalidStateError`);
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     return pc.createOffer({ offerToReceiveAudio: true })
     .then(offer => pc.setRemoteDescription(offer))
     .then(() => pc.setRemoteDescription({

--- a/webrtc/RTCPeerConnection-setRemoteDescription-tracks.https.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription-tracks.https.html
@@ -21,8 +21,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const localTrack = tracks[0];
       caller.addTrack(localTrack);
@@ -44,8 +47,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const localTrack = tracks[0];
       const localStream = streams[0];
@@ -73,9 +79,12 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
+    t.add_cleanup(() => callee.close());
+
     let eventSequence = '';
-    return getUserMediaTracksAndStreams(1)
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const ontrackResolver = new Resolver();
       callee.ontrack = () => {
@@ -101,8 +110,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(2)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 2)
     .then(t.step_func(([tracks, streams]) => {
       const localTrack1 = tracks[0];
       const localTrack2 = tracks[1];
@@ -143,8 +155,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(2)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 2)
     .then(t.step_func(([tracks, streams]) => {
       const localTracks = tracks;
       const localStream = streams[0];
@@ -178,9 +193,12 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
+    t.add_cleanup(() => callee.close());
+
     let eventSequence = '';
-    return getUserMediaTracksAndStreams(2)
+    return getUserMediaTracksAndStreams(t, 2)
     .then(t.step_func(([tracks, streams]) => {
       const localTracks = tracks;
       const localStream = streams[0];
@@ -214,8 +232,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(2)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 2)
     .then(t.step_func(([tracks, streams]) => {
       const localTrack = tracks[0];
       const localStreams = streams;
@@ -247,8 +268,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       caller.addTrack(tracks[0]);
       const offerPromise = performOffer(caller, callee);
@@ -265,8 +289,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0]);
       assert_not_equals(sender, null);
@@ -292,8 +319,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       assert_not_equals(sender, null);
@@ -319,9 +349,12 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
+    t.add_cleanup(() => callee.close());
+
     let eventSequence = '';
-    return getUserMediaTracksAndStreams(1)
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0], streams[0]);
       assert_not_equals(sender, null);
@@ -353,8 +386,11 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
-    return getUserMediaTracksAndStreams(1)
+    t.add_cleanup(() => callee.close());
+
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0]);
       assert_not_equals(sender, null);
@@ -377,9 +413,12 @@
 
   async_test(t => {
     const caller = new RTCPeerConnection();
+    t.add_cleanup(() => caller.close());
     const callee = new RTCPeerConnection();
+    t.add_cleanup(() => callee.close());
+
     let eventSequence = '';
-    return getUserMediaTracksAndStreams(1)
+    return getUserMediaTracksAndStreams(t, 1)
     .then(t.step_func(([tracks, streams]) => {
       const sender = caller.addTrack(tracks[0]);
       assert_not_equals(sender, null);

--- a/webrtc/RTCPeerConnection-setRemoteDescription.html
+++ b/webrtc/RTCPeerConnection-setRemoteDescription.html
@@ -50,6 +50,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     // SDP is validated after WebIDL validation
     return promise_rejects(t, new TypeError(),
@@ -61,6 +62,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
 
     // SDP is validated after validating type
     return promise_rejects(t, 'InvalidStateError',
@@ -75,6 +77,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     test_state_change_event(t, pc,
       ['have-remote-offer', 'stable', 'have-remote-offer']);

--- a/webrtc/RTCRtpParameters-codecs.html
+++ b/webrtc/RTCRtpParameters-codecs.html
@@ -82,6 +82,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -101,6 +103,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -120,6 +124,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -139,6 +145,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -159,6 +167,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -179,6 +189,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -199,6 +211,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -218,6 +232,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);

--- a/webrtc/RTCRtpParameters-degradationPreference.html
+++ b/webrtc/RTCRtpParameters-degradationPreference.html
@@ -42,6 +42,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
 
     const param = sender.getParameters();
@@ -63,6 +65,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
 
     const param = sender.getParameters();

--- a/webrtc/RTCRtpParameters-encodings.html
+++ b/webrtc/RTCRtpParameters-encodings.html
@@ -114,8 +114,10 @@
           Otherwise, set it to a list containing a single RTCRtpEncodingParameters
           with active set to true.
    */
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const param = transceiver.sender.getParameters();
     validateSenderRtpParameters(param);
@@ -125,8 +127,10 @@
     assert_equals(encoding.active, true);
   }, 'addTransceiver() with undefined sendEncodings should have default encoding parameter with active set to true');
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', { sendEncodings: [] });
 
     const param = transceiver.sender.getParameters();
@@ -151,8 +155,10 @@
     5.2.  getParameters
       - encodings is set to the value of the [[send encodings]] internal slot.
    */
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio', {
       sendEncodings: [{
         dtx: 'enabled',
@@ -192,6 +198,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -210,6 +218,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
@@ -223,8 +233,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
     const encoding = getFirstEncoding(param);
@@ -245,8 +256,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
     const encoding = getFirstEncoding(param);
@@ -267,8 +279,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
     const encoding = getFirstEncoding(param);
@@ -289,6 +302,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio', {
       sendEncodings: [{ rid: 'foo' }],
     });
@@ -313,8 +328,9 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
     const encoding = getFirstEncoding(param);
@@ -327,8 +343,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
     const encoding = getFirstEncoding(param);
@@ -349,6 +366,8 @@
   function test_modified_encoding(field, value1, value2, desc) {
     promise_test(t => {
       const pc = new RTCPeerConnection();
+      t.add_cleanup(() => pc.close());
+
       const { sender } = pc.addTransceiver('audio', {
         sendEncodings: [{
           [field]: value1

--- a/webrtc/RTCRtpParameters-headerExtensions.html
+++ b/webrtc/RTCRtpParameters-headerExtensions.html
@@ -57,6 +57,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);

--- a/webrtc/RTCRtpParameters-rtcp.html
+++ b/webrtc/RTCRtpParameters-rtcp.html
@@ -56,8 +56,9 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
 
@@ -80,8 +81,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
 

--- a/webrtc/RTCRtpParameters-transactionId.html
+++ b/webrtc/RTCRtpParameters-transactionId.html
@@ -60,8 +60,10 @@
       - transactionId is set to a new unique identifier, used to match this
         getParameters call to a setParameters call that may occur later.
    */
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { sender } = pc.addTransceiver('audio');
 
     const param1 = sender.getParameters();
@@ -85,8 +87,9 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
 
@@ -100,8 +103,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
 
@@ -114,8 +118,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param = sender.getParameters();
     validateSenderRtpParameters(param);
 
@@ -128,8 +133,9 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
-    const { sender } = pc.addTransceiver('audio');
+    t.add_cleanup(() => pc.close());
 
+    const { sender } = pc.addTransceiver('audio');
     const param1 = sender.getParameters();
     const param2 = sender.getParameters();
 

--- a/webrtc/RTCRtpReceiver-getContributingSources.https.html
+++ b/webrtc/RTCRtpReceiver-getContributingSources.https.html
@@ -38,9 +38,11 @@
         possibly encode, and 127 represents silence.
    */
 
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const ontrackPromise = new Promise(resolve => {
       pc2.addEventListener('track', trackEvent => {
@@ -52,9 +54,9 @@
       });
     });
 
-    return getTrackFromUserMedia('audio')
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
-      pc1.addTrack(track, mediaStream);
+       pc1.addTrack(track, mediaStream);
       exchangeIceCandidates(pc1, pc2);
       return doSignalingHandshake(pc1, pc2);
     })

--- a/webrtc/RTCRtpReceiver-getParameters.html
+++ b/webrtc/RTCRtpReceiver-getParameters.html
@@ -40,6 +40,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const { receiver } = pc.addTransceiver('audio');
     const param = pc.getParameters();
     validateReceiverRtpParameters(param);

--- a/webrtc/RTCRtpReceiver-getStats.html
+++ b/webrtc/RTCRtpReceiver-getStats.html
@@ -40,8 +40,9 @@
           added.
    */
 
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const { receiver } = pc.addTransceiver('audio');
 
     return receiver.getStats()

--- a/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
+++ b/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html
@@ -25,9 +25,11 @@
       };
    */
 
-  promise_test(() => {
+  promise_test(t => {
     const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
     const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
 
     const ontrackPromise = new Promise(resolve => {
       pc2.addEventListener('track', trackEvent => {
@@ -39,7 +41,7 @@
       });
     });
 
-    return getTrackFromUserMedia('audio')
+    return getTrackFromUserMedia(t, 'audio')
     .then(([track, mediaStream]) => {
       pc1.addTrack(track, mediaStream);
       exchangeIceCandidates(pc1, pc2);

--- a/webrtc/RTCRtpSender-getStats.html
+++ b/webrtc/RTCRtpSender-getStats.html
@@ -40,8 +40,9 @@
           objects added.
    */
 
-  promise_test(() => {
+  promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const { sender } = pc.addTransceiver('audio');
 
     return sender.getStats()

--- a/webrtc/RTCRtpSender-replaceTrack.html
+++ b/webrtc/RTCRtpSender-replaceTrack.html
@@ -33,6 +33,7 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     const track = generateMediaStreamTrack('audio');
 
     const transceiver = pc.addTransceiver('audio');
@@ -52,7 +53,10 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('video');
+    t.add_cleanup(() => track.stop());
 
     const transceiver = pc.addTransceiver('audio');
     const { sender } = transceiver;
@@ -69,7 +73,10 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
+    t.add_cleanup(() => track.stop());
 
     const transceiver = pc.addTransceiver('audio');
     const { sender } = transceiver;
@@ -88,7 +95,10 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
+    t.add_cleanup(() => track.stop());
 
     const transceiver = pc.addTransceiver('audio');
     const { sender } = transceiver;
@@ -102,8 +112,13 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track1 = generateMediaStreamTrack('audio');
+    t.add_cleanup(() => track1.stop());
+
     const track2 = generateMediaStreamTrack('audio');
+    t.add_cleanup(() => track2.stop());
 
     const transceiver = pc.addTransceiver(track1);
     const { sender } = transceiver;
@@ -118,7 +133,10 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
+    t.add_cleanup(() => track.stop());
 
     const transceiver = pc.addTransceiver(track);
     const { sender } = transceiver;
@@ -144,6 +162,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track = generateMediaStreamTrack('audio');
 
     const transceiver = pc.addTransceiver(track);
@@ -173,6 +193,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track1 = generateMediaStreamTrack('audio');
     const track2 = generateMediaStreamTrack('audio');
 
@@ -204,6 +226,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const track1 = generateMediaStreamTrack('audio');
     const track2 = generateMediaStreamTrack('audio');
 

--- a/webrtc/RTCRtpSender-setParameters.html
+++ b/webrtc/RTCRtpSender-setParameters.html
@@ -16,6 +16,8 @@
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { sender } = transceiver;
 

--- a/webrtc/RTCRtpTransceiver-setCodecPreferences.html
+++ b/webrtc/RTCRtpTransceiver-setCodecPreferences.html
@@ -29,24 +29,30 @@
           an InvalidAccessError.
    */
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities = RTCRtpSender.getCapabilities('audio');
     transceiver.setCodecPreferences(capabilities.codecs);
 
   }, `setCodecPreferences() on audio transceiver with codecs returned from RTCRtpSender.getCapabilities('audio') should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('video');
     const capabilities = RTCRtpReceiver.getCapabilities('video');
     transceiver.setCodecPreferences(capabilities.codecs);
 
   }, `setCodecPreferences() on video transceiver with codecs returned from RTCRtpReceiver.getCapabilities('video') should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities1 = RTCRtpSender.getCapabilities('audio');
     const capabilities2 = RTCRtpReceiver.getCapabilities('audio');
@@ -54,15 +60,19 @@
 
   }, `setCodecPreferences() with both sender receiver codecs combined should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     transceiver.setCodecPreferences([]);
 
   }, `setCodecPreferences([]) should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities = RTCRtpSender.getCapabilities('audio');
     const { codecs } = capabilities;
@@ -77,16 +87,20 @@
 
   }, `setCodecPreferences() with reordered codecs should succeed`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities = RTCRtpSender.getCapabilities('video');
     assert_throws(() => transceiver.setCodecPreferences(capabilities.codecs));
 
   }, `setCodecPreferences() on audio transceiver with codecs returned from getCapabilities('video') should throw InvalidAccessError`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const codecs = [{
       mimeType: 'audio/piepiper',
@@ -99,8 +113,10 @@
 
   }, `setCodecPreferences() with user defined codec should throw InvalidAccessError`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities = RTCRtpSender.getCapabilities('audio');
     const codecs = [
@@ -116,8 +132,10 @@
 
   }, `setCodecPreferences() with user defined codec together with codecs returned from getCapabilities() should throw InvalidAccessError`);
 
-  test(() => {
+  test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const capabilities = RTCRtpSender.getCapabilities('audio');
 

--- a/webrtc/RTCRtpTransceiver-setDirection.html
+++ b/webrtc/RTCRtpTransceiver-setDirection.html
@@ -29,6 +29,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     assert_equals(transceiver.direction, 'sendrecv');
     assert_equals(transceiver.currentDirection, null);
@@ -47,6 +49,8 @@
    */
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', { direction: 'sendonly' });
     assert_equals(transceiver.direction, 'sendonly');
     transceiver.setDirection('sendonly');
@@ -56,6 +60,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio', { direction: 'recvonly' });
     assert_equals(transceiver.direction, 'recvonly');
     assert_equals(transceiver.currentDirection, null);
@@ -90,5 +96,4 @@
       Untestable    0
       Total         7
    */
-
 </script>

--- a/webrtc/RTCSctpTransport-constructor.html
+++ b/webrtc/RTCSctpTransport-constructor.html
@@ -41,6 +41,8 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     assert_equals(pc.sctp, null);
     pc.createDataChannel('test');
 
@@ -65,6 +67,7 @@
 
   promise_test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
     assert_equals(pc.sctp, null);
 
     return generateOffer({ pc, data: true })

--- a/webrtc/RTCTrackEvent-constructor.html
+++ b/webrtc/RTCTrackEvent-constructor.html
@@ -30,6 +30,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
     const { track } = receiver;
@@ -52,6 +54,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
     const { track } = receiver;
@@ -72,6 +76,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
     const { track } = receiver;
@@ -93,6 +99,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const receiver = pc.addTransceiver('audio').receiver;
     const track =  pc.addTransceiver('audio').receiver.track;
@@ -113,6 +121,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
     const { track } = receiver;
@@ -126,6 +136,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
 
@@ -138,6 +150,8 @@
 
   test(t => {
     const pc = new RTCPeerConnection();
+    t.add_cleanup(() => pc.close());
+
     const transceiver = pc.addTransceiver('audio');
     const { receiver } = transceiver;
     const { track } = receiver;


### PR DESCRIPTION
Fixes #8301.

This PR introduce add hoc clean up of peer connections and tracks using `t.add_cleanup()` in each test. This approach is use so that we can have minimal disruption to existing tests and make the changes more easily reviewable.

An alternative approach along the line of using a helper function like `makePeerConnection(t)` has been attempted before. But I discovered it is much harder to verify whether the refactoring has been done correctly or not.

This PR affects almost all tests in /webrtc, but it should _not_ affect the results of existing tests. I have tried to make sure that the test results remain the same as before, but there might be lurking mistakes
not yet executed by failing tests.

Some of the async tests require careful refactoring, in particular test of signaling state changes as closing pc too early may produce wrong assertion during event callback.

It may not be worthwhile to merge the whole PR if we find this too difficult or too large to review. If that is the case we may consider to only add the cleanup to the most resource intensive tests, and then gradually introduce cleanup to other small tests at a later time.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
