### PR TITLE
Fix a couple of self.skipWaiting() Service Worker tests

### DIFF
--- a/service-workers/service-worker/skip-waiting-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-using-registration.https.html
@@ -50,9 +50,6 @@ promise_test(function(t) {
         })
       .then(function(registration) {
           sw_registration = registration;
-          t.add_cleanup(function() {
-              registration.unregister();
-            });
           return saw_controllerchanged;
         })
       .then(function() {

--- a/service-workers/service-worker/skip-waiting-without-using-registration.https.html
+++ b/service-workers/service-worker/skip-waiting-without-using-registration.https.html
@@ -26,9 +26,6 @@ promise_test(function(t) {
         })
       .then(function(registration) {
           sw_registration = registration;
-          t.add_cleanup(function() {
-              registration.unregister();
-            });
           return wait_for_state(t, registration.installing, 'activated');
         })
       .then(function() {


### PR DESCRIPTION
The tests were timing out in WebKit because the service worker would get terminated before
it is done running the test. The issue is that the promise_test() in the html file sets a
cleanup handler to call unregister(), which effectively terminates the registration's
workers. However, the promise_test() calls fetch_tests_from_worker(sw_registration.active)
at the end which is asynchronous but does not return a promise. As a result, the test
running in the sw_registration.active runs after the promise_test() has completed and
its cleanup handler has been called to unregister.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
