### PR TITLE
Add references for CSS2/sec5

### DIFF
--- a/css/CSS2/sec5/class-000-ref.html
+++ b/css/CSS2/sec5/class-000-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    p {
+        color: fuchsia;
+    }
+    div {
+        color: orange;
+    }
+    h4 {
+        color: blue;
+    }
+</style>
+<body>
+    <p>This text should be fuchsia.</p>
+    <div>This text should be orange.</div>
+    <h4>This text should be blue.</h4>
+</body>

--- a/css/CSS2/sec5/class-000.xht
+++ b/css/CSS2/sec5/class-000.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: Class selectors</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="class-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class"/>
 <style type="text/css">

--- a/css/CSS2/sec5/class-001.xht
+++ b/css/CSS2/sec5/class-001.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: Class selectors with the universal selector</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="class-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class"/>
 <style type="text/css">

--- a/css/CSS2/sec5/class-002-ref.html
+++ b/css/CSS2/sec5/class-002-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    p {
+        color: fuchsia;
+    }
+    div {
+        color: fuchsia;
+        border: thin solid;
+    }
+    h4 {
+        color: blue;
+    }
+</style>
+<body>
+    <p>This text should be fuchsia.</p>
+    <div>This text should be fuchsia with a thin fuchsia border.</div>
+    <h4>This text should be blue without any border.</h4>
+</body>

--- a/css/CSS2/sec5/class-002.xht
+++ b/css/CSS2/sec5/class-002.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: Class selectors: Multiple classes</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="class-002-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified class or classes"/>
 <style type="text/css">

--- a/css/CSS2/sec5/first-child-000-ref.html
+++ b/css/CSS2/sec5/first-child-000-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    p {
+        color: fuchsia;
+    }
+    div {
+        color: orange;
+    }
+    h4 {
+        color: blue;
+    }
+    .silver {
+        color: silver;
+    }
+</style>
+<body>
+    <p><em>This text should be fuchsia.</em> <span class="silver">Filler text.</span></p>
+    <div>This text should be orange.</div>
+    <p class="silver">Filler text.</p>
+    <h4>This text should be blue. <span class="silver">Filler text.</span></h4>
+</body>

--- a/css/CSS2/sec5/first-child-000.xht
+++ b/css/CSS2/sec5/first-child-000.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: The :first-child pseudo-class</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
+  <link rel="match" href="first-child-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the element which is the first child of its parent"/>
 <style type="text/css">

--- a/css/CSS2/sec5/first-child-001.xht
+++ b/css/CSS2/sec5/first-child-001.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: The :first-child pseudo-class with the universal selector</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
+  <link rel="match" href="first-child-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the element which is the first child of its parent"/>
 <style type="text/css">

--- a/css/CSS2/sec5/first-line-000-ref.html
+++ b/css/CSS2/sec5/first-line-000-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    p {
+        color: fuchsia;
+    }
+    span {
+        color: silver;
+    }
+</style>
+<body>
+    <p>The first line of this paragraph should be fuchsia (same as in the next block).<br /><span>Filler text.</span></p>
+    <p>Lorem ipsum dolor.<br /><span>Filler text.</span></p>
+</body>

--- a/css/CSS2/sec5/first-line-000.xht
+++ b/css/CSS2/sec5/first-line-000.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: The :first-line pseudo-element</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+  <link rel="match" href="first-line-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply the rule only to the first line of a block-level element"/>
 <style type="text/css">

--- a/css/CSS2/sec5/id-000.xht
+++ b/css/CSS2/sec5/id-000.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: ID selectors</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors" />
+  <link rel="match" href="class-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified ID"/>
 <style type="text/css">

--- a/css/CSS2/sec5/id-001.xht
+++ b/css/CSS2/sec5/id-001.xht
@@ -5,6 +5,7 @@
   <title>CSS Test: Selectors: ID selectors with universal selector</title>
   <link rel="author" title="Gabriele Romanato" href="mailto:gabriele.romanato@gmail.com" />
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors" />
+  <link rel="match" href="class-000-ref.html"/>
   <meta name="flags" content="" />
   <meta name="assert" content="Browsers should apply each rule to the elements which have the specified ID"/>
 <style type="text/css">


### PR DESCRIPTION
Some CSS2/sec5 tests were missing references. This adds in references for the remaining sec5 tests without references except for first-letter-000.xht.

Part of #8670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
