### PR TITLE
need to hardcode the -- for paramters

### DIFF
--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -143,8 +143,7 @@ class EdgeDriverServer(WebDriverServer):
 
     def make_command(self):
         return [self.binary,
-                cmd_arg("port", str(self.port)),
-                cmd_arg("url-base", self.base_path) if self.base_path else ""] + self._args
+                "--port=%s" % str(self.port)] + self._args
 
 class OperaDriverServer(ChromeDriverServer):
     def __init__(self, logger, binary="operadriver", port=None,


### PR DESCRIPTION
MicrosoftWebDriver requires "--" not "-". I don't want to change the
cmd_args() function because that may be used by other drivers on
Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9070)
<!-- Reviewable:end -->
