### PR TITLE
Prefix lines containing disabled tests with 'disabled: ' during wpt metadata update,

### DIFF
--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -65,9 +65,9 @@ def update_expected(test_paths, serve_root, log_file_names,
                 for test in tree.iterchildren():
                     for subtest in test.iterchildren():
                         if subtest.new_disabled:
-                            print os.path.dirname(subtest.root.test_path) + "/" + subtest.name
+                            print "disabled: %s" % os.path.dirname(subtest.root.test_path) + "/" + subtest.name
                     if test.new_disabled:
-                        print test.root.test_path
+                        print "disabled: %s" % test.root.test_path
 
     results_changed = [item.test_path for item in expected_map.itervalues() if item.modified]
 


### PR DESCRIPTION

MozReview-Commit-ID: 1ZIORpl0XZH

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433457 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9271)
<!-- Reviewable:end -->
