### PR TITLE
Make percentage height calculation quirk tests match implementations

### DIFF
--- a/quirks/percentage-height-calculation.html
+++ b/quirks/percentage-height-calculation.html
@@ -64,7 +64,7 @@
         {style:'#foo { height:100px } #test { height:calc(100% + 1px) }', body:'<div id=foo><div id=test></div></div>', q:101, s:101},
         {style:'#foo { height:100px } #test { height:5px; height:calc(100% + 1px) }', body:'<div id=foo><div><div id=test></div></div></div>', q:0, s:0},
         {style:'html { display:inline } #test { height:100% }', body:'<div id=test></div>', q:184, s:0}, // display:inline on root has no effect
-        {style:'html { margin:10px } body { display:inline } #test { height:100% }', body:'<div id=test></div>', q:200, s:0},
+        {style:'html { margin:10px } body { display:inline } #test { height:100% }', body:'<div id=test></div>', q:180, s:0},
         {style:'body { margin:0 } #test { height:100% }', body:'<div id=test></div>', q:200, s:0},
         {style:'body { margin:0; padding:10px } #test { height:100% }', body:'<div id=test></div>', q:180, s:0},
         {style:'body { margin:0; border:10px solid } #test { height:100% }', body:'<div id=test></div>', q:180, s:0},
@@ -118,10 +118,10 @@
         {input:'<html xmlns="{html}"><head><style>#test { height:100% }</style></head><body/><div id="test"/></html>', q:200, s:0},
         {input:'<html xmlns="{html}"><head><style>#test { height:100% }</style></head><span><body><div id="test"/></body></span></html>', q:200, s:0},
         {input:'<html xmlns="{html}"><head><style>#test { height:100% }</style></head><body><body><div id="test"/></body></body></html>', q:200, s:0},
-        {input:'<html><head xmlns="{html}"><style>#test { height:100% }</style></head><body xmlns="{html}"><div id="test"/></body></html>', q:200, s:0},
-        {input:'<div xmlns="{html}"><head><style>#test { height:100% }</style></head><body><div id="test"/></body></div>', q:200, s:0},
+        {input:'<html><head xmlns="{html}"><style>#test { height:100% }</style></head><body xmlns="{html}"><div id="test"/></body></html>', q:184, s:0},
+        {input:'<div xmlns="{html}"><head><style>#test { height:100% }</style></head><body><div id="test"/></body></div>', q:184, s:0},
         {input:'<html xmlns="{html}"><head><style>#test { height:100% }</style></head><body xmlns=""><div xmlns="{html}" id="test"/></body></html>', q:200, s:0},
-        {input:'<HTML xmlns="{html}"><head><style>#test { height:100% }</style></head><body><div id="test"/></body></HTML>', q:200, s:0},
+        {input:'<HTML xmlns="{html}"><head><style>#test { height:100% }</style></head><body><div id="test"/></body></HTML>', q:184, s:0},
         {input:'<html xmlns="{html}"><head><style>#test { height:100% }</style></head><BODY><div id="test"/></BODY></html>', q:200, s:0},
         ];
 


### PR DESCRIPTION
These tests are all failing in the same way in Chrome, Edge, Firefox and
Safari: https://wpt.fyi/quirks/percentage-height-calculation.html

They came up when looking at tests that have been failing for a very
long time: https://docs.google.com/document/d/1kFYTqUMEbo9p87i6wAzORoicMWgHsuYwL2CgtvdhDaE/edit?usp=sharing

<!-- Reviewable:start -->

<!-- Reviewable:end -->
