### PR TITLE
layout: background-origin attribute for gradients

### DIFF
--- a/css/css-images/gradient-border-box-ref.html
+++ b/css/css-images/gradient-border-box-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+#x {
+  width: 280px;
+  height: 280px;
+  background-image: repeating-linear-gradient(to bottom right, white, black, white 30px);
+}
+  </style>
+</head>
+<body>
+  <div id="x"></div>
+</body>
+</html>

--- a/css/css-images/gradient-border-box.html
+++ b/css/css-images/gradient-border-box.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Gradient Background aligned to Content Box</title>
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#the-background-origin">
+  <link rel="match" href="gradient-border-box-ref.html">
+  <meta name="assert" content="The background-origin: border-box; statement is understood.">
+  <style>
+#x {
+  background-origin: border-box;
+  width: 200px;
+  height: 200px;
+  border-style: solid;
+  border-width: 40px;
+  border-color: transparent;
+  background-image: repeating-linear-gradient(to bottom right, white, black, white 30px);
+}
+  </style>
+</head>
+<body>
+  <div id="x"></div>
+</body>
+</html>

--- a/css/css-images/gradient-content-box-ref.html
+++ b/css/css-images/gradient-content-box-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+#x {
+  width: 200px;
+  height: 200px;
+  border: 40px;
+  border-style: solid;
+  border-color: transparent;
+  background-image: repeating-linear-gradient(to bottom right, white, black, white 30px);
+}
+  </style>
+</head>
+<body>
+  <div id="x"></div>
+</body>
+</html>

--- a/css/css-images/gradient-content-box.html
+++ b/css/css-images/gradient-content-box.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Gradient Background aligned to Content Box</title>
+  <link rel="help" href="https://www.w3.org/TR/css-backgrounds-3/#the-background-origin">
+  <link rel="match" href="gradient-content-box-ref.html">
+  <meta name="assert" content="The background-origin: content-box; statement is understood.">
+  <style>
+#x {
+  background-origin: content-box;
+  width: 200px;
+  height: 200px;
+  padding: 40px;
+  background-image: repeating-linear-gradient(to bottom right, white, black, white 30px);
+}
+  </style>
+</head>
+<body>
+  <div id="x"></div>
+</body>
+</html>


### PR DESCRIPTION

Fixes the glitches mentioned in #19554.
Now gradient tiles are placed in the whole bounding box.

Upstreamed from https://github.com/servo/servo/pull/19568 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8916)
<!-- Reviewable:end -->
