### PR TITLE
[eme] Set server certificate if available to avoid unnecessary message

### DIFF
--- a/encrypted-media/drm-expiration.https.html
+++ b/encrypted-media/drm-expiration.https.html
@@ -59,6 +59,7 @@
                         messagehandler:     handler.messagehandler,
                         initDataType:       initDataType,
                         initData:           initData,
+                        servercertificate:  handler.servercertificate,
                         expiration:         Date.now().valueOf() + 120000    // Two minutes from now
                     } );
         } );

--- a/encrypted-media/drm-invalid-license.https.html
+++ b/encrypted-media/drm-invalid-license.https.html
@@ -14,6 +14,9 @@
     <script src=/encrypted-media/util/utf8.js></script>
     <script src=/encrypted-media/util/fetch.js></script>
 
+    <!-- Message handler for DRM servers -->
+    <script src=/encrypted-media/util/drm-messagehandler.js></script>
+
     <!-- The script for this specific test -->
     <script src=/encrypted-media/scripts/invalid-license.js></script>
 
@@ -23,8 +26,10 @@
 
     <script>
         var keysystem = getSupportedKeySystem(),
+            handler = new MessageHandler( keysystem ),
             config = {
-                keysystem: keysystem
+                keysystem:          keysystem,
+                servercertificate:  handler.servercertificate
             };
         runTest(config);
     </script>

--- a/encrypted-media/drm-mp4-playback-temporary-expired.https.html
+++ b/encrypted-media/drm-mp4-playback-temporary-expired.https.html
@@ -44,7 +44,8 @@
                         videoPath:          contentitem.video.path,
                         audioType:          contentitem.audio.type,
                         videoType:          contentitem.video.type,
-                        initDataType:       contentitem.initDataType
+                        initDataType:       contentitem.initDataType,
+                        servercertificate:  handler.servercertificate
                       };
 
         runTest(config);

--- a/encrypted-media/drm-temporary-license-type.https.html
+++ b/encrypted-media/drm-temporary-license-type.https.html
@@ -63,7 +63,8 @@
                         content:            content,
                         messagehandler:     handler.messagehandler,
                         initDataType:       initDataType,
-                        initData:           initData
+                        initData:           initData,
+                        servercertificate:  handler.servercertificate
                     } );
         } );
 

--- a/encrypted-media/scripts/expiration.js
+++ b/encrypted-media/scripts/expiration.js
@@ -35,6 +35,8 @@ function runTest(config,qualifier) {
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
             _mediaKeys = mediaKeys;
+            return setCertificate(mediaKeys, config.servercertificate);
+        }).then(function() {
             _mediaKeySession = _mediaKeys.createSession( 'temporary' );
             waitForEventAndRunStep('message', _mediaKeySession, onMessage, test);
             return _mediaKeySession.generateRequest(config.initDataType, config.initData);

--- a/encrypted-media/scripts/invalid-license.js
+++ b/encrypted-media/scripts/invalid-license.js
@@ -12,6 +12,8 @@ function runTest(config)
             initData = getInitData(initDataType);
             return access.createMediaKeys();
         }).then(function (mediaKeys) {
+            return setCertificate(mediaKeys, config.servercertificate);
+        }).then(function (mediaKeys) {
             var keySession = mediaKeys.createSession();
             var eventWatcher = new EventWatcher(test, keySession, ['message']);
             var promise = eventWatcher.wait_for('message');

--- a/encrypted-media/scripts/playback-temporary-expired.js
+++ b/encrypted-media/scripts/playback-temporary-expired.js
@@ -78,6 +78,8 @@ function runTest(config,qualifier) {
             return access.createMediaKeys();
         }).then(function(mediaKeys) {
             _mediaKeys = mediaKeys;
+            return setCertificate(_mediaKeys, config.servercertificate);
+        }).then(function() {
             return _video.setMediaKeys(_mediaKeys);
         }).then(function(){
             waitForEventAndRunStep('encrypted', _video, onEncrypted, test);

--- a/encrypted-media/scripts/temporary-license-type.js
+++ b/encrypted-media/scripts/temporary-license-type.js
@@ -51,6 +51,8 @@ function runTest(config,qualifier) {
                 initData = getInitData(config.content, initDataType);
             }
             return access.createMediaKeys();
+        }).then(function(mediaKeys) {
+            return setCertificate(mediaKeys, config.servercertificate);
         }).then(test.step_func(function(mediaKeys) {
             mediaKeySession = mediaKeys.createSession('temporary');
             waitForEventAndRunStep('message', mediaKeySession, test.step_func(processMessage), test);

--- a/encrypted-media/util/drm-messagehandler.js
+++ b/encrypted-media/util/drm-messagehandler.js
@@ -15,7 +15,8 @@ drmconfig = {
         "serverURL": "https://lic.staging.drmtoday.com/license-proxy-widevine/cenc/",
         "servertype" : "drmtoday",
         "merchant" : "w3c-eme-test",
-        "secret" : drmtodaysecret
+        "secret" : drmtodaysecret,
+        "certificate" : "Cr8CCAMSEChwNFTACPY2GK3nRD22xMgYi+f5kAUijgIwggEKAoIBAQC1IRK40F0CP8xdleLCUcHGSbQXfNjSvu81W7BnQ95mHj0qvDGCt5lG1V/cCN/pVAeBXppidLMiosf14Ge7XwrAeonUWuqUslFvB1tm74EdDSbhuaa4lPK5hXliqhccT2ZjDT5MYCcYiX9eHvm2qvWtTboqfhQXbfE0odMYW1ohisBaTEHwge//gKOgQMULCbvHQO7c2PFNZ1qRmA+Syn3cZGoGra1RAfdKDkmMwB8AUyusIXhQvZBekJI2Vrff7+9CSGdn8z72KD1PQlSrcliTkL7lWAjx1mgIDUXYk8K8ovdNYKDA0KCZPO8BYEcDM0w2OBOUhrydryT9Z6B/mtlDAgMBAAE6EnN0YWdpbmcuZ29vZ2xlLmNvbRKAA5g+MDUmdfQLpxX8JJva5dSsckmiZmUh5DZVc5Upch/4gOCq78Xie8mA2uravz/DhtCEoCyCU3hIzHU/9JewEafal3iKAOKqa4TNfXHAekjr9hYCzKWj8yAwpylcMNqRW5HcGLm8lZO43ou1Dw3twSk4uOngOc3eGPqC6BuwMmMP6VXYWlZs4VQwC/bUwb0SaWY1ayh9ZXsYzmPQ79RfxSael+qxHLVj5VZDsm/0nxCcIQGvyvNbgy8ojw2dRZYOJZ6F+10k29LPgnZMXdm/cn776chh+GkyH2reGJBfTZL5ptplNtuEdYcdFo6HC7IwPPcMbpeEyT0t6EWtgmK+fg1OLkoHWc74LRCdJZLHJCn4wBdCuuKz3srbwzw+X0uvXhbst06tuvy3xnBfep47bzlAOD+cURbSAqIMkinulpwlGXGDA7UNATDDNS4GsBTYOFQPigwifAAR4PWzjk4pjtLLMB60Vkll9VxdeXV6JQpOuchKs+ZTn2tv31aJnqKZFA=="
     } ],
     "com.microsoft.playready": [ {
         "serverURL": "http://playready-testserver.azurewebsites.net/rightsmanager.asmx",

--- a/encrypted-media/util/utils.js
+++ b/encrypted-media/util/utils.js
@@ -282,4 +282,15 @@ function checkEventSequence(events,pattern) {
     assert_equals(j,pattern.length,"Expected more events than received");
 }
 
+// Sets |certificate| on |mediaKeys| if |certificate| is specified. Returns
+// a promise that resolves to |mediaKeys|.
+function setCertificate(mediaKeys, certificate) {
+    if (!certificate) {
+        return Promise.resolve(mediaKeys);
+    }
 
+    return mediaKeys.setServerCertificate(certificate).then(function(result) {
+        assert_true(result);
+        return mediaKeys;
+    });
+}


### PR DESCRIPTION
Widevine now requires the server certificate to be set before requesting
any license. If not set specifically, the first request to the server will
be to get it. Several of the tests expect the first message request to do
something (like set the expiration time), so this change calls
MediaKeys.setServerCertificate() first if a certificate has been specified
for the particular key system. Fixes #8410.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
