### PR TITLE
Make composite member of Keyframe dictionary objects accept null values;

### DIFF
--- a/web-animations/interfaces/KeyframeEffect/composite.html
+++ b/web-animations/interfaces/KeyframeEffect/composite.html
@@ -29,8 +29,8 @@ test(t => {
 
   anim.effect.composite = 'add';
   const keyframes = anim.effect.getKeyframes();
-  assert_equals(keyframes[0].composite, undefined,
-                'unspecified keyframe composite value should be absent even ' +
+  assert_equals(keyframes[0].composite, null,
+                'unspecified keyframe composite value should be null even ' +
                 'if effect composite is set');
 }, 'Unspecified keyframe composite value when setting effect composite');
 

--- a/web-animations/interfaces/KeyframeEffect/constructor.html
+++ b/web-animations/interfaces/KeyframeEffect/constructor.html
@@ -57,7 +57,7 @@ test(t => {
     assert_equals(effect.getKeyframes()[0].composite, composite,
                   `resulting composite for '${composite}'`);
   }
-  for (const composite of gBadCompositeValueTests) {
+  for (const composite of gBadKeyframeCompositeValueTests) {
     assert_throws(new TypeError, () => {
       new KeyframeEffectReadOnly(target, getKeyframe(composite));
     });
@@ -76,7 +76,7 @@ test(t => {
     assert_equals(effect.getKeyframes()[0].composite, composite,
                   `resulting composite for '${composite}'`);
   }
-  for (const composite of gBadCompositeValueTests) {
+  for (const composite of gBadKeyframeCompositeValueTests) {
     assert_throws(new TypeError, () => {
       new KeyframeEffectReadOnly(target, getKeyframes(composite));
     });
@@ -89,17 +89,17 @@ test(t => {
     const effect = new KeyframeEffectReadOnly(target, {
       left: ['10px', '20px']
     }, { composite: composite });
-    assert_equals(effect.getKeyframes()[0].composite, undefined,
+    assert_equals(effect.getKeyframes()[0].composite, null,
                   `resulting composite for '${composite}'`);
   }
-  for (const composite of gBadCompositeValueTests) {
+  for (const composite of gBadOptionsCompositeValueTests) {
     assert_throws(new TypeError, () => {
       new KeyframeEffectReadOnly(target, {
         left: ['10px', '20px']
       }, { composite: composite });
     });
   }
-}, 'composite value is absent if the composite operation specified on the ' +
+}, 'composite value is null if the composite operation specified on the ' +
    'keyframe effect is being used');
 
 for (const subtest of gKeyframesTests) {

--- a/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
+++ b/web-animations/interfaces/KeyframeEffect/processing-a-keyframes-argument-001.html
@@ -180,9 +180,27 @@ test(() => {
     { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
-    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
-    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      left: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 0.5,
+      easing: 'linear',
+      left: '300px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      left: '200px',
+      composite: null,
+    },
   ]);
 }, 'Keyframes are read from a custom iterator');
 
@@ -197,9 +215,27 @@ test(() => {
   keyframes.offset = '0.1';
   const effect = new KeyframeEffect(null, keyframes);
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
-    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
-    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      left: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 0.5,
+      easing: 'linear',
+      left: '300px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      left: '200px',
+      composite: null,
+    },
   ]);
 }, '\'easing\' and \'offset\' are ignored on iterable objects');
 
@@ -211,11 +247,29 @@ test(() => {
     { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', left: '100px',
-      top: '200px' },
-    { offset: null, computedOffset: 0.5, easing: 'linear', left: '300px' },
-    { offset: null, computedOffset: 1, easing: 'linear', left: '200px',
-      top: '100px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      left: '100px',
+      top: '200px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 0.5,
+      easing: 'linear',
+      left: '300px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      left: '200px',
+      top: '100px',
+      composite: null,
+    },
   ]);
 }, 'Keyframes are read from a custom iterator with multiple properties'
    + ' specified');
@@ -228,9 +282,27 @@ test(() => {
     { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', left: '100px' },
-    { offset: 0.75, computedOffset: 0.75, easing: 'linear', left: '250px' },
-    { offset: null, computedOffset: 1, easing: 'linear', left: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      left: '100px',
+      composite: null,
+    },
+    {
+      offset: 0.75,
+      computedOffset: 0.75,
+      easing: 'linear',
+      left: '250px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      left: '200px',
+      composite: null,
+    },
   ]);
 }, 'Keyframes are read from a custom iterator with where an offset is'
    + ' specified');
@@ -253,7 +325,7 @@ test(() => {
     { done: true },
   ]));
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 1, easing: 'linear' }
+    { offset: null, computedOffset: 1, easing: 'linear', composite: null }
   ]);
 }, 'A list of values returned from a custom iterator should be ignored');
 
@@ -270,8 +342,20 @@ test(() => {
   const effect = new KeyframeEffect(null, [keyframe, { height: '200px' }]);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', height: '100px' },
-    { offset: null, computedOffset: 1, easing: 'linear', height: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      height: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      height: '200px',
+      composite: null,
+    },
   ]);
 }, 'Only enumerable properties on keyframes are read');
 
@@ -289,8 +373,20 @@ test(() => {
   const effect = new KeyframeEffect(null, [keyframe, { top: '200px' }]);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', top: '100px' },
-    { offset: null, computedOffset: 1, easing: 'linear', top: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      top: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      top: '200px',
+      composite: null,
+    },
   ]);
 }, 'Only properties defined directly on keyframes are read');
 
@@ -305,8 +401,20 @@ test(() => {
   const effect = new KeyframeEffect(null, keyframes);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', height: '100px' },
-    { offset: null, computedOffset: 1, easing: 'linear', height: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      height: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      height: '200px',
+      composite: null,
+    },
   ]);
 }, 'Only enumerable properties on property-indexed keyframes are read');
 
@@ -324,8 +432,20 @@ test(() => {
   const effect = new KeyframeEffect(null, keyframes);
 
   assert_frame_lists_equal(effect.getKeyframes(), [
-    { offset: null, computedOffset: 0, easing: 'linear', top: '100px' },
-    { offset: null, computedOffset: 1, easing: 'linear', top: '200px' },
+    {
+      offset: null,
+      computedOffset: 0,
+      easing: 'linear',
+      top: '100px',
+      composite: null,
+    },
+    {
+      offset: null,
+      computedOffset: 1,
+      easing: 'linear',
+      top: '200px',
+      composite: null,
+    },
   ]);
 }, 'Only properties defined directly on property-indexed keyframes are read');
 

--- a/web-animations/resources/keyframe-tests.js
+++ b/web-animations/resources/keyframe-tests.js
@@ -12,14 +12,18 @@
 // ------------------------------
 
 const gGoodKeyframeCompositeValueTests = [
-  'replace', 'add', 'accumulate', undefined
+  'replace', 'add', 'accumulate', null
+];
+
+const gBadKeyframeCompositeValueTests = [
+  'unrecognised', 'replace ', 'Replace'
 ];
 
 const gGoodOptionsCompositeValueTests = [
   'replace', 'add', 'accumulate'
 ];
 
-const gBadCompositeValueTests = [
+const gBadOptionsCompositeValueTests = [
   'unrecognised', 'replace ', 'Replace', null
 ];
 
@@ -50,9 +54,7 @@ const keyframe = (offset, props, easing='linear', composite) => {
   // Object.assign instead.
   const result = {};
   Object.assign(result, offset, props, { easing });
-  if (composite) {
-    result.composite = composite;
-  }
+  result.composite = composite || null;
   return result;
 };
 


### PR DESCRIPTION

This patch reflects the following change to the Web Animations spec:

  https://github.com/w3c/csswg-drafts/commit/abf76745b50c8943e8b16c13abc61cb6ca814830

MozReview-Commit-ID: A2GD1igUf5f

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1429671 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9155)
<!-- Reviewable:end -->
