### PR TITLE
Add HTMLInputElement select event test

### DIFF
--- a/html/semantics/forms/the-input-element/event-select-manual.html
+++ b/html/semantics/forms/the-input-element/event-select-manual.html
@@ -19,7 +19,7 @@
 <h2>Test steps:</h2>
 <ol>
   <li>
-    Select any numberic characters in the input flag below
+    Select any numeric characters in the input flag below
   </li>
 </ol>
 
@@ -27,8 +27,7 @@
 
 let input = document.getElementById("testInput");
 
-setup({explicit_done : true});
-setup({explicit_timeout : true});
+setup({explicit_done : true, explicit_timeout : true});
 
 on_event(input, "select", evt => {
   test(() => {

--- a/html/semantics/forms/the-input-element/event-select-manual.html
+++ b/html/semantics/forms/the-input-element/event-select-manual.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTMLInputElement Test: select event</title>
+<link rel="author" title="Intel" href="www.intel.com/">
+<meta name="flags" content="interact">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<form id="testForm" name="testForm">
+  <input id="testInput" type="text" value="0123456789"/>
+</form>
+
+<h2>Description</h2>
+<p>
+  This test validates that select characters in input element should fired select event.
+</p>
+
+<h2>Test steps:</h2>
+<ol>
+  <li>
+    Select any numberic characters in the input flag below
+  </li>
+</ol>
+
+<script>
+
+let input = document.getElementById("testInput");
+
+setup({explicit_done : true});
+setup({explicit_timeout : true});
+
+on_event(input, "select", evt => {
+  test(() => {
+    assert_greater_than(input.value.substring(input.selectionStart, input.selectionEnd).length, 0, "Check if the select event captured when text selected");
+  });
+  done();
+});
+
+</script>


### PR DESCRIPTION
The purpose of the test is fire a select event when select characters in input element. It's according to the [spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select).

@Ms2ger , PTAL.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
