### PR TITLE
fixes style-attr-braces-002-quirks

### DIFF
--- a/css/css-style-attr/style-attr-braces-002-quirks.htm
+++ b/css/css-style-attr/style-attr-braces-002-quirks.htm
@@ -8,7 +8,7 @@
   <meta name="assert" content="Style attribute values are the content of a
     declaration block: the braces must not be included and are therefore invalid."/>
   <style type="text/css">
-    p { background: lime; color: green; }
+    p { background: lime; color: green; margin-top: 1em; }
   </style>
  </head>
  <body>


### PR DESCRIPTION
This is in reference to #8633 .
Test passes on firefox on adding `p { margin-top: 1em; }` as suggested by @zcorpan .

<!-- Reviewable:start -->

<!-- Reviewable:end -->
