### PR TITLE
WebRTC: Add test for null ICE candidate

### DIFF
--- a/webrtc/RTCPeerConnection-addIceCandidate.html
+++ b/webrtc/RTCPeerConnection-addIceCandidate.html
@@ -334,6 +334,15 @@ a=rtcp-rsize
     return pc.setRemoteDescription(sessionDesc)
     .then(() =>
       promise_rejects(t, new TypeError(),
+                      pc.addIceCandidate(null)));
+  }, 'Add null candidate should reject with TypeError');
+
+  promise_test(t => {
+    const pc = new RTCPeerConnection();
+
+    return pc.setRemoteDescription(sessionDesc)
+    .then(() =>
+      promise_rejects(t, new TypeError(),
         pc.addIceCandidate({
           candidate: candidateStr1
         })));


### PR DESCRIPTION
The spec does not seem to allow for a null ICE candidate, and
explicitly test for presence of mid or midx attributes.

This should mean that a null ICE candidate is a type error.

New test presently passes on Chrome, fails on Firefox.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
