### PR TITLE
Correct colors-083-ref.xht

### DIFF
--- a/css/CSS2/colors/color-083-ref.xht
+++ b/css/CSS2/colors/color-083-ref.xht
@@ -30,7 +30,6 @@
   </div>
 
   <div>
-    <br />
     <img alt="Image download support must be enabled" src="support/800000_color.png" />
   </div>
 


### PR DESCRIPTION
css/CSS2/colors/colors-083-ref.xht had an extra line break which was causing colors-083.xht and colors-084.xht to fail. This change removes the extra line break.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
