### PR TITLE
cc Add https://streams.spec.whatwg.org/demos tests

### DIFF
--- a/conformance-checkers/html/elements/script/streams-demo-append-child-isvalid.html
+++ b/conformance-checkers/html/elements/script/streams-demo-append-child-isvalid.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Append child writable stream demo</title>
+
+<script src="transforms/transform-stream-polyfill.js"></script>
+<script src="transforms/text-encode-transform.js"></script>
+<script src="transforms/parse-json.js"></script>
+<script src="transforms/split-stream.js"></script>
+<script src="resources/highlight.pack.js"></script>
+<script src="resources/web-animations.min.js"></script>
+<script src="tags/view-source.js"></script>
+
+<link rel=stylesheet href="resources/common.css">
+<link rel=stylesheet href="resources/commits.css">
+
+<h1>Append child writable stream demo</h1>
+<a id=back-to-index href=index.html>Back to demo index</a>
+<view-source></view-source>
+
+<div id=buttons>
+  <button id="load">Load JSON stream</button>
+  <button id="reset">Reset</button>
+</div>
+
+<div id=target></div>
+
+<script>
+'use strict';
+const loadButton = document.querySelector('#load');
+const resetButton = document.querySelector('#reset');
+const targetDiv = document.querySelector('#target');
+const FIELDS =  ['Hash', 'Date', 'Author', 'Subject'];
+const FIELDS_LOWERCASE = FIELDS.map(string => string.toLowerCase());
+
+function createTable(parentElement) {
+  const table = document.createElement('table');
+  table.id = 'commits';
+  const tr = document.createElement('tr');
+  for (const heading of FIELDS) {
+    const th = document.createElement('th');
+    th.textContent = heading;
+    tr.appendChild(th);
+  }
+  table.appendChild(tr);
+  parentElement.appendChild(table);
+  return table;
+}
+
+// BEGIN SOURCE TO VIEW
+function appendChildWritableStream(parentNode) {
+  return new WritableStream({
+    write(chunk) {
+      parentNode.appendChild(chunk);
+    }
+  });
+}
+
+async function fetchThenJSONToDOM() {
+  const jsonToElementTransform = new TransformStream({
+    transform(chunk, controller) {
+      const tr = document.createElement('tr');
+      for (const cell of FIELDS_LOWERCASE) {
+        const td = document.createElement('td');
+        td.textContent = chunk[cell];
+        tr.appendChild(td);
+      }
+      controller.enqueue(tr);
+    }
+  });
+
+  const response = await fetch('data/commits.json',
+                               {
+                                 mode: 'same-origin',
+                                 headers: {
+                                   'Cache-Control': 'no-cache, no-store'
+                                 }
+                               });
+
+  const table = createTable(targetDiv);
+  return response.body
+    .pipeThrough(new TextDecoder())
+    .pipeThrough(splitStream('\n'))
+    .pipeThrough(parseJSON())
+    .pipeThrough(jsonToElementTransform)
+    .pipeTo(appendChildWritableStream(table));
+}
+// END SOURCE TO VIEW
+
+loadButton.onclick = () => {
+  loadButton.disabled = true;
+  setTimeout(fetchThenJSONToDOM, 0);
+};
+
+resetButton.onclick = () => {
+  targetDiv.innerHTML = '';
+  loadButton.disabled = false;
+};
+</script>

--- a/conformance-checkers/html/elements/script/streams-demo-streaming-element-backpressure-isvalid.html
+++ b/conformance-checkers/html/elements/script/streams-demo-streaming-element-backpressure-isvalid.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Streaming element with backpressure demo</title>
+
+<script src="transforms/transform-stream-polyfill.js"></script>
+<script src="transforms/text-encode-transform.js"></script>
+<script src="tags/streaming-element-backpressure.js"></script>
+<script src="resources/highlight.pack.js"></script>
+<script src="resources/web-animations.min.js"></script>
+<script src="tags/view-source.js"></script>
+
+<link rel=stylesheet href="resources/common.css">
+<link rel=stylesheet href="resources/jank-meter.css">
+<link rel=stylesheet href="resources/commits.css">
+
+<h1>Streaming element with backpressure demo</h1>
+<a id=back-to-index href=index.html>Back to demo index</a>
+<view-source></view-source>
+
+<div id=buttons>
+  <button id="load">Load HTML stream, applying backpressure</button>
+  <button id="reset">Reset</button>
+</div>
+
+<div id=jank-meter>JANK METER</div>
+
+<streaming-element-backpressure id=target></streaming-element-backpressure>
+
+<script>
+'use strict';
+const loadButton = document.querySelector('#load');
+const resetButton = document.querySelector('#reset');
+const targetDiv = document.querySelector('#target');
+
+loadButton.onclick = async () => {
+  loadButton.disabled = true;
+  fetchDirectlyIntoDOM();
+};
+
+// BEGIN SOURCE TO VIEW
+async function fetchDirectlyIntoDOM() {
+  const response = await fetch('data/commits.include',
+                             {
+                               mode: 'same-origin',
+                               headers: {
+                                 'Cache-Control': 'no-cache, no-store'
+                               }
+                             });
+
+  await response.body
+      .pipeThrough(new TextDecoder())
+      .pipeTo(targetDiv.writable);
+}
+// END SOURCE TO VIEW
+
+resetButton.onclick = () => {
+  targetDiv.reset();
+  loadButton.disabled = false;
+};
+</script>

--- a/conformance-checkers/html/elements/script/streams-demo-streaming-element-isvalid.html
+++ b/conformance-checkers/html/elements/script/streams-demo-streaming-element-isvalid.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Streaming element demo</title>
+
+<script src="transforms/transform-stream-polyfill.js"></script>
+<script src="transforms/text-encode-transform.js"></script>
+<script src="tags/streaming-element.js"></script>
+<script src="resources/highlight.pack.js"></script>
+<script src="resources/web-animations.min.js"></script>
+<script src="tags/view-source.js"></script>
+
+<link rel=stylesheet href="resources/common.css">
+<link rel=stylesheet href="resources/jank-meter.css">
+<link rel=stylesheet href="resources/commits.css">
+
+<h1>Streaming element demo</h1>
+<a id=back-to-index href=index.html>Back to demo index</a>
+<view-source></view-source>
+
+<div id=buttons>
+  <button id="load">Load HTML stream</button>
+  <button id="reset">Reset</button>
+</div>
+
+<div id=jank-meter>JANK METER</div>
+
+<streaming-element id=target></streaming-element>
+
+<script>
+'use strict';
+const loadButton = document.querySelector('#load');
+const resetButton = document.querySelector('#reset');
+const targetDiv = document.querySelector('#target');
+
+// BEGIN SOURCE TO VIEW
+async function streamDirectlyIntoDOM() {
+  const response = await fetch('data/commits.include',
+                               {
+                                 mode: 'same-origin',
+                                 headers: {
+                                   'Cache-Control': 'no-cache, no-store'
+                                 }
+                               });
+
+  await response.body
+      .pipeThrough(new TextDecoder())
+      .pipeTo(targetDiv.writable);
+}
+
+loadButton.onclick = () => {
+  loadButton.disabled = true;
+  streamDirectlyIntoDOM();
+};
+// END SOURCE TO VIEW
+
+resetButton.onclick = () => {
+  targetDiv.reset();
+  loadButton.disabled = false;
+};
+</script>


### PR DESCRIPTION
When JavaScript-syntax checking for `script`-element contents was
recently added to the HTML checker, it broke the build of the Streams
spec due to some documents in https://streams.spec.whatwg.org/demos/
using some newer JavaScript syntax that the Rhino parser (which the HTML
checker relies on) doesn’t understand yet.

So to ensure those cases get handled correctly, some refinements were
made to the HTML checker and the Rhino fork it uses. The documents are
added here to ensure no regressions occur.

Thanks @domenic

<!-- Reviewable:start -->

<!-- Reviewable:end -->
