### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=180939

### DIFF
--- a/service-workers/service-worker/resources/fetch-request-xhr-iframe.https.html
+++ b/service-workers/service-worker/resources/fetch-request-xhr-iframe.https.html
@@ -179,7 +179,7 @@ function form_data_test() {
           '\r\n' +
           'file content\r\n' +
           '--' + boundary + '--\r\n';
-        assert_equals(response.body, expected_body);
+        assert_true(response.body === expected_body, "form data response content is as expected");
       });
 }
 


### PR DESCRIPTION
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=180939
Service Worker should not clean HTTP headers added by the application or by fetch specification before service worker interception

<!-- Reviewable:start -->

<!-- Reviewable:end -->
