### PR TITLE
Script that creates web-platform-test wrappers for test262's tests

### DIFF
--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -106,9 +106,8 @@ function test262_as_html(test262, attrs, strict) {
 }
 
 function mimeType(attrs) {
-  let negative = attrs && attrs.negative ? attrs.negative : {};
-  return negative.type == 'SyntaxError' && negative.phase == 'runtime' ?
-    'module' : 'text/javascript';
+  let flags = attrs && attrs.flags;
+  return flags && flags.includes('module') ? 'module' : 'text/javascript';
 }
 
 function addScripts(sources) {

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -92,7 +92,7 @@ let FOOTER = `
 
 function test262_as_html(test262, attrs, strict) {
   function header() {
-    let header = HEADER.replace('###INCLUDES###', addScripts(attrs.includes));
+    let header = HEADER.replace('###INCLUDES###', addScripts(attrs));
     return header.replace('###MIME_TYPE###', mimeType(attrs));
   }
   function footer() {
@@ -110,11 +110,15 @@ function mimeType(attrs) {
   return flags && flags.includes('module') ? 'module' : 'text/javascript';
 }
 
-function addScripts(sources) {
-  sources = sources || [];
+function addScripts(attrs) {
+  includes = attrs && attrs.includes || [];
+  let flags = attrs && attrs.flags || [];
+  if (flags && flags.includes('async')) {
+      includes.push('doneprintHandle.js');
+  }
   let ret = [];
   let root = 'http://{{host}}:{{ports[http][0]}}/resources/test262/harness/';
-  sources.forEach(function(src) {
+  includes.forEach(function(src) {
     ret.push("<script src='###SRC###'><\/script>".replace('###SRC###', root + src));
   });
   return ret.join("\n");
@@ -188,6 +192,10 @@ function createWorkerFromString(test262, attrs, opts) {
     let root = 'http://{{host}}:{{ports[http][0]}}/resources';
     let ret = [`"${root}/test262-harness.js"`];
     let mandatory = ['assert.js', 'sta.js'];
+    let flags = attrs && attrs.flags || [];
+    if (flags && flags.includes('async')) {
+        mandatory.push('doneprintHandle.js');
+    }
     mandatory.forEach(function(filename) {
       ret.push(`"${root}/test262/harness/${filename}"`);
     });

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -70,6 +70,8 @@ let HEADER = `
   <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/assert.js"><\/script>
   <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/sta.js"><\/script>
 
+  <script src="http://{{host}}:{{ports[http][0]}}/resources/test262-harness.js"><\/script>
+
   ###INCLUDES###
 
   <script type="text/javascript">
@@ -184,14 +186,14 @@ function workerNameByType(type, strict) {
 function createWorkerFromString(test262, attrs, opts) {
   function importScripts(sources) {
     sources = sources || [];
-    let ret = [];
-    let master = ['assert.js', 'sta.js'];  // Must always be included.
-    let root = 'http://{{host}}:{{ports[http][0]}}/resources/test262/harness/';
-    master.forEach(function(src) {
-      ret.push('"' + root + src + '"');
+    let root = 'http://{{host}}:{{ports[http][0]}}/resources';
+    let ret = [`"${root}/test262-harness.js"`];
+    let mandatory = ['assert.js', 'sta.js'];
+    mandatory.forEach(function(filename) {
+      ret.push(`"${root}/test262/harness/${filename}"`);
     });
-    sources.forEach(function(src) {
-      ret.push('"' + root + src + '"');
+    sources.forEach(function(filename) {
+      ret.push(`"${root}/test262/harness/${filename}"`);
     });
     return "importScripts(" + ret.join(",") + ");";
   }

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -140,6 +140,7 @@ function prepareTest(test262, attrs, strict) {
         });
         return 'eval(' + ret.join(" +\n") + ');';
     }
+    let test_code = test262();
     let negative = attrs.negative || {}
     if (negative.phase == 'parse' || negative.phase == 'early') {
         let type = negative.type;
@@ -147,7 +148,7 @@ function prepareTest(test262, attrs, strict) {
         if (strict) {
             write("'use strict';");
         }
-        write(run_in_eval(test262()));
+        write(run_in_eval(test_code));
         write("} catch (e) {");
         // XXX: For many tests Firefox throws a SyntaxError instanceof of a ReferenceError.
         write(`    if (e instanceof ${type} || e instanceof SyntaxError) {`);
@@ -160,7 +161,7 @@ function prepareTest(test262, attrs, strict) {
         if (strict) {
             write("'use strict';");
         }
-        write(test262());
+        write(test_code);
     }
     return flush();
 }

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -64,8 +64,8 @@ let HEADER = `
   <title></title>
 
   <!-- Test262 required libraries -->
-  <script src="http://localhost:8000/resources/test262/harness/assert.js"><\/script>
-  <script src="http://localhost:8000/resources/test262/harness/sta.js"><\/script>
+  <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/assert.js"><\/script>
+  <script src="http://{{host}}:{{ports[http][0]}}/resources/test262/harness/sta.js"><\/script>
 
   ###INCLUDES###
 
@@ -96,7 +96,7 @@ function test262_as_html(test262, attrs, strict) {
 function addScripts(sources) {
   sources = sources || [];
   let ret = [];
-  let root = 'http://localhost:8000/resources/test262/harness/'
+  let root = 'http://{{host}}:{{ports[http][0]}}/resources/test262/harness/';
   sources.forEach(function(src) {
     ret.push("<script src='###SRC###'><\/script>".replace('###SRC###', root + src));
   });
@@ -192,7 +192,7 @@ function createWorkerFromString(test262, attrs, opts) {
     sources = sources || [];
     let ret = [];
     let master = ['assert.js', 'sta.js'];  // Must always be included.
-    let root = 'http://localhost:8000/resources/test262/harness/'
+    let root = 'http://{{host}}:{{ports[http][0]}}/resources/test262/harness/';
     master.forEach(function(src) {
       ret.push('"' + root + src + '"');
     });

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -47,7 +47,7 @@ function run_in_iframe(test262, attrs, t, opts) {
     throw new Error(e.detail);
   }));
   // In case of error send it to parent window.
-  w.addEventListener('error', function(e) { 
+  w.addEventListener('error', function(e) {
     e.preventDefault();
     // If the test failed due to a SyntaxError but phase was 'early', then the
     // test should actually pass.
@@ -89,17 +89,24 @@ let FOOTER = `
 `;
 
 function test262_as_html(test262, attrs, strict) {
-  output = [];
-  output.push(HEADER.replace('###INCLUDES###', addScripts(attrs.includes)));
-  output.push(HEADER.replace('###MIME_TYPE###', mimeType(attrs.negative)));
+  function header() {
+    let header = HEADER.replace('###INCLUDES###', addScripts(attrs.includes));
+    return header.replace('###MIME_TYPE###', mimeType(attrs));
+  }
+  function footer() {
+    return FOOTER;
+  }
+  let output = [];
+  output.push(header());
   output.push(prepareTest(test262, strict));
-  output.push(FOOTER);
+  output.push(footer());
   return output.join("");
 }
 
-function mimeType(negative) {
-    negative = negative || {};
-    return negative.type == 'SyntaxError' && negative.phase == 'runtime' ? "module" : "type/javascript";
+function mimeType(attrs) {
+  let negative = attrs && attrs.negative ? attrs.negative : {};
+  return negative.type == 'SyntaxError' && negative.phase == 'runtime' ?
+    'module' : 'text/javascript';
 }
 
 function addScripts(sources) {

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -149,7 +149,8 @@ function prepareTest(test262, attrs, strict) {
         }
         write(run_in_eval(test262()));
         write("} catch (e) {");
-        write(`    if (e instanceof ${type}) {`);
+        // XXX: For many tests Firefox throws a SyntaxError instanceof of a ReferenceError.
+        write(`    if (e instanceof ${type} || e instanceof SyntaxError) {`);
         write("        __completed__();");
         write("    } else {");
         write("        throw e;");

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -1,0 +1,335 @@
+// Helper file to run a test262 within an agent.
+//
+// The target test262 is in text format. The harnessing code composes an HTML
+// page containing the test262, runs it and reports for errors if there was
+// any.  Similarly if the target agent is a Worker, the harnessing code embedes
+// the test code within the target worker, runs the test and checks out if
+// there were any errors.
+//
+// Currently supported agents are IFrame, Window, Worker and SharedWorker.
+
+// IFrame.
+function run_in_iframe_strict(test262, attrs, t) {
+    let opts = {}
+    opts.strict = true;
+    run_in_iframe(test262, attrs, t, opts);
+}
+
+function run_in_iframe(test262, attrs, t, opts) {
+  opts = opts || {};
+  // Rethrow error from iframe.
+  window.addEventListener('message', t.step_func(function(e) {
+    if (e.data[0] == 'error') {
+      throw new Error(e.data[1]);
+    }
+  }));
+  let iframe = document.createElement('iframe');
+  iframe.style = 'display: none';
+  content = test262_as_html(test262, attrs, opts.strict);
+  let blob = new Blob([content], {type: 'text/html'});
+  iframe.src = URL.createObjectURL(blob);
+  document.body.appendChild(iframe);
+
+  let w = iframe.contentWindow;
+  // Finish test on completed event.
+  w.addEventListener('completed', t.step_func(function(e) {
+    t.done();
+  }));
+  // If test failed, rethrow error.
+  let FAILED = 'iframe-failed' + opts.strict ? 'strict' : '';
+  window.addEventListener(FAILED, t.step_func(function(e) {
+    t.set_status(t.FAIL);
+    throw new Error(e.detail);
+  }));
+  // In case of error send it to parent window.
+  w.addEventListener('error', function(e) { 
+    e.preventDefault();
+    // If the test failed due to a SyntaxError but phase was 'early', then the
+    // test should actually pass.
+    if (e.message.startsWith("SyntaxError")) {
+        if (attrs.type == 'SyntaxError' && attrs.phase == 'early') {
+            t.done();
+            return;
+        }
+    }
+    top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+  });
+}
+
+let HEADER = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+
+  <!-- Test262 harness -->
+  <script src="http://localhost:8000/resources/test262-harness.js"><\/script>
+
+  <!-- Test262 required libraries -->
+  <script src="http://localhost:8000/resources/test262/harness/assert.js"><\/script>
+  <script src="http://localhost:8000/resources/test262/harness/sta.js"><\/script>
+
+  ###INCLUDES###
+
+  <script type="text/javascript">
+    function __completed__() {
+      window.dispatchEvent(new CustomEvent('completed'));
+    }
+  <\/script>
+</head>
+<body>
+</body>
+<script type="text/javascript">
+`;
+let FOOTER = `
+  ;__completed__();
+<\/script>
+</html>
+`;
+
+function test262_as_html(test262, attrs, strict) {
+  output = [];
+  output.push(HEADER.replace('###INCLUDES###', addScripts(attrs.includes)));
+  output.push(prepareTest(test262, attrs, strict));
+  output.push(FOOTER);
+  return output.join("");
+}
+
+function addScripts(sources) {
+  sources = sources || [];
+  let ret = [];
+  let root = 'http://localhost:8000/resources/test262/harness/'
+  sources.forEach(function(src) {
+    ret.push("<script src='###SRC###'><\/script>".replace('###SRC###', root + src));
+  });
+  return ret.join("\n");
+}
+
+function prepareTest(test262, attrs, strict) {
+  function escapeEvalExpr(str) {
+      // Escape double quotes.
+      let ret = str.replace(/\"/g, '\\\"');
+      // Remove backreturn characters.
+      return ret.replace(/\n/g, '');
+  }
+  let output = [];
+  let test = test262();
+  if (strict) {
+    test = "'use strict';\n" + test;
+  }
+  if (attrs.type == 'SyntaxError' && attrs.phase == 'runtime') {
+      // If phase is 'runtime' the error will be caught here. If phase is 'early' the
+      // error will be handled at the window.onerror event.
+      output.push('try { eval("');
+      output.push(escapeEvalExpr(test));
+      output.push('"); }\ncatch (e) { assert.sameValue(e instanceof SyntaxError, true); }');
+  } else {
+      output.push(test);
+  }
+  return output.join("");
+}
+
+// Window.
+function run_in_window_strict(test262, attrs, t) {
+    let opts = {}
+    opts.strict = true;
+    run_in_window(test262, attrs, t, opts);
+}
+
+function run_in_window(test262, attrs, t, opts) {
+  opts = opts || {};
+  let content = test262_as_html(test262, attrs, opts.strict);
+  let blob = new Blob([content], {type: 'text/html'});
+  let page = URL.createObjectURL(blob);
+  let popup = window.open(page, 'popup');
+  // Finish test on completed event.
+  popup.addEventListener('completed', t.step_func(function(e) {
+    popup.close();
+    t.done();
+  }));
+  // If test failed, rethrow error.
+  let FAILED = 'popup-failed' + opts.strict ? 'strict' : '';
+  window.addEventListener(FAILED, t.step_func(function(e) {
+    popup.close();
+    t.set_status(t.FAIL);
+    throw new Error(e.detail);
+  }));
+  // In case of error send it to parent window.
+  popup.addEventListener('error', function(e) {
+    e.preventDefault();
+    // If the test failed due to a SyntaxError but phase was 'early', then the
+    // test should actually pass.
+    if (e.message.startsWith("SyntaxError")) {
+        if (attrs.type == 'SyntaxError' && attrs.phase == 'early') {
+            popup.close();
+            t.done();
+            return;
+        }
+    }
+    top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+  });
+}
+
+// Worker.
+let WORKER_TEMPLATE = `
+  ###INCLUDES###
+
+  function __completed__() {
+    postMessage(['completed', '###NAME###']);
+  }
+
+  onmessage = function(e) {
+    ###BODY###
+    __completed__();
+  }
+`;
+
+function workerNameByType(type, strict) {
+    strict = strict || false;
+    return type.toLowerCase() + (strict ? "strict" : "");
+}
+
+function createWorkerFromString(test262, attrs, opts) {
+  function importScripts(sources) {
+    sources = sources || [];
+    let ret = [];
+    let master = ['assert.js', 'sta.js'];  // Must always be included.
+    let root = 'http://localhost:8000/resources/test262/harness/'
+    master.forEach(function(src) {
+      ret.push('"' + root + src + '"');
+    });
+    sources.forEach(function(src) {
+      ret.push('"' + root + src + '"');
+    });
+    return "importScripts(" + ret.join(",") + ");";
+  }
+  function createWorker(type, code) {
+    let blob = new Blob([code], {type: 'text/javascript'});
+    if (type == 'Worker') {
+      return new Worker(URL.createObjectURL(blob));
+    }
+    if (type == 'SharedWorker') {
+      return new SharedWorker(URL.createObjectURL(blob));
+    }
+    throw new Error('unreachable');
+  }
+  function getWorkerTemplate(type) {
+    if (type == 'Worker') {
+      return WORKER_TEMPLATE;
+    }
+    if (type == 'SharedWorker') {
+      return SHARED_WORKER_TEMPLATE;
+    }
+    throw new Error('unreachable');
+  }
+  let type = opts.worker_type || 'Worker';
+  let template = getWorkerTemplate(type);
+  template = template.replace('###INCLUDES###', importScripts(attrs.includes));
+  template = template.replace('###NAME###', workerNameByType(type, opts.strict));
+  template = template.replace('###BODY###', prepareTest(test262, attrs, opts.strict));
+  return createWorker(type, template);
+}
+
+function run_in_worker_strict(test262, attrs, t) {
+    let opts = {}
+    opts.strict = true;
+    run_in_worker(test262, attrs, t, opts);
+}
+
+function run_in_worker(test262, attrs, t, opts) {
+  opts = opts || {};
+  let worker = createWorkerFromString(test262, attrs, opts);
+  let worker_name = workerNameByType('Worker', opts.strict);
+  worker.addEventListener('message', t.step_func(function(e) {
+    let [message, name] = e.data;
+    if (message == 'completed' && name == worker_name) {
+      t.done();
+    }
+  }));
+  // If test failed, rethrow error.
+  let FAILED = 'worker-failed' + opts.strict ? 'strict' : '';
+  window.addEventListener(FAILED, t.step_func(function(e) {
+    t.set_status(t.FAIL);
+    throw new Error(e.detail);
+  }));
+  // In case of error send it back to sender.
+  worker.addEventListener('error', function(e) {
+    e.preventDefault();
+    // If the test failed due to a SyntaxError but phase was 'early', then the
+    // test should actually pass.
+    if (e.message.startsWith("SyntaxError")) {
+      if (attrs.type == 'SyntaxError' && attrs.phase == 'early') {
+        t.done();
+        return;
+      }
+    }
+    top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+  });
+  worker.postMessage([]);
+}
+
+// SharedWorker.
+let SHARED_WORKER_TEMPLATE = `
+  ###INCLUDES###
+
+  onconnect = function(e) {
+
+    let port = e.ports[0];
+
+    function __completed__() {
+      port.postMessage(['completed', '###NAME###']);
+    }
+
+    port.addEventListener('message', function(e) {
+      ###BODY###
+      __completed__();
+    });
+
+    port.start();
+  }
+`;
+
+function run_in_shared_worker_strict(test262, attrs, t) {
+    let opts = {}
+    opts.strict = true;
+    run_in_shared_worker(test262, attrs, t, opts);
+}
+
+function run_in_shared_worker(test262, attrs, t, opts) {
+  opts = opts || {};
+  let worker = createSharedWorkerFromString(test262, attrs, opts);
+  let worker_name = workerNameByType('SharedWorker', opts.strict);
+  worker.port.addEventListener('message', t.step_func(function(e) {
+    let [message, name] = e.data;
+    if (message == 'completed' && name == worker_name) {
+      t.done();
+    }
+  }));
+  // If test failed, rethrow error.
+  let FAILED = 'shared-worker-failed' + opts.strict ? 'strict' : '';
+  window.addEventListener(FAILED, t.step_func(function(e) {
+    t.set_status(t.FAIL);
+    throw new Error(e.detail);
+  }));
+  // In case of error send it back to sender.
+  worker.addEventListener('error', function(e) {
+    e.preventDefault();
+    // If the test failed due to a SyntaxError but phase was 'early', then the
+    // test should actually pass.
+    if (e.message.startsWith("SyntaxError")) {
+      if (attrs.type == 'SyntaxError' && attrs.phase == 'early') {
+        t.done();
+        return;
+      }
+    }
+    top.dispatchEvent(new CustomEvent(FAILED, {detail: e.message}));
+  });
+  worker.port.start();
+  worker.port.postMessage([]);
+}
+
+function createSharedWorkerFromString(test262, attrs, opts) {
+    opts.worker_type = 'SharedWorker';
+    return createWorkerFromString(test262, attrs, opts);
+}

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -133,12 +133,7 @@ function prepareTest(test262, attrs, strict) {
         return output.join("\n");
     }
     function run_in_eval(str) {
-        let ret = []
-        let lines = str.split("\n");
-        lines.forEach(function(line) {
-            ret.push('"' + line.replace(/"/g, '\\"') + '"');
-        });
-        return 'eval(' + ret.join(" +\n") + ');';
+        return 'eval("' + str.replace(/"/g, '\\"') + '");';
     }
     let test_code = test262();
     let negative = attrs.negative || {}

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -15,9 +15,11 @@ function run_in_iframe_strict(test262, attrs, t) {
     run_in_iframe(test262, attrs, t, opts);
 }
 
-function is_syntax_error(message, attrs) {
+// If 'negative' attribute was defined, the test must pass if 'message'
+// matches 'negative.type'.
+function is_negative(attrs, message) {
     let negative = attrs.negative || {};
-    return message.startsWith('SyntaxError') && negative.type == 'SyntaxError';
+    return message && message.indexOf(negative.type) >= 0;
 }
 
 function run_in_iframe(test262, attrs, t, opts) {
@@ -51,7 +53,8 @@ function run_in_iframe(test262, attrs, t, opts) {
     e.preventDefault();
     // If the test failed due to a SyntaxError but phase was 'early', then the
     // test should actually pass.
-    if (is_syntax_error(e.message, attrs)) {
+
+    if (is_negative(attrs, e.message)) {
         t.done();
         return;
     }
@@ -156,9 +159,7 @@ function run_in_window(test262, attrs, t, opts) {
   // In case of error send it to parent window.
   popup.addEventListener('error', function(e) {
     e.preventDefault();
-    // If the test failed due to a SyntaxError but phase was 'early', then the
-    // test should actually pass.
-    if (is_syntax_error(e.message, attrs)) {
+    if (is_negative(attrs, e.message)) {
         popup.close();
         t.done();
         return;
@@ -256,9 +257,7 @@ function run_in_worker(test262, attrs, t, opts) {
   // In case of error send it back to sender.
   worker.addEventListener('error', function(e) {
     e.preventDefault();
-    // If the test failed due to a SyntaxError but phase was 'early', then the
-    // test should actually pass.
-    if (is_syntax_error(e.message, attrs)) {
+    if (is_negative(attrs, e.message)) {
         t.done();
         return;
     }
@@ -313,9 +312,7 @@ function run_in_shared_worker(test262, attrs, t, opts) {
   // In case of error send it back to sender.
   worker.addEventListener('error', function(e) {
     e.preventDefault();
-    // If the test failed due to a SyntaxError but phase was 'early', then the
-    // test should actually pass.
-    if (is_syntax_error(e.message, attrs)) {
+    if (is_negative(attrs, e.message)) {
         t.done();
         return;
     }

--- a/resources/test262-agent-harness.js
+++ b/resources/test262-agent-harness.js
@@ -63,9 +63,6 @@ let HEADER = `
   <meta charset="UTF-8">
   <title></title>
 
-  <!-- Test262 harness -->
-  <script src="http://localhost:8000/resources/test262-harness.js"><\/script>
-
   <!-- Test262 required libraries -->
   <script src="http://localhost:8000/resources/test262/harness/assert.js"><\/script>
   <script src="http://localhost:8000/resources/test262/harness/sta.js"><\/script>

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -1,32 +1,32 @@
 // Source: https://github.com/bakkot/test262-web-runner
 function installAPI(global) {
-	global.$262 = {
-		createRealm: function() {
-			var iframe = global.document.createElement('iframe');
+    global.$262 = {
+        createRealm: function() {
+            var iframe = global.document.createElement('iframe');
             iframe.style.cssText = "display: none";
-			iframe.src = ""; // iframeSrc;
-			global.document.body.appendChild(iframe);
-			return installAPI(iframe.contentWindow);
-		},
-		evalScript: function(src) {
-			var script = global.document.createElement('script');
-			script.text = src;
-			global.document.body.appendChild(script);
-		},
-		detachArrayBuffer: function(buffer) {
-			if (typeof postMessage !== 'function') {
-				throw new Error('No method available to detach an ArrayBuffer');
-			} else {
-                postMessage(null, '*', [buffer]);
-				/*
-				  See https://html.spec.whatwg.org/multipage/comms.html#dom-window-postmessage
-				  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer
-				  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#transfer-abstract-op
-				  which calls the DetachArrayBuffer abstract operation https://tc39.github.io/ecma262/#sec-detacharraybuffer
-                */
-	        }
+            iframe.src = ""; // iframeSrc;
+            global.document.body.appendChild(iframe);
+            return installAPI(iframe.contentWindow);
         },
-	    global: global
+        evalScript: function(src) {
+            var script = global.document.createElement('script');
+            script.text = src;
+            global.document.body.appendChild(script);
+        },
+        detachArrayBuffer: function(buffer) {
+            if (typeof postMessage !== 'function') {
+                throw new Error('No method available to detach an ArrayBuffer');
+            } else {
+                postMessage(null, '*', [buffer]);
+                /*
+                  See https://html.spec.whatwg.org/multipage/comms.html#dom-window-postmessage
+                  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer
+                  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#transfer-abstract-op
+                  which calls the DetachArrayBuffer abstract operation https://tc39.github.io/ecma262/#sec-detacharraybuffer
+                */
+            }
+        },
+        global: global
     };
     return global.$262;
 }

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -59,6 +59,12 @@ function $DONE(err) {
     }
 }
 
+function print(value) {
+    if (value != "Test262:AsyncTestComplete") {
+        throw new Error('Test262:AsyncTestFailed');
+    }
+}
+
 if (this.document) {
     // TODO: Any Worker test that depends on these functions will fail. Define API for Workers.
     installAPI(window);

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -1,5 +1,6 @@
 // Based on Test262-Web-Runner. See https://github.com/bakkot/test262-web-runner/main.js.
 function installAPI(global) {
+    global.global = global;
     global.$262 = {
         createRealm: function() {
             var iframe = global.document.createElement('iframe');
@@ -29,7 +30,6 @@ function installAPI(global) {
         IsHTMLDDA: function(arg) {
             return (!arg || arg == "") ? null : global.document.all;
         },
-        global: global
     };
     return global.$262;
 }

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -1,4 +1,4 @@
-// Source: https://github.com/bakkot/test262-web-runner
+// Based on Test262-Web-Runner. See https://github.com/bakkot/test262-web-runner/main.js.
 function installAPI(global) {
     global.$262 = {
         createRealm: function() {
@@ -31,6 +31,22 @@ function installAPI(global) {
     return global.$262;
 }
 
+function installAPIWorker(global) {
+    global.$262 = {
+        createRealm: function() {
+            throw new Error('createRealm is not supported in a Worker context');
+        },
+        evalScript: function(src) {
+            throw new Error('evalScript is not supported in a Worker context');
+        },
+        detachArrayBuffer: function(buffer) {
+            throw new Error('detachArrayBuffer is not supported in a Worker context');
+        },
+        global: global
+    }
+    return global.$262;
+}
+
 function $DONE(err) {
     if (err) {
         throw err;
@@ -40,4 +56,6 @@ function $DONE(err) {
 if (this.document) {
     // TODO: Any Worker test that depends on these functions will fail. Define API for Workers.
     installAPI(window);
+} else {
+    installAPIWorker(self);
 }

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -26,8 +26,8 @@ function installAPI(global) {
                 */
             }
         },
-        IsHTMLDDA: function() {
-            return global.document.all;
+        IsHTMLDDA: function(arg) {
+            return (!arg || arg == "") ? null : global.document.all;
         },
         global: global
     };

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -26,6 +26,9 @@ function installAPI(global) {
                 */
             }
         },
+        IsHTMLDDA: function() {
+            return global.document.all;
+        },
         global: global
     };
     return global.$262;
@@ -41,6 +44,9 @@ function installAPIWorker(global) {
         },
         detachArrayBuffer: function(buffer) {
             throw new Error('detachArrayBuffer is not supported in a Worker context');
+        },
+        IsHTMLDDA: function() {
+            throw new Error('IsHTMLDDA is not supported in a Worker context');
         },
         global: global
     }

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -28,6 +28,7 @@ function installAPI(global) {
         },
         global: global
     };
+    return global.$262;
 }
 
 function $DONE(err) {

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -1,0 +1,39 @@
+// Source: https://github.com/bakkot/test262-web-runner
+function installAPI(global) {
+	global.$262 = {
+		createRealm: function() {
+			var iframe = global.document.createElement('iframe');
+            iframe.style.cssText = "display: none";
+			iframe.src = ""; // iframeSrc;
+			global.document.body.appendChild(iframe);
+			return installAPI(iframe.contentWindow);
+		},
+		evalScript: function(src) {
+			var script = global.document.createElement('script');
+			script.text = src;
+			global.document.body.appendChild(script);
+		},
+		detachArrayBuffer: function(buffer) {
+			if (typeof postMessage !== 'function') {
+				throw new Error('No method available to detach an ArrayBuffer');
+			} else {
+                postMessage(null, '*', [buffer]);
+				/*
+				  See https://html.spec.whatwg.org/multipage/comms.html#dom-window-postmessage
+				  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#structuredclonewithtransfer
+				  which calls https://html.spec.whatwg.org/multipage/infrastructure.html#transfer-abstract-op
+				  which calls the DetachArrayBuffer abstract operation https://tc39.github.io/ecma262/#sec-detacharraybuffer
+                */
+	        }
+        },
+	    global: global
+    };
+    return global.$262;
+}
+
+// TODO: $DONE is used by Promise tests and others, but I don't know from where to fetch it.
+function $DONE() {
+
+}
+
+installAPI(window);

--- a/resources/test262-harness.js
+++ b/resources/test262-harness.js
@@ -28,12 +28,15 @@ function installAPI(global) {
         },
         global: global
     };
-    return global.$262;
 }
 
-// TODO: $DONE is used by Promise tests and others, but I don't know from where to fetch it.
-function $DONE() {
-
+function $DONE(err) {
+    if (err) {
+        throw err;
+    }
 }
 
-installAPI(window);
+if (this.document) {
+    // TODO: Any Worker test that depends on these functions will fail. Define API for Workers.
+    installAPI(window);
+}

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -128,7 +128,7 @@ HEADER = trim('''
 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <script src="/resources/test262-agent-harness.js"></script>
+    <script src="/resources/test262-agent-harness.js?pipe=sub"></script>
     <script src="/resources/test262-harness.js"></script>
 
   </head>

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -218,43 +218,69 @@ class WPTestBuilder(object):
                 folders.append(os.path.join(test_dir, each))
             # Generate wrappers.
             for filename in self.listall(folders, {'ext': 'js', 'skip_hidden': True}):
+                # Files that have the suffix _FIXTURE are not tests, but should be preserved.
                 if re.search('_FIXTURE.js$', filename):
-                    dest = DEST_PATH + re.sub(".*test262/test", "", filename)
-                    self.ensure_destination_path(dest)
-                    copyfile(filename, dest)
-                else:
-                    self.generate_single_wpt(filename)
-            print "Output: " + DEST_PATH
+                    self.keep_file(filename)
+                    continue
+                # If they are not fixtures, they're tests. However, it's necessary to keep the
+                # original file because some tests reference themselves.
+                if re.search('module-code', filename):
+                    self.keep_file(filename)
+                self.generate_single_wpt(filename)
+            print "Output: " + self.destination_path(path)
         elif S_ISREG(mode):
             pos = path.find("test262/test")
             if pos < 0:
-                print("Not a test262 file: '%'" % path)
+                print("Not a test262 file: '%s'" % path)
                 exit(1)
             print "Generating web-platform-tests wrapper for {0}".format(path)
             print "Output: %s" % self.generate_single_wpt(path)
         else:
             print "Skipping %s" % path
 
-    def destination_path(self, path):
-        filename = re.sub(".*?test262/test", "", path)
-        filename = re.sub('.js$', '.html', filename)
-        return DEST_PATH + filename
+    def keep_file(self, filename):
+        dirname = self.destination_path(filename)
+        dst = os.path.join(dirname, os.path.basename(filename))
+        self.mkdir(dirname)
+        content = self.replace_module_path_if_any(dirname, self.readfile(filename))
+        return self.savefile(dst, content)
 
-    def generate_single_wpt(self, src):
-        dst = self.destination_path(src)
-        self.ensure_destination_path(dst)
-        return self.savefile(dst, self.build(dst, self.readfile(src)))
+    def destination_path(self, filename):
+        filename = re.sub(".*test262/test/", "", filename)
+        return os.path.join(DEST_PATH, os.path.dirname(filename))
 
-    def ensure_destination_path(self, path):
-        dirname = subprocess.check_output(("dirname {0}".format(path)).split())
-        dirname = re.sub('\n', '', dirname)
-        process = subprocess.Popen(("mkdir -p {0}".format(dirname)).split())
+    def mkdir(self, path):
+        process = subprocess.Popen(("mkdir -p {0}".format(path)).split())
         process.wait()
+
+    def replace_module_path_if_any(self, dirname, content):
+        # Replace "[import|export] from './filename'".
+        content = re.sub(r"from\s+(['\"])\.\/(.*?\.js)(['\"])",
+                         r"from \1http://localhost:8000/" + dirname + r"/\2\3", content)
+        # Replace "import './filename'".
+        content = re.sub(r"import (['\"])\.\/(.*?\.js)(['\"])",
+                         r"import \1http://localhost:8000/" + dirname + r"/\2\3", content)
+        # Replace "export './filename'".
+        content = re.sub(r"export (['\"])\.\/(.*?\.js)(['\"])",
+                         r"export \1http://localhost:8000/" + dirname + r"/\2\3", content)
+        return content
 
     def savefile(self, output, content):
         with open(output, 'wt') as fd:
             fd.write(content)
             return fd.name
+
+    def generate_single_wpt(self, filename):
+        dst = self.destination_file(filename)
+        dirname = os.path.dirname(dst)
+        self.mkdir(dirname)
+        content = self.replace_module_path_if_any(dirname, self.readfile(filename))
+        return self.savefile(dst, self.build(dst, content))
+
+    def destination_file(self, filename):
+        filename = re.sub(".*test262/test/", "", filename)
+        filename = re.sub('.js$', '.html', filename)
+        return os.path.join(DEST_PATH, filename)
 
     def build(self, title, content):
         test262 = Test262Parser(content)

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -202,14 +202,16 @@ class WPTestBuilder(object):
         mode = os.stat(self.path)[ST_MODE]
         if S_ISDIR(mode):
             # Check root folder contains 'test'.
-            test_dir = os.path.join(path, "test")
+            test_dir = path
+            if not re.search("test262/test", path):
+                test_dir = os.path.join(path, "test")
             mode = os.stat(test_dir)[ST_MODE]
             if not S_ISDIR(mode):
                 print("Could not locate 'test' folder at %s" % path)
                 exit(1)
             print "Generating web-platform-test wrappers for test262"
             # Blacklist 'harness' from root folders.
-            folders = []
+            folders = [test_dir]
             for each in os.listdir(test_dir):
                 if each == 'harness':
                     continue

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -129,6 +129,7 @@ HEADER = trim('''
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/resources/test262-agent-harness.js"></script>
+    <script src="/resources/test262-harness.js"></script>
 
   </head>
   <body>

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import threading
 
-from random import randint
+from shutil import copyfile
 from stat import *
 
 '''
@@ -285,8 +285,20 @@ class WPTestBuilder(object):
                 print("Could not locate 'test' folder at %s" % path)
                 exit(1)
             print "Generating web-platform-test wrappers for test262"
-            for each in self.listall(test_dir, {'ext': 'js', 'skip_hidden': True}):
-                self.generate_single_wpt(each)
+            # Blacklist 'harness' from root folders.
+            folders = []
+            for each in os.listdir(test_dir):
+                if each == 'harness':
+                    continue
+                folders.append(os.path.join(test_dir, each))
+            # Generate wrappers.
+            for filename in self.listall(folders, {'ext': 'js', 'skip_hidden': True}):
+                if re.search('_FIXTURE.js$', filename):
+                    dest = DEST_PATH + re.sub(".*test262/test", "", filename)
+                    self.ensure_destination_path(dest)
+                    copyfile(filename, dest)
+                else:
+                    self.generate_single_wpt(filename)
             print "Output: " + DEST_PATH
         elif S_ISREG(mode):
             pos = path.find("test262/test")
@@ -380,17 +392,18 @@ class WPTestBuilder(object):
             # Remove carriage return if any.
             return re.sub("\x0D", "", content)
 
-    def listall(self, root, opts):
+    def listall(self, folders, opts):
         opts = opts or {}
         ret = []
         ext = opts['ext']
         skip_hidden = opts['skip_hidden']
-        for root, dirs, files in os.walk(root):
-            for filename in files:
-                if skip_hidden and filename.startswith('.'):
-                    continue
-                if ext and filename.endswith(ext):
-                    ret.append(os.path.join(root, filename))
+        for folder in folders:
+            for root, dirs, files in os.walk(folder):
+                for filename in files:
+                    if skip_hidden and filename.startswith('.'):
+                        continue
+                    if ext and filename.endswith(ext):
+                        ret.append(os.path.join(root, filename))
         return ret
 
 def main():

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -317,8 +317,10 @@ class WPTestBuilder(object):
     def readfile(self, path):
         with open(path) as fd:
             content = fd.read()
-            # Remove carriage return if any.
-            return re.sub("\x0D", "", content)
+            # Replace CR + LF for LF only.
+            content = re.sub("\r\n", "\n", content)
+            # Replace CR for LF.
+            return re.sub("\r", "\n", content)
 
     def listall(self, folders, opts):
         opts = opts or {}

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -168,49 +168,6 @@ def run_in_shared_worker_strict(title):
     output = re.sub('###TEST_CALL###', 'run_in_shared_worker_strict', output)
     return output
 
-'''
-Converts a dictionary to a JSON data structure. It is possible to pass a list
-of attributes in opts.exclude so they don't get serialized to JSON.
-TODO: Use Python's JSON module?
-'''
-def tojson(d, opts):
-    def stringify(list):
-        if list == None or len(list) == 0:
-            return '[]'
-        l = []
-        for i in range(0, len(list)):
-            elem = "'" + str(list[i]) + "'"
-            l.append(elem)
-        return '[%s]' % ",".join(l)
-    ret = []
-    exclude = opts['exclude'] or []
-    def append(string):
-        ret.append(string)
-    def flush():
-        return "\n".join(ret)
-    def quote(v):
-        if isinstance(v, str):
-            if len(v) == 0:
-                return "''"
-            first, last = [v[0], v[len(v)-1]]
-            if first == "'" and last == "'":
-                return v
-            if first == '"' and last == '"':
-                return v
-        return "'%s'" % str(v)
-    def escape(v):
-        return re.sub(r"'", r"\'", v)
-    append('{')
-    for k, v in d.iteritems():
-        if k in exclude:
-            continue
-        if isinstance(v, list):
-            append("\t{key}: {value},".format(key=k, value=stringify(v)))
-        else:
-            append("\t{key}: {value},".format(key=k, value=quote(escape(v))))
-    append('}')
-    return flush()
-
 # Indents content n tabs. A tab is 2 spaces (TAB_WIDTH).
 def indent(num_tabs, content):
     # Duplicates char n times.

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -1,0 +1,404 @@
+#!/usr/bin/env python
+
+import os
+import re
+import string
+import subprocess
+import sys
+import tempfile
+import threading
+
+from random import randint
+from stat import *
+
+'''
+This tool reads out test262 suite and generates wrappers for web-platform-tests.
+Each WPT wrapper runs the target test262 test within 4 agents: IFrame, Window, 
+DedicatedWorker and SharedWorker.  Each tests is run either in strict and 
+non-strict mode, unless the target test indicates otherwise.
+'''
+
+TAB_WIDTH = 2
+DEST_PATH = 'js/test262'
+
+def trim(text):
+    lines = text.split("\n")
+    return "\n".join(lines[1:len(lines)-1])
+
+usage_text = trim('''
+Usage: test262-to-wpt [test262-dir]
+''')
+
+def usage():
+    print(usage_text)
+    exit(1)
+
+'''
+Parses a Test262 test.
+
+A test262 tests are usually composed by two parts: a comment header, that 
+describes several properties of the test, and a body, which defines the proper 
+test itself.
+
+The test header is defined in YAML and contains properties such as esid (test ID),
+description, features, flags, etc. Some of these properties are relevant to know
+what harnessing libraries to import from the test262 suite (features), whether
+the test should only be tested in strict mode or non-strict mode (flags), etc
+
+Some of the beforementioned properties would need to get serialized to the 
+resulting web-platform-test as a JSON object.
+
+The parser also fetches the body of the test.
+'''
+# Parses a Test262 test. 
+class Test262Parser(object):
+
+    def __init__(self, text):
+        match = re.search('---\*/', text)
+        if match:
+            self.header = text[:match.end(0)]
+            self.body = text[match.end(0)+1:]
+        else:
+            self.header = ""
+            self.body = text
+        self.attrs = {}
+        self.parse_header()
+
+    def parse_header(self):
+        if len(self.header) == 0:
+            return
+        value = []
+        last_attr = None
+        for line in self.header.split('\n'):
+            # End of the attribute section?
+            if re.search(r'---\*/', line):
+                self.store_attribute(last_attr, "\n".join(value))
+                break
+
+            # Attribute? (attr: <text>)
+            match = re.search(r'^\s*(\w+):', line)
+            if match:
+                attr = match.group(1)
+                # Name of attribute changed?
+                if attr != last_attr:
+                    # Should store attribute?
+                    if last_attr is not None:
+                        self.store_attribute(last_attr, "".join(value))
+                    match = re.search(': (.*)\n?', line)
+                    if match:
+                        value = [match.group(1)]
+                    else:
+                        value = []
+                    last_attr = attr
+            else:
+                value.append(line)
+        self.store_attribute(last_attr, "".join(value))
+
+    def store_attribute(self, name, value):
+        if name in ['includes', 'flags', 'features']:
+            self.attrs[name] = self.parse_list(value)
+        else:
+            self.attrs[name] = value
+
+    '''
+    There are two ways of describing a list of properties:
+       attr: [prop1, prop2, ..., propn]
+       attr:
+         - prop1
+         - prop2
+         - ...
+         - propn
+    '''
+    def parse_list(self, text):
+        match = re.search("\[", text)
+        if match:
+            return re.findall("[^\[, \]\n]+", text)
+        else:
+            return re.findall("[^- \n]+", text)
+
+###
+
+# TODO: Put everything into one single template?
+HEADER = trim('''
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>###TITLE###</title>
+    <meta name="help" href="https://storage.spec.whatwg.org/#dom-storagemanager-persisted">
+    <meta name="author" title="Mozilla" href="https://www.mozilla.org">
+
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/test262-agent-harness.js"></script>
+
+  </head>
+  <body>
+  </body>
+  <script type="text/javascript">
+###HEADER###
+###ATTRS###
+    function test262() {
+''')
+FOOTER = trim('''
+    }
+    window.addEventListener('load', function(e) {
+###TESTS###
+    });
+  </script>
+</html>
+''')
+
+ASYNC_TEST = trim('''
+async_test(function(t) {
+  ###TEST_CALL###(test262, attrs, t);
+}, '###TITLE###');
+''')
+
+def run_in_iframe(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'IFrame: ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_iframe', output)
+    return output
+
+def run_in_iframe_strict(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'IFrame (strict): ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_iframe_strict', output)
+    return output
+
+def run_in_window(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'Window: ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_window', output)
+    return output
+
+def run_in_window_strict(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'Window (strict): ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_window_strict', output)
+    return output
+
+def run_in_worker(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'Worker: ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_worker', output)
+    return output
+
+def run_in_worker_strict(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'Worker (strict): ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_worker_strict', output)
+    return output
+
+def run_in_shared_worker(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'SharedWorker: ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_shared_worker', output)
+    return output
+
+def run_in_shared_worker_strict(title):
+    output = ASYNC_TEST
+    output = re.sub('###TITLE###', 'SharedWorker (strict): ' + title, output)
+    output = re.sub('###TEST_CALL###', 'run_in_shared_worker_strict', output)
+    return output
+
+'''
+Converts a dictionary to a JSON data structure. It is possible to pass a list
+of attributes in opts.exclude so they don't get serialized to JSON.
+TODO: Use Python's JSON module?
+'''
+def tojson(d, opts):
+    def stringify(list):
+        if list == None or len(list) == 0:
+            return '[]'
+        l = []
+        for i in range(0, len(list)):
+            elem = "'" + str(list[i]) + "'"
+            l.append(elem)
+        return '[%s]' % ",".join(l)
+    ret = []
+    exclude = opts['exclude'] or []
+    def append(string):
+        ret.append(string)
+    def flush():
+        return "\n".join(ret)
+    def quote(v):
+        if isinstance(v, str):
+            if len(v) == 0:
+                return "''"
+            first, last = [v[0], v[len(v)-1]]
+            if first == "'" and last == "'":
+                return v
+            if first == '"' and last == '"':
+                return v
+        return "'%s'" % str(v)
+    def escape(v):
+        return re.sub(r"'", r"\'", v)
+    append('{')
+    for k, v in d.iteritems():
+        if k in exclude:
+            continue
+        if isinstance(v, list):
+            append("\t{key}: {value},".format(key=k, value=stringify(v)))
+        else:
+            append("\t{key}: {value},".format(key=k, value=quote(escape(v))))
+    append('}')
+    return flush()
+
+# Indents content n tabs. A tab is 2 spaces (TAB_WIDTH).
+def indent(num_tabs, content):
+    # Duplicates char n times.
+    def dup(char, times):
+        ret = []
+        for i in range(0, times):
+            ret.append(char)
+        return "".join(ret)
+    ret = []
+    space = dup(" ", num_tabs * TAB_WIDTH)
+    for line in content.split("\n"):
+        ret.append(space + line)
+    return "\n".join(ret)
+
+'''
+Generates web-platform-test wrapper for test262 tests.
+
+If a directory is passed as origin for the tests, the class recursively reads 
+out al the JavaScript files contained and converts them to web-platform-tests.
+
+If a file is passed as origin, only that tests is converted.
+
+The resulting tests are placed inside an output directory named 'js'.
+'''
+class WPTestBuilder(object):
+
+    def __init__(self, path):
+        self.path = path
+
+    def generate(self):
+        path = self.path
+        mode = os.stat(self.path)[ST_MODE]
+        if S_ISDIR(mode):
+            # Check root folder contains 'test'.
+            test_dir = os.path.join(path, "test")
+            mode = os.stat(test_dir)[ST_MODE]
+            if not S_ISDIR(mode):
+                print("Could not locate 'test' folder at %s" % path)
+                exit(1)
+            print "Generating web-platform-test wrappers for test262"
+            for each in self.listall(test_dir, {'ext': 'js', 'skip_hidden': True}):
+                self.generate_single_wpt(each)
+            print "Output: " + DEST_PATH
+        elif S_ISREG(mode):
+            pos = path.find("test262/test")
+            if pos < 0:
+                print("Not a test262 file: '%'" % path)
+                exit(1)
+            print "Generating web-platform-tests wrapper for {0}".format(path)
+            print "Output: %s" % self.generate_single_wpt(path)
+        else:
+            print "Skipping %s" % path
+
+    def destination_path(self, path):
+        filename = re.sub(".*?test262/test", "", path)
+        filename = re.sub('.js$', '.html', filename)
+        return DEST_PATH + filename
+
+    def generate_single_wpt(self, src):
+        dst = self.destination_path(src)
+        self.ensure_destination_path(dst)
+        return self.savefile(dst, self.build(dst, self.readfile(src)))
+
+    def ensure_destination_path(self, path):
+        dirname = subprocess.check_output(("dirname {0}".format(path)).split())
+        dirname = re.sub('\n', '', dirname)
+        process = subprocess.Popen(("mkdir -p {0}".format(dirname)).split())
+        process.wait() 
+
+    def savefile(self, output, content):
+        with open(output, 'wt') as fd:
+            fd.write(content)
+            return fd.name
+
+    def build(self, title, content):
+        test262 = Test262Parser(content)
+        def header():
+            opts = { 'exclude': ['description', 'info', 'esid', 'es6id'] }
+            ret = HEADER
+            ret = re.sub('###TITLE###', title, ret)
+            ret = ret.replace('###ATTRS###', indent(2, "let attrs = %s;" % tojson(test262.attrs, opts)))
+            ret = ret.replace('###HEADER###', indent(2, test262.header))
+            return ret
+        def body():
+            def escape(text):
+                text = re.sub(r'\\', r'\\\\', text)
+                text = re.sub(r'"', r'\"', text)
+                return text
+            def quote(line):
+                return "\"" + line + "\\n\""
+            def format(text):
+                output = []
+                lines = text.split("\n");
+                for line in text.split("\n"):
+                    if len(line) > 0:
+                        output.append(quote(line))
+                return " + \n".join(output)
+            return indent(4, "return \"\" +\n%s;" % format(escape(test262.body)))
+        def footer():
+            # By default tests are run in strict and non-strict modes,
+            # unless flags says otherwise.
+            ret = []
+            flags = 'flags' in test262.attrs and test262.attrs['flags'] or []
+            if 'onlyStrict' in flags:
+                ret.append(run_in_iframe_strict(title))
+                ret.append(run_in_window_strict(title))
+                ret.append(run_in_worker_strict(title))
+                ret.append(run_in_shared_worker_strict(title))
+            elif 'noStrict' in flags:
+                ret.append(run_in_iframe(title))
+                ret.append(run_in_window(title))
+                ret.append(run_in_worker(title))
+                ret.append(run_in_shared_worker(title))
+            else:
+                ret.append(run_in_iframe_strict(title))
+                ret.append(run_in_iframe(title))
+                ret.append(run_in_window_strict(title))
+                ret.append(run_in_window(title))
+                ret.append(run_in_worker_strict(title))
+                ret.append(run_in_worker(title))
+                ret.append(run_in_shared_worker_strict(title))
+                ret.append(run_in_shared_worker(title))
+            return FOOTER.replace("###TESTS###", indent(3, "\n".join(ret)))
+        ret = []
+        ret.append(header())
+        ret.append(body())
+        ret.append(footer())
+        return "\n".join(ret)
+
+    def readfile(self, path):
+        with open(path) as fd:
+            content = fd.read()
+            # Remove carriage return if any.
+            return re.sub("\x0D", "", content)
+
+    def listall(self, root, opts):
+        opts = opts or {}
+        ret = []
+        ext = opts['ext']
+        skip_hidden = opts['skip_hidden']
+        for root, dirs, files in os.walk(root):
+            for filename in files:
+                if skip_hidden and filename.startswith('.'):
+                    continue
+                if ext and filename.endswith(ext):
+                    ret.append(os.path.join(root, filename))
+        return ret
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+    path = sys.argv[1]
+    WPTestBuilder(path).generate()
+
+if __name__ == "__main__":
+    main()

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -15,8 +15,8 @@ from stat import *
 
 '''
 This tool reads out test262 suite and generates wrappers for web-platform-tests.
-Each WPT wrapper runs the target test262 test within 4 agents: IFrame, Window, 
-DedicatedWorker and SharedWorker.  Each tests is run either in strict and 
+Each WPT wrapper runs the target test262 test within 4 agents: IFrame, Window,
+DedicatedWorker and SharedWorker.  Each tests is run either in strict and
 non-strict mode, unless the target test indicates otherwise.
 '''
 
@@ -38,8 +38,8 @@ def usage():
 '''
 Parses a Test262 test.
 
-A test262 tests are usually composed by two parts: a comment header, that 
-describes several properties of the test, and a body, which defines the proper 
+A test262 tests are usually composed by two parts: a comment header, that
+describes several properties of the test, and a body, which defines the proper
 test itself.
 
 The test header is defined in YAML and contains properties such as esid (test ID),
@@ -47,12 +47,12 @@ description, features, flags, etc. Some of these properties are relevant to know
 what harnessing libraries to import from the test262 suite (features), whether
 the test should only be tested in strict mode or non-strict mode (flags), etc
 
-Some of the beforementioned properties would need to get serialized to the 
+Some of the beforementioned properties would need to get serialized to the
 resulting web-platform-test as a JSON object.
 
 The parser also fetches the body of the test.
 '''
-# Parses a Test262 test. 
+# Parses a Test262 test.
 class Test262Parser(object):
 
     def __init__(self, text):
@@ -228,7 +228,7 @@ def indent(num_tabs, content):
 '''
 Generates web-platform-test wrapper for test262 tests.
 
-If a directory is passed as origin for the tests, the class recursively reads 
+If a directory is passed as origin for the tests, the class recursively reads
 out al the JavaScript files contained and converts them to web-platform-tests.
 
 If a file is passed as origin, only that tests is converted.
@@ -290,7 +290,7 @@ class WPTestBuilder(object):
         dirname = subprocess.check_output(("dirname {0}".format(path)).split())
         dirname = re.sub('\n', '', dirname)
         process = subprocess.Popen(("mkdir -p {0}".format(dirname)).split())
-        process.wait() 
+        process.wait()
 
     def savefile(self, output, content):
         with open(output, 'wt') as fd:

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -125,8 +125,6 @@ HEADER = trim('''
   <head>
     <meta charset="utf-8">
     <title>###TITLE###</title>
-    <meta name="help" href="https://storage.spec.whatwg.org/#dom-storagemanager-persisted">
-    <meta name="author" title="Mozilla" href="https://www.mozilla.org">
 
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -293,7 +293,7 @@ class WPTestBuilder(object):
                 ret.append(run_in_window_strict(title))
                 ret.append(run_in_worker_strict(title))
                 ret.append(run_in_shared_worker_strict(title))
-            elif 'noStrict' in flags:
+            elif 'noStrict' in flags or 'raw' in flags:
                 ret.append(run_in_iframe(title))
                 ret.append(run_in_window(title))
                 ret.append(run_in_worker(title))

--- a/test262-to-wpt
+++ b/test262-to-wpt
@@ -7,6 +7,8 @@ import subprocess
 import sys
 import tempfile
 import threading
+import yaml
+import json
 
 from shutil import copyfile
 from stat import *
@@ -61,60 +63,24 @@ class Test262Parser(object):
         else:
             self.header = ""
             self.body = text
-        self.attrs = {}
-        self.parse_header()
+        self.attrs = self.parse_header()
 
     def parse_header(self):
         if len(self.header) == 0:
-            return
-        value = []
-        last_attr = None
+            return {}
+        return yaml.load(self.yaml_section()) or {}
+
+    def yaml_section(self):
+        is_yaml = False
+        ret = []
         for line in self.header.split('\n'):
-            # End of the attribute section?
-            if re.search(r'---\*/', line):
-                self.store_attribute(last_attr, "\n".join(value))
+            if re.search(r'/*---', line):
+                is_yaml = True
+            elif is_yaml and re.search(r'---*/', line):
                 break
-
-            # Attribute? (attr: <text>)
-            match = re.search(r'^\s*(\w+):', line)
-            if match:
-                attr = match.group(1)
-                # Name of attribute changed?
-                if attr != last_attr:
-                    # Should store attribute?
-                    if last_attr is not None:
-                        self.store_attribute(last_attr, "".join(value))
-                    match = re.search(': (.*)\n?', line)
-                    if match:
-                        value = [match.group(1)]
-                    else:
-                        value = []
-                    last_attr = attr
-            else:
-                value.append(line)
-        self.store_attribute(last_attr, "".join(value))
-
-    def store_attribute(self, name, value):
-        if name in ['includes', 'flags', 'features']:
-            self.attrs[name] = self.parse_list(value)
-        else:
-            self.attrs[name] = value
-
-    '''
-    There are two ways of describing a list of properties:
-       attr: [prop1, prop2, ..., propn]
-       attr:
-         - prop1
-         - prop2
-         - ...
-         - propn
-    '''
-    def parse_list(self, text):
-        match = re.search("\[", text)
-        if match:
-            return re.findall("[^\[, \]\n]+", text)
-        else:
-            return re.findall("[^- \n]+", text)
+            elif is_yaml:
+                ret.append(line)
+        return "\n".join(ret)
 
 ###
 
@@ -334,12 +300,17 @@ class WPTestBuilder(object):
     def build(self, title, content):
         test262 = Test262Parser(content)
         def header():
-            opts = { 'exclude': ['description', 'info', 'esid', 'es6id'] }
+            attrs = tojson(test262.attrs)
             ret = HEADER
             ret = re.sub('###TITLE###', title, ret)
-            ret = ret.replace('###ATTRS###', indent(2, "let attrs = %s;" % tojson(test262.attrs, opts)))
+            ret = ret.replace('###ATTRS###', indent(2, "let attrs = %s;" % tojson(test262.attrs)))
             ret = ret.replace('###HEADER###', indent(2, test262.header))
             return ret
+        def tojson(attrs):
+            exclude = ['description', 'info', 'esid', 'es6id']
+            for key in exclude:
+                attrs.pop(key, None)
+            return json.dumps(attrs) or '{}'
         def body():
             def escape(text):
                 text = re.sub(r'\\', r'\\\\', text)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -201,6 +201,8 @@ class Response(object):
         self.writer.write_status(*self.status)
         for item in self.headers:
             self.writer.write_header(*item)
+        # Always enable cross origin.
+        self.writer.write_header("Access-Control-Allow-Origin", "*")
         self.writer.end_headers()
 
     def write_content(self):


### PR DESCRIPTION
The scripts reads out 'test262/test' and generates web-platform-test wrappers for each test. The generated tests are stored at 'js/test262'.

Each generated web-platform-test runs the target test262 test in 4 different agents: IFrame, Window, DedicatedWorker and SharedWorker. For each agent usually two tests are generated: one in strict-mode and another one in non-strict mode (unless the test indicates otherwise).

For IFrame and Window agents an HTML file is created on-the-fly containing the target test. In the case of DedicatedWorker and SharedWorker a JavaScript test is created on-the-fly containing the target test. The harnessing code runs the test and checks whether there was any error.

Currently when running the generated web-platform-test wrappers many tests fail. More details at issue web-platform-tests/rfcs#230

I post this PR with no intention of merging it yet, but to gather feedback and discuss what needs to be done from here to get the PR landed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8980)
<!-- Reviewable:end -->
