### PR TITLE
Sync Mozilla tests as of 2018-01-11

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-001-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<meta charset="utf-8">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+.parent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 200px;
+  height: 200px;
+  background: yellow;
+}
+
+.child {
+  position: absolute;
+  left: 50px;
+  top: 50px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<div class="parent"><div class="child"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-001.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<title>CSS Test: Absolutely positioned children of flex container with CSS align</title>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#abspos-items">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1386654">
+<link rel="match" href="position-absolute-containing-block-001-ref.html">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+.parent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 200px;
+  height: 200px;
+  background: yellow;
+}
+
+.child {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<div class="parent"><div class="child"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-002-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<meta charset="utf-8">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+.parent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 200px;
+  height: 200px;
+  background: yellow;
+}
+
+.child {
+  position: absolute;
+  left: 60px;
+  top: 60px;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<div class="parent"><div class="child"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/position-absolute-containing-block-002.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<title>CSS Test: Absolutely positioned children of flex container with CSS align</title>
+<meta charset="utf-8">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox/#abspos-items">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1386654">
+<link rel="match" href="position-absolute-containing-block-002-ref.html">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+.parent {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 180px;
+  height: 180px;
+
+  /* Expand the background area to 200px, without touching the content-box,
+     which is what flex absolute children should be aligned relative to. */
+  border-top: 5px solid yellow;
+  padding-top: 15px;
+  border-left: 5px solid yellow;
+  padding-left: 15px;
+
+  background: yellow;
+}
+
+.child {
+  position: absolute;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+</style>
+<div class="parent"><div class="child"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -213,3 +213,7 @@
 == flexbox-single-line-clamp-1.html flexbox-single-line-clamp-1-ref.html
 == flexbox-single-line-clamp-2.html flexbox-single-line-clamp-2-ref.html
 == flexbox-single-line-clamp-3.html flexbox-single-line-clamp-3-ref.html
+
+# Flexbox as an absolute containing block.
+== position-absolute-containing-block-001.html position-absolute-containing-block-001-ref.html
+== position-absolute-containing-block-002.html position-absolute-containing-block-002-ref.html


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/c4e4613dbe32bb218957a140e5d0bd4fe7d1e98c .

This contains a single change by @emilio, already reviewed in [bug 1386654](https://bugzilla.mozilla.org/show_bug.cgi?id=1386654).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
