### PR TITLE
webdriver: add timeouts test cases to create new session tests

### DIFF
--- a/webdriver/tests/sessions/new_session/invalid_capabilities.py
+++ b/webdriver/tests/sessions/new_session/invalid_capabilities.py
@@ -37,7 +37,7 @@ invalid_data = [
                {"proxyType": 1}, {"proxyType": []}, {"proxyType": {"value": "system"}},
                {" proxyType": "system"}, {"proxyType ": "system"}, {"proxyType ": " system"},
                {"proxyType": "system "}]),
-    ("timeouts", [1, [], "{}", {}, False, {"pageLOAD": 10}, {"page load": 10},
+    ("timeouts", [1, [], "{}", False, {"pageLOAD": 10}, {"page load": 10},
                   {"page load": 10}, {"pageLoad": "10"}, {"pageLoad": {"value": 10}},
                   {"invalid": 10}, {"pageLoad": -1}, {"pageLoad": 2**64},
                   {"pageLoad": None}, {"pageLoad": 1.1}, {"pageLoad": 10, "invalid": 10},

--- a/webdriver/tests/sessions/new_session/support/create.py
+++ b/webdriver/tests/sessions/new_session/support/create.py
@@ -6,6 +6,10 @@ valid_data = [
     ("platformName", [None]),
     ("pageLoadStrategy", ["none", "eager", "normal", None]),
     ("proxy", [None]),
+    ("timeouts", [{"script": 0, "pageLoad": 2.0, "implicit": 2**64 - 1},
+                  {"script": 50, "pageLoad": 25},
+                  {"script": 500},
+                  {}]),
     ("unhandledPromptBehavior", ["dismiss", "accept", None]),
     ("test:extension", [True, "abc", 123, [], {"key": "value"}, None]),
 ]


### PR DESCRIPTION
It checks that correct timeout values are correctly parsed when
processing capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8975)
<!-- Reviewable:end -->
