### PR TITLE
Consider DOCUMENT_NODE a valid web element.

### DIFF
--- a/webdriver/tests/element_retrieval/find_element.py
+++ b/webdriver/tests/element_retrieval/find_element.py
@@ -71,3 +71,13 @@ def test_xhtml_namespace(session, using, value):
     response = find_element(session, using, value)
     value = assert_success(response)
     assert_same_element(session, value, expected)
+
+
+@pytest.mark.parametrize("using,value",
+                         [("css selector", ":root"),
+                          ("tag name", "html"),
+                          ("xpath", "/html")])
+def test_htmldocument(session, using, value):
+    session.url = inline("")
+    response = find_element(session, using, value)
+    assert_success(response)

--- a/webdriver/tests/element_retrieval/find_element_from_element.py
+++ b/webdriver/tests/element_retrieval/find_element_from_element.py
@@ -72,3 +72,11 @@ def test_xhtml_namespace(session, using, value):
     response = find_element(session, from_element.id, using, value)
     value = assert_success(response)
     assert_same_element(session, value, expected)
+
+
+def test_parent_htmldocument(session):
+    session.url = inline("")
+    from_element = session.execute_script("return document.documentElement")
+
+    response = find_element(session, from_element.id, "xpath", "..")
+    assert_success(response)

--- a/webdriver/tests/element_retrieval/find_elements.py
+++ b/webdriver/tests/element_retrieval/find_elements.py
@@ -77,3 +77,15 @@ def test_xhtml_namespace(session, using, value):
 
     found_element = value[0]
     assert_same_element(session, found_element, expected)
+
+
+@pytest.mark.parametrize("using,value",
+                         [("css selector", ":root"),
+                          ("tag name", "html"),
+                          ("xpath", "/html")])
+def test_htmldocument(session, using, value):
+    session.url = inline("")
+    response = find_elements(session, using, value)
+    value = assert_success(response)
+    assert isinstance(value, list)
+    assert len(value) == 1

--- a/webdriver/tests/element_retrieval/find_elements_from_element.py
+++ b/webdriver/tests/element_retrieval/find_elements_from_element.py
@@ -75,3 +75,13 @@ def test_xhtml_namespace(session, using, value):
 
     found_element = value[0]
     assert_same_element(session, found_element, expected)
+
+
+def test_parent_htmldocument(session):
+    session.url = inline("")
+    from_element = session.execute_script("return document.documentElement")
+
+    response = find_elements(session, from_element.id, "xpath", "..")
+    value = assert_success(response)
+    assert isinstance(value, list)
+    assert len(value) == 1


### PR DESCRIPTION

When looking up the parent of <html> using an XPath parent expression
such as "..", the nodeType of the returned HTMLDocument will be 9
(DOCUMENT_NODE).  <html> is a valid web element and we should be
able to serialise and return it to the user.

It is worth noting that other WebDriver implementations fail this
test because they fail on the nodeType check.

MozReview-Commit-ID: 4FMJEd8B4PZ

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1424635 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8866)
<!-- Reviewable:end -->
