### PR TITLE
Insert whitespace in front of letters in clear-applies-to-012.xht

### DIFF
--- a/css/CSS2/floats-clear/clear-applies-to-008-ref.xht
+++ b/css/CSS2/floats-clear/clear-applies-to-008-ref.xht
@@ -20,7 +20,7 @@
 
   <p>Test passes if the word PASS appears on a single line below.</p>
 
-  <div>PASS</div>
+  <div>P<span>A</span>SS</div>
 
  </body>
 </html>


### PR DESCRIPTION
This prevents the letters from negatively overflowing their containing
block, in case the glyphs had negative left side bearings. This was
observable with the layout test runner on Linux Chromium.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
