### PR TITLE
Add support for WebKit product

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -467,3 +467,27 @@ class Sauce(Browser):
 
     def version(self, root):
         return None
+
+class WebKit(Browser):
+    """WebKit-specific interface.
+
+    Includes installation, webdriver installation, and wptrunner setup methods.
+    """
+
+    product = "webkit"
+    requirements = "requirements_webkit.txt"
+
+    def install(self, dest=None):
+        raise NotImplementedError
+
+    def find_binary(self, path=None):
+        return None
+
+    def find_webdriver(self):
+        return None
+
+    def install_webdriver(self):
+        raise NotImplementedError
+
+    def version(self, root):
+        return None

--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -469,10 +469,7 @@ class Sauce(Browser):
         return None
 
 class WebKit(Browser):
-    """WebKit-specific interface.
-
-    Includes installation, webdriver installation, and wptrunner setup methods.
-    """
+    """WebKit-specific interface."""
 
     product = "webkit"
     requirements = "requirements_webkit.txt"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -343,6 +343,17 @@ class Servo(BrowserSetup):
             kwargs["binary"] = binary
 
 
+class WebKit(BrowserSetup):
+    name = "webkit"
+    browser_cls = browser.WebKit
+
+    def install(self, venv):
+        raise NotImplementedError
+
+    def setup_kwargs(self, kwargs):
+        pass
+
+
 product_setup = {
     "firefox": Firefox,
     "chrome": Chrome,
@@ -352,6 +363,7 @@ product_setup = {
     "servo": Servo,
     "sauce": Sauce,
     "opera": Opera,
+    "webkit": WebKit,
 }
 
 

--- a/tools/wptrunner/requirements_webkit.txt
+++ b/tools/wptrunner/requirements_webkit.txt
@@ -1,0 +1,2 @@
+mozprocess == 0.26
+selenium == 3.9.0

--- a/tools/wptrunner/wptrunner/browsers/__init__.py
+++ b/tools/wptrunner/wptrunner/browsers/__init__.py
@@ -30,4 +30,5 @@ product_list = ["chrome",
                 "sauce",
                 "servo",
                 "servodriver",
-                "opera"]
+                "opera",
+                "webkit"]

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -41,7 +41,7 @@ def capabilities_for_port(webkit_port, binary, binary_args):
         }
         return capabilities
 
-    return None
+    return {}
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -8,7 +8,7 @@ from ..webdriver_server import WebKitDriverServer
 
 __wptrunner__ = {"product": "webkit",
                  "check_args": "check_args",
-                 "browser": "WebKit",
+                 "browser": "WebKitBrowser",
                  "browser_kwargs": "browser_kwargs",
                  "executor": {"testharness": "SeleniumTestharnessExecutor",
                               "reftest": "SeleniumRefTestExecutor",
@@ -65,7 +65,11 @@ def env_options():
             "bind_hostname": "true"}
 
 
-class WebKit(Browser):
+class WebKitBrowser(Browser):
+    """Generic WebKit browser is backed by WebKit's WebDriver implementation,
+    which is supplied through ``wptrunner.webdriver.WebKitDriverServer``.
+    """
+
     def __init__(self, logger, binary, webdriver_binary=None,
                  webdriver_args=None):
         Browser.__init__(self, logger)

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -31,12 +31,16 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
 
 
 def capabilities_for_port(webkit_port, binary, binary_args):
+    from selenium.webdriver import DesiredCapabilities
+
     if webkit_port == "gtk":
-        return {"browserName": "MiniBrowser",
-                "version": "",
-                "platform": "ANY",
-                "webkitgtk:browserOptions": {"binary": binary,
-                                             "args": binary_args}}
+        capabilities = dict(DesiredCapabilities.WEBKITGTK.copy())
+        capabilities["webkitgtk:browserOptions"] = {
+            "binary": binary,
+            "args": binary_args
+        }
+        return capabilities
+
     return None
 
 

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -61,8 +61,7 @@ def env_extras(**kwargs):
 
 
 def env_options():
-    return {"host": "web-platform.test",
-            "bind_hostname": "true"}
+    return {"bind_hostname": "true"}
 
 
 class WebKitBrowser(Browser):

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -1,0 +1,91 @@
+from .base import Browser, ExecutorBrowser, require_arg
+from ..executors import executor_kwargs as base_executor_kwargs
+from ..executors.executorselenium import (SeleniumTestharnessExecutor,
+                                          SeleniumRefTestExecutor)
+from ..executors.executorwebkit import WebKitDriverWdspecExecutor
+from ..webdriver_server import WebKitDriverServer
+
+
+__wptrunner__ = {"product": "webkit",
+                 "check_args": "check_args",
+                 "browser": "WebKit",
+                 "browser_kwargs": "browser_kwargs",
+                 "executor": {"testharness": "SeleniumTestharnessExecutor",
+                              "reftest": "SeleniumRefTestExecutor",
+                              "wdspec": "WebKitDriverWdspecExecutor"},
+                 "executor_kwargs": "executor_kwargs",
+                 "env_extras": "env_extras",
+                 "env_options": "env_options"}
+
+
+def check_args(**kwargs):
+    require_arg(kwargs, "binary")
+    require_arg(kwargs, "webdriver_binary")
+    require_arg(kwargs, "webkit_port")
+
+
+def browser_kwargs(test_type, run_info_data, **kwargs):
+    return {"binary": kwargs["binary"],
+            "webdriver_binary": kwargs["webdriver_binary"],
+            "webdriver_args": kwargs.get("webdriver_args")}
+
+
+def capabilities_for_port(webkit_port, binary, binary_args):
+    if webkit_port == "gtk":
+        return {"browserName": "MiniBrowser",
+                "version": "",
+                "platform": "ANY",
+                "webkitgtk:browserOptions": {"binary": binary,
+                                             "args": binary_args}}
+    return None
+
+
+def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
+                    **kwargs):
+    executor_kwargs = base_executor_kwargs(test_type, server_config,
+                                           cache_manager, **kwargs)
+    executor_kwargs["close_after_done"] = True
+    capabilities = capabilities_for_port(kwargs["webkit_port"],
+                                         kwargs["binary"],
+                                         kwargs.get("binary_args", []))
+    executor_kwargs["capabilities"] = capabilities
+    return executor_kwargs
+
+
+def env_extras(**kwargs):
+    return []
+
+
+def env_options():
+    return {"host": "web-platform.test",
+            "bind_hostname": "true"}
+
+
+class WebKit(Browser):
+    def __init__(self, logger, binary, webdriver_binary=None,
+                 webdriver_args=None):
+        Browser.__init__(self, logger)
+        self.binary = binary
+        self.server = WebKitDriverServer(self.logger, binary=webdriver_binary,
+                                         args=webdriver_args)
+
+    def start(self, **kwargs):
+        self.server.start(block=False)
+
+    def stop(self, force=False):
+        self.server.stop(force=force)
+
+    def pid(self):
+        return self.server.pid
+
+    def is_alive(self):
+        # TODO(ato): This only indicates the driver is alive,
+        # and doesn't say anything about whether a browser session
+        # is active.
+        return self.server.is_alive()
+
+    def cleanup(self):
+        self.stop()
+
+    def executor_browser(self):
+        return ExecutorBrowser, {"webdriver_url": self.server.url}

--- a/tools/wptrunner/wptrunner/executors/executorwebkit.py
+++ b/tools/wptrunner/wptrunner/executors/executorwebkit.py
@@ -1,0 +1,10 @@
+from ..webdriver_server import WebKitDriverServer
+from .base import WdspecExecutor, WebDriverProtocol
+
+
+class WebKitDriverProtocol(WebDriverProtocol):
+    server_cls = WebKitDriverServer
+
+
+class WebKitDriverWdspecExecutor(WdspecExecutor):
+    protocol_cls = WebKitDriverProtocol

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -201,7 +201,7 @@ class WebKitDriverServer(WebDriverServer):
         WebDriverServer.__init__(self, logger, binary, port=port, args=args)
 
     def make_command(self):
-        return [self.binary, "--port=%s" % str(self.port) ] + self._args
+        return [self.binary, "--port=%s" % str(self.port)] + self._args
 
 
 def cmd_arg(name, value=None):

--- a/tools/wptrunner/wptrunner/webdriver_server.py
+++ b/tools/wptrunner/wptrunner/webdriver_server.py
@@ -13,7 +13,7 @@ import mozprocess
 
 __all__ = ["SeleniumServer", "ChromeDriverServer", "OperaDriverServer",
            "GeckoDriverServer", "InternetExplorerDriverServer", "EdgeDriverServer",
-           "ServoDriverServer", "WebDriverServer"]
+           "ServoDriverServer", "WebKitDriverServer", "WebDriverServer"]
 
 
 class WebDriverServer(object):
@@ -194,6 +194,14 @@ class ServoDriverServer(WebDriverServer):
         if self.binary_args:
             command += self.binary_args
         return command
+
+
+class WebKitDriverServer(WebDriverServer):
+    def __init__(self, logger, binary=None, port=None, args=None):
+        WebDriverServer.__init__(self, logger, binary, port=port, args=args)
+
+    def make_command(self):
+        return [self.binary, "--port=%s" % str(self.port) ] + self._args
 
 
 def cmd_arg(name, value=None):

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -245,6 +245,10 @@ scheme host and port.""")
                              dest="sauce_connect_binary",
                              help="Path to Sauce Connect binary")
 
+    webkit_group = parser.add_argument_group("WebKit-specific")
+    webkit_group.add_argument("--webkit-port", dest="webkit_port",
+                             help="WebKit port")
+
     parser.add_argument("test_list", nargs="*",
                         help="List of URLs for tests to run, or paths including tests to run. "
                              "(equivalent to --include)")


### PR DESCRIPTION
Allow testing development builds of various WebKit ports against the
web-platform-tests suite. The generic Selenium executors are used for
the testharness and reference tests. Wdspec tests are also supported.

Port-specific WebDriver capabilities have to be set on the executor.
This port can be defined through the --webkit-port command line flag.
At the moment only the GTK+ port is supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9666)
<!-- Reviewable:end -->
