### PR TITLE
Add explicit line-height to marker-font-properties.html.

### DIFF
--- a/css/css-pseudo/marker-font-properties-ref.html
+++ b/css/css-pseudo/marker-font-properties-ref.html
@@ -5,6 +5,10 @@
 <title>CSS Test: ::marker formatting with font properties reference file</title>
 <link rel="author" title="Daniel Bates" href="mailto:dbates@webkit.org">
 <style>
+ol {
+    line-height: 30px;
+}
+
 li {
     font-family: sans-serif;
     font-size: 24px;

--- a/css/css-pseudo/marker-font-properties.html
+++ b/css/css-pseudo/marker-font-properties.html
@@ -8,6 +8,10 @@
 <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#marker-pseudo">
 <meta name="assert" content="Tests ::marker rendering with font properties">
 <style>
+ol {
+    line-height: 30px;
+}
+
 li {
     list-style-type: lower-alpha;
 }


### PR DESCRIPTION
This should make the test more stable in WebKit.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
