### PR TITLE
Making test_handle_prompt_accept consistent with other similar tests

### DIFF
--- a/webdriver/tests/fullscreen_window.py
+++ b/webdriver/tests/fullscreen_window.py
@@ -85,7 +85,7 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     response = fullscreen(session)
 
     assert_dialog_handled(session, "accept #3")
-    assert read_global(session, "accept3") == ""
+    assert read_global(session, "accept3") == "" or read_global(session, "accept3") == "undefined"
 
 
 def test_handle_prompt_missing_value(session, create_dialog):


### PR DESCRIPTION
Other webdriver tests that test the same thing for other commands all test
for accepting a `prompt()` dialog to look for either the empty string ("")
or undefined as the value returned by the method. This makes the
fullscreen tests consistent with those others.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
