### PR TITLE
Fix virtualenv creation when Python 3 is the default

### DIFF
--- a/tools/wpt/virtualenv.py
+++ b/tools/wpt/virtualenv.py
@@ -21,7 +21,7 @@ class Virtualenv(object):
     def create(self):
         if os.path.exists(self.path):
             shutil.rmtree(self.path)
-        call(self.virtualenv, self.path)
+        call(self.virtualenv, self.path, "-p", sys.executable)
 
     @property
     def bin_path(self):


### PR DESCRIPTION
`sys.executable` is the path to the currently-running Python interpreter. `-p` specifies what to use instead of the virtualenv executable’s default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8982)
<!-- Reviewable:end -->
