### PR TITLE
Correct integration with Sauce Labs service

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -84,18 +84,29 @@ class TestEnvironment(object):
         self.cache_manager = multiprocessing.Manager()
         self.stash = serve.stash.StashServer()
         self.env_extras = env_extras
+        self.env_extras_cms = None
 
 
     def __enter__(self):
         self.stash.__enter__()
         self.ssl_env.__enter__()
         self.cache_manager.__enter__()
-        for cm in self.env_extras:
-            cm.__enter__(self.options)
-        self.setup_server_logging()
+
         self.config = self.load_config()
+        self.setup_server_logging()
         ports = serve.get_ports(self.config, self.ssl_env)
         self.config = serve.normalise_config(self.config, ports)
+
+        assert self.env_extras_cms is None, (
+            "A TestEnvironment object cannot be nested")
+
+        self.env_extras_cms = []
+
+        for env in self.env_extras:
+            cm = env(self.options, self.config)
+            cm.__enter__()
+            self.env_extras_cms.append(cm)
+
         self.servers = serve.start(self.config, self.ssl_env,
                                    self.get_routes())
         if self.options.get("supports_debugger") and self.debug_info and self.debug_info.interactive:
@@ -108,8 +119,11 @@ class TestEnvironment(object):
         for scheme, servers in self.servers.iteritems():
             for port, server in servers:
                 server.kill()
-        for cm in self.env_extras:
+        for cm in self.env_extras_cms:
             cm.__exit__(exc_type, exc_val, exc_tb)
+
+        self.env_extras_cms = None
+
         self.cache_manager.__exit__(exc_type, exc_val, exc_tb)
         self.ssl_env.__exit__(exc_type, exc_val, exc_tb)
         self.stash.__exit__()

--- a/tools/wptrunner/wptrunner/font.py
+++ b/tools/wptrunner/wptrunner/font.py
@@ -17,7 +17,10 @@ class FontInstaller(object):
         self.created_dir = False
         self.fonts = fonts
 
-    def __enter__(self, options=None):
+    def __call__(self, env_options=None, env_config=None):
+        return self
+
+    def __enter__(self):
         for _, font_path in self.fonts.items():
             font_name = font_path.split('/')[-1]
             install = getattr(self, 'install_%s_font' % SYSTEM, None)

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -20,15 +20,15 @@ def test_sauceconnect_success():
         exists.return_value = True
 
         sauce_connect = sauce.SauceConnect(
-            config={
-                "domains": {"": "example.net"}
-            },
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
             sauce_connect_binary="ddd")
 
-        sauce_connect.__enter__(None)
+        env_config = {
+            "domains": {"": "example.net"}
+        }
+        sauce_connect.__enter__(None, env_config)
 
 
 @pytest.mark.parametrize("readyfile,returncode", [
@@ -49,16 +49,16 @@ def test_sauceconnect_failure_exit(readyfile, returncode):
         exists.return_value = readyfile
 
         sauce_connect = sauce.SauceConnect(
-            config={
-                "domains": {"": "example.net"}
-            },
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
             sauce_connect_binary="ddd")
 
+        env_config = {
+            "domains": {"": "example.net"}
+        }
         with pytest.raises(sauce.SauceException):
-            sauce_connect.__enter__(None)
+            sauce_connect.__enter__(None, env_config)
 
         # Given we appear to exit immediately with these mocks, sleep shouldn't be called
         sleep.assert_not_called()
@@ -74,16 +74,16 @@ def test_sauceconnect_failure_never_ready():
         exists.return_value = False
 
         sauce_connect = sauce.SauceConnect(
-            config={
-                "domains": {"": "example.net"}
-            },
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
             sauce_connect_binary="ddd")
 
+        env_config = {
+            "domains": {"": "example.net"}
+        }
         with pytest.raises(sauce.SauceException):
-            sauce_connect.__enter__(None)
+            sauce_connect.__enter__(None, env_config)
 
         # We should sleep while waiting for it to create the readyfile
         sleep.assert_called()
@@ -102,15 +102,15 @@ def test_sauceconnect_tunnel_domains():
         exists.return_value = True
 
         sauce_connect = sauce.SauceConnect(
-            config={
-                "domains": {"foo": "foo.bar.example.com", "": "example.net"}
-            },
             sauce_user="aaa",
             sauce_key="bbb",
             sauce_tunnel_id="ccc",
             sauce_connect_binary="ddd")
 
-        sauce_connect.__enter__(None)
+        env_config = {
+            "domains": {"foo": "foo.bar.example.com", "": "example.net"}
+        }
+        sauce_connect.__enter__(None, env_config)
 
         Popen.assert_called_once()
         args, kwargs = Popen.call_args


### PR DESCRIPTION
A recently merged patch centralized configuration values which defined the domain names available during test execution [1]. That patch was based on a mistaken assumption regarding the location of that value and the stage of the test execution at which it would be available. (Specifically: the value is not present in the environment configuration object when the "environment extras" are initialized.) This interfered with the initialization of the "environment" for the Sauce Labs service, making it impossible to run the tests there.

Defer the retrieval of the environment configuration object to the time that object's context manager is activated. Update the call sites to provide the environment configuration at this moment. Also update the signature of the context manager for the `FontInstaller` "environment extra" to accept this second parameter.

[1] #8614

This depends on gh-9480

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9484)
<!-- Reviewable:end -->
