### PR TITLE
Fix setting scrollTop to 0 on an element with a pending scroll position restore to actually work correctly.

### DIFF
--- a/css/cssom-view/scrollTop-display-change-ref.html
+++ b/css/cssom-view/scrollTop-display-change-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+<div id="scroller" style="height: 100px; overflow: scroll">
+  <div style="height: 1000px">
+    I should be visible.
+  </div>
+  I should not be visible.
+</div>

--- a/css/cssom-view/scrollTop-display-change.html
+++ b/css/cssom-view/scrollTop-display-change.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Setting scrollTop to 0 immediately after toggling display from "none" on an element that had nonzero scrollTop before should work.</title>
+<link rel=match href="scrollTop-display-change-ref.html">
+<div id="scroller" style="height: 100px; overflow: scroll">
+  <div style="height: 1000px">
+    I should be visible.
+  </div>
+  I should not be visible.
+</div>
+<script>
+  scroller.scrollTop = 1000;
+  scroller.style.display = "none";
+  var win = scroller.scrollTop; // Force layout flush
+  scroller.style.display = "";
+  scroller.scrollTop = 0;
+</script>


### PR DESCRIPTION

MozReview-Commit-ID: 949eBXmKHlA

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1425107 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8867)
<!-- Reviewable:end -->
