### PR TITLE
Adding property name for self-referential array object

### DIFF
--- a/webdriver/tests/execute_script/cyclic.py
+++ b/webdriver/tests/execute_script/cyclic.py
@@ -34,7 +34,7 @@ def test_array_in_object(session):
     response = execute_script(session, """
         let arr = [];
         arr.push(arr);
-        return {arr};
+        return {'arrayValue': arr};
         """)
     assert_error(response, "javascript error")
 


### PR DESCRIPTION
To create a full object for use with Internet Explorer, the object literal
should contain a property name for the self-referential array object
added as a property value.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
