### PR TITLE
Fix windowclient-navigate.https.html to expect success for uncontroll…

### DIFF
--- a/service-workers/service-worker/windowclient-navigate.https.html
+++ b/service-workers/service-worker/windowclient-navigate.https.html
@@ -44,7 +44,6 @@ navigate_test({
     src_url: '/common/blank.html',
     dest_url: 'blank.html?navigate',
     expected: normalizeURL(SCOPE) + '?navigate',
-    expected: 'TypeError',
   });
 
 navigate_test({

--- a/service-workers/service-worker/windowclient-navigate.https.html
+++ b/service-workers/service-worker/windowclient-navigate.https.html
@@ -28,14 +28,14 @@ navigate_test({
 navigate_test({
     description: 'in scope but not controlled test on installing worker',
     dest_url: 'blank.html?navigate',
-    expected: 'TypeError',
+    expected: normalizeURL(SCOPE) + '?navigate',
     wait_state: 'installing',
   });
 
 navigate_test({
     description: 'in scope but not controlled test on active worker',
     dest_url: 'blank.html?navigate',
-    expected: 'TypeError',
+    expected: normalizeURL(SCOPE) + '?navigate',
     should_be_reload: false,
   });
 
@@ -43,6 +43,7 @@ navigate_test({
     description: 'out of scope',
     src_url: '/common/blank.html',
     dest_url: 'blank.html?navigate',
+    expected: normalizeURL(SCOPE) + '?navigate',
     expected: 'TypeError',
   });
 


### PR DESCRIPTION
…ed clients.

The test uses `Clients.matchAll({ includeUncontrolled: true })` and
`Client.navigate()` does not care if the window is controlled.  The
navigate algorithm only checks if the final window is cross-origin.

Its unclear to me why chrome expects these navigations to fail to return a Client, but I don't see anything in the spec matching that behavior.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
