### PR TITLE
Correct css-masking/clip tests

### DIFF
--- a/css/css-masking/clip/clip-rect-auto-001.html
+++ b/css/css-masking/clip/clip-rect-auto-001.html
@@ -12,7 +12,7 @@
     in the bottom right corner of the blue square.">
 </head>
 <body>
-    <p>The test passes if there is a blue square and a smaller green square in the bottom right corner of the blue square   .</p>
+    <p>The test passes if there is a blue square and a smaller green square in the bottom right corner of the blue square.</p>
     <div style="position: absolute; clip: rect(auto, auto, auto, auto); width: 100px; height: 100px;">
         <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green;"></div>
     </div>

--- a/css/css-masking/clip/clip-rect-comma-002.html
+++ b/css/css-masking/clip/clip-rect-comma-002.html
@@ -12,6 +12,6 @@
 </head>
 <body>
     <p>The test passes if there is a green square with a blue border.</p>
-    <div style="width: 100px; height: 100px; border: solid red 50px; background-color: green; position: absolute; clip: rect(50px 150px, 150px, 50px);"></div>
+    <div style="width: 100px; height: 100px; border: solid blue 50px; background-color: green; position: absolute; clip: rect(50px 150px, 150px, 50px);"></div>
 </body>
 </html>

--- a/css/css-masking/clip/reference/clip-horizontal-stripe-ref.html
+++ b/css/css-masking/clip/reference/clip-horizontal-stripe-ref.html
@@ -5,7 +5,7 @@
     <link rel="author" title="Dirk Schulze" href="mailto:dschulze@adobe.com">
 </head>
 <body>
-    <p>The test passes if there is only a vertical blue stripe.</p>
+    <p>The test passes if there is only a horizontal blue stripe.</p>
     <div style="width: 200px; height: 50px; background-color: blue;"></div>
 </body>
 </html>


### PR DESCRIPTION
This change fixes:
- clip-rect-auto-001.html having extra spaces within text so it didn't match the reference
- clip-rect-comma-002.html having a red border instead of blue like clip-rect-comma-003.html causing failure
- and clip-horizontal-stripe-ref.html having incorrect reference text causing failure

<!-- Reviewable:start -->

<!-- Reviewable:end -->
