### PR TITLE
Run master commits on Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,687 @@
+allowPullRequests: collaborators
+tasks:
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-1, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 1 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-2, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 2 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-3, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 3 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-4, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 4 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-5, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 5 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-reftest-6, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome reftest 6 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-wdspec-1, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome wdspec 1 1"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-1, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 1 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-2, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 2 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-3, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 3 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-4, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 4 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-5, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 5 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-6, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 6 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-7, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 7 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-8, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 8 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-9, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 9 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-10, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 10 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-11, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 11 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-chrome-dev-testharness-12, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ chrome testharness 12 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-1, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 1 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-2, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 2 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-3, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 3 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-4, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 4 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-5, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 5 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-reftest-6, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox reftest 6 6"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-wdspec-1, owner: '{{ event.head.user.email
+      }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox wdspec 1 1"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-1, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 1 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-2, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 2 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-3, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 3 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-4, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 4 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-5, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 5 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-6, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 6 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-7, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 7 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-8, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 8 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-9, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 9 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-10, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 10 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-11, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 11 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+- extra:
+    github:
+      branches: [master]
+      events: [push]
+  metadata: {description: '', name: wpt-firefox-nightly-testharness-12, owner: '{{
+      event.head.user.email }}', source: '{{ event.head.repo.url }}'}
+  payload:
+    artifacts:
+      public/results: {path: /home/test/artifacts, type: directory}
+    command: [/bin/bash, --login, -c, ">-\n            ~/start.sh &&\n           \
+        \ cd /home/test/web-platform-tests &&\n            git fetch {{event.head.repo.url}}\
+        \ &&\n            git config advice.detachedHead false &&\n            git\
+        \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
+        \ firefox testharness 12 12"]
+    image: harjgam/web-platform-tests:0.5
+    maxRunTime: 5400
+  provisionerId: '{{ taskcluster.docker.provisionerId }}'
+  workerType: '{{ taskcluster.docker.workerType }}'
+version: 0

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,3 +1,5 @@
+# GENERATED FILE DO NOT EDIT
+# To regenerate this file run ./wpt make-tasks
 allowPullRequests: collaborators
 tasks:
 - extra:
@@ -14,7 +16,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 1 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -32,7 +34,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 2 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -50,7 +52,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 3 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -68,7 +70,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 4 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -86,7 +88,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 5 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -104,7 +106,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 6 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -122,7 +124,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome wdspec 1 1"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -140,7 +142,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 1 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -158,7 +160,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 2 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -176,7 +178,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 3 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -194,7 +196,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 4 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -212,7 +214,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 5 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -230,7 +232,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 6 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -248,7 +250,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 7 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -266,7 +268,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 8 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -284,7 +286,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 9 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -302,7 +304,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 10 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -320,7 +322,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 11 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -338,7 +340,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 12 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -356,7 +358,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 1 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -374,7 +376,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 2 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -392,7 +394,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 3 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -410,7 +412,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 4 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -428,7 +430,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 5 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -446,7 +448,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 6 6"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -464,7 +466,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox wdspec 1 1"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -482,7 +484,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 1 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -500,7 +502,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 2 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -518,7 +520,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 3 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -536,7 +538,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 4 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -554,7 +556,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 5 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -572,7 +574,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 6 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -590,7 +592,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 7 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -608,7 +610,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 8 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -626,7 +628,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 9 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -644,7 +646,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 10 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -662,7 +664,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 11 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'
@@ -680,7 +682,7 @@ tasks:
         \ &&\n            git config advice.detachedHead false &&\n            git\
         \ checkout {{event.head.sha}} &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 12 12"]
-    image: harjgam/web-platform-tests:0.5
+    image: harjgam/web-platform-tests:0.6
     maxRunTime: 5400
   provisionerId: '{{ taskcluster.docker.provisionerId }}'
   workerType: '{{ taskcluster.docker.workerType }}'

--- a/tools/ci/ci_taskcluster.sh
+++ b/tools/ci/ci_taskcluster.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ $1 == "firefox" ]; then
+    ./wpt run firefox --log-tbpl=- --log-tbpl-level=debug --log-wptreport=../artifacts/wpt_report.json --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y --install-browser --no-pause --no-restart-on-unexpected
+elif [ $1 == "chrome" ]; then
+    ./wpt run chrome --log-tbpl=- --log-tbpl-level=debug --log-wptreport=../artifacts/wpt_report.json --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected
+fi

--- a/tools/ci/commands.json
+++ b/tools/ci/commands.json
@@ -4,6 +4,6 @@
     "check-stability": {"path": "check_stability.py", "script": "run", "parser": "get_parser", "parse_known": true, "help": "Check test stability",
                         "virtualenv": true, "install": ["requests"], "requirements": ["../wptrunner/requirements.txt"]},
     "make-hosts-file": {"path": "make_hosts_file.py", "script": "run", "parser": "create_parser", "help": "Output a hosts file to stdout", "virtualenv": false},
-    "generate-tasks": {"path": "taskgraph.py", "script": "run", "parser": "get_parser", "parse_known": true, "help": "Generate taskcluster.yml file containing the run tasks",
+    "make-tasks": {"path": "taskgraph.py", "script": "run", "parser": "get_parser", "parse_known": true, "help": "Generate taskcluster.yml file containing the run tasks",
                         "virtualenv": true, "install": ["pyyaml"]}
 }

--- a/tools/ci/commands.json
+++ b/tools/ci/commands.json
@@ -3,5 +3,7 @@
                   "virtualenv": false},
     "check-stability": {"path": "check_stability.py", "script": "run", "parser": "get_parser", "parse_known": true, "help": "Check test stability",
                         "virtualenv": true, "install": ["requests"], "requirements": ["../wptrunner/requirements.txt"]},
-  "make-hosts-file": {"path": "make_hosts_file.py", "script": "run", "parser": "create_parser", "help": "Output a hosts file to stdout", "virtualenv": false}
+    "make-hosts-file": {"path": "make_hosts_file.py", "script": "run", "parser": "create_parser", "help": "Output a hosts file to stdout", "virtualenv": false},
+    "generate-tasks": {"path": "taskgraph.py", "script": "run", "parser": "get_parser", "parse_known": true, "help": "Generate taskcluster.yml file containing the run tasks",
+                        "virtualenv": true, "install": ["pyyaml"]}
 }

--- a/tools/ci/taskgraph.py
+++ b/tools/ci/taskgraph.py
@@ -1,0 +1,120 @@
+import argparse
+import copy
+import os
+import six
+
+import yaml
+
+
+here = os.path.dirname(__file__)
+wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
+
+
+task_template = {
+    "provisionerId": "{{ taskcluster.docker.provisionerId }}",
+    "workerType": "{{ taskcluster.docker.workerType }}",
+    "extra": {
+        "github": {
+            "events": ["push"],
+            "branches": ["master"],
+        },
+    },
+    "payload": {
+        "maxRunTime": 5400,
+        "image": "harjgam/web-platform-tests:0.5",
+        "command":[
+            "/bin/bash",
+            "--login",
+            "-c",
+            """>-
+            ~/start.sh &&
+            cd /home/test/web-platform-tests &&
+            git fetch {{event.head.repo.url}} &&
+            git config advice.detachedHead false &&
+            git checkout {{event.head.sha}} &&
+            %(command)s"""],
+        "artifacts": {
+            "public/results": {
+                "path": "/home/test/artifacts",
+                "type": "directory"
+            }
+        }
+    },
+    "metadata": {
+        "name": "wpt-%(browser_name)s-%(suite)s-%(chunk)s",
+        "description": "",
+        "owner": "{{ event.head.user.email }}",
+        "source": "{{ event.head.repo.url }}",
+    }
+}
+
+
+file_template = {
+    "version": 0,
+    "tasks": [],
+    "allowPullRequests": "collaborators"
+}
+
+suites = {
+    "testharness": {"chunks": 12},
+    "reftest": {"chunks": 6},
+    "wdspec": {"chunks": 1}
+}
+
+browsers = {
+    "firefox": {"name": "firefox-nightly"},
+    "chrome": {"name": "chrome-dev"}
+}
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dest",
+                        action="store",
+                        default=wpt_root,
+                        help="Directory to write the .taskcluster.yml file to")
+    return parser
+
+
+def fill(template, data):
+    rv = {}
+    for key, value in template.iteritems():
+        rv[key] = fill_inner(value, data)
+    return rv
+
+
+def fill_inner(value, data):
+    if isinstance(value, six.string_types):
+        return value % data
+    elif isinstance(value, dict):
+        return fill(value, data)
+    elif isinstance(value, list):
+        return [fill_inner(item, data) for item in value]
+    elif isinstance(value, (float,) + six.integer_types):
+        return value
+    else:
+        raise ValueError
+
+
+def run(venv, *args, **kwargs):
+    if not os.path.isdir(kwargs["dest"]):
+        raise ValueError("Invalid directory %s" % kwargs["dest"])
+
+    task_config = copy.deepcopy(file_template)
+    for browser, browser_props in browsers.iteritems():
+        for suite, suite_props in suites.iteritems():
+            total_chunks = suite_props.get("chunks", 1)
+            for chunk in six.moves.xrange(1, total_chunks + 1):
+                data = {
+                    "suite": suite,
+                    "chunk": chunk,
+                    "browser_name": browser_props["name"],
+                    "command": ("./tools/ci/ci_taskcluster.sh %s %s %s %s" %
+                                (browser, suite, chunk, total_chunks))
+                }
+
+                task_data = fill(task_template, data)
+                task_config["tasks"].append(task_data)
+
+    with open(os.path.join(kwargs["dest"], ".taskcluster.yml"), "w") as f:
+        yaml.dump(task_config, f)

--- a/tools/ci/taskgraph.py
+++ b/tools/ci/taskgraph.py
@@ -117,4 +117,7 @@ def run(venv, *args, **kwargs):
                 task_config["tasks"].append(task_data)
 
     with open(os.path.join(kwargs["dest"], ".taskcluster.yml"), "w") as f:
+        f.write("""# GENERATED FILE DO NOT EDIT
+# To regenerate this file run ./wpt make-tasks
+""")
         yaml.dump(task_config, f)

--- a/tools/ci/taskgraph.py
+++ b/tools/ci/taskgraph.py
@@ -21,7 +21,7 @@ task_template = {
     },
     "payload": {
         "maxRunTime": 5400,
-        "image": "harjgam/web-platform-tests:0.5",
+        "image": "harjgam/web-platform-tests:0.6",
         "command":[
             "/bin/bash",
             "--login",

--- a/tools/docker/.bashrc
+++ b/tools/docker/.bashrc
@@ -1,0 +1,4 @@
+function xvfb_start() {
+    GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
+    xvfb-run --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" $@
+}

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,76 @@
+FROM ubuntu:16.04
+
+# No interactive frontend during docker build
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true
+
+# General requirements not in the base image
+RUN apt-get -qqy update \
+  && apt-get -qqy install \
+    bzip2 \
+    ca-certificates \
+    dbus-x11 \
+    git \
+    locales \
+    pulseaudio \
+    python \
+    python-pip \
+    tzdata \
+    sudo \
+    unzip \
+    wget \
+    xvfb
+
+# Installing just the deps of firefox and chrome is moderately tricky, so
+# just install the default versions of them, and some extra deps we happen
+# to know that chrome requires
+
+RUN apt-get -qqy install \
+    firefox \
+    chromium-browser \
+    libnss3-tools \
+    fonts-liberation \
+    indicator-application \
+    libappindicator1 \
+    libappindicator3-1 \
+    libdbusmenu-gtk3-4 \
+    libindicator3-7 \
+    libindicator7
+
+RUN pip install --upgrade pip
+RUN pip install virtualenv
+
+ENV TZ "UTC"
+RUN echo "${TZ}" > /etc/timezone \
+  && dpkg-reconfigure --frontend noninteractive tzdata
+
+RUN useradd test \
+         --shell /bin/bash  \
+         --create-home \
+  && usermod -a -G sudo test \
+  && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
+  && echo 'test:secret' | chpasswd
+
+ENV SCREEN_WIDTH 1280
+ENV SCREEN_HEIGHT 1024
+ENV SCREEN_DEPTH 24
+ENV DISPLAY :99.0
+
+USER test
+
+WORKDIR /home/test
+
+COPY .bashrc /home/test/.bashrc
+
+COPY start.sh /home/test/start.sh
+
+# Remove information on how to use sudo on login
+RUN sudo echo ""
+
+RUN git clone --depth=1 https://github.com/w3c/web-platform-tests.git
+
+RUN mkdir -p /home/test/.fonts && \
+    cp web-platform-tests/fonts/Ahem.ttf ~/.fonts && \
+    fc-cache -f -v
+
+RUN mkdir -p /home/test/artifacts

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get -qqy update \
     bzip2 \
     ca-certificates \
     dbus-x11 \
+    gdebi \
     git \
     locales \
     pulseaudio \
@@ -27,7 +28,6 @@ RUN apt-get -qqy update \
 
 RUN apt-get -qqy install \
     firefox \
-    chromium-browser \
     libnss3-tools \
     fonts-liberation \
     indicator-application \

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+sudo sh -c 'echo "
+127.0.0.1	web-platform.test
+127.0.0.1	www.web-platform.test
+127.0.0.1	www1.web-platform.test
+127.0.0.1	www2.web-platform.test
+127.0.0.1	xn--n8j6ds53lwwkrqhv28a.web-platform.test
+127.0.0.1	xn--lve-6lad.web-platform.test
+0.0.0.0	nonexistent-origin.web-platform.test" >> /etc/hosts'
+
+cd web-platform-tests
+git pull --depth=1
+
+# Install Chome unstable
+deb_archive=google-chrome-unstable_current_amd64.deb
+wget https://dl.google.com/linux/direct/$deb_archive
+
+# Installation will fail in cases where the package has unmet dependencies.
+# When this occurs, attempt to use the system package manager to fetch the
+# required packages and retry.
+if ! sudo dpkg --install $deb_archive; then
+    sudo apt-get -y install --fix-broken
+    sudo dpkg --install $deb_archive
+fi
+
+sudo Xvfb $DISPLAY -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -1,27 +1,14 @@
 #!/bin/bash
 
-sudo sh -c 'echo "
-127.0.0.1	web-platform.test
-127.0.0.1	www.web-platform.test
-127.0.0.1	www1.web-platform.test
-127.0.0.1	www2.web-platform.test
-127.0.0.1	xn--n8j6ds53lwwkrqhv28a.web-platform.test
-127.0.0.1	xn--lve-6lad.web-platform.test
-0.0.0.0	nonexistent-origin.web-platform.test" >> /etc/hosts'
-
 cd web-platform-tests
 git pull --depth=1
 
-# Install Chome unstable
+sudo sh -c './wpt make-hosts-file >> /etc/hosts'
+
+# Install Chome dev
 deb_archive=google-chrome-unstable_current_amd64.deb
 wget https://dl.google.com/linux/direct/$deb_archive
 
-# Installation will fail in cases where the package has unmet dependencies.
-# When this occurs, attempt to use the system package manager to fetch the
-# required packages and retry.
-if ! sudo dpkg --install $deb_archive; then
-    sudo apt-get -y install --fix-broken
-    sudo dpkg --install $deb_archive
-fi
+sudo gdebi -n $deb_archive
 
 sudo Xvfb $DISPLAY -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -457,7 +457,8 @@ def run(venv, **kwargs):
 
 def run_single(venv, **kwargs):
     from wptrunner import wptrunner
-    return wptrunner.start(**kwargs)
+    wptrunner.start(**kwargs)
+    return
 
 
 def main():


### PR DESCRIPTION
This PR actually has two parts:

1. A docker image for running tests. I assume this will be relatively uncontroversial, although there are certainly ways that we could improve the details.
2. The required configuration to run each push on master on TaskCluster. This won't do anything unless the relevant GitHub integration is enabled. If it is, however, it will typically provide the full results of the testsuite within about an hour of a merge to master. You can see an [example](https://tools.taskcluster.net/groups/bLpNdT49RGCR7nEhELQE1A) run from my fork. Each job uploads an artifact containing the results from that chunk in `wptreport.json` format; these could be combined to give the full set of results for each push.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9226)
<!-- Reviewable:end -->
