### PR TITLE
Fire DOM change event on WebDriver:ElementClear.

### DIFF
--- a/webdriver/tests/interaction/element_clear.py
+++ b/webdriver/tests/interaction/element_clear.py
@@ -4,6 +4,20 @@ from tests.support.asserts import assert_error, assert_success
 from tests.support.inline import inline
 
 
+def add_event_listeners(element):
+    element.session.execute_script("""
+        let [target] = arguments;
+        window.events = [];
+        for (let expected of ["focus", "blur", "change"]) {
+          target.addEventListener(expected, ({type}) => window.events.push(type));
+        }
+        """, args=(element,))
+
+
+def get_events(session):
+    return session.execute_script("return window.events")
+
+
 @pytest.fixture(scope="session")
 def text_file(tmpdir_factory):
     fh = tmpdir_factory.mktemp("tmp").join("hello.txt")
@@ -84,11 +98,16 @@ def test_keyboard_interactable(session):
 def test_input(session, type, value, default):
     session.url = inline("<input type=%s value='%s'>" % (type, value))
     element = session.find.css("input", all=False)
+    add_event_listeners(element)
     assert element.property("value") == value
 
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("value") == default
+    events = get_events(session)
+    assert "focus" in events
+    assert "change" in events
+    assert "blur" in events
 
 
 @pytest.mark.parametrize("type",
@@ -144,11 +163,16 @@ def test_input_readonly(session, type):
 def test_textarea(session):
     session.url = inline("<textarea>foobar</textarea>")
     element = session.find.css("textarea", all=False)
+    add_event_listeners(element)
     assert element.property("value") == "foobar"
 
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("value") == ""
+    events = get_events(session)
+    assert "focus" in events
+    assert "change" in events
+    assert "blur" in events
 
 
 def test_textarea_disabled(session):
@@ -231,32 +255,14 @@ def test_button_with_subtree(session):
 def test_contenteditable(session):
     session.url = inline("<p contenteditable>foobar</p>")
     element = session.find.css("p", all=False)
+    add_event_listeners(element)
     assert element.property("innerHTML") == "foobar"
 
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("innerHTML") == ""
+    assert get_events(session) == ["focus", "change", "blur"]
 
-
-def test_contenteditable_focus(session):
-    session.url = inline("""
-        <p contenteditable>foobar</p>
-
-        <script>
-        window.events = [];
-        let p = document.querySelector("p");
-        for (let ev of ["focus", "blur"]) {
-          p.addEventListener(ev, ({type}) => window.events.push(type));
-        }
-        </script>
-        """)
-    element = session.find.css("p", all=False)
-    assert element.property("innerHTML") == "foobar"
-
-    response = element_clear(session, element)
-    assert_success(response)
-    assert element.property("innerHTML") == ""
-    assert session.execute_script("return window.events") == ["focus", "blur"]
 
 
 def test_designmode(session):
@@ -270,46 +276,16 @@ def test_designmode(session):
     assert element.property("innerHTML") == "<br>"
 
 
-def test_resettable_element_focus(session):
-    session.url = inline("""
-        <input value="foobar">
-
-        <script>
-        window.events = [];
-        let input = document.querySelector("input");
-        for (let ev of ["focus", "blur"]) {
-          input.addEventListener(ev, ({type}) => window.events.push(type));
-        }
-        </script>
-        """)
-    element = session.find.css("input", all=False)
-    assert element.property("value") == "foobar"
-
-    response = element_clear(session, element)
-    assert_success(response)
-    assert element.property("value") == ""
-    assert session.execute_script("return window.events") == ["focus", "blur"]
-
-
 def test_resettable_element_focus_when_empty(session):
-    session.url = inline("""
-        <input>
-
-        <script>
-        window.events = [];
-        let p = document.querySelector("input");
-        for (let ev of ["focus", "blur"]) {
-          p.addEventListener(ev, ({type}) => window.events.push(type));
-        }
-        </script>
-        """)
+    session.url = inline("<input>")
     element = session.find.css("input", all=False)
+    add_event_listeners(element)
     assert element.property("value") == ""
 
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("value") == ""
-    assert session.execute_script("return window.events") == []
+    assert get_events(session) == []
 
 
 @pytest.mark.parametrize("type,invalid_value",


### PR DESCRIPTION

When clearing an element using the WebDriver Element Clear command,
the DOM change event should be fired.

MozReview-Commit-ID: 94iG8bsRe4S

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1430571 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9264)
<!-- Reviewable:end -->
