### PR TITLE
Parsing tests for clip, clip-path, clip-rule

### DIFF
--- a/css/css-masking/parsing/clip-invalid.html
+++ b/css/css-masking/parsing/clip-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#clip-property">
+<meta name="assert" content="clip supports only the grammar 'rect() | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("clip", "none");
+test_invalid_value("clip", "rect(10px, 20px, 30px)");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/clip-path-invalid.html
+++ b/css/css-masking/parsing/clip-path-invalid.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip-path with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<meta name="assert" content="clip-path supports only the grammar '<clip-source> | [ <basic-shape> || <geometry-box> ] | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("clip-path", "auto");
+test_invalid_value("clip-path", "path('m 12 34 h 56')");
+test_invalid_value("clip-path", "ray(0deg)");
+
+test_invalid_value("clip-path", "inset()");
+test_invalid_value("clip-path", "inset(123)");
+test_invalid_value("clip-path", "inset(1% 2% 3% 4% 5%)");
+test_invalid_value("clip-path", "inset(round 0)");
+test_invalid_value("clip-path", "inset(0px round)");
+test_invalid_value("clip-path", "inset(0px round 123)");
+test_invalid_value("clip-path", "inset(0px round 1% 2% 3% 4% 5%)");
+test_invalid_value("clip-path", "inset(0px round / 1px)");
+test_invalid_value("clip-path", "inset(10px round -20px)");
+test_invalid_value("clip-path", "inset(30% round -40%)");
+
+test_invalid_value("clip-path", "circle(123)");
+test_invalid_value("clip-path", "circle(at)");
+test_invalid_value("clip-path", "circle(10% 20%)");
+test_invalid_value("clip-path", "circle(-10px at 20px 30px)");
+test_invalid_value("clip-path", "circle(-10% at 20% 30%)");
+test_invalid_value("clip-path", "circle(1% 2% at 0% 100%)");
+
+test_invalid_value("clip-path", "ellipse(farthest-side at)");
+test_invalid_value("clip-path", "ellipse(1% 2% top right)");
+test_invalid_value("clip-path", "ellipse(3% at 100% 0%)");
+test_invalid_value("clip-path", "ellipse(10% -20% at 30% 40%)");
+test_invalid_value("clip-path", "ellipse(-50px 60px at 70% 80%)");
+
+test_invalid_value("clip-path", "polygon(1%)");
+
+test_invalid_value("clip-path", "unknown-box");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/clip-path-invalid.html
+++ b/css/css-masking/parsing/clip-path-invalid.html
@@ -13,7 +13,6 @@
 <body>
 <script>
 test_invalid_value("clip-path", "auto");
-test_invalid_value("clip-path", "path('m 12 34 h 56')");
 test_invalid_value("clip-path", "ray(0deg)");
 
 test_invalid_value("clip-path", "inset()");

--- a/css/css-masking/parsing/clip-path-valid.html
+++ b/css/css-masking/parsing/clip-path-valid.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip-path with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
+<meta name="assert" content="clip-path supports the full grammar '<clip-source> | [ <basic-shape> || <geometry-box> ] | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clip-path", "none");
+
+// <basic-shape>
+test_valid_value("clip-path", "inset(100%)");
+test_valid_value("clip-path", "inset(0 1px)", "inset(0px 1px)");
+test_valid_value("clip-path", "inset(0px 1px 2%)");
+test_valid_value("clip-path", "inset(0px 1px 2% 3em)");
+test_valid_value("clip-path", "inset(0px round 100%)");
+test_valid_value("clip-path", "inset(0px round 0 1px)", "inset(0px round 0px 1px)");
+test_valid_value("clip-path", "inset(0px round 0px 1px 2%)");
+test_valid_value("clip-path", "inset(0px round 0px 1px 2% 3em)");
+test_valid_value("clip-path", "inset(10px round 20% / 0px 1px 2% 3em)");
+
+test_valid_value("clip-path", "circle()", "circle(at 50% 50%)");
+test_valid_value("clip-path", "circle(1px)", "circle(1px at 50% 50%)");
+test_valid_value("clip-path", "circle(closest-side)", "circle(at 50% 50%)");
+test_valid_value("clip-path", "circle(at 10% 20%)");
+test_valid_value("clip-path", "circle(farthest-side at center top)", "circle(farthest-side at 50% 0%)");
+test_valid_value("clip-path", "circle(4% at top right)", "circle(4% at 100% 0%)");
+
+test_valid_value("clip-path", "ellipse()", "ellipse(at 50% 50%)");
+test_valid_value("clip-path", "ellipse(1px closest-side)", "ellipse(1px at 50% 50%)");
+test_valid_value("clip-path", "ellipse(at 10% 20%)");
+test_valid_value("clip-path", "ellipse(farthest-side 4% at bottom left)", "ellipse(farthest-side 4% at 0% 100%)");
+
+test_valid_value("clip-path", "polygon(1% 2%)");
+test_valid_value("clip-path", "polygon(nonzero, 1px 2px, 3em 4em)", "polygon(1px 2px, 3em 4em)");
+test_valid_value("clip-path", "polygon(evenodd, 1px 2px, 3em 4em, 5pt 6%)");
+
+// <geometry-box>
+test_valid_value("clip-path", "border-box");
+test_valid_value("clip-path", "padding-box");
+test_valid_value("clip-path", "content-box");
+test_valid_value("clip-path", "margin-box");
+test_valid_value("clip-path", "fill-box");
+test_valid_value("clip-path", "stroke-box");
+test_valid_value("clip-path", "view-box");
+
+// basic-shape> <geometry-box>
+test_valid_value("clip-path", "circle(7% at 8% 9%) border-box");
+
+// <geometry-box> basic-shape>
+test_valid_value("clip-path", "border-box circle(7% at 8% 9%)");
+
+//  <clip-source>
+test_valid_value("clip-path", "url(https://example.com/)", ["url(https://example.com/)", "url(\"https://example.com/\")"]);
+test_valid_value("clip-path", "url(\"https://example.com/\")", ["url(https://example.com/)", "url(\"https://example.com/\")"]);
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/clip-rule-invalid.html
+++ b/css/css-masking/parsing/clip-rule-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip-rule with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-rule">
+<meta name="assert" content="clip-rule supports only the grammar 'nonzero | evenodd'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("clip-rule", "auto");
+test_invalid_value("clip-rule", "1");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/clip-rule-valid.html
+++ b/css/css-masking/parsing/clip-rule-valid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip-rule with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-rule">
+<meta name="assert" content="clip-rule supports the full grammar 'nonzero | evenodd'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clip-rule", "nonzero");
+test_valid_value("clip-rule", "evenodd");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/clip-valid.html
+++ b/css/css-masking/parsing/clip-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Masking Module Level 1: parsing clip with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/css-masking-1/#clip-property">
+<meta name="assert" content="clip supports the full grammar 'rect() | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clip", "auto");
+test_valid_value("clip", "rect(10px, 20px, -30px, 40px)", ["rect(10px, 20px, -30px, 40px)", "rect(10px 20px -30px 40px)"]);
+test_valid_value("clip", "rect(10%, -20%, auto, auto)");
+</script>
+</body>
+</html>

--- a/css/css-masking/parsing/resources/parsing-testcommon.js
+++ b/css/css-masking/parsing/resources/parsing-testcommon.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function test_valid_value(property, value, serializedValue) {
+    if (arguments.length < 3)
+        serializedValue = value;
+
+    var stringifiedValue = JSON.stringify(value);
+
+    test(function(){
+        var div = document.createElement('div');
+        div.style[property] = value;
+        assert_not_equals(div.style[property], "");
+    }, "e.style['" + property + "'] = " + stringifiedValue + " should set the property value");
+
+    test(function(){
+        var div = document.createElement('div');
+        div.style[property] = value;
+        var readValue = div.style[property];
+        if (serializedValue instanceof Array)
+            assert_true(serializedValue.includes(readValue))
+        else
+            assert_equals(readValue, serializedValue);
+
+        div.style[property] = readValue;
+        assert_equals(div.style[property], readValue);
+    }, "Serialization should round-trip after setting e.style['" + property + "'] = " + stringifiedValue);
+}
+
+function test_invalid_value(property, value) {
+    var stringifiedValue = JSON.stringify(value);
+
+    test(function(){
+        var div = document.createElement('div');
+        div.style[property] = value;
+        assert_equals(div.style[property], "");
+    }, "e.style['" + property + "'] = " + stringifiedValue + " should not set the property value");
+}

--- a/css/css-masking/parsing/resources/parsing-testcommon.js
+++ b/css/css-masking/parsing/resources/parsing-testcommon.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// serializedValue can be the expected serialization of value,
+// or an array of permitted serializations,
+// or omitted if value should serialize as value.
 function test_valid_value(property, value, serializedValue) {
     if (arguments.length < 3)
         serializedValue = value;
@@ -9,21 +12,20 @@ function test_valid_value(property, value, serializedValue) {
     test(function(){
         var div = document.createElement('div');
         div.style[property] = value;
-        assert_not_equals(div.style[property], "");
-    }, "e.style['" + property + "'] = " + stringifiedValue + " should set the property value");
+        assert_not_equals(div.style[property], "", "property should be set");
 
-    test(function(){
         var div = document.createElement('div');
         div.style[property] = value;
         var readValue = div.style[property];
         if (serializedValue instanceof Array)
-            assert_true(serializedValue.includes(readValue))
+            assert_true(serializedValue.includes(readValue), "serialization should be sound");
         else
-            assert_equals(readValue, serializedValue);
+            assert_equals(readValue, serializedValue, "serialization should be canonical");
 
         div.style[property] = readValue;
-        assert_equals(div.style[property], readValue);
-    }, "Serialization should round-trip after setting e.style['" + property + "'] = " + stringifiedValue);
+        assert_equals(div.style[property], readValue, "serialization should round-trip");
+
+    }, "e.style['" + property + "'] = " + stringifiedValue + " should set the property value");
 }
 
 function test_invalid_value(property, value) {


### PR DESCRIPTION
Spec: https://drafts.fxtf.org/css-masking-1/

Blink, Edge, Firefox, WebKit don’t support clip rect containing auto.

Blink fails to reject clip-path ellipse containing single radius.

Blink fails to support clip-path containing geometry-box

Edge, Firefox, WebKit fail to support clip-path containing basic-shape
and/or geometry-box

<!-- Reviewable:start -->

<!-- Reviewable:end -->
