### PR TITLE
Drop redundant and contradictory test from web-animations/interfaces/finished.html;

### DIFF
--- a/web-animations/interfaces/Animation/finished.html
+++ b/web-animations/interfaces/Animation/finished.html
@@ -182,27 +182,6 @@ promise_test(t => {
 promise_test(t => {
   const div = createDiv(t);
   const animation = div.animate({}, 100 * MS_PER_SEC);
-  animation.cancel();
-  // The spec says we still create a new finished promise and reject the old
-  // one even if we're already idle. That behavior might change, but for now
-  // test that we do that.
-  const retPromise = animation.finished.catch(err => {
-    assert_equals(err.name, 'AbortError',
-                  'finished promise is rejected with AbortError');
-  });
-
-  // Redundant call to cancel();
-  const previousFinishedPromise = animation.finished;
-  animation.cancel();
-  assert_not_equals(animation.finished, previousFinishedPromise,
-                    'A redundant call to cancel() should still generate a new'
-                    + ' finished promise');
-  return retPromise;
-}, 'cancelling an idle animation still replaces the finished promise');
-
-promise_test(t => {
-  const div = createDiv(t);
-  const animation = div.animate({}, 100 * MS_PER_SEC);
   const HALF_DUR = 100 * MS_PER_SEC / 2;
   const QUARTER_DUR = 100 * MS_PER_SEC / 4;
   let gotNextFrame = false;


### PR DESCRIPTION

The behavior covered in this dropped test (canceling an idle animation) is
covered by the tests added in the previous patch. Furthermore, the behavior
expected by the dropped test contradicts what the spec now requires.

MozReview-Commit-ID: 49zik7qjID0

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1422248 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8869)
<!-- Reviewable:end -->
