### PR TITLE
Fix the flaky MIME parsing test

### DIFF
--- a/mimesniff/mime-types/parsing.any.js
+++ b/mimesniff/mime-types/parsing.any.js
@@ -1,8 +1,10 @@
+// META: timeout=long
+
 promise_test(() => {
   return Promise.all([
     fetch("resources/mime-types.json"),
     fetch("resources/generated-mime-types.json")
-  ]).then(([res, res2]) => res.json().then(runTests).then(res2.json().then(runTests)));
+  ]).then(([res, res2]) => res.json().then(runTests).then(() => res2.json().then(runTests)));
 }, "Loading data…");
 
 function isByteCompatible(str) {


### PR DESCRIPTION
The test has two sources of flakiness:
1. It's taking too long but not marked as timeout=long.
2. The execution order of runTests(res) and renTests(res2) was not guaranteed.

Ideally, the big generated test could be splitted into smaller ones.

Lastly, I'm really not a JavaScript expert. The fix correct if my understanding of Promise is correct...

<!-- Reviewable:start -->

<!-- Reviewable:end -->
