### PR TITLE
[css-grid-1] Add test for exclusion of cyclic-sizing-dependency items from baseline alignment.

### DIFF
--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>
 	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions
 </title>
@@ -15,7 +16,7 @@
 		border: solid silver;
 		margin: 1em 0.25em;
 		display: inline-grid;
-		grid-template-columns: repeat(4, max-content);
+		grid-template-columns: repeat(3, auto);
 		font: 20px/1 Ahem;
 		height: 5em;
 	}
@@ -43,7 +44,7 @@
 		align-self: start;
 	}
 	.content.ref > div {
-		algin-content: baseline;
+		align-content: start;
 	}
 </style>
 

--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<title>
+	Grid Item (First) Baseline Alignment: Row Cyclic Sizing Exclusions
+</title>
+<meta name="assert" content="
+	A grid item whose size is input
+	to the size of the track
+	on which its size depends
+	cannot participate in baseline alignment.
+">
+<link rel="help" href="https://www.w3.org/TR/css-grid-1/#row-align">
+<link rel="match" href="references/grid-baseline-align-cycles-001-ref.html">
+<style>
+	.grid {
+		border: solid silver;
+		margin: 1em 0.25em;
+		display: inline-grid;
+		grid-template-columns: repeat(4, max-content);
+		font: 20px/1 Ahem;
+		height: 5em;
+	}
+	.grid > div {
+		border: 1em aqua;
+		border-style: solid none;
+	}
+	.index {
+		padding: 1em 0;
+	}
+	.percent {
+		height: 20%;
+	}
+	.orthogonal {
+		writing-mode: vertical-rl;
+	}
+
+	.self > div {
+		align-self: baseline;
+	}
+	.content > div {
+		align-content: baseline
+	}
+	.self.ref > div {
+		align-self: start;
+	}
+	.content.ref > div {
+		algin-content: baseline;
+	}
+</style>
+
+<p>Test passes if the upper set of boxes is identical to the lower set.
+
+<div class="grid self">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<div class="grid content">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<br>
+
+<div class="grid self ref">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<div class="grid content ref">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>

--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -17,7 +17,7 @@
     border: solid silver;
     margin: 1em 0.25em;
     display: inline-grid;
-    grid-template-columns: repeat(3, auto);
+    grid-template-columns: repeat(2, auto);
     font: 20px/1 Ahem;
     height: 5em;
   }
@@ -58,6 +58,12 @@
   <div class="percent">
     X
   </div>
+</div>
+
+<div class="grid self">
+  <div class="index">
+    X
+  </div>
   <div class="orthogonal">
     X
   </div>
@@ -68,6 +74,12 @@
     X
   </div>
   <div class="percent">
+    X
+  </div>
+</div>
+
+<div class="grid content">
+  <div class="index">
     X
   </div>
   <div class="orthogonal">
@@ -84,6 +96,12 @@
   <div class="percent">
     X
   </div>
+</div>
+
+<div class="grid self ref">
+  <div class="index">
+    X
+  </div>
   <div class="orthogonal">
     X
   </div>
@@ -94,6 +112,12 @@
     X
   </div>
   <div class="percent">
+    X
+  </div>
+</div>
+
+<div class="grid content ref">
+  <div class="index">
     X
   </div>
   <div class="orthogonal">

--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -1,101 +1,102 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>
-	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions
+  CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions
 </title>
 <meta name="assert" content="
-	A grid item whose size is input
-	to the size of the track
-	on which its size depends
-	cannot participate in baseline alignment.
+  A grid item whose size is input
+  to the size of the track
+  on which its size depends
+  cannot participate in baseline alignment.
 ">
 <link rel="help" href="https://www.w3.org/TR/css-grid-1/#row-align">
 <link rel="match" href="references/grid-baseline-align-cycles-001-ref.html">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
-	.grid {
-		border: solid silver;
-		margin: 1em 0.25em;
-		display: inline-grid;
-		grid-template-columns: repeat(3, auto);
-		font: 20px/1 Ahem;
-		height: 5em;
-	}
-	.grid > div {
-		border: 1em aqua;
-		border-style: solid none;
-	}
-	.index {
-		padding: 1em 0;
-	}
-	.percent {
-		height: 20%;
-	}
-	.orthogonal {
-		writing-mode: vertical-rl;
-	}
+  .grid {
+    border: solid silver;
+    margin: 1em 0.25em;
+    display: inline-grid;
+    grid-template-columns: repeat(3, auto);
+    font: 20px/1 Ahem;
+    height: 5em;
+  }
+  .grid > div {
+    border: 1em aqua;
+    border-style: solid none;
+  }
+  .index {
+    padding: 1em 0;
+  }
+  .percent {
+    height: 20%;
+  }
+  .orthogonal {
+    writing-mode: vertical-rl;
+  }
 
-	.self > div {
-		align-self: baseline;
-	}
-	.content > div {
-		align-content: baseline;
-	}
-	.self.ref > div {
-		align-self: start;
-	}
-	.content.ref > div {
-		align-content: start;
-	}
+  .self > div {
+    align-self: baseline;
+  }
+  .content > div {
+    align-content: baseline;
+  }
+  .self.ref > div {
+    align-self: start;
+  }
+  .content.ref > div {
+    align-content: start;
+  }
 </style>
 
 <p>Test passes if the upper set of boxes is identical to the lower set.
 
 <div class="grid self">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <div class="grid content">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <br>
 
 <div class="grid self ref">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <div class="grid content ref">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>

--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>
-	Grid Item (First) Baseline Alignment: Row Cyclic Sizing Exclusions
+	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions
 </title>
 <meta name="assert" content="
 	A grid item whose size is input

--- a/css/css-grid/alignment/grid-baseline-align-cycles-001.html
+++ b/css/css-grid/alignment/grid-baseline-align-cycles-001.html
@@ -37,7 +37,7 @@
 		align-self: baseline;
 	}
 	.content > div {
-		align-content: baseline
+		align-content: baseline;
 	}
 	.self.ref > div {
 		align-self: start;

--- a/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
+++ b/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <title>
-	Reference
+	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions Reference File
 </title>
 <style>
 	.grid {

--- a/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
+++ b/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<title>
+	Reference
+</title>
+<style>
+	.grid {
+		border: solid silver;
+		margin: 1em 0.25em;
+		display: inline-grid;
+		grid-template-columns: repeat(4, max-content);
+		font: 20px/1 Ahem;
+		height: 5em;
+	}
+	.grid > div {
+		border: 1em aqua;
+		border-style: solid none;
+	}
+	.index {
+		padding: 1em 0;
+	}
+	.percent, .orthognal {
+		height: 1em;
+	}
+
+	.self > div {
+		align-self: start;
+	}
+	.content > div {
+		align-content: start
+	}
+	.self.ref > div {
+		align-self: start;
+	}
+	.content.ref > div {
+		algin-content: baseline;
+	}
+</style>
+
+<p>Test passes if the upper set of boxes is identical to the lower set.
+
+<div class="grid self">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<div class="grid content">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<br>
+
+<div class="grid self ref">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>
+
+<div class="grid content ref">
+	<div class="index">
+		X
+	</div>
+	<div class="percent">
+		X
+	</div>
+	<div class="orthogonal">
+		X
+	</div>
+</div>

--- a/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
+++ b/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
@@ -47,6 +47,12 @@
   <div class="percent">
     X
   </div>
+</div>
+
+<div class="grid self">
+  <div class="index">
+    X
+  </div>
   <div class="orthogonal">
     X
   </div>
@@ -57,6 +63,12 @@
     X
   </div>
   <div class="percent">
+    X
+  </div>
+</div>
+
+<div class="grid content">
+  <div class="index">
     X
   </div>
   <div class="orthogonal">
@@ -73,6 +85,12 @@
   <div class="percent">
     X
   </div>
+</div>
+
+<div class="grid self ref">
+  <div class="index">
+    X
+  </div>
   <div class="orthogonal">
     X
   </div>
@@ -83,6 +101,12 @@
     X
   </div>
   <div class="percent">
+    X
+  </div>
+</div>
+
+<div class="grid content ref">
+  <div class="index">
     X
   </div>
   <div class="orthogonal">

--- a/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
+++ b/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
@@ -1,90 +1,91 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>
-	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions Reference File
+  CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions Reference File
 </title>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
-	.grid {
-		border: solid silver;
-		margin: 1em 0.25em;
-		display: inline-grid;
-		grid-template-columns: repeat(3, auto);
-		font: 20px/1 Ahem;
-		height: 5em;
-	}
-	.grid > div {
-		border: 1em aqua;
-		border-style: solid none;
-	}
-	.index {
-		padding: 1em 0;
-	}
-	.percent, .orthognal {
-		height: 1em;
-	}
+  .grid {
+    border: solid silver;
+    margin: 1em 0.25em;
+    display: inline-grid;
+    grid-template-columns: repeat(3, auto);
+    font: 20px/1 Ahem;
+    height: 5em;
+  }
+  .grid > div {
+    border: 1em aqua;
+    border-style: solid none;
+  }
+  .index {
+    padding: 1em 0;
+  }
+  .percent, .orthognal {
+    height: 1em;
+  }
 
-	.self > div {
-		align-self: start;
-	}
-	.content > div {
-		align-content: start;
-	}
-	.self.ref > div {
-		align-self: start;
-	}
-	.content.ref > div {
-		align-content: start;
-	}
+  .self > div {
+    align-self: start;
+  }
+  .content > div {
+    align-content: start;
+  }
+  .self.ref > div {
+    align-self: start;
+  }
+  .content.ref > div {
+    align-content: start;
+  }
 </style>
 
 <p>Test passes if the upper set of boxes is identical to the lower set.
 
 <div class="grid self">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <div class="grid content">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <br>
 
 <div class="grid self ref">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>
 
 <div class="grid content ref">
-	<div class="index">
-		X
-	</div>
-	<div class="percent">
-		X
-	</div>
-	<div class="orthogonal">
-		X
-	</div>
+  <div class="index">
+    X
+  </div>
+  <div class="percent">
+    X
+  </div>
+  <div class="orthogonal">
+    X
+  </div>
 </div>

--- a/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
+++ b/css/css-grid/alignment/references/grid-baseline-align-cycles-001-ref.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <title>
 	CSS Grid Layout Test: Grid Item (First) Baseline Alignment Row Cyclic Sizing Exclusions Reference File
 </title>
@@ -7,7 +8,7 @@
 		border: solid silver;
 		margin: 1em 0.25em;
 		display: inline-grid;
-		grid-template-columns: repeat(4, max-content);
+		grid-template-columns: repeat(3, auto);
 		font: 20px/1 Ahem;
 		height: 5em;
 	}
@@ -26,13 +27,13 @@
 		align-self: start;
 	}
 	.content > div {
-		align-content: start
+		align-content: start;
 	}
 	.self.ref > div {
 		align-self: start;
 	}
 	.content.ref > div {
-		algin-content: baseline;
+		align-content: start;
 	}
 </style>
 


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/issues/1365

<!-- Reviewable:start -->

<!-- Reviewable:end -->
