### PR TITLE
Use assert_times_equal for comparing timing values.

### DIFF
--- a/web-animations/interfaces/Animation/playbackRate.html
+++ b/web-animations/interfaces/Animation/playbackRate.html
@@ -14,16 +14,14 @@ function assert_playbackrate(animation,
                              previousAnimationCurrentTime,
                              previousTimelineCurrentTime,
                              description) {
-  const accuracy = 0.001; /* accuracy of DOMHighResTimeStamp */
   const animationCurrentTimeDifference =
     animation.currentTime - previousAnimationCurrentTime;
   const timelineCurrentTimeDifference =
     animation.timeline.currentTime - previousTimelineCurrentTime;
 
-  assert_approx_equals(animationCurrentTimeDifference,
-                       timelineCurrentTimeDifference * animation.playbackRate,
-                       accuracy,
-                       description);
+  assert_times_equal(animationCurrentTimeDifference,
+                     timelineCurrentTimeDifference * animation.playbackRate,
+                     description);
 }
 
 promise_test(t => {


### PR DESCRIPTION

MozReview-Commit-ID: CUn1f8M0jo5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1430654 [ci skip]

<!-- Reviewable:start -->

<!-- Reviewable:end -->
