### PR TITLE
Update assumptions test to match HTML spec

### DIFF
--- a/infrastructure/assumptions/html-elements.html
+++ b/infrastructure/assumptions/html-elements.html
@@ -10,7 +10,7 @@
 div.b {
   all: initial;
   direction: initial;
-  unicode-bidi: initial;
+  unicode-bidi: isolate;
   display: block;
 }
 


### PR DESCRIPTION
Per HTML, div defaults to `unicode-bidi: isolate` (except under ISO-8859-8!).

This makes the test pass in Firefox, though makes it regress in Chromium ([issue 296863](https://bugs.chromium.org/p/chromium/issues/detail?id=296863)).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
