### PR TITLE
[css-grid] Fix grid-alignment-implies-size-change tests

### DIFF
--- a/css/css-grid/alignment/grid-alignment-implies-size-change-001.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-001.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-002.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-002.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-003.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-003.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-004.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-004.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-005.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-005.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-006.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-006.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-007.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-007.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-008.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-008.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-009.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-009.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-height", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-010.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-010.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-011.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-011.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-012.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-012.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-013.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-013.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 200);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-014.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-014.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-015.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-015.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-016.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-016.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-017.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-017.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 100);
   grid.style.alignItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-height", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-018.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-018.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-height", 80);
   grid.style.alignItems = "start";
   evaluateStyleChange(item, "after", "data-expected-height", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-019.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-019.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 120);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-020.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-020.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-021.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-021.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.alignItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-022.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-022.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-023.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-023.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-024.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-024.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 120);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-025.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-025.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-026.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-026.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 120);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-027.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-027.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 120);
   grid.style.justifyItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-width", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-028.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-028.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 120);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-029.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-029.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-030.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-030.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-031.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-031.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 200);
   grid.style.justifyItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-width", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-032.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-032.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 200);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-033.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-033.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "normal";
   evaluateStyleChange(item, "after", "data-expected-width", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-034.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-034.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-035.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-035.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 100);
   grid.style.justifyItems = "stretch";
   evaluateStyleChange(item, "after", "data-expected-width", 80);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/grid-alignment-implies-size-change-036.html
+++ b/css/css-grid/alignment/grid-alignment-implies-size-change-036.html
@@ -26,12 +26,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/check-layout-th.js"></script>
-<script src="../support/style-change.js"></script>
+<script src="support/style-change.js"></script>
 <script>
 function runTest() {
   evaluateStyleChange(item, "before", "data-expected-width", 80);
   grid.style.justifyItems = "start";
   evaluateStyleChange(item, "after", "data-expected-width", 100);
+  done();
 }
 </script>
 <body onload="runTest()">

--- a/css/css-grid/alignment/support/style-change.js
+++ b/css/css-grid/alignment/support/style-change.js
@@ -1,5 +1,5 @@
 function evaluateStyleChange(element, phase, expectedProperty, expectedResult) {
     element.className += " " + phase;
     element.setAttribute(expectedProperty, expectedResult);
-    checkLayout("." + phase);
+    checkLayout("." + phase, false);
 }


### PR DESCRIPTION
This should fix w3c/csswg-drafts#2194 as it's moving the style-change.js script
under css/css-grid/alignment/support/ folder.

On top of that it's fixing those tests as the second checkLayout() call
was never checked.
This was because by default checkLayout() calls done(), and the test thinks
it has already finished.
Modified the call to checkLayout() in the script style-change.js
and calling manually done() in the tests fixes the problem.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
