### PR TITLE
Add references for CSS2/selectors

### DIFF
--- a/css/CSS2/selectors/class-selector-009.xht
+++ b/css/CSS2/selectors/class-selector-009.xht
@@ -5,13 +5,14 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/class/002.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="../reference/ref-green-background.xht" />
   <style type="text/css">
    p { background: green; color: white; }
    .fail.test { background: red; color: yellow; }
   </style>
  </head>
  <body>
-  <p class="pass test">This line should be green.</p>
+  <p class="pass test">This should have a green background.</p>
  </body>
 </html>
 

--- a/css/CSS2/selectors/class-selector-010.xht
+++ b/css/CSS2/selectors/class-selector-010.xht
@@ -5,13 +5,14 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/class/003.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="../reference/ref-green-background.xht" />
   <style type="text/css">
    p { background: red; color: yellow; }
    .pass.test { background: green; color: white; }
   </style>
  </head>
  <body>
-  <p class="pass test">This line should be green.</p>
+  <p class="pass test">This should have a green background.</p>
  </body>
 </html>
 

--- a/css/CSS2/selectors/class-selector-011.xht
+++ b/css/CSS2/selectors/class-selector-011.xht
@@ -5,13 +5,14 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/class/004.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="../reference/ref-green-background.xht" />
   <style type="text/css">
    p { background: red; color: yellow; }
    .pass { background: green; color: white; }
   </style>
  </head>
  <body>
-  <p class="pass test">This line should be green.</p>
+  <p class="pass test">This should have a green background.</p>
  </body>
 </html>
 

--- a/css/CSS2/selectors/class-selector-012-ref.html
+++ b/css/CSS2/selectors/class-selector-012-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    p {
+        color: white;
+        background: green;
+    }
+</style>
+<body>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+    <p>This line should be green.</p>
+</body>
+</html>

--- a/css/CSS2/selectors/class-selector-012.xht
+++ b/css/CSS2/selectors/class-selector-012.xht
@@ -5,6 +5,7 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/class/005.html" type="text/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#class-html" />
+  <link rel="match" href="class-selector-012-ref.html" />
   <style type="text/css">
    p { background: red; color: yellow; }
    .test { background: green; color: white; }

--- a/css/CSS2/selectors/first-child-selector-001-ref.html
+++ b/css/CSS2/selectors/first-child-selector-001-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    .green {
+        color: green;
+    }
+</style>
+<body>
+    <div class="green">Filler Text</div>
+    <div>Filler Text</div>
+    <p>Test passes if the first "Filler Text" above is green and the second one is black.</p>
+</body>
+</html>

--- a/css/CSS2/selectors/first-child-selector-001.xht
+++ b/css/CSS2/selectors/first-child-selector-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-child pseudo-class</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
+        <link rel="match" href="first-child-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="First-child pseudo-class matches only the first element of its type." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-child-selector-002-ref.html
+++ b/css/CSS2/selectors/first-child-selector-002-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    .green {
+        color: green;
+    }
+</style>
+<body>
+    Filler Text
+    <div class="green">Filler Text</div>
+    <div>Filler Text</div>
+    <p>Test passes if the second line of "Filler Text" above is green and the first and third lines are black.</p>
+</body>
+</html>

--- a/css/CSS2/selectors/first-child-selector-002.xht
+++ b/css/CSS2/selectors/first-child-selector-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-child pseudo-class with text node</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
+        <link rel="match" href="first-child-selector-002-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="First-child pseudo-class matches only the first element of its type ignoring text nodes." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-child-selector-003.xht
+++ b/css/CSS2/selectors/first-child-selector-003.xht
@@ -5,12 +5,13 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/child/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-child" />
+  <link rel="match" href="../reference/ref-this-text-should-be-green.xht" />
   <style type="text/css">
-   html { color: green; }
-   html:first-child { color: red ! important; }
+   html { color: red; }
+   :root:first-child { color: green; }
   </style>
  </head>
  <body>
-  <p>This should be green.</p>
+  <p>This text should be green.</p>
  </body>
 </html>

--- a/css/CSS2/selectors/first-letter-selector-000-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-000-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    div {
+        color: green;
+        font: 2em sans-serif;
+    }
+</style>
+<body>
+    <p>This next line should be green:</p>
+    <div>TESTING</div>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-000.xht
+++ b/css/CSS2/selectors/first-letter-selector-000.xht
@@ -5,6 +5,7 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-letter/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+  <link rel="match" href="first-letter-selector-000-ref.html" />
   <style type="text/css">
    .test { float: left; font: 2em sans-serif; }
    .test:first-letter { color: green; }

--- a/css/CSS2/selectors/first-letter-selector-001-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-001-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    span {
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letter "F" below is green.</p>
+    <div><span>F</span>iller Text</div>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-001.xht
+++ b/css/CSS2/selectors/first-letter-selector-001.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter pseudo-element</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The :first-letter pseudo-element matches the first letter in a given element." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-002-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-002-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<body>
+    <p>Test passes if there is no red visible on the page.</p>
+    <div><img alt="15x15 blue box" src="support/blue15x15.png" />Filler Text</div>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-002.xht
+++ b/css/CSS2/selectors/first-letter-selector-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter pseudo-element with image missing alt text</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-002-ref.html" />
         <meta name="flags" content="image" />
         <meta name="assert" content="If there is preceding content (an image) or alt text the :first-letter pseudo-element does not match the first letter." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-003-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-003-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    span {
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the number "4" below is green.</p>
+    <div><span>4</span>2 Filler Text</div>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-003.xht
+++ b/css/CSS2/selectors/first-letter-selector-003.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter as a digit</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-003-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The ':first-letter' applies if the first letter is a digit." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-004.xht
+++ b/css/CSS2/selectors/first-letter-selector-004.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter and :before</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="If an element has ':before' or ':after' content, the ':first-letter applies to the first letter of the element including that content." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-005-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-005-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<body>
+    <p>Test passes if there is no red visible on the page.</p>
+    <div><br />Filler Text</div>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-005.xht
+++ b/css/CSS2/selectors/first-letter-selector-005.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter with leading line break</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-005-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The first letter occurs on the first formatted line." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-007-ref.html
+++ b/css/CSS2/selectors/first-letter-selector-007-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    span {
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the letter "F" below is green.</p>
+    <table>
+        <tr>
+            <td><span>F</span>iller Text</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/css/CSS2/selectors/first-letter-selector-007.xht
+++ b/css/CSS2/selectors/first-letter-selector-007.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter with table cell elements</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-007-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The :first-letter pseudo-element applies to table-cells." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-008.xht
+++ b/css/CSS2/selectors/first-letter-selector-008.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter with inline-block elements</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The first-letter pseudo-element applies to inline-block elements." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-letter-selector-019.xht
+++ b/css/CSS2/selectors/first-letter-selector-019.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter in descendents</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-letter" />
+        <link rel="match" href="first-letter-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="A user agent acts as if the fictional start tag of the first-letter pseudo-element is just before the first text of the element, even if that first text is in a descendant." />
         <style type="text/css">

--- a/css/CSS2/selectors/first-line-pseudo-017.xht
+++ b/css/CSS2/selectors/first-line-pseudo-017.xht
@@ -12,6 +12,6 @@
   </style>
  </head>
  <body>
-  <p><span>This sentence should have a green background.</span></p>
+  <p><span>This should have a green background.</span></p>
  </body>
 </html>

--- a/css/CSS2/selectors/first-line-pseudo-019.xht
+++ b/css/CSS2/selectors/first-line-pseudo-019.xht
@@ -6,11 +6,12 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-line/003.xml" type="application/xhtml+xml"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-line/003.html" type="type/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+  <link rel="match" href="../reference/ref-this-text-should-be-green.xht" />
   <style type="text/css">
    :first-line { color: green; }
   </style>
  </head>
  <body>
-  <p>This line should be green.</p>
+  <p>This text should be green.</p>
  </body>
 </html>

--- a/css/CSS2/selectors/first-line-pseudo-020.xht
+++ b/css/CSS2/selectors/first-line-pseudo-020.xht
@@ -6,11 +6,12 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-line/004.xml" type="application/xhtml+xml"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-line/004.html" type="type/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+  <link rel="match" href="../reference/ref-this-text-should-be-green.xht" />
   <style type="text/css">
    *:first-line { color: green; }
   </style>
  </head>
  <body>
-  <p>This line should be green.</p>
+  <p>This text should be green.</p>
  </body>
 </html>

--- a/css/CSS2/selectors/first-line-pseudo-021.xht
+++ b/css/CSS2/selectors/first-line-pseudo-021.xht
@@ -5,6 +5,7 @@
   <link rel="author" title="Ian Hickson" href="mailto:ian@hixie.ch"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/selectors/first-line/005.html" type="type/html"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+  <link rel="match" href="../reference/ref-this-text-should-be-green.xht" />
   <style type="text/css">
    p { color: red; }
    p:first-line { color: green; }
@@ -12,6 +13,6 @@
   </style>
  </head>
  <body>
-  <p><span>This line should be green.</span></p>
+  <p><span>This text should be green.</span></p>
  </body>
 </html>

--- a/css/CSS2/selectors/first-line-selector-010.xht
+++ b/css/CSS2/selectors/first-line-selector-010.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-line after a BR</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+        <link rel="match" href="first-letter-selector-005-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The :first-line pseudo-element start tag is inserted right after the start tag of the block element." />
         <style type="text/css">

--- a/css/CSS2/selectors/id-selector-002.xht
+++ b/css/CSS2/selectors/id-selector-002.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: ID selector syntax - Begins with hyphen</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#id-selectors" />
+        <link rel="match" href="../reference/filler-text-below-green.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="Identifier selectors starting with a hyphen are valid." />
         <style type="text/css">
@@ -18,7 +19,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is no red visible on the page.</p>
+        <p>Test passes if the "Filler Text" below is green.</p>
         <div id="-div1">Filler Text</div>
     </body>
 </html>

--- a/css/CSS2/selectors/lang-selector-004-ref.html
+++ b/css/CSS2/selectors/lang-selector-004-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<style>
+    div {
+        color: green;
+    }
+</style>
+<body>
+    <p>Test passes if the "Filler Text" below is green.</p>
+    <div>Filler Text
+        <p>Filler Text</p>
+    </div>
+</body>
+</html>

--- a/css/CSS2/selectors/lang-selector-004.xht
+++ b/css/CSS2/selectors/lang-selector-004.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Inherited lang attribute selected</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#lang" />
+        <link rel="match" href="lang-selector-004-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="Lang attribute is inherited and lang selector works on children." />
         <style type="text/css">

--- a/css/CSS2/selectors/lang-selector-005.xht
+++ b/css/CSS2/selectors/lang-selector-005.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Lang selector and document language set via server's content-language</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#lang" />
+        <link rel="match" href="../reference/filler-text-below-green.xht" />
         <meta name="flags" content="http" />
         <meta name="assert" content="Lang attribute is selectable when specified by HTTP header." />
         <style type="text/css">
@@ -18,7 +19,6 @@
         </style>
     </head>
     <body>
-        <p id="prerequisite">PREREQUISITE: Set the page "content-language" header to "fr" (French).</p>
         <p>Test passes if the "Filler Text" below is green.</p>
         <div>Filler Text</div>
     </body>

--- a/css/CSS2/selectors/lang-selector-006.xht
+++ b/css/CSS2/selectors/lang-selector-006.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: Lang selector and document language set via meta tag</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#lang" />
+        <link rel="match" href="../reference/filler-text-below-green.xht" />
         <meta name="flags" content="" />
         <meta http-equiv="content-language" content="fr" />
         <meta name="assert" content="Lang attribute is selectable when specified in a meta tag." />

--- a/css/CSS2/selectors/pseudo-006.xht
+++ b/css/CSS2/selectors/pseudo-006.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-letter pseudo-element case sensitivity</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+        <link rel="match" href="first-letter-selector-001-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="First-letter is case-insensitive." />
         <style type="text/css">

--- a/css/CSS2/selectors/pseudo-007.xht
+++ b/css/CSS2/selectors/pseudo-007.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: First-child pseudo-element case sensitivity</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+        <link rel="match" href="universal-selector-002-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="First-child is case-insensitive." />
         <style type="text/css">

--- a/css/CSS2/selectors/pseudo-008-ref.html
+++ b/css/CSS2/selectors/pseudo-008-ref.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<title>CSS Reftest Reference</title>
+<body>
+    <p>Test passes if the words "Filler Text" are below.</p>
+    <div>Filler Text</div>
+</body>
+</html>

--- a/css/CSS2/selectors/pseudo-008.xht
+++ b/css/CSS2/selectors/pseudo-008.xht
@@ -4,6 +4,7 @@
         <title>CSS Test: After and before case sensitivity</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/selector.html#first-line-pseudo" />
+        <link rel="match" href="pseudo-008-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="After and before are case-insensitive." />
         <style type="text/css">


### PR DESCRIPTION
Many CSS2/selectors tests were missing references. This change adds in references for a large number of these tests.

The only major change to a test was in first-child-selector-003.xht; I don't see how it was correct as written (I flipped the colors).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
