### PR TITLE
Fix an error in executorservo.py

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -185,7 +185,7 @@ class ServoRefTestExecutor(ProcessTestExecutor):
         self.screenshot_cache = screenshot_cache
         self.implementation = RefTestImplementation(self)
         self.tempdir = tempfile.mkdtemp()
-        self.hosts_path = make_hosts_file()
+        self.hosts_path = write_hosts_file(server_config)
 
     def teardown(self):
         try:


### PR DESCRIPTION

```
TypeError: make_hosts_file() takes exactly 2 arguments (0 given)
```

Upstreamed from https://github.com/servo/servo/pull/20055 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9541)
<!-- Reviewable:end -->
