### PR TITLE
Update JS module tests now that repeated instantiation failures of a module are no longer required to throw the same value

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/instantiation-error-1.html
+++ b/html/semantics/scripting-1/the-script-element/module/instantiation-error-1.html
@@ -6,25 +6,19 @@
 <script>
     setup({allow_uncaught_exception: true});
 
-    window.log = [];
-
-    window.addEventListener("error", ev => log.push(ev.error));
-
     const test_load = async_test(
         "Test that missing exports lead to SyntaxError events on window and " +
         "load events on script");
+
+    window.log = [];
+    window.addEventListener("error", ev => {
+      test_load.step(() => assert_equals(ev.error.constructor, SyntaxError));
+      log.push(ev.message);
+    });
+
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 10);
-      assert_equals(log[0].constructor, SyntaxError);
-      assert_equals(log[1], 1);
-      assert_equals(log[2].constructor, SyntaxError);
-      assert_equals(log[3], 2);
-      assert_equals(log[4].constructor, SyntaxError);
-      assert_equals(log[5], 3);
-      assert_equals(log[6].constructor, SyntaxError);
-      assert_equals(log[7], 4);
-      assert_equals(log[8].constructor, SyntaxError);
-      assert_equals(log[9], 5);
+      const msg = log[0];
+      assert_array_equals(log, [msg, 1, msg, 2, msg, 3, msg, 4, msg, 5]);
     }));
 
     function unreachable() { log.push("unexpected"); }

--- a/html/semantics/scripting-1/the-script-element/module/instantiation-error-2.html
+++ b/html/semantics/scripting-1/the-script-element/module/instantiation-error-2.html
@@ -6,25 +6,19 @@
 <script>
     setup({allow_uncaught_exception: true});
 
-    window.log = [];
-
-    window.addEventListener("error", ev => log.push(ev.error));
-
     const test_load = async_test(
         "Test that missing exports lead to SyntaxError events on window and " +
         "load events on script");
+
+    window.log = [];
+    window.addEventListener("error", ev => {
+      test_load.step(() => assert_equals(ev.error.constructor, SyntaxError));
+      log.push(ev.message);
+    });
+
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 10);
-      assert_equals(log[0].constructor, SyntaxError);
-      assert_equals(log[1], 1);
-      assert_equals(log[2].constructor, SyntaxError);
-      assert_equals(log[3], 2);
-      assert_equals(log[4].constructor, SyntaxError);
-      assert_equals(log[5], 3);
-      assert_equals(log[6].constructor, SyntaxError);
-      assert_equals(log[7], 4);
-      assert_equals(log[8].constructor, SyntaxError);
-      assert_equals(log[9], 5);
+      const msg = log[0];
+      assert_array_equals(log, [msg, 1, msg, 2, msg, 3, msg, 4, msg, 5]);
     }));
 
     function unreachable() { log.push("unexpected"); }

--- a/html/semantics/scripting-1/the-script-element/module/instantiation-error-3.html
+++ b/html/semantics/scripting-1/the-script-element/module/instantiation-error-3.html
@@ -6,21 +6,19 @@
 <script>
     setup({allow_uncaught_exception: true});
 
-    window.log = [];
-
-    window.addEventListener("error", ev => log.push(ev.error));
-
     const test_load = async_test(
         "Test that unresolvable cycles lead to SyntaxError events on window " +
         "and load events on script");
+
+    window.log = [];
+    window.addEventListener("error", ev => {
+      test_load.step(() => assert_equals(ev.error.constructor, SyntaxError));
+      log.push(ev.message);
+    });
+
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 6);
-      assert_equals(log[0].constructor, SyntaxError);
-      assert_equals(log[1], 1);
-      assert_equals(log[2].constructor, SyntaxError);
-      assert_equals(log[3], 2);
-      assert_equals(log[4].constructor, SyntaxError);
-      assert_equals(log[5], 3);
+      const msg = log[0];
+      assert_array_equals(log, [msg, 1, msg, 2, msg, 3]);
     }));
 
     function unreachable() { log.push("unexpected"); }

--- a/html/semantics/scripting-1/the-script-element/module/instantiation-error-4.html
+++ b/html/semantics/scripting-1/the-script-element/module/instantiation-error-4.html
@@ -7,18 +7,18 @@
     setup({allow_uncaught_exception: true});
 
     window.log = [];
-
-    window.addEventListener("error", ev => log.push(ev.error));
-
     const test_load = async_test(
         "Test that loading a graph in which a module is already " +
-        "errored results in that module's error.");
+        "errored results in an error.");
+
+    window.addEventListener("error", ev => {
+      test_load.step(() => assert_equals(ev.error.constructor, SyntaxError));
+      log.push(ev.message);
+    });
+
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 4);
-      assert_equals(log[0].constructor, SyntaxError);
-      assert_equals(log[1], 1);
-      assert_equals(log[2].constructor, SyntaxError);
-      assert_equals(log[3], 2);
+      const msg = log[0];
+      assert_array_equals(log, [msg, 1, msg, 2]);
     }));
 
     function unreachable() { log.push("unexpected"); }

--- a/html/semantics/scripting-1/the-script-element/module/instantiation-error-5.html
+++ b/html/semantics/scripting-1/the-script-element/module/instantiation-error-5.html
@@ -6,20 +6,19 @@
 <script>
     setup({allow_uncaught_exception: true});
 
-    window.log = [];
-
-    window.addEventListener("error", ev => log.push(ev.error));
-
     const test_load = async_test(
         "Test that loading a graph in which a module is already " +
-        "errored results in that module's error.");
+        "errored results an error.");
+
+    window.log = [];
+    window.addEventListener("error", ev => {
+      test_load.step(() => assert_equals(ev.error.constructor, SyntaxError));
+      log.push(ev.message);
+    });
+
     window.addEventListener("load", test_load.step_func_done(ev => {
-      assert_equals(log.length, 4);
-      assert_equals(log[0].constructor, SyntaxError);
-      assert_equals(log[1], 1);
-      assert_equals(log[2].constructor, SyntaxError);
-      assert_equals(log[3], 2);
-      assert_not_equals(log[0], log[2], "errors should be different");
+      const msg = log[0];
+      assert_array_equals(log, [msg, 1, msg, 2]);
     }));
 
     function unreachable() { log.push("unexpected"); }


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1420925 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8874)
<!-- Reviewable:end -->
