### PR TITLE
[css-text] Add lang=ja in css3-text-line-break-jazh tests

### DIFF
--- a/css/css-text/i18n/css3-text-line-break-jazh-059.html
+++ b/css/css-text/i18n/css3-text-line-break-jazh-059.html
@@ -29,7 +29,7 @@
 
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 <!--Notes:

--- a/css/css-text/i18n/css3-text-line-break-jazh-159.html
+++ b/css/css-text/i18n/css3-text-line-break-jazh-159.html
@@ -29,7 +29,7 @@
 
 
 
-<div class='ref'>中中中<br/>&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中中<br/>&#xFFE0;文</div></div>
 
 
 <!--Notes:

--- a/css/css-text/i18n/css3-text-line-break-jazh-259.html
+++ b/css/css-text/i18n/css3-text-line-break-jazh-259.html
@@ -29,7 +29,7 @@
 
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 <!--Notes:

--- a/css/css-text/i18n/reference/css3-text-line-break-jazh-059-ref.html
+++ b/css/css-text/i18n/reference/css3-text-line-break-jazh-059-ref.html
@@ -20,13 +20,13 @@
 <p class='instructions'>Test passes if the two orange boxes are identical.</p>
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 

--- a/css/css-text/i18n/reference/css3-text-line-break-jazh-159-ref.html
+++ b/css/css-text/i18n/reference/css3-text-line-break-jazh-159-ref.html
@@ -20,13 +20,13 @@
 <p class='instructions'>Test passes if the two orange boxes are identical.</p>
 
 
-<div class='ref'>中中中<br/>&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中中<br/>&#xFFE0;文</div></div>
 
 
 
 
 
-<div class='ref'>中中中<br/>&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中中<br/>&#xFFE0;文</div></div>
 
 
 

--- a/css/css-text/i18n/reference/css3-text-line-break-jazh-259-ref.html
+++ b/css/css-text/i18n/reference/css3-text-line-break-jazh-259-ref.html
@@ -20,13 +20,13 @@
 <p class='instructions'>Test passes if the two orange boxes are identical.</p>
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 
 
 
-<div class='ref'>中中<br/>中&#xFFE0;文</div></div>
+<div class='ref' lang='ja'>中中<br/>中&#xFFE0;文</div></div>
 
 
 


### PR DESCRIPTION
Without the lang attribute, the reference was choosing
a different character for English vs Japanese in some configurations.

The patch just adds "lang='ja'" to both the test and reference elements.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
