### PR TITLE
Add [SecureContext] to navigator.credentials

### DIFF
--- a/credential-management/require_securecontext.html
+++ b/credential-management/require_securecontext.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Test that Credential Management requires secure contexts</title>
+<link rel="help" href="https://w3c.github.io/webappsec-credential-management/#idl-index">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+"use strict";
+  test(() => {
+    assert_false(isSecureContext);
+    assert_false('credentials' in navigator);
+  }, "Credential Management must not be accessible in insecure contexts");
+</script>


### PR DESCRIPTION

It was neglected to mark navigator.credentials as [SecureContext], yet it
must be for spec compliance and powerful-features compliance.

MozReview-Commit-ID: BYKGqqhoS2L

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1430947 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9163)
<!-- Reviewable:end -->
