### PR TITLE
Adding additional enabled <option> element in WebDriver test page

### DIFF
--- a/webdriver/tests/element_click/select.py
+++ b/webdriver/tests/element_click/select.py
@@ -217,6 +217,7 @@ def test_option_disabled(session):
     session.url = inline("""
         <select>
           <option disabled>foo
+          <option>bar
         </select>""")
     option = session.find.css("option", all=False)
     assert not option.selected


### PR DESCRIPTION
Clicking on a disabled <option> element should not allow it to become
selected. However, if the disabled <option> is the only child element of
the <select> element, it may be marked as selected by the user agent. This
commit allows the test to attempt to call elementClick on a disabled
<option> without it being selected.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
