### PR TITLE
Fix interaction.moveCaretToEnd element conditions.

### DIFF
--- a/webdriver/tests/element_send_keys/form_controls.py
+++ b/webdriver/tests/element_send_keys/form_controls.py
@@ -1,0 +1,36 @@
+from tests.support.asserts import assert_error, assert_same_element, assert_success
+from tests.support.inline import inline
+
+
+def element_send_keys(session, element, text):
+    return session.transport.send(
+        "POST",
+        "/session/{session_id}/element/{element_id}/value".format(
+            session_id=session.session_id,
+            element_id=element.id),
+        {"text": text})
+
+
+
+def test_input_append(session):
+    session.url = inline("<input value=a>")
+    element = session.find.css("input", all=False)
+    assert element.property("value") == "a"
+
+    element_send_keys(session, element, "b")
+    assert element.property("value") == "ab"
+
+    element_send_keys(session, element, "c")
+    assert element.property("value") == "abc"
+
+
+def test_textarea_append(session):
+    session.url = inline("<textarea>a</textarea>")
+    element = session.find.css("textarea", all=False)
+    assert element.property("value") == "a"
+
+    element_send_keys(session, element, "b")
+    assert element.property("value") == "ab"
+
+    element_send_keys(session, element, "c")
+    assert element.property("value") == "abc"


### PR DESCRIPTION

Bug 1432864 introduced a regression where the element conditions
for moving the caret to the end of the textual input were wrong.
Apparently if conditions are hard.

MozReview-Commit-ID: KlRv6sCroXW

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433422 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9276)
<!-- Reviewable:end -->
