### PR TITLE
Remove obsolete optional parameter `reset_session_id` from `delete_session`.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -96,7 +96,7 @@ class MarionetteProtocol(Protocol):
     def teardown(self):
         try:
             self.marionette._request_in_app_shutdown()
-            self.marionette.delete_session(send_request=False, reset_session_id=True)
+            self.marionette.delete_session(send_request=False)
         except Exception:
             # This is typically because the session never started
             pass


### PR DESCRIPTION

By calling "delete_session" the currently used session id always has to be reset,
because each session has its own unique id.

MozReview-Commit-ID: H9RiuNj7fRd

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1429562 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9154)
<!-- Reviewable:end -->
