### PR TITLE
Fix markup in graphics-aam tests; handle MediaWiki quirk in make_tests.pl

### DIFF
--- a/graphics-aam/graphics-document_on_html_element-manual.html
+++ b/graphics-aam/graphics-document_on_html_element-manual.html
@@ -93,7 +93,7 @@
   <body>
   <p>This test examines the ARIA properties for graphics-document on HTML element.</p>
     <div id="test" role="graphics-document" aria-label="house">
-    <div role="graphics-object" aria-label="door">
+    <div role="graphics-object" aria-label="door"></div>
   </div>
 
   <div id="manualMode"></div>

--- a/graphics-aam/graphics-object_on_html_element-manual.html
+++ b/graphics-aam/graphics-object_on_html_element-manual.html
@@ -87,7 +87,7 @@
   <body>
   <p>This test examines the ARIA properties for graphics-object on HTML element.</p>
     <div role="graphics-document" aria-label="house">
-    <div id="test" role="graphics-object" aria-label="door">
+    <div id="test" role="graphics-object" aria-label="door"></div>
   </div>
 
   <div id="manualMode"></div>

--- a/graphics-aam/graphics-symbol_on_html_element-manual.html
+++ b/graphics-aam/graphics-symbol_on_html_element-manual.html
@@ -86,7 +86,7 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for graphics-symbol on HTML element.</p>
-    <div>Spinach Salad with Strawberry & Almonds
+    <div>Spinach Salad with Strawberry &amp; Almonds
     <span id="test" aria-label="vegetarian" role="graphics-symbol">🌿</span>
     <span aria-label="contains nuts" role="graphics-symbol">🌰</span>
   </div>

--- a/wai-aria/tools/make_tests.pl
+++ b/wai-aria/tools/make_tests.pl
@@ -230,6 +230,9 @@ while (<$io>) {
         $theCode =~ s/ +$//;
         $theCode =~ s/\t/ /g;
         $theCode .= $_;
+        # In MediaWiki, to display & symbol escapes as literal text, one
+        # must use "&amp;&" for the "&" character. We need to undo that.
+        $theCode =~ s/&amp;(\S)/&$1/g;
       }
     }
   } elsif ($state == 3) {


### PR DESCRIPTION
* Add a couple of missing closing tags
* Fix character entity

Because MediaWiki requires one use "&amp;&" to display & symbol escapes
as literal text, we need to handle that in wai-aria's make_tests.pl.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
