### PR TITLE
Make fetch_tests_from_window work with cross origin windows.

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1708,7 +1708,13 @@ policies and contribution forms [3].
         this.tests = new Array();
 
         var this_obj = this;
-        remote.onerror = function(error) { this_obj.remote_error(error); };
+        // If remote context is cross origin assigning to onerror is not
+        // possible, so silently catch those errors.
+        try {
+          remote.onerror = function(error) { this_obj.remote_error(error); };
+        } catch (e) {
+          // Ignore.
+        }
 
         // Keeping a reference to the remote object and the message handler until
         // remote_done() is seen prevents the remote object and its message channel


### PR DESCRIPTION
Generally fetch_tests_from_window works fine with cross origin windows
since all communication goes over postMessage anyway, except for setting
an onerror event handler. So silently swallow any exceptions from trying
to set the onerror event handler.

Split out from https://github.com/w3c/web-platform-tests/pull/8612

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8627)
<!-- Reviewable:end -->
