### PR TITLE
On MacOS, search for Firefox binary in common paths (Fixes #7125)

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -138,7 +138,24 @@ class Firefox(Browser):
         return find_executable("firefox", os.path.join(dest, "firefox"))
 
     def find_binary(self):
-        return find_executable("firefox")
+        platform = {
+            "Linux": "linux",
+            "Windows": "win",
+            "Darwin": "macos"
+        }.get(uname[0])
+
+        path = find_executable("firefox")
+
+        if not path and platform == "macos":
+            macpaths = ["/Applications/FirefoxNightly.app/Contents/MacOS",
+                        os.path.expanduser("~/Applications/FirefoxNightly.app/Contents/MacOS"),
+                        "/Applications/Firefox Developer Edition.app/Contents/MacOS",
+                        os.path.expanduser("~/Applications/Firefox Developer Edition.app/Contents/MacOS"),
+                        "/Applications/Firefox.app/Contents/MacOS",
+                        os.path.expanduser("~/Applications/Firefox.app/Contents/MacOS")]
+            return find_executable("firefox", os.pathsep.join(macpaths))
+
+        return path
 
     def find_certutil(self):
         path = find_executable("certutil")


### PR DESCRIPTION
I chose to make PATH override the common installation folders, my thinking is if the user put Firefox in PATH they probably want that one to be used. This picks up Nightly first, then Dev Edition, then Beta/Stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9806)
<!-- Reviewable:end -->
