### PR TITLE
Fix a bunch of typo in the doc

### DIFF
--- a/tools/wptrunner/README.rst
+++ b/tools/wptrunner/README.rst
@@ -197,7 +197,7 @@ language e.g.::
 
   if debug and (platform == "linux" or platform == "osx"): FAIL
 
-For test expectations the avaliable variables are those in the
+For test expectations the available variables are those in the
 `run_info` which for desktop are `version`, `os`, `bits`, `processor`,
 `debug` and `product`.
 


### PR DESCRIPTION

MozReview-Commit-ID: LRgL0CMJdDP

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433417 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9279)
<!-- Reviewable:end -->
