### PR TITLE
Add tests for the use and lack of the .https file name flag

### DIFF
--- a/infrastructure/assumptions/non-secure-context.any.js
+++ b/infrastructure/assumptions/non-secure-context.any.js
@@ -1,0 +1,9 @@
+test(() => {
+  assert_false(self.isSecureContext);
+}, "Lack of .https file name flag implies non-secure context");
+
+test(() => {
+  assert_equals(location.protocol, "http:");
+}, "Lack of .https file name flag implies HTTP scheme");
+
+done();

--- a/infrastructure/assumptions/secure-context.https.any.js
+++ b/infrastructure/assumptions/secure-context.https.any.js
@@ -1,0 +1,9 @@
+test(() => {
+  assert_true(self.isSecureContext);
+}, "Use of .https file name flag implies secure context");
+
+test(() => {
+  assert_equals(location.protocol, "https:");
+}, "Use of .https file name flag implies HTTPS scheme");
+
+done();


### PR DESCRIPTION
In https://github.com/w3c/web-platform-tests/pull/8979 it became obvious
that it's easy to have things mostly working without .https working as
intended, and having infrastructure tests for this seems helpful. (I
tried to run all the infrastructure tests first.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
