### PR TITLE
Don't strictly enforce a particular FetchEvent.clientId for navigatio…

### DIFF
--- a/service-workers/service-worker/resources/clients-get-worker.js
+++ b/service-workers/service-worker/resources/clients-get-worker.js
@@ -4,12 +4,10 @@
 // the `event` object. In the case of the `onmessage` handler, it provides the
 // Client instance attributes of the requested clients.
 self.onfetch = function(e) {
-  if (e.request.mode === 'navigate' && e.clientId !== "") {
-    e.respondWith(Response.error(
-      '`clientId` incorrectly set to non-empty string for request with mode `navigate`'
-    ));
-    return;
-  }
+  // NOTE: Until FetchEvent.resultingClientId is implemented some browsers
+  // return null for the FetchEvent.clientId on navigation requests.  Since
+  // this is not in the spec yet, though, we don't strictly enforce it in the
+  // test any more.
 
   if (/\/clientId$/.test(e.request.url)) {
     e.respondWith(new Response(e.clientId));

--- a/service-workers/service-worker/resources/clients-get-worker.js
+++ b/service-workers/service-worker/resources/clients-get-worker.js
@@ -4,11 +4,6 @@
 // the `event` object. In the case of the `onmessage` handler, it provides the
 // Client instance attributes of the requested clients.
 self.onfetch = function(e) {
-  // NOTE: Until FetchEvent.resultingClientId is implemented some browsers
-  // return null for the FetchEvent.clientId on navigation requests.  Since
-  // this is not in the spec yet, though, we don't strictly enforce it in the
-  // test any more.
-
   if (/\/clientId$/.test(e.request.url)) {
     e.respondWith(new Response(e.clientId));
     return;


### PR DESCRIPTION
…n requests.  (w3c/ServiceWorker#1266)

Note, `FetchEvent.clientId` is also covered by fetch-event.https.html, so we don't need this coverage here.  Since this part of the spec is changing and a bit confused at the moment here it would be nice to let these tests verify their other parts without this check for now.  Also, the tests are not well written and currently timeout if this check fails.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
