### PR TITLE
ReadableStream: Add a test that all queued writes complete when closing after first write

### DIFF
--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -458,4 +458,53 @@ promise_test(() => {
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes; preventClose = true');
 
+promise_test(() => {
+
+  const rs = recordingReadableStream();
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+
+  let resolveWritePromise;
+  const ws = recordingWritableStream({
+    write() {
+      resolveWriteCalled();
+
+      return new Promise(resolve => {
+        resolveWritePromise = resolve;
+      });
+    }
+  }, new CountQueuingStrategy({ highWaterMark: 2 }));
+
+  let pipeComplete = false;
+  const pipePromise = rs.pipeTo(ws, { preventClose: true }).then(() => {
+    pipeComplete = true;
+  });
+
+  rs.controller.enqueue('a');
+  rs.controller.enqueue('b');
+
+  return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the chunk must have been written, but close must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
+
+    rs.controller.close();
+    resolveWritePromise();
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
+      'the second chunk must have been written, but close must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
+
+    resolveWritePromise();
+    return pipePromise;
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
+      'all chunks must have been written, but close must not have happened yet');
+  });
+
+}, 'Closing must be propagated forward: shutdown must not occur until the final write completes; becomes closed after first write; preventClose = true');
+
 done();

--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -479,6 +479,55 @@ promise_test(() => {
   }, new CountQueuingStrategy({ highWaterMark: 2 }));
 
   let pipeComplete = false;
+  const pipePromise = rs.pipeTo(ws).then(() => {
+    pipeComplete = true;
+  });
+
+  rs.controller.enqueue('a');
+  rs.controller.enqueue('b');
+
+  return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the chunk must have been written, but close must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
+
+    rs.controller.close();
+    resolveWritePromise();
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
+      'the second chunk must have been written, but close must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
+
+    resolveWritePromise();
+    return pipePromise;
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'close'],
+      'all chunks must have been written and close must have happened');
+  });
+
+}, 'Closing must be propagated forward: shutdown must not occur until the final write completes; becomes closed after first write');
+
+promise_test(() => {
+
+  const rs = recordingReadableStream();
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+
+  let resolveWritePromise;
+  const ws = recordingWritableStream({
+    write() {
+      resolveWriteCalled();
+
+      return new Promise(resolve => {
+        resolveWritePromise = resolve;
+      });
+    }
+  }, new CountQueuingStrategy({ highWaterMark: 2 }));
+
+  let pipeComplete = false;
   const pipePromise = rs.pipeTo(ws, { preventClose: true }).then(() => {
     pipeComplete = true;
   });


### PR DESCRIPTION
This PR adds more tests for the new behavior introduced in whatwg/streams#884, namely that all queued writes must complete before a pipe operation becomes completed.

When the readable stream closes, the pipe operation should wait for all writes to complete, then close the writable stream (only if `preventClose != true`), and then resolve the pipe operation's promise. The new tests check the handling of both `preventClose = true` and `preventClose != true`, although the latter case was already handled correctly by the reference implementation.

The new tests are very similar to the one added in #5636, which verifies similar behavior for when the readable stream becomes errored.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
