### PR TITLE
Recurse to nested arrays in reading arrays

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -159,7 +159,7 @@ function runGenericSensorTests(sensorType) {
 
     win.close();
     sensor.stop();
-    assert_array_equals(cachedSensor1, cachedSensor2);
+    assert_object_equals(cachedSensor1, cachedSensor2);
   }, `${sensorType.name}: sensor readings can not be fired on the background tab`);
 }
 


### PR DESCRIPTION
  Use assert_object_equals instead of assert_array_equals
  which would compare individual values in nested arrays

<!-- Reviewable:start -->

<!-- Reviewable:end -->
