### PR TITLE
Update csp test to not use alert(),

### DIFF
--- a/content-security-policy/reporting/report-multiple-violations-02.html
+++ b/content-security-policy/reporting/report-multiple-violations-02.html
@@ -12,7 +12,7 @@
 <body>
   <script>
     for (var i = 0; i<5; i++)
-      setTimeout("alert('PASS: setTimeout #" + i + " executed.');", 0);
+      setTimeout("document.body.innerHTML += ('<p>PASS: setTimeout #" + i + " executed.');", 0);
   </script>
   <script async defer src='../support/checkReport.sub.js?reportField=violated-directive&reportValue=script-src%20%27unsafe-inline%27%20%27self%27&reportCount=1'></script>
 </body>


### PR DESCRIPTION

Alert() tends to interfere with the harness and can disrupt subsequent tests

MozReview-Commit-ID: 1mKSXDm8eWU

Upstreamed from https://bugzilla.mozilla.org/show_bug.cgi?id=1435337 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9382)
<!-- Reviewable:end -->
