### PR TITLE
Update reftests in manifest when reftests become non-reftests

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -86,13 +86,13 @@ class Manifest(object):
             if not is_new:
                 old_hash, old_type = self._path_hash[rel_path]
                 old_files[old_type].remove(rel_path)
-                if old_type == "reftest" and new_type != old_type:
-                    reftest_changes = True
                 if old_hash != file_hash:
                     new_type, manifest_items = source_file.manifest_items()
                     hash_changed = True
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
+                if old_type == "reftest" and new_type != old_type:
+                    reftest_changes = True
             else:
                 new_type, manifest_items = source_file.manifest_items()
 

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -86,6 +86,8 @@ class Manifest(object):
             if not is_new:
                 old_hash, old_type = self._path_hash[rel_path]
                 old_files[old_type].remove(rel_path)
+                if old_type == "reftest" and new_type != old_type:
+                    reftest_changes = True
                 if old_hash != file_hash:
                     new_type, manifest_items = source_file.manifest_items()
                     hash_changed = True

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -232,6 +232,28 @@ def test_reftest_computation_chain_update_remove():
     assert list(m) == [("reftest", test2.path, {test2})]
 
 
+def test_reftest_computation_chain_update_test_type():
+    m = manifest.Manifest()
+
+    s1 = SourceFileWithTest("test", "0"*40, item.RefTest, [("/test-ref", "==")])
+
+    assert m.update([s1]) is True
+
+    test1 = s1.manifest_items()[1][0]
+
+    assert list(m) == [("reftest", test1.path, {test1})]
+
+    # test becomes a testharness test (hash change because that is determined
+    # based on the file contents). The updated manifest should not includes the
+    # old reftest.
+    s2 = SourceFileWithTest("test", "1"*40, item.TestharnessTest)
+    assert m.update([s2]) is True
+
+    test2 = s2.manifest_items()[1][0]
+
+    assert list(m) == [("testharness", test2.path, {test2})]
+
+
 def test_iterpath():
     m = manifest.Manifest()
 


### PR DESCRIPTION
In https://github.com/w3c/web-platform-tests/pull/9523 some tests were
converted from reftests to testharness, but the incremental manifest
update mechanism doesn't handle this case. This appears to be the cause
of the mysterious Travis failures on that PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9598)
<!-- Reviewable:end -->
