### PR TITLE
Add in references for css/CSS2/selector tests

### DIFF
--- a/css/CSS2/selector/attribute-value-selector-007-ref.html
+++ b/css/CSS2/selector/attribute-value-selector-007-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .green {
+        background-color: green;
+        color: white;
+    }
+</style>
+<body>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <p class="green">This line should be green <em>and this should also be green</em></p>
+
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green<p>This line should NOT be green</p></div>
+    <p>This line should NOT be green <em>and this should not be green either</em></p>
+</body>

--- a/css/CSS2/selector/attribute-value-selector-007.html
+++ b/css/CSS2/selector/attribute-value-selector-007.html
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com">
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors">
+    <link rel="match" href="attribute-value-selector-007-ref.html" />
     <meta name="flags" content="HTMLonly">
     <meta name="assert" content="lang attribute selector with att=val in HTML should not be case sensitive, and should only match when att is exactly val">
     <style type="text/css">

--- a/css/CSS2/selector/attribute-value-selector-008-ref.html
+++ b/css/CSS2/selector/attribute-value-selector-008-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .green {
+        background-color: green;
+        color: white;
+    }
+</style>
+<body>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <p class="green">This line should be green <em>and this should also be green</em></p>
+
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green<p>This line should NOT be green</p></div>
+    <p>This line should NOT be green <em>and this should not be green either</em></p>
+</body>

--- a/css/CSS2/selector/attribute-value-selector-008.xht
+++ b/css/CSS2/selector/attribute-value-selector-008.xht
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors"/>
+    <link rel="match" href="attribute-value-selector-008-ref.html" />
     <meta name="flags" content="nonHTML"/>
     <meta name="assert" content="attribute selector with att=val in XHTML should be case sensitive, and should only match when att is exactly val"/>
     <style type="text/css"><![CDATA[

--- a/css/CSS2/selector/attribute-value-selector-009-ref.html
+++ b/css/CSS2/selector/attribute-value-selector-009-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .green {
+        background-color: green;
+        color: white;
+    }
+</style>
+<body>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <p class="green">This line should be green <em>and this should be green too</em></p>
+
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green<p>This line should NOT be green</p></div>
+    <p>This line should NOT be green <em>and this should not be green either</em></p>
+</body>

--- a/css/CSS2/selector/attribute-value-selector-009.xht
+++ b/css/CSS2/selector/attribute-value-selector-009.xht
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors"/>
+    <link rel="match" href="attribute-value-selector-009-ref.html" />
     <meta name="flags" content="nonHTML"/>
     <meta name="assert" content="lang attribute selector with 'att |= val' in XHTML should be case sensitive, and match hyphen-separated list"/>
     <style type="text/css"><![CDATA[

--- a/css/CSS2/selector/attribute-value-selector-010-ref.html
+++ b/css/CSS2/selector/attribute-value-selector-010-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .green {
+        background-color: green;
+        color: white;
+    }
+</style>
+<body>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <p class="green">This line should be green <em>and this should be green too</em></p>
+
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green<p>This line should NOT be green</p></div>
+    <p>This line should NOT be green <em>and this should not be green either</em></p>
+</body>

--- a/css/CSS2/selector/attribute-value-selector-010.html
+++ b/css/CSS2/selector/attribute-value-selector-010.html
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com">
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#attribute-selectors">
+    <link rel="match" href="attribute-value-selector-010-ref.html" />
     <meta name="flags" content="HTMLonly">
     <meta name="assert" content="lang attribute selector with 'att |= val' in HTML should not be case sensitive, and match hyphen-separated list">
     <style type="text/css">

--- a/css/CSS2/selector/lang-pseudoclass-001-ref.html
+++ b/css/CSS2/selector/lang-pseudoclass-001-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .green {
+        background-color: green;
+        color: white;
+    }
+</style>
+<body>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+    <div class="green">This line should be green</div>
+
+    <p class="green">This line should be green <em>and this should be green too</em></p>
+    <div><p class="green">This line should be green</p>This line should NOT be green</div>
+    <p>This line should NOT be green <em class="green">but this should be green</em></p>
+
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+    <div>This line should NOT be green</div>
+</body>

--- a/css/CSS2/selector/lang-pseudoclass-001.html
+++ b/css/CSS2/selector/lang-pseudoclass-001.html
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com">
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#lang">
+    <link rel="match" href="lang-pseudoclass-001-ref.html" />
     <meta name="flags" content="HTMLonly" >
     <meta name="assert" content=":lang pseudoclass in HTML should not be case-sensitive, and match a substring">
     <style type="text/css">

--- a/css/CSS2/selector/lang-pseudoclass-002.xht
+++ b/css/CSS2/selector/lang-pseudoclass-002.xht
@@ -5,6 +5,7 @@
     <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org"/>
     <link rel="author" title="Eira Monstad, Opera Software ASA" href="mailto:public-testsuites@opera.com"/>
     <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#lang"/>
+    <link rel="match" href="lang-pseudoclass-001-ref.html" />
     <meta name="flags" content="nonHTML" />
     <meta name="assert" content=":lang pseudoclass in XHTML should be case sensitive, and match a substring"/>
     <style type="text/css"><![CDATA[
@@ -23,8 +24,6 @@
 
     <div xml:lang="en-GB">This line should be green</div>
     <div xml:lang="en-GB-scouse">This line should be green</div>
-
-    <div xml:lang="es">This line should be green</div>
 
     <p xml:lang="es">This line should be green <em>and this should be green too</em></p>
 


### PR DESCRIPTION
All CSS2/selector tests were missing references. This change adds in references for these tests.

I removed one line from lang-pseudoclass-002.xht as it was an exact duplicate of line 21 in the test, and made it so that only one reference would be needed for both lang-pseudoclass tests.

Part of #8670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
