### PR TITLE
Add in references for some CSS2/lists/counter-increment-* tests

### DIFF
--- a/css/CSS2/lists/counter-increment-014-ref.html
+++ b/css/CSS2/lists/counter-increment-014-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '2' appears below.</p>
+    <div>2</div>
+</body>

--- a/css/CSS2/lists/counter-increment-014.xht
+++ b/css/CSS2/lists/counter-increment-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-014-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with only an identifier, grouped twice." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-021-ref.html
+++ b/css/CSS2/lists/counter-increment-021-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '20' appears below.</p>
+    <div>20</div>
+</body>

--- a/css/CSS2/lists/counter-increment-021.xht
+++ b/css/CSS2/lists/counter-increment-021.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-021-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and an integer value, grouped twice." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-022.xht
+++ b/css/CSS2/lists/counter-increment-022.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-021-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and a positive integer value, grouped twice." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-027-ref.html
+++ b/css/CSS2/lists/counter-increment-027-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '3' appears below.</p>
+    <div>3</div>
+</body>

--- a/css/CSS2/lists/counter-increment-027.xht
+++ b/css/CSS2/lists/counter-increment-027.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-027-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with only an identifier, grouped three times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-034-ref.html
+++ b/css/CSS2/lists/counter-increment-034-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '30' appears below.</p>
+    <div>30</div>
+</body>

--- a/css/CSS2/lists/counter-increment-034.xht
+++ b/css/CSS2/lists/counter-increment-034.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-034-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and an integer value, grouped three times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-035.xht
+++ b/css/CSS2/lists/counter-increment-035.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-034-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and a positive integer value, grouped three times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-040-ref.html
+++ b/css/CSS2/lists/counter-increment-040-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '32' appears below.</p>
+    <div>32</div>
+</body>

--- a/css/CSS2/lists/counter-increment-040.xht
+++ b/css/CSS2/lists/counter-increment-040.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-040-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with only an identifier, grouped thirty-two times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-047-ref.html
+++ b/css/CSS2/lists/counter-increment-047-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '320' appears below.</p>
+    <div>320</div>
+</body>

--- a/css/CSS2/lists/counter-increment-047.xht
+++ b/css/CSS2/lists/counter-increment-047.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and an integer value, grouped thirty-two times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-048.xht
+++ b/css/CSS2/lists/counter-increment-048.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-047-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with an identifier and a positive integer value, grouped thirty-two times." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-053-ref.html
+++ b/css/CSS2/lists/counter-increment-053-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the numbers '5 5 10' appear below in the same order.</p>
+    <div>5</div>
+    <div>5</div>
+    <div>10</div>
+</body>

--- a/css/CSS2/lists/counter-increment-053.xht
+++ b/css/CSS2/lists/counter-increment-053.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-053-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The counter-increment set to 'none' does not increment counter." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-054-ref.html
+++ b/css/CSS2/lists/counter-increment-054-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the numbers '5 10' appear below in the same order.</p>
+    <div>5</div>
+    <div>10</div>
+</body>

--- a/css/CSS2/lists/counter-increment-054.xht
+++ b/css/CSS2/lists/counter-increment-054.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-054-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The counter-increment with the value inherit specified." />
         <style type="text/css">

--- a/css/CSS2/lists/counter-increment-055-ref.html
+++ b/css/CSS2/lists/counter-increment-055-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 30px;
+    }
+</style>
+<body>
+    <p>Test passes if the number '1' appears below.</p>
+    <div>1</div>
+</body>

--- a/css/CSS2/lists/counter-increment-055.xht
+++ b/css/CSS2/lists/counter-increment-055.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-counter-increment" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#counters" />
+        <link rel="match" href="counter-increment-055-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'counter-increment' property with only an identifier." />
         <style type="text/css">


### PR DESCRIPTION
Many CSS2/lists/counter-increment-* tests are missing references. This change adds in references for some of the simple cases (not those covered by #8888).

Part of #8670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
