### PR TITLE
Correct serialization of box-shadow and text-shadow

### DIFF
--- a/css/css-variables/variable-substitution-shadow-properties.html
+++ b/css/css-variables/variable-substitution-shadow-properties.html
@@ -29,11 +29,11 @@
         let templates = [
             {
                 testName:"box-shadow",
-                expectedValue:"1px 1px 1px 1px rgb(0,128,0)",
+                expectedValue:"rgb(0, 128, 0) 1px 1px 1px 1px",
             },
             {
                 testName:"text-shadow",
-                expectedValue:"1px 1px 1px rgb(0,128,0)",
+                expectedValue:"rgb(0, 128, 0) 1px 1px 1px",
             },
         ];
 


### PR DESCRIPTION
Following https://github.com/w3c/csswg-drafts/issues/2305, the canonical serialization for box-shadow was changed to the color then lengths. https://drafts.csswg.org/css-text-decor-3/#text-shadow-property also defines the canonical serialization for text-shadow as the color and then lengths. This caused the test to fail in Firefox, Chrome, and Safari. Update the test to match the spec in both instances.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
