### PR TITLE
Unfocussing steps will target <body> element.

### DIFF
--- a/webdriver/tests/element_send_keys/interactability.py
+++ b/webdriver/tests/element_send_keys/interactability.py
@@ -46,7 +46,7 @@ def test_document_element_is_interactable(session):
 
     response = send_keys_to_element(session, element, "foo")
     assert_success(response)
-    assert_same_element(session, element, session.active_element)
+    assert_same_element(session, body, session.active_element)
     assert result.property("value") == "foo"
 
 
@@ -65,7 +65,7 @@ def test_iframe_is_interactable(session):
 
     response = send_keys_to_element(session, frame, "foo")
     assert_success(response)
-    assert_same_element(session, frame, session.active_element)
+    assert_same_element(session, body, session.active_element)
 
     # Any key events are immediately routed to the nested
     # browsing context's active document.


### PR DESCRIPTION

The WebDriver Element Send Keys command is meant to run the HTML
unfocussing steps after clearing the element.  When HTMLElement.blur()
is called on the root document element (<html>) it is the <body>
that is in focus when the unfocussing steps have run.

The same applies in the case of typing into an <iframe> element.
The controlling element of the <iframe> is the <body>, as this is
the element ath will receive focus should you blur the frame.

MozReview-Commit-ID: 19Ox3W9CF8O

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1432864 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9268)
<!-- Reviewable:end -->
