### PR TITLE
Fix and link to the refs from two i18n Writing Modes tests

### DIFF
--- a/css/css-writing-modes/bidi-table-001.html
+++ b/css/css-writing-modes/bidi-table-001.html
@@ -6,6 +6,7 @@
 
 <link rel="author" title="Richard Ishida" href='mailto:ishida@w3.org'/>
 <link rel="help" href='http://www.w3.org/TR/css-writing-modes-3/#text-direction'/>
+<link rel="match" href="reference/bidi-table-001.html"/>
 <meta name="assert" content='If direction is applied to the ancestor of a table element, columns will be displayed in that direction.'/>
 <style type="text/css">
 .test { direction: rtl; }

--- a/css/css-writing-modes/block-plaintext-006.html
+++ b/css/css-writing-modes/block-plaintext-006.html
@@ -6,6 +6,7 @@
 
 <link rel="author" title="Richard Ishida" href='mailto:ishida@w3.org'/>
 <link rel="help" href='http://www.w3.org/TR/css-writing-modes-3/#text-direction'/>
+<link rel="match" href="reference/block-plaintext-006.html"/>
 <meta name="assert" content='If unicode-bidi:plaintext is applied to a pre element, each line of characters after a linebreak is displayed according to the first strong character after the linebreak.'/>
 <style type="text/css">
 .test pre { unicode-bidi: plaintext; }
@@ -20,7 +21,7 @@ input { margin: 5px; }
     font-style: normal;
     }
 .test, .ref { font-family: ezra_silregular, serif; }
-pre { font-family: ezra_silregular, serif; height:5em; width: 100%; border: 0; font-size: 1em; }
+pre { font-family: ezra_silregular, serif; width: 100%; border: 0; margin: 0; font-size: 1em; }
 </style>
 </head>
 <body>
@@ -36,10 +37,11 @@ Key to entities used below:
 
 
 <div class="test">
-<pre>
+<pre><!-- comment token so following LF character isn't ignored by the HTML parser -->
 &gt; a &gt; &#x5d1; &gt; c &gt;
 &gt; &#x5d0; &gt; b &gt; &#x5d2; &gt;
 &gt; a &gt; &#x5d1; &gt; c &gt;
+<!-- need a blank line for whitespace to appear-->
 </pre>
 </div>
 


### PR DESCRIPTION
Part of #8670.

I can't get `css/css-writing-modes/block-plaintext-005.html` to match, which is now the only test by @r12a in the Writing Modes testsuite which doesn't link to its ref because it tests behaviour with a form element (`textarea`) and I can't figure out how to get it to match.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
