### PR TITLE
Refactor selection-start-end test

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-start-end.html
+++ b/html/semantics/forms/textfieldselection/selection-start-end.html
@@ -59,10 +59,16 @@
     assert_equals(testValue.length, 10);
   }, "Sanity check for testValue length; if this fails, variou absolute offsets in the test below need to be adjusted to be less than testValue.length");
 
+  for (let prop of ["selectionStart", "selectionEnd"]) {
+    for (let el of createTestElements(testValue)) {
+      test(function() {
+        assert_equals(el.selectionStart, testValue.length);
+      }, `Initial .value set on ${el.id} should set ${prop} to end of value`);
+    }
+  }
+
   test(function() {
     for (let el of createTestElements(testValue)) {
-      assert_equals(el.selectionStart, testValue.length,
-                    `Initial .value set on ${el.id} should set selectionStart to end of value`);
       var t = async_test(`onselect should fire when selectionStart is changed on ${el.id}`);
       el.onselect = t.step_func_done(function(e) {
         assert_equals(e.type, "select");
@@ -74,8 +80,6 @@
 
   test(function() {
     for (let el of createTestElements(testValue)) {
-      assert_equals(el.selectionEnd, testValue.length,
-                    `Initial .value set on ${el.id} should set selectionEnd to end of value`);
       var t = async_test(`onselect should fire when selectionEnd is changed on ${el.id}`);
       el.onselect = t.step_func_done(function(e) {
         assert_equals(e.type, "select");
@@ -87,8 +91,6 @@
 
   test(function() {
     for (let el of createTestElements(testValue)) {
-      assert_equals(el.selectionStart, testValue.length,
-                    `Initial .value set on ${el.id} should set selectionStart to end of value`);
       el.selectionStart = 0;
       el.selectionEnd = 5;
       el.selectionStart = 8;
@@ -100,10 +102,6 @@
 
   test(function() {
     for (let el of createTestElements(testValue)) {
-      assert_equals(el.selectionStart, testValue.length,
-                    `Initial .value set on ${el.id} should set selectionStart to end of value`);
-      assert_equals(el.selectionEnd, testValue.length,
-                    `Initial .value set on ${el.id} should set selectionEnd to end of value`);
       el.selectionStart = 8;
       el.selectionEnd = 5;
       assert_equals(el.selectionStart, 5, `selectionStart on ${el.id}`);


### PR DESCRIPTION

Move assertions about the initial value of selection{Start,End} to their
own tests. This ensures that when one of these assertions fails, it
doesn't prevent other tests from being defined. Thus we have a clearer
view of which tests are passing or failing, since all tests get defined
regardless of which assertions fail.

Upstreamed from https://github.com/servo/servo/pull/19272 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8904)
<!-- Reviewable:end -->
