### PR TITLE
Remove the "sound" property from the Notification interface

### DIFF
--- a/notifications/interfaces.html
+++ b/notifications/interfaces.html
@@ -38,7 +38,6 @@ interface Notification : EventTarget {
   readonly attribute USVString image;
   readonly attribute USVString icon;
   readonly attribute USVString badge;
-  readonly attribute USVString sound;
   [SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
   readonly attribute DOMTimeStamp timestamp;
   readonly attribute boolean renotify;
@@ -58,7 +57,6 @@ dictionary NotificationOptions {
   USVString image;
   USVString icon;
   USVString badge;
-  USVString sound;
   VibratePattern vibrate;
   DOMTimeStamp timestamp;
   boolean renotify = false;


### PR DESCRIPTION
The property will be removed from the standard per the following PR:
https://github.com/whatwg/notifications/pull/127

<!-- Reviewable:start -->

<!-- Reviewable:end -->
