### PR TITLE
Use document.scrollingElement for browsing-the-web/scroll-to-fragid/003.html

### DIFF
--- a/html/browsers/browsing-the-web/scroll-to-fragid/003.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/003.html
@@ -10,14 +10,14 @@
 <div id="test1">scroll 2</div>
 <script>
 test(function() {
-  assert_equals(document.body.scrollTop, 0);
+  assert_equals(document.scrollingElement.scrollTop, 0);
   location.hash = "test";
 
-  var scroll1 = document.body.scrollTop;
+  var scroll1 = document.scrollingElement.scrollTop;
   assert_true(scroll1 > 0);
 
   location.hash = "test1";
-  var scroll2 = document.body.scrollTop;
+  var scroll2 = document.scrollingElement.scrollTop;
   assert_true(scroll2 > scroll1);
 
   location.hash = ""


### PR DESCRIPTION
browsing-the-web/scroll-to-fragid/003.html uses document.body in standard mode
to handle scrolling of the viewport while the CSSOMView specification says it
should use document.documentElement. This makes the test fails in all web
engines but WebKit due to [1]. This commit replace such instances by
document.scrollingElement so that the test works in any mode or web engine.
This closes issue #6289.

[1] https://bugs.webkit.org/show_bug.cgi?id=5991

<!-- Reviewable:start -->

<!-- Reviewable:end -->
