### PR TITLE
css-ui] Skip anonymous boxes (rather than all pseudos) when looking for the 'overflow' style frame.

### DIFF
--- a/css/css-ui/text-overflow-024-ref.html
+++ b/css/css-ui/text-overflow-024-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Reference: text-overflow on tr::before with overflow:hidden</title>
+  <style type="text/css">
+
+    td {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+  </style>
+</head>
+<body>
+PASS if there is an ellipsis at the end of the text below.
+  <table style="table-layout: fixed; width: 130px" cellpadding="0" cellspacing="0">
+    <tr><td>Some long text here that overflows and whatnot.</td></tr>
+  </table>
+
+</body>
+</html>

--- a/css/css-ui/text-overflow-024.html
+++ b/css/css-ui/text-overflow-024.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Test: text-overflow on tr::before with overflow:hidden</title>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu">
+  <link rel="help" href="https://www.w3.org/TR/css3-ui/#text-overflow" title="5.2. the 'text-overflow' property">
+  <link rel="match" href="text-overflow-024-ref.html">
+  <style type="text/css">
+
+    tr::before {
+      content: "Some long text here that overflows and whatnot.";
+      display: table-cell;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+  </style>
+</head>
+<body>
+PASS if there is an ellipsis at the end of the text below.
+  <table style="table-layout: fixed; width: 130px" cellpadding="0" cellspacing="0">
+    <tr></tr>
+  </table>
+
+</body>
+</html>

--- a/css/css-ui/text-overflow-025-ref.html
+++ b/css/css-ui/text-overflow-025-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Reference: text-overflow on tr::before without overflow:hidden</title>
+  <style type="text/css">
+
+    td {
+      white-space: nowrap;
+    }
+
+  </style>
+</head>
+<body>
+PASS if there is no ellipsis below.
+  <table style="table-layout: fixed; width: 130px" cellpadding="0" cellspacing="0">
+    <tr><td>Some long text here that overflows and whatnot.</td></tr>
+  </table>
+
+</body>
+</html>

--- a/css/css-ui/text-overflow-025.html
+++ b/css/css-ui/text-overflow-025.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html><head>
+  <meta charset="utf-8">
+  <title>Test: text-overflow on tr::before without overflow:hidden</title>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu">
+  <link rel="help" href="https://www.w3.org/TR/css3-ui/#text-overflow" title="5.2. the 'text-overflow' property">
+  <link rel="match" href="text-overflow-025-ref.html">
+  <style type="text/css">
+
+    tr::before {
+      content: "Some long text here that overflows and whatnot.";
+      display: table-cell;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    tr {
+      overflow: hidden;
+    }
+
+  </style>
+</head>
+<body>
+PASS if there is no ellipsis below.
+  <table style="table-layout: fixed; width: 130px" cellpadding="0" cellspacing="0">
+    <tr></tr>
+  </table>
+
+</body>
+</html>


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1343980 [ci skip]