### PR TITLE
Stop toggling selectedness state of <option disabled>.

### DIFF
--- a/webdriver/tests/element_click/select.py
+++ b/webdriver/tests/element_click/select.py
@@ -211,3 +211,15 @@ def test_out_of_view_multiple(session):
     last_option = options[-1]
     last_option.click()
     assert last_option.selected
+
+
+def test_option_disabled(session):
+    session.url = inline("""
+        <select>
+          <option disabled>foo
+        </select>""")
+    option = session.find.css("option", all=False)
+    assert not option.selected
+
+    option.click()
+    assert not option.selected


### PR DESCRIPTION

When WebDriver:ElementClick clicks an <option disabled> element,
its selectedness state should according to a new specification
change proposed not change:

	https://github.com/w3c/webdriver/pull/1189

This patch provides tests for the specification change.

MozReview-Commit-ID: EXG98LjgB7d

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1429384 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9152)
<!-- Reviewable:end -->
