### PR TITLE
Do not return value from "cleanup" functions

### DIFF
--- a/html/semantics/forms/the-select-element/selected-index.html
+++ b/html/semantics/forms/the-select-element/selected-index.html
@@ -70,7 +70,7 @@ test(function () {
   assertSelectedIndex(select, 0);
   select.selectedIndex = 2;
   assertSelectedIndex(select, 2);
-  this.add_cleanup(() => select.selectedIndex = 0);
+  this.add_cleanup(() => { select.selectedIndex = 0; });
 }, "set (HTMLSelectElement)");
 
 test(function () {
@@ -78,7 +78,7 @@ test(function () {
   assertSelectedIndex(select, 0);
   select.options.selectedIndex = 2;
   assertSelectedIndex(select, 2);
-  this.add_cleanup(() => select.selectedIndex = 0);
+  this.add_cleanup(() => { select.selectedIndex = 0; });
 }, "set (HTMLOptionsCollection)");
 
 test(function () {

--- a/service-workers/service-worker/postmessage.https.html
+++ b/service-workers/service-worker/postmessage.https.html
@@ -13,7 +13,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          t.add_cleanup(() => r.unregister());
+          t.add_cleanup(() => { r.unregister(); });
           registration = r;
           worker = registration.installing;
 
@@ -62,7 +62,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          t.add_cleanup(() => r.unregister());
+          t.add_cleanup(() => { r.unregister(); });
 
           var ab = text_encoder.encode(message);
           assert_equals(ab.byteLength, message.length);
@@ -102,7 +102,7 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
-          t.add_cleanup(() => r.unregister());
+          t.add_cleanup(() => { r.unregister(); });
 
           var channel = new MessageChannel;
           port = channel.port1;

--- a/service-workers/service-worker/postmessage.https.html
+++ b/service-workers/service-worker/postmessage.https.html
@@ -13,6 +13,10 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
+          // TODO: return the Promise created by `r.unregister`once
+          // `testharness.js` has been updated to honor thenables returned by
+          // cleanup functions.
+          // See https://github.com/w3c/web-platform-tests/pull/8748
           t.add_cleanup(() => { r.unregister(); });
           registration = r;
           worker = registration.installing;
@@ -62,6 +66,10 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
+          // TODO: return the Promise created by `r.unregister`once
+          // `testharness.js` has been updated to honor thenables returned by
+          // cleanup functions.
+          // See https://github.com/w3c/web-platform-tests/pull/8748
           t.add_cleanup(() => { r.unregister(); });
 
           var ab = text_encoder.encode(message);
@@ -102,6 +110,10 @@ promise_test(t => {
 
     return service_worker_unregister_and_register(t, script, scope)
       .then(r => {
+          // TODO: return the Promise created by `r.unregister`once
+          // `testharness.js` has been updated to honor thenables returned by
+          // cleanup functions.
+          // See https://github.com/w3c/web-platform-tests/pull/8748
           t.add_cleanup(() => { r.unregister(); });
 
           var channel = new MessageChannel;


### PR DESCRIPTION
Today, the return value of functions provided to the global
`add_cleanup` function has no effect on the behavior of the test runner.
An upcoming feature addition to `testharness.js` will cause the return
value to influence test results [1].

Despite this, some existing tests have already been authored to return a
value. Introducing the new test harness functionality may trigger
unexpected results in those contexts. To avoid this, refactor existing
tests to avoid returning a value.

[1] https://github.com/w3c/web-platform-tests/issues/6075

---

The Service Worker test I've modified returns a "thenable" which is actually
amenable to the proposed `testharness.js` extension. We could leave it as-is,
and when/if an implementation for gh-6075 lands, that test would become less
fragile automatically. Still, it seems safer to introduce the new functionality
with the confidence that it doesn't trigger *any* implicit opt-in, and then
incrementally begin to use it with intentional follow-up commits. (And for the
Service Worker test suite, this will entail updating many files besides the one
modified here.)

For those curious: I located these tests programatically by [modifying the test
runner](https://github.com/w3c/web-platform-tests/compare/w3c:de65155...bocoup:8fe4fe1) and using that to run all tests that reference `add_cleanup`:

    grep 'add_cleanup' . -rl --include '*.js' --include '*.html' | xargs ./wpt run chrome

And

    grep 'add_cleanup' . -rl --include '*.js' --include '*.html' | xargs ./wpt run firefox

Both browsers identified the same usages.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
