### PR TITLE
Correct CSS2/css1/c414-flt-fit-000.xht and reference

### DIFF
--- a/css/CSS2/css1/c414-flt-fit-000-ref.xht
+++ b/css/CSS2/css1/c414-flt-fit-000-ref.xht
@@ -17,13 +17,12 @@
   margin-left: 10px;
   padding: 1em;
   table-layout: fixed;
-  width: 16.375em;
+  width: 16em;
   /*
    14em (5em column + 5em column + 4em column)
   + 2em (left and right horizontal padding)
-  + 6px (2 vertical 3px borders)
   =====
-  16.375em
+  16em
   */
   }
 
@@ -33,7 +32,6 @@
 
   td
   {
-  color: navy;
   padding: 0;
   }
   ]]></style>

--- a/css/CSS2/css1/c414-flt-fit-000.xht
+++ b/css/CSS2/css1/c414-flt-fit-000.xht
@@ -11,7 +11,7 @@
 
   <style type="text/css"><![CDATA[
    div { border: solid blue; padding: 1em; width: 14em; margin: 10px; }
-   div p { margin: 0; width: 5em; float: left; color: navy; }
+   div p { margin: 0; width: 5em; float: left; }
   ]]></style>
 
  </head>


### PR DESCRIPTION
The reference for CSS2/css1/c414-flt-fit-000.xht did not match the test, as it added the border size into the expected width, and did not have navy everywhere the test had it. This change fixes these issues by removing the border size from the expected width, and removing navy from both the test and reference.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
