### PR TITLE
Remove the expectations from test names in createImageBitmap-invalid-args.html.

### DIFF
--- a/2dcontext/imagebitmap/createImageBitmap-invalid-args.html
+++ b/2dcontext/imagebitmap/createImageBitmap-invalid-args.html
@@ -46,8 +46,7 @@ function makeAvailableButBrokenImage() {
 
 testCases = [
   {
-    description: 'createImageBitmap with a <sourceType> source and sw set to ' +
-        '0 rejects with a RangeError.',
+    description: 'createImageBitmap with a <sourceType> source and sw set to 0',
     promiseTestFunction:
       (source, t) => {
         return promise_rejects(t, new RangeError(),
@@ -55,8 +54,7 @@ testCases = [
       }
   },
   {
-    description: 'createImageBitmap with a <sourceType> source and sh set to ' +
-        '0 rejects with a RangeError.',
+    description: 'createImageBitmap with a <sourceType> source and sh set to 0',
     promiseTestFunction:
       (source, t) => {
         return promise_rejects(t, new RangeError(),
@@ -66,10 +64,11 @@ testCases = [
   {
     // This case is not explicitly documented in the specification for
     // createImageBitmap, but it is expected that internal failures cause
+    // InvalidStateError.
     //
+    // Note: https://bugs.chromium.org/p/chromium/issues/detail?id=799025
     description: 'createImageBitmap with a <sourceType> source and oversized ' +
-        '(unallocatable) crop region rejects with an InvalidStateError ' +
-        'DOMException.',
+        '(unallocatable) crop region',
     promiseTestFunction:
       (source, t) => {
         return promise_rejects(t, new DOMException('', 'InvalidStateError'),
@@ -93,61 +92,61 @@ imageSourceTypes.forEach(imageSourceType => {
 
 promise_test( t => {
   return promise_rejects(t, new TypeError(), createImageBitmap(undefined));
-}, "createImageBitmap with undefined image source rejects with a TypeError.");
+}, "createImageBitmap with undefined image source.");
 
 promise_test( t => {
   return promise_rejects(t, new TypeError(), createImageBitmap(null));
-}, "createImageBitmap with null image source rejects with a TypeError.");
+}, "createImageBitmap with null image source.");
 
 promise_test( t => {
   return promise_rejects(t, "InvalidStateError",
     createImageBitmap(new Image()));
-}, "createImageBitmap with empty image source rejects with a InvalidStateError.");
+}, "createImageBitmap with empty image source.");
 
 promise_test( t => {
   return promise_rejects(t, "InvalidStateError",
     createImageBitmap(document.createElement('video')));
-}, "createImageBitmap with empty video source rejects with a InvalidStateError.");
+}, "createImageBitmap with empty video source.");
 
 promise_test( t => {
   return makeOversizedCanvas().then(canvas => {
     return promise_rejects(t, "InvalidStateError",
         createImageBitmap(canvas));
   });
-}, "createImageBitmap with an oversized canvas source rejects with a RangeError.");
+}, "createImageBitmap with an oversized canvas source.");
 
 promise_test( t => {
   return makeOversizedOffscreenCanvas().then(offscreenCanvas => {
     return promise_rejects(t, "InvalidStateError",
         createImageBitmap(offscreenCanvas));
   });
-}, "createImageBitmap with an invalid OffscreenCanvas source rejects with a RangeError.");
+}, "createImageBitmap with an invalid OffscreenCanvas source.");
 
 promise_test( t => {
   return makeInvalidBlob().then(blob => {
     return promise_rejects(t, "InvalidStateError",
         createImageBitmap(blob));
   });
-}, "createImageBitmap with an undecodable blob source rejects with an InvalidStateError.");
+}, "createImageBitmap with an undecodable blob source.");
 
 promise_test( t => {
   return makeBrokenImage().then(image => {
     return promise_rejects(t, "InvalidStateError",
         createImageBitmap(image));
   });
-}, "createImageBitmap with a broken image source rejects with an InvalidStateError.");
+}, "createImageBitmap with a broken image source.");
 
 promise_test( t => {
   return makeAvailableButBrokenImage().then(image => {
     return promise_rejects(t, "InvalidStateError",
         createImageBitmap(image));
   });
-}, "createImageBitmap with an available but undecodable image source rejects with an InvalidStateError.");
+}, "createImageBitmap with an available but undecodable image source.");
 
 promise_test( t => {
   return makeImageBitmap().then(bitmap => {
     bitmap.close()
     return promise_rejects(t, "InvalidStateError", createImageBitmap(bitmap));
   });
-}, "createImageBitmap with a closed ImageBitmap rejects with an InvalidStateError.");
+}, "createImageBitmap with a closed ImageBitmap.");
 </script>


### PR DESCRIPTION
This is generally frowned upon, because it means the test name needs to change
if the expecation changes. This was already forgotten in some of the tests here.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
