### PR TITLE
Correct gutter references in css-grid

### DIFF
--- a/css/css-grid/reference/grid-collapsed-row-gutters-ref.html
+++ b/css/css-grid/reference/grid-collapsed-row-gutters-ref.html
@@ -38,6 +38,7 @@
     }
 </style>
 
+<p>The test passes if it has the same visual effect as reference. Column gap should be percentage of width. Row gap should resolve to auto, and therefore collapse to 0 height.</p>
 <div id="grid">
     <div></div>
     <div></div>

--- a/css/css-grid/reference/grid-different-gutters-ref.html
+++ b/css/css-grid/reference/grid-different-gutters-ref.html
@@ -38,6 +38,7 @@
     }
 </style>
 
+<p>The test passes if it has the same visual effect as reference.</p>
 <div id="grid">
     <div></div>
     <div></div>

--- a/css/css-grid/reference/grid-equal-gutters-ref.html
+++ b/css/css-grid/reference/grid-equal-gutters-ref.html
@@ -38,6 +38,7 @@
     }
 </style>
 
+<p>The test passes if it has the same visual effect as reference.</p>
 <div id="grid">
     <div></div>
     <div></div>


### PR DESCRIPTION
The references for grid-gutters-* were missing the text included in each test file and thus would fail no matter what. Include the text so the tests will run properly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
