### PR TITLE
Add tests for GeolocationSensor.read()

### DIFF
--- a/geolocation-sensor/GeolocationSensor-disabled-by-feature-policy.https.html
+++ b/geolocation-sensor/GeolocationSensor-disabled-by-feature-policy.https.html
@@ -9,5 +9,17 @@
 "use strict";
 
 run_fp_tests_disabled(GeolocationSensor);
+
+promise_test(async t => {
+  await promise_rejects(t, 'SecurityError', GeolocationSensor.read());
+}, "GeolocationSensor.read(): 'SecurityError' is thrown when disabled by Feature Policy");
+
+promise_test(async t => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  controller.abort();
+
+  await promise_rejects(t, 'AbortError', GeolocationSensor.read({ signal }));
+}, "GeolocationSensor.read(): 'AbortError' takes priority");
 </script>
 </body>

--- a/geolocation-sensor/GeolocationSensor_read.https.html
+++ b/geolocation-sensor/GeolocationSensor_read.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>GeolocationSensor.read() Test</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="https://wicg.github.io/geolocation-sensor/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+const properties = [
+    'timestamp',
+    'latitude',
+    'longitude',
+    'altitude',
+    'accuracy',
+    'altitudeAccuracy',
+    'heading',
+    'speed'
+  ];
+
+promise_test(async t => {
+  const geo = await GeolocationSensor.read({ signal: null });
+  assert_not_equals(geo.timestamp, null);
+  properties.forEach(property => assert_own_property(geo, property));
+}, "Test that read() method resolves with valid reading when signal is null");
+
+promise_test(async t => {
+  const geo = await GeolocationSensor.read();
+  assert_not_equals(geo.timestamp, null);
+  properties.forEach(property => assert_own_property(geo, property));
+}, "Test that read() method resolves with valid reading");
+
+promise_test(async t => {
+  const controller = new AbortController();
+  const signal = controller.signal;
+  controller.abort();
+
+  await promise_rejects(t, 'AbortError', GeolocationSensor.read({ signal }));
+}, "Test that read() method rejects 'AbortError' if signal's aborted flag is set");
+</script>

--- a/geolocation-sensor/GeolocationSensor_read.https.html
+++ b/geolocation-sensor/GeolocationSensor_read.https.html
@@ -7,15 +7,15 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 const properties = [
-    'timestamp',
-    'latitude',
-    'longitude',
-    'altitude',
-    'accuracy',
-    'altitudeAccuracy',
-    'heading',
-    'speed'
-  ];
+  'timestamp',
+  'latitude',
+  'longitude',
+  'altitude',
+  'accuracy',
+  'altitudeAccuracy',
+  'heading',
+  'speed'
+];
 
 promise_test(async t => {
   const geo = await GeolocationSensor.read({ signal: null });


### PR DESCRIPTION
covers:
  - verify sensor reading when call read() method
  - verify sensor reading when signal is set to null
  - throw AbortError when singal's abort flag is set
  - throw SecurityError when disabled by Feature Policy
  - AbortError takes priority when disabled by Feature Policy

<!-- Reviewable:start -->

<!-- Reviewable:end -->
