### PR TITLE
Update reftest graph when node changes to support

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -91,7 +91,7 @@ class Manifest(object):
                     hash_changed = True
                 else:
                     new_type, manifest_items = old_type, self._data[old_type][rel_path]
-                if old_type == "reftest" and new_type != old_type:
+                if old_type in ("reftest", "reftest_node") and new_type != old_type:
                     reftest_changes = True
             else:
                 new_type, manifest_items = source_file.manifest_items()

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -254,6 +254,31 @@ def test_reftest_computation_chain_update_test_type():
     assert list(m) == [("testharness", test2.path, {test2})]
 
 
+def test_reftest_computation_chain_update_node_change():
+    m = manifest.Manifest()
+
+    s1 = SourceFileWithTest("test1", "0"*40, item.RefTest, [("/test2", "==")])
+    s2 = SourceFileWithTest("test2", "0"*40, item.RefTestNode, [("/test3", "==")])
+
+    assert m.update([s1, s2]) is True
+
+    test1 = s1.manifest_items()[1][0]
+    test2 = s2.manifest_items()[1][0]
+
+    assert list(m) == [("reftest", test1.path, {test1}),
+                       ("reftest_node", test2.path, {test2})]
+
+    #test2 changes to support type
+    s3 = SourceFileWithTest("test2", "1"*40, item.SupportFile)
+
+    # This doesn't check whether the reftest graph was computed or not,
+    # the m.update([s3]) assert will just check whether m.update() returned True (I think).
+    # Regardless, the test works even when the graph isn't being recomputed.
+    assert m.update([s3]) is True
+    test3 = s3.manifest_items()[1][0]
+    assert list(m) == [("support", test3.path, {test3})]
+
+
 def test_iterpath():
     m = manifest.Manifest()
 

--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -269,14 +269,13 @@ def test_reftest_computation_chain_update_node_change():
                        ("reftest_node", test2.path, {test2})]
 
     #test2 changes to support type
-    s3 = SourceFileWithTest("test2", "1"*40, item.SupportFile)
+    s2 = SourceFileWithTest("test2", "1"*40, item.SupportFile)
 
-    # This doesn't check whether the reftest graph was computed or not,
-    # the m.update([s3]) assert will just check whether m.update() returned True (I think).
-    # Regardless, the test works even when the graph isn't being recomputed.
-    assert m.update([s3]) is True
-    test3 = s3.manifest_items()[1][0]
-    assert list(m) == [("support", test3.path, {test3})]
+    assert m.update([s1,s2]) is True
+    test3 = s2.manifest_items()[1][0]
+
+    assert list(m) == [("reftest", test1.path, {test1}),
+                       ("support", test3.path, {test3})]
 
 
 def test_iterpath():


### PR DESCRIPTION
Modified conditional in manifest.py to check for a reftest node changing
to another type.
Wrote a test in test_manifest.py for the same, but this needs some review.

Closes https://github.com/w3c/web-platform-tests/issues/9671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9732)
<!-- Reviewable:end -->
