### PR TITLE
Fix broken markup for content-height-005-ref.html

### DIFF
--- a/css/CSS2/visudet/reference/content-height-005-ref.html
+++ b/css/CSS2/visudet/reference/content-height-005-ref.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <title>CSS Test Reference file</title>
 <link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<style>
 
 div {
   font-size: 50px;


### PR DESCRIPTION
Credit to @pyfisch for noticing this.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
