### PR TITLE
Correct test for serialization of a FontFaceRule

### DIFF
--- a/css/cssom/cssom-fontfacerule.html
+++ b/css/cssom/cssom-fontfacerule.html
@@ -3,7 +3,7 @@
     <head>
         <title>CSSOM Parsing Test: @font-face rules parsed into CSSOM CSSFontFaceRules</title>
         <link rel="author" title="Paul Irish" href="mailto:paul.irish@gmail.com">
-        <link rel="help" href="http://www.w3.org/TR/cssom-1/#css-font-face-rule">
+        <link rel="help" href="https://drafts.csswg.org/cssom/#css-rules">
 
         <meta name="flags" content="dom">
 
@@ -44,7 +44,7 @@
 
             test(function(){
 
-                assert_equals(validRules[0].style.src, 'url(http://foo/bar/font.ttf)');
+                assert_equals(validRules[0].style.src, 'url("http://foo/bar/font.ttf")');
                 assert_equals(validRules[1].style.fontFamily, 'STIXGeneral');
 
                 /* unimplemented @font-face properties are not represented in CSSOM */


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom/#serialize-a-url, URLs should be serialized as a string (https://drafts.csswg.org/cssom/#serialize-a-string), which includes double quotes on each side. Correct the test to match the spec. Also update the link for the spec; the old link no longer exists.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
