### PR TITLE
Check if git is a batch file on Windows

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -14,7 +14,11 @@ class Git(object):
     def get_func(repo_path):
         def git(cmd, *args):
             full_cmd = ["git", cmd] + list(args)
-            return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT)
+            try:
+                return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT)
+            except WindowsError:
+                full_cmd[0] = "git.bat"
+                return subprocess.check_output(full_cmd, cwd=repo_path, stderr=subprocess.STDOUT)
         return git
 
     @classmethod


### PR DESCRIPTION
In the steps for manifest generation, if git is contained in a batch file, `subprocess` will not be able to find git and will throw a `WindowsError`. This change makes it so that if a `WindowsError` is thrown, it will check if using `git.bat` works.

Chromium has run into this issue on Windows (see https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/7Q0cv67h5p8). I'm not sure if this is the best solution, open to thoughts on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9652)
<!-- Reviewable:end -->
