### PR TITLE
WebDriver: don't send a request body for HTTP GET requests

### DIFF
--- a/tools/webdriver/webdriver/transport.py
+++ b/tools/webdriver/webdriver/transport.py
@@ -131,13 +131,16 @@ class HTTPWireProtocol(object):
         if body is None and method == "POST":
             body = {}
 
-        try:
-            payload = json.dumps(body, cls=encoder, **codec_kwargs)
-        except ValueError:
-            raise ValueError("Failed to encode request body as JSON:\n"
-                "%s" % json.dumps(body, indent=2))
-        if isinstance(payload, text_type):
-            payload = body.encode("utf-8")
+        payload = None
+        if body is not None:
+            try:
+                payload = json.dumps(body, cls=encoder, **codec_kwargs)
+            except ValueError:
+                raise ValueError("Failed to encode request body as JSON:\n"
+                    "%s" % json.dumps(body, indent=2))
+
+            if isinstance(payload, text_type):
+                payload = body.encode("utf-8")
 
         if headers is None:
             headers = {}


### PR DESCRIPTION
Due to the fact that Python's None is serializable as JSON,
the transport was always sending the string "null" as the body
for all requests which did not specify some other body. This
leads to HTTP GET requests with a non-zero Content-Length,
which is bad.

Fix this by only trying to encode the payload if the body
parameter has a non-default value. I don't think there is
a valid use case where a request payload is a top-level 'null'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9465)
<!-- Reviewable:end -->
