### PR TITLE
Add tests for slot.assignedElements method

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -1130,6 +1130,7 @@ interface HTMLTemplateElement : HTMLElement {
 interface HTMLSlotElement : HTMLElement {
   [CEReactions] attribute DOMString name;
   sequence<Node> assignedNodes(optional AssignedNodesOptions options);
+  sequence<Element> assignedElements(optional AssignedNodesOptions options);
 };
 
 dictionary AssignedNodesOptions {

--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -12,6 +12,8 @@
 <div id="log"></div>
 <script>
 
+const slotMethods = ['assignedNodes', 'assignedElements'];
+
 test(function () {
     assert_true('HTMLSlotElement' in window, 'HTMLSlotElement must be defined on window');
     assert_equals(HTMLSlotElement.prototype.__proto__, HTMLElement.prototype, 'HTMLSlotElement should inherit from HTMLElement');
@@ -35,29 +37,19 @@ test(function () {
 
 function testSlotOutsideShadowTree(options)
 {
+  for (const method of slotMethods) {
     test(function () {
-        assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
+      assert_true(method in HTMLSlotElement.prototype, `"${method}" method must be defined on HTMLSlotElement.prototype`);
 
-        var slotElement = document.createElement('slot');
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when the slot element is not in any tree');
+      const slotElement = document.createElement('slot');
+      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when the slot element is not in any tree`);
 
-        document.body.appendChild(slotElement);
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when the slot element is in a document tree');
+      document.body.appendChild(slotElement);
+      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when the slot element is in a document tree`);
 
-    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '')
-        + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
-
-    test(function () {
-        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
-
-        var slotElement = document.createElement('slot');
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when the slot element is not in any tree');
-
-        document.body.appendChild(slotElement);
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when the slot element is in a document tree');
-
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '')
-        + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
+    }, method + '(' + ( options ? JSON.stringify(options) : '' )
+        + ' on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
+  }
 }
 
 testSlotOutsideShadowTree(null);
@@ -66,82 +58,36 @@ testSlotOutsideShadowTree({flattened: true});
 
 function testSingleLevelOfSlotting(options)
 {
+  for (const method of ['assignedNodes', 'assignedElements']) {
     test(function () {
-        assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
+      assert_true(method in HTMLSlotElement.prototype, `"${method}" method must be defined on HTMLSlotElement.prototype`);
 
-        var shadowHost = document.createElement('div');
-        var child = document.createElement('p');
+      const shadowHost = document.createElement('div');
+      const child = document.createElement('p');
 
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        shadowRoot.appendChild(slotElement);
+      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+      const slotElement = document.createElement('slot');
+      shadowRoot.appendChild(slotElement);
 
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when there are no nodes in the shadow tree');
+      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when there are no nodes in the shadow tree`);
 
-        shadowHost.appendChild(child);
-        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on a default slot must return an element without slot element');
+      shadowHost.appendChild(child);
+      assert_array_equals(slotElement[method](options), [child], `${method}() on a default slot must return an element without slot element`);
 
-        child.setAttribute('slot', 'foo');
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() on a default slot must not return an element with non-empty slot attribute');
+      child.setAttribute('slot', 'foo');
+      assert_array_equals(slotElement[method](options), [], `${method}() on a default slot must not return an element with non-empty slot attribute`);
 
-        child.setAttribute('slot', '');
-        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on a default slot must return an element with empty slot attribute');
+      child.setAttribute('slot', '');
+      assert_array_equals(slotElement[method](options), [child], `${method}() on a default slot must return an element with empty slot attribute`);
 
-        slotElement.setAttribute('name', 'bar');
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() on a named slot must not return an element with empty slot attribute');
+      slotElement.setAttribute('name', 'bar');
+      assert_array_equals(slotElement[method](options), [], `${method}() on a named slot must not return an element with empty slot attribute`);
 
-        slotElement.setAttribute('name', '');
-        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on an empty name slot must return an element with empty slot attribute');
+      slotElement.setAttribute('name', '');
+      assert_array_equals(slotElement[method](options), [child], `${method}() on an empty name slot must return an element with empty slot attribute`);
 
-    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
-
-    test(function () {
-        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
-
-        var shadowHost = document.createElement('div');
-        var child = document.createElement('p');
-
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        shadowRoot.appendChild(slotElement);
-
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when there are no nodes in the shadow tree');
-
-        shadowHost.appendChild(child);
-        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on a default slot must return an element without slot element');
-
-        child.setAttribute('slot', 'foo');
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() on a default slot must not return an element with non-empty slot attribute');
-
-        child.setAttribute('slot', '');
-        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on a default slot must return an element with empty slot attribute');
-
-        slotElement.setAttribute('name', 'bar');
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() on a named slot must not return an element with empty slot attribute');
-
-        slotElement.setAttribute('name', '');
-        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on an empty name slot must return an element with empty slot attribute');
-
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned elements when none of the assigned nodes themselves are slots');
-
-    test(function () {
-        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
-
-        var shadowHost = document.createElement('div');
-        var elementChild = document.createElement('p');
-        var textChild = document.createTextNode('test');
-
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        shadowRoot.appendChild(slotElement);
-
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when there are no nodes in the shadow tree');
-
-        shadowHost.appendChild(elementChild);
-        shadowHost.appendChild(textChild);
-        assert_array_equals(slotElement.assignedElements(options), [elementChild], 'assignedElements() on a slot with mixed assigned nodes must return only elements');
-
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes limited to elements');
+    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
+  }
 }
 
 testSingleLevelOfSlotting(null);
@@ -150,61 +96,34 @@ testSingleLevelOfSlotting({flattened: true});
 
 function testMutatingSlottedContents(options)
 {
+  for (const method of slotMethods) {
     test(function () {
-        var shadowHost = document.createElement('div');
-        var p = document.createElement('p');
-        var b = document.createElement('b');
-        shadowHost.appendChild(p);
-        shadowHost.appendChild(b);
+      const shadowHost = document.createElement('div');
+      const p = document.createElement('p');
+      const b = document.createElement('b');
+      shadowHost.appendChild(p);
+      shadowHost.appendChild(b);
 
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        shadowRoot.appendChild(slotElement);
+      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+      const slotElement = document.createElement('slot');
+      shadowRoot.appendChild(slotElement);
 
-        assert_array_equals(slotElement.assignedNodes(options), [p, b], 'assignedNodes must return the distributed nodes');
+      assert_array_equals(slotElement[method](options), [p, b], `${method} must return the distributed nodes`);
 
-        slotElement.name = 'foo';
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty when there are no matching elements for the slot name');
+      slotElement.name = 'foo';
+      assert_array_equals(slotElement[method](options), [], `${method} must be empty when there are no matching elements for the slot name`);
 
-        b.slot = 'foo';
-        assert_array_equals(slotElement.assignedNodes(options), [b], 'assignedNodes must return the nodes with the matching slot name');
+      b.slot = 'foo';
+      assert_array_equals(slotElement[method](options), [b], `${method} must return the nodes with the matching slot name`);
 
-        p.slot = 'foo';
-        assert_array_equals(slotElement.assignedNodes(options), [p, b], 'assignedNodes must return the nodes with the matching slot name in the tree order');
+      p.slot = 'foo';
+      assert_array_equals(slotElement[method](options), [p, b], `${method} must return the nodes with the matching slot name in the tree order`);
 
-        slotElement.removeAttribute('name');
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty for a default slot when all elements have "slot" attributes specified');
+      slotElement.removeAttribute('name');
+      assert_array_equals(slotElement[method](options), [], `${method} must be empty for a default slot when all elements have "slot" attributes specified`);
 
-    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
-
-    test(function () {
-        var shadowHost = document.createElement('div');
-        var p = document.createElement('p');
-        var t = document.createTextNode('test');
-        var b = document.createElement('b');
-        shadowHost.appendChild(p);
-        shadowHost.appendChild(t);
-        shadowHost.appendChild(b);
-
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        shadowRoot.appendChild(slotElement);
-
-        assert_array_equals(slotElement.assignedElements(options), [p, b], 'assignedElements must return the distributed nodes limited to elements');
-
-        slotElement.name = 'foo';
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty when there are no matching elements for the slot name');
-
-        b.slot = 'foo';
-        assert_array_equals(slotElement.assignedElements(options), [b], 'assignedElements must return the elements with the matching slot name');
-
-        p.slot = 'foo';
-        assert_array_equals(slotElement.assignedElements(options), [p, b], 'assignedElements must return the elements with the matching slot name in the tree order');
-
-        slotElement.removeAttribute('name');
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty for a default slot when all elements have "slot" attributes specified');
-
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
+    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
+  }
 }
 
 testMutatingSlottedContents(null);
@@ -213,31 +132,20 @@ testMutatingSlottedContents({flattened: true});
 
 function testMutatingSlotName(options)
 {
+  for (const method of slotMethods) {
     test(function () {
-        var shadowHost = document.createElement('div');
-        var child = document.createElement('span');
-        shadowHost.appendChild(child);
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        slotElement.name = 'foo';
-        shadowRoot.appendChild(slotElement);
-        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty when there are no matching elements for the slot name');
-        slotElement.removeAttribute('name');
-        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes must be empty when there are no matching elements for the slot name');
-    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
-
-    test(function () {
-        var shadowHost = document.createElement('div');
-        var child = document.createElement('span');
-        shadowHost.appendChild(child);
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-        var slotElement = document.createElement('slot');
-        slotElement.name = 'foo';
-        shadowRoot.appendChild(slotElement);
-        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty when there are no matching elements for the slot name');
-        slotElement.removeAttribute('name');
-        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements must be empty when there are no matching elements for the slot name');
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
+      const shadowHost = document.createElement('div');
+      const child = document.createElement('span');
+      shadowHost.appendChild(child);
+      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+      const slotElement = document.createElement('slot');
+      slotElement.name = 'foo';
+      shadowRoot.appendChild(slotElement);
+      assert_array_equals(slotElement[method](options), [], `${method} must be empty when there are no matching elements for the slot name`);
+      slotElement.removeAttribute('name');
+      assert_array_equals(slotElement[method](options), [child], `${method} must be empty when there are no matching elements for the slot name`);
+    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
+  }
 }
 
 testMutatingSlotName(null);
@@ -246,232 +154,125 @@ testMutatingSlotName({flattened: true});
 
 function testInsertingAndRemovingSlots(options)
 {
+  for (const method of slotMethods) {
     test(function () {
-        var shadowHost = document.createElement('div');
-        var p = document.createElement('p');
-        var text = document.createTextNode('');
-        var comment = document.createComment('');
-        var processingInstruction = document.createProcessingInstruction('target', 'data');
-        var b = document.createElement('b');
-        shadowHost.appendChild(p);
-        shadowHost.appendChild(text);
-        shadowHost.appendChild(comment);
-        shadowHost.appendChild(processingInstruction);
-        shadowHost.appendChild(b);
+      const shadowHost = document.createElement('div');
+      const p = document.createElement('p');
+      const text = document.createTextNode('');
+      const comment = document.createComment('');
+      const processingInstruction = document.createProcessingInstruction('target', 'data');
+      const b = document.createElement('b');
+      shadowHost.appendChild(p);
+      shadowHost.appendChild(text);
+      shadowHost.appendChild(comment);
+      shadowHost.appendChild(processingInstruction);
+      shadowHost.appendChild(b);
 
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
 
-        var firstSlotElement = document.createElement('slot');
-        shadowRoot.appendChild(firstSlotElement);
+      const firstSlotElement = document.createElement('slot');
+      shadowRoot.appendChild(firstSlotElement);
 
-        var secondSlotElement = document.createElement('slot');
-        shadowRoot.appendChild(secondSlotElement);
+      const secondSlotElement = document.createElement('slot');
+      shadowRoot.appendChild(secondSlotElement);
 
-        assert_array_equals(firstSlotElement.assignedNodes(options), [p, text, b],
-            'assignedNodes on a default slot must return the elements without slot attributes and text nodes');
-        assert_array_equals(secondSlotElement.assignedNodes(options), [],
-            'assignedNodes on the second unnamed slot element must return an empty array');
+      assert_array_equals(firstSlotElement[method](options), [p, text, b],
+      `${method} on a default slot must return the elements without slot attributes and text nodes`);
+      assert_array_equals(secondSlotElement[method](options), [],
+      `${method} on the second unnamed slot element must return an empty array`);
 
-        shadowRoot.removeChild(firstSlotElement);
-        assert_array_equals(firstSlotElement.assignedNodes(options), [],
-            'assignedNodes on a detached formerly-default slot must return an empty array');
-        assert_array_equals(secondSlotElement.assignedNodes(options), [p, text, b],
-            'assignedNodes on the second unnamed slot element after removing the first must return the elements without slot attributes and text nodes');
+      shadowRoot.removeChild(firstSlotElement);
+      assert_array_equals(firstSlotElement[method](options), [],
+      `${method} on a detached formerly-default slot must return an empty array`);
+      assert_array_equals(secondSlotElement[method](options), [p, text, b],
+      `${method} on the second unnamed slot element after removing the first must return the elements without slot attributes and text nodes`);
 
-        shadowRoot.removeChild(secondSlotElement);
-        shadowRoot.appendChild(secondSlotElement);
-        assert_array_equals(firstSlotElement.assignedNodes(options), [],
-            'Removing and re-inserting a default slot must not change the result of assignedNodes on a detached slot');
-        assert_array_equals(secondSlotElement.assignedNodes(options), [p, text, b],
-            'Removing and re-inserting a default slot must not change the result of assignedNodes');
+      shadowRoot.removeChild(secondSlotElement);
+      shadowRoot.appendChild(secondSlotElement);
+      assert_array_equals(firstSlotElement[method](options), [],
+      `Removing and re-inserting a default slot must not change the result of ${method} on a detached slot`);
+      assert_array_equals(secondSlotElement[method](options), [p, text, b],
+      `Removing and re-inserting a default slot must not change the result of ${method}`);
 
-        shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
-        assert_array_equals(firstSlotElement.assignedNodes(options), [p, text, b],
-            'assignedNodes on a newly inserted unnamed slot element must return the elements without slot attributes and text nodes');
-        assert_array_equals(secondSlotElement.assignedNodes(options), [],
-            'assignedNodes on formerly-first but now second unnamed slot element must return an empty array');
+      shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
+      assert_array_equals(firstSlotElement[method](options), [p, text, b],
+      `${method} on a newly inserted unnamed slot element must return the elements without slot attributes and text nodes`);
+      assert_array_equals(secondSlotElement[method](options), [],
+      `${method} on formerly-first but now second unnamed slot element must return an empty array`);
 
-    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
-
-    test(function () {
-        var shadowHost = document.createElement('div');
-        var p = document.createElement('p');
-        var text = document.createTextNode('');
-        var comment = document.createComment('');
-        var processingInstruction = document.createProcessingInstruction('target', 'data');
-        var b = document.createElement('b');
-        shadowHost.appendChild(p);
-        shadowHost.appendChild(text);
-        shadowHost.appendChild(comment);
-        shadowHost.appendChild(processingInstruction);
-        shadowHost.appendChild(b);
-
-        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
-
-        var firstSlotElement = document.createElement('slot');
-        shadowRoot.appendChild(firstSlotElement);
-
-        var secondSlotElement = document.createElement('slot');
-        shadowRoot.appendChild(secondSlotElement);
-
-        assert_array_equals(firstSlotElement.assignedElements(options), [p, b],
-            'assignedElements on a default slot must return the elements nodes only');
-        assert_array_equals(secondSlotElement.assignedElements(options), [],
-            'assignedElements on the second unnamed slot element must return an empty array');
-
-        shadowRoot.removeChild(firstSlotElement);
-        assert_array_equals(firstSlotElement.assignedElements(options), [],
-            'assignedElements on a detached formerly-default slot must return an empty array');
-        assert_array_equals(secondSlotElement.assignedElements(options), [p, b],
-            'assignedElements on the second unnamed slot element after removing the first must return the elements nodes only');
-
-        shadowRoot.removeChild(secondSlotElement);
-        shadowRoot.appendChild(secondSlotElement);
-        assert_array_equals(firstSlotElement.assignedElements(options), [],
-            'Removing and re-inserting a default slot must not change the result of assignedElements on a detached slot');
-        assert_array_equals(secondSlotElement.assignedElements(options), [p, b],
-            'Removing and re-inserting a default slot must not change the result of assignedElements');
-
-        shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
-        assert_array_equals(firstSlotElement.assignedElements(options), [p, b],
-            'assignedElements on a newly inserted unnamed slot element must return the elements nodes only');
-        assert_array_equals(secondSlotElement.assignedElements(options), [],
-            'assignedElements on formerly-first but now second unnamed slot element must return an empty array');
-
-    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
+    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
+  }
 }
 
 testInsertingAndRemovingSlots(null);
 testInsertingAndRemovingSlots({flattened: false});
 testInsertingAndRemovingSlots({flattened: true});
 
-test(function () {
-    var outerHost = document.createElement('div');
-    var outerChild = document.createElement('span');
+for (const method of slotMethods) {
+  test(function () {
+    const outerHost = document.createElement('div');
+    const outerChild = document.createElement('span');
     outerHost.appendChild(outerChild);
 
-    var outerShadow = outerHost.attachShadow({mode: 'closed'});
-    var innerHost = document.createElement('div');
-    var outerSlot = document.createElement('slot');
-    var innerChild = document.createElement('b');
+    const outerShadow = outerHost.attachShadow({mode: 'closed'});
+    const innerHost = document.createElement('div');
+    const outerSlot = document.createElement('slot');
+    const innerChild = document.createElement('b');
     outerShadow.appendChild(innerHost);
     innerHost.appendChild(outerSlot);
     innerHost.appendChild(innerChild);
 
-    var innerShadow = innerHost.attachShadow({mode: 'closed'});
-    var innerSlot = document.createElement('slot');
+    const innerShadow = innerHost.attachShadow({mode: 'closed'});
+    const innerSlot = document.createElement('slot');
     innerShadow.appendChild(innerSlot);
 
-    assert_array_equals(outerSlot.assignedNodes(), [outerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [outerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [outerChild], 'assignedNodes({flatten: true}) on a default slot must return the assigned nodes if they are not themselves slots');
+    assert_array_equals(outerSlot[method](), [outerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(outerSlot[method]({flatten: false}), [outerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(outerSlot[method]({flatten: true}), [outerChild], `${method}({flatten: true}) on a default slot must return the assigned nodes if they are not themselves slots`);
 
-    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
+    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
 
     outerSlot.name = 'foo';
-    assert_array_equals(outerSlot.assignedNodes(), [], 'assignedNodes() on a named slot must return an empty array if there are no matching elements');
-    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) on a named slot must return an empty array if there are no matching elements');
-    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) on a named slot must return an empty array if there are no matching elements');
+    assert_array_equals(outerSlot[method](), [], `${method}() on a named slot must return an empty array if there are no matching elements`);
+    assert_array_equals(outerSlot[method]({flatten: false}), [], `${method}({flatten: false}) on a named slot must return an empty array if there are no matching elements`);
+    assert_array_equals(outerSlot[method]({flatten: true}), [], `${method}({flatten: true}) on a named slot must return an empty array if there are no matching elements`);
 
-    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
+    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: true}), [innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
 
     outerChild.slot = 'foo';
-    assert_array_equals(outerSlot.assignedNodes(), [outerChild], 'assignedNodes() on a named slot must return matching elements');
-    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [outerChild], 'assignedNodes({flatten: false}) on a named slot must return matching elements');
-    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [outerChild], 'assignedNodes({flatten: true}) on a named slot must return matching elements');
+    assert_array_equals(outerSlot[method](), [outerChild], `${method}() on a named slot must return matching elements`);
+    assert_array_equals(outerSlot[method]({flatten: false}), [outerChild], `${method}({flatten: false}) on a named slot must return matching elements`);
+    assert_array_equals(outerSlot[method]({flatten: true}), [outerChild], `${method}({flatten: true}) on a named slot must return matching elements`);
 
-    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
+    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
 
     var newInnerSlot = document.createElement('slot');
     innerShadow.insertBefore(newInnerSlot, innerSlot);
-    assert_array_equals(newInnerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(newInnerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(newInnerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
+    assert_array_equals(newInnerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(newInnerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(newInnerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
 
-    assert_array_equals(innerSlot.assignedNodes(), [], 'assignedNodes() on a nameless slot element which appears after a default slot must return an empty array');
-    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array');
-    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array');
-
-    innerShadow.removeChild(newInnerSlot);
-    assert_array_equals(newInnerSlot.assignedNodes(), [], 'assignedNodes() must return an empty array when the slot element is not in any tree');
-    assert_array_equals(newInnerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) must return an empty array when the slot element is not in any tree');
-    assert_array_equals(newInnerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) must return an empty array when the slot element is not in any tree');
-
-    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
-    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
-
-}, 'assignedNodes({flatten: true}) must return the distributed nodes, and assignedNodes() and assignedNodes({flatten: false}) must returned the assigned nodes');
-
-test(function () {
-    var outerHost = document.createElement('div');
-    var outerChild = document.createElement('span');
-    outerHost.appendChild(outerChild);
-
-    var outerShadow = outerHost.attachShadow({mode: 'closed'});
-    var innerHost = document.createElement('div');
-    var outerSlot = document.createElement('slot');
-    var innerChild = document.createElement('b');
-    outerShadow.appendChild(innerHost);
-    innerHost.appendChild(outerSlot);
-    innerHost.appendChild(innerChild);
-
-    var innerShadow = innerHost.attachShadow({mode: 'closed'});
-    var innerSlot = document.createElement('slot');
-    innerShadow.appendChild(innerSlot);
-
-    assert_array_equals(outerSlot.assignedElements(), [outerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: false}), [outerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: true}), [outerChild], 'assignedElements({flatten: true}) on a default slot must return the assigned elements if they are not themselves slots');
-
-    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
-
-    outerSlot.name = 'foo';
-    assert_array_equals(outerSlot.assignedElements(), [], 'assignedElements() on a named slot must return an empty array if there are no matching elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) on a named slot must return an empty array if there are no matching elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) on a named slot must return an empty array if there are no matching elements');
-
-    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the elements nodes');
-    assert_array_equals(innerSlot.assignedElements({flatten: true}), [innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
-
-    outerChild.slot = 'foo';
-    assert_array_equals(outerSlot.assignedElements(), [outerChild], 'assignedElements() on a named slot must return matching elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: false}), [outerChild], 'assignedElements({flatten: false}) on a named slot must return matching elements');
-    assert_array_equals(outerSlot.assignedElements({flatten: true}), [outerChild], 'assignedElements({flatten: true}) on a named slot must return matching elements');
-
-    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
-
-    var newInnerSlot = document.createElement('slot');
-    innerShadow.insertBefore(newInnerSlot, innerSlot);
-    assert_array_equals(newInnerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(newInnerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
-    assert_array_equals(newInnerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
-
-    assert_array_equals(innerSlot.assignedElements(), [], 'assignedElements() on a nameless slot element which appears after a default slot must return an empty array');
-    assert_array_equals(innerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array');
-    assert_array_equals(innerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array');
+    assert_array_equals(innerSlot[method](), [], `${method}() on a nameless slot element which appears after a default slot must return an empty array`);
+    assert_array_equals(innerSlot[method]({flatten: false}), [], `${method}({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array`);
+    assert_array_equals(innerSlot[method]({flatten: true}), [], `${method}({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array`);
 
     innerShadow.removeChild(newInnerSlot);
-    assert_array_equals(newInnerSlot.assignedElements(), [], 'assignedElements() must return an empty array when the slot element is not in any tree');
-    assert_array_equals(newInnerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) must return an empty array when the slot element is not in any tree');
-    assert_array_equals(newInnerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) must return an empty array when the slot element is not in any tree');
+    assert_array_equals(newInnerSlot[method](), [], `${method}() must return an empty array when the slot element is not in any tree`);
+    assert_array_equals(newInnerSlot[method]({flatten: false}), [], `${method}({flatten: false}) must return an empty array when the slot element is not in any tree`);
+    assert_array_equals(newInnerSlot[method]({flatten: true}), [], `${method}({flatten: true}) must return an empty array when the slot element is not in any tree`);
 
-    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
-    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
+    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
 
-}, 'assignedElements({flatten: true}) must return the distributed elements, and assignedElements() and assignedElements({flatten: false}) must returned the assigned elements');
+  }, `${method}({flatten: true}) must return the distributed nodes, and ${method}() and ${method}({flatten: false}) must returned the assigned nodes`);
+}
 
 </script>
 </body>

--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -33,7 +33,7 @@ test(function () {
     assert_equals(slotElement.getAttribute('name'), 'bar', '"name" attribute must update the "name" content attribute');
 }, '"name" attribute on HTMLSlotElement must reflect "name" attribute');
 
-function testSlotNodesOutsideShadowTree(options)
+function testSlotOutsideShadowTree(options)
 {
     test(function () {
         assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
@@ -46,14 +46,7 @@ function testSlotNodesOutsideShadowTree(options)
 
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '')
         + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
-}
 
-testSlotNodesOutsideShadowTree(null);
-testSlotNodesOutsideShadowTree({flattened: false});
-testSlotNodesOutsideShadowTree({flattened: true});
-
-function testSlotElementsOutsideShadowTree(options)
-{
     test(function () {
         assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
 
@@ -67,11 +60,11 @@ function testSlotElementsOutsideShadowTree(options)
         + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
 }
 
-testSlotElementsOutsideShadowTree(null);
-testSlotElementsOutsideShadowTree({flattened: false});
-testSlotElementsOutsideShadowTree({flattened: true});
+testSlotOutsideShadowTree(null);
+testSlotOutsideShadowTree({flattened: false});
+testSlotOutsideShadowTree({flattened: true});
 
-function testSingleLevelOfSlottingNodes(options)
+function testSingleLevelOfSlotting(options)
 {
     test(function () {
         assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
@@ -101,14 +94,7 @@ function testSingleLevelOfSlottingNodes(options)
         assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on an empty name slot must return an element with empty slot attribute');
 
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
-}
 
-testSingleLevelOfSlottingNodes(null);
-testSingleLevelOfSlottingNodes({flattened: false});
-testSingleLevelOfSlottingNodes({flattened: true});
-
-function testSingleLevelOfSlottingElements(options)
-{
     test(function () {
         assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
 
@@ -137,14 +123,7 @@ function testSingleLevelOfSlottingElements(options)
         assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on an empty name slot must return an element with empty slot attribute');
 
     }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned elements when none of the assigned nodes themselves are slots');
-}
 
-testSingleLevelOfSlottingElements(null);
-testSingleLevelOfSlottingElements({flattened: false});
-testSingleLevelOfSlottingElements({flattened: true});
-
-function testSingleLevelOfSlottingMixed(options)
-{
     test(function () {
         assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
 
@@ -165,11 +144,11 @@ function testSingleLevelOfSlottingMixed(options)
     }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes limited to elements');
 }
 
-testSingleLevelOfSlottingMixed(null);
-testSingleLevelOfSlottingMixed({flattened: false});
-testSingleLevelOfSlottingMixed({flattened: true});
+testSingleLevelOfSlotting(null);
+testSingleLevelOfSlotting({flattened: false});
+testSingleLevelOfSlotting({flattened: true});
 
-function testMutatingSlottedNodesContents(options)
+function testMutatingSlottedContents(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
@@ -197,14 +176,7 @@ function testMutatingSlottedNodesContents(options)
         assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty for a default slot when all elements have "slot" attributes specified');
 
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
-}
 
-testMutatingSlottedNodesContents(null);
-testMutatingSlottedNodesContents({flattened: false});
-testMutatingSlottedNodesContents({flattened: true});
-
-function testMutatingSlottedElementsContents(options)
-{
     test(function () {
         var shadowHost = document.createElement('div');
         var p = document.createElement('p');
@@ -235,59 +207,44 @@ function testMutatingSlottedElementsContents(options)
     }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
 }
 
-testMutatingSlottedElementsContents(null);
-testMutatingSlottedElementsContents({flattened: false});
-testMutatingSlottedElementsContents({flattened: true});
+testMutatingSlottedContents(null);
+testMutatingSlottedContents({flattened: false});
+testMutatingSlottedContents({flattened: true});
 
-function testMutatingSlotNameNodes(options)
+function testMutatingSlotName(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
         var child = document.createElement('span');
         shadowHost.appendChild(child);
-
         var shadowRoot = shadowHost.attachShadow({mode: 'open'});
         var slotElement = document.createElement('slot');
         slotElement.name = 'foo';
         shadowRoot.appendChild(slotElement);
-
         assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty when there are no matching elements for the slot name');
-
         slotElement.removeAttribute('name');
         assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes must be empty when there are no matching elements for the slot name');
-
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
-}
 
-testMutatingSlotNameNodes(null);
-testMutatingSlotNameNodes({flattened: false});
-testMutatingSlotNameNodes({flattened: true});
-
-function testMutatingSlotNameElements(options)
-{
     test(function () {
         var shadowHost = document.createElement('div');
         var child = document.createElement('span');
         shadowHost.appendChild(child);
-
         var shadowRoot = shadowHost.attachShadow({mode: 'open'});
         var slotElement = document.createElement('slot');
         slotElement.name = 'foo';
         shadowRoot.appendChild(slotElement);
-
         assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty when there are no matching elements for the slot name');
-
         slotElement.removeAttribute('name');
         assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements must be empty when there are no matching elements for the slot name');
-
-    }, 'assignedElements must update when a default slot is introduced dynamically by a slot rename');
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
 }
 
-testMutatingSlotNameElements(null);
-testMutatingSlotNameElements({flattened: false});
-testMutatingSlotNameElements({flattened: true});
+testMutatingSlotName(null);
+testMutatingSlotName({flattened: false});
+testMutatingSlotName({flattened: true});
 
-function testInsertingAndRemovingSlotsNodes(options)
+function testInsertingAndRemovingSlots(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
@@ -335,14 +292,7 @@ function testInsertingAndRemovingSlotsNodes(options)
             'assignedNodes on formerly-first but now second unnamed slot element must return an empty array');
 
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
-}
 
-testInsertingAndRemovingSlotsNodes(null);
-testInsertingAndRemovingSlotsNodes({flattened: false});
-testInsertingAndRemovingSlotsNodes({flattened: true});
-
-function testInsertingAndRemovingSlotsElements(options)
-{
     test(function () {
         var shadowHost = document.createElement('div');
         var p = document.createElement('p');
@@ -388,12 +338,12 @@ function testInsertingAndRemovingSlotsElements(options)
         assert_array_equals(secondSlotElement.assignedElements(options), [],
             'assignedElements on formerly-first but now second unnamed slot element must return an empty array');
 
-    }, 'assignedElements must update when slot elements are inserted or removed');
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
 }
 
-testInsertingAndRemovingSlotsElements(null);
-testInsertingAndRemovingSlotsElements({flattened: false});
-testInsertingAndRemovingSlotsElements({flattened: true});
+testInsertingAndRemovingSlots(null);
+testInsertingAndRemovingSlots({flattened: false});
+testInsertingAndRemovingSlots({flattened: true});
 
 test(function () {
     var outerHost = document.createElement('div');

--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -33,7 +33,7 @@ test(function () {
     assert_equals(slotElement.getAttribute('name'), 'bar', '"name" attribute must update the "name" content attribute');
 }, '"name" attribute on HTMLSlotElement must reflect "name" attribute');
 
-function testSlotOutsideShadowTree(options)
+function testSlotNodesOutsideShadowTree(options)
 {
     test(function () {
         assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
@@ -48,11 +48,30 @@ function testSlotOutsideShadowTree(options)
         + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
 }
 
-testSlotOutsideShadowTree(null);
-testSlotOutsideShadowTree({flattened: false});
-testSlotOutsideShadowTree({flattened: true});
+testSlotNodesOutsideShadowTree(null);
+testSlotNodesOutsideShadowTree({flattened: false});
+testSlotNodesOutsideShadowTree({flattened: true});
 
-function testSingleLevelOfSlotting(options)
+function testSlotElementsOutsideShadowTree(options)
+{
+    test(function () {
+        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
+
+        var slotElement = document.createElement('slot');
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when the slot element is not in any tree');
+
+        document.body.appendChild(slotElement);
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when the slot element is in a document tree');
+
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '')
+        + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
+}
+
+testSlotElementsOutsideShadowTree(null);
+testSlotElementsOutsideShadowTree({flattened: false});
+testSlotElementsOutsideShadowTree({flattened: true});
+
+function testSingleLevelOfSlottingNodes(options)
 {
     test(function () {
         assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
@@ -84,11 +103,73 @@ function testSingleLevelOfSlotting(options)
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
 }
 
-testSingleLevelOfSlotting(null);
-testSingleLevelOfSlotting({flattened: false});
-testSingleLevelOfSlotting({flattened: true});
+testSingleLevelOfSlottingNodes(null);
+testSingleLevelOfSlottingNodes({flattened: false});
+testSingleLevelOfSlottingNodes({flattened: true});
 
-function testMutatingSlottedContents(options)
+function testSingleLevelOfSlottingElements(options)
+{
+    test(function () {
+        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
+
+        var shadowHost = document.createElement('div');
+        var child = document.createElement('p');
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        shadowRoot.appendChild(slotElement);
+
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when there are no nodes in the shadow tree');
+
+        shadowHost.appendChild(child);
+        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on a default slot must return an element without slot element');
+
+        child.setAttribute('slot', 'foo');
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() on a default slot must not return an element with non-empty slot attribute');
+
+        child.setAttribute('slot', '');
+        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on a default slot must return an element with empty slot attribute');
+
+        slotElement.setAttribute('name', 'bar');
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() on a named slot must not return an element with empty slot attribute');
+
+        slotElement.setAttribute('name', '');
+        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements() on an empty name slot must return an element with empty slot attribute');
+
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned elements when none of the assigned nodes themselves are slots');
+}
+
+testSingleLevelOfSlottingElements(null);
+testSingleLevelOfSlottingElements({flattened: false});
+testSingleLevelOfSlottingElements({flattened: true});
+
+function testSingleLevelOfSlottingMixed(options)
+{
+    test(function () {
+        assert_true('assignedElements' in HTMLSlotElement.prototype, '"assignedElements" method must be defined on HTMLSlotElement.prototype');
+
+        var shadowHost = document.createElement('div');
+        var elementChild = document.createElement('p');
+        var textChild = document.createTextNode('test');
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        shadowRoot.appendChild(slotElement);
+
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements() must return an empty array when there are no nodes in the shadow tree');
+
+        shadowHost.appendChild(elementChild);
+        shadowHost.appendChild(textChild);
+        assert_array_equals(slotElement.assignedElements(options), [elementChild], 'assignedElements() on a slot with mixed assigned nodes must return only elements');
+
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes limited to elements');
+}
+
+testSingleLevelOfSlottingMixed(null);
+testSingleLevelOfSlottingMixed({flattened: false});
+testSingleLevelOfSlottingMixed({flattened: true});
+
+function testMutatingSlottedNodesContents(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
@@ -118,11 +199,47 @@ function testMutatingSlottedContents(options)
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
 }
 
-testMutatingSlottedContents(null);
-testMutatingSlottedContents({flattened: false});
-testMutatingSlottedContents({flattened: true});
+testMutatingSlottedNodesContents(null);
+testMutatingSlottedNodesContents({flattened: false});
+testMutatingSlottedNodesContents({flattened: true});
 
-function testMutatingSlotName(options)
+function testMutatingSlottedElementsContents(options)
+{
+    test(function () {
+        var shadowHost = document.createElement('div');
+        var p = document.createElement('p');
+        var t = document.createTextNode('test');
+        var b = document.createElement('b');
+        shadowHost.appendChild(p);
+        shadowHost.appendChild(t);
+        shadowHost.appendChild(b);
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        shadowRoot.appendChild(slotElement);
+
+        assert_array_equals(slotElement.assignedElements(options), [p, b], 'assignedElements must return the distributed nodes limited to elements');
+
+        slotElement.name = 'foo';
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty when there are no matching elements for the slot name');
+
+        b.slot = 'foo';
+        assert_array_equals(slotElement.assignedElements(options), [b], 'assignedElements must return the elements with the matching slot name');
+
+        p.slot = 'foo';
+        assert_array_equals(slotElement.assignedElements(options), [p, b], 'assignedElements must return the elements with the matching slot name in the tree order');
+
+        slotElement.removeAttribute('name');
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty for a default slot when all elements have "slot" attributes specified');
+
+    }, 'assignedElements(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
+}
+
+testMutatingSlottedElementsContents(null);
+testMutatingSlottedElementsContents({flattened: false});
+testMutatingSlottedElementsContents({flattened: true});
+
+function testMutatingSlotNameNodes(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
@@ -142,11 +259,35 @@ function testMutatingSlotName(options)
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
 }
 
-testMutatingSlotName(null);
-testMutatingSlotName({flattened: false});
-testMutatingSlotName({flattened: true});
+testMutatingSlotNameNodes(null);
+testMutatingSlotNameNodes({flattened: false});
+testMutatingSlotNameNodes({flattened: true});
 
-function testInsertingAndRemovingSlots(options)
+function testMutatingSlotNameElements(options)
+{
+    test(function () {
+        var shadowHost = document.createElement('div');
+        var child = document.createElement('span');
+        shadowHost.appendChild(child);
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        slotElement.name = 'foo';
+        shadowRoot.appendChild(slotElement);
+
+        assert_array_equals(slotElement.assignedElements(options), [], 'assignedElements must be empty when there are no matching elements for the slot name');
+
+        slotElement.removeAttribute('name');
+        assert_array_equals(slotElement.assignedElements(options), [child], 'assignedElements must be empty when there are no matching elements for the slot name');
+
+    }, 'assignedElements must update when a default slot is introduced dynamically by a slot rename');
+}
+
+testMutatingSlotNameElements(null);
+testMutatingSlotNameElements({flattened: false});
+testMutatingSlotNameElements({flattened: true});
+
+function testInsertingAndRemovingSlotsNodes(options)
 {
     test(function () {
         var shadowHost = document.createElement('div');
@@ -196,9 +337,63 @@ function testInsertingAndRemovingSlots(options)
     }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
 }
 
-testInsertingAndRemovingSlots(null);
-testInsertingAndRemovingSlots({flattened: false});
-testInsertingAndRemovingSlots({flattened: true});
+testInsertingAndRemovingSlotsNodes(null);
+testInsertingAndRemovingSlotsNodes({flattened: false});
+testInsertingAndRemovingSlotsNodes({flattened: true});
+
+function testInsertingAndRemovingSlotsElements(options)
+{
+    test(function () {
+        var shadowHost = document.createElement('div');
+        var p = document.createElement('p');
+        var text = document.createTextNode('');
+        var comment = document.createComment('');
+        var processingInstruction = document.createProcessingInstruction('target', 'data');
+        var b = document.createElement('b');
+        shadowHost.appendChild(p);
+        shadowHost.appendChild(text);
+        shadowHost.appendChild(comment);
+        shadowHost.appendChild(processingInstruction);
+        shadowHost.appendChild(b);
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+
+        var firstSlotElement = document.createElement('slot');
+        shadowRoot.appendChild(firstSlotElement);
+
+        var secondSlotElement = document.createElement('slot');
+        shadowRoot.appendChild(secondSlotElement);
+
+        assert_array_equals(firstSlotElement.assignedElements(options), [p, b],
+            'assignedElements on a default slot must return the elements nodes only');
+        assert_array_equals(secondSlotElement.assignedElements(options), [],
+            'assignedElements on the second unnamed slot element must return an empty array');
+
+        shadowRoot.removeChild(firstSlotElement);
+        assert_array_equals(firstSlotElement.assignedElements(options), [],
+            'assignedElements on a detached formerly-default slot must return an empty array');
+        assert_array_equals(secondSlotElement.assignedElements(options), [p, b],
+            'assignedElements on the second unnamed slot element after removing the first must return the elements nodes only');
+
+        shadowRoot.removeChild(secondSlotElement);
+        shadowRoot.appendChild(secondSlotElement);
+        assert_array_equals(firstSlotElement.assignedElements(options), [],
+            'Removing and re-inserting a default slot must not change the result of assignedElements on a detached slot');
+        assert_array_equals(secondSlotElement.assignedElements(options), [p, b],
+            'Removing and re-inserting a default slot must not change the result of assignedElements');
+
+        shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
+        assert_array_equals(firstSlotElement.assignedElements(options), [p, b],
+            'assignedElements on a newly inserted unnamed slot element must return the elements nodes only');
+        assert_array_equals(secondSlotElement.assignedElements(options), [],
+            'assignedElements on formerly-first but now second unnamed slot element must return an empty array');
+
+    }, 'assignedElements must update when slot elements are inserted or removed');
+}
+
+testInsertingAndRemovingSlotsElements(null);
+testInsertingAndRemovingSlotsElements({flattened: false});
+testInsertingAndRemovingSlotsElements({flattened: true});
 
 test(function () {
     var outerHost = document.createElement('div');
@@ -263,6 +458,70 @@ test(function () {
     assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
 }, 'assignedNodes({flatten: true}) must return the distributed nodes, and assignedNodes() and assignedNodes({flatten: false}) must returned the assigned nodes');
+
+test(function () {
+    var outerHost = document.createElement('div');
+    var outerChild = document.createElement('span');
+    outerHost.appendChild(outerChild);
+
+    var outerShadow = outerHost.attachShadow({mode: 'closed'});
+    var innerHost = document.createElement('div');
+    var outerSlot = document.createElement('slot');
+    var innerChild = document.createElement('b');
+    outerShadow.appendChild(innerHost);
+    innerHost.appendChild(outerSlot);
+    innerHost.appendChild(innerChild);
+
+    var innerShadow = innerHost.attachShadow({mode: 'closed'});
+    var innerSlot = document.createElement('slot');
+    innerShadow.appendChild(innerSlot);
+
+    assert_array_equals(outerSlot.assignedElements(), [outerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: false}), [outerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: true}), [outerChild], 'assignedElements({flatten: true}) on a default slot must return the assigned elements if they are not themselves slots');
+
+    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+
+    outerSlot.name = 'foo';
+    assert_array_equals(outerSlot.assignedElements(), [], 'assignedElements() on a named slot must return an empty array if there are no matching elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) on a named slot must return an empty array if there are no matching elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) on a named slot must return an empty array if there are no matching elements');
+
+    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the elements nodes');
+    assert_array_equals(innerSlot.assignedElements({flatten: true}), [innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+
+    outerChild.slot = 'foo';
+    assert_array_equals(outerSlot.assignedElements(), [outerChild], 'assignedElements() on a named slot must return matching elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: false}), [outerChild], 'assignedElements({flatten: false}) on a named slot must return matching elements');
+    assert_array_equals(outerSlot.assignedElements({flatten: true}), [outerChild], 'assignedElements({flatten: true}) on a named slot must return matching elements');
+
+    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+
+    var newInnerSlot = document.createElement('slot');
+    innerShadow.insertBefore(newInnerSlot, innerSlot);
+    assert_array_equals(newInnerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(newInnerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
+    assert_array_equals(newInnerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+
+    assert_array_equals(innerSlot.assignedElements(), [], 'assignedElements() on a nameless slot element which appears after a default slot must return an empty array');
+    assert_array_equals(innerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array');
+    assert_array_equals(innerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array');
+
+    innerShadow.removeChild(newInnerSlot);
+    assert_array_equals(newInnerSlot.assignedElements(), [], 'assignedElements() must return an empty array when the slot element is not in any tree');
+    assert_array_equals(newInnerSlot.assignedElements({flatten: false}), [], 'assignedElements({flatten: false}) must return an empty array when the slot element is not in any tree');
+    assert_array_equals(newInnerSlot.assignedElements({flatten: true}), [], 'assignedElements({flatten: true}) must return an empty array when the slot element is not in any tree');
+
+    assert_array_equals(innerSlot.assignedElements(), [outerSlot, innerChild], 'assignedElements() on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: false}), [outerSlot, innerChild], 'assignedElements({flatten: false}) on a default slot must return the assigned elements');
+    assert_array_equals(innerSlot.assignedElements({flatten: true}), [outerChild, innerChild], 'assignedElements({flatten: true}) on a default slot must return the distributed elements');
+
+}, 'assignedElements({flatten: true}) must return the distributed elements, and assignedElements() and assignedElements({flatten: false}) must returned the assigned elements');
 
 </script>
 </body>

--- a/shadow-dom/HTMLSlotElement-interface.html
+++ b/shadow-dom/HTMLSlotElement-interface.html
@@ -12,8 +12,6 @@
 <div id="log"></div>
 <script>
 
-const slotMethods = ['assignedNodes', 'assignedElements'];
-
 test(function () {
     assert_true('HTMLSlotElement' in window, 'HTMLSlotElement must be defined on window');
     assert_equals(HTMLSlotElement.prototype.__proto__, HTMLElement.prototype, 'HTMLSlotElement should inherit from HTMLElement');
@@ -37,19 +35,17 @@ test(function () {
 
 function testSlotOutsideShadowTree(options)
 {
-  for (const method of slotMethods) {
     test(function () {
-      assert_true(method in HTMLSlotElement.prototype, `"${method}" method must be defined on HTMLSlotElement.prototype`);
+        assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
 
-      const slotElement = document.createElement('slot');
-      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when the slot element is not in any tree`);
+        var slotElement = document.createElement('slot');
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when the slot element is not in any tree');
 
-      document.body.appendChild(slotElement);
-      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when the slot element is in a document tree`);
+        document.body.appendChild(slotElement);
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when the slot element is in a document tree');
 
-    }, method + '(' + ( options ? JSON.stringify(options) : '' )
-        + ' on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
-  }
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '')
+        + ') on a HTMLSlotElement must return an empty array when the slot element is not in a tree or in a document tree');
 }
 
 testSlotOutsideShadowTree(null);
@@ -58,36 +54,34 @@ testSlotOutsideShadowTree({flattened: true});
 
 function testSingleLevelOfSlotting(options)
 {
-  for (const method of ['assignedNodes', 'assignedElements']) {
     test(function () {
-      assert_true(method in HTMLSlotElement.prototype, `"${method}" method must be defined on HTMLSlotElement.prototype`);
+        assert_true('assignedNodes' in HTMLSlotElement.prototype, '"assignedNodes" method must be defined on HTMLSlotElement.prototype');
 
-      const shadowHost = document.createElement('div');
-      const child = document.createElement('p');
+        var shadowHost = document.createElement('div');
+        var child = document.createElement('p');
 
-      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
-      const slotElement = document.createElement('slot');
-      shadowRoot.appendChild(slotElement);
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        shadowRoot.appendChild(slotElement);
 
-      assert_array_equals(slotElement[method](options), [], `${method}() must return an empty array when there are no nodes in the shadow tree`);
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() must return an empty array when there are no nodes in the shadow tree');
 
-      shadowHost.appendChild(child);
-      assert_array_equals(slotElement[method](options), [child], `${method}() on a default slot must return an element without slot element`);
+        shadowHost.appendChild(child);
+        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on a default slot must return an element without slot element');
 
-      child.setAttribute('slot', 'foo');
-      assert_array_equals(slotElement[method](options), [], `${method}() on a default slot must not return an element with non-empty slot attribute`);
+        child.setAttribute('slot', 'foo');
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() on a default slot must not return an element with non-empty slot attribute');
 
-      child.setAttribute('slot', '');
-      assert_array_equals(slotElement[method](options), [child], `${method}() on a default slot must return an element with empty slot attribute`);
+        child.setAttribute('slot', '');
+        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on a default slot must return an element with empty slot attribute');
 
-      slotElement.setAttribute('name', 'bar');
-      assert_array_equals(slotElement[method](options), [], `${method}() on a named slot must not return an element with empty slot attribute`);
+        slotElement.setAttribute('name', 'bar');
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes() on a named slot must not return an element with empty slot attribute');
 
-      slotElement.setAttribute('name', '');
-      assert_array_equals(slotElement[method](options), [child], `${method}() on an empty name slot must return an element with empty slot attribute`);
+        slotElement.setAttribute('name', '');
+        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes() on an empty name slot must return an element with empty slot attribute');
 
-    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
-  }
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must return the list of assigned nodes when none of the assigned nodes themselves are slots');
 }
 
 testSingleLevelOfSlotting(null);
@@ -96,34 +90,32 @@ testSingleLevelOfSlotting({flattened: true});
 
 function testMutatingSlottedContents(options)
 {
-  for (const method of slotMethods) {
     test(function () {
-      const shadowHost = document.createElement('div');
-      const p = document.createElement('p');
-      const b = document.createElement('b');
-      shadowHost.appendChild(p);
-      shadowHost.appendChild(b);
+        var shadowHost = document.createElement('div');
+        var p = document.createElement('p');
+        var b = document.createElement('b');
+        shadowHost.appendChild(p);
+        shadowHost.appendChild(b);
 
-      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
-      const slotElement = document.createElement('slot');
-      shadowRoot.appendChild(slotElement);
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        shadowRoot.appendChild(slotElement);
 
-      assert_array_equals(slotElement[method](options), [p, b], `${method} must return the distributed nodes`);
+        assert_array_equals(slotElement.assignedNodes(options), [p, b], 'assignedNodes must return the distributed nodes');
 
-      slotElement.name = 'foo';
-      assert_array_equals(slotElement[method](options), [], `${method} must be empty when there are no matching elements for the slot name`);
+        slotElement.name = 'foo';
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty when there are no matching elements for the slot name');
 
-      b.slot = 'foo';
-      assert_array_equals(slotElement[method](options), [b], `${method} must return the nodes with the matching slot name`);
+        b.slot = 'foo';
+        assert_array_equals(slotElement.assignedNodes(options), [b], 'assignedNodes must return the nodes with the matching slot name');
 
-      p.slot = 'foo';
-      assert_array_equals(slotElement[method](options), [p, b], `${method} must return the nodes with the matching slot name in the tree order`);
+        p.slot = 'foo';
+        assert_array_equals(slotElement.assignedNodes(options), [p, b], 'assignedNodes must return the nodes with the matching slot name in the tree order');
 
-      slotElement.removeAttribute('name');
-      assert_array_equals(slotElement[method](options), [], `${method} must be empty for a default slot when all elements have "slot" attributes specified`);
+        slotElement.removeAttribute('name');
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty for a default slot when all elements have "slot" attributes specified');
 
-    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
-  }
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot and name attributes are modified');
 }
 
 testMutatingSlottedContents(null);
@@ -132,20 +124,22 @@ testMutatingSlottedContents({flattened: true});
 
 function testMutatingSlotName(options)
 {
-  for (const method of slotMethods) {
     test(function () {
-      const shadowHost = document.createElement('div');
-      const child = document.createElement('span');
-      shadowHost.appendChild(child);
-      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
-      const slotElement = document.createElement('slot');
-      slotElement.name = 'foo';
-      shadowRoot.appendChild(slotElement);
-      assert_array_equals(slotElement[method](options), [], `${method} must be empty when there are no matching elements for the slot name`);
-      slotElement.removeAttribute('name');
-      assert_array_equals(slotElement[method](options), [child], `${method} must be empty when there are no matching elements for the slot name`);
-    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
-  }
+        var shadowHost = document.createElement('div');
+        var child = document.createElement('span');
+        shadowHost.appendChild(child);
+
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var slotElement = document.createElement('slot');
+        slotElement.name = 'foo';
+        shadowRoot.appendChild(slotElement);
+
+        assert_array_equals(slotElement.assignedNodes(options), [], 'assignedNodes must be empty when there are no matching elements for the slot name');
+
+        slotElement.removeAttribute('name');
+        assert_array_equals(slotElement.assignedNodes(options), [child], 'assignedNodes must be empty when there are no matching elements for the slot name');
+
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when a default slot is introduced dynamically by a slot rename');
 }
 
 testMutatingSlotName(null);
@@ -154,125 +148,121 @@ testMutatingSlotName({flattened: true});
 
 function testInsertingAndRemovingSlots(options)
 {
-  for (const method of slotMethods) {
     test(function () {
-      const shadowHost = document.createElement('div');
-      const p = document.createElement('p');
-      const text = document.createTextNode('');
-      const comment = document.createComment('');
-      const processingInstruction = document.createProcessingInstruction('target', 'data');
-      const b = document.createElement('b');
-      shadowHost.appendChild(p);
-      shadowHost.appendChild(text);
-      shadowHost.appendChild(comment);
-      shadowHost.appendChild(processingInstruction);
-      shadowHost.appendChild(b);
+        var shadowHost = document.createElement('div');
+        var p = document.createElement('p');
+        var text = document.createTextNode('');
+        var comment = document.createComment('');
+        var processingInstruction = document.createProcessingInstruction('target', 'data');
+        var b = document.createElement('b');
+        shadowHost.appendChild(p);
+        shadowHost.appendChild(text);
+        shadowHost.appendChild(comment);
+        shadowHost.appendChild(processingInstruction);
+        shadowHost.appendChild(b);
 
-      const shadowRoot = shadowHost.attachShadow({mode: 'open'});
+        var shadowRoot = shadowHost.attachShadow({mode: 'open'});
 
-      const firstSlotElement = document.createElement('slot');
-      shadowRoot.appendChild(firstSlotElement);
+        var firstSlotElement = document.createElement('slot');
+        shadowRoot.appendChild(firstSlotElement);
 
-      const secondSlotElement = document.createElement('slot');
-      shadowRoot.appendChild(secondSlotElement);
+        var secondSlotElement = document.createElement('slot');
+        shadowRoot.appendChild(secondSlotElement);
 
-      assert_array_equals(firstSlotElement[method](options), [p, text, b],
-      `${method} on a default slot must return the elements without slot attributes and text nodes`);
-      assert_array_equals(secondSlotElement[method](options), [],
-      `${method} on the second unnamed slot element must return an empty array`);
+        assert_array_equals(firstSlotElement.assignedNodes(options), [p, text, b],
+            'assignedNodes on a default slot must return the elements without slot attributes and text nodes');
+        assert_array_equals(secondSlotElement.assignedNodes(options), [],
+            'assignedNodes on the second unnamed slot element must return an empty array');
 
-      shadowRoot.removeChild(firstSlotElement);
-      assert_array_equals(firstSlotElement[method](options), [],
-      `${method} on a detached formerly-default slot must return an empty array`);
-      assert_array_equals(secondSlotElement[method](options), [p, text, b],
-      `${method} on the second unnamed slot element after removing the first must return the elements without slot attributes and text nodes`);
+        shadowRoot.removeChild(firstSlotElement);
+        assert_array_equals(firstSlotElement.assignedNodes(options), [],
+            'assignedNodes on a detached formerly-default slot must return an empty array');
+        assert_array_equals(secondSlotElement.assignedNodes(options), [p, text, b],
+            'assignedNodes on the second unnamed slot element after removing the first must return the elements without slot attributes and text nodes');
 
-      shadowRoot.removeChild(secondSlotElement);
-      shadowRoot.appendChild(secondSlotElement);
-      assert_array_equals(firstSlotElement[method](options), [],
-      `Removing and re-inserting a default slot must not change the result of ${method} on a detached slot`);
-      assert_array_equals(secondSlotElement[method](options), [p, text, b],
-      `Removing and re-inserting a default slot must not change the result of ${method}`);
+        shadowRoot.removeChild(secondSlotElement);
+        shadowRoot.appendChild(secondSlotElement);
+        assert_array_equals(firstSlotElement.assignedNodes(options), [],
+            'Removing and re-inserting a default slot must not change the result of assignedNodes on a detached slot');
+        assert_array_equals(secondSlotElement.assignedNodes(options), [p, text, b],
+            'Removing and re-inserting a default slot must not change the result of assignedNodes');
 
-      shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
-      assert_array_equals(firstSlotElement[method](options), [p, text, b],
-      `${method} on a newly inserted unnamed slot element must return the elements without slot attributes and text nodes`);
-      assert_array_equals(secondSlotElement[method](options), [],
-      `${method} on formerly-first but now second unnamed slot element must return an empty array`);
+        shadowRoot.insertBefore(firstSlotElement, secondSlotElement);
+        assert_array_equals(firstSlotElement.assignedNodes(options), [p, text, b],
+            'assignedNodes on a newly inserted unnamed slot element must return the elements without slot attributes and text nodes');
+        assert_array_equals(secondSlotElement.assignedNodes(options), [],
+            'assignedNodes on formerly-first but now second unnamed slot element must return an empty array');
 
-    }, method + '(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
-  }
+    }, 'assignedNodes(' + (options ? JSON.stringify(options) : '') + ') must update when slot elements are inserted or removed');
 }
 
 testInsertingAndRemovingSlots(null);
 testInsertingAndRemovingSlots({flattened: false});
 testInsertingAndRemovingSlots({flattened: true});
 
-for (const method of slotMethods) {
-  test(function () {
-    const outerHost = document.createElement('div');
-    const outerChild = document.createElement('span');
+test(function () {
+    var outerHost = document.createElement('div');
+    var outerChild = document.createElement('span');
     outerHost.appendChild(outerChild);
 
-    const outerShadow = outerHost.attachShadow({mode: 'closed'});
-    const innerHost = document.createElement('div');
-    const outerSlot = document.createElement('slot');
-    const innerChild = document.createElement('b');
+    var outerShadow = outerHost.attachShadow({mode: 'closed'});
+    var innerHost = document.createElement('div');
+    var outerSlot = document.createElement('slot');
+    var innerChild = document.createElement('b');
     outerShadow.appendChild(innerHost);
     innerHost.appendChild(outerSlot);
     innerHost.appendChild(innerChild);
 
-    const innerShadow = innerHost.attachShadow({mode: 'closed'});
-    const innerSlot = document.createElement('slot');
+    var innerShadow = innerHost.attachShadow({mode: 'closed'});
+    var innerSlot = document.createElement('slot');
     innerShadow.appendChild(innerSlot);
 
-    assert_array_equals(outerSlot[method](), [outerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(outerSlot[method]({flatten: false}), [outerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(outerSlot[method]({flatten: true}), [outerChild], `${method}({flatten: true}) on a default slot must return the assigned nodes if they are not themselves slots`);
+    assert_array_equals(outerSlot.assignedNodes(), [outerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [outerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [outerChild], 'assignedNodes({flatten: true}) on a default slot must return the assigned nodes if they are not themselves slots');
 
-    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
+    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
     outerSlot.name = 'foo';
-    assert_array_equals(outerSlot[method](), [], `${method}() on a named slot must return an empty array if there are no matching elements`);
-    assert_array_equals(outerSlot[method]({flatten: false}), [], `${method}({flatten: false}) on a named slot must return an empty array if there are no matching elements`);
-    assert_array_equals(outerSlot[method]({flatten: true}), [], `${method}({flatten: true}) on a named slot must return an empty array if there are no matching elements`);
+    assert_array_equals(outerSlot.assignedNodes(), [], 'assignedNodes() on a named slot must return an empty array if there are no matching elements');
+    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) on a named slot must return an empty array if there are no matching elements');
+    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) on a named slot must return an empty array if there are no matching elements');
 
-    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: true}), [innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
+    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
     outerChild.slot = 'foo';
-    assert_array_equals(outerSlot[method](), [outerChild], `${method}() on a named slot must return matching elements`);
-    assert_array_equals(outerSlot[method]({flatten: false}), [outerChild], `${method}({flatten: false}) on a named slot must return matching elements`);
-    assert_array_equals(outerSlot[method]({flatten: true}), [outerChild], `${method}({flatten: true}) on a named slot must return matching elements`);
+    assert_array_equals(outerSlot.assignedNodes(), [outerChild], 'assignedNodes() on a named slot must return matching elements');
+    assert_array_equals(outerSlot.assignedNodes({flatten: false}), [outerChild], 'assignedNodes({flatten: false}) on a named slot must return matching elements');
+    assert_array_equals(outerSlot.assignedNodes({flatten: true}), [outerChild], 'assignedNodes({flatten: true}) on a named slot must return matching elements');
 
-    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
+    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
     var newInnerSlot = document.createElement('slot');
     innerShadow.insertBefore(newInnerSlot, innerSlot);
-    assert_array_equals(newInnerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(newInnerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(newInnerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
+    assert_array_equals(newInnerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(newInnerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(newInnerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
-    assert_array_equals(innerSlot[method](), [], `${method}() on a nameless slot element which appears after a default slot must return an empty array`);
-    assert_array_equals(innerSlot[method]({flatten: false}), [], `${method}({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array`);
-    assert_array_equals(innerSlot[method]({flatten: true}), [], `${method}({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array`);
+    assert_array_equals(innerSlot.assignedNodes(), [], 'assignedNodes() on a nameless slot element which appears after a default slot must return an empty array');
+    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) on a nameless slot element which appears after a default slot must return an empty array');
+    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) on a nameless slot element which appears after a default slot must return an empty array');
 
     innerShadow.removeChild(newInnerSlot);
-    assert_array_equals(newInnerSlot[method](), [], `${method}() must return an empty array when the slot element is not in any tree`);
-    assert_array_equals(newInnerSlot[method]({flatten: false}), [], `${method}({flatten: false}) must return an empty array when the slot element is not in any tree`);
-    assert_array_equals(newInnerSlot[method]({flatten: true}), [], `${method}({flatten: true}) must return an empty array when the slot element is not in any tree`);
+    assert_array_equals(newInnerSlot.assignedNodes(), [], 'assignedNodes() must return an empty array when the slot element is not in any tree');
+    assert_array_equals(newInnerSlot.assignedNodes({flatten: false}), [], 'assignedNodes({flatten: false}) must return an empty array when the slot element is not in any tree');
+    assert_array_equals(newInnerSlot.assignedNodes({flatten: true}), [], 'assignedNodes({flatten: true}) must return an empty array when the slot element is not in any tree');
 
-    assert_array_equals(innerSlot[method](), [outerSlot, innerChild], `${method}() on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: false}), [outerSlot, innerChild], `${method}({flatten: false}) on a default slot must return the assigned nodes`);
-    assert_array_equals(innerSlot[method]({flatten: true}), [outerChild, innerChild], `${method}({flatten: true}) on a default slot must return the distributed nodes`);
+    assert_array_equals(innerSlot.assignedNodes(), [outerSlot, innerChild], 'assignedNodes() on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: false}), [outerSlot, innerChild], 'assignedNodes({flatten: false}) on a default slot must return the assigned nodes');
+    assert_array_equals(innerSlot.assignedNodes({flatten: true}), [outerChild, innerChild], 'assignedNodes({flatten: true}) on a default slot must return the distributed nodes');
 
-  }, `${method}({flatten: true}) must return the distributed nodes, and ${method}() and ${method}({flatten: false}) must returned the assigned nodes`);
-}
+}, 'assignedNodes({flatten: true}) must return the distributed nodes, and assignedNodes() and assignedNodes({flatten: false}) must returned the assigned nodes');
 
 </script>
 </body>

--- a/shadow-dom/slots-fallback.html
+++ b/shadow-dom/slots-fallback.html
@@ -146,7 +146,7 @@ test(() => {
 
   assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot');
+}, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot, elements only');
 </script>
 
 <div id="test5">

--- a/shadow-dom/slots-fallback.html
+++ b/shadow-dom/slots-fallback.html
@@ -98,16 +98,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.f1]);
 }, 'Slots fallback: Fallback contents should not be used if a node is assigned.');
-
-test(() => {
-  let n = createTestTree(test3);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), []);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f1]);
-}, 'Slots fallback: Fallback contents should not be used if a node is assigned, elements only.');
 </script>
 
 <div id="test4">
@@ -137,16 +127,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot');
-
-test(() => {
-  let n = createTestTree(test4);
-
-  assert_array_equals(n.s1.assignedElements(), []);
-  assert_array_equals(n.s2.assignedElements(), [n.c1]);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot, elements only');
 </script>
 
 <div id="test5">
@@ -218,20 +198,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test5);
-
-  let d1 = document.createElement('div');
-  let t1 = document.createTextNode('test');
-  n.s2.appendChild(d1);
-  n.s2.appendChild(t1);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1, n.f2, d1]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c1, n.f2, d1]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.c1, n.f2, d1, n.f4]);
-}, 'Slots fallback: Mutation. Append fallback contents, elements only.');
-
-test(() => {
-  let n = createTestTree(test5);
   removeWhiteSpaceOnlyTextNodes(n.test5);
 
   n.f2.remove();
@@ -241,17 +207,6 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.c1, n.f4]);
 }, 'Slots fallback: Mutation. Remove fallback contents.');
-
-test(() => {
-  let n = createTestTree(test5);
-
-  n.f2.remove();
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.c1, n.f4]);
-}, 'Slots fallback: Mutation. Remove fallback contents, elements only.');
 
 test(() => {
   let n = createTestTree(test5);
@@ -269,19 +224,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test5);
-
-  let d2 = document.createElement('div');
-  d2.setAttribute('slot', 'slot2');
-  n.host1.appendChild(d2);
-
-  assert_array_equals(n.s2.assignedElements(), [d2]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [d2]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [d2]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), [d2, n.f4]);
-}, 'Slots fallback: Mutation. Assign a node to a slot so that fallback contens are no longer used, elements only.');
-
-test(() => {
-  let n = createTestTree(test5);
   removeWhiteSpaceOnlyTextNodes(n.test5);
 
   n.c1.remove();
@@ -293,20 +235,6 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.f1, n.f2]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.f1, n.f2, n.f4]);
 }, 'Slots fallback: Mutation. Remove an assigned node from a slot so that fallback contens will be used.');
-
-test(() => {
-  let n = createTestTree(test5);
-
-  n.c1.remove();
-
-  assert_array_equals(n.s1.assignedElements(), []);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f1, n.f2]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.f1, n.f2]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.f1, n.f2, n.f4]);
-}, 'Slots fallback: Mutation. Remove an assigned node from a slot so that fallback contens will be used. Elements only.');
-
 
 test(() => {
   let n = createTestTree(test5);
@@ -322,17 +250,4 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.f2]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.f2, n.f4]);
 }, 'Slots fallback: Mutation.  Remove a slot which is a fallback content of another slot.');
-
-test(() => {
-  let n = createTestTree(test5);
-
-  n.s1.remove();
-
-  assert_array_equals(n.s1.assignedElements(), []);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f2]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.f2]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.f2, n.f4]);
-}, 'Slots fallback: Mutation.  Remove a slot which is a fallback content of another slot, elements only.');
 </script>

--- a/shadow-dom/slots-fallback.html
+++ b/shadow-dom/slots-fallback.html
@@ -25,6 +25,13 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes(), []);
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.f1]);
 }, 'Slots fallback: Basic.');
+
+test(() => {
+  let n = createTestTree(test1);
+
+  assert_array_equals(n.s1.assignedElements(), []);
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
+}, 'Slots fallback: Basic, elements only.');
 </script>
 
 <div id="test2">
@@ -52,6 +59,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.f1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.f1]);
 }, 'Slots fallback: Slots in Slots.');
+
+test(() => {
+  let n = createTestTree(test2);
+
+  assert_array_equals(n.s1.assignedElements(), []);
+  assert_array_equals(n.s2.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f1]);
+}, 'Slots fallback: Slots in Slots, elements only.');
 </script>
 
 <div id="test3">
@@ -81,6 +98,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.f1]);
 }, 'Slots fallback: Fallback contents should not be used if a node is assigned.');
+
+test(() => {
+  let n = createTestTree(test3);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f1]);
+}, 'Slots fallback: Fallback contents should not be used if a node is assigned, elements only.');
 </script>
 
 <div id="test4">
@@ -109,7 +136,17 @@ test(() => {
 
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
-}, 'Slots fallback: Slots in Slots: Assinged nodes should be used as fallback contents of another slot');
+}, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot');
+
+test(() => {
+  let n = createTestTree(test4);
+
+  assert_array_equals(n.s1.assignedElements(), []);
+  assert_array_equals(n.s2.assignedElements(), [n.c1]);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+}, 'Slots fallback: Slots in Slots: Assigned nodes should be used as fallback contents of another slot');
 </script>
 
 <div id="test5">
@@ -154,6 +191,20 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test5);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), []);
+  assert_array_equals(n.s3.assignedElements(), [n.s2]);
+  assert_array_equals(n.s4.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1, n.f2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c1, n.f2]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.c1, n.f2, n.f4]);
+}, 'Slots fallback: Complex case, elements only.');
+
+test(() => {
+  let n = createTestTree(test5);
   removeWhiteSpaceOnlyTextNodes(n.test5);
 
   let d1 = document.createElement('div');
@@ -167,6 +218,20 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test5);
+
+  let d1 = document.createElement('div');
+  let t1 = document.createTextNode('test');
+  n.s2.appendChild(d1);
+  n.s2.appendChild(t1);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1, n.f2, d1]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c1, n.f2, d1]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.c1, n.f2, d1, n.f4]);
+}, 'Slots fallback: Mutation. Append fallback contents, elements only.');
+
+test(() => {
+  let n = createTestTree(test5);
   removeWhiteSpaceOnlyTextNodes(n.test5);
 
   n.f2.remove();
@@ -176,6 +241,17 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.c1, n.f4]);
 }, 'Slots fallback: Mutation. Remove fallback contents.');
+
+test(() => {
+  let n = createTestTree(test5);
+
+  n.f2.remove();
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.c1, n.f4]);
+}, 'Slots fallback: Mutation. Remove fallback contents, elements only.');
 
 test(() => {
   let n = createTestTree(test5);
@@ -193,6 +269,19 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test5);
+
+  let d2 = document.createElement('div');
+  d2.setAttribute('slot', 'slot2');
+  n.host1.appendChild(d2);
+
+  assert_array_equals(n.s2.assignedElements(), [d2]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [d2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [d2]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [d2, n.f4]);
+}, 'Slots fallback: Mutation. Assign a node to a slot so that fallback contens are no longer used, elements only.');
+
+test(() => {
+  let n = createTestTree(test5);
   removeWhiteSpaceOnlyTextNodes(n.test5);
 
   n.c1.remove();
@@ -204,6 +293,20 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.f1, n.f2]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.f1, n.f2, n.f4]);
 }, 'Slots fallback: Mutation. Remove an assigned node from a slot so that fallback contens will be used.');
+
+test(() => {
+  let n = createTestTree(test5);
+
+  n.c1.remove();
+
+  assert_array_equals(n.s1.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f1, n.f2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.f1, n.f2]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.f1, n.f2, n.f4]);
+}, 'Slots fallback: Mutation. Remove an assigned node from a slot so that fallback contens will be used. Elements only.');
+
 
 test(() => {
   let n = createTestTree(test5);
@@ -219,4 +322,17 @@ test(() => {
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), [n.f2]);
   assert_array_equals(n.s4.assignedNodes({ flatten: true }), [n.f2, n.f4]);
 }, 'Slots fallback: Mutation.  Remove a slot which is a fallback content of another slot.');
+
+test(() => {
+  let n = createTestTree(test5);
+
+  n.s1.remove();
+
+  assert_array_equals(n.s1.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.f1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.f2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.f2]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), [n.f2, n.f4]);
+}, 'Slots fallback: Mutation.  Remove a slot which is a fallback content of another slot, elements only.');
 </script>

--- a/shadow-dom/slots.html
+++ b/shadow-dom/slots.html
@@ -105,18 +105,6 @@ test(() => {
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), []);
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), []);
 }, 'Slots: Distributed nodes for Slots not in a shadow tree.');
-
-test(() => {
-  let n = createTestTree(test_slot_not_in_shadow_2);
-
-  assert_array_equals(n.s1.assignedElements(), []);
-  assert_array_equals(n.s2.assignedElements(), []);
-  assert_array_equals(n.s3.assignedElements(), []);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c2, n.c3_1, n.c3_2]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c3_1, n.c3_2]);
-}, 'Slots: Distributed elements for Slots not in a shadow tree.');
 </script>
 
 <div id="test_slot_name_matching">
@@ -168,12 +156,6 @@ test(() => {
 
   assert_array_equals(n.s1.assignedNodes(), [n.c1, n.c2]);
 }, 'Slots: No direct host child.');
-
-test(() => {
-  let n = createTestTree(test_no_direct_host_child);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1, n.c2]);
-}, 'Slots: No direct host child, elements only.');
 </script>
 
 <div id="test_default_slot">
@@ -250,16 +232,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Slot is assigned to another slot');
-
-test(() => {
-  let n = createTestTree(test_slot_is_assigned_to_slot);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), [n.s1]);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots: Slot is assigned to another slot, elements only');
 </script>
 
 <div id="test_open_closed">
@@ -291,16 +263,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Open > Closed.');
-
-test(() => {
-  let n = createTestTree(test_open_closed);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), [n.s1]);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots: Open > Closed, elements only.');
 </script>
 
 <div id="test_closed_closed">
@@ -333,16 +295,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Closed > Closed.');
-
-test(() => {
-  let n = createTestTree(test_closed_closed);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), [n.s1]);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots: Closed > Closed, elements only.');
 </script>
 
 <div id="test_closed_open">
@@ -374,16 +326,6 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Closed > Open.');
-
-test(() => {
-  let n = createTestTree(test_closed_open);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), [n.s1]);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
-}, 'Slots: Closed > Open, elements only.');
 </script>
 
 <div id="test_complex">
@@ -454,28 +396,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-  assert_array_equals(n.s2.assignedElements(), [n.c2]);
-  assert_array_equals(n.s3.assignedElements(), [n.c3]);
-  assert_array_equals(n.s4.assignedElements(), []);
-  assert_array_equals(n.s5.assignedElements(), [n.s1, n.c5]);
-  assert_array_equals(n.s6.assignedElements(), [n.s2, n.c6]);
-  assert_array_equals(n.s7.assignedElements(), [n.s3, n.c7]);
-  assert_array_equals(n.s8.assignedElements(), []);
-
-  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
-  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c2]);
-  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c3]);
-  assert_array_equals(n.s4.assignedElements({ flatten: true }), []);
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, n.c5]);
-  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c2, n.c6]);
-  assert_array_equals(n.s7.assignedElements({ flatten: true }), [n.c3, n.c7]);
-  assert_array_equals(n.s8.assignedElements({ flatten: true }), []);
-}, 'Slots: Complex case: Basic line, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   let d1 = document.createElement('div');
@@ -490,20 +410,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  let d1 = document.createElement('div');
-  let t1 = document.createTextNode('test');
-  d1.setAttribute('slot', 'slot1');
-  n.host1.appendChild(d1);
-  n.host1.appendChild(t1);
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1, d1]);
-
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, d1, n.c5]);
-}, 'Slots: Mutation: appendChild, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.c1.setAttribute('slot', 'slot-none');
@@ -513,16 +419,6 @@ test(() => {
 
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c5]);
 }, 'Slots: Mutation: Change slot= attribute 1.');
-
-test(() => {
-  let n = createTestTree(test_complex);
-
-  n.c1.setAttribute('slot', 'slot-none');
-
-  assert_array_equals(n.s1.assignedElements(), []);
-
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
-}, 'Slots: Mutation: Change slot= attribute 1, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -540,18 +436,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  n.c1.setAttribute('slot', 'slot2');
-
-  assert_array_equals(n.s1.assignedElements(), []);
-  assert_array_equals(n.s2.assignedElements(), [n.c1, n.c2]);
-
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
-  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c1, n.c2, n.c6]);
-}, 'Slots: Mutation: Change slot= attribute 2, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.c4.setAttribute('slot', 'slot1');
@@ -561,16 +445,6 @@ test(() => {
 
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c1, n.c4, n.c5]);
 }, 'Slots: Mutation: Change slot= attribute 3.');
-
-test(() => {
-  let n = createTestTree(test_complex);
-
-  n.c4.setAttribute('slot', 'slot1');
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1, n.c4]);
-
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, n.c4, n.c5]);
-}, 'Slots: Mutation: Change slot= attribute 3, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -586,16 +460,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  n.c1.remove();
-
-  assert_array_equals(n.s1.assignedElements(), []);
-
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
-}, 'Slots: Mutation: Remove a child, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   let slot = document.createElement('slot');
@@ -604,16 +468,6 @@ test(() => {
 
   assert_array_equals(slot.assignedNodes(), []);
 }, 'Slots: Mutation: Add a slot: after.');
-
-test(() => {
-  let n = createTestTree(test_complex);
-
-  let slot = document.createElement('slot');
-  slot.setAttribute('name', 'slot1');
-  n.host2.appendChild(slot);
-
-  assert_array_equals(slot.assignedElements(), []);
-}, 'Slots: Mutation: Add a slot: after, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -632,19 +486,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  let slot = document.createElement('slot');
-  slot.setAttribute('name', 'slot1');
-  n.host2.insertBefore(slot, n.s1);
-
-  assert_array_equals(slot.assignedElements(), [n.c1]);
-
-  assert_array_equals(n.s7.assignedElements(), [slot, n.s3, n.c7]);
-  assert_array_equals(n.s7.assignedElements({ flatten: true }), [n.c1, n.c3, n.c7]);
-}, 'Slots: Mutation: Add a slot: before, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.s1.remove();
@@ -655,17 +496,6 @@ test(() => {
   assert_array_equals(n.s5.assignedNodes(), [n.c5]);
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c5]);
 }, 'Slots: Mutation: Remove a slot.');
-
-test(() => {
-  let n = createTestTree(test_complex);
-
-  n.s1.remove();
-
-  assert_array_equals(n.s1.assignedElements(), []);
-
-  assert_array_equals(n.s5.assignedElements(), [n.c5]);
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
-}, 'Slots: Mutation: Remove a slot, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -683,17 +513,6 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
-
-  n.s1.setAttribute('name', 'slot2');
-
-  assert_array_equals(n.s1.assignedElements(), [n.c2]);
-
-  assert_array_equals(n.s5.assignedElements(), [n.s1, n.c5]);
-  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c2, n.c5]);
-}, 'Slots: Mutation: Change slot name= attribute, elements only.');
-
-test(() => {
-  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.s1.setAttribute('slot', 'slot6');
@@ -704,16 +523,4 @@ test(() => {
   assert_array_equals(n.s6.assignedNodes(), [n.s1, n.s2, n.c6]);
   assert_array_equals(n.s6.assignedNodes({ flatten: true }), [n.c1, n.c2, n.c6]);
 }, 'Slots: Mutation: Change slot slot= attribute.');
-
-test(() => {
-  let n = createTestTree(test_complex);
-
-  n.s1.setAttribute('slot', 'slot6');
-
-  assert_array_equals(n.s1.assignedElements(), [n.c1]);
-
-  assert_array_equals(n.s5.assignedElements(), [n.c5]);
-  assert_array_equals(n.s6.assignedElements(), [n.s1, n.s2, n.c6]);
-  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c1, n.c2, n.c6]);
-}, 'Slots: Mutation: Change slot slot= attribute, elements only.');
 </script>

--- a/shadow-dom/slots.html
+++ b/shadow-dom/slots.html
@@ -22,6 +22,12 @@ test(() => {
   assert_equals(n.c1.assignedSlot, n.s1);
   assert_array_equals(n.s1.assignedNodes(), [n.c1]);
 }, 'Slots: Basic.');
+
+test(() => {
+  let n = createTestTree(test_basic);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+}, 'Slots: Basic, elements only.');
 </script>
 
 <div id="test_basic_closed">
@@ -41,6 +47,12 @@ test(() => {
   assert_equals(n.c1.assignedSlot, null);
   assert_array_equals(n.s1.assignedNodes(), [n.c1]);
 }, 'Slots: Slots in closed.');
+
+test(() => {
+  let n = createTestTree(test_basic_closed);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+}, 'Slots: Slots in closed, elements only.');
 </script>
 
 <div id="test_slot_not_in_shadow">
@@ -54,6 +66,12 @@ test(() => {
 
   assert_array_equals(n.s1.assignedNodes(), []);
 }, 'Slots: Slots not in a shadow tree.');
+
+test(() => {
+  let n = createTestTree(test_slot_not_in_shadow);
+
+  assert_array_equals(n.s1.assignedElements(), []);
+}, 'Slots: Slots not in a shadow tree, elements only.');
 </script>
 
 <div id="test_slot_not_in_shadow_2">
@@ -86,7 +104,19 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), []);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), []);
   assert_array_equals(n.s3.assignedNodes({ flatten: true }), []);
-}, 'Slots: Distributed nooes for Slots not in a shadow tree.');
+}, 'Slots: Distributed nodes for Slots not in a shadow tree.');
+
+test(() => {
+  let n = createTestTree(test_slot_not_in_shadow_2);
+
+  assert_array_equals(n.s1.assignedElements(), []);
+  assert_array_equals(n.s2.assignedElements(), []);
+  assert_array_equals(n.s3.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c2, n.c3_1, n.c3_2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c3_1, n.c3_2]);
+}, 'Slots: Distributed elements for Slots not in a shadow tree.');
 </script>
 
 <div id="test_slot_name_matching">
@@ -138,6 +168,12 @@ test(() => {
 
   assert_array_equals(n.s1.assignedNodes(), [n.c1, n.c2]);
 }, 'Slots: No direct host child.');
+
+test(() => {
+  let n = createTestTree(test_no_direct_host_child);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1, n.c2]);
+}, 'Slots: No direct host child, elements only.');
 </script>
 
 <div id="test_default_slot">
@@ -214,6 +250,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Slot is assigned to another slot');
+
+test(() => {
+  let n = createTestTree(test_slot_is_assigned_to_slot);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), [n.s1]);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+}, 'Slots: Slot is assigned to another slot, elements only');
 </script>
 
 <div id="test_open_closed">
@@ -245,6 +291,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Open > Closed.');
+
+test(() => {
+  let n = createTestTree(test_open_closed);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), [n.s1]);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+}, 'Slots: Open > Closed, elements only.');
 </script>
 
 <div id="test_closed_closed">
@@ -277,6 +333,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Closed > Closed.');
+
+test(() => {
+  let n = createTestTree(test_closed_closed);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), [n.s1]);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+}, 'Slots: Closed > Closed, elements only.');
 </script>
 
 <div id="test_closed_open">
@@ -308,6 +374,16 @@ test(() => {
   assert_array_equals(n.s1.assignedNodes({ flatten: true }), [n.c1]);
   assert_array_equals(n.s2.assignedNodes({ flatten: true }), [n.c1]);
 }, 'Slots: Closed > Open.');
+
+test(() => {
+  let n = createTestTree(test_closed_open);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), [n.s1]);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c1]);
+}, 'Slots: Closed > Open, elements only.');
 </script>
 
 <div id="test_complex">
@@ -378,6 +454,28 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+  assert_array_equals(n.s2.assignedElements(), [n.c2]);
+  assert_array_equals(n.s3.assignedElements(), [n.c3]);
+  assert_array_equals(n.s4.assignedElements(), []);
+  assert_array_equals(n.s5.assignedElements(), [n.s1, n.c5]);
+  assert_array_equals(n.s6.assignedElements(), [n.s2, n.c6]);
+  assert_array_equals(n.s7.assignedElements(), [n.s3, n.c7]);
+  assert_array_equals(n.s8.assignedElements(), []);
+
+  assert_array_equals(n.s1.assignedElements({ flatten: true }), [n.c1]);
+  assert_array_equals(n.s2.assignedElements({ flatten: true }), [n.c2]);
+  assert_array_equals(n.s3.assignedElements({ flatten: true }), [n.c3]);
+  assert_array_equals(n.s4.assignedElements({ flatten: true }), []);
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, n.c5]);
+  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c2, n.c6]);
+  assert_array_equals(n.s7.assignedElements({ flatten: true }), [n.c3, n.c7]);
+  assert_array_equals(n.s8.assignedElements({ flatten: true }), []);
+}, 'Slots: Complex case: Basic line, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   let d1 = document.createElement('div');
@@ -392,6 +490,20 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  let d1 = document.createElement('div');
+  let t1 = document.createTextNode('test');
+  d1.setAttribute('slot', 'slot1');
+  n.host1.appendChild(d1);
+  n.host1.appendChild(t1);
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1, d1]);
+
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, d1, n.c5]);
+}, 'Slots: Mutation: appendChild, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.c1.setAttribute('slot', 'slot-none');
@@ -401,6 +513,16 @@ test(() => {
 
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c5]);
 }, 'Slots: Mutation: Change slot= attribute 1.');
+
+test(() => {
+  let n = createTestTree(test_complex);
+
+  n.c1.setAttribute('slot', 'slot-none');
+
+  assert_array_equals(n.s1.assignedElements(), []);
+
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
+}, 'Slots: Mutation: Change slot= attribute 1, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -418,6 +540,18 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  n.c1.setAttribute('slot', 'slot2');
+
+  assert_array_equals(n.s1.assignedElements(), []);
+  assert_array_equals(n.s2.assignedElements(), [n.c1, n.c2]);
+
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
+  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c1, n.c2, n.c6]);
+}, 'Slots: Mutation: Change slot= attribute 2, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.c4.setAttribute('slot', 'slot1');
@@ -427,6 +561,16 @@ test(() => {
 
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c1, n.c4, n.c5]);
 }, 'Slots: Mutation: Change slot= attribute 3.');
+
+test(() => {
+  let n = createTestTree(test_complex);
+
+  n.c4.setAttribute('slot', 'slot1');
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1, n.c4]);
+
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c1, n.c4, n.c5]);
+}, 'Slots: Mutation: Change slot= attribute 3, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -442,6 +586,16 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  n.c1.remove();
+
+  assert_array_equals(n.s1.assignedElements(), []);
+
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
+}, 'Slots: Mutation: Remove a child, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   let slot = document.createElement('slot');
@@ -450,6 +604,16 @@ test(() => {
 
   assert_array_equals(slot.assignedNodes(), []);
 }, 'Slots: Mutation: Add a slot: after.');
+
+test(() => {
+  let n = createTestTree(test_complex);
+
+  let slot = document.createElement('slot');
+  slot.setAttribute('name', 'slot1');
+  n.host2.appendChild(slot);
+
+  assert_array_equals(slot.assignedElements(), []);
+}, 'Slots: Mutation: Add a slot: after, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -468,6 +632,19 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  let slot = document.createElement('slot');
+  slot.setAttribute('name', 'slot1');
+  n.host2.insertBefore(slot, n.s1);
+
+  assert_array_equals(slot.assignedElements(), [n.c1]);
+
+  assert_array_equals(n.s7.assignedElements(), [slot, n.s3, n.c7]);
+  assert_array_equals(n.s7.assignedElements({ flatten: true }), [n.c1, n.c3, n.c7]);
+}, 'Slots: Mutation: Add a slot: before, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.s1.remove();
@@ -478,6 +655,17 @@ test(() => {
   assert_array_equals(n.s5.assignedNodes(), [n.c5]);
   assert_array_equals(n.s5.assignedNodes({ flatten: true }), [n.c5]);
 }, 'Slots: Mutation: Remove a slot.');
+
+test(() => {
+  let n = createTestTree(test_complex);
+
+  n.s1.remove();
+
+  assert_array_equals(n.s1.assignedElements(), []);
+
+  assert_array_equals(n.s5.assignedElements(), [n.c5]);
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c5]);
+}, 'Slots: Mutation: Remove a slot, elements only.');
 
 test(() => {
   let n = createTestTree(test_complex);
@@ -495,6 +683,17 @@ test(() => {
 
 test(() => {
   let n = createTestTree(test_complex);
+
+  n.s1.setAttribute('name', 'slot2');
+
+  assert_array_equals(n.s1.assignedElements(), [n.c2]);
+
+  assert_array_equals(n.s5.assignedElements(), [n.s1, n.c5]);
+  assert_array_equals(n.s5.assignedElements({ flatten: true }), [n.c2, n.c5]);
+}, 'Slots: Mutation: Change slot name= attribute, elements only.');
+
+test(() => {
+  let n = createTestTree(test_complex);
   removeWhiteSpaceOnlyTextNodes(n.test_complex);
 
   n.s1.setAttribute('slot', 'slot6');
@@ -505,4 +704,16 @@ test(() => {
   assert_array_equals(n.s6.assignedNodes(), [n.s1, n.s2, n.c6]);
   assert_array_equals(n.s6.assignedNodes({ flatten: true }), [n.c1, n.c2, n.c6]);
 }, 'Slots: Mutation: Change slot slot= attribute.');
+
+test(() => {
+  let n = createTestTree(test_complex);
+
+  n.s1.setAttribute('slot', 'slot6');
+
+  assert_array_equals(n.s1.assignedElements(), [n.c1]);
+
+  assert_array_equals(n.s5.assignedElements(), [n.c5]);
+  assert_array_equals(n.s6.assignedElements(), [n.s1, n.s2, n.c6]);
+  assert_array_equals(n.s6.assignedElements({ flatten: true }), [n.c1, n.c2, n.c6]);
+}, 'Slots: Mutation: Change slot slot= attribute, elements only.');
 </script>


### PR DESCRIPTION
This is the follow up of #4541 which became stale after comments regarding code duplication. The tests in `shadow-dom/HTMLSlotElement-interface.html` are deduplicated. The tests in the other two files are not deduplicated per [this comment](https://github.com/w3c/web-platform-tests/pull/4541#issuecomment-274730713). As I am eagerly waiting for this function, I went ahead and published this updated PR.

Supersedes and closes #4541
Ref https://github.com/whatwg/html/pull/2269

<!-- Reviewable:start -->

<!-- Reviewable:end -->
