### PR TITLE
Handle cases where selection API doesn't apply

### DIFF
--- a/html/semantics/forms/textfieldselection/select-event.html
+++ b/html/semantics/forms/textfieldselection/select-event.html
@@ -47,10 +47,10 @@ const actions = [
   }
 ];
 
-for (const el of els) {
+els.forEach((el) => {
   const elLabel = el.localName === "textarea" ? "textarea" : "input type " + el.type;
 
-  for (const action of actions) {
+  actions.forEach((action) => {
     // promise_test instead of async_test is important because these need to happen in sequence (to test that events
     // fire if and only if the selection changes).
     promise_test(t => {
@@ -79,6 +79,6 @@ for (const el of els) {
         }, 200);
       });
     }, `${elLabel}: ${action.label} a second time (must not fire select)`);
-  }
-}
+  });
+});
 </script>

--- a/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -7,45 +7,90 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-  var types = ["hidden", "email", "datetime-local", "date", "month", "week", "time", "number", "range", "color", "checkbox", "radio", "file", "submit", "image", "reset", "button"]; //types for which the API doesn't apply
-  var types2 = ["text", "search", "tel", "url", "password"]; //types for which the API applies
+  var nonApplicableTypes = ["hidden", "email", "datetime-local", "date", "month", "week", "time", "number", "range", "color", "checkbox", "radio", "file", "submit", "image", "reset", "button"];
+  var applicableTypes = ["text", "search", "tel", "url", "password", "aninvalidtype", null];
 
-  types.forEach(function(type){
-    test(function(){
-      var el = document.createElement("input");
-      el.type = type;
+  nonApplicableTypes.forEach(function(type){
+    var el = document.createElement("input");
+    el.type = type;
+
+    test(() => {
       assert_equals(el.selectionStart, null);
+    }, `selectionStart on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_equals(el.selectionEnd, null);
+    }, `selectionEnd on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_equals(el.selectionDirection, null);
+    }, `selectionDirection on an input[type=${type}] returns null`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionStart = 0;
       });
+    }, `assigning selectionStart on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionEnd = 0;
       });
+    }, `assigning selectionEnd on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.selectionDirection = 'none';
       });
+    }, `assigning selectionDirection on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.setRangeText("foobar");
       });
+    }, `setRangeText on an input[type=${type}] throws InvalidStateError`);
+
+    test(() => {
       assert_throws("InvalidStateError", function(){
         el.setSelectionRange(0, 1);
       });
-    }, "text field selection for the input " + type);
+    }, `setSelectionRange on an input[type=${type}] throws InvalidStateError`);
   });
 
-  types2.forEach(function(type) {
-    test(function() {
-      var el = document.createElement("input");
-      el.type = type;
+  applicableTypes.forEach(function(type) {
+    var el = document.createElement("input");
+    if (type) el.type = type;
+
+    test(() => {
       assert_equals(el.selectionStart, 0);
+    }, `selectionStart on an input[type=${type}] returns a value`);
+
+    test(() => {
       assert_equals(el.selectionEnd, 0);
+    }, `selectionEnd on an input[type=${type}] returns a value`);
+
+    test(() => {
+      assert_equals(el.selectionDirection, "none");
+    }, `selectionDirection on an input[type=${type}] returns a value`);
+
+    test(() => {
       el.selectionStart = 1;
+    }, `assigning selectionStart on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.selectionEnd = 1;
+    }, `assigning selectionEnd on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.selectionDirection = "forward";
+    }, `assigning selectionDirection on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.setRangeText("foobar");
+    }, `setRangeText on an input[type=${type}] doesn't throw an exception`);
+
+    test(() => {
       el.setSelectionRange(0, 1);
-    }, "text field selection for the input " + type);
+    }, `setSelectionRange on an input[type=${type}] doesn't throw an exception`);
   });
 </script>


### PR DESCRIPTION

The selection API only applies to certain <input> types:

https://html.spec.whatwg.org/multipage/#do-not-apply

This commit ensures that we handle that correctly.

Some notes:

1. TextControl::set_dom_selection_direction now calls
   set_selection_range(), which means that setting selectionDirection will
   now fire a selection event, as it should per the spec.

2. There is a test for the firing of the select event in
   tests/wpt/web-platform-tests/html/semantics/forms/textfieldselection/select-event.html,
   however the test did not run due to this syntax error:

   (pid:26017) "ERROR:script::dom::bindings::error: Error at http://web-platform.test:8000/html/semantics/forms/textfieldselection/select-event.html:50:11 missing = in const declaration"

   This happens due to the us of the "for (const foo of ...)" construct.
   Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of
   this should actually work, so it's somewhat unsatisfying to have to
   change the test.

4. If an <input>'s type is unset, it defaults to a text, and the
   selection API applies. Also, if an <input>'s type is set to an
   invalid value, it defaults to a text too. I've expanded the tests
   to account for this second case.

Upstreamed from https://github.com/servo/servo/pull/19461 [ci skip]