### PR TITLE
Run native focussing steps on interaction commands.

### DIFF
--- a/webdriver/tests/interaction/element_clear.py
+++ b/webdriver/tests/interaction/element_clear.py
@@ -1,6 +1,10 @@
 import pytest
 
-from tests.support.asserts import assert_error, assert_success
+from tests.support.asserts import (
+    assert_element_has_focus,
+    assert_error,
+    assert_success,
+)
 from tests.support.inline import inline
 
 
@@ -108,6 +112,7 @@ def test_input(session, type, value, default):
     assert "focus" in events
     assert "change" in events
     assert "blur" in events
+    assert_element_has_focus(session.execute_script("return document.body"))
 
 
 @pytest.mark.parametrize("type",
@@ -262,6 +267,7 @@ def test_contenteditable(session):
     assert_success(response)
     assert element.property("innerHTML") == ""
     assert get_events(session) == ["focus", "change", "blur"]
+    assert_element_has_focus(session.execute_script("return document.body"))
 
 
 
@@ -274,6 +280,7 @@ def test_designmode(session):
     response = element_clear(session, element)
     assert_success(response)
     assert element.property("innerHTML") == "<br>"
+    assert_element_has_focus(session.execute_script("return document.body"))
 
 
 def test_resettable_element_focus_when_empty(session):

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -137,3 +137,14 @@ def assert_same_element(session, a, b):
         pass
 
     raise AssertionError(message)
+
+
+def assert_element_has_focus(target_element):
+    session = target_element.session
+
+    active_element = session.execute_script("return document.activeElement")
+    active_tag = active_element.property("localName")
+    target_tag = target_element.property("localName")
+
+    assert active_element == target_element, (
+        "Focussed element is <%s>, not <%s>" % (active_tag, target_tag))


### PR DESCRIPTION

Instead of generating custom focus events when interacting with elements,
we can run the HTMLElement.focus() function will do the correct thing.

Before this patch we only simulated focus events, whereas this
patch will actually focus the element.

MozReview-Commit-ID: IoBV2ngqOA5

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1432864 [ci skip]