### PR TITLE
[presentation-api] fix a bug in the PresentationConnectionList test

### DIFF
--- a/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
+++ b/presentation-api/receiving-ua/support/PresentationConnectionList_onconnectionavailable_receiving-ua.html
@@ -31,7 +31,7 @@
         return receiver.connectionList.then(list => {
           connections = list.connections;
           if (action === 'close') {
-            assert_true(connections.length === number - 1 && connections.includes(connection),
+            assert_true(connections.length === number - 1 && !connections.includes(connection),
               'A closed presentation connection is removed from the set of presentation controllers.');
           } else if (action === 'connect') {
             assert_true(connections.length === number + 1 && connections.includes(connection),


### PR DESCRIPTION
This PR fixes a bug in the PresentationConnectionList test:

- add a missing `!` in the line that checks disappearance of a presentation connection

<!-- Reviewable:start -->

<!-- Reviewable:end -->
