### PR TITLE
Add a testharness.js wrapper for Acid3

### DIFF
--- a/acid/acid3/numbered-tests.html
+++ b/acid/acid3/numbered-tests.html
@@ -9,7 +9,7 @@ function gotMessage(e) {
   var m = e.data;
   if (tests === undefined && "num_tests" in m) {
     tests = [];
-    for (var i = 0; i < m.tests; i++) {
+    for (var i = 0; i < m.num_tests; i++) {
       tests.push(async_test("Test " + i));
     }
   } else if ("result" in m) {

--- a/acid/acid3/numbered-tests.html
+++ b/acid/acid3/numbered-tests.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<title>Acid3 numbered tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+var tests = undefined;
+
+function gotMessage(e) {
+  var m = e.data;
+  if (tests === undefined && "tests" in m) {
+    tests = [];
+    for (var i = 0; i < m.tests; i++) {
+      tests.push(async_test("Test " + i));
+    }
+  } else if ("result" in m) {
+    var test = m.test;
+    var passed = m.result === "pass";
+    var message = m.message;
+    tests[test].step_func_done(function() {
+      assert_true(passed, message);
+    })();
+  }
+}
+window.addEventListener("message", gotMessage, false);
+</script>
+<iframe src="test.html"></iframe>

--- a/acid/acid3/numbered-tests.html
+++ b/acid/acid3/numbered-tests.html
@@ -7,7 +7,7 @@ var tests = undefined;
 
 function gotMessage(e) {
   var m = e.data;
-  if (tests === undefined && "tests" in m) {
+  if (tests === undefined && "num_tests" in m) {
     tests = [];
     for (var i = 0; i < m.tests; i++) {
       tests.push(async_test("Test " + i));
@@ -16,9 +16,10 @@ function gotMessage(e) {
     var test = m.test;
     var passed = m.result === "pass";
     var message = m.message;
-    tests[test].step_func_done(function() {
+    tests[test].step(function() {
       assert_true(passed, message);
-    })();
+    });
+    tests[test].done();
   }
 }
 window.addEventListener("message", gotMessage, false);

--- a/acid/acid3/test.html
+++ b/acid/acid3/test.html
@@ -3419,7 +3419,7 @@
     }
 
   ];
-  window.parent.postMessage({tests: tests.length}, "*");
+  window.parent.postMessage({num_tests: tests.length}, "*");
   var log = '';
   var delay = 10;
   var score = 0, index = 0, retry = 0, errors = 0;

--- a/acid/acid3/test.html
+++ b/acid/acid3/test.html
@@ -3419,6 +3419,7 @@
     }
 
   ];
+  window.parent.postMessage({tests: tests.length}, "*");
   var log = '';
   var delay = 10;
   var score = 0, index = 0, retry = 0, errors = 0;
@@ -3456,6 +3457,7 @@
         } else {
           fail("no error message");
         }
+        window.parent.postMessage({test: index, result: "pass"}, "*");
       } catch (e) {
         var s;
         if (e.message)
@@ -3464,6 +3466,7 @@
           s = e;
         errors += 1;
         log += "Test " + zeroPaddedIndex + " failed: " + s + "\n";
+        window.parent.postMessage({test: index, result: "fail", message: s}, "*");
       };
       retry = 0;
       index += 1;


### PR DESCRIPTION
This allows us to track individual subtests and their results, rather than simply a PASS/FAIL result for the entirety of Acid3.

See also #8479.

<!-- Reviewable:start -->

<!-- Reviewable:end -->