### PR TITLE
g. Implement testAnimationSampleRotate3d.

### DIFF
--- a/web-animations/animation-model/animation-types/property-list.js
+++ b/web-animations/animation-model/animation-types/property-list.js
@@ -1519,6 +1519,18 @@ function testAnimationSampleMatrices(animation, idlName, testSamples) {
   }
 }
 
+function testAnimationSampleRotate3d(animation, idlName, testSamples) {
+  const target = animation.effect.target;
+  for (const testSample of testSamples) {
+    animation.currentTime = testSample.time;
+    const actual = getComputedStyle(target)[idlName];
+    const expected = testSample.expected;
+    assert_rotate3d_equals(actual, expected,
+                         `The value should be ${expected} at`
+                         + ` ${testSample.time}ms but got ${actual}`);
+  }
+}
+
 function createTestElement(t, setup) {
   return setup ? setup(t) : createElement(t);
 }

--- a/web-animations/testcommon.js
+++ b/web-animations/testcommon.js
@@ -262,3 +262,25 @@ function assert_matrix_equals(actual, expected, description) {
       `expected ${expected} but got ${actual}: ${description}`);
   }
 }
+
+// Compare rotate3d vector like '0 1 0 45deg' with tolerances.
+function assert_rotate3d_equals(actual, expected, description) {
+  const rotationRegExp =/^((([+-]?\d+(\.+\d+)?\s){3})?\d+(\.+\d+)?)deg/;
+
+  assert_regexp_match(actual, rotationRegExp,
+    'Actual value is not a rotate3d vector')
+  assert_regexp_match(expected, rotationRegExp,
+    'Expected value is not a rotate3d vector');
+
+  const actualRotationVector =
+    actual.match(rotationRegExp)[1].split(' ').map(Number);
+  const expectedRotationVector =
+    expected.match(rotationRegExp)[1].split(' ').map(Number);
+
+  assert_equals(actualRotationVector.length, expectedRotationVector.length,
+    `dimension of the matrix: ${description}`);
+  for (let i = 0; i < actualRotationVector.length; i++) {
+    assert_approx_equals(actualRotationVector[i], expectedRotationVector[i], 0.0001,
+      `expected ${expected} but got ${actual}: ${description}`);
+  }
+}


### PR DESCRIPTION

testAnimationSamples is not enough for comparing the computed value of rotate
property so we need this new function.

MozReview-Commit-ID: J77e89BbjLx

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1207734 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9379)
<!-- Reviewable:end -->
