### PR TITLE
Correct default Selectionstart and SelectionEnd

### DIFF
--- a/html/semantics/forms/textfieldselection/defaultSelection.html
+++ b/html/semantics/forms/textfieldselection/defaultSelection.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<title></title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<textarea>g</textarea>
+<input type="text" value="foo">
+</input>
+<script>
+test(function() {
+    let textarea = document.querySelector('textarea');
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+}, "Default selectionStart and selectionEnd for textarea");
+
+test(function() {
+    let textarea = document.querySelector('input');
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+}, "Default selectionStart and selectionEnd for input");
+
+test(function() {
+    let textarea = document.querySelector('textarea');
+    textarea.value="g";
+    assert_equals(textarea.selectionStart, 0);
+    assert_equals(textarea.selectionEnd, 0);
+}, "selectionStart and selectionEnd do not change when same value set again");
+
+test(function() {
+    let textarea = document.querySelector('textarea');
+    textarea.value="G";
+    assert_equals(textarea.selectionStart, 1);
+    assert_equals(textarea.selectionEnd, 1);
+}, "selectionStart and selectionEnd change when value changed to upper case");
+</script>


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/19963 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9487)
<!-- Reviewable:end -->
