### PR TITLE
Use US spelling of canceling/canceled in finished.html;

### DIFF
--- a/web-animations/interfaces/Animation/finished.html
+++ b/web-animations/interfaces/Animation/finished.html
@@ -163,7 +163,7 @@ promise_test(t => {
   animation.cancel();
 
   return retPromise;
-}, 'finished promise is rejected when an animation is cancelled by calling ' +
+}, 'finished promise is rejected when an animation is canceled by calling ' +
    'cancel()');
 
 promise_test(t => {
@@ -175,9 +175,9 @@ promise_test(t => {
     animation.cancel();
     assert_not_equals(animation.finished, previousFinishedPromise,
                       'A new finished promise should be created when'
-                      + ' cancelling a finished animation');
+                      + ' canceling a finished animation');
   });
-}, 'cancelling an already-finished animation replaces the finished promise');
+}, 'canceling an already-finished animation replaces the finished promise');
 
 promise_test(t => {
   const div = createDiv(t);


### PR DESCRIPTION

MozReview-Commit-ID: 5S7vYc2tOWW

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1422248 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8871)
<!-- Reviewable:end -->
