### PR TITLE
Add in more references for css-color tests

### DIFF
--- a/css/css-color/t32-opacity-basic-0.6-a-ref.html
+++ b/css/css-color/t32-opacity-basic-0.6-a-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+  .test { color: rgb(102, 102, 102); }
+</style>
+<body>
+    <p class="test">This text should be the same color as the line below.</p>
+    <p class="test">This text should be the same color as the line above.</p>
+</body>

--- a/css/css-color/t32-opacity-basic-0.6-a.xht
+++ b/css/css-color/t32-opacity-basic-0.6-a.xht
@@ -6,6 +6,7 @@
 		<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#transparency" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgb-color" />
+		<link rel="match" href="t32-opacity-basic-0.6-a-ref.html" />
 		<meta name="flags" content="" />
 		<meta name="assert" content="Opacity of 0.6 makes box partially opaque.  Colors are in sRGB color space (may test)." />
 		<style type="text/css"><![CDATA[

--- a/css/css-color/t32-opacity-zorder-c-ref.html
+++ b/css/css-color/t32-opacity-zorder-c-ref.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+  table { border-spacing: 2px; }
+  td { border: 1px solid; }
+  td, div { width: 10px; height: 10px; }
+  div.opc { opacity: 0.99; }
+  div.green { background: green; }
+  div.up { margin-top: -10px; }
+  div.red { background: red; }
+</style>
+<body>
+  <p>Each of the following boxes should have a green or
+  very-nearly-green square inside of it:</p>
+  <table><tr>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="red"></div>
+      <div class="up opc green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="red"></div>
+      <div class="up opc green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="red"></div>
+      <div class="up opc green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="green"></div>
+    </td>
+    <td>
+      <div class="red"></div>
+      <div class="up opc green"></div>
+    </td>
+    <td>
+      <div class="red"></div>
+      <div class="up opc green"></div>
+    </td>
+  </tr></table>
+</body>

--- a/css/css-color/t32-opacity-zorder-c.xht
+++ b/css/css-color/t32-opacity-zorder-c.xht
@@ -5,6 +5,7 @@
 		<link rel="author" title="L. David Baron" href="https://dbaron.org/" />
 		<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#transparency" />
+		<link rel="match" href="t32-opacity-zorder-c-ref.html" />
 		<meta name="flags" content="" />
 		<meta name="assert" content="Opacity has z-ordering treatment of positioned elements and z-index applies." />
 		<style type="text/css"><![CDATA[

--- a/css/css-color/t421-rgb-hex3-expand-b-ref.html
+++ b/css/css-color/t421-rgb-hex3-expand-b-ref.html
@@ -17,8 +17,8 @@
   <p>The left and right cells in each row of the following table should be slightly <em>different</em> colors.  The right side should be slightly darker than the left.</p>
 
   <table>
-    <tr><td style="background: #e09020">&nbsp;</td><td style="background: #e09020">&nbsp;</td></tr>
-    <tr><td style="background: #f0b000">&nbsp;</td><td style="background: #f0b000">&nbsp;</td></tr>
-    <tr><td style="background: #308010">&nbsp;</td><td style="background: #308010">&nbsp;</td></tr>
+    <tr><td style="background: #ee9922">&nbsp;</td><td style="background: #e09020">&nbsp;</td></tr>
+    <tr><td style="background: #ffbb00">&nbsp;</td><td style="background: #f0b000">&nbsp;</td></tr>
+    <tr><td style="background: #338811">&nbsp;</td><td style="background: #308010">&nbsp;</td></tr>
   </table>
 </body>

--- a/css/css-color/t421-rgb-hex3-expand-b.xht
+++ b/css/css-color/t421-rgb-hex3-expand-b.xht
@@ -5,6 +5,7 @@
 		<link rel="author" title="L. David Baron" href="https://dbaron.org/" />
 		<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgb-color" />
+		<link rel="match" href="t421-rgb-hex3-expand-b-ref.html" />
 		<meta name="flags" content="" />
 		<meta name="assert" content="Test that 3-digit #rgb values are expanded into #rrggbb and not #r0g0b0" />
 		<style type="text/css"><![CDATA[

--- a/css/css-color/t422-rgba-a0.6-a.xht
+++ b/css/css-color/t422-rgba-a0.6-a.xht
@@ -6,6 +6,7 @@
 		<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgba-color" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgb-color" />
+		<link rel="match" href="t32-opacity-basic-0.6-a-ref.html" />
 		<meta name="flags" content="" />
 		<meta name="assert" content="Opacity of 0.6 makes text partially opaque.  Colors are in sRGB color space (may test)." />
 		<style type="text/css"><![CDATA[
@@ -16,7 +17,7 @@
 		]]></style>
 	</head>
 	<body>
-		<p id="one">This text should be the same color (a shade of gray) as the line below.</p>
-		<p id="two">This text should be the same color (a shade of gray) as the line above.</p>
+		<p id="one">This text should be the same color as the line below.</p>
+		<p id="two">This text should be the same color as the line above.</p>
 	</body>
 </html>

--- a/css/css-color/t425-hsla-basic-a-ref.html
+++ b/css/css-color/t425-hsla-basic-a-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    #one { color: #66FF66; }
+</style>
+<body>
+    <p id="one">This text should be light green (the same color as the line below).</p>
+    <p id="one">This text should be light green (the same color as the line above).</p>
+</body>

--- a/css/css-color/t425-hsla-basic-a.xht
+++ b/css/css-color/t425-hsla-basic-a.xht
@@ -5,11 +5,11 @@
 		<link rel="author" title="L. David Baron" href="https://dbaron.org/" />
 		<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
 		<link rel="help" href="http://www.w3.org/TR/css3-color/#hsla-color" />
+		<link rel="match" href="t425-hsla-basic-a-ref.html" />
 		<meta name="flags" content="" />
 		<meta name="assert" content="Test basic functioning of hsla() colors." />
 		<style type="text/css"><![CDATA[
 		html, body { background: white; }
-		p { font-weight: bold; margin: 0; }
 		#one { color: hsla(120, 100%, 70%, 1.0); }
 		#two { color: hsla(120, 100%, 50%, 0.6); }
 		]]></style>


### PR DESCRIPTION
These should be the last tests missing references in css-color.

The tests `t32-opacity-basic-0.6-a.xht`, `t422-rgba-a0.6-a.xht`, and `t425-hsla-basic-a.xht` are failing on all platforms with Travis, but the references are basically verifying the reference `<p>` in the test itself, so I'm not sure if this is just something that all implementations have done incorrectly or what.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
