### PR TITLE
Test that invalid paths do not render

### DIFF
--- a/svg/path/error-handling/bounding.svg
+++ b/svg/path/error-handling/bounding.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
+    <h:meta name="assert" content="render up to (but not including) the first error"/>
+  </metadata>
+  <g id="container">
+    <path transform="translate(90,10)" />
+    <path transform="translate(80,20)" d="none" />
+    <path transform="translate(70,30)" d="# invalid" />
+    <path transform="translate(60,40)" d="m 0 0 l 3 -4 z # ignored suffix v 123" />
+    <path transform="translate(50,50)" d="" />
+    <path transform="translate(40,60)" d="m 0 0 l -9 11 -123 z # ignore last l parameter" />
+    <polygon transform="translate(20,80)" />
+    <polyline transform="translate(10,90)" />
+  </g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+  test(function() {
+    var container = document.getElementById('container');
+    var bbox = container.getBBox();
+
+    // The rendered paths are "m 0 0 l 3 -4 z" and "m 0 0 l -9 11"
+    assert_equals(bbox.x, 31);
+    assert_equals(bbox.y, 36);
+
+    assert_equals(bbox.width, 32);
+    assert_equals(bbox.height, 35);
+  });
+  ]]></script>
+</svg>

--- a/svg/path/error-handling/render-until-error-ref.svg
+++ b/svg/path/error-handling/render-until-error-ref.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="100" height="100">
+  <style>
+    path {
+      stroke: lime;
+    }
+  </style>
+  <g id="container">
+    <path transform="translate(60,40)" d="m 0 0 l 3 -4 z" />
+    <path transform="translate(40,60)" d="m 0 0 l -9 11" />
+  </g>
+</svg>

--- a/svg/path/error-handling/render-until-error.svg
+++ b/svg/path/error-handling/render-until-error.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="100" height="100">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataErrorHandling"/>
+    <h:link rel="match" href="render-until-error-ref.svg"/>
+    <h:meta name="assert" content="render up to (but not including) the first error"/>
+  </metadata>
+  <style>
+    path {
+      stroke: lime;
+    }
+  </style>
+  <g id="container">
+    <path transform="translate(90,10)" />
+    <path transform="translate(80,20)" d="none" />
+    <path transform="translate(70,30)" d="# invalid" />
+    <path transform="translate(60,40)" d="m 0 0 l 3 -4 z # ignored suffix v 123" />
+    <path transform="translate(50,50)" d="" />
+    <path transform="translate(40,60)" d="m 0 0 l -9 11 -123 z # ignore last l parameter" />
+    <polygon transform="translate(20,80)" />
+    <polyline transform="translate(10,90)" />
+  </g>
+</svg>


### PR DESCRIPTION
Paths with no data set, and invalid path commands appearing
after valid commands, do not contribute to rendering or
bounding box calculations.

https://svgwg.org/svg2-draft/single-page.html#changes-paths
"Define ‘path’, ‘polygon’ and ‘polyline’ elements with no data set (empty
or zero valid commands) to not render."

<!-- Reviewable:start -->

<!-- Reviewable:end -->
