### PR TITLE
Add tests for the breaking of a multicolumn across columns, including backgrounds and column rules

### DIFF
--- a/css/css-multicol/multicol-breaking-000-ref.html
+++ b/css/css-multicol/multicol-breaking-000-ref.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.blueborders {
+  position: absolute;
+  top: 0;
+  left: 194px; /* 188px first column + (16px gap - 4px rule) / 2 */
+  width: 200px; /* 188px second column + (16px gap - 4px rule) */
+  height: 100px;
+  border-right: blue solid 4px;
+  border-left: blue solid 4px;
+}
+
+.innerbg {
+  height: 100px;
+  width: 188px;
+  background: rgba(255, 0, 255, 0.3);
+  position: absolute;
+  top: 0;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="blueborders"></div>
+  <div class="innerbg" style="left: 0"></div>
+  <div class="inner lefthalf" style="left: 0; height: 60px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="innerbg" style="left: 204px"></div>
+  <div class="innerbg" style="left: 408px"></div>
+</div>

--- a/css/css-multicol/multicol-breaking-000.html
+++ b/css/css-multicol/multicol-breaking-000.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-000-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-rule: 4px solid blue;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  background: rgba(255, 0, 255, 0.3);
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-001-ref.html
+++ b/css/css-multicol/multicol-breaking-001-ref.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.blueborders {
+  position: absolute;
+  top: 0;
+  left: 194px; /* 188px first column + (16px gap - 4px rule) / 2 */
+  width: 200px; /* 188px second column + (16px gap - 4px rule) */
+  height: 100px;
+  border-right: blue solid 4px;
+  border-left: blue solid 4px;
+}
+
+.innerbg {
+  height: 100px;
+  width: 188px;
+  background: rgba(255, 0, 255, 0.3);
+  position: absolute;
+  top: 0;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="blueborders"></div>
+  <div class="innerbg" style="left: 0"></div>
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="innerbg" style="left: 204px"></div>
+  <div class="inner lefthalf" style="left: 204px; height: 80px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ<br>
+  </div>
+  <div class="innerbg" style="left: 408px"></div>
+</div>

--- a/css/css-multicol/multicol-breaking-001.html
+++ b/css/css-multicol/multicol-breaking-001.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-001-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-rule: 4px solid blue;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  background: rgba(255, 0, 255, 0.3);
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-002-ref.html
+++ b/css/css-multicol/multicol-breaking-002-ref.html
@@ -1,0 +1,99 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.blueborders {
+  position: absolute;
+  top: 0;
+  left: 194px; /* 188px first column + (16px gap - 4px rule) / 2 */
+  width: 200px; /* 188px second column + (16px gap - 4px rule) */
+  height: 100px;
+  border-right: blue solid 4px;
+  border-left: blue solid 4px;
+}
+
+.innerbg {
+  height: 100px;
+  width: 188px;
+  background: rgba(255, 0, 255, 0.3);
+  position: absolute;
+  top: 0;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="blueborders"></div>
+  <div class="innerbg" style="left: 0"></div>
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="innerbg" style="left: 204px"></div>
+  <div class="inner lefthalf" style="left: 204px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    PPPPP<br>
+    QQQQQ<br>
+    RRRRR<br>
+    SSSSS<br>
+    TTTTT
+  </div>
+  <div class="innerbg" style="left: 408px"></div>
+  <div class="inner lefthalf" style="left: 408px">
+    UUUUU<br>
+    VVVVV<br>
+    WWWWW<br>
+    XXXXX<br>
+    YYYYY
+  </div>
+  <div class="inner righthalf" style="left: 503px">
+    ZZZZZ<br>
+    aaaaa<br>
+    bbbbb<br>
+    ccccc<br>
+    ddddd
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-002.html
+++ b/css/css-multicol/multicol-breaking-002.html
@@ -1,0 +1,64 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-002-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-rule: 4px solid blue;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  background: rgba(255, 0, 255, 0.3);
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ<br>
+    RRRRR<br>
+    SSSSS<br>
+    TTTTT<br>
+    UUUUU<br>
+    VVVVV<br>
+    WWWWW<br>
+    XXXXX<br>
+    YYYYY<br>
+    ZZZZZ<br>
+    aaaaa<br>
+    bbbbb<br>
+    ccccc<br>
+    ddddd
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-003-ref.html
+++ b/css/css-multicol/multicol-breaking-003-ref.html
@@ -1,0 +1,82 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.blueborders {
+  position: absolute;
+  top: 0;
+  left: 194px; /* 188px first column + (16px gap - 4px rule) / 2 */
+  width: 200px; /* 188px second column + (16px gap - 4px rule) */
+  height: 100px;
+  border-right: blue solid 4px;
+  border-left: blue solid 4px;
+}
+
+.innerbg {
+  height: 100px;
+  width: 188px;
+  background: rgba(255, 0, 255, 0.3);
+  position: absolute;
+  top: 0;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="blueborders"></div>
+  <div class="innerbg" style="left: 0"></div>
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="innerbg" style="left: 204px"></div>
+  <div class="inner lefthalf" style="left: 204px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    PPPPP<br>
+    QQQQQ
+  </div>
+  <div class="innerbg" style="left: 408px"></div>
+</div>

--- a/css/css-multicol/multicol-breaking-003.html
+++ b/css/css-multicol/multicol-breaking-003.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-003-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-rule: 4px solid blue;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  background: rgba(255, 0, 255, 0.3);
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px; column-fill: auto">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-000-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-000-ref.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner lefthalf" style="left: 0; height: 60px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    DDDDD<br>
+    EEEEE
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-000.html
+++ b/css/css-multicol/multicol-breaking-nobackground-000.html
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-nobackground-000-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-001-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-001-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="inner lefthalf" style="left: 204px; height: 80px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ<br>
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-001.html
+++ b/css/css-multicol/multicol-breaking-nobackground-001.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-nobackground-001-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-002-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-002-ref.html
@@ -1,0 +1,77 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="inner lefthalf" style="left: 204px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    PPPPP<br>
+    QQQQQ<br>
+    RRRRR<br>
+    SSSSS<br>
+    TTTTT
+  </div>
+  <div class="inner lefthalf" style="left: 408px">
+    UUUUU<br>
+    VVVVV<br>
+    WWWWW<br>
+    XXXXX<br>
+    YYYYY
+  </div>
+  <div class="inner righthalf" style="left: 503px">
+    ZZZZZ<br>
+    aaaaa<br>
+    bbbbb<br>
+    ccccc<br>
+    ddddd
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-002.html
+++ b/css/css-multicol/multicol-breaking-nobackground-002.html
@@ -1,0 +1,62 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-nobackground-002-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ<br>
+    RRRRR<br>
+    SSSSS<br>
+    TTTTT<br>
+    UUUUU<br>
+    VVVVV<br>
+    WWWWW<br>
+    XXXXX<br>
+    YYYYY<br>
+    ZZZZZ<br>
+    aaaaa<br>
+    bbbbb<br>
+    ccccc<br>
+    ddddd
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-003-ref.html
+++ b/css/css-multicol/multicol-breaking-nobackground-003-ref.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML>
+<title>CSS Test Reference: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<style>
+
+.outer {
+  height: 100px;
+  width: 800px;
+  background: rgba(0, 0, 255, 0.3);
+  position: relative;
+}
+
+.inner {
+  height: 100px;
+  width: 86px;
+  font: 16px/1.25 sans-serif;
+  position: absolute;
+  top: 0;
+}
+
+.lefthalf {
+  border-right: 2px solid fuchsia;
+  padding-right: 7px;
+}
+
+.righthalf {
+  padding-left: 7px;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner lefthalf" style="left: 0">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE
+  </div>
+  <div class="inner righthalf" style="left: 95px">
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ
+  </div>
+  <div class="inner lefthalf" style="left: 204px">
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO
+  </div>
+  <div class="inner righthalf" style="left: 299px">
+    PPPPP<br>
+    QQQQQ
+  </div>
+</div>

--- a/css/css-multicol/multicol-breaking-nobackground-003.html
+++ b/css/css-multicol/multicol-breaking-nobackground-003.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML>
+<title>CSS Test: breaking of a multicolumn</title>
+<meta charset="utf-8">
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="https://mozilla.org/">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#column-gaps-and-rules">
+<link rel="help" href="https://drafts.csswg.org/css-multicol/#cf">
+<link rel="match" href="multicol-breaking-nobackground-003-ref.html">
+<style>
+
+.outer {
+  height: 100px;
+  column-fill: auto;
+  width: 800px;
+  column-count: 4;
+  column-gap: 16px;
+  background: rgba(0, 0, 255, 0.3);
+}
+
+.inner {
+  column-count: 2;
+  column-rule: 2px solid fuchsia;
+  column-gap: 16px;
+  font: 16px/1.25 sans-serif;
+}
+
+</style>
+
+<div class="outer">
+  <div class="inner" style="height: 300px; column-fill: auto">
+    AAAAA<br>
+    BBBBB<br>
+    CCCCC<br>
+    DDDDD<br>
+    EEEEE<br>
+    FFFFF<br>
+    GGGGG<br>
+    HHHHH<br>
+    IIIII<br>
+    JJJJJ<br>
+    KKKKK<br>
+    LLLLL<br>
+    MMMMM<br>
+    NNNNN<br>
+    OOOOO<br>
+    PPPPP<br>
+    QQQQQ
+  </div>
+</div>


### PR DESCRIPTION
The \*-nobackground-\* tests pass in Firefox and Chrome, and the others
pass in Chrome and fail in Firefox due to what I (as a Gecko
implementor) consider to be a Firefox bug.  I haven't yet tested other
engines.

Given the level of ambiguity in the multicol spec, I suspect these tests
probably test some things that aren't formally specified.  However, I
think that's probably OK for now.  One issue that I know of that they
depend on the spec for is w3c/csswg-drafts#2309.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
