### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=181286

### DIFF
--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -26,10 +26,6 @@ async_test(function(t) {
             header_names.hasOwnProperty('accept'),
             'request includes "Accept" header as inserted by Fetch'
           );
-          assert_true(
-            header_names.hasOwnProperty('upgrade-insecure-requests'),
-            'request specifies "Upgrade-Insecure Requests header as inserted by Fetch'
-          );
 
           return service_worker_unregister_and_done(t, scope);
         })


### PR DESCRIPTION
LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/fetch-event.https.html should not expect Upgrade-Insecure Requests header

<!-- Reviewable:start -->

<!-- Reviewable:end -->
