### PR TITLE
Add in additional CSS2/generated-content references

### DIFF
--- a/css/CSS2/generated-content/after-inheritable-001-ref.html
+++ b/css/CSS2/generated-content/after-inheritable-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: solid;
+        color: green;
+        text-align: center;
+    }
+</style>
+<body>
+    <p>Test passes if the words "PASS PASS" below are green and the words are centered within the box below.</p>
+    <div>PASS PASS</div>
+</body>

--- a/css/CSS2/generated-content/after-inheritable-001.xht
+++ b/css/CSS2/generated-content/after-inheritable-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Pseudo-element ':after' inherits inheritable values</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="after-inheritable-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The pseudo-element ':after' generated content inherits any inheritable properties from the element." />
         <style type="text/css">

--- a/css/CSS2/generated-content/after-inheritable-002-ref.html
+++ b/css/CSS2/generated-content/after-inheritable-002-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 15px solid blue;
+        color: green;
+    }
+    a {
+    	border-color: orange;
+        border-style: solid;
+    }
+</style>
+<body>
+    <p>Test passes if the words "PASS PASS" are green, they are contained within an orange box with thinner lines than the blue box.</p>
+    <div><a>PASS PASS</a></div>
+</body>

--- a/css/CSS2/generated-content/after-inheritable-002.xht
+++ b/css/CSS2/generated-content/after-inheritable-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Pseudo-element ':after' does not inherit non-inheritable values</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="after-inheritable-002-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Non-inherited properties apply their initial value when applying to ':after'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/after-location-001-ref.html
+++ b/css/CSS2/generated-content/after-location-001-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>Test passes if the words "PASS PASS" appear below and are to the right of the arrow.</p>
+    <div>--&gt;PASS PASS</div>
+</body>

--- a/css/CSS2/generated-content/after-location-001.xht
+++ b/css/CSS2/generated-content/after-location-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: After applies after text</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="after-location-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="After places the generated content after the element content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/before-inheritable-001.xht
+++ b/css/CSS2/generated-content/before-inheritable-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Pseudo-element ':before' inherits inheritable values</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="after-inheritable-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The pseudo-element ':before' generated content inherits any inheritable properties from the element." />
         <style type="text/css">

--- a/css/CSS2/generated-content/before-inheritable-002.xht
+++ b/css/CSS2/generated-content/before-inheritable-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Pseudo-element ':before' does not inherit non-inheritable values</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="after-inheritable-002-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Non-inherited properties apply the initial value when applying to ':before'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/before-location-001-ref.html
+++ b/css/CSS2/generated-content/before-location-001-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>Test passes if the words "PASS PASS" appear below and are to the left of the arrow.</p>
+    <div>PASS PASS&lt;--</div>
+</body>

--- a/css/CSS2/generated-content/before-location-001.xht
+++ b/css/CSS2/generated-content/before-location-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Before applies before text</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#before-after-content" />
+        <link rel="match" href="before-location-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Before places generated content before the element content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/bidi-generated-content-001-ref.html
+++ b/css/CSS2/generated-content/bidi-generated-content-001-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The two lines below should be identical:</p>
+    <p>This sentence should be readable</p>
+    <p>This sentence should be readable</p>
+</body>

--- a/css/CSS2/generated-content/bidi-generated-content-001.xht
+++ b/css/CSS2/generated-content/bidi-generated-content-001.xht
@@ -5,6 +5,7 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
+    <link rel="match" href="bidi-generated-content-001-ref.html" />
     <meta name="assert" content="A right-to-left override should be applied when u+202E is inserted through the content property"/>
     <style type="text/css"><![CDATA[
       .force:before {

--- a/css/CSS2/generated-content/bidi-generated-content-002-ref.html
+++ b/css/CSS2/generated-content/bidi-generated-content-002-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The two lines below should be identical:</p>
+    <p>ab c d</p>
+    <p>ab c d</p>
+</body>

--- a/css/CSS2/generated-content/bidi-generated-content-002.xht
+++ b/css/CSS2/generated-content/bidi-generated-content-002.xht
@@ -5,6 +5,7 @@
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#direction"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content"/>
+    <link rel="match" href="bidi-generated-content-002-ref.html" />
     <meta name="flags" content=""/>
     <meta name="assert" content="A left-to-right override should be correctly applied when inserted through the content property"/>
     <style type="text/css"><![CDATA[

--- a/css/CSS2/generated-content/content-005-ref.html
+++ b/css/CSS2/generated-content/content-005-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a zero "0" in the box below.</p>
+    <div>0</div>
+</body>

--- a/css/CSS2/generated-content/content-005.xht
+++ b/css/CSS2/generated-content/content-005.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-005-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function as a value." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-006-ref.html
+++ b/css/CSS2/generated-content/content-006-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a bullet (&#x2022;) in the box below.</p>
+    <div>&#x2022;</div>
+</body>

--- a/css/CSS2/generated-content/content-006.xht
+++ b/css/CSS2/generated-content/content-006.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-006-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-007-ref.html
+++ b/css/CSS2/generated-content/content-007-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a bullet (&#x25E6;) in the box below.</p>
+    <div>&#x25E6;</div>
+</body>

--- a/css/CSS2/generated-content/content-007.xht
+++ b/css/CSS2/generated-content/content-007.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-007-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-009.xht
+++ b/css/CSS2/generated-content/content-009.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-005-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-010-ref.html
+++ b/css/CSS2/generated-content/content-010-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there are double zeros "00" in the box below.</p>
+    <div>00</div>
+</body>

--- a/css/CSS2/generated-content/content-010.xht
+++ b/css/CSS2/generated-content/content-010.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-010-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is are double zeros "00" in the box below.</p>
+        <p>Test passes if there are double zeros "00" in the box below.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-011-ref.html
+++ b/css/CSS2/generated-content/content-011-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a letter "i" in the box below.</p>
+    <div>i</div>
+</body>

--- a/css/CSS2/generated-content/content-011.xht
+++ b/css/CSS2/generated-content/content-011.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-011-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-012-ref.html
+++ b/css/CSS2/generated-content/content-012-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a letter "I" in the box below.</p>
+    <div>I</div>
+</body>

--- a/css/CSS2/generated-content/content-012.xht
+++ b/css/CSS2/generated-content/content-012.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-012-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-013-ref.html
+++ b/css/CSS2/generated-content/content-013-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a greek letter "&#x03B1;" in the box below.</p>
+    <div>&#x03B1;</div>
+</body>

--- a/css/CSS2/generated-content/content-013.xht
+++ b/css/CSS2/generated-content/content-013.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-013-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-014-ref.html
+++ b/css/CSS2/generated-content/content-014-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a letter "a" in the box below.</p>
+    <div>a</div>
+</body>

--- a/css/CSS2/generated-content/content-014.xht
+++ b/css/CSS2/generated-content/content-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-014-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-015-ref.html
+++ b/css/CSS2/generated-content/content-015-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a letter "A" in the box below.</p>
+    <div>A</div>
+</body>

--- a/css/CSS2/generated-content/content-015.xht
+++ b/css/CSS2/generated-content/content-015.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-015-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-016-ref.html
+++ b/css/CSS2/generated-content/content-016-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is an Armenian character "&#x0531;" below.</p>
+    <div>&#x0531;</div>
+</body>

--- a/css/CSS2/generated-content/content-016.xht
+++ b/css/CSS2/generated-content/content-016.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-016-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">
@@ -21,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is an Armenian character "&#x0561;" or "&#x0531;" below.</p>
+        <p>Test passes if there is an Armenian character "&#x0531;" below.</p>
         <div></div>
     </body>
 </html>

--- a/css/CSS2/generated-content/content-017-ref.html
+++ b/css/CSS2/generated-content/content-017-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a Georgian character "&#x10d0;" in the box below.</p>
+    <div>&#x10d0;</div>
+</body>

--- a/css/CSS2/generated-content/content-017.xht
+++ b/css/CSS2/generated-content/content-017.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-017-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-018.xht
+++ b/css/CSS2/generated-content/content-018.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-014-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-019.xht
+++ b/css/CSS2/generated-content/content-019.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-015-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counter()' function with a list-style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-021-ref.html
+++ b/css/CSS2/generated-content/content-021-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the numbers "0" and "0.0" are in the box below.</p>
+    <div>0<br>0.0</div>
+</body>

--- a/css/CSS2/generated-content/content-021.xht
+++ b/css/CSS2/generated-content/content-021.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-021-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string value." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are the numbers "0" and "0.0" in the box below.</p>
+        <p>Test passes if the numbers "0" and "0.0" are in the box below.</p>
         <div id="div1">
             <div></div>
         </div>

--- a/css/CSS2/generated-content/content-022-ref.html
+++ b/css/CSS2/generated-content/content-022-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are bullets "&#x2022;" and "&#x2022;.&#x2022;" in the box below.</p>
+    <div>&#x2022;<br>&#x2022;.&#x2022;</div>
+</body>

--- a/css/CSS2/generated-content/content-022.xht
+++ b/css/CSS2/generated-content/content-022.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-022-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-023-ref.html
+++ b/css/CSS2/generated-content/content-023-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are circles "&#x25E6;" and "&#x25E6;.&#x25E6;" in the box below.</p>
+    <div>&#x25E6;<br>&#x25E6;.&#x25E6;</div>
+</body>

--- a/css/CSS2/generated-content/content-023.xht
+++ b/css/CSS2/generated-content/content-023.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-023-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-025.xht
+++ b/css/CSS2/generated-content/content-025.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-021-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are numbers "0" and "0.0" in the box below.</p>
+        <p>Test passes if the numbers "0" and "0.0" are in the box below.</p>
         <div id="div1">
             <div></div>
         </div>

--- a/css/CSS2/generated-content/content-026-ref.html
+++ b/css/CSS2/generated-content/content-026-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are numbers "00" and "00.00" in the box below.</p>
+    <div>00<br>00.00</div>
+</body>

--- a/css/CSS2/generated-content/content-026.xht
+++ b/css/CSS2/generated-content/content-026.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-026-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-027-ref.html
+++ b/css/CSS2/generated-content/content-027-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are letters "i" and "i.i" in the box below.</p>
+    <div>i<br>i.i</div>
+</body>

--- a/css/CSS2/generated-content/content-027.xht
+++ b/css/CSS2/generated-content/content-027.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-027-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-028-ref.html
+++ b/css/CSS2/generated-content/content-028-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are letters "I" and "I.I" in the box below.</p>
+    <div>I<br>I.I</div>
+</body>

--- a/css/CSS2/generated-content/content-028.xht
+++ b/css/CSS2/generated-content/content-028.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-028-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-029-ref.html
+++ b/css/CSS2/generated-content/content-029-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are greek letters "&#x03B1;" and "&#x03B1;.&#x03B1;" in the box below.</p>
+    <div>&#x03B1;<br>&#x03B1;.&#x03B1;</div>
+</body>

--- a/css/CSS2/generated-content/content-029.xht
+++ b/css/CSS2/generated-content/content-029.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-029-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-030-ref.html
+++ b/css/CSS2/generated-content/content-030-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are letters "a" and "a.a" in the box below.</p>
+    <div>a<br>a.a</div>
+</body>

--- a/css/CSS2/generated-content/content-030.xht
+++ b/css/CSS2/generated-content/content-030.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-030-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-031-ref.html
+++ b/css/CSS2/generated-content/content-031-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are letters "A" and "A.A" in the box below.</p>
+    <div>A<br>A.A</div>
+</body>

--- a/css/CSS2/generated-content/content-031.xht
+++ b/css/CSS2/generated-content/content-031.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-031-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-032-ref.html
+++ b/css/CSS2/generated-content/content-032-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are Armenian characters "&#x0531;" and "&#x0531;.&#x0531;" in the box below.</p>
+    <div>&#x0531;<br>&#x0531;.&#x0531;</div>
+</body>

--- a/css/CSS2/generated-content/content-032.xht
+++ b/css/CSS2/generated-content/content-032.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-032-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">
@@ -21,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there are Armenian characters "&#x0561;" and "&#x0561;.&#x0561;" or "&#x0531;" and "&#x0531;.&#x0531;" in the box below.</p>
+        <p>Test passes if there are Armenian characters "&#x0531;" and "&#x0531;.&#x0531;" in the box below.</p>
         <div id="div1">
             <div></div>
         </div>

--- a/css/CSS2/generated-content/content-033-ref.html
+++ b/css/CSS2/generated-content/content-033-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if there are Georgian characters "&#x10d0;" and "&#x10d0;.&#x10d0;" in the box below.</p>
+    <div>&#x10d0;<br>&#x10d0;.&#x10d0;</div>
+</body>

--- a/css/CSS2/generated-content/content-033.xht
+++ b/css/CSS2/generated-content/content-033.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-033-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-034.xht
+++ b/css/CSS2/generated-content/content-034.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-030-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-035.xht
+++ b/css/CSS2/generated-content/content-035.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-031-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'counters()' function with a string and a list style." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-040-ref.html
+++ b/css/CSS2/generated-content/content-040-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letter "P" appears in the box below.</p>
+    <div>P</div>
+</body>

--- a/css/CSS2/generated-content/content-040.xht
+++ b/css/CSS2/generated-content/content-040.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-040-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'accesskey'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(accesskey);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-042-ref.html
+++ b/css/CSS2/generated-content/content-042-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the words "center" appear in the box below.</p>
+    <div align="center">center</div>
+</body>

--- a/css/CSS2/generated-content/content-042.xht
+++ b/css/CSS2/generated-content/content-042.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-042-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'align'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-043-ref.html
+++ b/css/CSS2/generated-content/content-043-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        color: green;
+    }
+</style>
+<body>
+	<div>#ffff00</div>
+    <p>Test passes if there is the text "#ffff00" above.</p>
+</body>

--- a/css/CSS2/generated-content/content-043.xht
+++ b/css/CSS2/generated-content/content-043.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-043-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'alink'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-048-ref.html
+++ b/css/CSS2/generated-content/content-048-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+	body {
+		background: #ffff00;
+	}
+    div {
+        color: green;
+    }
+</style>
+<body>
+	<div>#ffff00</div>
+    <p>Test passes if there is the text "#ffff00" above.</p>
+</body>

--- a/css/CSS2/generated-content/content-048.xht
+++ b/css/CSS2/generated-content/content-048.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-048-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'bgcolor'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-050-ref.html
+++ b/css/CSS2/generated-content/content-050-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+	table:before {
+		content: "1";
+	}
+    table {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+	<p>Test passes if the number "1" appears in the box below.</p>
+	<table>
+	    <tr>
+	        <td></td>
+	    </tr>
+	</table>
+</body>

--- a/css/CSS2/generated-content/content-050.xht
+++ b/css/CSS2/generated-content/content-050.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-050-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'cellpadding'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-052-ref.html
+++ b/css/CSS2/generated-content/content-052-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the letter "A" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>A</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-052.xht
+++ b/css/CSS2/generated-content/content-052.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-052-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'char'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-053-ref.html
+++ b/css/CSS2/generated-content/content-053-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the number "1" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>1</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-053.xht
+++ b/css/CSS2/generated-content/content-053.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-053-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'charoff'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-063-ref.html
+++ b/css/CSS2/generated-content/content-063-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "green" appears in the box below.</p>
+    <div>green</div>
+</body>

--- a/css/CSS2/generated-content/content-063.xht
+++ b/css/CSS2/generated-content/content-063.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-063-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'color'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(color);
                 color: green;
             }
-            font
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-065.xht
+++ b/css/CSS2/generated-content/content-065.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-053-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'colspan'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-068-ref.html
+++ b/css/CSS2/generated-content/content-068-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the number "10" appears in the box below.</p>
+    <div>10</div>
+</body>

--- a/css/CSS2/generated-content/content-068.xht
+++ b/css/CSS2/generated-content/content-068.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-068-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'coords'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(coords);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-070-ref.html
+++ b/css/CSS2/generated-content/content-070-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    ins {
+        border: 2px solid black;
+        color: green;
+        text-decoration-color: black;
+    }
+</style>
+<body>
+    <p>Test passes if the text "2000-01-01T00:00:00-08:00" appears in the box below.</p>
+    <ins>2000-01-01T00:00:00-08:00</ins>
+</body>

--- a/css/CSS2/generated-content/content-070.xht
+++ b/css/CSS2/generated-content/content-070.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-070-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'datetime'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-072-ref.html
+++ b/css/CSS2/generated-content/content-072-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "defer" appears in the box below.</p>
+    <div>defer</div>
+</body>

--- a/css/CSS2/generated-content/content-072.xht
+++ b/css/CSS2/generated-content/content-072.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-072-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property correctly handles the 'attr()' function when calling the attribute 'defer'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-073-ref.html
+++ b/css/CSS2/generated-content/content-073-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letters "ltr" appear in the box below.</p>
+    <div>ltr</div>
+</body>

--- a/css/CSS2/generated-content/content-073.xht
+++ b/css/CSS2/generated-content/content-073.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-073-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'dir'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-075-ref.html
+++ b/css/CSS2/generated-content/content-075-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the text "multipart/form-data" appear in the box below.</p>
+    <div>multipart/form-data</div>
+</body>

--- a/css/CSS2/generated-content/content-075.xht
+++ b/css/CSS2/generated-content/content-075.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-075-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'enctype'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-081-ref.html
+++ b/css/CSS2/generated-content/content-081-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the number "10" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>10</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-081.xht
+++ b/css/CSS2/generated-content/content-081.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-081-ref.html" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'height'." />
         <style type="text/css">
             td:before

--- a/css/CSS2/generated-content/content-082-ref.html
+++ b/css/CSS2/generated-content/content-082-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the character "#" appears in the box below.</p>
+    <a href="#"><div>#</div></a>
+</body>

--- a/css/CSS2/generated-content/content-082.xht
+++ b/css/CSS2/generated-content/content-082.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-082-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'href'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(href);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-083-ref.html
+++ b/css/CSS2/generated-content/content-083-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letters "aa" appear in the box below.</p>
+    <div>aa</div>
+</body>

--- a/css/CSS2/generated-content/content-083.xht
+++ b/css/CSS2/generated-content/content-083.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-083-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'hreflang'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(hreflang);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-089-ref.html
+++ b/css/CSS2/generated-content/content-089-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letters "aa" appear in the box below.</p>
+    <div>aa</div>
+</body>

--- a/css/CSS2/generated-content/content-089.xht
+++ b/css/CSS2/generated-content/content-089.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-089-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'lang'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-090-ref.html
+++ b/css/CSS2/generated-content/content-090-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "ecmascript" appears in the box below.</p>
+    <div>ecmascript</div>
+</body>

--- a/css/CSS2/generated-content/content-090.xht
+++ b/css/CSS2/generated-content/content-090.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-090-ref.html" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'language'." />
         <style type="text/css">
             script:before

--- a/css/CSS2/generated-content/content-096-ref.html
+++ b/css/CSS2/generated-content/content-096-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    body {
+        margin: 0px;
+    }
+    .test {
+        color: green;
+    }
+    p {
+        margin-left: 8px;
+    }
+</style>
+<body>
+    <div class="test">all</div>
+    <p>Test passes if the word "all" appears above this text.</p>
+</body>

--- a/css/CSS2/generated-content/content-096.xht
+++ b/css/CSS2/generated-content/content-096.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-096-ref.html" />
         <link media="all" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'media'." />

--- a/css/CSS2/generated-content/content-097-ref.html
+++ b/css/CSS2/generated-content/content-097-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "get" appears in the box below.</p>
+    <div>get</div>
+</body>

--- a/css/CSS2/generated-content/content-097.xht
+++ b/css/CSS2/generated-content/content-097.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-097-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'method'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-100-ref.html
+++ b/css/CSS2/generated-content/content-100-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "nohref" appears in the box below.</p>
+    <div>nohref</div>
+</body>

--- a/css/CSS2/generated-content/content-100.xht
+++ b/css/CSS2/generated-content/content-100.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-100-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'nohref'." />
         <style type="text/css">
@@ -21,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if the word "nohref" appear in the box below.</p>
+        <p>Test passes if the word "nohref" appears in the box below.</p>
         <div>
             <map id="test">
                 <area alt="" nohref="nohref" />

--- a/css/CSS2/generated-content/content-103-ref.html
+++ b/css/CSS2/generated-content/content-103-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the word "nowrap" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>nowrap</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-103.xht
+++ b/css/CSS2/generated-content/content-103.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-103-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'nowrap'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-126-ref.html
+++ b/css/CSS2/generated-content/content-126-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if only the word "Alternate" appears in the box below.</p>
+    <div>Alternate</div>
+</body>

--- a/css/CSS2/generated-content/content-126.xht
+++ b/css/CSS2/generated-content/content-126.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-126-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'rel'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(rel);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-127.xht
+++ b/css/CSS2/generated-content/content-127.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-126-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'rev'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(rev);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-129.xht
+++ b/css/CSS2/generated-content/content-129.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-053-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'rowspan'." />
         <style type="text/css">
@@ -20,7 +21,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if only the number "1" appears in the box below.</p>
+        <p>Test passes if the number "1" appears in the box below.</p>
         <table>
             <tr>
                 <td rowspan="1"></td>

--- a/css/CSS2/generated-content/content-132-ref.html
+++ b/css/CSS2/generated-content/content-132-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if only the word "col" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>col</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-132.xht
+++ b/css/CSS2/generated-content/content-132.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-132-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'scope'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-135-ref.html
+++ b/css/CSS2/generated-content/content-135-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if only the word "circle" appears in the box below.</p>
+    <div>circle</div>
+</body>

--- a/css/CSS2/generated-content/content-135.xht
+++ b/css/CSS2/generated-content/content-135.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-135-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'shape'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(shape);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-136-ref.html
+++ b/css/CSS2/generated-content/content-136-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    font {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if the number "5" appears in the box below.</p>
+    <div><font size="5">5</font></div>
+</body>

--- a/css/CSS2/generated-content/content-136.xht
+++ b/css/CSS2/generated-content/content-136.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-136-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'size'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-141-ref.html
+++ b/css/CSS2/generated-content/content-141-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the words "color: green;" appear in the box below.</p>
+    <div>color: green;</div>
+</body>

--- a/css/CSS2/generated-content/content-141.xht
+++ b/css/CSS2/generated-content/content-141.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-141-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'style'." />
         <meta http-equiv="Content-Style-Type" content="text/css" />

--- a/css/CSS2/generated-content/content-143-ref.html
+++ b/css/CSS2/generated-content/content-143-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the number "5" appears in the box below.</p>
+    <div>5</div>
+</body>

--- a/css/CSS2/generated-content/content-143.xht
+++ b/css/CSS2/generated-content/content-143.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-143-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'tabindex'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(tabindex);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-144-ref.html
+++ b/css/CSS2/generated-content/content-144-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the word "_blank" appears in the box below.</p>
+    <div>_blank</div>
+</body>

--- a/css/CSS2/generated-content/content-144.xht
+++ b/css/CSS2/generated-content/content-144.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-144-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'target'." />
         <style type="text/css">
@@ -13,7 +14,7 @@
                 content: attr(target);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }

--- a/css/CSS2/generated-content/content-147-ref.html
+++ b/css/CSS2/generated-content/content-147-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the words "text/plain" appear in the box below.</p>
+    <div>text/plain</div>
+</body>

--- a/css/CSS2/generated-content/content-147.xht
+++ b/css/CSS2/generated-content/content-147.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-147-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'type'." />
         <style type="text/css">
@@ -13,14 +14,14 @@
                 content: attr(type);
                 color: green;
             }
-            a
+            div
             {
                 border: 2px solid black;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if the words "text/plain"" appear in the box below.</p>
+        <p>Test passes if the words "text/plain" appear in the box below.</p>
         <div>
             <a type="text/plain"></a>
         </div>

--- a/css/CSS2/generated-content/content-149-ref.html
+++ b/css/CSS2/generated-content/content-149-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    td {
+        color: green;
+        border: 2px solid black;
+    }
+</style>
+<body>
+    <p>Test passes if only the word "baseline" appears in the box below.</p>
+    <table>
+        <tr>
+            <td>baseline</td>
+        </tr>
+    </table>
+</body>

--- a/css/CSS2/generated-content/content-149.xht
+++ b/css/CSS2/generated-content/content-149.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-149-ref.html" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'valign'." />
         <style type="text/css">
             td:before

--- a/css/CSS2/generated-content/content-150-ref.html
+++ b/css/CSS2/generated-content/content-150-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    li {
+        color: green;
+        border: 2px solid black;
+        display: block;
+    }
+</style>
+<body>
+    <p>Test passes if only the number "1" appears in the box below.</p>
+    <ol>
+        <li>1</li>
+    </ol>
+</body>

--- a/css/CSS2/generated-content/content-150.xht
+++ b/css/CSS2/generated-content/content-150.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-150-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'value'." />
         <style type="text/css">
@@ -21,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if only the number "1" appear in the box below.</p>
+        <p>Test passes if only the number "1" appears in the box below.</p>
         <ol>
             <li value="1"></li>
         </ol>

--- a/css/CSS2/generated-content/content-155-ref.html
+++ b/css/CSS2/generated-content/content-155-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    pre {
+        border: 2px solid black;
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the number "10" appears in the box below.</p>
+    <pre>10</pre>
+</body>

--- a/css/CSS2/generated-content/content-155.xht
+++ b/css/CSS2/generated-content/content-155.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-155-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles the 'attr()' function when calling the attribute 'width'." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-156-ref.html
+++ b/css/CSS2/generated-content/content-156-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid blue;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a quote (") in the blue box below.</p>
+    <div>"</div>
+</body>

--- a/css/CSS2/generated-content/content-156.xht
+++ b/css/CSS2/generated-content/content-156.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-156-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles an 'open-quote' value." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-157.xht
+++ b/css/CSS2/generated-content/content-157.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-156-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'close-quote' value." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-158-ref.html
+++ b/css/CSS2/generated-content/content-158-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid blue;
+        height: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if there is a single quote (') in the blue box below.</p>
+    <div>'</div>
+</body>

--- a/css/CSS2/generated-content/content-158.xht
+++ b/css/CSS2/generated-content/content-158.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-158-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'no-open-quote' value." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-159-ref.html
+++ b/css/CSS2/generated-content/content-159-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: 2px solid blue;
+    }
+</style>
+<body>
+    <p>Test passes if there are 3 quotes (" ' ") in the blue box.</p>
+    <div>" ' "</div>
+</body>

--- a/css/CSS2/generated-content/content-159.xht
+++ b/css/CSS2/generated-content/content-159.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-159-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'content' property properly handles a 'no-close-quote' value." />
         <style type="text/css">
@@ -24,7 +25,7 @@
             {
                 content: no-close-quote;
             }
-            #span1
+            div
             {
                 border: 2px solid blue;
             }

--- a/css/CSS2/generated-content/content-auto-reset-001-ref.html
+++ b/css/CSS2/generated-content/content-auto-reset-001-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>Test passes if there is the number '0' below.</p>
+    <div>0</div>
+</body>

--- a/css/CSS2/generated-content/content-auto-reset-001.xht
+++ b/css/CSS2/generated-content/content-auto-reset-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Content property on out of scope counter</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-auto-reset-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="If content refers to a counter that is not in scope, it is assumed that a counter-reset has occurred and the counter is reset to zero." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-newline-001-ref.html
+++ b/css/CSS2/generated-content/content-newline-001-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        height: 100px;
+        width: 200px;
+    }
+</style>
+<body>
+    <p>Test passes if there are exactly two lines of text below.</p>
+    <div>This text<br />should be on two lines.</div>
+</body>

--- a/css/CSS2/generated-content/content-newline-001.xht
+++ b/css/CSS2/generated-content/content-newline-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Content property \A creates newline</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-newline-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="A '\A' creates a newline for strings in the content property." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-white-space-001-ref.html
+++ b/css/CSS2/generated-content/content-white-space-001-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: solid green;
+        width: 25em;
+    }
+    #test {
+    	border: solid blue;
+    }
+</style>
+<body>
+    <p>Test passes if the text in the green box and the blue box have the same spacing between words and the lines wrap at the same point.</p>
+    <div>This text<br />should be on two lines.</div>
+    <div id="test">This text<br />should be on two lines.</div>
+</body>

--- a/css/CSS2/generated-content/content-white-space-001.xht
+++ b/css/CSS2/generated-content/content-white-space-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Content property and white-space: pre-line</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-white-space-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="'white-space: pre-line' applies to generated string content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-white-space-002-ref.html
+++ b/css/CSS2/generated-content/content-white-space-002-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: solid silver;
+        margin: 0.5em;
+        padding: 0.2em;
+        color: blue;
+        white-space: pre;
+    }
+</style>
+<body>
+    <p>Test passes if the contents of the two silver boxes are identical.</p>
+    <div>This text
+        should be on
+        four
+        lines.</div>
+    <div>This text
+        should be on
+        four
+        lines.</div>
+</body>

--- a/css/CSS2/generated-content/content-white-space-002.xht
+++ b/css/CSS2/generated-content/content-white-space-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-white-space-002-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="'white-space: pre' applies to generated string content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-white-space-003-ref.html
+++ b/css/CSS2/generated-content/content-white-space-003-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: solid silver;
+        margin: 0.5em;
+        padding: 0.2em;
+        color: blue;
+    }
+</style>
+<body>
+    <p>Test passes if the contents of the two silver boxes are identical.</p>
+    <div>This text should be on one line.</div>
+    <div>This text should be on one line.</div>
+</body>

--- a/css/CSS2/generated-content/content-white-space-003.xht
+++ b/css/CSS2/generated-content/content-white-space-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-white-space-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="'white-space: nowrap' applies to generated string content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/content-white-space-004-ref.html
+++ b/css/CSS2/generated-content/content-white-space-004-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        border: solid silver;
+        margin: 0.5em;
+        padding: 0.2em;
+        color: blue;
+        width: 10em;
+    }
+</style>
+<body>
+    <p>Test passes if the contents of the two silver boxes are identical.</p>
+    <div>This text should wrap normally.</div>
+    <div>This text should wrap normally.</div>
+</body>

--- a/css/CSS2/generated-content/content-white-space-004.xht
+++ b/css/CSS2/generated-content/content-white-space-004.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact" />
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#content" />
+        <link rel="match" href="content-white-space-004-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="'white-space: normal' applies to generated string content." />
         <style type="text/css">

--- a/css/CSS2/generated-content/counters-hidden-000-ref.html
+++ b/css/CSS2/generated-content/counters-hidden-000-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The following should be identical:</p>
+    <div>0</div>
+    <div>0</div>
+</body>

--- a/css/CSS2/generated-content/counters-hidden-000.xht
+++ b/css/CSS2/generated-content/counters-hidden-000.xht
@@ -7,6 +7,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-hidden-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-hidden-001.xht
+++ b/css/CSS2/generated-content/counters-hidden-001.xht
@@ -7,6 +7,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-hidden-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-hidden-002-ref.html
+++ b/css/CSS2/generated-content/counters-hidden-002-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The following should be identical:</p>
+    <div>1</div>
+    <div>1</div>
+</body>

--- a/css/CSS2/generated-content/counters-hidden-002.xht
+++ b/css/CSS2/generated-content/counters-hidden-002.xht
@@ -7,6 +7,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-hidden-002-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-multi-000-ref.html
+++ b/css/CSS2/generated-content/counters-multi-000-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The following should be identical:</p>
+    <div>12</div>
+    <div>12</div>
+</body>

--- a/css/CSS2/generated-content/counters-multi-000.xht
+++ b/css/CSS2/generated-content/counters-multi-000.xht
@@ -6,6 +6,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-multi-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-multi-001.xht
+++ b/css/CSS2/generated-content/counters-multi-001.xht
@@ -6,6 +6,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-multi-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-order-000-ref.html
+++ b/css/CSS2/generated-content/counters-order-000-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The following should be identical:</p>
+    <div>0 1 2 3 4 4 4 4 8 9 10 11 12 12 12 12</div>
+    <div>0 1 2 3 4 4 4 4 8 9 10 11 12 12 12 12</div>
+</body>

--- a/css/CSS2/generated-content/counters-order-000.xht
+++ b/css/CSS2/generated-content/counters-order-000.xht
@@ -6,6 +6,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-order-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }

--- a/css/CSS2/generated-content/counters-root-000-ref.html
+++ b/css/CSS2/generated-content/counters-root-000-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>The following should be identical:</p>
+    <div>4.8</div>
+    <div>4.8</div>
+</body>

--- a/css/CSS2/generated-content/counters-root-000.xht
+++ b/css/CSS2/generated-content/counters-root-000.xht
@@ -6,6 +6,7 @@
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-content"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#counter"/>
+  <link rel="match" href="counters-root-000-ref.html" />
   <style type="text/css">
 
   body { white-space: nowrap; }


### PR DESCRIPTION
Many CSS2/generated-content tests were missing references. This change adds in more references for these tests.

The only significant changes to tests were in content-016.xht and content-032.xht, which specified that either an uppercase or lowercase Armenian character would pass each test. According to [the CSS2 spec](https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type), `armenian` is "Traditional uppercase Armenian numbering", so I don't see any reason why a lowercase letter would be correct. [The current spec](https://drafts.csswg.org/css-counter-styles/#simple-numeric) agrees with this, indicating that `armenian` and `upper-armenian` are synonyms.

This is part of #8670, and finishes most of CSS2/generated-content. However, more references are needed.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
