### PR TITLE
Update registration-scope.https.html to expect a TypeError when regis…

### DIFF
--- a/service-workers/service-worker/resources/registration-tests-scope.js
+++ b/service-workers/service-worker/resources/registration-tests-scope.js
@@ -94,7 +94,7 @@ function registration_tests_scope(register_method, check_error_types) {
       var script = 'resources/empty-worker.js';
       var scope = 'filesystem:' + normalizeURL('resources/scope/filesystem-scope-url');
       return promise_rejects(t,
-          check_error_types ? 'SecurityError' : null,
+          check_error_types ? new TypeError() : null,
           register_method(script, {scope: scope}),
           'Registering with the scope that has same-origin filesystem: URL ' +
               'should fail with SecurityError.');


### PR DESCRIPTION
…tering a non-HTTP/HTTPS URL

The test expected a SecurityError, which does not match the latest specification:
- https://w3c.github.io/ServiceWorker/#start-register (Step 2)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
