### PR TITLE
Default to Python 2.x

### DIFF
--- a/wpt
+++ b/wpt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 if __name__ == "__main__":
     from tools.wpt import wpt


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0394/ has recommended for several years now that a `python2` executable always exist in `$PATH`, whichever is the system’s default version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/8983)
<!-- Reviewable:end -->
