### PR TITLE
Fix discrepancy between OffscreenCanvas.convertToBlob() and canvas.toBlob()

### DIFF
--- a/offscreen-canvas/the-offscreen-canvas/offscreencanvas.convert.to.blob.html
+++ b/offscreen-canvas/the-offscreen-canvas/offscreencanvas.convert.to.blob.html
@@ -136,13 +136,12 @@ async_test(function(t) {
 
 async_test(function(t) {
     var offscreenCanvas = new OffscreenCanvas(0, 0);
-    offscreenCanvas.convertToBlob().then(t.step_func_done(function() {
-        assert_false("convertToBlob didn't throw, but should be");
+    offscreenCanvas.convertToBlob().then(t.step_func_done(function(blob) {
+        assert_equals(null, blob, "convertToBlob should return null as result blob.");
     }), t.step_func_done(function(e) {
-        assert_true(e instanceof DOMException);
-        assert_equals(e.name, "IndexSizeError");
+        assert_false("convertToBlob should not throw exception.");
     }));
-}, "Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception");
+}, "Test that call convertToBlob on a OffscreenCanvas with size 0 returns null blob");
 
 </script>
 

--- a/offscreen-canvas/the-offscreen-canvas/offscreencanvas.convert.to.blob.html
+++ b/offscreen-canvas/the-offscreen-canvas/offscreencanvas.convert.to.blob.html
@@ -139,9 +139,9 @@ async_test(function(t) {
     offscreenCanvas.convertToBlob().then(t.step_func_done(function(blob) {
         assert_equals(null, blob, "convertToBlob should return null as result blob.");
     }), t.step_func_done(function(e) {
-        assert_false("convertToBlob should not throw exception.");
+        assert_false("convertToBlob should not throw an exception.");
     }));
-}, "Test that call convertToBlob on a OffscreenCanvas with size 0 returns null blob");
+}, "Test that calls convertToBlob on a OffscreenCanvas with size 0 returns a null blob");
 
 </script>
 


### PR DESCRIPTION
This is a follow-up work of https://chromium-review.googlesource.com/c/chromium/src/+/834394. When canvas has invalid image size (width/height is zero), calling canvas.toBlob() returns a null blob. In OffscreenCanvas, it throws exception; this is wrong and we should make it consistent with canvas.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
