### PR TITLE
Use WebDriver conformant interactability checks for sendKeysToElement.

### DIFF
--- a/webdriver/OWNERS
+++ b/webdriver/OWNERS
@@ -4,3 +4,4 @@
 @lukeis
 @mjzffr
 @shs96c
+@whimboo

--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -1,0 +1,136 @@
+from tests.support.asserts import assert_error, assert_same_element, assert_success
+from tests.support.inline import iframe, inline
+
+
+def send_keys_to_element(session, element, text):
+    return session.transport.send(
+        "POST",
+        "/session/{session_id}/element/{element_id}/value".format(
+            session_id=session.session_id,
+            element_id=element.id),
+        {"text": text})
+
+
+def test_body_is_interactable(session):
+    session.url = inline("""
+        <body onkeypress="document.getElementById('result').value += event.key">
+          <input type="text" id="result"/>
+        </body>
+    """)
+
+    element = session.find.css("body", all=False)
+    result = session.find.css("input", all=False)
+
+    # By default body is the active element
+    assert_same_element(session, element, session.active_element)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+    assert_same_element(session, element, session.active_element)
+    assert result.property("value") == "foo"
+
+
+def test_document_element_is_interactable(session):
+    session.url = inline("""
+        <html onkeypress="document.getElementById('result').value += event.key">
+          <input type="text" id="result"/>
+        </html>
+    """)
+
+    body = session.find.css("body", all=False)
+    element = session.find.css(":root", all=False)
+    result = session.find.css("input", all=False)
+
+    # By default body is the active element
+    assert_same_element(session, body, session.active_element)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+    assert_same_element(session, element, session.active_element)
+    assert result.property("value") == "foo"
+
+
+def test_iframe_is_interactable(session):
+    session.url = inline(iframe("""
+        <body onkeypress="document.getElementById('result').value += event.key">
+          <input type="text" id="result"/>
+        </body>
+    """))
+
+    body = session.find.css("body", all=False)
+    frame = session.find.css("iframe", all=False)
+
+    # By default the body has the focus
+    assert_same_element(session, body, session.active_element)
+
+    response = send_keys_to_element(session, frame, "foo")
+    assert_success(response)
+    assert_same_element(session, frame, session.active_element)
+
+    # Any key events are immediately routed to the nested
+    # browsing context's active document.
+    session.switch_frame(frame)
+    result = session.find.css("input", all=False)
+    assert result.property("value") == "foo"
+
+
+def test_transparent_element(session):
+    session.url = inline("<input style=\"opacity: 0;\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+    assert element.property("value") == "foo"
+
+
+def test_readonly_element(session):
+    session.url = inline("<input readonly>")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+    assert element.property("value") == ""
+
+
+def test_obscured_element(session):
+    session.url = inline("""
+      <input type="text" />
+      <div style="position: relative; top: -3em; height: 5em; background-color: blue"></div>
+    """)
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+    assert element.property("value") == "foo"
+
+
+def test_not_a_focusable_element(session):
+    session.url = inline("<div>foo</div>")
+    element = session.find.css("div", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_error(response, "element not interactable")
+
+
+def test_not_displayed_element(session):
+    session.url = inline("<input style=\"display: none\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_error(response, "element not interactable")
+
+
+def test_hidden_element(session):
+    session.url = inline("<input style=\"visibility: hidden\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_error(response, "element not interactable")
+
+
+def test_disabled_element(session):
+    session.url = inline("<input disabled=\"false\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_error(response, "element not interactable")

--- a/webdriver/tests/element_send_keys/scroll_into_view.py
+++ b/webdriver/tests/element_send_keys/scroll_into_view.py
@@ -1,0 +1,78 @@
+from tests.support.asserts import assert_success
+from tests.support.fixtures import is_element_in_viewport
+from tests.support.inline import inline
+
+
+def send_keys_to_element(session, element, text):
+    return session.transport.send(
+        "POST",
+        "/session/{session_id}/element/{element_id}/value".format(
+            session_id=session.session_id,
+            element_id=element.id),
+        {"text": text})
+
+
+def test_element_outside_of_not_scrollable_viewport(session):
+    session.url = inline("<input style=\"position: relative; left: -9999px;\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+
+    assert not is_element_in_viewport(session, element)
+
+
+def test_element_outside_of_scrollable_viewport(session):
+    session.url = inline("<input style=\"margin-top: 102vh;\">")
+    element = session.find.css("input", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+
+    assert is_element_in_viewport(session, element)
+
+
+def test_option_select_container_outside_of_scrollable_viewport(session):
+    session.url = inline("""
+        <select style="margin-top: 102vh;">
+          <option value="foo">foo</option>
+          <option value="bar" id="bar">bar</option>
+        </select>
+    """)
+    element = session.find.css("option#bar", all=False)
+    select = session.find.css("select", all=False)
+
+    response = send_keys_to_element(session, element, "bar")
+    assert_success(response)
+
+    assert is_element_in_viewport(session, select)
+    assert is_element_in_viewport(session, element)
+
+
+def test_option_stays_outside_of_scrollable_viewport(session):
+    session.url = inline("""
+        <select multiple style="height: 105vh; margin-top: 100vh;">
+          <option value="foo" id="foo" style="height: 100vh;">foo</option>
+          <option value="bar" id="bar" style="background-color: yellow;">bar</option>
+        </select>
+    """)
+    select = session.find.css("select", all=False)
+    option_foo = session.find.css("option#foo", all=False)
+    option_bar = session.find.css("option#bar", all=False)
+
+    response = send_keys_to_element(session, option_bar, "bar")
+    assert_success(response)
+
+    assert is_element_in_viewport(session, select)
+    assert is_element_in_viewport(session, option_foo)
+    assert not is_element_in_viewport(session, option_bar)
+
+
+def test_contenteditable_element_outside_of_scrollable_viewport(session):
+    session.url = inline("<div contenteditable style=\"margin-top: 102vh;\"></div>")
+    element = session.find.css("div", all=False)
+
+    response = send_keys_to_element(session, element, "foo")
+    assert_success(response)
+
+    assert is_element_in_viewport(session, element)

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -1,5 +1,6 @@
 from webdriver import Element, WebDriverException
 
+
 # WebDriver specification ID: dfn-error-response-data
 errors = {
     "element click intercepted": 400,
@@ -31,6 +32,7 @@ errors = {
     "unknown method": 405,
     "unsupported operation": 500,
 }
+
 
 # WebDriver specification ID: dfn-send-an-error
 #
@@ -98,7 +100,7 @@ def assert_dialog_handled(session, expected_text):
     except:
         assert (result.status == 200 and
                 result.body["value"] != expected_text), (
-               "Dialog with text '%s' was not handled." % expected_text)
+            "Dialog with text '%s' was not handled." % expected_text)
 
 
 def assert_same_element(session, a, b):
@@ -123,7 +125,7 @@ def assert_same_element(session, a, b):
         return
 
     message = ("Expected element references to describe the same element, " +
-        "but they did not.")
+               "but they did not.")
 
     # Attempt to provide more information, accounting for possible errors such
     # as stale element references or not visible elements.

--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -267,3 +267,19 @@ def create_dialog(session):
 def clear_all_cookies(session):
     """Removes all cookies associated with the current active document"""
     session.transport.send("DELETE", "session/%s/cookie" % session.session_id)
+
+
+def is_element_in_viewport(session, element):
+    """Check if element is outside of the viewport"""
+    return session.execute_script("""
+        let el = arguments[0];
+
+        let rect = el.getBoundingClientRect();
+        let viewport = {
+          height: window.innerHeight || document.documentElement.clientHeight,
+          width: window.innerWidth || document.documentElement.clientWidth,
+        };
+
+        return !(rect.right < 0 || rect.bottom < 0 ||
+            rect.left > viewport.width || rect.top > viewport.height)
+    """, args=(element,))


### PR DESCRIPTION

Enables webdriver spec keyboard interactability tests for 'Element Send Keys'
by default by re-using the same capability 'moz:webdriverClick' from
'Element Click'. It can be disabled by turning off this preference.

Also various webplatform tests for webdriver spec have been added which
cover both the scroll into view action, and keyboard interactability check.

Existing Marionette unit tests will be run in both modes, until we can
get rid of the legacy mode.

MozReview-Commit-ID: dFB8sQ6CN5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1414322 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8853)
<!-- Reviewable:end -->
