### PR TITLE
Remove spurious onload="load_test_attr.done()" in testharness.js tests

### DIFF
--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -6,7 +6,7 @@ The test suite for the `testharness.js` testing framework.
 
 Install the following dependencies:
 
-- [Python 2.7](https://www.python.org/)
+- [Python 2.7.9+](https://www.python.org/)
 - [the tox Python package](https://tox.readthedocs.io/en/latest/)
 - [the Mozilla Firefox web browser](https://mozilla.org/firefox)
 - [the GeckoDriver server](https://github.com/mozilla/geckodriver)

--- a/resources/test/tests/api-tests-2.html
+++ b/resources/test/tests/api-tests-2.html
@@ -3,7 +3,7 @@
 <head>
 <title>Sample HTML5 API Tests</title>
 </head>
-<body onload="load_test_attr.done()">
+<body>
 <h1>Sample HTML5 API Tests</h1>
 <p>There should be two results</p>
 <div id="log"></div>

--- a/resources/test/tests/api-tests-3.html
+++ b/resources/test/tests/api-tests-3.html
@@ -5,7 +5,7 @@
 </head>
 <script src="../../testharness.js"></script>
 
-<body onload="load_test_attr.done()">
+<body>
 <h1>Sample HTML5 API Tests</h1>
 <div id="log"></div>
 <script>


### PR DESCRIPTION
These appear to be copy+pasted from api-test-1.html where
load_test_attr does exist, but in these two tests they do not, and the
error in the load event handler will be silently ignored.

Drive-by: document that Python 2.7.9+ is needed to run the tests at
all, as that is when ssl.SSLContext was introduced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8774)
<!-- Reviewable:end -->
