### PR TITLE
Fix selection{Start,End} test

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-start-end.html
+++ b/html/semantics/forms/textfieldselection/selection-start-end.html
@@ -62,7 +62,7 @@
   for (let prop of ["selectionStart", "selectionEnd"]) {
     for (let el of createTestElements(testValue)) {
       test(function() {
-        assert_equals(el.selectionStart, testValue.length);
+        assert_equals(el[prop], testValue.length);
       }, `Initial .value set on ${el.id} should set ${prop} to end of value`);
     }
   }


### PR DESCRIPTION
Likely due to a copy and paste error, one of the tests that was
meant to cover both selectionStart and selectionEnd only covered
the former. Fix so that it covers both, as it should have from the
start.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
