### PR TITLE
Add references to a couple more Flexbox tests

### DIFF
--- a/css/css-flexbox/flex-direction-row-vertical-ref.html
+++ b/css/css-flexbox/flex-direction-row-vertical-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+ <head>
+  <title>CSS Reference: flex-direction:row has the same orientation as inline axis</title>
+  <style>
+    #vertical {
+      writing-mode: vertical-lr;
+    }
+
+    .test {
+      display: flex;
+      width: 3em;
+      flex-direction: row;
+    }
+
+    .test > span {
+      width: 1em;
+    }
+  </style>
+ </head>
+ <body>
+  <p>Test passes if both the two columns below are identical.</p>
+  <div id="vertical">
+    <div class="test">
+      <span>A</span><span>B</span><span>C</span>
+    </div>
+    <div class="test">
+      <span>A</span><span>B</span><span>C</span>
+    </div>
+  </div>
+ </body>
+</html>

--- a/css/css-flexbox/flex-direction-row-vertical.html
+++ b/css/css-flexbox/flex-direction-row-vertical.html
@@ -5,6 +5,7 @@
   <link rel="author" title="Sylvain Galineau" href="mailto:galineau@adobe.com">
   <link rel="reviewer" title="Arron Eicholz" href="mailto:arronei@microsoft.com">
   <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-direction">
+  <link rel="match" href="flex-direction-row-vertical-ref.html">
   <meta name="flags" content="">
   <meta name="assert" content="This test checks that the main axis of the row flex-direction has the same orientation as the inline axis of the current vertical writing mode">
   <style>

--- a/css/css-flexbox/flexbox_stf-fixpos.html
+++ b/css/css-flexbox/flexbox_stf-fixpos.html
@@ -2,6 +2,7 @@
 <title>flexbox | flexcontainer versus stf :: fixed</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
+<link rel="match" href="about:blank">
 <style>
 #test {
 	background: red;

--- a/css/css-flexbox/flexbox_stf-fixpos.html
+++ b/css/css-flexbox/flexbox_stf-fixpos.html
@@ -2,7 +2,7 @@
 <title>flexbox | flexcontainer versus stf :: fixed</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
-<link rel="match" href="about:blank">
+<link rel="match" href="flexbox_empty-ref.html">
 <style>
 #test {
 	background: red;

--- a/css/css-flexbox/flexbox_stf-fixpos.html
+++ b/css/css-flexbox/flexbox_stf-fixpos.html
@@ -2,7 +2,7 @@
 <title>flexbox | flexcontainer versus stf :: fixed</title>
 <link rel="author" href="http://opera.com" title="Opera Software">
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-items">
-<link rel="match" href="flexbox_empty-ref.html">
+<link rel="match" href="about:blank">
 <style>
 #test {
 	background: red;


### PR DESCRIPTION
Part of #8670.

http://test.csswg.org/harness/results/css-flexbox-1_dev/grouped/flex-direction-row-vertical/ shows that that test apparently fails in Edge, so this gives us automated coverage of that failure.

For the Opera test, see https://github.com/operasoftware/presto-testo/blob/master/css/flexbox/stf-fixpos.html

<!-- Reviewable:start -->

<!-- Reviewable:end -->
