### PR TITLE
Add references for CSS2/tables

### DIFF
--- a/css/CSS2/tables/caption-side-applies-to-001-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-001-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<body>
+    <p>Test passes if the words "Filler Text" below are all on the same line.</p>
+    <div>Filler Text Filler Text Filler Text</div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-001.xht
+++ b/css/CSS2/tables/caption-side-applies-to-001.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: inline' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-002-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-002-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .blue {
+        background: blue;
+    }
+</style>
+<body>
+    <p>Test passes if there are three lines of "Filler Text" below and the middle line has a blue background.</p>
+    <div>Filler Text</div>
+    <div class="blue">Filler Text</div>
+    <div>Filler Text</div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-002.xht
+++ b/css/CSS2/tables/caption-side-applies-to-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-002-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: block' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-003-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-003-ref.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        margin-left: 2em;
+    }
+    .orange {
+        background: orange;
+        display: list-item;
+    }
+</style>
+<body>
+    <p>Test passes if there are three lines of "Filler Text" below and if the middle "Filler Text" has a orange background and a marker bullet on its left-hand side. The marker bullet should not have an orange background.</p>
+    <div>Filler Text</div>
+    <div class="orange">Filler Text</div>
+    <div>Filler Text</div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-003.xht
+++ b/css/CSS2/tables/caption-side-applies-to-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: list-item' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-005.xht
+++ b/css/CSS2/tables/caption-side-applies-to-005.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: inline-block' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-006-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-006-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .box {
+        background: blue;
+        height: 1in;
+        width: 2in;
+    }
+</style>
+<body>
+    <p>Test passes if the "Filler Text" below is below the box.</p>
+    <div class="box"></div>
+    <div>Filler Text</div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-006.xht
+++ b/css/CSS2/tables/caption-side-applies-to-006.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-006-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-007.xht
+++ b/css/CSS2/tables/caption-side-applies-to-007.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-006-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: inline-table' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-008-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-008-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    .box {
+        background: blue;
+        height: 1in;
+        width: 2in;
+    }
+</style>
+<body>
+    <p>Test passes if the "Filler Text" below is above the box.</p>
+    <div>Filler Text</div>
+    <div class="box"></div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-008.xht
+++ b/css/CSS2/tables/caption-side-applies-to-008.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-row-group' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-009.xht
+++ b/css/CSS2/tables/caption-side-applies-to-009.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-header-group' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-010.xht
+++ b/css/CSS2/tables/caption-side-applies-to-010.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-footer-group' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-011.xht
+++ b/css/CSS2/tables/caption-side-applies-to-011.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-column' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-012.xht
+++ b/css/CSS2/tables/caption-side-applies-to-012.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-row' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-013.xht
+++ b/css/CSS2/tables/caption-side-applies-to-013.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-column-group' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-014.xht
+++ b/css/CSS2/tables/caption-side-applies-to-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side does not apply to 'display: table-cell' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-015.xht
+++ b/css/CSS2/tables/caption-side-applies-to-015.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-006-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side applies to 'display: table-caption' elements." />
         <style type="text/css">

--- a/css/CSS2/tables/caption-side-applies-to-017-ref.html
+++ b/css/CSS2/tables/caption-side-applies-to-017-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        background: blue;
+        width: 2in;
+    }
+    .box {
+        height: 1in;
+    }
+</style>
+<body>
+    <p>Test passes if the "Filler Text" below is inside the box.</p>
+    <div>Filler Text</div>
+    <div class="box"></div>
+</body>

--- a/css/CSS2/tables/caption-side-applies-to-017.xht
+++ b/css/CSS2/tables/caption-side-applies-to-017.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#propdef-caption-side" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#caption-position" />
+        <link rel="match" href="caption-side-applies-to-017-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Caption-side applies to 'display: inherit' elements which do not inherit the value of 'table-caption'." />
         <style type="text/css">

--- a/css/CSS2/tables/collapsing-border-model-001-ref.html
+++ b/css/CSS2/tables/collapsing-border-model-001-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        height: 120px;
+        width: 220px;
+    }
+    .orange {
+        background: orange;
+    }
+    .blue {
+        background: blue;
+    }
+</style>
+<body>
+    <p>Test passes if the orange and blue boxes below are the same width.</p>
+    <div class="orange"></div>
+    <div class="blue"></div>
+</body>

--- a/css/CSS2/tables/collapsing-border-model-001.xht
+++ b/css/CSS2/tables/collapsing-border-model-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Collapsing borders model row width equation (auto layout)</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The user agent adheres to the collapsing border model row width equation in auto table layout." />
         <style type="text/css">
@@ -22,7 +23,7 @@
             #div1
             {
                 background: orange;
-                height: 110px;
+                height: 120px;
                 width: 220px;
             }
         </style>

--- a/css/CSS2/tables/collapsing-border-model-003-ref.html
+++ b/css/CSS2/tables/collapsing-border-model-003-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<style>
+    div {
+        height: 1.5in;
+        width: 100px;
+    }
+    .orange {
+        background: orange;
+    }
+    .blue {
+        background: blue;
+        width: 50px;
+        float: right;
+    }
+</style>
+<body>
+    <p>Test passes if the orange and blue boxes below are the same height.</p>
+    <div class="orange"><div class="blue"></div></div>
+</body>

--- a/css/CSS2/tables/collapsing-border-model-003.xht
+++ b/css/CSS2/tables/collapsing-border-model-003.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Top table border width under collapsing borders model</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The top border width of the table is half of the maximum collapsed top border width." />
         <style type="text/css">

--- a/css/CSS2/tables/collapsing-border-model-004.xht
+++ b/css/CSS2/tables/collapsing-border-model-004.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Tables under the collapsing borders model don't have padding</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Padding doesn't apply to a table under the collapsing border model." />
         <style type="text/css">
@@ -23,7 +24,7 @@
             #div1
             {
                 background: orange;
-                height: 110px;
+                height: 120px;
                 width: 220px;
             }
         </style>

--- a/css/CSS2/tables/collapsing-border-model-007.xht
+++ b/css/CSS2/tables/collapsing-border-model-007.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Left table border width under collapsing borders model</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The left border width of the table is half of the first cell's collapsed left border width." />
         <style type="text/css">
@@ -14,21 +15,22 @@
             }
             col
             {
-                width: 1in;
+                width: 165px;
             }
             td, #div1
             {
-                height: 1in;
+                height: 120px;
             }
             td
             {
-                border-left: 1in solid blue;
+                width: 110px;
+                border-left: 110px solid blue;
                 padding: 0;
             }
             #div1
             {
                 background: orange;
-                width: 1.5in;
+                width: 220px;
             }
         </style>
     </head>

--- a/css/CSS2/tables/collapsing-border-model-008.xht
+++ b/css/CSS2/tables/collapsing-border-model-008.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Right table border width under collapsing borders model</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The right border width of the table is half of the collapsed right border width of the last cell of the first row." />
         <style type="text/css">
@@ -14,21 +15,22 @@
             }
             col
             {
-                width: 1in;
+                width: 165px;
             }
             td, #div1
             {
-                height: 1in;
+                height: 120px;
             }
             td
             {
-                border-right: 1in solid blue;
+                width: 110px;
+                border-right: 110px solid blue;
                 padding: 0;
             }
             #div1
             {
                 background: orange;
-                width: 1.5in;
+                width: 220px;
             }
         </style>
     </head>

--- a/css/CSS2/tables/collapsing-border-model-009.xht
+++ b/css/CSS2/tables/collapsing-border-model-009.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Bottom table border width under collapsing borders model</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#collapsing-borders" />
+        <link rel="match" href="collapsing-border-model-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The bottom border width of the table is half of the maximum collapsed bottom border width." />
         <style type="text/css">

--- a/css/CSS2/tables/row-visibility-001.xht
+++ b/css/CSS2/tables/row-visibility-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Row and the 'visibility' property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#dynamic-effects" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="A 'visibility' value of 'collapse' applies to table rows." />
         <style type="text/css">
@@ -27,13 +28,13 @@
             .cell
             {
                 display: table-cell;
-                height: 1in;
-                width: 1in;
+                height: 100px;
+                width: 100px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is no red visible on the page.</p>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
         <div id="table">
             <div id="row1">
                 <div class="cell"></div>

--- a/css/CSS2/tables/row-visibility-002.xht
+++ b/css/CSS2/tables/row-visibility-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Row group and the 'visibility' property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#dynamic-effects" />
+        <link rel="match" href="../reference/ref-filled-green-100px-square.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'visibility' value of 'collapse' applies to table row groups." />
         <style type="text/css">
@@ -31,13 +32,13 @@
             .cell
             {
                 display: table-cell;
-                height: 1in;
-                width: 1in;
+                height: 100px;
+                width: 100px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is no red visible on the page.</p>
+        <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
         <div id="table">
             <div id="rowgroup1">
                 <div id="row">

--- a/css/CSS2/tables/table-cell-001.xht
+++ b/css/CSS2/tables/table-cell-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Table-cell</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#table-display" />
+        <link rel="match" href="../reference/ref-filled-black-96px-square.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="An element with 'display: table-cell' is rendered as if it were a table cell." />
         <style type="text/css">
@@ -19,13 +20,13 @@
             {
                 background: black;
                 display: table-cell;
-                height: 2em;
-                width: 2em;
+                height: 48px;
+                width: 48px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is a square below.</p>
+        <p>Test passes if there is a filled black square.</p>
         <div class="table">
            <div class="tr">
                 <div class="td"></div>


### PR DESCRIPTION
Many css/CSS2/tables tests were missing references. This change adds in
references for caption-side-applies-to-\*.xht and collapsing-border-model-\*.xht
tests, as well as a few other simple ones.

Part of #8670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
