### PR TITLE
[css-color] Create tests for hsl and hsla

### DIFF
--- a/css/css-color/hsl-001.html
+++ b/css/css-color/hsl-001.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with number and no alpha, also no comma">
+<style>
+    .test {color: hsl(120 100% 25%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-002.html
+++ b/css/css-color/hsl-002.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with angle and no alpha, also no comma">
+<style>
+    .test {color: hsl(120deg 100% 25%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-003.html
+++ b/css/css-color/hsl-003.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with number and numeric alpha, also no comma">
+<style>
+    .test {color: hsl(120 100% 25% / 1.0)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-004.html
+++ b/css/css-color/hsl-004.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with angle and numeric alpha, also no comma">
+<style>
+    .test {color: hsl(120deg 100% 25% / 1)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-005.html
+++ b/css/css-color/hsl-005.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with number and percent alpha, also no comma">
+<style>
+    .test {color: hsl(120 100% 25% / 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-006.html
+++ b/css/css-color/hsl-006.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with angle and percent alpha, also no comma">
+<style>
+    .test {color: hsl(120deg 100% 25% / 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-007.html
+++ b/css/css-color/hsl-007.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsl() with number and percent alpha, and commas">
+<style>
+    .test {color: hsl(120, 100%, 25%, 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-008.html
+++ b/css/css-color/hsl-008.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="hsl() with angle and percent alpha, with commas">
+<style>
+    .test {color: hsl(120deg, 100%, 25%, 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsl-008.html
+++ b/css/css-color/hsl-008.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
 <link rel="match" href="greentext-ref.html">
-<meta name="assert" content="hsl() with angle and percent alpha, with commas">
+<meta name="assert" content="legacy hsl() with angle and percent alpha, with commas">
 <style>
     .test {color: hsl(120deg, 100%, 25%, 100%)}
 </style>

--- a/css/css-color/hsla-001.html
+++ b/css/css-color/hsla-001.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with number and no alpha, also no comma">
+<style>
+    .test {color: hsla(120 100% 25%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-002.html
+++ b/css/css-color/hsla-002.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with angle and no alpha, also no comma">
+<style>
+    .test {color: hsla(120deg 100% 25%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-003.html
+++ b/css/css-color/hsla-003.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with number and numeric alpha, also no comma">
+<style>
+    .test {color: hsla(120 100% 25% / 1.0)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-004.html
+++ b/css/css-color/hsla-004.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with angle and numeric alpha, also no comma">
+<style>
+    .test {color: hsla(120deg 100% 25% / 1)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-005.html
+++ b/css/css-color/hsla-005.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with number and percent alpha, also no comma">
+<style>
+    .test {color: hsla(120 100% 25% / 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-006.html
+++ b/css/css-color/hsla-006.html
@@ -4,7 +4,7 @@
 <link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
 <link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
 <link rel="match" href="greentext-ref.html">
-<meta name="assert" content="legacy rgba() with angle and percent alpha, also no comma">
+<meta name="assert" content="legacy hsla() with angle and percent alpha, also no comma">
 <style>
     .test {color: hsla(120deg 100% 25% / 100%)}
 </style>

--- a/css/css-color/hsla-006.html
+++ b/css/css-color/hsla-006.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy rgba() with angle and percent alpha, also no comma">
+<style>
+    .test {color: hsla(120deg 100% 25% / 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-007.html
+++ b/css/css-color/hsla-007.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with number and percent alpha, and commas">
+<style>
+    .test {color: hsla(120, 100%, 25%, 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>

--- a/css/css-color/hsla-008.html
+++ b/css/css-color/hsla-008.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: HSL functions hsl() and hsla()</title>
+<link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#the-hsl-notation">
+<link rel="match" href="greentext-ref.html">
+<meta name="assert" content="legacy hsla() with angle and percent alpha, with commas">
+<style>
+    .test {color: hsla(120deg, 100%, 25%, 100%)}
+</style>
+<body>
+    <p class="test">Test passes if this text is green</p>
+</body>


### PR DESCRIPTION
The hsl and hsla functions, while changed in CSS Color 4, did not have any web platform tests. This creates tests  for the functions, based off of the tests for the rgb/rgba functions.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
