### PR TITLE
css-display] Update display: contents on Unusual Elements to the spec.

### DIFF
--- a/css/css-display/display-contents-fieldset-nested-legend-ref.html
+++ b/css/css-display/display-contents-fieldset-nested-legend-ref.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<title>CSS Test Reference</title>
+<fieldset style="color: green">P<legend style="padding: 0">legend</legend>ASS</fieldset>

--- a/css/css-display/display-contents-fieldset-nested-legend.html
+++ b/css/css-display/display-contents-fieldset-nested-legend.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<meta charset="utf-8">
+<link rel="match" href="display-contents-fieldset-nested-legend-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-display/#unbox">
+<link rel="help" href="https://drafts.csswg.org/css-display/#valdef-display-contents">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1427292">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mats Palmgren" href="mailto:mats@mozilla.com">
+<title>CSS Test: display: contents on legend</title>
+<style>
+fieldset {
+  color: red;
+}
+.contents {
+  display: contents;
+  color: green;
+  border: 10px solid red;
+}
+</style>
+<fieldset><legend class="contents">P<legend>legend</legend>ASS</legend></fieldset>


### PR DESCRIPTION

This will pass[1] whenever the next WPT sync happens.

See: https://drafts.csswg.org/css-display/#unbox-html

[1]: https://github.com/w3c/web-platform-tests/blob/master/css/css-display/display-contents-unusual-html-elements-none.html

MozReview-Commit-ID: 19dqDSxVm7A

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1427292 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9144)
<!-- Reviewable:end -->
