### PR TITLE
Test that there is a micro task checkpoint before requestAnimationFrame callbacks.

### DIFF
--- a/web-animations/timing-model/timelines/timelines.html
+++ b/web-animations/timing-model/timelines/timelines.html
@@ -71,4 +71,17 @@ async_test(t => {
 }, 'Timeline time should be the same for all RAF callbacks in an animation'
    + ' frame');
 
+async_test(t => {
+  const div = createDiv(t);
+  const animation = div.animate(null, 100 * MS_PER_SEC);
+
+  animation.ready.then(t.step_func(() => {
+    const readyTimelineTime = document.timeline.currentTime;
+    requestAnimationFrame(t.step_func_done(() => {
+      assert_equals(readyTimelineTime, document.timeline.currentTime,
+                    'There should be a microtask checkpoint');
+    }));
+  }));
+}, 'Performs a microtask checkpoint after updating timelins');
+
 </script>


### PR DESCRIPTION

The test intentionally uses async_test to avoid browser's awkward micro task
handling.

MozReview-Commit-ID: K5WzEML7D5M

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1416966 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8861)
<!-- Reviewable:end -->
