### PR TITLE
CSS2  tests were only correct if the default font has two weights.

### DIFF
--- a/css/CSS2/fonts/font-weight-100-ref.html
+++ b/css/CSS2/fonts/font-weight-100-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<style>
+div { font-weight: 100 }
+</style>
+<body>
+  <p>Test passes if the lines of "Filler Text" below match.</p>
+  <div>Filler Text</div>
+  <div>Filler Text</div>
+</body>

--- a/css/CSS2/fonts/font-weight-100-ref.html
+++ b/css/CSS2/fonts/font-weight-100-ref.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reference</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
 <style>
 div { font-weight: 100 }
 </style>

--- a/css/CSS2/fonts/font-weight-900-ref.html
+++ b/css/CSS2/fonts/font-weight-900-ref.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>CSS Reference</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="author" title="Mike Bremford" href="http://bfo.com">
 <style>
-div { font-weight: 100 }
+div { font-weight: 900 }
 </style>
 <body>
   <p>Test passes if the lines of "Filler Text" below match.</p>

--- a/css/CSS2/fonts/font-weight-900-ref.html
+++ b/css/CSS2/fonts/font-weight-900-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<style>
+div { font-weight: 100 }
+</style>
+<body>
+  <p>Test passes if the lines of "Filler Text" below match.</p>
+  <div>Filler Text</div>
+  <div>Filler Text</div>
+</body>

--- a/css/CSS2/fonts/font-weight-rule-005.xht
+++ b/css/CSS2/fonts/font-weight-rule-005.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-weight-prop" />
-        <link rel="match" href="font-weight-bold-ref.html" />
+        <link rel="match" href="font-weight-900-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'font-weight' property set to 'bolder' does not increase the value of font weight when the parent values is already set at 900." />
         <style type="text/css">

--- a/css/CSS2/fonts/font-weight-rule-007.xht
+++ b/css/CSS2/fonts/font-weight-rule-007.xht
@@ -5,7 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/fonts.html#font-boldness" />
         <link rel="help" href="http://www.w3.org/TR/css-fonts-3/#font-weight-prop" />
-        <link rel="match" href="font-weight-normal-ref.html" />
+        <link rel="match" href="font-weight-100-ref.html" />
         <meta name="flags" content="" />
         <meta name="assert" content="A font weight of 'lighter' selects the next lighter weight compared to its parent's weight." />
         <style type="text/css">


### PR DESCRIPTION
font-weight-rule 005 and 007 both made the incorrect assumption that there were no weights lighter than 400 or greater than 700 in the default font.

Added new reference tests for them which don't depend on this.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
