### PR TITLE
Fix test that didn't take account of module scripts' defer scheduling

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/module-in-xhtml.xhtml
+++ b/html/semantics/scripting-1/the-script-element/module/module-in-xhtml.xhtml
@@ -10,7 +10,11 @@
 window.evaluated_module_script = true;
 </script>
 <script>
-test(() => assert_true(window.evaluated_module_script), "module script in XHTML documents should be evaluated.");
+  var test = async_test("module script in XHTML documents should be evaluated.");
+  window.addEventListener("load", () => {
+    test.step(() => { assert_true(window.evaluated_module_script); });
+    test.done();
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1426642 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9139)
<!-- Reviewable:end -->
