### PR TITLE
Test that geometry elements have path length

### DIFF
--- a/svg/types/elements/SVGGeometryElement-rect.svg
+++ b/svg/types/elements/SVGGeometryElement-rect.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#types-InterfaceSVGGeometryElement"/>
+    <h:meta name="assert" content="SVGGeometryElement members work for rect elements."/>
+  </metadata>
+  <style>
+    rect {
+      stroke-width: 10;
+    }
+  </style>
+  <rect id="box" x="50" y="50" width="200" height="100" pathLength="6"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+  test(function() {
+    var box = document.getElementById('box');
+
+    assert_equals(box.pathLength.baseVal, 6);
+
+    assert_equals(box.getTotalLength(), 600);
+
+    assert_equals(box.getPointAtLength(210).x, 250);
+    assert_equals(box.getPointAtLength(210).y, 60);
+  }, 'getTotalLength and getPointAtLength do not take pathLength into account');
+  ]]></script>
+</svg>


### PR DESCRIPTION
The attribute 'pathLength' and the methods
'getTotalLength()' and 'getPointAtLength(float distance)'
were previously defined only for <path> elements. In SVG2,
they are available for all SVGGeometryElement instances.

Spec:
https://svgwg.org/svg2-draft/single-page.html#types-InterfaceSVGGeometryElement

<!-- Reviewable:start -->

<!-- Reviewable:end -->
