### PR TITLE
registration-security-error.https.html redirects to an invalid URL

### DIFF
--- a/service-workers/service-worker/resources/registration-tests-security-error.js
+++ b/service-workers/service-worker/resources/registration-tests-security-error.js
@@ -40,7 +40,7 @@ function registration_tests_security_error(register_method, check_error_types) {
 
   promise_test(function(t) {
       var script = 'resources/redirect.py?Redirect=' +
-                    encodeURIComponent('/resources/registration-worker.js');
+                    encodeURIComponent('/service-workers/service-worker/resources/registration-worker.js');
       var scope = 'resources/scope/redirect/';
       return promise_rejects(t,
           check_error_types ? 'SecurityError' : null,


### PR DESCRIPTION
As a result, the promise gets rejected even if the browser does not use "error" redirect mode
for fetching the script.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
