### PR TITLE
Clicking on element before sending special keys in WebDriver tests

### DIFF
--- a/webdriver/tests/actions/special_keys.py
+++ b/webdriver/tests/actions/special_keys.py
@@ -20,6 +20,8 @@ def test_webdriver_special_key_sends_keydown(session,
             document.body.addEventListener("keydown",
                     function(e) { e.preventDefault() });
         """)
+    key_reporter.click()
+    session.execute_script("resetEvents();")
     key_chain.key_down(getattr(Keys, name)).perform()
 
     # only interested in keydown

--- a/webdriver/tests/actions/special_keys.py
+++ b/webdriver/tests/actions/special_keys.py
@@ -2,6 +2,7 @@
 
 import pytest
 import time
+from tests.support.fixtures import configuration
 from tests.actions.support.keys import ALL_EVENTS, Keys
 from tests.actions.support.refine import filter_dict, get_keys, get_events
 
@@ -20,8 +21,9 @@ def test_webdriver_special_key_sends_keydown(session,
             document.body.addEventListener("keydown",
                     function(e) { e.preventDefault() });
         """)
-    key_reporter.click()
-    session.execute_script("resetEvents();")
+    if (session.capabilities["browserName"] == 'internet explorer'):
+        key_reporter.click()
+        session.execute_script("resetEvents();")
     key_chain.key_down(getattr(Keys, name)).perform()
 
     # only interested in keydown


### PR DESCRIPTION
This commit is, admittedly, to work around a browser-specific (or perhaps
an operating-system-specific) issue. When the Alt key is pressed on
Windows, the system menu bar is activated. This causes the page in at
least one browser to lose focus, and the key reporting element will no
longer receive keydown and keyup events until focus is restored. This
causes failures in succeeding tests.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
