### PR TITLE
SVG Shapes: line supports pathLength

### DIFF
--- a/svg/shapes/line-dasharray-ref.svg
+++ b/svg/shapes/line-dasharray-ref.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="300" height="200">
+  <style>
+    line {
+      stroke: blue;
+      stroke-dasharray: 24 8;
+    }
+  </style>
+  <line id="interval" x1="50" y1="100" x2="250" y2="100"/>
+</svg>

--- a/svg/shapes/line-dasharray.svg
+++ b/svg/shapes/line-dasharray.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="300" height="200">
+  <metadata>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/painting.html#StrokeDashing"/>
+    <h:link rel="match" href="line-dasharray-ref.svg"/>
+    <h:meta name="assert" content="The ‘pathLength’ attribute on a ‘path’ element affects stroke-dasharray."/>
+  </metadata>
+  <style>
+    line {
+      stroke: blue;
+      stroke-dasharray: 3 1;
+    }
+  </style>
+  <line id="interval" x1="50" y1="100" x2="250" y2="100" pathLength="25"/>
+</svg>

--- a/svg/shapes/line-getPointAtLength.svg
+++ b/svg/shapes/line-getPointAtLength.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#InterfaceSVGLineElement"/>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGeometryElement"/>
+    <h:meta name="assert" content="The line element supports getPointAtLength."/>
+  </metadata>
+  <line id="interval" x1="300" y1="400" x2="500" y2="400"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var interval = document.getElementById('interval');
+      assert_true(interval.getTotalLength !== undefined, 'getTotalLength is defined for SVGLineElement');
+      assert_true(interval.getPointAtLength !== undefined, 'getPointAtLength is defined for SVGLineElement');
+      assert_equals(interval.getTotalLength(), 200, 'total length');
+
+      var point = interval.getPointAtLength(10);
+      assert_equals(point.x, 310, 'x');
+      assert_equals(point.y, 400, 'y');
+    }, 'line supports getPointAtLength');
+
+    test(function() {
+      var interval = document.getElementById('interval');
+      interval.setAttribute('pathLength', '25');
+
+      assert_equals(interval.getTotalLength(), 200, 'total length');
+
+      var point = interval.getPointAtLength(10);
+      assert_equals(point.x, 310, 'x');
+      assert_equals(point.y, 400, 'y');
+    }, 'line getPointAtLength ignores pathLength');
+  ]]></script>
+</svg>

--- a/svg/shapes/line-pathLength.svg
+++ b/svg/shapes/line-pathLength.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#InterfaceSVGLineElement"/>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGeometryElement"/>
+    <h:meta name="assert" content="The pathLength IDL attribute reflects the ‘pathLength’ content attribute."/>
+  </metadata>
+  <line id="interval" x1="300" y1="400" x2="500" y2="400" pathLength="25"/>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+  test(function() {
+    var interval = document.getElementById('interval');
+    assert_true(interval.pathLength !== undefined, "pathLength is defined for SVGLineElement");
+    assert_equals(interval.pathLength.baseVal, 25);
+  }, 'line supports pathLength attribute');
+  ]]></script>
+</svg>


### PR DESCRIPTION
Tests that SVGLineElement has the SVGGeometryElement members
pathLength, getTotalLength(), getPointAtLength().

Verifies that pathLength does not affect the results of
getTotalLength(), getPointAtLength() but does affect how
stroke-dasharray in interpreted.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
