### PR TITLE
interfaces: Remove arcTo() overload from html.idl's CanvasPath.

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -1330,7 +1330,6 @@ interface mixin CanvasPath {
   void quadraticCurveTo(unrestricted double cpx, unrestricted double cpy, unrestricted double x, unrestricted double y);
   void bezierCurveTo(unrestricted double cp1x, unrestricted double cp1y, unrestricted double cp2x, unrestricted double cp2y, unrestricted double x, unrestricted double y);
   void arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius);
-  void arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation);
   void rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
   void arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
   void ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);


### PR DESCRIPTION
It was removed in https://github.com/whatwg/html/pull/3371.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
