### PR TITLE
Move all assert helps into support.asserts.

### DIFF
--- a/webdriver/tests/actions/mouse.py
+++ b/webdriver/tests/actions/mouse.py
@@ -1,7 +1,8 @@
 import pytest
 
-from tests.actions.support.mouse import assert_move_to_coordinates, get_center
+from tests.actions.support.mouse import get_center
 from tests.actions.support.refine import get_events, filter_dict
+from tests.support.asserts import assert_move_to_coordinates
 from tests.support.inline import inline
 from tests.support.wait import wait
 

--- a/webdriver/tests/actions/mouse_dblclick.py
+++ b/webdriver/tests/actions/mouse_dblclick.py
@@ -1,7 +1,8 @@
 import pytest
 
-from tests.actions.support.mouse import assert_move_to_coordinates, get_center
+from tests.actions.support.mouse import get_center
 from tests.actions.support.refine import get_events, filter_dict
+from tests.support.asserts import assert_move_to_coordinates
 
 
 _DBLCLICK_INTERVAL = 640

--- a/webdriver/tests/actions/support/mouse.py
+++ b/webdriver/tests/actions/support/mouse.py
@@ -1,11 +1,3 @@
-def assert_move_to_coordinates(point, target, events):
-    for e in events:
-        if e["type"] != "mousemove":
-            assert e["pageX"] == point["x"]
-            assert e["pageY"] == point["y"]
-            assert e["target"] == target
-
-
 def get_center(rect):
     return {
         "x": rect["width"] / 2 + rect["x"],

--- a/webdriver/tests/support/asserts.py
+++ b/webdriver/tests/support/asserts.py
@@ -148,3 +148,11 @@ def assert_element_has_focus(target_element):
 
     assert active_element == target_element, (
         "Focussed element is <%s>, not <%s>" % (active_tag, target_tag))
+
+
+def assert_move_to_coordinates(point, target, events):
+    for e in events:
+        if e["type"] != "mousemove":
+            assert e["pageX"] == point["x"]
+            assert e["pageY"] == point["y"]
+            assert e["target"] == target


### PR DESCRIPTION

For a better management of assertion helpers those should be
added to the central assertion helper module.

MozReview-Commit-ID: DYMfOFl9Fjd

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433390 [ci skip]