### PR TITLE
Avoid for(const ... of ...) usage in webidl parser.

### DIFF
--- a/resources/webidl2/lib/webidl2.js
+++ b/resources/webidl2/lib/webidl2.js
@@ -14,7 +14,8 @@
     const types = ["float", "integer", "identifier", "string", "whitespace", "other"];
     while (str.length > 0) {
       let matched = false;
-      for (const type of types) {
+      for (var i in types) {
+        const type = types[i];
         str = str.replace(re[type], tok => {
           tokens.push({ type, value: tok });
           matched = true;
@@ -119,10 +120,11 @@
             "multiline-comment": /^\/\*((?:.|\n|\r)*?)\*\//
           };
           const wsTypes = [];
-          for (const k in re) wsTypes.push(k);
+          for (var k in re) wsTypes.push(k);
           while (w.length) {
             let matched = false;
-            for (const type of wsTypes) {
+            for (var i in wsTypes) {
+              const type = wsTypes[i];
               w = w.replace(re[type], (tok, m1) => {
                 store.push({ type: type + (pea ? ("-" + pea) : ""), value: m1 });
                 matched = true;


### PR DESCRIPTION

Servo's JS engine doesn't support this construct yet.

Upstreamed from https://github.com/servo/servo/pull/19728 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8974)
<!-- Reviewable:end -->
