### PR TITLE
Update the css-properties-values-api IDL file

### DIFF
--- a/css/css-properties-values-api/idlharness.html
+++ b/css/css-properties-values-api/idlharness.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>CSS Properties Values API IDL tests</title>
+<link rel="help" href="https://drafts.css-houdini.org/css-properties-values-api-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script>
+  "use strict";
+
+  promise_test(async () => {
+    const idl = await fetch("/interfaces/css-properties-values-api.idl").then(r => r.text());
+    const cssom = await fetch("/interfaces/cssom.idl").then(r => r.text());
+
+    const idl_array = new IdlArray();
+    idl_array.add_idls(idl);
+    idl_array.add_dependency_idls(cssom);
+    idl_array.test();
+  }, "Test IDL implementation of CSS Properties Values API");
+</script>

--- a/interfaces/css-properties-values-api.idl
+++ b/interfaces/css-properties-values-api.idl
@@ -1,0 +1,15 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "CSS Properties and Values API Level 1" spec.
+// See: https://drafts.css-houdini.org/css-properties-values-api-1/
+
+dictionary PropertyDescriptor {
+  required DOMString name;
+           DOMString syntax       = "*";
+  required boolean   inherits;
+           DOMString initialValue;
+};
+
+partial namespace CSS {
+  void registerProperty(PropertyDescriptor descriptor);
+};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The Spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
