### PR TITLE
webdriver: fix typo when raising exception for unparseable HTTP respo…

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -39,8 +39,8 @@ class Response(object):
         try:
             body = json.load(http_response, cls=decoder, **kwargs)
         except ValueError:
-            raise ValueError("Failed to decode response body as JSON:\n"
-                "%s" % json.dumps(body, indent=2))
+            raise ValueError("Failed to decode response body as JSON:\n" +
+                http_response.read())
 
         return cls(http_response.status, body)
 


### PR DESCRIPTION
…nse.

When the server sends something that's not parseable as JSON, the transport
tries to raise an exception with the unparseable response formatted as JSON.
This won't work, so just dump the HTTP response as a string in the exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9399)
<!-- Reviewable:end -->
