### PR TITLE
[css-writing-modes] Adds tests for https://github.com/w3c/csswg-drafts/issues/1782

### DIFF
--- a/css/css-writing-modes/ch-units-vrl-001.html
+++ b/css/css-writing-modes/ch-units-vrl-001.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>upright vertical writing mode and ch unit on table rows</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-001-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table rows takes the writing mode (with upright text-orientation) into account,
+                            even though theses properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+}
+tr {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  line-height: 5ch; /* using the inherited line-height (which the affects the content of the td)
+                       instead of directly using the height property,
+                       because sizing on table cells is complicated and out of scope for this. */
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(1) {
+  background: blue;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(2) {
+  background: orange;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-002.html
+++ b/css/css-writing-modes/ch-units-vrl-002.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>upright vertical writing mode and ch unit on table row groups</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-001-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table row groups takes the writing mode (with upright text-orientatino) into account,
+                            even though these properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+}
+tbody {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  line-height: 5ch; /* using the inherited line-height (which the affects the content of the td)
+                       instead of directly using the height property,
+                       because sizing on table cells is complicated and out of scope for this. */
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(1) {
+  background: blue;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(2) {
+  background: orange;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-003.html
+++ b/css/css-writing-modes/ch-units-vrl-003.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>upright vertical writing mode and ch unit on table columns</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-001-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table columns takes the writing mode (with upright orientation) into account,
+                            even though these properties do no apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+}
+col {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(1) {
+  background: blue;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(2) {
+  background: orange;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><col><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-004.html
+++ b/css/css-writing-modes/ch-units-vrl-004.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>upright vertical writing mode and ch unit on table column groups</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-001-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table column groups takes the writing mode (with upright text-orientation) into account,
+                            even though these properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+}
+colgroup {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(1) {
+  background: blue;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(2) {
+  background: orange;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-005.html
+++ b/css/css-writing-modes/ch-units-vrl-005.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>sideways vertical writing mode and ch unit on table rows</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-005-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table rows takes the writing mode (with a sideways text-orientation) into account,
+                            even though theese properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+}
+tr {
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+  line-height: 5ch; /* using the inherited line-height (which the affects the content of the td)
+                       instead of directly using the height property,
+                       because sizing on table cells is complicated and out of scope for this. */
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(2) {
+  background: orange;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(1) {
+  background: blue;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-006.html
+++ b/css/css-writing-modes/ch-units-vrl-006.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>sideways vertical writing mode and ch unit on table row groups</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-005-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table row groups takes the writing mode (with a sideways text-orientation) into account,
+                            even though these properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+}
+tbody {
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+  line-height: 5ch; /* using the inherited line-height (which the affects the content of the td)
+                       instead of directly using the height property,
+                       because sizing on table cells is complicated and out of scope for this. */
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(2) {
+  background: orange;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(1) {
+  background: orange;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-007.html
+++ b/css/css-writing-modes/ch-units-vrl-007.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>sideways vertical writing mode and ch unit on table columns</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-005-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table columns takes the writing mode (with a sideways orientation) into account,
+                            even though these properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+}
+col {
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+  width: 5ch;
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(2) {
+  background: orange;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(1) {
+  background: blue;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><col><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/ch-units-vrl-008.html
+++ b/css/css-writing-modes/ch-units-vrl-008.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>sideways vertical writing mode and ch unit on table column groups</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/ch-units-vrl-005-ref.html"
+<meta name="assert" content="The font-metric dependent ch unit on table column groups takes the writing mode (with a sideways orientation) into account,
+                            even though theses properties do not apply to that element.">
+<style>
+table {
+  font-size: 20px;
+  border-collapse: collapse;
+  border: none;
+}
+td {
+  padding: 0;
+  background: green;
+  height: 5ch;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+}
+colgroup {
+  writing-mode: vertical-rl;
+  text-orientation: sideways;
+  width: 5ch;
+}
+
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+/* Sizing the reference divs using the actual 0 (after which the ch unit is based) in the inline dimensions,
+   and using the ch unit in the block dimension,
+   to make sure that the ch unit itself works well in the general case.
+   If it doesn't, or if writing modes don't work, the divs won't be square.
+ */
+div:nth-of-type(2) {
+  background: orange;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  width: 5ch;
+}
+div:nth-of-type(1) {
+  background: blue;
+  height: 5ch;
+  display: inline-block; /* shrinkwrap */
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <table><colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+  <div>00000</div>
+  <div>00000</div>
+</body>

--- a/css/css-writing-modes/logical-props-001.html
+++ b/css/css-writing-modes/logical-props-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>writing-modes and logical props: tr</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/logical-props-001-ref.html"
+<meta name="assert" content="The logical properties on table rows are resolved taking the writing mode of the element into account,
+                            even though the writing mode property does not apply to that element.">
+<style>
+table { border-collapse: collapse; }
+td {
+  padding: 0;
+  height: 100px;
+  width: 100px;
+}
+tr {
+  writing-mode: vertical-rl;
+  border-inline-start: 5px green solid;
+}
+
+.red {
+  position: absolute;
+  width: 100px;
+  height: 5px;
+  background: red;
+  z-index: -1;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>horizontal green stripe</strong> below and <strong>no red</strong>.
+  <div class=red></div>
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+</body>

--- a/css/css-writing-modes/logical-props-002.html
+++ b/css/css-writing-modes/logical-props-002.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>writing-modes and logical props: tbody</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/logical-props-001-ref.html"
+<meta name="assert" content="The logical properties on table row groups are resolved taking the writing mode of the element into account,
+                            even though the writing mode property does not apply to that element.">
+<style>
+table { border-collapse: collapse; }
+td {
+  padding: 0;
+  height: 100px;
+  width: 100px;
+}
+tbody {
+  writing-mode: vertical-rl;
+  border-inline-start: 5px green solid;
+}
+
+.red {
+  position: absolute;
+  width: 100px;
+  height: 5px;
+  background: red;
+  z-index: -1;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>horizontal green stripe</strong> below and <strong>no red</strong>.
+  <div class=red></div>
+  <table><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+</body>

--- a/css/css-writing-modes/logical-props-003.html
+++ b/css/css-writing-modes/logical-props-003.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>writing-modes and logical props: col</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/logical-props-001-ref.html"
+<meta name="assert" content="The logical properties on table columns are resolved taking the writing mode of the element into account,
+                            even though the writing mode property does not apply to that element.">
+<style>
+table { border-collapse: collapse; }
+td {
+  padding: 0;
+  height: 100px;
+  width: 100px;
+}
+col {
+  writing-mode: vertical-rl;
+  border-inline-start: 5px green solid;
+}
+
+.red {
+  position: absolute;
+  width: 100px;
+  height: 5px;
+  background: red;
+  z-index: -1;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>horizontal green stripe</strong> below and <strong>no red</strong>.
+  <div class=red></div>
+  <table><col><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+</body>

--- a/css/css-writing-modes/logical-props-004.html
+++ b/css/css-writing-modes/logical-props-004.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>writing-modes and logical props: colgroup</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#placement">
+<link rel="match" href="reference/logical-props-001-ref.html"
+<meta name="assert" content="The logical properties on table column groups are resolved taking the writing mode of the element into account,
+                            even though the writing mode property does not apply to that element.">
+<style>
+table { border-collapse: collapse; }
+td {
+  padding: 0;
+  height: 100px;
+  width: 100px;
+}
+colgroup {
+  writing-mode: vertical-rl;
+  border-inline-start: 5px green solid;
+}
+
+.red {
+  position: absolute;
+  width: 100px;
+  height: 5px;
+  background: red;
+  z-index: -1;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>horizontal green stripe</strong> below and <strong>no red</strong>.
+  <div class=red></div>
+  <table><colgroup><tbody><tr><td>&nbsp;</td></tr></tbody></table>
+</body>

--- a/css/css-writing-modes/reference/ch-units-vrl-001-ref.html
+++ b/css/css-writing-modes/reference/ch-units-vrl-001-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+div:nth-of-type(1) { background: green; }
+div:nth-of-type(2) { background: blue; }
+div:nth-of-type(1),
+div:nth-of-type(2) {
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  height: 5ch;
+  width: 5ch;
+}
+div:nth-of-type(3) {
+  background: orange;
+  height: 5ch;
+  width: 5ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <div></div>
+  <div></div>
+  <div></div>
+</body>

--- a/css/css-writing-modes/reference/ch-units-vrl-005-ref.html
+++ b/css/css-writing-modes/reference/ch-units-vrl-005-ref.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  font-size: 20px;
+  color: transparent;
+}
+
+div:nth-of-type(1) { background: green; }
+div:nth-of-type(2) { background: blue; }
+div:nth-of-type(1),
+div:nth-of-type(2) {
+  height: 5ch;
+  width: 5ch;
+}
+div:nth-of-type(3) {
+  background: orange;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  height: 5ch;
+  width: 5ch;
+}
+</style>
+<body>
+  <p>Test passes if there is a <strong>green square</strong> below, and if it is the <strong>same size as the blue</strong> one, not the orange one.
+  <p>If any of the 3 colored shapes is not a square, or if the orange and blue squares are the same size, the test fails.
+  <div></div>
+  <div></div>
+  <div></div>
+</body>

--- a/css/css-writing-modes/reference/logical-props-001-ref.html
+++ b/css/css-writing-modes/reference/logical-props-001-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS test reference</title>
+<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+<style>
+div {
+  position: absolute;
+  width: 100px;
+  height: 5px;
+  background: green;
+}
+
+</style>
+<body>
+  <p>Test passes if there is a <strong>horizontal green stripe</strong> below and <strong>no red</strong>.
+  <div></div>
+</body>


### PR DESCRIPTION
The spec change/clarification introduced in https://github.com/w3c/csswg-drafts/issues/1782 makes clear that font dependent units or logical properties need to take `writing-mode` (and, as appropriate, `text-orientation`) into account, even on elements where these two properties are described as "not applying".

These tests use the `ch` unit and the `border-inline-start` properties on various table parts to check that they account for `writing-mode` and `text-orientation`.

I have not included tests for ruby base containers nor ruby annotation containers because the css-ruby spec and ruby implementations are not sufficiently mature, and I could not reliably find logical properties or properties that take a `<length>` (so that I could use the `ch` unit) that apply to ruby base containers or ruby annotation containers (or be sure that this wouldn't change as the ruby spec matures).

From the point of view of the writing mode spec, this does not matter, as css-writing-modes does not have a dependency on the less mature css-ruby. We should reconsider writing these tests for the ruby spec later one

<!-- Reviewable:start -->

<!-- Reviewable:end -->
