### PR TITLE
Make WindowClient.navigate()'s return promise type nullable

### DIFF
--- a/service-workers/service-worker/resources/interfaces-idls.js
+++ b/service-workers/service-worker/resources/interfaces-idls.js
@@ -44,7 +44,7 @@ interface WindowClient : Client {
   readonly attribute boolean focused;
   [SameObject] readonly attribute FrozenArray<USVString> ancestorOrigins;
   [NewObject] Promise<WindowClient> focus();
-  [NewObject] Promise<WindowClient> navigate(USVString url);
+  [NewObject] Promise<WindowClient?> navigate(USVString url);
 };
 
 [Exposed=ServiceWorker]


### PR DESCRIPTION
Per https://github.com/w3c/ServiceWorker/commit/fb87f29eaed9ea1df0f8f97fa791eb62b4f3e495.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
