### PR TITLE
Test the serialization of the text-decoration shorthand

### DIFF
--- a/css/css-text-decor/text-decoration-serialization.html
+++ b/css/css-text-decor/text-decoration-serialization.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<title>text-decoration shorthand serialization</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-decor-3/#text-decoration-property">
+<link rel="help" href="https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block">
+<script type="text/javascript" src="/resources/testharness.js"></script>
+<script type="text/javascript" src="/resources/testharnessreport.js"></script>
+<div style="text-decoration: underline"></div>
+<script>
+test(() => {
+  const style = getComputedStyle(document.querySelector('div'));
+  assert_equals(style.getPropertyValue("text-decoration"), "underline solid rgb(0, 0, 0)");
+});
+</script>

--- a/css/css-text-decor/text-decoration-serialization.tentative.html
+++ b/css/css-text-decor/text-decoration-serialization.tentative.html
@@ -8,6 +8,10 @@
 <script>
 test(() => {
   const style = getComputedStyle(document.querySelector('div'));
-  assert_equals(style.getPropertyValue("text-decoration"), "underline solid rgb(0, 0, 0)");
+  // Chrome serializes as "underline solid rgb(0, 0, 0)" while Edge, Firefox an
+  // Safari use "underline", which Chrome used to do as well. The spec should
+  // probably require "underline":
+  // https://github.com/w3c/csswg-drafts/issues/1564
+  assert_equals(style.getPropertyValue("text-decoration"), "underline");
 });
 </script>


### PR DESCRIPTION
This is to keep tracking the interop issue hidden here:
https://github.com/w3c/web-platform-tests/pull/8548

<!-- Reviewable:start -->

<!-- Reviewable:end -->
