### PR TITLE
Add first-letter test for combining characters

### DIFF
--- a/css/css-pseudo/first-letter-004-ref.html
+++ b/css/css-pseudo/first-letter-004-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        font-size: 36px;
+    }
+    span {
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the "T" and surrounding punctuation below are green.</p>
+    <div><span>&#x104e;&#x300;T&#x300;&#x104e;&#x300;</span>est</div>
+</body>

--- a/css/css-pseudo/first-letter-004.html
+++ b/css/css-pseudo/first-letter-004.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>CSS Test: ::first-letter formatting</title>
+    <link rel="author" title="Chris Nardi" href="mailto:csnardi1@gmail.com">
+    <link rel="match" href="first-letter-004-ref.html">
+    <link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#first-letter-pseudo">
+    <meta name="flags" content="">
+    <meta name="assert" content="Test checks that punctuation and letters with combining characters still have proper ::first-letter styling.">
+    <style>
+        div {
+            font-size: 36px;
+        }
+        div::first-letter {
+            color: green;
+        }
+    </style>
+</head>
+<body>
+    <p>Test passes if the "T" and surrounding punctuation below are green.</p>
+    <div>&#x104e;&#x300;T&#x300;&#x104e;&#x300;est</div>
+</body>
+</html>


### PR DESCRIPTION
In the process of creating https://chromium-review.googlesource.com/c/chromium/src/+/847293, I noticed that there was no first-letter test for combining characters with punctuation and letters. This change adds in such a test.

Submitted directly as Chromium does not import css-pseudo yet.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
