### PR TITLE
Accept cookie domains with leading dot character

### DIFF
--- a/webdriver/tests/cookies/add_cookie.py
+++ b/webdriver/tests/cookies/add_cookie.py
@@ -1,15 +1,14 @@
 from tests.support.fixtures import clear_all_cookies
-from tests.support.fixtures import server_config
 from datetime import datetime, timedelta
 
-def test_add_domain_cookie(session, url):
+def test_add_domain_cookie(session, url, server_config):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
     create_cookie_request = {
         "cookie": {
             "name": "hello",
             "value": "world",
-            "domain": "web-platform.test",
+            "domain": server_config["domains"][""],
             "path": "/",
             "httpOnly": False,
             "secure": False
@@ -37,16 +36,16 @@ def test_add_domain_cookie(session, url):
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
-    assert cookie["domain"] == ".web-platform.test"
+    assert cookie["domain"] == ".%s" % server_config["domains"][""]
 
-def test_add_cookie_for_ip(session, url, server_config):
+def test_add_cookie_for_ip(session, url, server_config, configuration):
     session.url = "http://127.0.0.1:%s/404" % (server_config["ports"]["http"][0])
     clear_all_cookies(session)
     create_cookie_request = {
         "cookie": {
             "name": "hello",
             "value": "world",
-            "domain": "127.0.0.1",
+            "domain": configuration["host"],
             "path": "/",
             "httpOnly": False,
             "secure": False
@@ -142,3 +141,37 @@ def test_add_session_cookie(session, url):
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
+
+def test_add_session_cookie_with_leading_dot_character_in_domain(session, url, server_config):
+    session.url = url("/common/blank.html")
+    clear_all_cookies(session)
+    create_cookie_request = {
+        "cookie": {
+            "name": "hello",
+            "value": "world",
+            "domain": ".%s" % server_config["domains"][""]
+        }
+    }
+    result = session.transport.send("POST", "session/%s/cookie" % session.session_id, create_cookie_request)
+    assert result.status == 200
+    assert "value" in result.body
+    assert isinstance(result.body["value"], dict)
+
+    result = session.transport.send("GET", "session/%s/cookie" % session.session_id)
+    assert result.status == 200
+    assert "value" in result.body
+    assert isinstance(result.body["value"], list)
+    assert len(result.body["value"]) == 1
+    assert isinstance(result.body["value"][0], dict)
+
+    cookie = result.body["value"][0]
+    assert "name" in cookie
+    assert isinstance(cookie["name"], basestring)
+    assert "value" in cookie
+    assert isinstance(cookie["value"], basestring)
+    assert "domain" in cookie
+    assert isinstance(cookie["domain"], basestring)
+
+    assert cookie["name"] == "hello"
+    assert cookie["value"] == "world"
+    assert cookie["domain"] == ".%s" % server_config["domains"][""]

--- a/webdriver/tests/cookies/get_named_cookie.py
+++ b/webdriver/tests/cookies/get_named_cookie.py
@@ -61,14 +61,14 @@ def test_get_named_cookie(session, url):
     # convert from seconds since epoch
     assert datetime.utcfromtimestamp(cookie["expiry"]).strftime(utc_string_format) == a_year_from_now
 
-def test_duplicated_cookie(session, url):
+def test_duplicated_cookie(session, url, server_config):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
     create_cookie_request = {
         "cookie": {
             "name": "hello",
             "value": "world",
-            "domain": "web-platform.test",
+            "domain": server_config["domains"][""],
             "path": "/",
             "httpOnly": False,
             "secure": False
@@ -79,7 +79,7 @@ def test_duplicated_cookie(session, url):
     assert "value" in result.body
     assert isinstance(result.body["value"], dict)
 
-    session.url = inline("<script>document.cookie = 'hello=newworld; domain=web-platform.test; path=/';</script>")
+    session.url = inline("<script>document.cookie = 'hello=newworld; domain=%s; path=/';</script>" % server_config["domains"][""])
     result = session.transport.send("GET", "session/%s/cookie" % session.session_id)
     assert result.status == 200
     assert "value" in result.body


### PR DESCRIPTION

Domain cookies retrieved from Marionette have leading dot characters in
them. This change will ensure that adding cookies with leading dot
characters works as expected.

MozReview-Commit-ID: IriHVCcVcP3

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1415828 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8843)
<!-- Reviewable:end -->
