### PR TITLE
[custom-elements] Some fixes for "is" attribute behavior changes

### DIFF
--- a/custom-elements/Document-createElement.html
+++ b/custom-elements/Document-createElement.html
@@ -355,6 +355,7 @@ test(() => {
   // https://github.com/w3c/webcomponents/issues/608
   let div = document.createElement('div', { is: 'my-div' });
   assert_false(div instanceof MyElement);
+  assert_false(div.hasAttribute('is'));
 
   customElements.define('my-div', MyElement, { extends: 'div' });
   document.body.appendChild(div);

--- a/custom-elements/Document-createElementNS.html
+++ b/custom-elements/Document-createElementNS.html
@@ -38,6 +38,7 @@ test(() => {
   let element = document.createElementNS('http://www.w3.org/1999/xhtml', 'p:address', { is: 'my-builtin'});
   assert_true(element instanceof MyBuiltinElement);
   assert_equals(element.prefix, 'p');
+  assert_false(element.hasAttribute('is'));
 }, 'builtin: document.createElementNS should create custom elements with prefixes.');
 
 test(() => {
@@ -46,6 +47,7 @@ test(() => {
   customElements.define('my-builtin2', MyBuiltinElement2, { extends: 'address'});
   let element = document.createElementNS('urn:example', 'address', { is: 'my-builtin2' });
   assert_false(element instanceof MyBuiltinElement2);
+  assert_false(element.hasAttribute('is'));
 }, 'builtin: document.createElementNS should check namespaces.');
 </script>
 </body>

--- a/custom-elements/builtin-coverage.html
+++ b/custom-elements/builtin-coverage.html
@@ -800,10 +800,8 @@ for (const t of testData) {
     test(() => {
       let customized = new t.klass();
       assert_equals(customized.constructor, t.klass);
-      // cloneNode() won't create a customized built-in element due to no
-      // 'is' attribute. https://github.com/whatwg/html/issues/3402
-      assert_not_equals(customized.cloneNode().constructor, t.klass,
-                        'Cloning a customized built-in element should NOT succeed.');
+      assert_equals(customized.cloneNode().constructor, t.klass,
+                    'Cloning a customized built-in element should succeed.');
     }, `${t.tag}: Operator 'new' should instantiate a customized built-in element`);
 
     test(() => {

--- a/custom-elements/upgrading/Node-cloneNode.html
+++ b/custom-elements/upgrading/Node-cloneNode.html
@@ -49,6 +49,35 @@ test(function () {
         'A cloned custom element must be an instance of the custom element');
 }, 'Node.prototype.cloneNode(false) must be able to clone as a autonomous custom element when it contains is attribute');
 
+test(function () {
+    class MyDiv1 extends HTMLDivElement {};
+    class MyDiv2 extends HTMLDivElement {};
+    class MyDiv3 extends HTMLDivElement {};
+    customElements.define('my-div1', MyDiv1, { extends: 'div' });
+    customElements.define('my-div2', MyDiv2, { extends: 'div' });
+
+    let instance = document.createElement('div', { is: 'my-div1'});
+    assert_true(instance instanceof MyDiv1);
+    instance.setAttribute('is', 'my-div2');
+    let clone = instance.cloneNode(false);
+    assert_not_equals(instance, clone);
+    assert_true(clone instanceof MyDiv1,
+        'A cloned custom element must be an instance of the custom element even with an inconsistent "is" attribute');
+
+    let instance3 = document.createElement('div', { is: 'my-div3'});
+    assert_false(instance3 instanceof MyDiv3);
+    instance3.setAttribute('is', 'my-div2');
+    let clone3 = instance3.cloneNode(false);
+    assert_not_equals(instance3, clone);
+    customElements.define('my-div3', MyDiv3, { extends: 'div' });
+    document.body.appendChild(instance3);
+    document.body.appendChild(clone3);
+    assert_true(instance3 instanceof MyDiv3,
+        'An undefined element must be upgraded even with an inconsistent "is" attribute');
+    assert_true(clone3 instanceof MyDiv3,
+        'A cloned undefined element must be upgraded even with an inconsistent "is" attribute');
+}, 'Node.prototype.cloneNode(false) must be able to clone as a customized built-in element when it has an inconsistent "is" attribute');
+
 test_with_window(function (contentWindow) {
     var contentDocument = contentWindow.document;
     class MyCustomElement extends contentWindow.HTMLElement {}


### PR DESCRIPTION
This is for https://github.com/whatwg/dom/pull/566.

- document.createElement() and createElementNS() don't add "is" content
 attribute.

- cloneNode() should clone custom elements even if they have no "is"
 content attributes or have "is" content attribute inconsistent with
 "is value."

<!-- Reviewable:start -->

<!-- Reviewable:end -->
