### PR TITLE
Don't bind hostname when running wptrunner for Servo

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -54,7 +54,7 @@ def env_extras(**kwargs):
 def env_options():
     return {"host": "127.0.0.1",
             "external_host": "web-platform.test",
-            "bind_hostname": "true",
+            "bind_hostname": "false",
             "testharnessreport": "testharnessreport-servo.js",
             "supports_debugger": True}
 


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/19738 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9083)
<!-- Reviewable:end -->
