### PR TITLE
add XHR.prototype.open parameter toString test

### DIFF
--- a/xhr/open-parameters-toString.htm
+++ b/xhr/open-parameters-toString.htm
@@ -1,0 +1,54 @@
+<!doctype html>
+<title>XMLHttpRequest: open() attempts to toString its string parameters</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(() => {
+  let log = [];
+  let expected = [
+    'method',
+    'url',
+    // NOTE: 'async' intentionally missing
+    'username',
+    'password',
+  ];
+
+  let xhr = new XMLHttpRequest;
+  xhr.open(
+    {
+      toString() {
+        log.push('method');
+        return 'get';
+      },
+    },
+    {
+      toString() {
+        log.push('url');
+        return location.href;
+      },
+    },
+    // NOTE: ToBoolean should not invoke valueOf
+    {
+      valueOf() {
+        log.push('async');
+        return true;
+      },
+    },
+    {
+      toString() {
+        log.push('username');
+        return 'username';
+      },
+    },
+    {
+      toString() {
+        log.push('password');
+        return 'password';
+      },
+    }
+  );
+
+  assert_array_equals(log, expected);
+});
+</script>


### PR DESCRIPTION
This codifies the WHATWG algorithm. IE/Edge are known to fail this test, while other major browsers pass.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
