### PR TITLE
webrtc: use 'kind' instead of 'type'

### DIFF
--- a/webrtc/RTCPeerConnection-createOffer-offerToReceive.html
+++ b/webrtc/RTCPeerConnection-createOffer-offerToReceive.html
@@ -10,13 +10,13 @@
 
   // Run some tests for both audio and video kinds
   ['audio', 'video'].forEach((kind) => {
-    const capsType = kind[0].toUpperCase() + kind.slice(1);
+    const capsKind = kind[0].toUpperCase() + kind.slice(1);
 
     const offerToReceiveTrue = {};
-    offerToReceiveTrue[`offerToReceive${capsType}`] = true;
+    offerToReceiveTrue[`offerToReceive${capsKind}`] = true;
 
     const offerToReceiveFalse = {};
-    offerToReceiveFalse[`offerToReceive${capsType}`] = false;
+    offerToReceiveFalse[`offerToReceive${capsKind}`] = false;
 
     // Start testing
     promise_test(t => {
@@ -28,7 +28,7 @@
         assert_equals(pc.getTransceivers().length, 0,
           'Expect pc to have no transceivers');
       });
-    }, `createOffer() with offerToReceive${capsType} set to false should not create a transceiver`);
+    }, `createOffer() with offerToReceive${capsKind} set to false should not create a transceiver`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -42,7 +42,7 @@
         assert_equals(transceiver.direction, 'recvonly',
           'Expect transceiver to have "recvonly" direction');
       });
-    }, `createOffer() with offerToReceive${capsType} should create a "recvonly" transceiver`);
+    }, `createOffer() with offerToReceive${capsKind} should create a "recvonly" transceiver`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -62,7 +62,7 @@
           'Expect pc to still have only one transceiver');
       })
       ;
-    }, `offerToReceive${capsType} option should be ignored if a non-stopped "recvonly" transceiver exists`);
+    }, `offerToReceive${capsKind} option should be ignored if a non-stopped "recvonly" transceiver exists`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -86,7 +86,7 @@
           'Expect pc to still have only one transceiver');
       })
       ;
-    }, `offerToReceive${capsType} option should be ignored if a non-stopped "sendrecv" transceiver exists`);
+    }, `offerToReceive${capsKind} option should be ignored if a non-stopped "sendrecv" transceiver exists`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -105,7 +105,7 @@
           'Expect transceiver to have "sendonly" direction');
       })
       ;
-    }, `offerToReceive${capsType} set to false with a track should create a "sendonly" transceiver`);
+    }, `offerToReceive${capsKind} set to false with a track should create a "sendonly" transceiver`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -122,7 +122,7 @@
           'Expect transceiver to have "inactive" direction');
       })
       ;
-    }, `offerToReceive${capsType} set to false with a "recvonly" transceiver should change the direction to "inactive"`);
+    }, `offerToReceive${capsKind} set to false with a "recvonly" transceiver should change the direction to "inactive"`);
 
     promise_test(t => {
       const pc = new RTCPeerConnection();
@@ -148,7 +148,7 @@
           'Expect transceiver to have "sendonly" direction');
       })
       ;
-    }, `subsequent offerToReceive${capsType} set to false with a track should change the direction to "sendonly"`);
+    }, `subsequent offerToReceive${capsKind} set to false with a track should change the direction to "sendonly"`);
   });
 
   promise_test(t => {

--- a/webrtc/RTCPeerConnection-createOffer-offerToReceive.html
+++ b/webrtc/RTCPeerConnection-createOffer-offerToReceive.html
@@ -8,9 +8,9 @@
 <script>
   'use strict';
 
-  // Run some tests for both audio and video types
-  ['audio', 'video'].forEach((type) => {
-    const capsType = type[0].toUpperCase() + type.slice(1);
+  // Run some tests for both audio and video kinds
+  ['audio', 'video'].forEach((kind) => {
+    const capsType = kind[0].toUpperCase() + kind.slice(1);
 
     const offerToReceiveTrue = {};
     offerToReceiveTrue[`offerToReceive${capsType}`] = true;
@@ -67,7 +67,7 @@
     promise_test(t => {
       const pc = new RTCPeerConnection();
 
-      return getTrackFromUserMedia(type)
+      return getTrackFromUserMedia(kind)
       .then(([track, stream]) => {
         pc.addTrack(track, stream);
         return pc.createOffer();
@@ -91,7 +91,7 @@
     promise_test(t => {
       const pc = new RTCPeerConnection();
 
-      return getTrackFromUserMedia(type)
+      return getTrackFromUserMedia(kind)
       .then(([track, stream]) => {
         pc.addTrack(track, stream);
         return pc.createOffer(offerToReceiveFalse);
@@ -110,7 +110,7 @@
     promise_test(t => {
       const pc = new RTCPeerConnection();
 
-      pc.addTransceiver(type, {direction: 'recvonly'});
+      pc.addTransceiver(kind, {direction: 'recvonly'});
 
       return pc.createOffer(offerToReceiveFalse)
       .then(() => {
@@ -128,7 +128,7 @@
       const pc = new RTCPeerConnection();
       const pc2 = new RTCPeerConnection();
 
-      return getTrackFromUserMedia(type)
+      return getTrackFromUserMedia(kind)
       .then(([track, stream]) => {
         pc.addTrack(track, stream);
         return pc.createOffer();


### PR DESCRIPTION
spec change in https://github.com/w3c/webrtc-pc/pull/1686

@adam-be @alvestrand PTAL

<!-- Reviewable:start -->

<!-- Reviewable:end -->
