### PR TITLE
Test that resources fetched by cross-origin CSS are not in the timeline

### DIFF
--- a/fonts/Ahem.ttf.headers
+++ b/fonts/Ahem.ttf.headers
@@ -1,0 +1,1 @@
+Access-Control-Allow-Origin: *

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<meta charset=utf-8>
+<title>Make sure that resources fetched by cross origin CSS are not in the timeline.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<link rel=stylesheet id=cross_origin_style href="//{{domains[www1]}}:{{ports[http][1]}}{{location[path]}}/../resources/nested.css">
+<script>
+<<<<<<< HEAD
+<<<<<<< HEAD
+  let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
+  window.onload = function() {
+    // A timeout is needed as PerformanceObserver is not guaranteed to run before onload triggered.
+    t.step_timeout(function() {
+          let url = (new URL(document.getElementById("cross_origin_style").href));
+          let prefix = url.protocol + "//" + url.host;
+          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/resource_timing_test0.css?id=n1").length, 0, "Import is in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font is in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image is in timeline");
+<<<<<<< HEAD
+=======
+=======
+  let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
+>>>>>>> 36672595d0... Resolved lint complaints
+  window.onload = function() {
+    // A timeout is needed as PerformanceObserver is not guaranteed to run before onload triggered.
+    t.step_timeout(function() {
+          let url = (new URL(document.getElementById("cross_origin_style").href));
+          let prefix = url.protocol + "//" + url.host;
+          assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font is in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image is in timeline");
+<<<<<<< HEAD
+      }, "Make sure that CSS subresources are not included");
+>>>>>>> 3c0ba54dd2... Test that resources fetched by cross-origin CSS do not appear in the timeline
+=======
+>>>>>>> 36672595d0... Resolved lint complaints
+=======
+          t.done();
+>>>>>>> f1012e750d... Rebase and add import
+    },0)
+  };
+</script>
+<ol>Some content</ol>
+</body>
+

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -7,18 +7,18 @@
 <!-- The stylesheet is fetched from http://www1.web–platform.test:64941/resource-timing/resources/nested.css -->
 <link rel=stylesheet id=cross_origin_style href="//{{domains[www1]}}:{{ports[http][1]}}{{location[path]}}/../resources/nested.css">
 <script>
-  let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
-  window.onload = function() {
-    // A timeout is needed as PerformanceObserver is not guaranteed to run before onload triggered.
+  const t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
+  window.addEventListener("load", function() {
+    // A timeout is needed as entries are not guaranteed to be in the timeline before onload triggers.
     t.step_timeout(function() {
-          let url = (new URL(document.getElementById("cross_origin_style").href));
-          let prefix = url.protocol + "//" + url.host;
+          const url = (new URL(document.getElementById("cross_origin_style").href));
+          const prefix = url.protocol + "//" + url.host;
           assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/resource_timing_test0.css?id=n1").length, 0, "Import should not be in timeline");
           assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font should not be in timeline");
           assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image should not be in timeline");
           t.done();
     },0);
-  };
+  });
 </script>
 <ol>Some content</ol>
 </body>

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -4,7 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
-<!-- The stylesheet is fetched from http://www1.web-platform.test:64941/resource-timing/resources/nested.css -->
+<!-- The stylesheet is fetched from http://www1.web–platform.test:64941/resource-timing/resources/nested.css -->
 <link rel=stylesheet id=cross_origin_style href="//{{domains[www1]}}:{{ports[http][1]}}{{location[path]}}/../resources/nested.css">
 <script>
   let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -17,7 +17,7 @@
           assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font should not be in timeline");
           assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image should not be in timeline");
           t.done();
-    },0);
+    },100);
   });
 </script>
 <ol>Some content</ol>

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -6,8 +6,6 @@
 <body>
 <link rel=stylesheet id=cross_origin_style href="//{{domains[www1]}}:{{ports[http][1]}}{{location[path]}}/../resources/nested.css">
 <script>
-<<<<<<< HEAD
-<<<<<<< HEAD
   let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
   window.onload = function() {
     // A timeout is needed as PerformanceObserver is not guaranteed to run before onload triggered.
@@ -17,27 +15,8 @@
           assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/resource_timing_test0.css?id=n1").length, 0, "Import is in timeline");
           assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font is in timeline");
           assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image is in timeline");
-<<<<<<< HEAD
-=======
-=======
-  let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
->>>>>>> 36672595d0... Resolved lint complaints
-  window.onload = function() {
-    // A timeout is needed as PerformanceObserver is not guaranteed to run before onload triggered.
-    t.step_timeout(function() {
-          let url = (new URL(document.getElementById("cross_origin_style").href));
-          let prefix = url.protocol + "//" + url.host;
-          assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font is in timeline");
-          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image is in timeline");
-<<<<<<< HEAD
-      }, "Make sure that CSS subresources are not included");
->>>>>>> 3c0ba54dd2... Test that resources fetched by cross-origin CSS do not appear in the timeline
-=======
->>>>>>> 36672595d0... Resolved lint complaints
-=======
           t.done();
->>>>>>> f1012e750d... Rebase and add import
-    },0)
+    },0);
   };
 </script>
 <ol>Some content</ol>

--- a/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
+++ b/resource-timing/no-entries-for-cross-origin-css-fetched.sub.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <body>
+<!-- The stylesheet is fetched from http://www1.web-platform.test:64941/resource-timing/resources/nested.css -->
 <link rel=stylesheet id=cross_origin_style href="//{{domains[www1]}}:{{ports[http][1]}}{{location[path]}}/../resources/nested.css">
 <script>
   let t = async_test("Make sure that resources fetched by cross origin CSS are not in the timeline.");
@@ -12,9 +13,9 @@
     t.step_timeout(function() {
           let url = (new URL(document.getElementById("cross_origin_style").href));
           let prefix = url.protocol + "//" + url.host;
-          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/resource_timing_test0.css?id=n1").length, 0, "Import is in timeline");
-          assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font is in timeline");
-          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image is in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/resource_timing_test0.css?id=n1").length, 0, "Import should not be in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/fonts/Ahem.ttf?id=n1").length, 0, "Font should not be in timeline");
+          assert_equals(performance.getEntriesByName(prefix + "/resource-timing/resources/blue.png?id=n1").length, 0, "Image should not be in timeline");
           t.done();
     },0);
   };


### PR DESCRIPTION
Closes https://github.com/w3c/resource-timing/issues/70

This is a long standing missing test. Seems like all browsers are doing the wrong thing here, which leads me to think we may need to change the spec...

<!-- Reviewable:start -->

<!-- Reviewable:end -->
