### PR TITLE
wpt-export-for-webkit-181330

### DIFF
--- a/fetch/security/redirect-to-url-with-credentials.https.html
+++ b/fetch/security/redirect-to-url-with-credentials.https.html
@@ -1,0 +1,69 @@
+<html>
+<header>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
+</header>
+<body>
+<script>
+var host = get_host_info();
+
+var sameOriginImageURL = "/common/redirect.py?location=" + host.HTTPS_ORIGIN_WITH_CREDS + "/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin= " + host.HTTPS_ORIGIN + "%26PNGIMAGE%26ACACredentials=true";
+var imageURL = "/common/redirect.py?location=" + host.HTTPS_REMOTE_ORIGIN_WITH_CREDS + "/service-workers/service-worker/resources/fetch-access-control.py?ACAOrigin= " + host.HTTPS_ORIGIN + "%26PNGIMAGE%26ACACredentials=true";
+var frameURL = "/common/redirect.py?location=" + host.HTTPS_REMOTE_ORIGIN_WITH_CREDS + "/common/blank.html";
+
+promise_test((test) => {
+    return fetch(imageURL, {mode: "no-cors"});
+}, "No CORS fetch after a redirect with an URL containing credentials");
+
+promise_test((test) => {
+    return promise_rejects(test, new TypeError, fetch(imageURL, {mode: "cors"}));
+}, "CORS fetch after a redirect with a cross origin URL containing credentials");
+
+promise_test((test) => {
+    return fetch(sameOriginImageURL, {mode: "cors"});
+}, "CORS fetch after a redirect with a same origin URL containing credentials");
+
+promise_test((test) => {
+    return new Promise((resolve, reject) => {
+        var image = new Image();
+        image.onload = resolve;
+        image.onerror = (e) => reject(e);
+        image.src = imageURL;
+    });
+}, "Image loading after a redirect with an URL containing credentials");
+
+promise_test((test) => {
+    return new Promise((resolve, reject) => {
+        var image = new Image();
+        image.crossOrigin = "use-credentials";
+        image.onerror = resolve;
+        image.onload = () => reject("Image should not load");
+        image.src = imageURL;
+    });
+}, "CORS Image loading after a redirect with a cross origin URL containing credentials");
+
+promise_test((test) => {
+    return new Promise((resolve, reject) => {
+        var image = new Image();
+        image.crossOrigin = "use-credentials";
+        image.onload = resolve;
+        image.onerror = (e) => reject(e);
+        image.src = sameOriginImageURL;
+    });
+}, "CORS Image loading after a redirect with a same origin URL containing credentials");
+
+promise_test(async (test) => {
+    var iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    await new Promise((resolve, reject) => {
+        iframe.src = frameURL;
+        iframe.onload = resolve;
+        iframe.onerror = (e) => reject(e);
+        setTimeout(() => reject("Frame loading timed out"), 5000);
+    });
+    document.body.removeChild(iframe);
+}, "Frame loading after a redirect with an URL containing credentials");
+</script>
+</body>
+</html>

--- a/fetch/security/redirect-to-url-with-credentials.https.html
+++ b/fetch/security/redirect-to-url-with-credentials.https.html
@@ -60,7 +60,7 @@ promise_test(async (test) => {
         iframe.src = frameURL;
         iframe.onload = resolve;
         iframe.onerror = (e) => reject(e);
-        setTimeout(() => reject("Frame loading timed out"), 5000);
+        test.step_timeout(() => reject("Frame loading timed out"), 5000);
     });
     document.body.removeChild(iframe);
 }, "Frame loading after a redirect with an URL containing credentials");


### PR DESCRIPTION
Add testing for redirect URLs containing credentials in CORS mode for images and no cors mode for fetch, image and frame

<!-- Reviewable:start -->

<!-- Reviewable:end -->
