### PR TITLE
Rewrite preload test with PerfObserver

### DIFF
--- a/preload/link-header-preload.html
+++ b/preload/link-header-preload.html
@@ -6,10 +6,13 @@
     var t = async_test('Makes sure that Link headers preload resources');
 </script>
 <body>
-<script src="resources/dummy.js?pipe=trickle(d5)&link-header-preload"></script>
+<!--<script src="resources/dummy.js?pipe=trickle(d5)&link-header-preload"></script> -->
 <script>
     window.addEventListener("load", t.step_func(function() {
         verifyPreloadAndRTSupport();
+        waitUntilResourceDownloaded("resources/square.png?link-header-preload");
+        waitUntilResourceDownloaded("resources/dummy.js?link-header-preload");
+        waitUntilResourceDownloaded("resources/dummy.css?link-header-preload");
         verifyNumberOfDownloads("resources/square.png?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.js?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.css?link-header-preload", 1);

--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -20,3 +20,19 @@ function verifyNumberOfDownloads(url, number)
     });
     assert_equals(numDownloads, number, url);
 }
+
+async function waitUntilResourceDownloaded(url)
+{
+    if (performance.getEntriesByName(getAbsoluteURL(url)).length >= 1)
+        return true;
+
+    await new Promise((resolve, reject) => {
+      let observer = new PerformanceObserver(list => {
+          list.getEntries().forEach(entry => {
+              if (entry.name == url) {
+                  resolve();
+              }
+          });
+      });
+    });
+}


### PR DESCRIPTION
This rewrites one of the header based preload tests (which have no onload event) using the PerformanceObserver API. I'll convert more of them over time.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
