### PR TITLE
[css-writing-modes] Shift spec anchor for orthogonal flow block sizing tests.

### DIFF
--- a/css/css-writing-modes/float-lft-orthog-htb-in-vlr-002.xht
+++ b/css/css-writing-modes/float-lft-orthog-htb-in-vlr-002.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-lft-orthog-htb-in-vlr-002-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-lft-orthog-htb-in-vrl-002.xht
+++ b/css/css-writing-modes/float-lft-orthog-htb-in-vrl-002.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-lft-orthog-htb-in-vrl-002-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-lft-orthog-vlr-in-htb-002.xht
+++ b/css/css-writing-modes/float-lft-orthog-vlr-in-htb-002.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-lft-orthog-vlr-in-htb-002-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-lft-orthog-vrl-in-htb-002.xht
+++ b/css/css-writing-modes/float-lft-orthog-vrl-in-htb-002.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-lft-orthog-vrl-in-htb-002-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-rgt-orthog-htb-in-vlr-003.xht
+++ b/css/css-writing-modes/float-rgt-orthog-htb-in-vlr-003.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-rgt-orthog-htb-in-vlr-003-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-rgt-orthog-htb-in-vrl-003.xht
+++ b/css/css-writing-modes/float-rgt-orthog-htb-in-vrl-003.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-rgt-orthog-htb-in-vrl-003-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-rgt-orthog-vlr-in-htb-003.xht
+++ b/css/css-writing-modes/float-rgt-orthog-vlr-in-htb-003.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-rgt-orthog-vlr-in-htb-003-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/float-rgt-orthog-vrl-in-htb-003.xht
+++ b/css/css-writing-modes/float-rgt-orthog-vrl-in-htb-003.xht
@@ -15,7 +15,7 @@
   -->
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://drafts.csswg.org/css-writing-modes-3/#auto-multicol" title="7.3.2 Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="float-rgt-orthog-vrl-in-htb-003-ref.xht" />
 
   <meta content="" name="flags" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-001.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-001.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-001-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-003.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-003.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-004.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-004.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-004-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-006.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-006.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-007.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-007.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-007-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-008.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-008.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-008-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-009.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-009.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-010.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-010.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-010-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-011.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-011.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-011-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-012.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-012.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-013.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-013.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-013-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-015.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-015.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-016.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-016.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-016-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-018.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-018.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-019.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-019.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-019-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-020.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-020.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-020-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-021.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-021.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-022.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-022.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-022-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-023.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-023.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-023-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vlr-024.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vlr-024.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-lr' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-001.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-001.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-001-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-13T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-003.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-003.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-19T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-004.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-004.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-004-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-19T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-006.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-006.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-19T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-007.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-007.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-007-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-008.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-008.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-008-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-009.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-009.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-19T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-010.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-010.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-010-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-19T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-011.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-011.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-011-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-012.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-012.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-013.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-013.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-013-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-015.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-015.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-015-ref.xht" />
 
 

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-016.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-016.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vlr-016-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-018.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-018.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside auto-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-019.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-019.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-019-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-020.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-020.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-020-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-021.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-021.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-022.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-022.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-022-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-023.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-023.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-023-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-htb-in-vrl-024.xht
+++ b/css/css-writing-modes/sizing-orthog-htb-in-vrl-024.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'horizontal-tb' block with 'auto' inline size inside definite-sized 'vertical-rl' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-htb-in-vrl-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-12-20T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-001.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-001.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-001-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-003.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-003.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-004.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-004.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-004-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-006.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-006.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-007.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-007.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-007-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-008.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-008.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-008-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-009.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-009.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-009-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-010.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-010.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-010-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-011.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-011.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-011-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-012.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-012.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-012-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-013.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-013.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-013-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-015.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-015.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-016.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-016.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-016-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-018.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-018.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-019.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-019.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-019-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-020.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-020.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-020-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-021.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-021.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-022.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-022.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-022-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-023.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-023.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-023-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vlr-in-htb-024.xht
+++ b/css/css-writing-modes/sizing-orthog-vlr-in-htb-024.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-lr' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vlr-in-htb-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-10-04T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-001.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-001.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-001-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-02T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-003.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-003.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-003-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-08T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-004.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-004.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-004-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-006.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-006.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-006-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-007.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-007.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-007-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-008.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-008.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-008-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-009.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-009.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-009-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-010.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-010.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-010-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-011.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-011.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-011-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-012.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-012.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-012-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-15T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-013.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-013.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-013-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-015.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-015.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-016.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-016.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-016-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-018.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-018.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside auto-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-019.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-019.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-019-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-020.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-020.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-020-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-285T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-021.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-021.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-015-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-022.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-022.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-022-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-023.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-023.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-023-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />

--- a/css/css-writing-modes/sizing-orthog-vrl-in-htb-024.xht
+++ b/css/css-writing-modes/sizing-orthog-vrl-in-htb-024.xht
@@ -7,7 +7,7 @@
   <title>CSS Writing Modes Test: sizing of orthogonal 'vertical-rl' block with 'auto' inline size inside definite-sized 'horizontal-tb' containing block</title>
 
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#auto-multicol" title="7.3.2. Auto-sizing Block Containers in Orthogonal Flows" />
+  <link rel="help" href="https://www.w3.org/TR/css-writing-modes-3/#orthogonal-auto" />
   <link rel="match" href="sizing-orthog-vrl-in-htb-018-ref.xht" />
 
   <meta name="DC.date.created" content="2016-09-28T09:54:03+11:00" scheme="W3CDTF" />


### PR DESCRIPTION
This shifts tests tagged to a section that was deferred from L3 to L4 to the section right above it (which covers this functionality).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
