### PR TITLE
Increase individual web-platform test timeout on coverage builds.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -51,7 +51,10 @@ def get_timeout_multiplier(test_type, run_info_data, **kwargs):
         else:
             return 2
     elif run_info_data["debug"] or run_info_data.get("asan"):
-        return 3
+        if run_info_data.get("ccov"):
+            return 4
+        else:
+            return 3
     return 1
 
 


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1418283 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8850)
<!-- Reviewable:end -->
