### PR TITLE
Add in references for CSS2/generated-content tests

### DIFF
--- a/css/CSS2/generated-content/before-after-002.xht
+++ b/css/CSS2/generated-content/before-after-002.xht
@@ -4,12 +4,13 @@
         <title>CSS Test: Before, after is included in formatting changes</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Generated content is included in any formatting changes made to an element." />
         <style type="text/css">
             div
             {
-                border: solid;
+                border: 2px solid black;
                 color: green;
             }
             div:before
@@ -23,7 +24,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the words "PASS PASS" appear in green inside the box.</p>
+        <p>Test passes if the words "PASS PASS" appear in the box below.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-001-ref.html
+++ b/css/CSS2/generated-content/content-001-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is no red visible on the page.</p>
+    <div></div>
+</body>

--- a/css/CSS2/generated-content/content-001.xht
+++ b/css/CSS2/generated-content/content-001.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
-        <link rel="match" href="../reference/no-red-on-blank-page-ref.xht"/>
+        <link rel="match" href="content-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a value of 'none'." />
         <style type="text/css">
@@ -15,7 +15,7 @@
                 content: none;
                 color: red;
             }
-            #div1
+            div
             {
                 border: 2px solid black;
                 height: 30px;

--- a/css/CSS2/generated-content/content-002.xht
+++ b/css/CSS2/generated-content/content-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a value of 'normal'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-003-ref.html
+++ b/css/CSS2/generated-content/content-003-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the words "PASS PASS" appear in the box below.</p>
+    <div>PASS PASS</div>
+</body>

--- a/css/CSS2/generated-content/content-003.xht
+++ b/css/CSS2/generated-content/content-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a string as a value." />
         <style type="text/css">
@@ -16,12 +17,11 @@
             div
             {
                 border: 2px solid black;
-                height: 30px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if the words "PASS PASS" are in the box below.</p>
+        <p>Test passes if the words "PASS PASS" appear in the box below.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-004.xht
+++ b/css/CSS2/generated-content/content-004.xht
@@ -5,17 +5,18 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="../../reference/ref-filled-green-100px-square-only.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="The 'content' property properly handles the 'url()' function as a value." />
         <style type="text/css">
             div:before
             {
-                content: url('support/green15x15.png');
+                content: url('../support/green_box.png');
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is a green box below.</p>
+        <p>Test passes if there is a filled green square.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-020.xht
+++ b/css/CSS2/generated-content/content-020.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-036.xht
+++ b/css/CSS2/generated-content/content-036.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
-        <link rel="match" href="../reference/no-red-on-blank-page-ref.xht"/>
+        <link rel="match" href="content-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">
@@ -16,9 +16,10 @@
                 counter-reset: test;
                 color: red;
             }
-            #div1
+            div
             {
                 border: 2px solid black;
+                height: 30px;
             }
         </style>
     </head>

--- a/css/CSS2/generated-content/content-037-ref.html
+++ b/css/CSS2/generated-content/content-037-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the words "PASS PASS" appear in the box below.</p>
+    <table>
+        <tr>
+            <td>PASS PASS</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-037.xht
+++ b/css/CSS2/generated-content/content-037.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-037-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'abbr'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-038.xht
+++ b/css/CSS2/generated-content/content-038.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'accept-charset'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-039.xht
+++ b/css/CSS2/generated-content/content-039.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'accept'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-041-ref.html
+++ b/css/CSS2/generated-content/content-041-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "PASS" appears in the box below.</p>
+    <div>PASS</div>
+</body>

--- a/css/CSS2/generated-content/content-041.xht
+++ b/css/CSS2/generated-content/content-041.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-041-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'action'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-046.xht
+++ b/css/CSS2/generated-content/content-046.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-037-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'axis'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-047-ref.html
+++ b/css/CSS2/generated-content/content-047-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    body {
+        margin: 0px;
+    }
+    .test {
+        color: green;
+    }
+    p {
+        margin-left: 8px;
+    }
+</style>
+<body>
+    <div class="test">PASS PASS</div>
+    <p>Test passes if the words "PASS PASS" appear above this text.</p>
+</body>

--- a/css/CSS2/generated-content/content-047.xht
+++ b/css/CSS2/generated-content/content-047.xht
@@ -5,17 +5,23 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'background'." />
         <style type="text/css">
-            body:before
-            {
+            body:before {
                 content: attr(background);
                 color: green;
+            }
+            body {
+                margin: 0px;
+            }
+            p {
+                margin-left: 8px;
             }
         </style>
     </head>
     <body background="PASS PASS">
-        <p>Test passes if only the words "PASS PASS" appear above.</p>
+        <p>Test passes if the words "PASS PASS" appear above this text.</p>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-054.xht
+++ b/css/CSS2/generated-content/content-054.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'charset'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(charset);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-056.xht
+++ b/css/CSS2/generated-content/content-056.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'cite'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(cite);
                 color: green;
             }
-            q
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-057.xht
+++ b/css/CSS2/generated-content/content-057.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'class'." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the words "PASS PASS" appears in the box below.</p>
+        <p>Test passes if the words "PASS PASS" appear in the box below.</p>
         <div class="PASS PASS"></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-067.xht
+++ b/css/CSS2/generated-content/content-067.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'content'." />
         <meta content="PASS PASS" />

--- a/css/CSS2/generated-content/content-076.xht
+++ b/css/CSS2/generated-content/content-076.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'face'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(face);
                 color: green;
             }
-            font
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-077.xht
+++ b/css/CSS2/generated-content/content-077.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-041-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'for'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(for);
                 color: green;
             }
-            label
+            .box
             {
                 border: 2px solid black;
             }
@@ -21,7 +22,7 @@
     </head>
     <body>
         <p>Test passes if the word "PASS" appears in the box below.</p>
-        <div>
+        <div class="box">
             <label for="PASS"></label>
             <div id="PASS"></div>
         </div>

--- a/css/CSS2/generated-content/content-080-ref.html
+++ b/css/CSS2/generated-content/content-080-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "PASS" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>PASS</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-080.xht
+++ b/css/CSS2/generated-content/content-080.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-080-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'headers'." />
         <style type="text/css">
@@ -23,10 +24,10 @@
         <p>Test passes if the word "PASS" appears in the box below.</p>
         <table>
             <tr>
-                <th id="PASS"></th>
+                <td headers="PASS"></td>
             </tr>
             <tr>
-                <td headers="PASS"></td>
+                <th id="PASS"></th>
             </tr>
         </table>
     </body>

--- a/css/CSS2/generated-content/content-085.xht
+++ b/css/CSS2/generated-content/content-085.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'http-equiv'." />
         <meta content="" http-equiv="PASS PASS" />

--- a/css/CSS2/generated-content/content-086.xht
+++ b/css/CSS2/generated-content/content-086.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-041-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'id'." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the word "PASS" appear in the box below.</p>
+        <p>Test passes if the word "PASS" appears in the box below.</p>
         <div id="PASS"></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-091-ref.html
+++ b/css/CSS2/generated-content/content-091-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        color: green;
+    }
+</style>
+<body>
+    <div>green</div>
+    <p>Test passes if the word "green" appears above.</p>
+</body>

--- a/css/CSS2/generated-content/content-091.xht
+++ b/css/CSS2/generated-content/content-091.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-091-ref.html" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'link'." />
         <style type="text/css">
             body:before

--- a/css/CSS2/generated-content/content-099.xht
+++ b/css/CSS2/generated-content/content-099.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-041-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'name'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(name);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-105.xht
+++ b/css/CSS2/generated-content/content-105.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="../../reference/only_pass_parens_semicolon.html" />
         <meta name="flags" content="dom" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'onblur'." />
         <meta http-equiv="Content-Script-Type" content="text/javascript" />
@@ -14,7 +15,7 @@
                 content: attr(onblur);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-109.xht
+++ b/css/CSS2/generated-content/content-109.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="../../reference/only_pass_parens_semicolon.html" />
         <meta name="flags" content="dom" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'onfocus'." />
         <meta http-equiv="Content-Script-Type" content="text/javascript" />
@@ -14,7 +15,7 @@
                 content: attr(onfocus);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-113-ref.html
+++ b/css/CSS2/generated-content/content-113-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        color: green;
+    }
+</style>
+<body>
+    <div>PASS();</div>
+    <p>Test passes if only the word "PASS();" appears above. Fail if there is any other additional text.</p>
+</body>

--- a/css/CSS2/generated-content/content-113.xht
+++ b/css/CSS2/generated-content/content-113.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-113-ref.html" />
         <meta name="flags" content="dom" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'onload'." />
         <meta http-equiv="Content-Script-Type" content="text/javascript" />

--- a/css/CSS2/generated-content/content-122.xht
+++ b/css/CSS2/generated-content/content-122.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-113-ref.html" />
         <meta name="flags" content="dom" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'onunload'." />
         <meta http-equiv="Content-Script-Type" content="text/javascript" />

--- a/css/CSS2/generated-content/content-123.xht
+++ b/css/CSS2/generated-content/content-123.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'profile'." />
         <style type="text/css">
@@ -20,6 +21,6 @@
         </style>
     </head>
     <body>
-        <p>Test passes if only the words "PASS PASS" appear above.</p>
+        <p>Test passes if the words "PASS PASS" appear above this text.</p>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-131.xht
+++ b/css/CSS2/generated-content/content-131.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'scheme'." />
         <meta content="" scheme="PASS PASS" />
@@ -21,6 +22,6 @@
         </style>
     </head>
     <body>
-        <p>Test passes if only the words "PASS PASS" appear above this text.</p>
+        <p>Test passes if the words "PASS PASS" appear above this text.</p>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-138.xht
+++ b/css/CSS2/generated-content/content-138.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'src'." />
         <style type="text/css">
@@ -21,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if only the words "PASS PASS" appear in the box below.</p>
+        <p>Test passes if the words "PASS PASS" appear in the box below.</p>
         <script src="PASS PASS" type="text/javascript"></script>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-145.xht
+++ b/css/CSS2/generated-content/content-145.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-091-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'text'." />
         <style type="text/css">
@@ -19,6 +20,6 @@
         </style>
     </head>
     <body text="green">
-        <p>Test passes if there is only the word "green" above.</p>
+        <p>Test passes if the word "green" appears above.</p>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-146.xht
+++ b/css/CSS2/generated-content/content-146.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'title'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(title);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-152.xht
+++ b/css/CSS2/generated-content/content-152.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'version'." />
         <style type="text/css">
@@ -16,6 +17,6 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the words "PASS PASS" appear above.</p>
+        <p>Test passes if the words "PASS PASS" appear above this text.</p>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-153.xht
+++ b/css/CSS2/generated-content/content-153.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-091-ref.html" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'vlink'." />
         <style type="text/css">
             body:before

--- a/css/CSS2/generated-content/content-attr-001.xht
+++ b/css/CSS2/generated-content/content-attr-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Content property missing attr(x)</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="../reference/ref-nothing-below.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="If attribute (x) does not exist then an empty string is returned for the attr(x) value." />
         <style type="text/css">
@@ -14,7 +15,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is nothing displayed below.</p>
+        <p>Test passes if there is nothing below.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-attr-case-001.html
+++ b/css/CSS2/generated-content/content-attr-case-001.html
@@ -4,12 +4,12 @@
         <title>CSS Test: Content property attr(x) case sensitivity</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/">
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content">
+        <link rel="match" href="../../reference/pass_if_pass_below.html" />
         <meta name="flags" content="HTMLonly">
         <meta name="assert" content="The attr(x) function selects the attribute even when case does not match.">
         <style type="text/css">
             div:before
             {
-                color: green;
                 content: attr(Title);
             }
         </style>

--- a/css/CSS2/generated-content/content-attr-case-002.xht
+++ b/css/CSS2/generated-content/content-attr-case-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: content attr(x) case sensitivity</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="../reference/no-red-on-blank-page-ref.xht" />
         <meta name="flags" content="nonHTML" />
         <meta name="assert" content="Verify in XHTML that attr(x) does not select the attribute when the case does not match" />
         <style type="text/css">
@@ -16,7 +17,7 @@
         </style>
     </head>
     <body>
-        <div>Test Passes if there is no red visible on the page.</div>
+        <p>Test passes if there is no red visible on the page.</p>
         <div id="test" title="FAIL"></div>
     </body>
 </html>


### PR DESCRIPTION
Many CSS2/generated-content tests were missing references. This change adds in references for some of these tests.

Part of #8670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
