### PR TITLE
Correct serialization of background-color

### DIFF
--- a/css/css-backgrounds/background-331.html
+++ b/css/css-backgrounds/background-331.html
@@ -57,7 +57,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-color"),
-                "transparent", "background initial value for background-color");
+                "rgba(0, 0, 0, 0)", "background initial value for background-color");
         }, "background_initial_color");
     </script>
   </body>

--- a/css/css-backgrounds/background-332.html
+++ b/css/css-backgrounds/background-332.html
@@ -57,7 +57,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-color"),
-                "gray", "background specified value for background-color");
+                "rgb(128, 128, 128)", "background specified value for background-color");
         }, "background_specified_color");
     </script>
   </body>

--- a/css/css-backgrounds/background-333.html
+++ b/css/css-backgrounds/background-333.html
@@ -57,7 +57,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-color"),
-                "red", "background specified value for background-color");
+                "rgb(255, 0, 0)", "background specified value for background-color");
         }, "background_specified_color_color");
     </script>
   </body>


### PR DESCRIPTION
According to https://drafts.csswg.org/css-color/#resolving-color-values, transparent should serialize to "rgba(0, 0, 0, 0)", and named colors should serialize to their equivalent value in rgb notation. Change the expectations for 3 background tests in order to match this part of the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
