### PR TITLE
[eme] Ensure license is expired before using it

### DIFF
--- a/encrypted-media/scripts/playback-temporary-expired.js
+++ b/encrypted-media/scripts/playback-temporary-expired.js
@@ -44,23 +44,26 @@ function runTest(config,qualifier) {
 
             assert_in_array(event.messageType, ['license-request', 'individualization-request']);
 
+            // Generate a license that expires 1 second from now.
             var expiration = Date.now().valueOf() + 1000;
             config.messagehandler(event.messageType, event.message, { expiration: expiration }).then(function(response) {
-                return event.target.update(response);
-            }).then(test.step_func(function() {
-                // License server may only have second granularity, so check
-                // that session expiration time is close to the desired value.
-                assert_approx_equals(event.target.expiration, expiration, 2000, "expiration attribute should equal provided expiration time");
-
-                // Since the expiration time is in the future, wait 5 seconds
-                // so that the license has expired before calling play().
+                // Wait 2 seconds before calling update() to ensure that the
+                // license has really expired. This is to avoid problems
+                // where the browser starts buffering frames as soon as a
+                // valid license is received.
                 test.step_timeout(function() {
-                    assert_greater_than(Date.now().valueOf(), expiration, "Starting play before license expired");
-                    _video.play();
-                    // Wait 2 seconds to ensure that the video does not play.
-                    test.step_timeout(function() { test.done(); }, 2000);
-                }, 5000);
-            })).catch(onFailure);
+                    event.target.update(response).then(function() {
+                        // License server may only have second granularity, so check
+                        // that session expiration time is close to the desired value.
+                        assert_approx_equals(event.target.expiration, expiration, 3000,
+                                             "expiration attribute should equal provided expiration time");
+                        assert_greater_than(Date.now().valueOf(), expiration, "Starting play before license expired");
+                        _video.play();
+                        // Wait 2 seconds to ensure that the video does not play.
+                        test.step_timeout(function() { test.done(); }, 2000);
+                    }).catch(onFailure);
+                }, 2000);
+            }).catch(onFailure);
         }
 
         function onPlaying(event) {


### PR DESCRIPTION
This test generates a license that expires 1s from the current time, calls
update() with it, and then waits for 5s before calling play(). However,
Chrome caches a few frames in advance of play() being called. Depending on
the time granularity, the CDM may see a valid license and decode part of
the media file.

This change delays calling update() for 2s to ensure that the license has
expired, and ensures that the browser can't cache frames to use when play()
is called.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
