### PR TITLE
Double epsilon value for assert_times_equal.

### DIFF
--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -21,7 +21,7 @@ const TIME_PRECISION = 0.0005; // ms
 // times based on their precision requirements.
 if (!window.assert_times_equal) {
   window.assert_times_equal = (actual, expected, description) => {
-    assert_approx_equals(actual, expected, TIME_PRECISION, description);
+    assert_approx_equals(actual, expected, TIME_PRECISION * 2, description);
   };
 }
 


### PR DESCRIPTION

Since the function assumes that both of actual and expected values
have the same precision requirements.

MozReview-Commit-ID: 4C3TAH6mUVg

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1430654 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9166)
<!-- Reviewable:end -->
