### PR TITLE
Switch most preload tests to PerformanceObserver instead of a timer

### DIFF
--- a/preload/download-resources.html
+++ b/preload/download-resources.html
@@ -47,14 +47,14 @@ function useAllResources() {
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport()
-        waitUntilResourceDownloaded("resources/dummy.js");
-        waitUntilResourceDownloaded("resources/dummy.css");
-        waitUntilResourceDownloaded("resources/square.png");
-        waitUntilResourceDownloaded("resources/CanvasTest.ttf");
-        waitUntilResourceDownloaded("resources/white.mp4");
-        waitUntilResourceDownloaded("resources/sound_5.oga");
-        waitUntilResourceDownloaded("resources/foo.vtt");
-        waitUntilResourceDownloaded("resources/dummy.xml");
+        await untilResourceDownloaded("resources/dummy.js");
+        await untilResourceDownloaded("resources/dummy.css");
+        await untilResourceDownloaded("resources/square.png");
+        await untilResourceDownloaded("resources/CanvasTest.ttf");
+        await untilResourceDownloaded("resources/white.mp4");
+        await untilResourceDownloaded("resources/sound_5.oga");
+        await untilResourceDownloaded("resources/foo.vtt");
+        await untilResourceDownloaded("resources/dummy.xml");
         verifyNumberOfDownloads("resources/dummy.js", 1);
         verifyNumberOfDownloads("resources/dummy.css", 1);
         verifyNumberOfDownloads("resources/square.png", 1);

--- a/preload/download-resources.html
+++ b/preload/download-resources.html
@@ -2,9 +2,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
-<script>
-    var t = async_test('Makes sure that preloaded resources are downloaded');
-</script>
 <link rel=preload href="resources/dummy.js" as=script>
 <link rel=preload href="resources/dummy.css" as=style>
 <link rel=preload href="resources/square.png" as=image>
@@ -16,12 +13,51 @@
 <link rel=preload href="resources/dummy.xml?novalue">
 <link rel=preload href="resources/dummy.xml" as="fetch">
 <body>
-<script src="resources/dummy.js?pipe=trickle(d5)&download-resources"></script>
 <script>
-    window.addEventListener("load", t.step_func(function() {
+function useAllResources() {
+    let style = document.createElement("style");
+    style.appendChild(document.createTextNode("@font-face { font-family:ahem; src: url(resources/CanvasTest.ttf); }span { font-family: ahem, Arial; }"));
+    document.body.appendChild(style);
+    let link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "resources/dummy.css";
+    document.body.appendChild(link);
+    let script = document.createElement("script");
+    script.src = "resources/dummy.js";
+    document.body.appendChild(script);
+    let img = new Image();
+    img.src = "resources/square.png";
+    document.body.appendChild(img);
+    let video = document.createElement("video");
+    video.src = "resources/white.mp4";
+    let track = document.createElement("track");
+    track.kind = "subtitles";
+    track.src = "resources/foo.vtt";
+    track.srclang = "en";
+    video.appendChild(track);
+    document.body.appendChild(video);
+    let audio = document.createElement("audio");
+    audio.src = "resources/sound_5.oga";
+    document.body.appendChild(audio);
+
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", "resources/dummy.xml");
+    xhr.send();
+}
+promise_test(async t => {
+    await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport()
+        waitUntilResourceDownloaded("resources/dummy.js");
+        waitUntilResourceDownloaded("resources/dummy.css");
+        waitUntilResourceDownloaded("resources/square.png");
+        waitUntilResourceDownloaded("resources/CanvasTest.ttf");
+        waitUntilResourceDownloaded("resources/white.mp4");
+        waitUntilResourceDownloaded("resources/sound_5.oga");
+        waitUntilResourceDownloaded("resources/foo.vtt");
+        waitUntilResourceDownloaded("resources/dummy.xml");
         verifyNumberOfDownloads("resources/dummy.js", 1);
         verifyNumberOfDownloads("resources/dummy.css", 1);
+        verifyNumberOfDownloads("resources/square.png", 1);
         verifyNumberOfDownloads("resources/CanvasTest.ttf", 1);
         verifyNumberOfDownloads("resources/white.mp4", 1);
         verifyNumberOfDownloads("resources/sound_5.oga", 1);
@@ -29,7 +65,9 @@
         verifyNumberOfDownloads("resources/dummy.xml?foo=bar", 0);
         verifyNumberOfDownloads("resources/dummy.xml?novalue", 0);
         verifyNumberOfDownloads("resources/dummy.xml", 1);
-        t.done();
-    }));
+        useAllResources();
+        resolve();
+    });
+}, 'Makes sure that preloaded resources are downloaded');
 </script>
 </body>

--- a/preload/download-resources.html
+++ b/preload/download-resources.html
@@ -46,7 +46,9 @@ function useAllResources() {
 }
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        verifyPreloadAndRTSupport()
+        if (!isPreloadAndRTSupported()) {
+            reject("Unsupported APIs");
+        }
         await untilResourceDownloaded("resources/dummy.js");
         await untilResourceDownloaded("resources/dummy.css");
         await untilResourceDownloaded("resources/square.png");

--- a/preload/dynamic-adding-preload.html
+++ b/preload/dynamic-adding-preload.html
@@ -22,5 +22,4 @@
         document.body.appendChild(link);
     });
 </script>
-<script src="resources/dummy.js?pipe=trickle(d5)&dynamic-adding-preload"></script>
 </body>

--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -2,16 +2,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
-<script>
-    var t = async_test('Makes sure that Link headers on subresources preload resources');
-</script>
 <link rel=stylesheet href="resources/dummy-preloads-subresource.css?link-header-on-subresource">
-<script src="resources/dummy.js?pipe=trickle(d5)&link-header-on-subresources"></script>
 <script>
-    window.addEventListener("load", t.step_func(function() {
+promise_test(async t => {
+    await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
+        waitUntilResourceDownloaded("/preload/resources/CanvasTest.ttf?link-header-on-subresource");
         verifyNumberOfDownloads("/preload/resources/CanvasTest.ttf?link-header-on-subresource", 1);
-        t.done();
-    }));
+        resolve();
+    });
+}, 'Makes sure that Link headers on subresources preload resources');
 </script>
 

--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -6,7 +6,9 @@
 <script>
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        verifyPreloadAndRTSupport();
+        if (!isPreloadAndRTSupported()) {
+            reject("Unsupported APIs");
+        }
         await untilResourceDownloaded("resources/CanvasTest.ttf");
         verifyNumberOfDownloads("resources/CanvasTest.ttf", 1);
         resolve();

--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -7,7 +7,7 @@
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
-        waitUntilResourceDownloaded("resources/CanvasTest.ttf");
+        await untilResourceDownloaded("resources/CanvasTest.ttf");
         verifyNumberOfDownloads("resources/CanvasTest.ttf", 1);
         resolve();
     });

--- a/preload/link-header-on-subresource.html
+++ b/preload/link-header-on-subresource.html
@@ -2,13 +2,13 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
-<link rel=stylesheet href="resources/dummy-preloads-subresource.css?link-header-on-subresource">
+<link rel=stylesheet href="resources/dummy-preloads-subresource.css">
 <script>
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
-        waitUntilResourceDownloaded("/preload/resources/CanvasTest.ttf?link-header-on-subresource");
-        verifyNumberOfDownloads("/preload/resources/CanvasTest.ttf?link-header-on-subresource", 1);
+        waitUntilResourceDownloaded("resources/CanvasTest.ttf");
+        verifyNumberOfDownloads("resources/CanvasTest.ttf", 1);
         resolve();
     });
 }, 'Makes sure that Link headers on subresources preload resources');

--- a/preload/link-header-preload-nonce.html
+++ b/preload/link-header-preload-nonce.html
@@ -6,7 +6,7 @@
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
-        waitUntilResourceDownloaded("resources/dummy.js?with-nonce");
+        await untilResourceDownloaded("resources/dummy.js?with-nonce");
         verifyNumberOfDownloads("resources/dummy.js?without-nonce", 0);
         verifyNumberOfDownloads("resources/dummy.js?with-nonce", 1);
         resolve();

--- a/preload/link-header-preload-nonce.html
+++ b/preload/link-header-preload-nonce.html
@@ -5,7 +5,9 @@
 <script nonce="abc">
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        verifyPreloadAndRTSupport();
+        if (!isPreloadAndRTSupported()) {
+            reject("Unsupported APIs");
+        }
         await untilResourceDownloaded("resources/dummy.js?with-nonce");
         verifyNumberOfDownloads("resources/dummy.js?without-nonce", 0);
         verifyNumberOfDownloads("resources/dummy.js?with-nonce", 1);

--- a/preload/link-header-preload-nonce.html
+++ b/preload/link-header-preload-nonce.html
@@ -3,14 +3,13 @@
 <script nonce="abc" src="/resources/testharnessreport.js"></script>
 <script nonce="abc" src="/preload/resources/preload_helper.js"></script>
 <script nonce="abc">
-    var t = async_test('Makes sure that Link headers preload resources with CSP nonce');
-</script>
-<script nonce="abc" src="resources/dummy.js?pipe=trickle(d5)&link-header-preload-nonce"></script>
-<script nonce="abc">
-    window.addEventListener('load', t.step_func(function() {
+promise_test(async t => {
+    await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
+        waitUntilResourceDownloaded("resources/dummy.js?with-nonce");
         verifyNumberOfDownloads("resources/dummy.js?without-nonce", 0);
         verifyNumberOfDownloads("resources/dummy.js?with-nonce", 1);
-        t.done();
-    }));
+        resolve();
+    });
+}, 'Makes sure that Link headers preload resources with CSP nonce');
 </script>

--- a/preload/link-header-preload.html
+++ b/preload/link-header-preload.html
@@ -7,9 +7,9 @@
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
-        waitUntilResourceDownloaded("resources/square.png?link-header-preload");
-        waitUntilResourceDownloaded("resources/dummy.js?link-header-preload");
-        waitUntilResourceDownloaded("resources/dummy.css?link-header-preload");
+        await untilResourceDownloaded("resources/square.png?link-header-preload");
+        await untilResourceDownloaded("resources/dummy.js?link-header-preload");
+        await untilResourceDownloaded("resources/dummy.css?link-header-preload");
         verifyNumberOfDownloads("resources/square.png?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.js?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.css?link-header-preload", 1);

--- a/preload/link-header-preload.html
+++ b/preload/link-header-preload.html
@@ -2,18 +2,19 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
-<script>
-    var t = async_test('Makes sure that Link headers preload resources');
-</script>
 <body>
-<script src="resources/dummy.js?pipe=trickle(d5)&link-header-preload"></script>
 <script>
-    window.addEventListener("load", t.step_func(function() {
+promise_test(async t => {
+    await new Promise(async (resolve, reject) => {
         verifyPreloadAndRTSupport();
+        waitUntilResourceDownloaded("resources/square.png?link-header-preload");
+        waitUntilResourceDownloaded("resources/dummy.js?link-header-preload");
+        waitUntilResourceDownloaded("resources/dummy.css?link-header-preload");
         verifyNumberOfDownloads("resources/square.png?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.js?link-header-preload", 1);
         verifyNumberOfDownloads("resources/dummy.css?link-header-preload", 1);
-        t.done();
-    }));
+        resolve();
+    });
+}, 'Makes sure that Link headers preload resources');
 </script>
 </body>

--- a/preload/link-header-preload.html
+++ b/preload/link-header-preload.html
@@ -6,7 +6,9 @@
 <script>
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        verifyPreloadAndRTSupport();
+        if (!isPreloadAndRTSupported()) {
+            reject("Unsupported APIs");
+        }
         await untilResourceDownloaded("resources/square.png?link-header-preload");
         await untilResourceDownloaded("resources/dummy.js?link-header-preload");
         await untilResourceDownloaded("resources/dummy.css?link-header-preload");

--- a/preload/resources/CanvasTest.ttf.sub.headers
+++ b/preload/resources/CanvasTest.ttf.sub.headers
@@ -1,1 +1,1 @@
-Cache-Control: max-age=1000
+Cache-Control: no-cache

--- a/preload/resources/dummy-preloads-subresource.css.sub.headers
+++ b/preload/resources/dummy-preloads-subresource.css.sub.headers
@@ -1,2 +1,2 @@
-Cache-Control: max-age=1000
-Link: </preload/resources/CanvasTest.ttf?link-header-on-subresource>; rel=preload;as=font;crossorigin
+Cache-Control: no-cache
+Link: </preload/resources/CanvasTest.ttf>; rel=preload;as=font;crossorigin

--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -28,7 +28,6 @@ function untilResourceDownloaded(url)
         return true;
     }
 
-    console.log("waiting on " + absoluteURL);
     return new Promise((resolve, reject) => {
       let observer = new PerformanceObserver(list => {
           list.getEntries().forEach(entry => {

--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -21,19 +21,22 @@ function verifyNumberOfDownloads(url, number)
     assert_equals(numDownloads, number, url);
 }
 
-async function waitUntilResourceDownloaded(url)
+function untilResourceDownloaded(url)
 {
-    if (performance.getEntriesByName(getAbsoluteURL(url)).length >= 1) {
+    let absoluteURL = getAbsoluteURL(url);
+    if (performance.getEntriesByName(absoluteURL).length >= 1) {
         return true;
     }
 
-    await new Promise((resolve, reject) => {
+    console.log("waiting on " + absoluteURL);
+    return new Promise((resolve, reject) => {
       let observer = new PerformanceObserver(list => {
           list.getEntries().forEach(entry => {
-              if (entry.name == url) {
+              if (entry.name == absoluteURL) {
                   resolve();
               }
           });
       });
+      observer.observe({entryTypes: ["resource"]});
     });
 }

--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -20,3 +20,20 @@ function verifyNumberOfDownloads(url, number)
     });
     assert_equals(numDownloads, number, url);
 }
+
+async function waitUntilResourceDownloaded(url)
+{
+    if (performance.getEntriesByName(getAbsoluteURL(url)).length >= 1) {
+        return true;
+    }
+
+    await new Promise((resolve, reject) => {
+      let observer = new PerformanceObserver(list => {
+          list.getEntries().forEach(entry => {
+              if (entry.name == url) {
+                  resolve();
+              }
+          });
+      });
+    });
+}

--- a/preload/resources/preload_helper.js
+++ b/preload/resources/preload_helper.js
@@ -1,17 +1,25 @@
-function verifyPreloadAndRTSupport()
-{
+function verifyPreloadAndRTSupport() {
     var link = window.document.createElement("link");
     assert_true(link.relList && link.relList.supports("preload"), "Preload not supported");
     assert_true(!!window.PerformanceResourceTiming, "ResourceTiming not supported");
 }
 
-function getAbsoluteURL(url)
-{
+function isPreloadAndRTSupported() {
+    var link = window.document.createElement("link");
+    if (!link.relList || !link.relList.supports("preload")) {
+        return false;
+    }
+    if (!window.PerformanceResourceTiming) {
+        return false;
+    }
+    return true;
+}
+
+function getAbsoluteURL(url) {
     return new URL(url, location.href).href;
 }
 
-function verifyNumberOfDownloads(url, number)
-{
+function verifyNumberOfDownloads(url, number) {
     var numDownloads = 0;
     performance.getEntriesByName(getAbsoluteURL(url)).forEach(entry => {
         if (entry.transferSize > 0) {
@@ -21,8 +29,7 @@ function verifyNumberOfDownloads(url, number)
     assert_equals(numDownloads, number, url);
 }
 
-function untilResourceDownloaded(url)
-{
+function untilResourceDownloaded(url) {
     let absoluteURL = getAbsoluteURL(url);
     if (performance.getEntriesByName(absoluteURL).length >= 1) {
         return true;

--- a/preload/resources/square.png.sub.headers
+++ b/preload/resources/square.png.sub.headers
@@ -1,1 +1,1 @@
-Cache-Control: max-age=1000
+Cache-Control: no-cache

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -34,9 +34,11 @@
 </video>
 <audio src="resources/sound_5.oga?single-download-preload"></audio>
 <script>
+var xhr = new XMLHttpRequest();
+xhr.open("GET", "resources/dummy.xml?single-download-preload");
+xhr.send();
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        await fetch("resources/dummy.xml?single-download-preload");
         verifyPreloadAndRTSupport();
         await untilResourceDownloaded("resources/dummy.js?single-download-preload");
         await untilResourceDownloaded("resources/dummy.css?single-download-preload");
@@ -46,6 +48,7 @@ promise_test(async t => {
         await untilResourceDownloaded("resources/white.mp4?single-download-preload");
         await untilResourceDownloaded("resources/sound_5.oga?single-download-preload");
         await untilResourceDownloaded("resources/foo.vtt?single-download-preload");
+        await untilResourceDownloaded("resources/dummy.xml?single-download-preload");
         verifyNumberOfDownloads("resources/dummy.js?single-download-preload", 1);
         verifyNumberOfDownloads("resources/dummy.css?single-download-preload", 1);
         verifyNumberOfDownloads("resources/square.png?single-download-preload", 1);

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -2,9 +2,6 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/preload/resources/preload_helper.js"></script>
-<script>
-    var t = async_test('Makes sure that preloaded resources are not downloaded again when used');
-</script>
 <link rel=preload href="resources/dummy.js?single-download-preload" as=script>
 <link rel=preload href="resources/dummy.css?single-download-preload" as=style>
 <link rel=preload href="resources/square.png?single-download-preload" as=image>
@@ -16,12 +13,11 @@
 <link rel=preload href="resources/dummy.xml?foo=bar" as=foobarxmlthing>
 <link rel=preload href="resources/dummy.xml?single-download-preload">
 <body>
-<script src="resources/dummy.js?pipe=trickle(d3)&single-download-preload"></script>
 <style>
     #background {
         width: 200px;
         height: 200px;
-        background-image: url(resources/square.png?backgroundi&single-download-preload);
+        background-image: url(resources/square.png?background&single-download-preload);
     }
     @font-face {
       font-family:ahem;
@@ -38,24 +34,30 @@
 </video>
 <audio src="resources/sound_5.oga?single-download-preload"></audio>
 <script>
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", "resources/dummy.xml?single-download-preload");
-    xhr.send();
-
-    window.addEventListener("load", t.step_func(function() {
+promise_test(async t => {
+    await new Promise(async (resolve, reject) => {
+        await fetch("resources/dummy.xml?single-download-preload");
         verifyPreloadAndRTSupport();
-        setTimeout(t.step_func(function() {
-            verifyNumberOfDownloads("resources/dummy.js?single-download-preload", 1);
-            verifyNumberOfDownloads("resources/dummy.css?single-download-preload", 1);
-            verifyNumberOfDownloads("resources/square.png?single-download-preload", 1);
-            verifyNumberOfDownloads("resources/square.png?background&single-download-preload", 1);
-            verifyNumberOfDownloads("resources/CanvasTest.ttf?single-download-preload", 1);
-            verifyNumberOfDownloads("resources/dummy.xml?foobar", 0);
-            verifyNumberOfDownloads("resources/foo.vtt?single-download-preload", 1);
-            verifyNumberOfDownloads("resources/dummy.xml?single-download-preload", 1);
-            // FIXME: We should verify for video and audio as well, but they seem to (flakily?) trigger multiple partial requests.
-            t.done();
-        }), 0);
-    }));
+        waitUntilResourceDownloaded("resources/dummy.js?single-download-preload");
+        waitUntilResourceDownloaded("resources/dummy.css?single-download-preload");
+        waitUntilResourceDownloaded("resources/square.png?single-download-preload");
+        waitUntilResourceDownloaded("resources/square.png?background&single-download-preload");
+        waitUntilResourceDownloaded("resources/CanvasTest.ttf?single-download-preload");
+        waitUntilResourceDownloaded("resources/white.mp4?single-download-preload");
+        waitUntilResourceDownloaded("resources/sound_5.oga?single-download-preload");
+        waitUntilResourceDownloaded("resources/foo.vtt?single-download-preload");
+        waitUntilResourceDownloaded("resources/dummy.xml?single-download-preload");
+        verifyNumberOfDownloads("resources/dummy.js?single-download-preload", 1);
+        verifyNumberOfDownloads("resources/dummy.css?single-download-preload", 1);
+        verifyNumberOfDownloads("resources/square.png?single-download-preload", 1);
+        verifyNumberOfDownloads("resources/square.png?background&single-download-preload", 1);
+        verifyNumberOfDownloads("resources/CanvasTest.ttf?single-download-preload", 1);
+        verifyNumberOfDownloads("resources/dummy.xml?foobar", 0);
+        verifyNumberOfDownloads("resources/foo.vtt?single-download-preload", 1);
+        verifyNumberOfDownloads("resources/dummy.xml?single-download-preload", 1);
+        // FIXME: We should verify for video and audio as well, but they seem to (flakily?) trigger multiple partial requests.
+        resolve();
+    });
+}, 'Makes sure that preloaded resources are not downloaded again when used');
 </script>
 <span>PASS - this text is here just so that the browser will download the font.</span>

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -34,10 +34,8 @@
 </video>
 <audio src="resources/sound_5.oga?single-download-preload"></audio>
 <script>
-var xhr = new XMLHttpRequest();
-xhr.open("GET", "resources/dummy.xml?single-download-preload");
-xhr.send();
 promise_test(async t => {
+    await (await fetch("resources/dummy.xml?single-download-preload")).arrayBuffer();
     await new Promise(async (resolve, reject) => {
         if (!isPreloadAndRTSupported()) {
             reject("Unsupported APIs");

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -39,7 +39,9 @@ xhr.open("GET", "resources/dummy.xml?single-download-preload");
 xhr.send();
 promise_test(async t => {
     await new Promise(async (resolve, reject) => {
-        verifyPreloadAndRTSupport();
+        if (!isPreloadAndRTSupported()) {
+            reject("Unsupported APIs");
+        }
         await untilResourceDownloaded("resources/dummy.js?single-download-preload");
         await untilResourceDownloaded("resources/dummy.css?single-download-preload");
         await untilResourceDownloaded("resources/square.png?single-download-preload");

--- a/preload/single-download-preload.html
+++ b/preload/single-download-preload.html
@@ -38,15 +38,14 @@ promise_test(async t => {
     await new Promise(async (resolve, reject) => {
         await fetch("resources/dummy.xml?single-download-preload");
         verifyPreloadAndRTSupport();
-        waitUntilResourceDownloaded("resources/dummy.js?single-download-preload");
-        waitUntilResourceDownloaded("resources/dummy.css?single-download-preload");
-        waitUntilResourceDownloaded("resources/square.png?single-download-preload");
-        waitUntilResourceDownloaded("resources/square.png?background&single-download-preload");
-        waitUntilResourceDownloaded("resources/CanvasTest.ttf?single-download-preload");
-        waitUntilResourceDownloaded("resources/white.mp4?single-download-preload");
-        waitUntilResourceDownloaded("resources/sound_5.oga?single-download-preload");
-        waitUntilResourceDownloaded("resources/foo.vtt?single-download-preload");
-        waitUntilResourceDownloaded("resources/dummy.xml?single-download-preload");
+        await untilResourceDownloaded("resources/dummy.js?single-download-preload");
+        await untilResourceDownloaded("resources/dummy.css?single-download-preload");
+        await untilResourceDownloaded("resources/square.png?single-download-preload");
+        await untilResourceDownloaded("resources/square.png?background&single-download-preload");
+        await untilResourceDownloaded("resources/CanvasTest.ttf?single-download-preload");
+        await untilResourceDownloaded("resources/white.mp4?single-download-preload");
+        await untilResourceDownloaded("resources/sound_5.oga?single-download-preload");
+        await untilResourceDownloaded("resources/foo.vtt?single-download-preload");
         verifyNumberOfDownloads("resources/dummy.js?single-download-preload", 1);
         verifyNumberOfDownloads("resources/dummy.css?single-download-preload", 1);
         verifyNumberOfDownloads("resources/square.png?single-download-preload", 1);


### PR DESCRIPTION
Currently many preload tests are slow due to their use of a timer. PerformanceObserver enables us to avoid that in most cases, by giving us a notification when resources were downloaded, independent from their load events.
This PR switches most of the preload tests to use that method. (Failed to switch all, as we don't have a notification when resources *failed* to load, nor guarantees regarding PerfObserver firing with regard to the resource's load event)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
