### PR TITLE
Change initiatorType for navigation preload to "navigation"

### DIFF
--- a/service-workers/service-worker/navigation-preload/resource-timing.https.html
+++ b/service-workers/service-worker/navigation-preload/resource-timing.https.html
@@ -14,9 +14,9 @@ function check_timing_entry(entry, url, decodedBodySize, encodedBodySize) {
     'The entryType of preload response timing entry must be "resource' +
     '" :' + url);
   assert_equals(
-    entry.initiatorType, 'other',
+    entry.initiatorType, 'navigation',
     'The initiatorType of preload response timing entry must be ' +
-    '"other":' + url);
+    '"navigation":' + url);
 
   // If the server returns the redirect response, |decodedBodySize| is null and
   // |entry.decodedBodySize| shuld be 0. Otherwise |entry.decodedBodySize| must


### PR DESCRIPTION
Based on the discussion at https://github.com/w3c/resource-timing/issues/110, the `initiatorType` for navigation preload is simply "navigation".

<!-- Reviewable:start -->

<!-- Reviewable:end -->
