### PR TITLE
Update getStats tests to latest specs and add new tests

### DIFF
--- a/webrtc/RTCPeerConnection-getStats.https.html
+++ b/webrtc/RTCPeerConnection-getStats.https.html
@@ -10,8 +10,8 @@
   'use strict';
 
   // Test is based on the following editor draft:
-  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
-  // https://w3c.github.io/webrtc-stats/archives/20170614/webrtc-stats.html
+  // webrtc-pc 20171130
+  // webrtc-stats 20171122
 
   // The following helper function is called from RTCPeerConnection-helper.js
   //   getTrackFromUserMedia
@@ -20,39 +20,25 @@
   //   validateStatsReport
   //   assert_stats_report_has_stats
 
+  // The following helper function is called from RTCPeerConnection-helper.js
+  //   exchangeIceCandidates
+  //   doSignalingHandshake
+
   /*
-    8.2.  RTCPeerConnection Interface Extensions
-      partial interface RTCPeerConnection {
-        Promise<RTCStatsReport> getStats(optional MediaStreamTrack? selector = null);
-      };
-
-    8.3.  RTCStatsReport Object
-      interface RTCStatsReport {
-        readonly maplike<DOMString, object>;
-      };
-
-    8.4.  RTCStats Dictionary
-      dictionary RTCStats {
-        DOMHighResTimeStamp timestamp;
-        RTCStatsType        type;
-        DOMString           id;
-      };
-
-      id
-        Two RTCStats objects, extracted from two different RTCStatsReport objects, MUST
-        have the same id if they were produced by inspecting the same underlying object.
-
     8.2.  getStats
       1.  Let selectorArg be the method's first argument.
       2.  Let connection be the RTCPeerConnection object on which the method was invoked.
-      3.  If selectorArg is neither null nor a valid MediaStreamTrack, return a promise
-          rejected with a newly created TypeError.
+      3.  If selectorArg is null, let selector be null.
+      4.  If selectorArg is a MediaStreamTrack let selector be an RTCRtpSender
+          or RTCRtpReceiver on connection which track member matches selectorArg.
+          If no such sender or receiver exists, or if more than one sender or
+          receiver fit this criteria, return a promise rejected with a newly
+          created InvalidAccessError.
       5.  Let p be a new promise.
       6.  Run the following steps in parallel:
         1.  Gather the stats indicated by selector according to the stats selection algorithm.
         2.  Resolve p with the resulting RTCStatsReport object, containing the gathered stats.
    */
-
   promise_test(() => {
     const pc = new RTCPeerConnection();
     return pc.getStats();
@@ -65,9 +51,11 @@
 
   /*
     8.2.  getStats
-      4.  Let selector be a RTCRtpSender or RTCRtpReceiver on connection which track
-          member matches selectorArg. If no such sender or receiver exists, return a promise
-          rejected with a newly created InvalidAccessError.
+      4.  If selectorArg is a MediaStreamTrack let selector be an RTCRtpSender
+          or RTCRtpReceiver on connection which track member matches selectorArg.
+          If no such sender or receiver exists, or if more than one sender or
+          receiver fit this criteria, return a promise rejected with a newly
+          created InvalidAccessError.
    */
   promise_test(t => {
     const pc = new RTCPeerConnection();
@@ -94,12 +82,6 @@
     return pc.getStats(track);
   }, 'getStats() with track added via addTransceiver should succeed');
 
-  /*
-    8.2.  getStats
-      4.  Let selector be a RTCRtpSender or RTCRtpReceiver on connection which track
-          member matches selectorArg. If more than one sender or receiver fit this criteria,
-          return a promise rejected with a newly created InvalidAccessError.
-   */
   promise_test(t => {
     const pc = new RTCPeerConnection();
     return getTrackFromUserMedia('audio')
@@ -183,5 +165,151 @@
       assert_stats_report_has_stats(statsReport, ['inbound-rtp']);
     });
   }, `getStats() on track associated with RtpReceiver should return stats report containing inbound-rtp stats`);
+
+  /*
+    8.6   Mandatory To Implement Stats
+      An implementation MUST support generating statistics of the following types
+      when the corresponding objects exist on a PeerConnection, with the attributes
+      that are listed when they are valid for that object.
+   */
+
+  const mandatoryStats = [
+    "codec",
+    "inbound-rtp",
+    "outbound-rtp",
+    "remote-inbound-rtp",
+    "remote-outbound-rtp",
+    "peer-connection",
+    "data-channel",
+    "stream",
+    "track",
+    "transport",
+    "candidate-pair",
+    "local-candidate",
+    "remote-candidate",
+    "certificate"
+  ];
+
+  async_test(t => {
+    const pc1 = new RTCPeerConnection();
+    t.add_cleanup(() => pc1.close());
+    const pc2 = new RTCPeerConnection();
+    t.add_cleanup(() => pc2.close());
+
+    const dataChannel = pc1.createDataChannel('test-channel');
+
+    return navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video: true
+    })
+    .then(t.step_func(mediaStream => {
+      const tracks = mediaStream.getTracks();
+      assert_equals(tracks.length, 2,
+        'Expect media stream to have one audio and one video track');
+
+      let audioTrack;
+      let videoTrack;
+
+      for (const track of tracks) {
+        t.add_cleanup(() => track.stop());
+
+        pc1.addTrack(track, mediaStream);
+
+        if (track.kind === 'audio') {
+          audioTrack = track;
+        } else if (track.kind === 'video') {
+          videoTrack = track;
+        }
+      }
+
+      if (!audioTrack || ! videoTrack) {
+        assert_unreached('Expect mediaStream to have both audio and video streams');
+      }
+
+      const testStatsReport = (pc, statsReport) => {
+        validateStatsReport(statsReport);
+        assert_stats_report_has_stats(statsReport, mandatoryStats);
+
+        const dataChannelStats = findStatsFromReport(statsReport,
+          stats => {
+            return stats.type === 'data-channel' &&
+              stats.dataChannelIdentifier === dataChannel.id;
+          },
+          'Expect data channel stats to be found');
+
+        assert_equals(dataChannelStats.label, 'test-channel');
+
+        const audioTrackStats = findStatsFromReport(statsReport,
+          stats => {
+            return stats.type === 'track' &&
+              stats.trackIdentifier === audioTrack.id;
+          },
+          'Expect audio track stats to be found');
+
+        assert_equals(audioTrackStats.kind, 'audio');
+
+        const videoTrackStats = findStatsFromReport(statsReport,
+          stats => {
+            return stats.type === 'track' &&
+              stats.trackIdentifier === videoTrack.id;
+          },
+          'Expect video track stats to be found');
+
+        assert_equals(videoTrackStats.kind, 'video');
+
+        const mediaStreamStats = findStatsFromReport(statsReport,
+          stats => {
+            return stats.type === 'stream' &&
+              stats.streamIdentifier === mediaStream.id;
+          },
+          'Expect media stream stats to be found');
+
+        assert_true(mediaStreamStats.trackIds.include(audioTrackStats.id));
+        assert_true(mediaStreamStats.trackIds.include(videoTrackStats.id));
+      }
+
+      const onConnected = t.step_func(() => {
+        // Wait a while for the peer connections to collect stats
+        t.step_timeout(() => {
+          Promise.all([
+            pc1.getStats()
+            .then(statsReport => testStatsReport(pc1, statsReport)),
+
+            pc2.getStats()
+            .then(statsReport => testStatsReport(pc2, statsReport))
+          ])
+          .then(t.step_func_done())
+          .catch(t.step_func(err => {
+            assert_unreached(`test failed with error: ${err}`);
+          }));
+        }, 200)
+      })
+
+      let onTrackCount = 0
+      let onDataChannelCalled = false
+
+      pc2.addEventListener('track', t.step_func(() => {
+        onTrackCount++;
+        if (onTrackCount === 2 && onDataChannelCalled) {
+          onConnected();
+        }
+      }));
+
+      pc2.addEventListener('datachannel', t.step_func(() => {
+        onDataChannelCalled = true;
+        if (onTrackCount === 2) {
+          onConnected();
+        }
+      }));
+
+
+      exchangeIceCandidates(pc1, pc2);
+      doSignalingHandshake(pc1, pc2);
+    }))
+    .catch(t.step_func(err => {
+      assert_unreached(`test failed with error: ${err}`);
+    }));
+
+  }, `getStats() with connected peer connections having tracks and data channel should return all mandatory to implement stats`);
 
 </script>

--- a/webrtc/RTCRtpSender-getStats.https.html
+++ b/webrtc/RTCRtpSender-getStats.https.html
@@ -9,8 +9,8 @@
   'use strict';
 
   // Test is based on the following editor draft:
-  // https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
-  // https://w3c.github.io/webrtc-stats/archives/20170614/webrtc-stats.html
+  // webrtc-pc 20171130
+  // webrtc-stats 20171122
 
   // The following helper function is called from RTCStats-helper.js
   //   validateStatsReport
@@ -18,11 +18,6 @@
 
   /*
     5.2.  RTCRtpSender Interface
-      interface RTCRtpSender {
-         Promise<RTCStatsReport> getStats();
-          ...
-      };
-
       getStats
         1.  Let selector be the RTCRtpSender object on which the method was invoked.
         2.  Let p be a new promise, and run the following steps in parallel:
@@ -49,6 +44,22 @@
       validateStatsReport(statsReport);
       assert_stats_report_has_stats(statsReport, ['outbound-rtp']);
     });
-  }, 'sender.getStats() should return stats report containing outbound-rtp stats');
+  }, 'sender.getStats() via addTransceiver should return stats report containing outbound-rtp stats');
+
+  promise_test(() => {
+    const pc = new RTCPeerConnection();
+
+    return navigator.mediaDevices.getUserMedia({ audio: true })
+    .then(mediaStream => {
+      const [track] = mediaStream.getTracks();
+      const sender = pc.addTrack(track, mediaStream);
+
+      return sender.getStats()
+      .then(statsReport => {
+        validateStatsReport(statsReport);
+        assert_stats_report_has_stats(statsReport, ['outbound-rtp']);
+      });
+    })
+  }, 'sender.getStats() via addTrack should return stats report containing outbound-rtp stats');
 
 </script>

--- a/webrtc/RTCStats-helper.js
+++ b/webrtc/RTCStats-helper.js
@@ -76,6 +76,16 @@ function assert_stats_report_has_stats(statsReport, statsTypes) {
   }
 }
 
+function findStatsFromReport(statsReport, predicate, message) {
+  for (const stats of statsReport.values()) {
+    if (predicate(stats)) {
+      return stats;
+    }
+  }
+
+  assert_unreached(message || 'none of stats in statsReport satisfy given condition')
+}
+
 // Get stats object of type that is expected to be
 // found in the statsReport
 function getRequiredStats(statsReport, type) {

--- a/webrtc/RTCStats-helper.js
+++ b/webrtc/RTCStats-helper.js
@@ -1,17 +1,11 @@
 'use strict';
 
 // Test is based on the following editor draft:
-// https://w3c.github.io/webrtc-pc/archives/20170605/webrtc.html
-// https://w3c.github.io/webrtc-stats/archives/20170614/webrtc-stats.html
-
+// webrtc-pc 20171130
+// webrtc-stats 20171122
 
 // This file depends on dictionary-helper.js which should
 // be loaded from the main HTML file.
-
-// To improve readability, the WebIDL definitions of the Stats
-// dictionaries are modified to annotate with required fields when
-// they are required by section 8.6 of webrtc-pc. ID fields are
-// also annotated with the stats type that they are linked to.
 
 /*
   [webrtc-stats]
@@ -141,35 +135,32 @@ function validateRtcStats(statsReport, stats) {
   [webrtc-stats]
   7.1.  RTCRTPStreamStats dictionary
     dictionary RTCRTPStreamStats : RTCStats {
-      required  unsigned long      ssrc;
-      required  DOMString          mediaType;
-
-      [RTCMediaStreamTrackStats]
-      required  DOMString          trackId;
-
-      [RTCTransportStats]
-      required  DOMString          transportId;
-
-      [RTCCodecStats]
-      required  DOMString          codecId;
-
-                unsigned long      firCount;
-                unsigned long      pliCount;
-      required  unsigned long      nackCount;
-                unsigned long      sliCount;
-                unsigned long long qpSum;
+      unsigned long      ssrc;
+      DOMString          mediaType;
+      DOMString          trackId;
+      DOMString          transportId;
+      DOMString          codecId;
+      unsigned long      firCount;
+      unsigned long      pliCount;
+      unsigned long      nackCount;
+      unsigned long      sliCount;
+      unsigned long long qpSum;
     };
+
+    mediaType of type DOMString
+      Either "audio" or "video".
 
   [webrtc-pc]
   8.6.  Mandatory To Implement Stats
-    - RTCRTPStreamStats, with attributes ssrc, associateStatsId, isRemote, mediaType,
-      mediaTrackId, transportId, codecId, nackCount
+    - RTCRTPStreamStats, with attributes ssrc, mediaType, trackId,
+      transportId, codecId, nackCount
  */
 function validateRtpStreamStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
 
   assert_unsigned_int_field(stats, 'ssrc');
   assert_string_field(stats, 'mediaType');
+  assert_enum_field(stats, 'mediaType', ['audio', 'video'])
 
   validateIdField(statsReport, stats, 'trackId', 'track');
   validateIdField(statsReport, stats, 'transportId', 'transport');
@@ -186,15 +177,12 @@ function validateRtpStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.2.  RTCCodecStats dictionary
     dictionary RTCCodecStats : RTCStats {
-      required  unsigned long payloadType;
-      required  RTCCodecType  codecType;
-
-      [RTCTransportStats]
+      unsigned long payloadType;
+      RTCCodecType  codecType;
       DOMString     transportId;
-
       DOMString     mimeType;
-      required  unsigned long clockRate;
-      required  unsigned long channels;
+      unsigned long clockRate;
+      unsigned long channels;
       DOMString     sdpFmtpLine;
       DOMString     implementation;
     };
@@ -206,7 +194,7 @@ function validateRtpStreamStats(statsReport, stats) {
 
   [webrtc-pc]
   8.6.  Mandatory To Implement Stats
-    - RTCCodecStats, with attributes payloadType, codec, clockRate, channels, parameters
+    - RTCCodecStats, with attributes payloadType, codec, clockRate, channels, sdpFmtpLine
  */
 
 function validateCodecStats(statsReport, stats) {
@@ -221,7 +209,7 @@ function validateCodecStats(statsReport, stats) {
   assert_unsigned_int_field(stats, 'clockRate');
   assert_unsigned_int_field(stats, 'channels');
 
-  assert_optional_string_field(stats, 'sdpFmtpLine');
+  assert_string_field(stats, 'sdpFmtpLine');
   assert_optional_string_field(stats, 'implementation');
 }
 
@@ -229,34 +217,42 @@ function validateCodecStats(statsReport, stats) {
   [webrtc-stats]
   7.3.  RTCReceivedRTPStreamStats dictionary
     dictionary RTCReceivedRTPStreamStats : RTCRTPStreamStats {
-      unsigned long      packetsReceived;
-      unsigned long long bytesReceived;
-      unsigned long      packetsLost;
-      double             jitter;
-      double             fractionLost;
-      unsigned long      packetsDiscarded;
-      unsigned long      packetsRepaired;
-      unsigned long      burstPacketsLost;
-      unsigned long      burstPacketsDiscarded;
-      unsigned long      burstLossCount;
-      unsigned long      burstDiscardCount;
-      double             burstLossRate;
-      double             burstDiscardRate;
-      double             gapLossRate;
-      double             gapDiscardRate;
+        unsigned long      packetsReceived;
+        unsigned long long bytesReceived;
+        long               packetsLost;
+        double             jitter;
+        double             fractionLost;
+        unsigned long      packetsDiscarded;
+        unsigned long      packetsFailedDecryption;
+        unsigned long      packetsRepaired;
+        unsigned long      burstPacketsLost;
+        unsigned long      burstPacketsDiscarded;
+        unsigned long      burstLossCount;
+        unsigned long      burstDiscardCount;
+        double             burstLossRate;
+        double             burstDiscardRate;
+        double             gapLossRate;
+        double             gapDiscardRate;
     };
+
+    [webrtc-pc]
+    8.6.  Mandatory To Implement Stats
+      - RTCReceivedRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes packetsReceived,
+        bytesReceived, packetsLost, jitter, packetsDiscarded
  */
 function validateReceivedRtpStreamStats(statsReport, stats) {
   validateRtpStreamStats(statsReport, stats);
 
-  assert_optional_unsigned_int_field(stats, 'packetsReceived');
-  assert_optional_unsigned_int_field(stats, 'bytesReceived');
-  assert_optional_unsigned_int_field(stats, 'packetsLost');
+  assert_unsigned_int_field(stats, 'packetsReceived');
+  assert_unsigned_int_field(stats, 'bytesReceived');
+  assert_unsigned_int_field(stats, 'packetsLost');
 
-  assert_optional_number_field(stats, 'jitter');
+  assert_number_field(stats, 'jitter');
   assert_optional_number_field(stats, 'fractionLost');
 
-  assert_optional_unsigned_int_field(stats, 'packetsDiscarded');
+  assert_unsigned_int_field(stats, 'packetsDiscarded');
+  assert_optional_unsigned_int_field(stats, 'packetsFailedDecryption');
   assert_optional_unsigned_int_field(stats, 'packetsRepaired');
   assert_optional_unsigned_int_field(stats, 'burstPacketsLost');
   assert_optional_unsigned_int_field(stats, 'burstPacketsDiscarded');
@@ -273,37 +269,21 @@ function validateReceivedRtpStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.4.  RTCInboundRTPStreamStats dictionary
     dictionary RTCInboundRTPStreamStats : RTCReceivedRTPStreamStats {
-      required  unsigned long      packetsReceived;
-      required  unsigned long long bytesReceived;
-      required  unsigned long      packetsLost;
-      required  double             jitter;
-      required  unsigned long      packetsDiscarded;
-
-      [RTCRemoteOutboundRTPStreamStats]
       DOMString           remoteId;
-
       unsigned long       framesDecoded;
       DOMHighResTimeStamp lastPacketReceivedTimestamp;
     };
 
   [webrtc-pc]
   8.6.  Mandatory To Implement Stats
-    - RTCInboundRTPStreamStats, with all required attributes from RTCRTPStreamStats,
-      and also attributes packetsReceived, bytesReceived, packetsLost, jitter,
-      packetsDiscarded
+    - RTCInboundRTPStreamStats, with all required attributes from its inherited
+      dictionaries, and also attributes remoteId, framesDecoded
  */
 function validateInboundRtpStreamStats(statsReport, stats) {
   validateReceivedRtpStreamStats(statsReport, stats);
 
-  assert_unsigned_int_field(stats, 'packetsReceived');
-  assert_unsigned_int_field(stats, 'bytesReceived');
-  assert_unsigned_int_field(stats, 'packetsLost');
-  assert_number_field(stats, 'jitter');
-  assert_unsigned_int_field(stats, 'packetsDiscarded');
-
-  validateOptionalIdField(statsReport, stats, 'remoteId', 'remote-outbound-rtp');
-
-  assert_optional_unsigned_int_field(stats, 'framesDecoded');
+  validateIdField(statsReport, stats, 'remoteId', 'remote-outbound-rtp');
+  assert_unsigned_int_field(stats, 'framesDecoded');
   assert_optional_number_field(stats, 'lastPacketReceivedTimeStamp');
 }
 
@@ -311,18 +291,20 @@ function validateInboundRtpStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.5.  RTCRemoteInboundRTPStreamStats dictionary
     dictionary RTCRemoteInboundRTPStreamStats : RTCReceivedRTPStreamStats {
-      [RTCOutboundRTPStreamStats]
-      DOMString localId;
-
-      double    roundTripTime;
+        DOMString localId;
+        double    roundTripTime;
     };
- */
 
+  [webrtc-pc]
+  8.6.  Mandatory To Implement Stats
+    - RTCRemoteInboundRTPStreamStats, with all required attributes from its
+      inherited dictionaries, and also attributes localId, roundTripTime
+ */
 function validateRemoteInboundRtpStreamStats(statsReport, stats) {
   validateReceivedRtpStreamStats(statsReport, stats);
 
-  validateOptionalIdField(statsReport, stats, 'localId', 'outbound-rtp');
-  assert_optional_number_field(stats, 'roundTripTime');
+  validateIdField(statsReport, stats, 'localId', 'outbound-rtp');
+  assert_number_field(stats, 'roundTripTime');
 }
 
 /*
@@ -334,13 +316,18 @@ function validateRemoteInboundRtpStreamStats(statsReport, stats) {
       unsigned long long bytesSent;
       unsigned long long bytesDiscardedOnSend;
     };
+
+    [webrtc-pc]
+    8.6.  Mandatory To Implement Stats
+      - RTCSentRTPStreamStats, with all required attributes from its inherited
+        dictionaries, and also attributes packetsSent, bytesSent
  */
 function validateSentRtpStreamStats(statsReport, stats) {
   validateRtpStreamStats(statsReport, stats);
 
-  assert_optional_unsigned_int_field(stats, 'packetsSent');
+  assert_unsigned_int_field(stats, 'packetsSent');
   assert_optional_unsigned_int_field(stats, 'packetsDiscardedOnSend');
-  assert_optional_unsigned_int_field(stats, 'bytesSent');
+  assert_unsigned_int_field(stats, 'bytesSent');
   assert_optional_unsigned_int_field(stats, 'bytesDiscardedOnSend');
 }
 
@@ -348,12 +335,7 @@ function validateSentRtpStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.7.  RTCOutboundRTPStreamStats dictionary
     dictionary RTCOutboundRTPStreamStats : RTCSentRTPStreamStats {
-      required  unsigned long      packetsSent;
-      required  unsigned long long bytesSent;
-
-      [RTCRemoteInboundRTPStreamStats]
       DOMString           remoteId;
-
       DOMHighResTimeStamp lastPacketSentTimestamp;
       double              targetBitrate;
       unsigned long       framesEncoded;
@@ -361,20 +343,19 @@ function validateSentRtpStreamStats(statsReport, stats) {
       double              averageRTCPInterval;
     };
 
-  [webrtc-pc]
-  8.6.  Mandatory To Implement Stats
-    - RTCOutboundRTPStreamStats, with all required attributes from RTCRTPStreamStats,
-      and also attributes packetsSent, bytesSent, roundTripTime
+    [webrtc-pc]
+    8.6.  Mandatory To Implement Stats
+      - RTCOutboundRTPStreamStats, with all required attributes from its
+        inherited dictionaries, and also attributes remoteId, framesEncoded
  */
 function validateOutboundRtpStreamStats(statsReport, stats) {
-  validateOptionalIdField(statsReport, stats, 'remoteId', 'remote-inbound-rtp');
+  validateSentRtpStreamStats(statsReport, stats)
 
-  assert_unsigned_int_field(stats, 'packetsSent');
-  assert_unsigned_int_field(stats, 'bytesSent');
+  validateIdField(statsReport, stats, 'remoteId', 'remote-inbound-rtp');
 
   assert_optional_number_field(stats, 'lastPacketSentTimestamp');
   assert_optional_number_field(stats, 'targetBitrate');
-  assert_optional_unsigned_int_field(stats, 'framesEncoded');
+  assert_unsigned_int_field(stats, 'framesEncoded');
   assert_optional_number_field(stats, 'totalEncodeTime');
   assert_optional_number_field(stats, 'averageRTCPInterval');
 }
@@ -383,17 +364,20 @@ function validateOutboundRtpStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.8.  RTCRemoteOutboundRTPStreamStats dictionary
     dictionary RTCRemoteOutboundRTPStreamStats : RTCSentRTPStreamStats {
-      [RTCInboundRTPStreamStats]
       DOMString           localId;
-
       DOMHighResTimeStamp remoteTimestamp;
     };
+
+  [webrtc-pc]
+  8.6.  Mandatory To Implement Stats
+    - RTCRemoteOutboundRTPStreamStats, with all required attributes from its
+      inherited dictionaries, and also attributes localId, remoteTimestamp
  */
 function validateRemoteOutboundRtpStreamStats(statsReport, stats) {
   validateSentRtpStreamStats(statsReport, stats);
 
-  validateOptionalIdField(statsReport, stats, 'localId', 'inbound-rtp');
-  assert_optional_number_field(stats, 'remoteTimeStamp');
+  validateIdField(statsReport, stats, 'localId', 'inbound-rtp');
+  assert_number_field(stats, 'remoteTimeStamp');
 }
 
 /*
@@ -401,10 +385,7 @@ function validateRemoteOutboundRtpStreamStats(statsReport, stats) {
   7.9.  RTCRTPContributingSourceStats
     dictionary RTCRTPContributingSourceStats : RTCStats {
       unsigned long contributorSsrc;
-
-      [RTCInboundRTPStreamStats]
       DOMString     inboundRtpStreamId;
-
       unsigned long packetsContributedTo;
       double        audioLevel;
     };
@@ -423,10 +404,10 @@ function validateContributingSourceStats(statsReport, stats) {
   [webrtc-stats]
   7.10. RTCPeerConnectionStats dictionary
     dictionary RTCPeerConnectionStats : RTCStats {
-      required  unsigned long dataChannelsOpened;
-      required  unsigned long dataChannelsClosed;
-                unsigned long dataChannelsRequested;
-                unsigned long dataChannelsAccepted;
+      unsigned long dataChannelsOpened;
+      unsigned long dataChannelsClosed;
+      unsigned long dataChannelsRequested;
+      unsigned long dataChannelsAccepted;
     };
 
   [webrtc-pc]
@@ -446,10 +427,8 @@ function validatePeerConnectionStats(statsReport, stats) {
   [webrtc-stats]
   7.11. RTCMediaStreamStats dictionary
     dictionary RTCMediaStreamStats : RTCStats {
-      required  DOMString           streamIdentifier;
-
-      [RTCMediaStreamTrackStats]
-      required  sequence<DOMString> trackIds;
+      DOMString           streamIdentifier;
+      sequence<DOMString> trackIds;
     };
 
   [webrtc-pc]
@@ -479,35 +458,37 @@ function validateMediaStreamStats(statsReport, stats) {
   [webrtc-stats]
   7.12. RTCMediaStreamTrackStats dictionary
     dictionary RTCMediaStreamTrackStats : RTCStats {
-      required  DOMString           trackIdentifier;
-      required  boolean             remoteSource;
-      required  boolean             ended;
-      required  boolean             detached;
-                DOMString           kind;
-                DOMHighResTimeStamp estimatedPlayoutTimestamp;
-      required  unsigned long       frameWidth;
-      required  unsigned long       frameHeight;
-      required  double              framesPerSecond;
-                unsigned long       framesCaptured;
-      required  unsigned long       framesSent;
-      required  unsigned long       framesReceived;
-      required  unsigned long       framesDecoded;
-      required  unsigned long       framesDropped;
-      required  unsigned long       framesCorrupted;
-                unsigned long       partialFramesLost;
-                unsigned long       fullFramesLost;
-      required  double              audioLevel;
-                double              totalAudioEnergy;
-                boolean             voiceActivityFlag;
-                double              echoReturnLoss;
-                double              echoReturnLossEnhancement;
-                unsigned long long  totalSamplesSent;
-                unsigned long long  totalSamplesReceived;
-                double              totalSamplesDuration;
-                unsigned long long  concealedSamples;
-                unsigned long long  concealmentEvents;
-                double              jitterBufferDelay;
-                RTCPriorityType     priority;
+      DOMString           trackIdentifier;
+      boolean             remoteSource;
+      boolean             ended;
+      boolean             detached;
+      DOMString           kind;
+      DOMHighResTimeStamp estimatedPlayoutTimestamp;
+      unsigned long       frameWidth;
+      unsigned long       frameHeight;
+      double              framesPerSecond;
+      unsigned long       framesCaptured;
+      unsigned long       framesSent;
+      unsigned long       keyFramesSent;
+      unsigned long       framesReceived;
+      unsigned long       keyFramesReceived;
+      unsigned long       framesDecoded;
+      unsigned long       framesDropped;
+      unsigned long       framesCorrupted;
+      unsigned long       partialFramesLost;
+      unsigned long       fullFramesLost;
+      double              audioLevel;
+      double              totalAudioEnergy;
+      boolean             voiceActivityFlag;
+      double              echoReturnLoss;
+      double              echoReturnLossEnhancement;
+      unsigned long long  totalSamplesSent;
+      unsigned long long  totalSamplesReceived;
+      double              totalSamplesDuration;
+      unsigned long long  concealedSamples;
+      unsigned long long  concealmentEvents;
+      double              jitterBufferDelay;
+      RTCPriorityType     priority;
     };
 
   [webrtc-pc]
@@ -520,8 +501,8 @@ function validateMediaStreamStats(statsReport, stats) {
     };
 
   8.6.  Mandatory To Implement Stats
-    - RTCMediaStreamTrackStats, with attributes trackIdentifier, remoteSource, ended,
-      detached, ssrcIds, frameWidth, frameHeight, framesPerSecond, framesSent,
+    - RTCMediaStreamTrackStats, with attributes trackIdentifier, remoteSource,
+      ended, detached, frameWidth, frameHeight, framesPerSecond, framesSent,
       framesReceived, framesDecoded, framesDropped, framesCorrupted, audioLevel
  */
 
@@ -533,7 +514,7 @@ function validateMediaStreamTrackStats(statsReport, stats) {
   assert_boolean_field(stats, 'ended');
   assert_boolean_field(stats, 'detached');
 
-  assert_optional_string_field(stats, 'kind');
+  assert_optional_enum_field(stats, 'kind', ['audio', 'video']);
   assert_optional_number_field(stats, 'estimatedPlayoutTimestamp');
 
   assert_unsigned_int_field(stats, 'frameWidth');
@@ -541,11 +522,13 @@ function validateMediaStreamTrackStats(statsReport, stats) {
   assert_number_field(stats, 'framesPerSecond');
 
   assert_optional_unsigned_int_field(stats, 'framesCaptured');
-  assert_unsigned_int_field(stats, 'frameSent');
-  assert_unsigned_int_field(stats, 'frameReceived');
-  assert_unsigned_int_field(stats, 'frameDecoded');
-  assert_unsigned_int_field(stats, 'frameDropped');
-  assert_unsigned_int_field(stats, 'frameCorrupted');
+  assert_unsigned_int_field(stats, 'framesSent');
+  assert_optional_unsigned_int_field(stats, 'keyFramesSent');
+  assert_unsigned_int_field(stats, 'framesReceived');
+  assert_optional_unsigned_int_field(stats, 'keyFramesReceived');
+  assert_unsigned_int_field(stats, 'framesDecoded');
+  assert_unsigned_int_field(stats, 'framesDropped');
+  assert_unsigned_int_field(stats, 'framesCorrupted');
 
   assert_optional_unsigned_int_field(stats, 'partialFramesLost');
   assert_optional_unsigned_int_field(stats, 'fullFramesLost');
@@ -571,18 +554,15 @@ function validateMediaStreamTrackStats(statsReport, stats) {
   [webrtc-stats]
   7.13. RTCDataChannelStats dictionary
     dictionary RTCDataChannelStats : RTCStats {
-      required  DOMString           label;
-      required  DOMString           protocol;
-      required  long                datachannelid;
-
-      [RTCTransportStats]
-                DOMString           transportId;
-
-      required  RTCDataChannelState state;
-      required  unsigned long       messagesSent;
-      required  unsigned long long  bytesSent;
-      required  unsigned long       messagesReceived;
-      required  unsigned long long  bytesReceived;
+      DOMString           label;
+      DOMString           protocol;
+      long                dataChannelIdentifier;
+      DOMString           transportId;
+      RTCDataChannelState state;
+      unsigned long       messagesSent;
+      unsigned long long  bytesSent;
+      unsigned long       messagesReceived;
+      unsigned long long  bytesReceived;
     };
 
   [webrtc-pc]
@@ -598,22 +578,19 @@ function validateMediaStreamTrackStats(statsReport, stats) {
     - RTCDataChannelStats, with attributes label, protocol, datachannelId, state,
       messagesSent, bytesSent, messagesReceived, bytesReceived
  */
-
 function validateDataChannelStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
 
   assert_string_field(stats, 'label');
   assert_string_field(stats, 'protocol');
-  assert_int_field(stats, 'datachannelid');
+  assert_int_field(stats, 'dataChannelIdentifier');
 
   validateOptionalIdField(statsReport, stats, 'transportId', 'transport');
 
   assert_enum_field(stats, 'state',
     ['connecting', 'open', 'closing', 'closed']);
 
-  assert_unsigned_int_field(stats, 'messageSent');
-
-  assert_unsigned_int_field(stats, 'messageSent');
+  assert_unsigned_int_field(stats, 'messagesSent');
   assert_unsigned_int_field(stats, 'bytesSent');
   assert_unsigned_int_field(stats, 'messagesReceived');
   assert_unsigned_int_field(stats, 'bytesReceived');
@@ -623,25 +600,16 @@ function validateDataChannelStats(statsReport, stats) {
   [webrtc-stats]
   7.14. RTCTransportStats dictionary
     dictionary RTCTransportStats : RTCStats {
-                unsigned long         packetsSent;
-                unsigned long         packetsReceived;
-      required  unsigned long long    bytesSent;
-      required  unsigned long long    bytesReceived;
-
-      [RTCTransportStats]
-      required  DOMString             rtcpTransportStatsId;
-
-                RTCIceRole            iceRole;
-                RTCDtlsTransportState dtlsState;
-
-      [RTCIceCandidatePairStats]
-      required  DOMString             selectedCandidatePairId;
-
-      [RTCCertificateStats]
-      required  DOMString             localCertificateId;
-
-      [RTCCertificateStats]
-      required  DOMString             remoteCertificateId;
+      unsigned long         packetsSent;
+      unsigned long         packetsReceived;
+      unsigned long long    bytesSent;
+      unsigned long long    bytesReceived;
+      DOMString             rtcpTransportStatsId;
+      RTCIceRole            iceRole;
+      RTCDtlsTransportState dtlsState;
+      DOMString             selectedCandidatePairId;
+      DOMString             localCertificateId;
+      DOMString             remoteCertificateId;
     };
 
   [webrtc-pc]
@@ -661,10 +629,10 @@ function validateDataChannelStats(statsReport, stats) {
     };
 
   8.6.  Mandatory To Implement Stats
-    - RTCTransportStats, with attributes bytesSent, bytesReceived, rtcpTransportStatsId,
-      activeConnection, selectedCandidatePairId, localCertificateId, remoteCertificateId
+    - RTCTransportStats, with attributes bytesSent, bytesReceived,
+      rtcpTransportStatsId, selectedCandidatePairId, localCertificateId,
+      remoteCertificateId
  */
-
 function validateTransportStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
 
@@ -690,18 +658,27 @@ function validateTransportStats(statsReport, stats) {
   [webrtc-stats]
   7.15. RTCIceCandidateStats dictionary
     dictionary RTCIceCandidateStats : RTCStats {
-      [RTCTransportStats]
-                DOMString           transportId;
+      DOMString           transportId;
+      boolean             isRemote;
+      RTCNetworkType      networkType;
+      DOMString           ip;
+      long                port;
+      DOMString           protocol;
+      RTCIceCandidateType candidateType;
+      long                priority;
+      DOMString           url;
+      DOMString           relayProtocol;
+      boolean             deleted = false;
+    };
 
-                boolean             isRemote;
-      required  DOMString           ip;
-      required  long                port;
-      required  DOMString           protocol;
-      required  RTCIceCandidateType candidateType;
-      required  long                priority;
-      required  DOMString           url;
-                DOMString           relayProtocol;
-                boolean             deleted = false;
+    enum RTCNetworkType {
+      "bluetooth",
+      "cellular",
+      "ethernet",
+      "wifi",
+      "wimax",
+      "vpn",
+      "unknown"
     };
 
   [webrtc-pc]
@@ -714,15 +691,17 @@ function validateTransportStats(statsReport, stats) {
     };
 
   8.6.  Mandatory To Implement Stats
-    - RTCIceCandidateStats, with attributes ip, port, protocol, candidateType, priority,
-      url
+    - RTCIceCandidateStats, with attributes ip, port, protocol, candidateType,
+      priority, url
  */
-
 function validateIceCandidateStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
 
   validateOptionalIdField(statsReport, stats, 'transportId', 'transport');
   assert_optional_boolean_field(stats, 'isRemote');
+
+  assert_optional_enum_field(stats, 'networkType',
+    ['bluetooth', 'cellular', 'ethernet', 'wifi', 'wimax', 'vpn', 'unknown'])
 
   assert_string_field(stats, 'ip');
   assert_int_field(stats, 'port');
@@ -741,40 +720,34 @@ function validateIceCandidateStats(statsReport, stats) {
   [webrtc-stats]
   7.16. RTCIceCandidatePairStats dictionary
     dictionary RTCIceCandidatePairStats : RTCStats {
-      [RTCTransportStats]
-      required  DOMString                     transportId;
-
-      [RTCIceCandidateStats]
-      required  DOMString                     localCandidateId;
-
-      [RTCIceCandidateStats]
-      required  DOMString                     remoteCandidateId;
-
-      required  RTCStatsIceCandidatePairState state;
-      required  unsigned long long            priority;
-      required  boolean                       nominated;
-                unsigned long                 packetsSent;
-                unsigned long                 packetsReceived;
-      required  unsigned long long            bytesSent;
-      required  unsigned long long            bytesReceived;
-                DOMHighResTimeStamp           lastPacketSentTimestamp;
-                DOMHighResTimeStamp           lastPacketReceivedTimestamp;
-                DOMHighResTimeStamp           firstRequestTimestamp;
-                DOMHighResTimeStamp           lastRequestTimestamp;
-                DOMHighResTimeStamp           lastResponseTimestamp;
-      required  double                        totalRoundTripTime;
-      required  double                        currentRoundTripTime;
-                double                        availableOutgoingBitrate;
-                double                        availableIncomingBitrate;
-                unsigned long                 circuitBreakerTriggerCount;
-                unsigned long long            requestsReceived;
-                unsigned long long            requestsSent;
-                unsigned long long            responsesReceived;
-                unsigned long long            responsesSent;
-                unsigned long long            retransmissionsReceived;
-                unsigned long long            retransmissionsSent;
-                unsigned long long            consentRequestsSent;
-                DOMHighResTimeStamp           consentExpiredTimestamp;
+      DOMString                     transportId;
+      DOMString                     localCandidateId;
+      DOMString                     remoteCandidateId;
+      RTCStatsIceCandidatePairState state;
+      unsigned long long            priority;
+      boolean                       nominated;
+      unsigned long                 packetsSent;
+      unsigned long                 packetsReceived;
+      unsigned long long            bytesSent;
+      unsigned long long            bytesReceived;
+      DOMHighResTimeStamp           lastPacketSentTimestamp;
+      DOMHighResTimeStamp           lastPacketReceivedTimestamp;
+      DOMHighResTimeStamp           firstRequestTimestamp;
+      DOMHighResTimeStamp           lastRequestTimestamp;
+      DOMHighResTimeStamp           lastResponseTimestamp;
+      double                        totalRoundTripTime;
+      double                        currentRoundTripTime;
+      double                        availableOutgoingBitrate;
+      double                        availableIncomingBitrate;
+      unsigned long                 circuitBreakerTriggerCount;
+      unsigned long long            requestsReceived;
+      unsigned long long            requestsSent;
+      unsigned long long            responsesReceived;
+      unsigned long long            responsesSent;
+      unsigned long long            retransmissionsReceived;
+      unsigned long long            retransmissionsSent;
+      unsigned long long            consentRequestsSent;
+      DOMHighResTimeStamp           consentExpiredTimestamp;
     };
 
     enum RTCStatsIceCandidatePairState {
@@ -788,8 +761,7 @@ function validateIceCandidateStats(statsReport, stats) {
   [webrtc-pc]
   8.6.  Mandatory To Implement Stats
     - RTCIceCandidatePairStats, with attributes transportId, localCandidateId,
-      remoteCandidateId, state, priority, nominated, writable, readable, bytesSent,
-      bytesReceived, totalRtt, currentRtt
+      remoteCandidateId, state, priority, nominated, bytesSent, bytesReceived, totalRoundTripTime, currentRoundTripTime
  */
 function validateIceCandidatePairStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
@@ -835,10 +807,10 @@ function validateIceCandidatePairStats(statsReport, stats) {
   [webrtc-stats]
   7.17. RTCCertificateStats dictionary
     dictionary RTCCertificateStats : RTCStats {
-      required  DOMString fingerprint;
-      required  DOMString fingerprintAlgorithm;
-      required  DOMString base64Certificate;
-      required  DOMString issuerCertificateId;
+      DOMString fingerprint;
+      DOMString fingerprintAlgorithm;
+      DOMString base64Certificate;
+      DOMString issuerCertificateId;
     };
 
   [webrtc-pc]
@@ -846,7 +818,6 @@ function validateIceCandidatePairStats(statsReport, stats) {
     - RTCCertificateStats, with attributes fingerprint, fingerprintAlgorithm,
       base64Certificate, issuerCertificateId
  */
-
 function validateCertificateStats(statsReport, stats) {
   validateRtcStats(statsReport, stats);
 

--- a/webrtc/tools/.eslintrc.js
+++ b/webrtc/tools/.eslintrc.js
@@ -129,6 +129,7 @@ module.exports = {
     // RTCStats-helper.js
     validateStatsReport: true,
     assert_stats_report_has_stats: true,
+    findStatsFromReport: true,
     getRequiredStats: true,
     getStatsById: true,
     validateIdField: true,


### PR DESCRIPTION
This PR updates the stats report object validation to follow the latest version of webrtc-pc and webrtc-stats.

New tests are also added to get stats from peer connection objects that are connected, so that we can collect some real time stats for validation.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
