### PR TITLE
Safely shutdown Firefox from in delete_session.

### DIFF
--- a/webdriver/tests/state/get_element_attribute.py
+++ b/webdriver/tests/state/get_element_attribute.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 import pytest
 
 from tests.support.asserts import assert_error, assert_success, assert_dialog_handled

--- a/webdriver/tests/state/get_element_property.py
+++ b/webdriver/tests/state/get_element_property.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog

--- a/webdriver/tests/state/get_element_tag_name.py
+++ b/webdriver/tests/state/get_element_tag_name.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog

--- a/webdriver/tests/state/is_element_selected.py
+++ b/webdriver/tests/state/is_element_selected.py
@@ -1,3 +1,5 @@
+# META: timeout=long
+
 from tests.support.asserts import assert_error, assert_dialog_handled, assert_success
 from tests.support.inline import inline
 from tests.support.fixtures import create_dialog


### PR DESCRIPTION

With the request to shutdown the browser, a given amount of time
has to be waited to allow the process to shutdown itself. Only
if the process is still running afterward it has to be killed.

Firefox has an integrated background monitor which observes
long running threads during shutdown, and kills those after
65s. To allow Firefox to shutdown on its own, geckodriver
has to wait that time, and some additional seconds.

MozReview-Commit-ID: 4LRLQE0jZzw

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1403923 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9140)
<!-- Reviewable:end -->
