### PR TITLE
[css-fonts] Fix CSS font-variant-alternates tests

### DIFF
--- a/css/css-fonts/font-variant-alternates-01-ref.html
+++ b/css/css-fonts/font-variant-alternates-01-ref.html
@@ -10,17 +10,15 @@
   }
   .test {
 	  font-family: fwf;
-	  font-size: 3em;
+	  font-size: 2em;
 	  line-height: 1.1;
   }
 </style>
 <body>
 
-<!-- very minimal test, only tests hist, does not test salt or stylistic sets -->
-
-<p>Test passes if the three lines below are identical, with one cross (✗)</p>
+<p>Test passes if the three lines below are identical, with twenty crosses (✗).</p>
 <section class="test">
-	<p class="ref">B</p>
-  <p class="ref">B</p>
-	<p class="ref">B</p>
+  <p class="ref">BBBBBBBBBBBBBBBBBBBB</p>
+  <p class="ref">BBBBBBBBBBBBBBBBBBBB</p>
+  <p class="ref">BBBBBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-01.html
+++ b/css/css-fonts/font-variant-alternates-01.html
@@ -28,10 +28,9 @@
 </style>
 <body>
 
-<p>Test passes if the three lines below are identical, with twenty crosses (✗)
-<!--, followed by one check mark (✓)-->. </p>
+<p>Test passes if the three lines below are identical, with twenty crosses (✗).</p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
-	<p class="low">Xnophijklmqrstuvwxyz</p>
-	<p class="ref">BBBBBBBBBBBBBBBBBBBB</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="low">Xnophijklmqrstuvwxyz</p>
+  <p class="ref">BBBBBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-02-ref.html
+++ b/css/css-fonts/font-variant-alternates-02-ref.html
@@ -10,7 +10,7 @@
   }
   .test {
 	  font-family: fwf;
-	  font-size: 3em;
+	  font-size: 2em;
 	  line-height: 1.1;
   }
 </style>
@@ -18,9 +18,9 @@
 
 <!-- very minimal test, only tests hist, does not test salt or stylistic sets -->
 
-<p>Test passes if the three lines below are identical, with onecheck mark (✓). </p>
+<p>Test passes if the three lines below are identical, with one check mark (✓) followed by nineteen crosses (✗). </p>
 <section class="test">
-	<p class="ref">A</p>
-  <p class="ref">A</p>
-	<p class="ref">A</p>
+  <p class="ref">ABBBBBBBBBBBBBBBBBBB</p>
+  <p class="ref">ABBBBBBBBBBBBBBBBBBB</p>
+  <p class="ref">ABBBBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-02.html
+++ b/css/css-fonts/font-variant-alternates-02.html
@@ -20,7 +20,7 @@
   .high {
 	 font-variant-alternates: historical-forms;
   }
-    .low {
+  .low {
    font-feature-settings: "hist" on, "salt" 00, "ss01" off, "ss02" off, "ss03" off,
     "cv01" off, "cv02" off, "cv03" off,  "swsh" 00, "cswh" 00, "ornm" 00, "nalt" 00;
   }
@@ -29,7 +29,7 @@
 
 <p>Test passes if the three lines below are identical, with one check mark (✓) followed by nineteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">ABBBBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-03.html
+++ b/css/css-fonts/font-variant-alternates-03.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with one cross (✗), one check mark (✓) followed by eighteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BABBBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-04.html
+++ b/css/css-fonts/font-variant-alternates-04.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with two crosses (✗), one check mark (✓) followed by seventeen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBABBBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-05-ref.html
+++ b/css/css-fonts/font-variant-alternates-05-ref.html
@@ -16,7 +16,7 @@
 </style>
 <body>
 
-<p>Test passes if the three lines below are identical, with two crosses (✗), one check mark (✓) followed by seventeen crosses (✗). </p>
+<p>Test passes if the three lines below are identical, with three crosses (✗), one check mark (✓) followed by sixteen crosses (✗). </p>
 <section class="test">
   <p class="ref">BBBABBBBBBBBBBBBBBBB</p>
   <p class="ref">BBBABBBBBBBBBBBBBBBB</p>

--- a/css/css-fonts/font-variant-alternates-05.html
+++ b/css/css-fonts/font-variant-alternates-05.html
@@ -35,9 +35,9 @@
 </style>
 <body>
 
-<p>Test passes if the three lines below are identical, with two crosses (✗), one check mark (✓) followed by seventeen crosses (✗). </p>
+<p>Test passes if the three lines below are identical, with three crosses (✗), one check mark (✓) followed by sixteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBABBBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-06.html
+++ b/css/css-fonts/font-variant-alternates-06.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with four crosses (✗), one check mark (✓) followed by fifteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBABBBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-07.html
+++ b/css/css-fonts/font-variant-alternates-07.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with five crosses (✗), one check mark (✓) followed by fourteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBABBBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-08.html
+++ b/css/css-fonts/font-variant-alternates-08.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with six crosses (✗), one check mark (✓) followed by thirteen crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBABBBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-09.html
+++ b/css/css-fonts/font-variant-alternates-09.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with seven crosses (✗), one check mark (✓) followed by twelve crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBABBBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-10.html
+++ b/css/css-fonts/font-variant-alternates-10.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with eight crosses (✗), one check mark (✓) followed by eleven crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBABBBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-11.html
+++ b/css/css-fonts/font-variant-alternates-11.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with nine crosses (✗), one check mark (✓) followed by ten crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBABBBBBBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-12.html
+++ b/css/css-fonts/font-variant-alternates-12.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with ten crosses (✗), one check mark (✓), two crosses (✗), one check mark (✓) followed by six crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBABBABBBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-13.html
+++ b/css/css-fonts/font-variant-alternates-13.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with eleven crosses (✗), one check mark (✓), two crosses (✗), one check mark (✓) followed by five crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBABBABBBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-14.html
+++ b/css/css-fonts/font-variant-alternates-14.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with twelve crosses (✗), one check mark (✓), two crosses (✗), one check mark (✓) followed by four crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBBABBABBBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-15.html
+++ b/css/css-fonts/font-variant-alternates-15.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with sixteen crosses (✗), one check mark (✓) followed by three crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBBBBBBABBB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-16.html
+++ b/css/css-fonts/font-variant-alternates-16.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with seventeen crosses (✗), one check mark (✓) followed by two crosses (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBBBBBBBABB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-17.html
+++ b/css/css-fonts/font-variant-alternates-17.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with eighteen crosses (✗), one check mark (✓) followed by one cross (✗). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBBBBBBBBAB</p>
 </section>

--- a/css/css-fonts/font-variant-alternates-18.html
+++ b/css/css-fonts/font-variant-alternates-18.html
@@ -37,7 +37,7 @@
 
 <p>Test passes if the three lines below are identical, with nineteen crosses (✗), then one check mark (✓). </p>
 <section class="test">
-	<p class="high">Xnophijklmqrstuvwxyz</p>
+  <p class="high">Xnophijklmqrstuvwxyz</p>
   <p class="low">Xnophijklmqrstuvwxyz</p>
   <p class="ref">BBBBBBBBBBBBBBBBBBBA</p>
 </section>


### PR DESCRIPTION
* css/css-fonts/font-variant-alternates-{01,02}-ref.html are wrong
  references that cannot possibly match the tests.
* css/css-fonts/font-variant-alternates-05{,-ref}.html have typos in the
  explanation text.
* Also take the chance to re-format the other files for consistency.

Fixes #8754

<!-- Reviewable:start -->

<!-- Reviewable:end -->
