### PR TITLE
Update move-to-fullscreen-iframe-manual.html to match the spec

### DIFF
--- a/fullscreen/model/move-to-fullscreen-iframe-manual.html
+++ b/fullscreen/model/move-to-fullscreen-iframe-manual.html
@@ -12,6 +12,8 @@ async_test(t => {
   // Enter fullscreen for the iframe's body element.
   trusted_request(t, iframeDoc.body, document.body);
   document.onfullscreenchange = t.step_func(() => {
+    assert_equals(document.fullscreenElement, iframe, "document's initial fullscreen element");
+    assert_equals(iframeDoc.fullscreenElement, iframeDoc.body, "iframe's initial fullscreen element");
 
     // Then, move the outer document's body into the iframe. This is an unusual
     // thing to do, but means that the iframe is removed from its document and
@@ -20,7 +22,7 @@ async_test(t => {
 
     // If we exit in an orderly fashion, that's all one can ask for.
     document.onfullscreenchange = t.step_func_done(() => {
-      assert_equals(document.fullscreenElement, null, "document's fullscreen element");
+      assert_equals(document.fullscreenElement, null, "document's final fullscreen element");
 
       // Because the iframe was removed, its browsing context was discarded and
       // its contentDocument has become null. Because that browsing context was
@@ -28,7 +30,7 @@ async_test(t => {
       // nothing at all was done with it in the exit fullscreen algorithm, so
       // its fullscreenElement is unchanged.
       assert_equals(iframe.contentDocument, null, "iframe's content document");
-      assert_equals(iframeDoc.fullscreenElement, iframeDoc.body, "iframe's fullscreen element");
+      assert_equals(iframeDoc.fullscreenElement, iframeDoc.body, "iframe's final fullscreen element");
     });
   });
 });

--- a/fullscreen/model/move-to-fullscreen-iframe-manual.html
+++ b/fullscreen/model/move-to-fullscreen-iframe-manual.html
@@ -22,10 +22,13 @@ async_test(t => {
     document.onfullscreenchange = t.step_func_done(() => {
       assert_equals(document.fullscreenElement, null, "document's fullscreen element");
 
-      // the iframe's contentDocument has become undefined, but the reference
-      // we're holding on to should not have a fullscreen element either.
-      assert_equals(iframe.contentDocuemnt, undefined, "iframe's content document");
-      assert_equals(iframeDoc.fullscreenElement, null, "iframe's fullscreen element");
+      // Because the iframe was removed, its browsing context was discarded and
+      // its contentDocument has become null. Because that browsing context was
+      // neither a descendant browsing context nor had an active document,
+      // nothing at all was done with it in the exit fullscreen algorithm, so
+      // its fullscreenElement is unchanged.
+      assert_equals(iframe.contentDocument, null, "iframe's content document");
+      assert_equals(iframeDoc.fullscreenElement, iframeDoc.body, "iframe's fullscreen element");
     });
   });
 });


### PR DESCRIPTION
This test is from https://chromium-review.googlesource.com/776599 and
the explanation seemed to make sense spec-wise. But when matching the
spec more closely this begins to fail, and it seems that per spec
this updated behavior is what would happen.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
