### PR TITLE
Cleanup tools/wpt/tests

### DIFF
--- a/tools/pytest.ini
+++ b/tools/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 norecursedirs = .* {arch} *.egg html5lib third_party pywebsocket six wpt wptrunner
+xfail_strict=true

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -13,9 +13,6 @@ import pytest
 from tools.wpt import wpt
 
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32",
-                                reason="Tests currently don't work on Windows for path reasons")
-
 def is_port_8000_in_use():
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
@@ -70,6 +67,8 @@ def test_help():
 @pytest.mark.remote_network
 @pytest.mark.xfail(sys.platform == "darwin",
                    reason="https://github.com/w3c/web-platform-tests/issues/9090")
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_run_firefox(manifest_dir):
     # TODO: It seems like there's a bug in argparse that makes this argument order required
     # should try to work around that
@@ -93,6 +92,8 @@ def test_run_firefox(manifest_dir):
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_run_chrome(manifest_dir):
     if is_port_8000_in_use():
         pytest.skip("port 8000 already in use")
@@ -106,6 +107,8 @@ def test_run_chrome(manifest_dir):
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_install_chromedriver():
     chromedriver_path = os.path.join(wpt.localpaths.repo_root, "_venv", "bin", "chromedriver")
     if os.path.exists(chromedriver_path):
@@ -121,6 +124,8 @@ def test_install_chromedriver():
 @pytest.mark.remote_network
 @pytest.mark.xfail(sys.platform == "darwin",
                    reason="https://github.com/w3c/web-platform-tests/issues/9090")
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_install_firefox():
     fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
     if os.path.exists(fx_path):
@@ -132,6 +137,8 @@ def test_install_firefox():
     shutil.rmtree(fx_path)
 
 
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_files_changed(capsys):
     commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
     with pytest.raises(SystemExit) as excinfo:
@@ -168,6 +175,8 @@ def test_files_changed_ignore_rules():
 
 
 @pytest.mark.slow  # this updates the manifest
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_tests_affected(capsys, manifest_dir):
     # This doesn't really work properly for random commits because we test the files in
     # the current working directory for references to the changed files, not the ones at
@@ -181,6 +190,8 @@ def test_tests_affected(capsys, manifest_dir):
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(sys.platform == "win32",
+                   reason="Tests currently don't work on Windows for path reasons")
 def test_serve():
     if is_port_8000_in_use():
         pytest.skip("port 8000 already in use")

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 import urllib2
@@ -12,7 +13,7 @@ import pytest
 from tools.wpt import wpt
 
 
-pytestmark = pytest.mark.skipif(os.name == "nt",
+pytestmark = pytest.mark.skipif(sys.platform == "win32",
                                 reason="Tests currently don't work on Windows for path reasons")
 
 def is_port_8000_in_use():
@@ -67,6 +68,8 @@ def test_help():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+@pytest.mark.xfail(sys.platform == "darwin",
+                   reason="https://github.com/w3c/web-platform-tests/issues/9090")
 def test_run_firefox(manifest_dir):
     # TODO: It seems like there's a bug in argparse that makes this argument order required
     # should try to work around that
@@ -116,6 +119,8 @@ def test_install_chromedriver():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
+@pytest.mark.xfail(sys.platform == "darwin",
+                   reason="https://github.com/w3c/web-platform-tests/issues/9090")
 def test_install_firefox():
     fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
     if os.path.exists(fx_path):

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import shutil
 import socket
@@ -13,6 +14,20 @@ from tools.wpt import wpt
 
 pytestmark = pytest.mark.skipif(os.name == "nt",
                                 reason="Tests currently don't work on Windows for path reasons")
+
+def is_port_8000_in_use():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 8000))
+    except socket.error as e:
+        if e.errno == errno.EADDRINUSE:
+            return True
+        else:
+            raise e
+    finally:
+        s.close()
+    return False
+
 
 @pytest.fixture(scope="module")
 def manifest_dir():
@@ -55,6 +70,9 @@ def test_help():
 def test_run_firefox(manifest_dir):
     # TODO: It seems like there's a bug in argparse that makes this argument order required
     # should try to work around that
+    if is_port_8000_in_use():
+        pytest.skip("port 8000 already in use")
+
     os.environ["MOZ_HEADLESS"] = "1"
     try:
         fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
@@ -73,6 +91,9 @@ def test_run_firefox(manifest_dir):
 
 @pytest.mark.slow
 def test_run_chrome(manifest_dir):
+    if is_port_8000_in_use():
+        pytest.skip("port 8000 already in use")
+
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["run", "--yes", "--no-pause", "--binary-arg", "headless",
                        "--metadata", manifest_dir,
@@ -156,14 +177,8 @@ def test_tests_affected(capsys, manifest_dir):
 
 @pytest.mark.slow
 def test_serve():
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(("127.0.0.1", 8000))
-    except socket.error as e:
-        if e.errno == 98:
-            pytest.skip("port 8000 already in use")
-    finally:
-        s.close()
+    if is_port_8000_in_use():
+        pytest.skip("port 8000 already in use")
 
     p = subprocess.Popen([os.path.join(wpt.localpaths.repo_root, "wpt"), "serve"],
                          preexec_fn=os.setsid)


### PR DESCRIPTION
Fixes #9056.

Having done a load of this while investigating #9058 to try and get the tests to run on Windows, we may as well land this.

This makes it possible to run all of the wpt tests locally, and not rely on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9069)
<!-- Reviewable:end -->
