### PR TITLE
Test BigInt as keys and values in IndexedDB

### DIFF
--- a/IndexedDB/bigint_value.htm
+++ b/IndexedDB/bigint_value.htm
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+// BigInt and BigInt wrappers are supported in serialization, per
+// https://github.com/whatwg/html/pull/3480
+// This support allows them to be used as IndexedDB values.
+
+let i = 0;
+function value(value, test) {
+    var t = async_test(document.title + " - " + (i++));
+    t.step(function() {
+        assert_true(test(value),
+                    "condition does not apply to initial value");
+    });
+
+    createdb(t).onupgradeneeded = function(e) {
+        e.target.result
+                .createObjectStore("store")
+                .add(value, 1);
+
+        e.target.onsuccess = t.step_func(function(e) {
+            e.target.result
+                    .transaction("store")
+                    .objectStore("store")
+                    .get(1)
+                    .onsuccess = t.step_func(function(e)
+            {
+                assert_true(test(e.target.result),
+                            "condition does not apply to deserialized result")
+                t.done();
+            });
+        });
+    };
+}
+
+value(1n, x => x === 1n);
+value(Object(1n), x => typeof x === 'object' && x instanceof BigInt
+                                             && x.valueOf() === 1n);
+
+// However, BigInt is not supported as an IndexedDB key; support
+// has been proposed in the following PR, but that change has not
+// landed at the time this patch was written
+// https://github.com/w3c/IndexedDB/pull/231
+
+function invalidKey(key) {
+    var t = async_test(document.title + " - " + (i++));
+
+    createdb(t).onupgradeneeded = function(e) {
+        let store = e.target.result.createObjectStore("store")
+        assert_throws('DataError', () => store.add(1, key));
+        t.done();
+    };
+}
+
+invalidKey(1n);
+invalidKey(Object(1n));  // Still an error even if the IndexedDB patch lands
+
+</script>
+
+<div id="log"></div>


### PR DESCRIPTION
BigInt and BigInt wrappers are supported in serialization, per
https://github.com/whatwg/html/pull/3480
This support allows them to be used as IndexedDB values.

However, BigInt is not supported as an IndexedDB key; support
has been proposed in the following PR, but that change has not
landed at the time this patch was written
https://github.com/w3c/IndexedDB/pull/231

<!-- Reviewable:start -->

<!-- Reviewable:end -->
