### PR TITLE
Added time input sanitization:

### DIFF
--- a/html/semantics/forms/the-input-element/type-change-state.html
+++ b/html/semantics/forms/the-input-element/type-change-state.html
@@ -15,16 +15,16 @@
     { type: "url", sanitizedValue: "foobar" },
     { type: "email", sanitizedValue: "foobar" },
     { type: "password", sanitizedValue: "  foobar  " },
-    { type: "datetime-local", sanitizedValue: "" },
-    { type: "date", sanitizedValue: "" },
-    { type: "month", sanitizedValue: "" },
-    { type: "week", sanitizedValue: "" },
-    { type: "time", sanitizedValue: "" },
-    { type: "number", sanitizedValue: "" },
-    { type: "range", sanitizedValue: "50" },
-    { type: "color", sanitizedValue: "#000000" },
-    { type: "checkbox" },
-    { type: "radio" },
+    { type: "datetime-local", sanitizedValue: "", overridesSanitization: true },
+    { type: "date", sanitizedValue: "", overridesSanitization: true },
+    { type: "month", sanitizedValue: "", overridesSanitization: true },
+    { type: "week", sanitizedValue: "", overridesSanitization: true },
+    { type: "time", sanitizedValue: "", overridesSanitization: true },
+    { type: "number", sanitizedValue: "", overridesSanitization: true },
+    { type: "range", sanitizedValue: "50", overridesSanitization: true },
+    { type: "color", sanitizedValue: "#000000", overridesSanitization: true },
+    { type: "checkbox", defaultValue: "on" },
+    { type: "radio", defaultValue: "on" },
     { type: "file" },
     { type: "submit" },
     { type: "image" },
@@ -36,26 +36,39 @@
       if (types[i] != types[j]) {
         test(function() {
           var input = document.createElement("input");
+          var expected = "  foo\rbar  ";
           input.type = types[i].type;
           if (types[i].type === "file") {
             assert_throws("INVALID_STATE_ERR", function() {
-              input.value = "  foo\rbar  ";
+              input.value = expected;
             });
             assert_equals(input.value, "");
           } else if (types[j].type === "file") {
-            input.value = "  foo\rbar  ";
+            input.value = expected;
             input.type = types[j].type;  // change state
             assert_equals(input.value, "");
           } else {
-            input.value = "  foo\rbar  ";
+            input.value = expected;
             input.type = types[j].type;  // change state
-            if (types[i].type !== "color" && (types[j].sanitizedValue || types[j].sanitizedValue === "")) {
-              assert_equals(input.value, types[j].sanitizedValue, "input.value should be " + types[j].sanitizedValue + " after change of state");
-            } else if (types[i].sanitizedValue || types[i].sanitizedValue === "") {
-              assert_equals(input.value, types[i].sanitizedValue, "input.value should be " + types[i].sanitizedValue + " after change of state");
-            } else {
-              assert_equals(input.value, "  foo\rbar  ", "input.value should be '  foo\\rbar  ' after change of state");
+
+            // type[i] sanitization
+            if (types[i].sanitizedValue || types[i].sanitizedValue === "") {
+              expected = types[i].sanitizedValue;
             }
+
+            // type[j] sanitization
+            if (types[j].sanitizedValue || types[j].sanitizedValue === "") {
+              if ((expected !== "" && !types[i].overridesSanitization) || types[j].overridesSanitization) {
+                expected = types[j].sanitizedValue;
+              }
+            }
+
+            // type[j] defaultValue
+            if (expected === "" && types[j].defaultValue) {
+              expected = types[j].defaultValue;
+            }
+
+            assert_equals(input.value, expected, "input.value should be '" + expected + "' after change of state");
           }
         }, "change state from " + types[i].type + " to " + types[j].type);
       }


### PR DESCRIPTION

- Implemented is_valid_time_string for DOMString.
- Use is_valid_time_string for sanitize_value with time input.
- Improved input type change test

Upstreamed from https://github.com/servo/servo/pull/19379 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8911)
<!-- Reviewable:end -->
