### PR TITLE
Fix HTMLTimeElement test issue

### DIFF
--- a/html/semantics/text-level-semantics/the-time-element/001.html
+++ b/html/semantics/text-level-semantics/the-time-element/001.html
@@ -59,8 +59,8 @@ test(function () {
   assert_equals( makeTime('go fish').dateTime, 'go fish' );
 }, 'the datetime attribute should be reflected by the .dateTime property even if it is invalid');
 test(function () {
-  assert_equals( makeTime(false,'2000-02-01T03:04:05Z').dateTime, '' );
-}, 'the datetime attribute should not reflect the textContent');
+  assert_equals( makeTime(false,'2000-02-01T03:04:05Z').dateTime, '2000-02-01T03:04:05Z' );
+}, 'the datetime attribute value should be the textContent value if it is unset');
 
     </script>
 


### PR DESCRIPTION
According to following sentence in [spec](https://html.spec.whatwg.org/multipage/text-level-semantics.html#datetime-value), there's a bug in current test.
> The datetime value of a time element is the value of the element's datetime content attribute, if it has one, otherwise the child text content of the time element.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
