### PR TITLE
FetchEvent.clientId is no longer nullable in the latest specification

### DIFF
--- a/service-workers/service-worker/resources/interfaces-worker.sub.js
+++ b/service-workers/service-worker/resources/interfaces-worker.sub.js
@@ -55,7 +55,7 @@ test(function() {
       false, 'Default FetchEvent.bubbles should be false');
     assert_equals(
       new FetchEvent('FetchEvent', {request: req}).clientId,
-      null, 'Default FetchEvent.clientId should be null');
+      '', 'Default FetchEvent.clientId should be the empty string');
     assert_equals(
       new FetchEvent('FetchEvent', {request: req}).isReload,
       false, 'Default FetchEvent.isReload should be false');


### PR DESCRIPTION
Update service-worker/resources/interfaces-worker.sub.js accordingly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
