### PR TITLE
Fix #9481: fix invalid output during environment initialization

### DIFF
--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -307,76 +307,81 @@ def run(venv, wpt_args, **kwargs):
 
     pr_number = pr()
 
-    with TravisFold("browser_setup"):
-        logger.info(markdown.format_comment_title(wpt_args.product))
+    try:
+        with TravisFold("browser_setup"):
+            logger.info(markdown.format_comment_title(wpt_args.product))
 
-        if pr is not None:
-            deepen_checkout(kwargs["user"])
+            if pr is not None:
+                deepen_checkout(kwargs["user"])
 
-        # Ensure we have a branch called "master"
-        fetch_wpt(kwargs["user"], "master:master")
+            # Ensure we have a branch called "master"
+            fetch_wpt(kwargs["user"], "master:master")
 
-        head_sha1 = get_sha1()
-        logger.info("Testing web-platform-tests at revision %s" % head_sha1)
+            head_sha1 = get_sha1()
+            logger.info("Testing web-platform-tests at revision %s" % head_sha1)
 
-        wpt_kwargs = Kwargs(vars(wpt_args))
+            wpt_kwargs = Kwargs(vars(wpt_args))
 
-        if not wpt_kwargs["test_list"]:
-            manifest_path = os.path.join(wpt_kwargs["metadata_root"], "MANIFEST.json")
-            tests_changed, files_affected = get_changed_files(manifest_path, kwargs["rev"],
-                                                              ignore_changes, skip_tests)
+            if not wpt_kwargs["test_list"]:
+                manifest_path = os.path.join(wpt_kwargs["metadata_root"], "MANIFEST.json")
+                tests_changed, files_affected = get_changed_files(manifest_path, kwargs["rev"],
+                                                                  ignore_changes, skip_tests)
 
-            if not (tests_changed or files_affected):
-                logger.info("No tests changed")
-                return 0
+                if not (tests_changed or files_affected):
+                    logger.info("No tests changed")
+                    return 0
 
-            if tests_changed:
-                logger.debug("Tests changed:\n%s" % "".join(" * %s\n" % item for item in tests_changed))
+                if tests_changed:
+                    logger.debug("Tests changed:\n%s" % "".join(" * %s\n" % item for item in tests_changed))
 
-            if files_affected:
-                logger.debug("Affected tests:\n%s" % "".join(" * %s\n" % item for item in files_affected))
+                if files_affected:
+                    logger.debug("Affected tests:\n%s" % "".join(" * %s\n" % item for item in files_affected))
 
-            wpt_kwargs["test_list"] = list(tests_changed | files_affected)
+                wpt_kwargs["test_list"] = list(tests_changed | files_affected)
 
-        set_default_args(wpt_kwargs)
+            set_default_args(wpt_kwargs)
 
-        do_delayed_imports()
+            do_delayed_imports()
 
-        wpt_kwargs["stability"] = True
-        wpt_kwargs["prompt"] = False
-        wpt_kwargs["install_browser"] = True
-        wpt_kwargs["install"] = wpt_kwargs["product"].split(":")[0] == "firefox"
+            wpt_kwargs["stability"] = True
+            wpt_kwargs["prompt"] = False
+            wpt_kwargs["install_browser"] = True
+            wpt_kwargs["install"] = wpt_kwargs["product"].split(":")[0] == "firefox"
 
-        wpt_kwargs = setup_wptrunner(venv, **wpt_kwargs)
+            wpt_kwargs = setup_wptrunner(venv, **wpt_kwargs)
 
-        logger.info("Using binary %s" % wpt_kwargs["binary"])
-
-
-    with TravisFold("running_tests"):
-        logger.info("Starting tests")
+            logger.info("Using binary %s" % wpt_kwargs["binary"])
 
 
-        wpt_logger = wptrunner.logger
-        iterations, results, inconsistent = run(venv, wpt_logger, **wpt_kwargs)
+        with TravisFold("running_tests"):
+            logger.info("Starting tests")
 
-    if results:
-        if inconsistent:
-            write_inconsistent(logger.error, inconsistent, iterations)
-            retcode = 2
+
+            wpt_logger = wptrunner.logger
+            iterations, results, inconsistent = run(venv, wpt_logger, **wpt_kwargs)
+
+        if results:
+            if inconsistent:
+                write_inconsistent(logger.error, inconsistent, iterations)
+                retcode = 2
+            else:
+                logger.info("All results were stable\n")
+            with TravisFold("full_results"):
+                write_results(logger.info, results, iterations,
+                              pr_number=pr_number,
+                              use_details=True)
+                if pr_number:
+                    post_results(results, iterations=iterations, url=results_url,
+                                 product=wpt_args.product, pr_number=pr_number,
+                                 status="failed" if inconsistent else "passed")
         else:
-            logger.info("All results were stable\n")
-        with TravisFold("full_results"):
-            write_results(logger.info, results, iterations,
-                          pr_number=pr_number,
-                          use_details=True)
-            if pr_number:
-                post_results(results, iterations=iterations, url=results_url,
-                             product=wpt_args.product, pr_number=pr_number,
-                             status="failed" if inconsistent else "passed")
-    else:
-        logger.info("No tests run.")
-
-    return retcode
+            logger.info("No tests run.")
+    except Exception as e:
+        logger.error(e)
+        raise
+    finally:
+        logger.shutdown()
+        return retcode
 
 
 if __name__ == "__main__":

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -450,8 +450,13 @@ def run(venv, **kwargs):
             log("All tests stable")
         rv = len(inconsistent) > 0
     else:
-        rv = run_single(venv, **kwargs) > 0
-
+        try:
+            rv = run_single(venv, **kwargs) > 0
+        except Exception as e:
+            logger.error(e)
+            raise
+        finally:
+            logger.shutdown()
     return rv
 
 
@@ -473,7 +478,6 @@ def main():
         return run(venv, vars(args))
     except WptrunError as e:
         exit(e.message)
-
 
 if __name__ == "__main__":
     import pdb

--- a/tools/wpt/update.py
+++ b/tools/wpt/update.py
@@ -28,5 +28,11 @@ def update_expectations(venv, **kwargs):
 
     logger = setup_logging(kwargs, {"mach": sys.stdout})
 
-    updater = WPTUpdate(logger, **kwargs)
-    updater.run()
+    try:
+        updater = WPTUpdate(logger, **kwargs)
+        updater.run()
+    except Exception as e:
+        logger.error(e)
+        raise
+    finally:
+        logger.shutdown()

--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -10,6 +10,9 @@ class WptreportFormatter(BaseFormatter):
         self.raw_results = {}
 
     def suite_end(self, data):
+        return
+
+    def shutdown(self, data):
         results = {}
         results["results"] = []
         for test_name in self.raw_results:

--- a/tools/wptrunner/wptrunner/update/__init__.py
+++ b/tools/wptrunner/wptrunner/update/__init__.py
@@ -42,5 +42,11 @@ def main():
     args = wptcommandline.parse_args_update()
     logger = setup_logging(args, {"mach": sys.stdout})
     assert structuredlog.get_default_logger() is not None
-    success = run_update(logger, **args)
-    sys.exit(0 if success else 1)
+    try:
+        success = run_update(logger, **args)
+    except Exception as e:
+        logger.error(e)
+        raise
+    finally:
+        logger.shutdown()
+        sys.exit(0 if success else 1)

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -274,8 +274,7 @@ def run_tests(config, test_paths, product, **kwargs):
                 if repeat_until_unexpected and unexpected_total > 0:
                     break
                 logger.suite_end()
-    return unexpected_total == 0
-
+    return unexpected_count == 0
 
 def check_stability(**kwargs):
     import stability
@@ -314,3 +313,5 @@ def main():
             pdb.post_mortem()
         else:
             raise
+    finally:
+        logger.shutdown()


### PR DESCRIPTION
Earlier the logger was emitting an empty JSON file for errors during
environment initialization. Now the mozlog shutdown() method is called
if the environment initialization fails to ensure that the generated report
file contains valid JSON object. The suite_end() method functionality
has been moved to the shutdown function to avoid redundancy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9633)
<!-- Reviewable:end -->
