### PR TITLE
Test that SVGAnimatedPathData is not supported

### DIFF
--- a/svg/path/interfaces/SVGAnimatedPathData-removed.svg
+++ b/svg/path/interfaces/SVGAnimatedPathData-removed.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#changes-paths"/>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG11/paths.html#InterfaceSVGAnimatedPathData"/>
+    <h:meta name="assert" content="SVGAnimatedPathData interface is not supported."/>
+  </metadata>
+  <path id="track" d="m 10 20 h 30"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+  test(function() {
+    assert_true(window.SVGAnimatedPathData === undefined);
+
+    var track = document.getElementById('track');
+    assert_equals(track.__proto__, SVGPathElement.prototype);
+    assert_true(track.pathSegList === undefined);
+    assert_true(track.normalizedPathSegList === undefined);
+    assert_true(track.animatedPathSegList === undefined);
+    assert_true(track.animatedNormalizedPathSegList === undefined);
+  });
+  ]]></script>
+</svg>


### PR DESCRIPTION
https://svgwg.org/svg2-draft/single-page.html#changes-paths
"Removed the SVGPathSeg* and SVGAnimatedPathData interfaces and the
related methods on SVGPathElement."

<!-- Reviewable:start -->

<!-- Reviewable:end -->
