### PR TITLE
Tests for PaymentCurrencyAmount's currencySystem

### DIFF
--- a/payment-request/PaymentCurrencyAmount/currencySystem-member.https.html
+++ b/payment-request/PaymentCurrencyAmount/currencySystem-member.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests for PaymentCurrencyAmount's currencySystem</title>
+<link rel="help" href="https://www.w3.org/TR/payment-request/#dom-paymentcurrencyamount-currencysystem">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const validAmount = {
+    value: "0",
+    currency: "USD",
+    currencySystem: "urn:iso:std:iso:4217",
+  }
+  const validMethods = [{ supportedMethods: "valid-method" }];
+  const validDetails = {
+    total: {
+      label: "",
+      amount: validAmount,
+    },
+  };
+  // smoke test
+  const request = new PaymentRequest(validMethods, validDetails);
+
+  // real test
+  assert_throws(new TypeError(), () => {
+    const invalidAmount = {
+      ...validAmount,
+      currencySystem: "this will cause the TypeError"
+    }
+    const invalidDetails = {
+      total: {
+        label: "",
+        amount: invalidAmount,
+      },
+    };
+    const request = new PaymentRequest(validMethods, invalidDetails);
+  })
+}, "Must throw if it encounters an unknown currencySystem");
+</script>


### PR DESCRIPTION
This test is to prove that no one supports this feature - thus can be dropped from the spec. 

Related issues: 
 * https://github.com/w3c/payment-request/issues/686
 * https://github.com/w3c/payment-request/issues/617

<!-- Reviewable:start -->

<!-- Reviewable:end -->
