### PR TITLE
WebDriver: fix some issues in fullscreen tests

### DIFF
--- a/webdriver/tests/fullscreen_window.py
+++ b/webdriver/tests/fullscreen_window.py
@@ -67,10 +67,8 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     session.url = inline("<title>WD doc title</title>")
     create_dialog(session)("alert", text="accept #1", result_var="accept1")
 
-    expected_title = read_global(session, "document.title")
     response = fullscreen(session)
 
-    assert_success(response, expected_title)
     assert_dialog_handled(session, "accept #1")
     assert read_global(session, "accept1") == None
 
@@ -79,16 +77,13 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
 
     response = fullscreen(session)
 
-    assert_success(response, expected_title)
     assert_dialog_handled(session, "accept #2")
     assert read_global(session, "accept2"), True
 
-    expected_title = read_global(session, "document.title")
     create_dialog(session)("prompt", text="accept #3", result_var="accept3")
 
     response = fullscreen(session)
 
-    assert_success(response, expected_title)
     assert_dialog_handled(session, "accept #3")
     assert read_global(session, "accept3") == ""
 
@@ -121,7 +116,7 @@ def test_handle_prompt_missing_value(session, create_dialog):
 
     assert_error(response, "unexpected alert open")
     assert_dialog_handled(session, "dismiss #1")
-    assert read_global(session, "accept1") == None
+    assert read_global(session, "dismiss1") == None
 
     create_dialog("confirm", text="dismiss #2", result_var="dismiss2")
 
@@ -140,6 +135,11 @@ def test_handle_prompt_missing_value(session, create_dialog):
     assert read_global(session, "dismiss3") == None
 
 
+def is_fullscreen(session):
+    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
+    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
+    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
+
 def test_fullscreen(session):
     """
     4. Call fullscreen an element with the current top-level browsing
@@ -148,7 +148,8 @@ def test_fullscreen(session):
     """
     response = fullscreen(session)
     assert_success(response)
-    assert session.execute_script("return window.fullScreen") is True
+
+    assert is_fullscreen(session) is True
 
 
 def test_payload(session):
@@ -197,12 +198,12 @@ def test_payload(session):
 
 
 def test_fullscreen_twice_is_idempotent(session):
-    assert session.execute_script("return window.fullScreen") is False
+    assert is_fullscreen(session) is False
 
     first_response = fullscreen(session)
     assert_success(first_response)
-    assert session.execute_script("return window.fullScreen") is True
+    assert is_fullscreen(session) is True
 
     second_response = fullscreen(session)
     assert_success(second_response)
-    assert session.execute_script("return window.fullScreen") is True
+    assert is_fullscreen(session) is True


### PR DESCRIPTION
The test test_handle_prompt_accept seems to think that the
Fullscreen Window command returns the window title, which is
not the case. Remove wrong assertions. The return payload is
checked by a different test case.

The test test_handle_prompt_missing_value has a typo in a
global variable lookup. This throws a JS exception at runtime.

Tests that use window.fullScreen fail when run in WebKit because
WebKit does not yet conform to the Fullscreen API, and its existing
properties and methods are prefixed. Add a fallback and a note
with the WebKit bug that blocks removing this fallback.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
