### PR TITLE
Add missing untested IDL for MediaStream tests

### DIFF
--- a/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
+++ b/mediacapture-streams/MediaDevices-IDL-enumerateDevices.html
@@ -23,6 +23,8 @@
   function doIdlTest(idlText) {
     const MDI_idl = new IdlArray();
 
+    MDI_idl.add_untested_idls("interface Event {};");
+    MDI_idl.add_untested_idls("interface EventTarget {};");
     MDI_idl.add_untested_idls("interface Navigator {};");
     MDI_idl.add_idls(idlText);
 


### PR DESCRIPTION
The cryptic failures in https://github.com/w3c/web-platform-tests/issues/8112
are because of this. (That issue is about fixing the failure mode.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
