### PR TITLE
SVG: closepath completes command by initial point

### DIFF
--- a/svg/path/closepath/segment-completing-ref.svg
+++ b/svg/path/closepath/segment-completing-ref.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="300" height="200">
+  <style>
+    path {
+      stroke: blue;
+    }
+  </style>
+  <path d="M 10 10 z m 20 70 h 10 v 10 h -10 l 0 -10 M 70 30 q 20 0 20 20 t -20 20 t -20 -20 T 70 30" />
+</svg>

--- a/svg/path/closepath/segment-completing.svg
+++ b/svg/path/closepath/segment-completing.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="300" height="200">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#paths-PathDataClosePathCommand"/>
+    <h:link rel="match" href="segment-completing-ref.svg"/>
+    <h:meta name="assert" content="initial subpath point used to complete segment."/>
+  </metadata>
+  <style>
+    path {
+      stroke: blue;
+    }
+  </style>
+  <path d="M 10 10 z m 20 70 h 10 v 10 h -10 l z M 70 30 q 20 0 20 20 t -20 20 t -20 -20 T z" />
+</svg>


### PR DESCRIPTION
https://svgwg.org/svg2-draft/single-page.html#paths-PathDataClosePathCommand
If the previous command is a "lineto", "curveto", "smooth curveto",
"quadratic Bézier curveto", "smooth quadratic Bézier curveto", or
"elliptical arc", that is missing required coordinate data, then this is
a segment-completing close path command. No additional path segment is
generated by the command; instead, the initial point for this subpath
must be used in place of each missing (x,y) coordinate to complete the
previous segment.

We test using lineto and quadratic Bézier curveto.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
