### PR TITLE
Teach idlharness.js to avoid invoking iterable-related members

### DIFF
--- a/interfaces/dom.idl
+++ b/interfaces/dom.idl
@@ -145,7 +145,7 @@ Text includes Slotable;
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-//  iterable<Node>;
+  iterable<Node>;
 };
 
 [Exposed=Window, LegacyUnenumerableNamedProperties]
@@ -548,5 +548,5 @@ interface DOMTokenList {
   [CEReactions] boolean replace(DOMString token, DOMString newToken);
   boolean supports(DOMString token);
   [CEReactions] stringifier attribute DOMString value;
-  //  iterable<DOMString>;
+  iterable<DOMString>;
 };

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2285,7 +2285,16 @@ IdlInterface.prototype.do_member_operation_asserts = function(memberHolderObject
     // check for globals, since otherwise we'll invoke window.close().  And we
     // have to skip this test for anything that on the proto chain of "self",
     // since that does in fact have implicit-this behavior.
-    if (!member["static"]) {
+
+    // For the entries/keys/values properties created by iterable declarations,
+    // the behavior is different for iterable<value_type> and
+    // iterable<key_type, value_type>, and for iterable<value_type> the function
+    // object should be the same as on Array, which will not throw if invoked
+    // with {}. We don't store which kind of iterable declaration was used, so
+    // all we can do here is to not make those assertions. TODO: propagate that
+    // information test the relevant behavior here.
+    var is_iterable_member = member["type"] === "operation" && member["idlType"] === "iterator";
+    if (!member["static"] && !is_iterable_member) {
         var cb;
         if (!this.is_global() &&
             memberHolderObject[member.name] != self[member.name])


### PR DESCRIPTION
This allows uncommenting iterable declarations and at least check for
the existence of the related members.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
