### PR TITLE
Don't return the response from python handler,

### DIFF
--- a/http/resources/securedimage.py
+++ b/http/resources/securedimage.py
@@ -6,12 +6,10 @@ def main(request, response):
     if "authorization" not in request.headers:
         response.status = 401
         response.headers.set("WWW-Authenticate", "Basic")
-        return response
     else:
         auth = request.headers.get("Authorization")
         if auth != "Basic dGVzdHVzZXI6dGVzdHBhc3M=":
             response.set_error(403, "Invalid username or password - " + auth)
-            return response
 
     response.status = 301
     response.headers.set("Location", image_url)


### PR DESCRIPTION

This isn't how the wptserve API works; the return value is supposed to
be the content itself or headers, content or status, headers, content.

MozReview-Commit-ID: 28wZC65crW4

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1396534 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
