### PR TITLE
Set computed default values when loading server config in wptrunner.

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -158,6 +158,8 @@ class TestEnvironment(object):
         config["key_file"] = key_file
         config["certificate"] = certificate
 
+        serve.set_computed_defaults(config)
+
         return config
 
     def setup_server_logging(self):


### PR DESCRIPTION
The recent changes to configuration in wptserve broke websockets tests
running in wptrunner because the server was being passed None as the
ws_doc_root, so it errored on startup. We can force this value to be
set by running set_computed_defaults on the config.

A longer term fix would remove the separate configuration for the
server in environment.py so that it can run through the same codepath
as in serve.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8589)
<!-- Reviewable:end -->
