### PR TITLE
Fix division by zero in gradient stop calculation

### DIFF
--- a/css/css-images/gradient-crash-ref.html
+++ b/css/css-images/gradient-crash-ref.html
@@ -1,0 +1,1 @@
+<!--intentionally blank-->

--- a/css/css-images/gradient-crash.html
+++ b/css/css-images/gradient-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Does this gradient crash the browser?</title>
+<link rel="match" href="gradient-crash-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-images-3/#color-stop-syntax">
+<meta name="assert" content="Gradients with total length zero and absolute positioned stops do not crash.">
+<style>
+  div {
+    background: linear-gradient(black 0,white);
+  }
+</style>
+<div></div>


### PR DESCRIPTION

Check if total_length is zero and return 0.0 instead
of NaN in this case.

Closes #18435

Regression test for crash.

Upstreamed from https://github.com/servo/servo/pull/19652 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8918)
<!-- Reviewable:end -->
