### PR TITLE
Add checkpoints to browser history traversal tests

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
+++ b/html/browsers/browsing-the-web/history-traversal/PopStateEvent.html
@@ -11,6 +11,11 @@ test(function () {
 }, 'initPopStateEvent');
 
 test(function () {
+  var popStateEvent = new PopStateEvent("popstate");
+  assert_equals(popStateEvent.state, null, "the PopStateEvent.state");
+}, "Initial value of PopStateEvent.state must be null");
+
+test(function () {
   var state = history.state;
   var data;
   window.addEventListener('popstate', function (e) {

--- a/html/browsers/browsing-the-web/history-traversal/hashchange_event.html
+++ b/html/browsers/browsing-the-web/history-traversal/hashchange_event.html
@@ -18,6 +18,12 @@ window.onload = t.step_func(function () {
 
   location.hash = 'foo';
   window.onhashchange = t.step_func(function (e) {
+    assert_true(e.isTrusted);
+    assert_equals(e.target, window);
+    assert_equals(e.type, "hashchange");
+    assert_true(e instanceof HashChangeEvent);
+    assert_true(e.bubbles, "bubble");
+    assert_false(e.cancelable, "cancelable");
     oldURLs.push(e.oldURL);
     newURLs.push(e.newURL);
     if (newURLs.length === 2) {


### PR DESCRIPTION
According to following sentence in [spec](https://www.w3.org/TR/html51/browsers.html#the-popstateevent-interface), add a PopStateEvent.status initial value test.

>The state attribute must return the value it was initialized to. When the object is created, this attribute must be initialized to null.

According to following sentence in [spec](https://www.w3.org/TR/html51/browsers.html#history-traversal), add some hashchange event checkpoints.

 >If hash changed is true, then fire a trusted event with the name hashchange at the browsing context’s Window object, using the HashChangeEvent interface, with the oldURL attribute initialized to old URL and the newURL attribute initialized to new URL. This event must bubble but not be cancelable and has no default action.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
