### PR TITLE
Add internal overflow-clip-box-block/-inline properties and make overflow-clip-box a shorthand.

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1054,12 +1054,6 @@ const gCSSProperties = {
     types: [
     ]
   },
-  'overflow-clip-box': {
-    // https://developer.mozilla.org/en/docs/Web/CSS/overflow-clip-box
-    types: [
-      { type: 'discrete', options: [ [ 'padding-box', 'content-box' ] ] }
-    ]
-  },
   'overflow-wrap': {
     // https://drafts.csswg.org/css-text-3/#propdef-overflow-wrap
     types: [


### PR DESCRIPTION

MozReview-Commit-ID: axoDaWnOJQ

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1422839 [ci skip]