### PR TITLE
Add a negative test for the DataChannel interface (Gecko only)

### DIFF
--- a/webrtc/historical.html
+++ b/webrtc/historical.html
@@ -25,6 +25,7 @@ test(function() {
 });
 
 [
+  "DataChannel",
   "mozRTCIceCandidate",
   "mozRTCPeerConnection",
   "mozRTCSessionDescription",


### PR DESCRIPTION
Prompted by web developer feedback on https://bugzilla.mozilla.org/show_bug.cgi?id=1173851#c5

<!-- Reviewable:start -->

<!-- Reviewable:end -->
