### PR TITLE
Use classic pytest output style for WPT. r=davehunt,jgraham

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -58,6 +58,7 @@ def run(path, server_config, session_config, timeout=0):
                          "--showlocals",  # display contents of variables in local scope
                          "-p", "no:mozlog",  # use the WPT result recorder
                          "-p", "no:cacheprovider",  # disable state preservation across invocations
+                         "-o=console_output_style=classic",  # disable test progress bar
                          path],
                         plugins=[harness, subtests])
         except Exception as e:


### PR DESCRIPTION

The upstream upgrade of pytest came with a new test progress
percentage feature that introduced a lot of unnecessary log output
in WPT wdspec tests.

This adds a pytest flag that reverts it to use the "classic" output
style, which does not have a test progress bar.

MozReview-Commit-ID: 9ucB7CzV5ig

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1429388 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9153)
<!-- Reviewable:end -->
