### PR TITLE
queue event instead of immediately fire

### DIFF
--- a/html/semantics/document-metadata/the-style-element/style_load_async.html
+++ b/html/semantics/document-metadata/the-style-element/style_load_async.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<meta charset="utf-8">
+<title>Style load event should be async</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    var t = async_test("style load should be async");
+    var sync = true;
+    function check() {
+        assert_false(sync);
+        t.done();
+    }
+</script>
+<style onload="t.step(check)">
+</style>
+<script>
+  sync = false
+</script>
+
+<body>
+  <div id="log"></div>
+  <div id="test"></div>
+</body>
+</html>


### PR DESCRIPTION

created checks to see if parser is in use before event dispatch

changed tests to expect crash and added async style test

Upstreamed from https://github.com/servo/servo/pull/19307 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8909)
<!-- Reviewable:end -->
