### PR TITLE
Move the .body getter from HTMLDocument to Document.

### DIFF
--- a/xhr/responsexml-document-properties.htm
+++ b/xhr/responsexml-document-properties.htm
@@ -24,7 +24,7 @@
         readyState:'complete',
         location:null,
         defaultView:null,
-        body:undefined,
+        body:null,
         images: undefined,
         doctype:null,
         forms:undefined,


### PR DESCRIPTION

The "body" part of responsexml-document-properties.htm is not really per current
spec text, and fails in every non-Firefox browser, and in Firefox after this
change.  https://github.com/w3c/web-platform-tests/issues/2668 tracks this issue
to some extent, but if all browsers are going to align here anyway, we should
just adjust the test and move on.

MozReview-Commit-ID: HTLfggvi5LL

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1276438 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9283)
<!-- Reviewable:end -->
