### PR TITLE
Wrap 'A' inside a SPAN in clear-applies-to-008-ref.xht

### DIFF
--- a/css/CSS2/floats-clear/clear-applies-to-008-ref.xht
+++ b/css/CSS2/floats-clear/clear-applies-to-008-ref.xht
@@ -20,7 +20,7 @@
 
   <p>Test passes if the word PASS appears on a single line below.</p>
 
-  <div>PASS</div>
+  <div>P<span>A</span>SS</div>
 
  </body>
 </html>


### PR DESCRIPTION
Avoids minor (and irrelevant to this test) rendering differences,
probably caused by kerning.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
