### PR TITLE
[testharness.js] Formalize test types

### DIFF
--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -31,6 +31,15 @@ following markup:
     <script src="../../testharness.js"></script>
     <script src="../../testharnessreport.js"></script>
 
+The file must also specify a `<meta>` tag whose `name` attribute is
+`wpt-test-type` and whose `value` attribute is either `unit` or `functional`.
+For example:
+
+    <meta name="wpt-test-type" value="functional">
+
+Subsequent sections of this file document the distinction between these two
+test types.
+
 This should be followed by one or more `<script>` tags that interface with the
 `testharness.js` API in some way. For example:
 
@@ -40,8 +49,26 @@ This should be followed by one or more `<script>` tags that interface with the
       }, 'This test is expected to fail.');
     </script>
 
-Finally, each test may include a summary of the expected results as a JSON
-string within a `<script>` tag with an `id` of `"expected"`, e.g.:
+### Unit tests
+
+The "unit test" type allows for concisely testing the expected behavior of
+assertion methods. These tests may define any number of sub-tests; the
+acceptance criteria is simply that any tests executed pass.
+
+### Functional tests
+
+In order to test the behavior of the harness itself, some tests must force
+Thoroughly testing the behavior of the harness itself requires ensuring a
+number of considerations which cannot be verified with the "unit testing"
+strategy. These include:
+
+- Ensuring that some tests are not run
+- Ensuring conditions to cause test failures
+- Ensuring conditions that cause harness errors
+
+Functional tests allow for these details to be verified. Every functional test
+must include a summary of the expected results as a JSON string within a
+`<script>` tag with an `id` of `"expected"`, e.g.:
 
     <script type="text/json" id="expected">
     {
@@ -62,6 +89,3 @@ string within a `<script>` tag with an `id` of `"expected"`, e.g.:
       "type": "complete"
     }
     </script>
-
-This is useful to test, for example, whether asserations that should fail or
-throw actually do.

--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -57,7 +57,6 @@ acceptance criteria is simply that any tests executed pass.
 
 ### Functional tests
 
-In order to test the behavior of the harness itself, some tests must force
 Thoroughly testing the behavior of the harness itself requires ensuring a
 number of considerations which cannot be verified with the "unit testing"
 strategy. These include:

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -52,6 +52,13 @@ class HTMLItem(pytest.Item, pytest.Collector):
         if not name:
             raise ValueError('No name found in file: %s' % filename)
 
+        if not self.test_type:
+            raise ValueError('No "wpt-test-type" found in file: %s' % filename)
+        if self.test_type not in ['unit', 'functional']:
+            raise ValueError(
+              'Unrecognized "wpt-test-type" ("%s") found in file: %s' % (self.test_type, filename)
+            )
+
         super(HTMLItem, self).__init__(name, parent)
 
 
@@ -66,10 +73,6 @@ class HTMLItem(pytest.Item, pytest.Collector):
             self._run_unit_test()
         elif self.test_type == 'functional':
             self._run_functional_test()
-        else:
-            raise ValueError(
-                'Tests for `testharness.js` must specify a "type" (found type: "%s")' % self.test_type
-            )
 
     def _run_unit_test(self):
         driver = self.session.config.driver

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -30,6 +30,8 @@ def pytest_configure(config):
 class HTMLItem(pytest.Item, pytest.Collector):
     def __init__(self, filename, parent):
         self.filename = filename
+        self.test_type = None
+
         with io.open(filename, encoding=ENC) as f:
             markup = f.read()
 
@@ -41,6 +43,8 @@ class HTMLItem(pytest.Item, pytest.Collector):
             if not name and element.tag == 'title':
                 name = element.text
                 continue
+            if element.tag == 'meta' and element.attrib.get('name') == 'wpt-test-type':
+                self.test_type = element.attrib.get('content')
             if element.attrib.get('id') == 'expected':
                 self.expected = json.loads(unicode(element.text))
                 continue
@@ -58,6 +62,31 @@ class HTMLItem(pytest.Item, pytest.Collector):
         return pytest.Collector.repr_failure(self, excinfo)
 
     def runtest(self):
+        if self.test_type == 'unit':
+            self._run_unit_test()
+        elif self.test_type == 'functional':
+            self._run_functional_test()
+        else:
+            raise ValueError(
+                'Tests for `testharness.js` must specify a "type" (found type: "%s")' % self.test_type
+            )
+
+    def _run_unit_test(self):
+        driver = self.session.config.driver
+        server = self.session.config.server
+
+        driver.get(server.url(HARNESS))
+
+        actual = driver.execute_async_script('runTest("%s", "foo", arguments[0])' % server.url(str(self.filename)))
+
+        summarized = self._summarize(actual)
+
+        assert summarized[u'summarized_status'][u'status_string'] == u'OK', summarized[u'summarized_status'][u'message']
+        for test in summarized[u'summarized_tests']:
+            msg = "%s\n%s:\n%s" % (test[u'name'], test[u'message'], test[u'stack'])
+            assert test[u'status_string'] == u'PASS', msg
+
+    def _run_functional_test(self):
         driver = self.session.config.driver
         server = self.session.config.server
 
@@ -70,20 +99,20 @@ class HTMLItem(pytest.Item, pytest.Collector):
         indices = [test_obj.get('index') for test_obj in actual['tests']]
         self._assert_sequence(indices)
 
+        summarized = self._summarize(actual)
+
+        assert summarized == self.expected
+
+    def _summarize(self, actual):
         summarized = {}
+
         summarized[u'summarized_status'] = self._summarize_status(actual['status'])
         summarized[u'summarized_tests'] = [
             self._summarize_test(test) for test in actual['tests']]
         summarized[u'summarized_tests'].sort(key=lambda test_obj: test_obj.get('name'))
         summarized[u'type'] = actual['type']
 
-        if not self.expected:
-            assert summarized[u'summarized_status'][u'status_string'] == u'OK', summarized[u'summarized_status'][u'message']
-            for test in summarized[u'summarized_tests']:
-                msg = "%s\n%s:\n%s" % (test[u'name'], test[u'message'], test[u'stack'])
-                assert test[u'status_string'] == u'PASS', msg
-        else:
-            assert summarized == self.expected
+        return summarized
 
     @staticmethod
     def _assert_sequence(nums):

--- a/resources/test/tests/add_cleanup.html
+++ b/resources/test/tests/add_cleanup.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test#add_cleanup</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/add_cleanup_count.html
+++ b/resources/test/tests/add_cleanup_count.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test#add_cleanup reported count</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/add_cleanup_err.html
+++ b/resources/test/tests/add_cleanup_err.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test#add_cleanup: error</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/add_cleanup_err_multi.html
+++ b/resources/test/tests/add_cleanup_err_multi.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test#add_cleanup: multiple functions with one in error</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Sample HTML5 API Tests</title>
+<meta name="wpt-test-type" content="functional">
 <meta name="timeout" content="6000">
 </head>
 <body onload="load_test_attr.done()">

--- a/resources/test/tests/api-tests-2.html
+++ b/resources/test/tests/api-tests-2.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Sample HTML5 API Tests</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <body onload="load_test_attr.done()">
 <h1>Sample HTML5 API Tests</h1>

--- a/resources/test/tests/api-tests-3.html
+++ b/resources/test/tests/api-tests-3.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Sample HTML5 API Tests</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <script src="../../testharness.js"></script>
 

--- a/resources/test/tests/force_timeout.html
+++ b/resources/test/tests/force_timeout.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Test#force_timeout</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <body>
 <h1>Test#force_timeout</h1>

--- a/resources/test/tests/generate-callback.html
+++ b/resources/test/tests/generate-callback.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Sample for using generate_tests to create a series of tests that share the same callback.</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/idlharness/IdlArray/is_json_type.html
+++ b/resources/test/tests/idlharness/IdlArray/is_json_type.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlArray.prototype.is_json_type()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlDictionary/get_inheritance_stack.html
+++ b/resources/test/tests/idlharness/IdlDictionary/get_inheritance_stack.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlDictionary.prototype.get_inheritance_stack()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterface/default_to_json_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/default_to_json_operation.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlDictionary.prototype.default_to_json_operation()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterface/get_inheritance_stack.html
+++ b/resources/test/tests/idlharness/IdlInterface/get_inheritance_stack.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlInterface.prototype.get_inheritance_stack()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterface/has_default_to_json_regular_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/has_default_to_json_regular_operation.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlInterface.prototype.has_default_to_json_regular_operation()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterface/has_to_json_regular_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/has_to_json_regular_operation.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlInterface.prototype.has_to_json_regular_operation()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>idlharness: Immutable prototypes</title>
+  <meta name="wpt-test-type" content="functional">
   <script src="../../../../testharness.js"></script>
   <script src="../../../../testharnessreport.js"></script>
   <script src="../../../../WebIDLParser.js"></script>

--- a/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>idlharness: Primary interface</title>
+  <meta name="wpt-test-type" content="unit">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>IdlInterface.prototype.test_to_json_operation()</title>
+  <meta name="wpt-test-type" content="functional">
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/idlharness/IdlInterface/traverse_inherited_and_consequential_interfaces.html
+++ b/resources/test/tests/idlharness/IdlInterface/traverse_inherited_and_consequential_interfaces.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlDictionary.prototype.traverse_inherited_and_consequential_interfaces()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/IdlInterfaceMember/is_to_json_regular_operation.html
+++ b/resources/test/tests/idlharness/IdlInterfaceMember/is_to_json_regular_operation.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>IdlInterfaceMember.prototype.is_to_json_regular_operation()</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/idlharness/basic.html
+++ b/resources/test/tests/idlharness/basic.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>idlharness basic</title>
+<meta name="wpt-test-type" content="unit">
 </head>
 <body>
 <div id="log"></div>

--- a/resources/test/tests/iframe-callback.html
+++ b/resources/test/tests/iframe-callback.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with iframe that notifies containing document via callbacks</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/iframe-consolidate-errors.html
+++ b/resources/test/tests/iframe-consolidate-errors.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with iframe that consolidates errors via fetch_tests_from_window</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/iframe-consolidate-tests.html
+++ b/resources/test/tests/iframe-consolidate-tests.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with iframe that consolidates tests via fetch_tests_from_window</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/iframe-msg.html
+++ b/resources/test/tests/iframe-msg.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with iframe that notifies containing document via cross document messaging</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/order.html
+++ b/resources/test/tests/order.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Ordering</title>
+<meta name="wpt-test-type" content="functional">
 <meta name="timeout" content="6000">
 </head>
 <body>

--- a/resources/test/tests/promise-async.html
+++ b/resources/test/tests/promise-async.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Async Tests and Promises</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <body>
 <h1>Async Tests and Promises</h1>

--- a/resources/test/tests/promise.html
+++ b/resources/test/tests/promise.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Promise Tests</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <body>
 <h1>Promise Tests</h1>

--- a/resources/test/tests/single-page-test-fail.html
+++ b/resources/test/tests/single-page-test-fail.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test (should fail)</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/single-page-test-no-assertions.html
+++ b/resources/test/tests/single-page-test-no-assertions.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no asserts</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/single-page-test-no-body.html
+++ b/resources/test/tests/single-page-test-no-body.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example single page test with no body</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/single-page-test-pass.html
+++ b/resources/test/tests/single-page-test-pass.html
@@ -1,5 +1,6 @@
 <!DOCTYPE HTML>
 <title>Example with file_is_test</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/uncaught-exception-handle.html
+++ b/resources/test/tests/uncaught-exception-handle.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Harness Handling Uncaught Exception</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <script src="../../testharness.js"></script>
 

--- a/resources/test/tests/uncaught-exception-ignore.html
+++ b/resources/test/tests/uncaught-exception-ignore.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Harness Ignoring Uncaught Exception</title>
+<meta name="wpt-test-type" content="functional">
 </head>
 <script src="../../testharness.js"></script>
 

--- a/resources/test/tests/worker-dedicated.html
+++ b/resources/test/tests/worker-dedicated.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Dedicated Worker Tests</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/worker-service.html
+++ b/resources/test/tests/worker-service.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with a service worker</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/worker-shared.html
+++ b/resources/test/tests/worker-shared.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>Example with a shared worker</title>
+<meta name="wpt-test-type" content="functional">
 <script src="../../testharness.js"></script>
 <script src="../../testharnessreport.js"></script>
 </head>


### PR DESCRIPTION
Previously, tests for the testharness.js framework were validated
according to an implicit heuristic based on the presence of a `<script>`
tag.

Introduce a declarative configuration to make this distinction explicit.
This pattern makes the validation behavior easier to understand. It also
enables future additions which further differentiate the way the two
test types are interpreted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8597)
<!-- Reviewable:end -->
