### PR TITLE
Ensure that resource_initiator_types test is only run once,

### DIFF
--- a/resource-timing/resource_initiator_types.html
+++ b/resource-timing/resource_initiator_types.html
@@ -17,6 +17,7 @@ let page_loaded = false;
 let ol_font_loaded = false;
 let ul_font_loaded = false;
 let xhr_loaded = false;
+let tests_run = false;
 
 function check_finished() {
     if (!ul_font_loaded) {
@@ -64,6 +65,10 @@ function onload_test() {
 }
 
 function perform_test() {
+    if (tests_run) {
+        return;
+    }
+    tests_run = true;
     const context = new PerformanceContext(document.getElementById('frameContext').contentWindow.performance);
     const entries = context.getEntriesByType('resource');
 


### PR DESCRIPTION

It's not obvious to me how this can run more than once, but it seems there's a
race condition; this is intended to bandaid that

MozReview-Commit-ID: LWAW6xEaJ5w

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1433618 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9285)
<!-- Reviewable:end -->
