### PR TITLE
Don't allow fallback alignment in place-content shorthand. r=xidorn,mats

### DIFF
--- a/css/css-align/content-distribution/place-content-shorthand-007-ref.html
+++ b/css/css-align/content-distribution/place-content-shorthand-007-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test Reference</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<style>
+div {
+  width: 400px;
+  height: 400px;
+  background: blue;
+  position: relative;
+}
+span {
+  background: green;
+  width: 200px;
+  height: 200px;
+  position: absolute;
+  bottom: 0;
+  left: 100px;
+}
+</style>
+Should see a green square centered and at the bottom of the blue square.
+<div><span></span></div>

--- a/css/css-align/content-distribution/place-content-shorthand-007.html
+++ b/css/css-align/content-distribution/place-content-shorthand-007.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment: place-content shorthand with fallback</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="help" href="https://drafts.csswg.org/css-align/#propdef-place-content">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1430622">
+<link rel="match" href="place-content-shorthand-007-ref.html">
+<style>
+div {
+  display: grid;
+  grid: 200px / 200px;
+  width: 400px;
+  height: 400px;
+  background: blue;
+  place-content: end space-evenly;
+}
+span {
+  background: green;
+}
+</style>
+Should see a green square centered and at the bottom of the blue square.
+<div><span></span></div>


### PR DESCRIPTION

MozReview-Commit-ID: sALBFJeqvr

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1430622 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9158)
<!-- Reviewable:end -->
