### PR TITLE
Correct CSS2/tables/table-anonymous-objects-* tests

### DIFF
--- a/css/CSS2/tables/reference/no_red_3x3_monospace_table_colors-ref.xht
+++ b/css/CSS2/tables/reference/no_red_3x3_monospace_table_colors-ref.xht
@@ -3,7 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <title>Reference rendering - no red, 3x3 monospace table</title>
-      <link rel="author" title="Opera" href="https://www.opera.com/" />
       <style>
          body {
             font-family: monospace;
@@ -33,9 +32,10 @@
       </style>
    </head>
    <body>
-      <p>There should be no red below, except for antialiasing issues.</p>
+      There should be no red below, except for antialiasing issues.
       <div>
          <div class="container"><table id="red">
+            <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
             <tr>
                <td>Row 1, Col 1</td>
                <td>Row 1, Col 2</td>
@@ -53,6 +53,7 @@
             </tr>
          </table></div>
          <div class="container"><table id="green">
+            <colgroup><col style="background: yellow"/><col style="background: cyan"/><col style="background: lime"/></colgroup>
             <tr>
                <td>Row 1, Col 1</td>
                <td>Row 1, Col 2</td>

--- a/css/CSS2/tables/reference/no_red_3x3_monospace_table_nowrap-ref.xht
+++ b/css/CSS2/tables/reference/no_red_3x3_monospace_table_nowrap-ref.xht
@@ -1,0 +1,86 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <head>
+      <title>Reference rendering - no red, 3x3 monospace table</title>
+      <style>
+         body {
+            font-family: monospace;
+            white-space: nowrap;
+         }
+         div {
+            position: relative;
+         }
+         .container {
+            position: absolute;
+            padding: 1px;
+         }
+         table {
+            font-size: 2em;
+            border-spacing: 0;
+            top: 1px;
+            left: 1px;
+         }
+         td {
+            padding: 0;
+         }
+         #red {
+            color: red;
+         }
+         #green {
+            color: green;
+         }
+      </style>
+   </head>
+   <body>
+      <p>There should be no red below, except for antialiasing issues.</p>
+      <div>
+         <div class="container">
+            <table id="red">
+               <tr>
+                  <td>Row 1, Col 1</td>
+                  <td>Row 1, Col 2</td>
+                  <td>Row 1, Col 3</td>
+               </tr>
+            </table>
+            <table id="red">
+               <tr>
+                  <td>Row 22, Col 1</td>
+                  <td>Row 22, Col 2</td>
+                  <td>Row 22, Col 3</td>
+               </tr>
+            </table>
+            <table id="red">
+               <tr>
+                  <td>Row 333, Col 1</td>
+                  <td>Row 333, Col 2</td>
+                  <td>Row 333, Col 3</td>
+               </tr>
+            </table>
+         </div>
+         <div class="container">
+            <table id="green">
+               <tr>
+                  <td>Row 1, Col 1</td>
+                  <td>Row 1, Col 2</td>
+                  <td>Row 1, Col 3</td>
+               </tr>
+            </table>
+            <table id="green">
+               <tr>
+                  <td>Row 22, Col 1</td>
+                  <td>Row 22, Col 2</td>
+                  <td>Row 22, Col 3</td>
+               </tr>
+            </table>
+            <table id="green">
+               <tr>
+                  <td>Row 333, Col 1</td>
+                  <td>Row 333, Col 2</td>
+                  <td>Row 333, Col 3</td>
+               </tr>
+            </table>
+         </div>
+      </div>
+   </body>
+</html>

--- a/css/CSS2/tables/table-anonymous-objects-079.xht
+++ b/css/CSS2/tables/table-anonymous-objects-079.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test 3-tables-ref.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-080.xht
+++ b/css/CSS2/tables/table-anonymous-objects-080.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test 3-tables-ref.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-081.xht
+++ b/css/CSS2/tables/table-anonymous-objects-081.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-082.xht
+++ b/css/CSS2/tables/table-anonymous-objects-082.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-083.xht
+++ b/css/CSS2/tables/table-anonymous-objects-083.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-084.xht
+++ b/css/CSS2/tables/table-anonymous-objects-084.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test blocks-divide-tables-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-085.xht
+++ b/css/CSS2/tables/table-anonymous-objects-085.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test infer-cells-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-086.xht
+++ b/css/CSS2/tables/table-anonymous-objects-086.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test infer-cells-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_nowrap-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace; white-space: nowrap;">

--- a/css/CSS2/tables/table-anonymous-objects-093.xht
+++ b/css/CSS2/tables/table-anonymous-objects-093.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">

--- a/css/CSS2/tables/table-anonymous-objects-094.xht
+++ b/css/CSS2/tables/table-anonymous-objects-094.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-1.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">

--- a/css/CSS2/tables/table-anonymous-objects-095.xht
+++ b/css/CSS2/tables/table-anonymous-objects-095.xht
@@ -5,11 +5,11 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">
-<p>There should be no red below, except for antialiasing issues.</p>
+There should be no red below, except for antialiasing issues.
 <div style="position: relative; font-size: 2em;">
 <div style="position: relative; z-index: 1; color: red; padding: 1px;">
 

--- a/css/CSS2/tables/table-anonymous-objects-096.xht
+++ b/css/CSS2/tables/table-anonymous-objects-096.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-2.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">

--- a/css/CSS2/tables/table-anonymous-objects-097.xht
+++ b/css/CSS2/tables/table-anonymous-objects-097.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-3.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">

--- a/css/CSS2/tables/table-anonymous-objects-098.xht
+++ b/css/CSS2/tables/table-anonymous-objects-098.xht
@@ -5,7 +5,7 @@
   <title>CSS Test: Auto-imported from Gecko test cols-test-3.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
+  <link rel="match" href="reference/no_red_3x3_monospace_table_colors-ref.xht"/>
   <meta name="flags" content=''/>
 </head>
 <body style="font-family: monospace">

--- a/css/CSS2/tables/table-anonymous-objects-115.xht
+++ b/css/CSS2/tables/table-anonymous-objects-115.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-9.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-116.xht
+++ b/css/CSS2/tables/table-anonymous-objects-116.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-9.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-117.xht
+++ b/css/CSS2/tables/table-anonymous-objects-117.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-10.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-118.xht
+++ b/css/CSS2/tables/table-anonymous-objects-118.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-10.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-119.xht
+++ b/css/CSS2/tables/table-anonymous-objects-119.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-11.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-120.xht
+++ b/css/CSS2/tables/table-anonymous-objects-120.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-11.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-121.xht
+++ b/css/CSS2/tables/table-anonymous-objects-121.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-12.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 

--- a/css/CSS2/tables/table-anonymous-objects-122.xht
+++ b/css/CSS2/tables/table-anonymous-objects-122.xht
@@ -4,7 +4,6 @@
   <title>CSS Test: Auto-imported from Gecko test dynamic-removal-12.html</title>
   <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
-  <link rel="match" href="reference/no_red_3x3_monospace_table-ref.xht"/>
   <link rel="match" href="reference/no_red_antialiasing_a_bc_d-ref.xht"/>
   <meta name="flags" content='dom'/>
 


### PR DESCRIPTION
The base reference for many css/CSS2/tables/table-anonymous-objects-* tests was incorrect. Additionally, some tests indicated two references when it was clear only one could match. This change adds in two additional references so that all tests can match, and corrects the original base reference.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
