### PR TITLE
Implement Element::has_css_layout_box()

### DIFF
--- a/css/cssom-view/scroll-no-layout-box.html
+++ b/css/cssom-view/scroll-no-layout-box.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>cssom-view - Scrolling element with no layout box</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scroll">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#css-layout-box">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div style="display: none">
+  <div id="elem"></div>
+</div>
+
+<script>
+test(() => {
+  const elem = document.getElementById('elem');
+  elem.scroll(1, 2);
+
+  assert_equals(elem.scrollTop, 0, "scrollTop should be unchanged");
+  assert_equals(elem.scrollLeft, 0, "scrollLeft should be unchanged");
+}, "scrolling an element with no CSS layout box should have no effect");
+</script>


### PR DESCRIPTION

Calling scroll() on an element which is not rendered (by a parent with
display: none) would previously cause a crash. In fact, we should
terminate the algorithm
[https://drafts.csswg.org/cssom-view/#dom-element-scroll] at step 10 in
this situation.

The fix hinges on implementing Element::has_css_layout_box() correctly,
rather than just returning true in all cases as we did previously.

Fixes #19430.

Upstreamed from https://github.com/servo/servo/pull/19803 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9309)
<!-- Reviewable:end -->
