### PR TITLE
Add manual tests for the copy, cut and paste events

### DIFF
--- a/clipboard-apis/copy-event-manual.html
+++ b/clipboard-apis/copy-event-manual.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>The copy event</title>
+<link rel="help" href="https://w3c.github.io/clipboard-apis/#clipboard-event-copy">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<p>Select and copy any part of this text to continue.
+<script>
+setup({explicit_timeout: true});
+async_test(t => {
+  document.oncopy = t.step_func_done(event => {
+    // Nothing can be asserted about the event target until
+    // https://github.com/w3c/clipboard-apis/issues/70 is resolved.
+    // assert_equals(event.target, document.body, "event.target");
+    assert_true(event.isTrusted, "event.isTrusted");
+    assert_true(event.composed, "event.composed");
+  });
+});
+</script>

--- a/clipboard-apis/cut-event-manual.html
+++ b/clipboard-apis/cut-event-manual.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>The cut event</title>
+<link rel="help" href="https://w3c.github.io/clipboard-apis/#clipboard-event-cut">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<input value="Select and cut any part of this text to continue" size="100">
+<script>
+setup({explicit_timeout: true});
+async_test(t => {
+  document.oncut = t.step_func_done(event => {
+    // Nothing can be asserted about the event target until
+    // https://github.com/w3c/clipboard-apis/issues/70 is resolved.
+    // assert_equals(event.target, document.body, "event.target");
+    assert_true(event.isTrusted, "event.isTrusted");
+    assert_true(event.composed, "event.composed");
+  });
+});
+</script>

--- a/clipboard-apis/paste-event-manual.html
+++ b/clipboard-apis/paste-event-manual.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>The paste event</title>
+<link rel="help" href="https://w3c.github.io/clipboard-apis/#clipboard-event-paste">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+<input placeholder="Paste any text here to continue" size="100">
+<p>Some pre-selected text to copy for convenience</p>
+<script>
+setup({explicit_timeout: true});
+async_test(t => {
+  getSelection().selectAllChildren(document.querySelector("p"));
+  document.onpaste = t.step_func_done(event => {
+    // Nothing can be asserted about the event target until
+    // https://github.com/w3c/clipboard-apis/issues/70 is resolved.
+    // assert_equals(event.target, document.body, "event.target");
+    assert_true(event.isTrusted, "event.isTrusted");
+    assert_true(event.composed, "event.composed");
+  });
+});
+</script>


### PR DESCRIPTION
Follows https://github.com/w3c/clipboard-apis/pull/62.

Per manual testing, this fails in Chrome and Firefox because the event
is not compose, but passes in Safari. Edge not tested.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
