### PR TITLE
webdriver: update timeouts test to check new integer limit

### DIFF
--- a/webdriver/tests/sessions/new_session/support/create.py
+++ b/webdriver/tests/sessions/new_session/support/create.py
@@ -6,7 +6,7 @@ valid_data = [
     ("platformName", [None]),
     ("pageLoadStrategy", ["none", "eager", "normal", None]),
     ("proxy", [None]),
-    ("timeouts", [{"script": 0, "pageLoad": 2.0, "implicit": 2**64 - 1},
+    ("timeouts", [{"script": 0, "pageLoad": 2.0, "implicit": 2**53 - 1},
                   {"script": 50, "pageLoad": 25},
                   {"script": 500},
                   {}]),


### PR DESCRIPTION
The spec has changed to limit integers to maximum safe integer instead
of 2^64 - 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9198)
<!-- Reviewable:end -->
