### PR TITLE
Add a test for execution order of inline async module scripts

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/inline-async-execorder.html
+++ b/html/semantics/scripting-1/the-script-element/module/inline-async-execorder.html
@@ -1,0 +1,29 @@
+<html>
+  <head>
+    <title>Inline async module script execution order</title>
+    <meta name=timeout content=long>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      let loaded = [];
+      let test = async_test("Inline async module script execution order");
+      window.addEventListener("load", test.step_func(function() {
+        assert_array_equals(loaded,
+                            ["fast", "fast", "fast", "slow", "slow", "slow"]);
+      test.done();
+      }));
+    </script>
+    <script type="module" async src="resources/slow-module.js?pipe=trickle(d2)&unique=1"></script>
+    <script type="module" async>
+      import "./resources/slow-module.js?pipe=trickle(d2)&unique=2";
+      loaded.push("slow");
+    </script>
+    <script type="module" async src="resources/fast-module.js?unique=1"></script>
+    <script type="module" async>
+      import "./resources/fast-module.js?unique=2";
+      loaded.push("fast");
+    </script>
+  </body>
+</html>

--- a/html/semantics/scripting-1/the-script-element/module/resources/fast-module.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/fast-module.js
@@ -1,0 +1,1 @@
+loaded.push("fast");

--- a/html/semantics/scripting-1/the-script-element/module/resources/slow-module.js
+++ b/html/semantics/scripting-1/the-script-element/module/resources/slow-module.js
@@ -1,0 +1,3 @@
+// This module is imported with pipe=trickle(d2) to make it load more slowly
+// than fast-module.js
+loaded.push("slow");


### PR DESCRIPTION

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1361369 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
