### PR TITLE
Use register_assert_rewrite to enable introspection in assertion helper.

### DIFF
--- a/webdriver/tests/__init__.py
+++ b/webdriver/tests/__init__.py
@@ -1,0 +1,4 @@
+import pytest
+
+# Enable pytest assert introspection for assertion helper
+pytest.register_assert_rewrite('tests.support.asserts')


### PR DESCRIPTION

Pytest by default only loads test modules, and enables assert
introspection for them. For any helper method which also uses
asserts, only a plain assertion is printed.

To enable introspection also for the assertion helper, the
module has to be registered for assertion rewrite.

MozReview-Commit-ID: 97JzuykXxWE

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433390 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9273)
<!-- Reviewable:end -->
