### PR TITLE
[wptserve] Add on-demand file hash computation

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-classic.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-classic.sub.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a module script</title>
+<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a classic script</title>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <meta http-equiv="Content-Security-Policy" content="require-sri-for script">
 
-<script src="/resources/testharness.js" integrity="sha384-4Nybydhnr3tOpv1yrTkDxu3RFpnxWAxlU5kGn7c8ebKvh1iUdfVMjqP6jf0dacrV"></script>
-<script src="/resources/testharnessreport.js" integrity="sha384-GOnHxuyo+nnsFAe4enY+RAl4/+w5NPMJPCQiDroTjxtR7ndRz7Uan8vNbM2qWKmU"></script>
+<script src="/resources/testharness.js" integrity="sha384-{{file_hash(sha384, resources/testharness.js)}}"></script>
+<script src="/resources/testharnessreport.js" integrity="sha384-{{file_hash(sha384, resources/testharnessreport.js)}}"></script>
 
 <div id="dummy"></div>
 
-<script type="module">
+<script>
 function createTestPromise() {
   return new Promise((resolve, reject) => {
     window.continueTest = resolve;

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-module.sub.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-integrity-module.sub.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a classic script</title>
+<title>import() doesn't have any integrity metadata when initiated by compiled strings inside a module script</title>
 <link rel="author" title="Domenic Denicola" href="mailto:d@domenic.me">
 <meta http-equiv="Content-Security-Policy" content="require-sri-for script">
 
-<script src="/resources/testharness.js" integrity="sha384-4Nybydhnr3tOpv1yrTkDxu3RFpnxWAxlU5kGn7c8ebKvh1iUdfVMjqP6jf0dacrV"></script>
-<script src="/resources/testharnessreport.js" integrity="sha384-GOnHxuyo+nnsFAe4enY+RAl4/+w5NPMJPCQiDroTjxtR7ndRz7Uan8vNbM2qWKmU"></script>
+<script src="/resources/testharness.js" integrity="sha384-{{file_hash(sha384, resources/testharness.js)}}"></script>
+<script src="/resources/testharnessreport.js" integrity="sha384-{{file_hash(sha384, resources/testharnessreport.js)}}"></script>
 
 <div id="dummy"></div>
 
-<script>
+<script type="module">
 function createTestPromise() {
   return new Promise((resolve, reject) => {
     window.continueTest = resolve;

--- a/tools/wptserve/tests/functional/docroot/sub_file_hash.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_file_hash.sub.txt
@@ -1,0 +1,6 @@
+md5: {{file_hash(md5, sub_file_hash_subject.txt)}}
+sha1: {{file_hash(sha1, sub_file_hash_subject.txt)}}
+sha224: {{file_hash(sha224, sub_file_hash_subject.txt)}}
+sha256: {{file_hash(sha256, sub_file_hash_subject.txt)}}
+sha384: {{file_hash(sha384, sub_file_hash_subject.txt)}}
+sha512: {{file_hash(sha512, sub_file_hash_subject.txt)}}

--- a/tools/wptserve/tests/functional/docroot/sub_file_hash_subject.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_file_hash_subject.txt
@@ -1,0 +1,2 @@
+This file is used to verify expected behavior of the `file_hash` "sub"
+function.

--- a/tools/wptserve/tests/functional/docroot/sub_file_hash_unrecognized.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_file_hash_unrecognized.sub.txt
@@ -1,0 +1,1 @@
+{{file_hash(sha007, sub_file_hash_subject.txt)}}

--- a/tools/wptserve/tests/functional/docroot/sub_location.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_location.sub.txt
@@ -1,0 +1,8 @@
+host: {{location[host]}}
+hostname: {{location[hostname]}}
+path: {{location[path]}}
+pathname: {{location[pathname]}}
+port: {{location[port]}}
+query: {{location[query]}}
+scheme: {{location[scheme]}}
+server: {{location[server]}}

--- a/tools/wptserve/tests/functional/docroot/sub_url_base.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_url_base.sub.txt
@@ -1,0 +1,1 @@
+Before {{url_base}} After

--- a/tools/wptserve/tests/functional/docroot/sub_uuid.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_uuid.sub.txt
@@ -1,0 +1,1 @@
+Before {{uuid()}} After

--- a/tools/wptserve/tests/functional/docroot/sub_var.sub.txt
+++ b/tools/wptserve/tests/functional/docroot/sub_var.sub.txt
@@ -1,0 +1,1 @@
+{{$first:host}} {{$second:ports[http][0]}} A {{$second}} B {{$first}} C

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -63,9 +63,36 @@ class TestSub(TestUsingServer):
         expected = "PASS"
         self.assertEqual(resp.read().rstrip(), expected)
 
+    def test_sub_location(self):
+        resp = self.request("/sub_location.sub.txt?query_string")
+        expected = """
+host: localhost:{0}
+hostname: localhost
+path: /sub_location.sub.txt
+pathname: /sub_location.sub.txt
+port: {0}
+query: ?query_string
+scheme: http
+server: http://localhost:{0}""".format(self.server.port)
+        self.assertEqual(resp.read().rstrip(), expected.strip())
+
     def test_sub_params(self):
         resp = self.request("/sub_params.txt", query="test=PASS&pipe=sub")
         expected = "PASS"
+        self.assertEqual(resp.read().rstrip(), expected)
+
+    def test_sub_url_base(self):
+        resp = self.request("/sub_url_base.sub.txt")
+        self.assertEqual(resp.read().rstrip(), "Before / After")
+
+    def test_sub_uuid(self):
+        resp = self.request("/sub_uuid.sub.txt")
+        self.assertRegexpMatches(resp.read().rstrip(), r"Before [a-f0-9-]+ After")
+
+    def test_sub_var(self):
+        resp = self.request("/sub_var.sub.txt")
+        port = self.server.port
+        expected = "localhost %s A %s B localhost C" % (port, port)
         self.assertEqual(resp.read().rstrip(), expected)
 
 class TestTrickle(TestUsingServer):

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+import urllib2
 import time
 import json
 
@@ -57,6 +58,22 @@ class TestSub(TestUsingServer):
         resp = self.request("/sub.txt", query="pipe=sub")
         expected = "localhost localhost %i" % self.server.port
         self.assertEqual(resp.read().rstrip(), expected)
+
+    def test_sub_file_hash(self):
+        resp = self.request("/sub_file_hash.sub.txt")
+        expected = """
+md5: JmI1W8fMHfSfCarYOSxJcw==
+sha1: nqpWqEw4IW8NjD6R375gtrQvtTo=
+sha224: RqQ6fMmta6n9TuA/vgTZK2EqmidqnrwBAmQLRQ==
+sha256: G6Ljg1uPejQxqFmvFOcV/loqnjPTW5GSOePOfM/u0jw=
+sha384: lkXHChh1BXHN5nT5BYhi1x67E1CyYbPKRKoF2LTm5GivuEFpVVYtvEBHtPr74N9E
+sha512: r8eLGRTc7ZznZkFjeVLyo6/FyQdra9qmlYCwKKxm3kfQAswRS9+3HsYk3thLUhcFmmWhK4dXaICz
+JwGFonfXwg=="""
+        self.assertEqual(resp.read().rstrip(), expected.strip())
+
+    def test_sub_file_hash_unrecognized(self):
+        with self.assertRaises(urllib2.HTTPError):
+            self.request("/sub_file_hash_unrecognized.sub.txt")
 
     def test_sub_headers(self):
         resp = self.request("/sub_headers.txt", query="pipe=sub", headers={"X-Test": "PASS"})

--- a/tools/wptserve/tests/test_replacement_tokenizer.py
+++ b/tools/wptserve/tests/test_replacement_tokenizer.py
@@ -6,7 +6,7 @@ from wptserve.pipes import ReplacementTokenizer
     "content,expected",
     [
         ["aaa", [('ident', 'aaa')]],
-        ["bbb()", [('ident', 'bbb()')]],
+        ["bbb()", [('ident', 'bbb'), ('arguments', [])]],
         ["$ccc:ddd", [('var', '$ccc'), ('ident', 'ddd')]],
         ["$eee", [('ident', '$eee')]],
         ["fff[0]", [('ident', 'fff'), ('index', 0)]],

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -351,7 +351,7 @@ def sub(request, response, escape_type="html"):
     It is also possible to assign a value to a variable name, which must start with
     the $ character, using the ":" syntax e.g.
 
-    {{$id:uuid()}
+    {{$id:uuid()}}
 
     Later substitutions in the same file may then refer to the variable
     by name e.g.


### PR DESCRIPTION
Certain tests require that all HTML `<script>` tags be declared with an
`integrity` attribute which specifies the cryptographic hash of the file
to be loaded. These tests were initially implemented with a static value
for the hash of the test harness files located in the shared "resources"
directory.

In order to support continued development of those shared files, the
tests should be authored in a way that is tolerant of such
modifications.

Introduce a new templating capability to the `wptserve` utility which
allows markup to be rendered with dynamically-computed hash values.
Allowing the shared resources to change independently of the tests that
rely on them.

---

Hi @gsnedders,

I'm working on an enhancement to `testharness.js` (see gh-6075), and I found
that my latest patch broke a few tests (specifically, those introduced via
gh-7684). I was surprised to find that the error had nothing to do with the
semantics of my change--just the fact that I had made any change at all.

This is an initial attempt to facilitate continued development of
`testharness.js`. It's pretty rough because it's based on an afternoon's review
of the `wptserve` internals. I'm requesting your review because I believe you
may have some vision for the overall direction of WPT's server. If you think
there is someone better to give direction, then I'm all ears!

(@annevk and @domenic: my hope is that if this lands, future tests that require
strict file integrity checking can be a little more resilient to change.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8735)
<!-- Reviewable:end -->
