### PR TITLE
Do not assume document stringifies to HTMLDocument

### DIFF
--- a/FileAPI/file/File-constructor.html
+++ b/FileAPI/file/File-constructor.html
@@ -47,7 +47,7 @@ test_first_argument(["bits", new Blob(["bits"]), new Blob(), new Uint8Array([0x5
 test_first_argument([12], 2, "Number in fileBits");
 test_first_argument([[1,2,3]], 5, "Array in fileBits");
 test_first_argument([{}], 15, "Object in fileBits"); // "[object Object]"
-test_first_argument([document], 21, "HTMLDocument in fileBits"); // "[object HTMLDocument]"
+test_first_argument([document.body], 24, "HTMLBodyElement in fileBits"); // "[object HTMLBodyElement]"
 test_first_argument([to_string_obj], 8, "Object with toString in fileBits");
 test_first_argument({[Symbol.iterator]() {
   let i = 0;
@@ -88,7 +88,7 @@ test_second_argument("dummy/foo", "dummy:foo", "Using special character in fileN
 test_second_argument(null, "null", "Using null fileName");
 test_second_argument(1, "1", "Using number fileName");
 test_second_argument('', '', "Using empty string fileName");
-test_second_argument(document, '[object HTMLDocument]', "Using object fileName");
+test_second_argument(document.body, '[object HTMLBodyElement]', "Using object fileName");
 
 // testing the third argument
 [


### PR DESCRIPTION
Per current spec, document should stringify to "[object Document]". Work
to remove "HTMLDocument" is tracked in
https://github.com/whatwg/dom/issues/221.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
