### PR TITLE
Use Safari 11 in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
       python: "2.7"
       env:
         - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
-        - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:safari:10.0 PLATFORM='macOS 10.12'
+        - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:safari:11.0 PLATFORM='macOS 10.12'
     - os: linux
       python: "2.7"
       env:
@@ -100,7 +100,7 @@ matrix:
         - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:MicrosoftEdge:14.14393 PLATFORM='Windows 10'
     - env:
         - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
-        - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:safari:10.0 PLATFORM='macOS 10.12'
+        - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=sauce:safari:11.0 PLATFORM='macOS 10.12'
 script:
   - ./tools/ci/run.sh
 cache:


### PR DESCRIPTION
Sauce for macOS 10.12 only has Safari 10.1 and Safari 11.0. Because the current version we're using is 10.0, no tests are being run since this is an unsupported version. Since wpt.fyi is using Safari 11, this changes Travis builds to use Safari 11 as well.

This would complete the Safari part of #8052.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8882)
<!-- Reviewable:end -->
