### PR TITLE
Fix InitializePropertiesFromCompatibleNativeObject to get the shape of the resulting object right.

### DIFF
--- a/dom/events/Event-subclasses-constructors.html
+++ b/dom/events/Event-subclasses-constructors.html
@@ -21,6 +21,23 @@ function assert_props(iface, event, defaults) {
   }
 }
 
+// Class declarations don't go on the global by default, so put it there ourselves:
+
+self.SubclassedEvent = class SubclassedEvent extends Event {
+  constructor(name, props) {
+    super(name, props);
+    if (props && typeof(props) == "object" && "customProp" in props) {
+      this.customProp = props.customProp;
+    } else {
+      this.customProp = 5;
+    }
+  }
+
+  get fixedProp() {
+    return 17;
+  }
+}
+
 var EventModifierInit = [
   ["ctrlKey", false, true],
   ["shiftKey", false, true],
@@ -32,6 +49,7 @@ var expected = {
     "properties": [
       ["bubbles", false, true],
       ["cancelable", false, true],
+      ["isTrusted", false, false],
     ],
   },
 
@@ -91,6 +109,14 @@ var expected = {
     "parent": "UIEvent",
     "properties": [
       ["data", "", "string"],
+    ],
+  },
+
+  "SubclassedEvent": {
+    "parent": "Event",
+    "properties": [
+      ["customProp", 5, 8],
+      ["fixedProp", 17, 17],
     ],
   },
 };


### PR DESCRIPTION

MozReview-Commit-ID: 8wnOnUv57pV

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1423875 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8859)
<!-- Reviewable:end -->
