### PR TITLE
Add a sanitize_value implementation for the color input

### DIFF
--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -49,7 +49,7 @@
           } else {
             input.value = "  foo\rbar  ";
             input.type = types[j].type;  // change state
-            if (types[j].sanitizedValue || types[j].sanitizedValue === "") {
+            if (types[i].type !== "color" && (types[j].sanitizedValue || types[j].sanitizedValue === "")) {
               assert_equals(input.value, types[j].sanitizedValue, "input.value should be " + types[j].sanitizedValue + " after change of state");
             } else if (types[i].sanitizedValue || types[i].sanitizedValue === "") {
               assert_equals(input.value, types[i].sanitizedValue, "input.value should be " + types[i].sanitizedValue + " after change of state");


### PR DESCRIPTION

I had to change the test a little bit to avoid some failures due to
color and text both having a sanitizedValue which was making the test
use the first assertion instead of the second one in some cases.

The sanitize_value implementation is pretty simple, we iterate over the
content and checks that the content is 7 characters long, that the first
character is a `#` and then that all the following characters are
hexadecimal. If all those requirements are met, we lowercase the
content, otherwise we put `#000000` in it.

Upstreamed from https://github.com/servo/servo/pull/19330 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8906)
<!-- Reviewable:end -->
