### PR TITLE
Show full pytest failure logs.

### DIFF
--- a/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
+++ b/tools/wptrunner/wptrunner/executors/pytestrunner/runner.py
@@ -52,7 +52,7 @@ def run(path, server_config, session_config, timeout=0):
     with TemporaryDirectory() as cache:
         try:
             pytest.main(["--strict",  # turn warnings into errors
-                         "--verbose",  # show each individual subtest
+                         "-vv",  # show each individual subtest and full failure logs
                          "--capture", "no",  # enable stdout/stderr from tests
                          "--basetemp", cache,  # temporary directory
                          "--showlocals",  # display contents of variables in local scope


### PR DESCRIPTION

pytest truncates long lists when printing a failed assertion.
This is not great for debugging and arguably it should be the
default to show the full diff when comparing lists.

MozReview-Commit-ID: L8vxIMM9g6m

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433422 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9275)
<!-- Reviewable:end -->
