### PR TITLE
Add test for wrappable content that has flex:none

### DIFF
--- a/css/css-flexbox/flexbox_flex-none-wrappable-content-ref.html
+++ b/css/css-flexbox/flexbox_flex-none-wrappable-content-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Reference for specifying flex:none on wrappable content should give content its full width</title>
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-common">
+
+<style>
+span {
+  font-family: Ahem;
+  color: green;
+}
+</style>
+
+<div><span>XXX XXX XXX</span></div>
+
+<div style="margin-top: 1em;">You should see three green rectangles above, all on the same line.</div>

--- a/css/css-flexbox/flexbox_flex-none-wrappable-content-ref.html
+++ b/css/css-flexbox/flexbox_flex-none-wrappable-content-ref.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <title>Reference for specifying flex:none on wrappable content should give content its full width</title>
-<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-common">
 
 <style>
 span {

--- a/css/css-flexbox/flexbox_flex-none-wrappable-content.html
+++ b/css/css-flexbox/flexbox_flex-none-wrappable-content.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <title>Specifying flex:none on wrappable content should give content its full width</title>
 <link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-common">
+<meta name="assert" content="When content has flex:none, it should be given its full width">
 <link rel="match" href="flexbox_flex-none-wrappable-content-ref.html">
 
 <style>

--- a/css/css-flexbox/flexbox_flex-none-wrappable-content.html
+++ b/css/css-flexbox/flexbox_flex-none-wrappable-content.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>Specifying flex:none on wrappable content should give content its full width</title>
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#flex-common">
+<link rel="match" href="flexbox_flex-none-wrappable-content-ref.html">
+
+<style>
+span {
+  font-family: Ahem;
+  color: green;
+}
+</style>
+
+<div style="display: flex; width: 5px;">
+  <div style="flex: none;">
+    <span>XXX XXX XXX</span>
+  </div>
+</div>
+
+<div style="margin-top: 1em;">You should see three green rectangles above, all on the same line.</div>


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1374540; per spec, the flex:none content should be allowed its full content width. This currently works in Chrome, Edge, Safari, and Opera.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
