### PR TITLE
Sync Mozilla reftests as of 2018-02-02

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-001-ref.html
@@ -53,6 +53,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div class="alignCenter"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-001.html
@@ -54,6 +54,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -75,6 +79,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-002-ref.html
@@ -51,6 +51,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -72,6 +76,10 @@
     <div class="container"><div class="alignCenter"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-002.html
@@ -53,6 +53,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-001-ref.html
@@ -54,6 +54,12 @@
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignStart"><!--stretch--></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignStart"><!--baseline--></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignEnd"><!--last baseline--></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignCenter"><!--center--></div>
@@ -87,6 +93,12 @@
                                 class="alignStart"><!--normal--></div>
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignStart"><!--stretch--></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignStart"><!--baseline--></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignEnd"><!--last baseline--></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><img src="support/colors-8x16.png"

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-001.html
@@ -53,6 +53,12 @@
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: stretch"></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: baseline"></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: last baseline"></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: center"></div>
@@ -86,6 +92,12 @@
                                 style="justify-self: normal"></div>
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: stretch"></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: baseline"></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: last baseline"></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><img src="support/colors-8x16.png"

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-002-ref.html
@@ -52,6 +52,12 @@
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignStart"><!--stretch--></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignStart"><!--baseline--></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignEnd"><!--last baseline--></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignCenter"><!--center--></div>
@@ -85,6 +91,12 @@
                                 class="alignStart"><!--normal--></div>
     <div class="container"><img src="support/colors-8x16.png"
                                 class="alignStart"><!--stretch--></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignStart"><!--baseline--></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                class="alignEnd"><!--last baseline--></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><img src="support/colors-8x16.png"

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-img-002.html
@@ -52,6 +52,12 @@
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: stretch"></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: baseline"></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: last baseline"></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: center"></div>
@@ -85,6 +91,12 @@
                                 style="justify-self: normal"></div>
     <div class="container"><img src="support/colors-8x16.png"
                                 style="justify-self: stretch"></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: baseline"></div>
+    <div class="container"><img src="support/colors-8x16.png"
+                                style="justify-self: last baseline"></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><img src="support/colors-8x16.png"

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-001-ref.html
@@ -53,6 +53,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-001.html
@@ -54,6 +54,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -75,6 +79,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-002-ref.html
@@ -53,6 +53,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-002.html
@@ -55,6 +55,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -76,6 +80,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-003-ref.html
@@ -51,6 +51,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -72,6 +76,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-003.html
@@ -53,6 +53,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-004-ref.html
@@ -51,6 +51,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -72,6 +76,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-rtl-004.html
@@ -54,6 +54,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -75,6 +79,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-001-ref.html
@@ -55,6 +55,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -76,6 +80,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-001.html
@@ -53,6 +53,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-002-ref.html
@@ -55,6 +55,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -76,6 +80,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-002.html
@@ -54,6 +54,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -75,6 +79,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-003-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-003-ref.html
@@ -53,6 +53,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-003.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-003.html
@@ -52,6 +52,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -73,6 +77,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-004-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-004-ref.html
@@ -53,6 +53,10 @@
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
+    <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>
     <div class="container"><div class="alignStart"><!--start--></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div class="alignStart"><!--auto--></div></div>
     <div class="container"><div class="alignStart"><!--normal--></div></div>
     <div class="container"><div class="alignStart"><!--stretch--></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div class="alignStart"><!--baseline--></div></div>
+    <div class="container"><div class="alignEnd"><!--last baseline--></div></div>
     <br>
     <!-- <self-position>, part 1: -->
     <div class="container"><div class="alignCenter"><!--center--></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-004.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/align3/grid-abspos-staticpos-justify-self-vertWM-004.html
@@ -53,6 +53,10 @@
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
     <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
+    <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>
     <div class="container"><div style="justify-self: start"></div></div>
@@ -74,6 +78,10 @@
     <div class="container"><div style="justify-self: auto"></div></div>
     <div class="container"><div style="justify-self: normal"></div></div>
     <div class="container"><div style="justify-self: stretch"></div></div>
+    <br>
+    <!-- <baseline-position> -->
+    <div class="container"><div style="justify-self: baseline"></div></div>
+    <div class="container"><div style="justify-self: last baseline"></div></div>
     <br>
     <!-- <self-position>, part 1 -->
     <div class="container"><div style="justify-self: center"></div></div>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-1-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-1-ref.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: compare individual transform with transform functions</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <meta name="assert" content="Tests whether individaul transform works correctlyi by compare the rendering result with transfrom functions of the 'transform' property."/>
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+      }
+      .row_1 {
+        top: 100px;
+      }
+      .scale_1{
+        left: 100px;
+        width: 50px;
+        height: 100px;
+        transform: scaleX(2);
+      }
+      .translate_1 {
+        left: 150px;
+        transform: translateX(150px);
+      }
+      .rotate_1 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        transform: rotate(90deg);
+      }
+
+      .row_2 {
+        top: 250px;
+      }
+      .scale_2{
+        left: 100px;
+        width: 50px;
+        height: 50px;
+        transform: scale(2, 2);
+      }
+      .translate_2 {
+        left: 150px;
+        top: 200px;
+        transform: translate(150px, 50px);
+      }
+      .rotate_2 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        transform: rotate3d(0, 0, 1, 90deg);
+      }
+      .row_3 {
+        transform: perspective(500px);
+        top: 400px;
+      }
+      .scale_3{
+        left: 100px;
+        width: 50px;
+        height: 50px;
+        transform: scale3d(2, 2, 2);
+      }
+      .translate_3 {
+        left: 150px;
+        transform: translate3d(150px, 10px, 10px);
+      }
+      .rotate_3 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        transform: rotate3d(0, 1, 0, 45deg);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="scale_1 row_1"></div>
+    <div class="translate_1 row_1"></div>
+    <div class="rotate_1 row_1"></div>
+    <div class="scale_2 row_2"></div>
+    <div class="translate_2 row_2"></div>
+    <div class="rotate_2 row_2"></div>
+    <div class="scale_3 row_3"></div>
+    <div class="translate_3 row_3"></div>
+    <div class="rotate_3 row_3"></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-1.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-1.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: compare individual transform with transform functions</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <meta name="assert" content="Tests whether individaul transform works correctlyi by compare the rendering result with transfrom functions of the 'transform' property."/>
+    <link rel="match" href="individual-transform-1-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+      }
+      .row_1 {
+        top: 100px;
+      }
+      .scale_1{
+        left: 100px;
+        width: 50px;
+        height: 100px;
+        /* test 'scale: <number>' */
+        scale: 2;
+      }
+      .translate_1 {
+        left: 150px;
+        /* test 'translate: <length-percentage>' */
+        translate: 150px;
+      }
+      .rotate_1 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        /* test 'rota: te<angle>' */
+        rotate: 90deg;
+      }
+
+      .row_2 {
+        top: 250px;
+      }
+      .scale_2{
+        left: 100px;
+        width: 50px;
+        height: 50px;
+        /* test 'scale: <number>{2}'' */
+        scale: 2 2;
+      }
+      .translate_2 {
+        left: 150px;
+        top: 200px;
+        /* test 'translate: <length-percentage><length-percentage>' */
+        translate: 150px 50px;
+      }
+      .rotate_2 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        /* test 'rotate: <number>{3}<angle>'*/
+        rotate: 0 0 1 90deg;
+      }
+      .row_3 {
+        transform: perspective(500px);
+        top: 400px;
+      }
+      .scale_3{
+        left: 100px;
+        width: 50px;
+        height: 50px;
+        /* test 'scale: <number>{3}'' */
+        scale: 2 2 2;
+      }
+      .translate_3 {
+        left: 150px;
+        /* test 'translate: <length-percentage><length>' */
+        translate: 150px 10px 10px;
+      }
+      .rotate_3 {
+        left: 450px;
+        transform-origin: 50% 50%;
+        /* test 'rotate: <number>{3}<angle>'*/
+        rotate: 0 1 0 45deg;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="scale_1 row_1"></div>
+    <div class="translate_1 row_1"></div>
+    <div class="rotate_1 row_1"></div>
+    <div class="scale_2 row_2"></div>
+    <div class="translate_2 row_2"></div>
+    <div class="rotate_2 row_2"></div>
+    <div class="scale_3 row_3"></div>
+    <div class="translate_3 row_3"></div>
+    <div class="rotate_3 row_3"></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        transform: translate(50px, 50px) rotate(45deg) scale(2, 2);
+      }
+
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2a.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2a.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <link rel="match" href="individual-transform-2-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        translate: 50px 50px;
+        rotate: 45deg;
+        scale: 2 2;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2b.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2b.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <link rel="match" href="individual-transform-2-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        rotate: 45deg;
+        scale: 2 2;
+        translate: 50px 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2c.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2c.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <link rel="match" href="individual-transform-2-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        translate: 50px 50px;
+        rotate: 45deg;
+        transform: scale(2, 2);
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2d.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2d.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <link rel="match" href="individual-transform-2-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        translate: 50px 50px;
+        transform: rotate(45deg) scale(2, 2);
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2e.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-2e.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Individual transform: combine individual transform properties</title>
+    <link rel="author" title="CJ Ku" href="mailto:cku@mozilla.com">
+    <link rel="author" title="Mozilla" href="https://www.mozilla.org">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#individual-transforms">
+    <link rel="help" href="https://drafts.csswg.org/css-transforms-2/#ctm">
+    <meta name="assert" content="Tests that we combine transforms in the correct order."/>
+    <link rel="match" href="individual-transform-2-ref.html">
+    <style>
+      div {
+        position: fixed;
+        width: 100px;
+        height: 100px;
+        top: 200px;
+        left: 200px;
+        transform-origin: 0 0;
+        border-style: solid;
+        border-width: 10px 0px 10px 0px;
+        border-color: lime;
+        translate: 0px 50px;
+        transform: translateX(50px) rotate(45deg) scale(2, 2);
+      }
+    </style>
+  </head>
+  <body>
+    <div></div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/transforms/reftest.list
@@ -4,3 +4,12 @@
 == perspective-containing-block-dynamic-1b.html containing-block-dynamic-1-ref.html
 == perspective-zero.html reference/green.html
 == perspective-zero-2.html perspective-zero-2-ref.html
+
+# stylo-vs-gecko comparison fails since we support individual transform on new
+# style system only.
+== individual-transform-1.html individual-transform-1-ref.html
+== individual-transform-2a.html individual-transform-2-ref.html
+== individual-transform-2b.html individual-transform-2-ref.html
+== individual-transform-2c.html individual-transform-2-ref.html
+== individual-transform-2d.html individual-transform-2-ref.html
+== individual-transform-2e.html individual-transform-2-ref.html


### PR DESCRIPTION
Sync Mozilla reftests as of https://hg.mozilla.org/mozilla-central/rev/0690bf69410ad52ba220d1a26e39c3a49c25cb58 .

This contains two changes:
* [bug 1434314](https://bugzilla.mozilla.org/show_bug.cgi?id=1434314) by @emilio; not clear to me if this is unreviewed or if it's just reverting an earlier change
* [bug 1207734](https://bugzilla.mozilla.org/show_bug.cgi?id=1207734) by @CJKu, already reviewed

<!-- Reviewable:start -->

<!-- Reviewable:end -->
