### PR TITLE
Align the .body setter with the spec a bit better.

### DIFF
--- a/html/dom/documents/dom-tree-accessors/Document.body.html
+++ b/html/dom/documents/dom-tree-accessors/Document.body.html
@@ -166,4 +166,54 @@ test(function() {
   doc.body = new_frameset;
   assert_equals(doc.body, new_frameset, "test6-3, append frameset to a new document");
 }, "Setting document.body to a new frameset element.");
+
+test(function() {
+  var doc = createDocument();
+  var html = doc.appendChild(doc.createElement("html"));
+  var f =
+    html.appendChild(doc.createElement("frameset"));
+  assert_equals(doc.body, f);
+
+  var b = doc.createElement("body");
+  doc.body = b;
+
+  assert_equals(f.parentNode, null,
+                "Frameset should have been removed from the tree");
+  assert_equals(doc.body, b, "Body should be the new doc.body");
+}, "Setting document.body to a body will replace an existing frameset if there is one.");
+
+test(function() {
+  var doc = createDocument();
+  var html = doc.appendChild(doc.createElement("html"));
+  var b =
+    html.appendChild(doc.createElement("body"));
+  assert_equals(doc.body, b);
+
+  var f = doc.createElement("frameset");
+  doc.body = f;
+
+  assert_equals(b.parentNode, null,
+                "Body should have been removed from the tree");
+  assert_equals(doc.body, f, "Frameset should be the new doc.body");
+}, "Setting document.body to a frameset will replace an existing body if there is one.");
+
+test(function() {
+  var doc = createDocument();
+  var html = doc.appendChild(doc.createElement("html"));
+  var b =
+    html.appendChild(doc.createElement("body"));
+  var f1 = html.appendChild(doc.createElement("frameset"));
+  assert_equals(doc.body, b);
+
+  var f2 = doc.createElement("frameset");
+  doc.body = f2;
+
+  assert_equals(b.parentNode, null,
+                "Body should have been removed from the tree");
+  assert_equals(f1.parentNode, html,
+                "Frameset following body should still be in the tree.");
+  assert_equals(doc.body, f2, "New frameset should be the new doc.body");
+  assert_equals(f2.nextSibling, f1, "New frameset should have replaced the body");
+}, "Setting document.body to a frameset will replace the first existing body/frameset.");
+
 </script>


### PR DESCRIPTION

There are two changes here:

1) We allow setting .body even if the root element is not an <html:html>.  This
is what the spec says to do, and what we used to do before the changes in bug
366200.  No tests for this yet, pending
https://github.com/whatwg/html/issues/3403 getting resolved.

2) We use GetBody(), not GetBodyElement(), to look for an existing thing to
replace.  This matters if there are <frameset>s involved.

MozReview-Commit-ID: JCaQGHKgzE7

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1276438 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9282)
<!-- Reviewable:end -->
