### PR TITLE
Fix #8954: update wptrunner requirements

### DIFF
--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -1,5 +1,5 @@
-html5lib >= 0.99
-mozinfo >= 0.7
-mozlog >= 3.5
+html5lib >= 1.0.1
+mozinfo >= 0.10
+mozlog >= 3.7
 mozdebug >= 0.1
-urllib3[secure]
+urllib3[secure] >= 1.22

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -1,5 +1,5 @@
-html5lib >= 1.0.1
-mozinfo >= 0.10
-mozlog >= 3.7
-mozdebug >= 0.1
-urllib3[secure] >= 1.22
+html5lib == 1.0.1
+mozinfo == 0.10
+mozlog == 3.7
+mozdebug == 0.1
+urllib3[secure] == 1.22

--- a/tools/wptrunner/requirements_chrome.txt
+++ b/tools/wptrunner/requirements_chrome.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/requirements_chrome.txt
+++ b/tools/wptrunner/requirements_chrome.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.19
-selenium >= 2.41.0
+mozprocess >= 0.26
+selenium >= 3.9.0

--- a/tools/wptrunner/requirements_chrome_android.txt
+++ b/tools/wptrunner/requirements_chrome_android.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/requirements_chrome_android.txt
+++ b/tools/wptrunner/requirements_chrome_android.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.19
-selenium >= 2.41.0
+mozprocess >= 0.26
+selenium >= 3.9.0

--- a/tools/wptrunner/requirements_edge.txt
+++ b/tools/wptrunner/requirements_edge.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/requirements_edge.txt
+++ b/tools/wptrunner/requirements_edge.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.19
-selenium >= 2.41.0
+mozprocess >= 0.26
+selenium >= 3.9.0

--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -1,6 +1,6 @@
-marionette_driver >= 2.5.0
-mozprofile >= 0.29
-mozprocess >= 0.26
-mozcrash >= 1.0
-mozrunner >= 6.14
-mozleak >= 0.1
+marionette_driver == 2.5.0
+mozprofile == 0.29
+mozprocess == 0.26
+mozcrash == 1.0
+mozrunner == 6.14
+mozleak == 0.1

--- a/tools/wptrunner/requirements_firefox.txt
+++ b/tools/wptrunner/requirements_firefox.txt
@@ -1,6 +1,6 @@
-marionette_driver >= 2.4
-mozprofile >= 0.21
-mozprocess >= 0.19
-mozcrash >= 0.13
-mozrunner >= 6.7
+marionette_driver >= 2.5.0
+mozprofile >= 0.29
+mozprocess >= 0.26
+mozcrash >= 1.0
+mozrunner >= 6.14
 mozleak >= 0.1

--- a/tools/wptrunner/requirements_ie.txt
+++ b/tools/wptrunner/requirements_ie.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/requirements_ie.txt
+++ b/tools/wptrunner/requirements_ie.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.19
-selenium >= 2.41.0
+mozprocess >= 0.26
+selenium >= 3.9.0

--- a/tools/wptrunner/requirements_opera.txt
+++ b/tools/wptrunner/requirements_opera.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/requirements_opera.txt
+++ b/tools/wptrunner/requirements_opera.txt
@@ -1,2 +1,2 @@
-mozprocess >= 0.19
-selenium >= 2.41.0
+mozprocess >= 0.26
+selenium >= 3.9.0

--- a/tools/wptrunner/requirements_sauce.txt
+++ b/tools/wptrunner/requirements_sauce.txt
@@ -1,3 +1,3 @@
-mozprocess >= 0.19
-selenium >= 3.3.0
+mozprocess >= 0.26
+selenium >= 3.9.0
 requests

--- a/tools/wptrunner/requirements_sauce.txt
+++ b/tools/wptrunner/requirements_sauce.txt
@@ -1,3 +1,3 @@
-mozprocess >= 0.26
-selenium >= 3.9.0
+mozprocess == 0.26
+selenium == 3.9.0
 requests

--- a/tools/wptrunner/requirements_servo.txt
+++ b/tools/wptrunner/requirements_servo.txt
@@ -1,1 +1,1 @@
-mozprocess >= 0.19
+mozprocess >= 0.26

--- a/tools/wptrunner/requirements_servo.txt
+++ b/tools/wptrunner/requirements_servo.txt
@@ -1,1 +1,1 @@
-mozprocess >= 0.26
+mozprocess == 0.26


### PR DESCRIPTION
Note this just uses the current stable release of all dependencies rather than trying to find what the minimum required actually is.

Fixes #8954.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9587)
<!-- Reviewable:end -->
