### PR TITLE
Add testcase for unclosed attribute value selector

### DIFF
--- a/dom/nodes/selectors.js
+++ b/dom/nodes/selectors.js
@@ -90,6 +90,7 @@ var validSelectors = [
 
   // - value                     [att=val]
   {name: "Attribute value selector, matching align attribute with value",                                    selector: "#attr-value [align=\"center\"]",                                     expect: ["attr-value-div1"], level: 2, testType: TEST_QSA | TEST_MATCH},
+  {name: "Attribute value selector, matching align attribute with value, unclosed bracket",                  selector: "#attr-value [align=\"center\"",                                      expect: ["attr-value-div1"], level: 2, testType: TEST_QSA | TEST_MATCH},
   {name: "Attribute value selector, matching align attribute with empty value",                              selector: "#attr-value [align=\"\"]",                                           expect: ["attr-value-div2"], level: 2, testType: TEST_QSA | TEST_MATCH},
   {name: "Attribute value selector, not matching align attribute with partial value",                        selector: "#attr-value [align=\"c\"]",                                          expect: [] /*no matches*/,   level: 2, testType: TEST_QSA},
   {name: "Attribute value selector, not matching align attribute with incorrect value",                      selector: "#attr-value [align=\"centera\"]",                                    expect: [] /*no matches*/,   level: 2, testType: TEST_QSA},


### PR DESCRIPTION
Per https://github.com/whatwg/dom/issues/549, all browsers except Safari accept this selector. Therefore, this test case verifies that unclosed brackets are valid and do not throw a `SyntaxError`. I verified this test-case passing in Firefox and Chrome, but I do not have a Safari browser to test this on. Would be greatly appreciated if someone could run this in Safari and verify this test case fails (as expected).

Closes https://github.com/whatwg/dom/issues/549

<!-- Reviewable:start -->

<!-- Reviewable:end -->
