### PR TITLE
Fix stability cyclic import

### DIFF
--- a/tools/wpt/markdown.py
+++ b/tools/wpt/markdown.py
@@ -1,5 +1,3 @@
-from .stability import is_inconsistent
-
 def format_comment_title(product):
     """Produce a Markdown-formatted string based on a given "product"--a string
     containing a browser identifier optionally followed by a colon and a
@@ -40,18 +38,3 @@ def table(headings, data, log):
     for row in data:
         log("|%s|" % "|".join(" %s" % row[i].ljust(max_widths[i] - 1) for i in cols))
     log("")
-
-
-def err_string(results_dict, iterations):
-    """Create and return string with errors from test run."""
-    rv = []
-    total_results = sum(results_dict.values())
-    for key, value in sorted(results_dict.items()):
-        rv.append("%s%s" %
-                  (key, ": %s/%s" % (value, iterations) if value != iterations else ""))
-    if total_results < iterations:
-        rv.append("MISSING: %s/%s" % (iterations - total_results, iterations))
-    rv = ", ".join(rv)
-    if is_inconsistent(results_dict, iterations):
-        rv = "**%s**" % rv
-    return rv

--- a/tools/wpt/tests/test_stability.py
+++ b/tools/wpt/tests/test_stability.py
@@ -1,0 +1,7 @@
+from tools.wpt import stability
+
+def test_is_inconsistent():
+    assert stability.is_inconsistent({"PASS": 10}, 10) is False
+    assert stability.is_inconsistent({"PASS": 9}, 10) is True
+    assert stability.is_inconsistent({"PASS": 9, "FAIL": 1}, 10) is True
+    assert stability.is_inconsistent({"PASS": 8, "FAIL": 1}, 10) is True

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -10,7 +10,8 @@ import pytest
 from tools.wpt import wpt
 
 
-# Tests currently don't work on Windows for path reasons
+pytestmark = pytest.mark.skipif(os.name == "nt",
+                                reason="Tests currently don't work on Windows for path reasons")
 
 def test_missing():
     with pytest.raises(SystemExit):
@@ -25,6 +26,9 @@ def test_help():
     assert excinfo.value.code == 0
 
 
+@pytest.mark.slow
+@pytest.mark.system_dependent
+@pytest.mark.remote_network
 def test_run_firefox():
     # TODO: It seems like there's a bug in argparse that makes this argument order required
     # should try to work around that
@@ -44,6 +48,8 @@ def test_run_firefox():
         del os.environ["MOZ_HEADLESS"]
 
 
+@pytest.mark.slow
+@pytest.mark.system_dependent
 def test_run_chrome():
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
@@ -52,6 +58,8 @@ def test_run_chrome():
     assert excinfo.value.code == 0
 
 
+@pytest.mark.slow
+@pytest.mark.remote_network
 def test_install_chromedriver():
     chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "bin", "chromedriver")
     if os.path.exists(chromedriver_path):
@@ -63,6 +71,8 @@ def test_install_chromedriver():
     os.unlink(chromedriver_path)
 
 
+@pytest.mark.slow
+@pytest.mark.remote_network
 def test_install_firefox():
     fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
     if os.path.exists(fx_path):
@@ -109,6 +119,8 @@ def test_files_changed_ignore_rules():
     assert compile_ignore_rule("foobar/baz/**").pattern == "^foobar/baz/.*$"
 
 
+@pytest.mark.slow  # this updates the manifest
+@pytest.mark.system_dependent
 def test_tests_affected(capsys):
     # This doesn't really work properly for random commits because we test the files in
     # the current working directory for references to the changed files, not the ones at
@@ -121,6 +133,8 @@ def test_tests_affected(capsys):
     assert "html/browsers/offline/appcache/workers/appcache-worker.html" in out
 
 
+@pytest.mark.slow
+@pytest.mark.system_dependent
 def test_serve():
     def test():
         s = socket.socket()

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -12,7 +12,7 @@ deps =
   -r{toxinidir}/../wptrunner/requirements_firefox.txt
 
 commands =
-  pytest --cov
+  pytest --cov {posargs}
 
 [testenv:py27-flake8]
 # flake8 versions should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
@@ -23,7 +23,7 @@ deps =
      pep8-naming==0.4.1
 
 commands =
-     flake8
+     flake8 {posargs}
 
 [flake8]
 # flake8 config should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini


### PR DESCRIPTION
18:49 < Hexcles> gsnedders: looks like you just introduced a circular import at 
                 https://github.com/w3c/web-platform-tests/commit/bad11688098ff2050305a075cbd03d4794affceb#diff-a10b8eac8d154cc1227cb09dfa339757R1
18:49 < Hexcles> stability already imports markdown, and now markdown imports stability
18:50 < Hexcles> example error: https://travis-ci.org/w3c/web-platform-tests/jobs/329555405#L588

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9053)
<!-- Reviewable:end -->
