### PR TITLE
Remove check for history.length in browsing-context.html.

### DIFF
--- a/html/browsers/windows/browsing-context.html
+++ b/html/browsers/windows/browsing-context.html
@@ -44,11 +44,6 @@
       assert_equals(doc.referrer, document.URL, "The document's referrer should be its creator document's address.");
       assert_equals(iframe.contentWindow.parent.document, document);
     }, "Check the document properties corresponding to the creator browsing context");
-
-    test(function () {
-      assert_equals(iframe.contentWindow.history.length, 1, "The history.length should be 1.");
-    }, "Check the history.length of the created browsing context");
-
     </script>
   </body>
 </html>


### PR DESCRIPTION
The History object reflects the state of the joint session history of the
top-level browsing context, rather than a fresh state created along with
the browsing context. This means the length cannot be assumed to be one.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
