### PR TITLE
Avoid a serialization interop issue in test_media_queries.html

### DIFF
--- a/css/mediaqueries/test_media_queries.html
+++ b/css/mediaqueries/test_media_queries.html
@@ -394,7 +394,7 @@ function run() {
 
     function query_applies(q) {
       style.setAttribute("media", q);
-      return body_cs.getPropertyValue("text-decoration") == "underline";
+      return body_cs.getPropertyValue("text-decoration-line") == "underline";
     }
 
     function should_apply(q) {


### PR DESCRIPTION
The serialization of the text-decoration shortand is the only difference
between wpt and a copy of the same test in Chromium. It was modified here:
https://chromium.googlesource.com/chromium/src/+/672db831143590b48f931358fd01eab0dc7c453e

Rather than following that change, avoid the difference. It will be
tested separately: https://github.com/w3c/web-platform-tests/pull/8602

<!-- Reviewable:start -->

<!-- Reviewable:end -->
