### PR TITLE
selectors: Allow white space in the brackets of an attribute selector.

### DIFF
--- a/css/selectors/selectors-attr-white-space-001-ref.html
+++ b/css/selectors/selectors-attr-white-space-001-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: White space in attribute selectors (reference)</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au"/>
+<style>
+body { color: green; }
+</style>
+<p>This text should be green.</p>
+<p>This text should be green.</p>
+<p>This text should be green.</p>
+<p>This text should be green.</p>

--- a/css/selectors/selectors-attr-white-space-001.html
+++ b/css/selectors/selectors-attr-white-space-001.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Selectors: White space in attribute selectors</title>
+<link rel="author" title="Cameron McCormack" href="mailto:cam@mcc.id.au"/>
+<link rel="help" href="https://drafts.csswg.org/selectors-3/#w3cselgrammar"/>
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#grammar"/>
+<link rel="match" href="selectors-attr-white-space-001-ref.html"/>
+<style>
+body { color: red; }
+[ data-test-1] { color: green; }
+[data-test-2 ] { color: green; }
+[data-test-3 = x] { color: green; }
+[ |data-test-4] { color: green; }
+[ | data-test-4] { color: red; }
+</style>
+<p data-test-1="">This text should be green.</p>
+<p data-test-2="">This text should be green.</p>
+<p data-test-3="x">This text should be green.</p>
+<p data-test-4="">This text should be green.</p>


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/19263 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8903)
<!-- Reviewable:end -->
