### PR TITLE
Improve browsing_context_name_cross_origin* slightly

### DIFF
--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_2.html
@@ -6,25 +6,21 @@
 <pre id="step_log"></pre>
 <iframe id="test"></iframe>
 <script>
-
 var t = async_test(undefined, {timeout:10000});
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
-var navigated = false;
 
 log = function(t) {l.textContent += ("\n" + t)}
 
 var steps = [
   function() {f.src = "browsing_context_name-1.html"},
   function() {
-                navigated = true;
                 assert_equals(f.contentWindow.name, "test", "Initial load");
                 setTimeout(next, 0);
               },
   function() {f.src = "browsing_context_name-3.html"},
   function() {
-                var navigated = true;
-                assert_equals(f.contentWindow.name, "test3", "Initial load");
+                assert_equals(f.contentWindow.name, "test3", "After navigation 1");
                 setTimeout(next, 0);
               },
   function() {f.src = f.src.replace("http://", "http://www.").replace("browsing_context_name-3", "browsing_context_name-2");},
@@ -33,10 +29,10 @@ var steps = [
              },
   function() {history.go(-2); setTimeout(next, 500)},
   function() {
-               assert_equals(f.contentWindow.name, "test3", "After navigation");
+               assert_equals(f.contentWindow.name, "test3", "After navigation 2");
                t.done();
              }
-].map(function(x) {return t.step_func(function() {log("Step " + step); x()})});
+].map(function(x) {return t.step_func(function() {log("Step " + step + " " + f.contentWindow.location); x()})});
 
 var step = 0;
 next = t.step_func(function() {steps[step++]()});

--- a/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
+++ b/html/browsers/browsing-the-web/history-traversal/browsing_context_name_cross_origin_3.html
@@ -9,31 +9,28 @@
 var t = async_test(undefined, {timeout:10000});
 var f = document.getElementById("test");
 var l = document.getElementById("step_log");
-var navigated = false;
 
 log = function(t) {l.textContent += ("\n" + t)}
 
 var steps = [
   function() {f.src = "browsing_context_name-1.html"},
   function() {
-                navigated = true;
                 assert_equals(f.contentWindow.name, "test", "Initial load");
                 setTimeout(next, 0);
               },
   function() {f.src = "browsing_context_name-3.html"},
   function() {
-                var navigated = true;
-                assert_equals(f.contentWindow.name, "test3", "Initial load");
+                assert_equals(f.contentWindow.name, "test3", "After navigation 1");
                 setTimeout(next, 0);
               },
   function() {f.src = f.src.replace("http://", "http://www.").replace("browsing_context_name-1", "browsing_context_name-2");},
   function() {f.src = f.src.replace("http://www.", "http://").replace("browsing_context_name-2", "browsing_context_name-4");},
   function() {
-                assert_equals(f.contentWindow.name, "test3", "After navigation");
+                assert_equals(f.contentWindow.name, "test3", "After navigation 2");
                 history.go(-3); setTimeout(next, 500)
              },
   function() {
-               assert_equals(f.contentWindow.name, "test3", "After navigation");
+               assert_equals(f.contentWindow.name, "test3", "After navigation 3");
                t.done();
              }
 ].map(function(x) {return t.step_func(function() {log("Step " + step + " " + f.contentWindow.location); x()})});


### PR DESCRIPTION
This doesn't make the tests pass, but gets rid of the `navigated`
variables which look like copypasta and prevented the test from
doing what appears to have been intended for.

Now the tests progress to a cross-origin navigation error instead.

Improve the debuggability a bit too.

Part of https://github.com/w3c/web-platform-tests/issues/9018.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
