### PR TITLE
ReadableStream: Add tests for shutting down when readable becomes errored with preventAbort = true

### DIFF
--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -454,6 +454,9 @@ promise_test(() => {
     resolveWritePromise();
 
     return pipePromise;
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the chunk must have been written, but close must not have happened yet');
   });
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes; preventClose = true');

--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -448,7 +448,7 @@ promise_test(() => {
   // Flush async events and verify that no shutdown occurs.
   return flushAsyncEvents().then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the chunk must have been written, but close must not have happened yet');
+      'the chunk must have been written, but close must not have happened');
     assert_equals(pipeComplete, false, 'the pipe must not be complete');
 
     resolveWritePromise();
@@ -456,7 +456,7 @@ promise_test(() => {
     return pipePromise;
   }).then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the chunk must have been written, but close must not have happened yet');
+      'the chunk must have been written, but close must not have happened');
   });
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes; preventClose = true');
@@ -540,21 +540,21 @@ promise_test(() => {
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the first chunk must have been written, but close must not have happened yet');
+      'the first chunk must have been written, but close must not have happened');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.close();
     resolveWritePromise();
   }).then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
-      'the second chunk must have been written, but close must not have happened yet');
+      'the second chunk must have been written, but close must not have happened');
     assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
 
     resolveWritePromise();
     return pipePromise;
   }).then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
-      'all chunks must have been written, but close must not have happened yet');
+      'all chunks must have been written, but close must not have happened');
   });
 
 }, 'Closing must be propagated forward: shutdown must not occur until the final write completes; becomes closed after first write; preventClose = true');

--- a/streams/piping/close-propagation-forward.js
+++ b/streams/piping/close-propagation-forward.js
@@ -491,7 +491,7 @@ promise_test(() => {
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the chunk must have been written, but close must not have happened yet');
+      'the first chunk must have been written, but close must not have happened yet');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.close();
@@ -540,7 +540,7 @@ promise_test(() => {
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the chunk must have been written, but close must not have happened yet');
+      'the first chunk must have been written, but close must not have happened yet');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.close();

--- a/streams/piping/error-propagation-forward.js
+++ b/streams/piping/error-propagation-forward.js
@@ -552,21 +552,21 @@ promise_test(t => {
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the first chunk must have been written, but abort must not have happened yet');
+      'the first chunk must have been written, but abort must not have happened');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.error(error1);
     resolveWritePromise();
   }).then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
-      'the second chunk must have been written, but abort must not have happened yet');
+      'the second chunk must have been written, but abort must not have happened');
     assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
 
     resolveWritePromise();
     return pipePromise;
   }).then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
-      'all chunks must have been written, but abort must not have happened yet');
+      'all chunks must have been written, but abort must not have happened');
   });
 
 }, 'Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write; preventAbort = true');

--- a/streams/piping/error-propagation-forward.js
+++ b/streams/piping/error-propagation-forward.js
@@ -474,6 +474,6 @@ promise_test(t => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'abort', error1], 'sink abort should be called');
   });
 
-}, 'Errors must be propagated forward: abort should not happen until all queued writes complete');
+}, 'Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write');
 
 done();

--- a/streams/piping/error-propagation-forward.js
+++ b/streams/piping/error-propagation-forward.js
@@ -446,6 +446,50 @@ promise_test(t => {
         resolveWritePromise = resolve;
       });
     }
+  });
+
+  let pipeComplete = false;
+  const pipePromise = promise_rejects(t, error1, rs.pipeTo(ws, { preventAbort: true })).then(() => {
+    pipeComplete = true;
+  });
+
+  rs.controller.enqueue('a');
+
+  return writeCalledPromise.then(() => {
+    rs.controller.error(error1);
+
+    // Flush async events and verify that no shutdown occurs.
+    return flushAsyncEvents();
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a']); // no 'abort'
+    assert_equals(pipeComplete, false, 'the pipe must not be complete');
+
+    resolveWritePromise();
+    return pipePromise;
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a']); // no 'abort'
+  });
+
+}, 'Errors must be propagated forward: shutdown must not occur until the final write completes; preventAbort = true');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream();
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+
+  let resolveWritePromise;
+  const ws = recordingWritableStream({
+    write() {
+      resolveWriteCalled();
+
+      return new Promise(resolve => {
+        resolveWritePromise = resolve;
+      });
+    }
   }, new CountQueuingStrategy({ highWaterMark: 2 }));
 
   let pipeComplete = false;
@@ -475,5 +519,54 @@ promise_test(t => {
   });
 
 }, 'Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write');
+
+promise_test(t => {
+
+  const rs = recordingReadableStream();
+
+  let resolveWriteCalled;
+  const writeCalledPromise = new Promise(resolve => {
+    resolveWriteCalled = resolve;
+  });
+
+  let resolveWritePromise;
+  const ws = recordingWritableStream({
+    write() {
+      resolveWriteCalled();
+
+      return new Promise(resolve => {
+        resolveWritePromise = resolve;
+      });
+    }
+  }, new CountQueuingStrategy({ highWaterMark: 2 }));
+
+  let pipeComplete = false;
+  const pipePromise = promise_rejects(t, error1, rs.pipeTo(ws, { preventAbort: true })).then(() => {
+    pipeComplete = true;
+  });
+
+  rs.controller.enqueue('a');
+  rs.controller.enqueue('b');
+
+  return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the chunk must have been written, but abort must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
+
+    rs.controller.error(error1);
+    resolveWritePromise();
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
+      'the second chunk must have been written, but abort must not have happened yet');
+    assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
+
+    resolveWritePromise();
+    return pipePromise;
+  }).then(() => flushAsyncEvents()).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
+      'all chunks must have been written, but abort must not have happened yet');
+  });
+
+}, 'Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write; preventAbort = true');
 
 done();

--- a/streams/piping/error-propagation-forward.js
+++ b/streams/piping/error-propagation-forward.js
@@ -501,7 +501,8 @@ promise_test(t => {
   rs.controller.enqueue('b');
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
-    assert_array_equals(ws.events, ['write', 'a'], 'abort should not be called before the first write completes');
+    assert_array_equals(ws.events, ['write', 'a'],
+      'the first chunk must have been written, but abort must not have happened yet');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.error(error1);
@@ -509,13 +510,14 @@ promise_test(t => {
     return flushAsyncEvents();
   }).then(() => {
     assert_array_equals(ws.events, ['write', 'a', 'write', 'b'],
-                        'abort should not be called before the second write completes');
+      'the second chunk must have been written, but abort must not have happened yet');
     assert_false(pipeComplete, 'the pipe should not complete while the second write is pending');
 
     resolveWritePromise();
     return pipePromise;
   }).then(() => {
-    assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'abort', error1], 'sink abort should be called');
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'b', 'abort', error1],
+      'all chunks must have been written and abort must have happened');
   });
 
 }, 'Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write');
@@ -550,7 +552,7 @@ promise_test(t => {
 
   return writeCalledPromise.then(() => flushAsyncEvents()).then(() => {
     assert_array_equals(ws.events, ['write', 'a'],
-      'the chunk must have been written, but abort must not have happened yet');
+      'the first chunk must have been written, but abort must not have happened yet');
     assert_false(pipeComplete, 'the pipe should not complete while the first write is pending');
 
     rs.controller.error(error1);


### PR DESCRIPTION
After looking at the new tests introduced in #5636 and #9573, I found that there was a small mismatch between the tests for forward close propagation and forward error propagation.

For closing, we have 4 tests for the shutdown behavior:
1. Closing must be propagated forward: shutdown must not occur until the final write completes
2. Closing must be propagated forward: shutdown must not occur until the final write completes; preventClose = true
3. Closing must be propagated forward: shutdown must not occur until the final write completes; becomes closed after first write
4. Closing must be propagated forward: shutdown must not occur until the final write completes; becomes closed after first write; preventClose = true

For erroring, we only have 2:
1. Errors must be propagated forward: shutdown must not occur until the final write completes
2. Errors must be propagated forward: abort should not happen until all queued writes complete

This PR reworks the forward error propagation tests, so we now have similar variants:
1. Errors must be propagated forward: shutdown must not occur until the final write completes
2. Errors must be propagated forward: shutdown must not occur until the final write completes; preventAbort = true
3. Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write
4. Errors must be propagated forward: shutdown must not occur until the final write completes; becomes errored after first write; preventAbort = true

<!-- Reviewable:start -->

<!-- Reviewable:end -->
