### PR TITLE
Switch external_host to host_ip.

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,7 +1,7 @@
 {"host": "web-platform.test",
  "doc_root": null,
  "ws_doc_root": null,
- "external_host": null,
+ "host_ip": null,
  "ports":{"http":[8000, "auto"],
           "https":[8443],
           "ws":["auto"],

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -16,10 +16,14 @@ test_infrastructure() {
 }
 
 main() {
-    hosts_fixup
     PRODUCTS=( "firefox" "chrome" )
     for PRODUCT in "${PRODUCTS[@]}"; do
-        if [ $(echo $PRODUCT | grep '^chrome') ]; then
+        if [ "$PRODUCT" != "firefox" ]; then
+            # Firefox is expected to work using pref settings for DNS
+            # Don't adjust the hostnames in that case to ensure this keeps working
+            hosts_fixup
+        fi
+        if [ "$PRODUCT" == "chrome" ]; then
             install_chrome dev
         fi
         test_infrastructure

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -646,9 +646,10 @@ def get_ports(config, ssl_environment):
 
 
 def normalise_config(config, ports):
-    host = config["external_host"] if config["external_host"] else config["host"]
+    host = config["host"]
     domains = get_subdomains(host)
     not_domains = get_not_subdomains(host)
+
     ports_ = {}
     for scheme, ports_used in ports.iteritems():
         ports_[scheme] = ports_used
@@ -668,7 +669,6 @@ def normalise_config(config, ports):
     # make a (shallow) copy of the config and update that, so that the
     # normalized config can be used in place of the original one.
     config_ = config.copy()
-    config_["host"] = host
     config_["domains"] = domains
     config_["not_domains"] = not_domains
     config_["ports"] = ports_
@@ -687,8 +687,9 @@ def get_ssl_config(config, ssl_environment):
             "cert_path": cert_path,
             "encrypt_after_connect": config["ssl"]["encrypt_after_connect"]}
 
+
 def start(config, ssl_environment, routes, **kwargs):
-    host = config["host"]
+    host = config.get("host_ip") or config["host"]
     ports = get_ports(config, ssl_environment)
     paths = get_paths(config)
     bind_hostname = config["bind_hostname"]

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -122,8 +122,8 @@ def env_options():
     # domains to localhost without relying on the network stack.
     #
     # https://github.com/w3c/web-platform-tests/pull/9480
-    return {"host": "127.0.0.1",
-            "external_host": "web-platform.test",
+    return {"host_ip": "127.0.0.1",
+            "host": "web-platform.test",
             "bind_hostname": "false",
             "certificate_domain": "web-platform.test",
             "supports_debugger": True}

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -52,8 +52,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {"host": "127.0.0.1",
-            "external_host": "web-platform.test",
+    return {"host": "web-platform.test",
+            "host_ip": "127.0.0.1",
             "bind_hostname": False,
             "testharnessreport": "testharnessreport-servo.js",
             "supports_debugger": True}

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -53,8 +53,8 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {"host": "127.0.0.1",
-            "external_host": "web-platform.test",
+    return {"host_ip": "127.0.0.1",
+            "host": "web-platform.test",
             "bind_hostname": "true",
             "testharnessreport": "testharnessreport-servodriver.js",
             "supports_debugger": True}

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -107,7 +107,8 @@ class TestEnvironment(object):
             cm.__enter__()
             self.env_extras_cms.append(cm)
 
-        self.servers = serve.start(self.config, self.ssl_env,
+        self.servers = serve.start(self.config,
+                                   self.ssl_env,
                                    self.get_routes())
         if self.options.get("supports_debugger") and self.debug_info and self.debug_info.interactive:
             self.ignore_interrupts()
@@ -153,9 +154,7 @@ class TestEnvironment(object):
         with open(default_config_path) as f:
             default_config = json.load(f)
 
-        #TODO: allow non-default configuration for ssl
-
-        local_config["external_host"] = self.options.get("external_host", None)
+        local_config["host_ip"] = self.options.get("host_ip", None)
         local_config["ssl"]["encrypt_after_connect"] = self.options.get("encrypt_after_connect", False)
 
         config = serve.merge_json(default_config, local_config)
@@ -234,20 +233,23 @@ class TestEnvironment(object):
             if not failed:
                 return
             time.sleep(0.5)
-        raise EnvironmentError("Servers failed to start (scheme:port): %s" % ("%s:%s" for item in failed))
+        raise EnvironmentError("Servers failed to start: %s" %
+                               ", ".join("%s:%s" % item for item in failed))
 
     def test_servers(self):
         failed = []
+        host = self.config.get("host_ip") or self.config.get("host")
         for scheme, servers in self.servers.iteritems():
             for port, server in servers:
                 if self.test_server_port:
                     s = socket.socket()
                     try:
-                        s.connect((self.config["host"], port))
+                        s.connect((host, port))
                     except socket.error:
-                        failed.append((scheme, port))
+                        failed.append((host, port))
                     finally:
                         s.close()
 
                 if not server.is_alive():
                     failed.append((scheme, port))
+        return failed


### PR DESCRIPTION
When running tests in Firefox we don't require that the hostname is
actually resolvable since we set up some internal DNS overrides. This
means that we don't actually need to have web-platform.test defined in
/etc/hosts. As a consequence when we check the server is responding,
the check will typically fail for Firefox developers if we try to
access by hostname. Previously we made use of a special dance in which
external_host held the ip at the point of the check and was later
replaced by host to actually run tests. But that changed, and instead
we relied on the fact that we (accidentially) didn't actually fail in
the case the servers couldn't be reached by host name. However in some
cases things still failed because local DNS resolved web-patform.test
to some ip address, causing hangs or other badness.

In this patch we simply add a host_ip property to the config, and
connect to that to test the servers are repopnsing rather than the
hostname. We also actually fil if we didn't manage to connect to all
the servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9651)
<!-- Reviewable:end -->
