### PR TITLE
Remove disabled attribute from Element Clear test.

### DIFF
--- a/webdriver/tests/interaction/element_clear.py
+++ b/webdriver/tests/interaction/element_clear.py
@@ -190,7 +190,7 @@ def test_input_file_multiple(session, text_file):
 
 def test_select(session):
     session.url = inline("""
-        <select disabled>
+        <select>
           <option>foo
         </select>
         """)


### PR DESCRIPTION

<select> is not a mutable form control element and it should not
be possible to call the WebDriver:ElementClear command on it.
We test this in test_select as part of element_clear.py in WPT,
but the test uses a <select disabled> element which triggers the
wrong code path in Marionette.

MozReview-Commit-ID: 4ybEdLY6OEo

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1432804 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9263)
<!-- Reviewable:end -->
