### PR TITLE
manifest.py: Fixed updating reftest graph when node changes to other type

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -91,7 +91,7 @@ class Manifest(object):
                     hash_changed = True
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
-                if (old_type == "reftest" and new_type != old_type) or (old_type=="reftest_node" and new_type!=old_type):
+                if old_type in ["reftest", "reftest_node"] and new_type != old_type:
                     reftest_changes = True
             else:
                 new_type, manifest_items = source_file.manifest_items()

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -91,7 +91,7 @@ class Manifest(object):
                     hash_changed = True
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
-                if old_type == "reftest" and new_type != old_type:
+                if (old_type == "reftest" and new_type != old_type) or (old_type=="refetest_node" and new_type!=old_type):
                     reftest_changes = True
             else:
                 new_type, manifest_items = source_file.manifest_items()

--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -91,7 +91,7 @@ class Manifest(object):
                     hash_changed = True
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
-                if (old_type == "reftest" and new_type != old_type) or (old_type=="refetest_node" and new_type!=old_type):
+                if (old_type == "reftest" and new_type != old_type) or (old_type=="reftest_node" and new_type!=old_type):
                     reftest_changes = True
             else:
                 new_type, manifest_items = source_file.manifest_items()


### PR DESCRIPTION
Slightly altered line 94 so reftest_changes is also set when
reftest_node changes to support, etc.

Closes https://github.com/w3c/web-platform-tests/issues/9671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9719)
<!-- Reviewable:end -->
