### PR TITLE
layout: support tiled gradients

### DIFF
--- a/css/css-images/tiled-gradients-ref.html
+++ b/css/css-images/tiled-gradients-ref.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            .bar {
+                width: 400px;
+                height: 100px;
+            }
+            .box {
+                display: inline-block;
+                width: 100px;
+                height: 100px;
+                border: 0px;
+                background-image: linear-gradient(to bottom left, red 50%, transparent 50%);
+            }
+
+        </style>
+    </head>
+    <body>
+        <div class="bar">
+            <div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div>
+        </div>
+        <div class="bar">
+            <div class="box"></div><div class="box"></div><div class="box"></div><div class="box"></div>
+        </div>
+    </body>
+</html>
+

--- a/css/css-images/tiled-gradients.html
+++ b/css/css-images/tiled-gradients.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Eight Red Triangles on White Ground (with gradients)</title>
+        <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
+        <meta name="assert" content="Gradients are correctly repeated.">
+        <link rel="match" href="tiled-gradients-ref.html">
+        <style>
+            #gradient {
+                width: 400px;
+                height: 200px;
+                background-size: 25% 50%;
+                background-image: linear-gradient(to bottom left, red 50%, transparent 50%);
+            }
+        </style>
+    </head>
+    <body>
+        <div id="gradient"></div>
+    </body>
+</html>
+

--- a/css/css-images/tiled-radial-gradients-ref.html
+++ b/css/css-images/tiled-radial-gradients-ref.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {
+                margin: 0px;
+            }
+
+            #outer {
+                position: absolute;
+                width: 600px;
+                height: 200px;
+                background-color: aquamarine;
+            }
+
+            #left, #right {
+                position: absolute;
+                width: 300px;
+                height: 200px;
+                background-image: radial-gradient(closest-side, red 40%, transparent 40%)
+
+            }
+            #left {
+                left: 80px;
+            }
+
+            #right {
+                left: 380px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="outer">
+            <div id="left"></div>
+            <div id="right"></div>
+        </div>
+    </body>
+</html>
+

--- a/css/css-images/tiled-radial-gradients.html
+++ b/css/css-images/tiled-radial-gradients.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Two Ellipses with Custom Placement (with gradients)</title>
+        <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#propdef-background-size">
+        <meta name="assert" content="Gradients are correctly repeated.">
+        <link rel="match" href="tiled-radial-gradients-ref.html">
+        <style>
+            body {
+                margin: 0px;
+            }
+            #gradient {
+                position: absolute;
+                width: 600px;
+                height: 200px;
+                left: 0px;
+                margin: 0px;
+                background-color: aquamarine;
+                background-image: radial-gradient(closest-side, red 40%, transparent 40%);
+                background-size: 300px 200px;
+                background-position: 80px 0px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="gradient"></div>
+    </body>
+</html>


### PR DESCRIPTION

Use background-size, background-position properties to render
CSS gradients.

Some cleanup in display_list_builder.rs related to gradient
calculations.

Adds two wpt tests for tiled gradients.

Note: For now even gradients with background-repeat: no-repeat
are repeated. Sometimes the gradient is not repeated everywhere.

Enable vars-background-shorthand-001.html CSS test.

Upstreamed from https://github.com/servo/servo/pull/19554 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8915)
<!-- Reviewable:end -->
