### PR TITLE
Add basic form control tests for Element Send Keys.

### DIFF
--- a/webdriver/tests/element_send_keys/form_controls.py
+++ b/webdriver/tests/element_send_keys/form_controls.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.support.asserts import assert_error, assert_same_element, assert_success
 from tests.support.inline import inline
 
@@ -10,6 +12,37 @@ def element_send_keys(session, element, text):
             element_id=element.id),
         {"text": text})
 
+
+def add_event_listeners(element):
+    element.session.execute_script("""
+        let [target] = arguments;
+        window.events = [];
+        for (let expected of ["focus", "blur", "change", "keypress", "keydown", "keyup", "input"]) {
+          target.addEventListener(expected, ({type}) => window.events.push(type));
+        }
+        """, args=(element,))
+
+
+def get_events(session):
+    return session.execute_script("return window.events")
+
+
+def test_input(session):
+    session.url = inline("<input>")
+    element = session.find.css("input", all=False)
+    assert element.property("value") == ""
+
+    element_send_keys(session, element, "foo")
+    assert element.property("value") == "foo"
+
+
+def test_textarea(session):
+    session.url = inline("<textarea>")
+    element = session.find.css("textarea", all=False)
+    assert element.property("value") == ""
+
+    element_send_keys(session, element, "foo")
+    assert element.property("value") == "foo"
 
 
 def test_input_append(session):
@@ -34,3 +67,28 @@ def test_textarea_append(session):
 
     element_send_keys(session, element, "c")
     assert element.property("value") == "abc"
+
+
+@pytest.mark.parametrize("tag", ["input", "textarea"])
+def test_events(session, tag):
+    session.url = inline("<%s>" % tag)
+    element = session.find.css(tag, all=False)
+    add_event_listeners(element)
+
+    element_send_keys(session, element, "foo")
+    assert element.property("value") == "foo"
+    assert get_events(session) == ["focus",
+                                   "keydown",
+                                   "keypress",
+                                   "input",
+                                   "keyup",
+                                   "keydown",
+                                   "keypress",
+                                   "input",
+                                   "keyup",
+                                   "keydown",
+                                   "keypress",
+                                   "input",
+                                   "keyup",
+                                   "change",
+                                   "blur"]


### PR DESCRIPTION

We are apparently missing even the most basic tests for Element
Send Keys.  This is a moderate contribution.

MozReview-Commit-ID: 9uWtTJ7MFZx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433422 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9277)
<!-- Reviewable:end -->
