### PR TITLE
Fix the flakiness in workers/worker-performance.worker.js

### DIFF
--- a/workers/worker-performance.worker.js
+++ b/workers/worker-performance.worker.js
@@ -16,6 +16,7 @@ test(function testPerformanceNow () {
 }, "Can use performance.now in workers");
 
 test(function testPerformanceMark () {
+    while (performance.now() == start) { }
     performance.mark("mark1");
      // Stall the minimum amount of time to ensure the marks are separate
     var now = performance.now();


### PR DESCRIPTION
This test was relying that performance.now() value changes from the time start was computed to when the first mark entry was created. Explicitly wait for performance.now() value to change instead to make the test more reliable.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
