### PR TITLE
Add tests that canceling an idle animation does not reject promises or fire events;

### DIFF
--- a/web-animations/timing-model/animations/canceling-an-animation.html
+++ b/web-animations/timing-model/animations/canceling-an-animation.html
@@ -58,5 +58,43 @@ test(t => {
   assert_not_equals(animation.ready, promise);
 }, 'The ready promise should be replaced when the animation is canceled');
 
+promise_test(t => {
+  const animation = new Animation(
+    new KeyframeEffect(null, null, { duration: 1000 }),
+    null
+  );
+  assert_equals(animation.playState, 'idle',
+                'The animation should be initially idle');
+
+  animation.finished.then(t.step_func(() => {
+    assert_unreached('Finished promise should not resolve');
+  }), t.step_func(() => {
+    assert_unreached('Finished promise should not reject');
+  }));
+
+  animation.cancel();
+
+  return waitForAnimationFrames(3);
+}, 'The finished promise should NOT be rejected if the animation is already'
+   + ' idle');
+
+promise_test(t => {
+  const animation = new Animation(
+    new KeyframeEffect(null, null, { duration: 1000 }),
+    null
+  );
+  assert_equals(animation.playState, 'idle',
+                'The animation should be initially idle');
+
+  animation.oncancel = t.step_func(() => {
+    assert_unreached('Cancel event should not be fired');
+  });
+
+  animation.cancel();
+
+  return waitForAnimationFrames(3);
+}, 'The cancel event should NOT be fired if the animation is already'
+   + ' idle');
+
 </script>
 </body>


### PR DESCRIPTION

Note that we don't need tests for the cancel events of CSS Animations or CSS
Transitions since we already have them in
dom/animation/test/css-{animations|transitions}/file_event-dispatch.html

(See the tests named "Call Animation.cancel after cancelling
transition/animation".)

MozReview-Commit-ID: GRtSxEvMkjz

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1422248 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8868)
<!-- Reviewable:end -->
