### PR TITLE
Fixing WebDriver add_cookie tests

### DIFF
--- a/webdriver/tests/cookies/add_cookie.py
+++ b/webdriver/tests/cookies/add_cookie.py
@@ -1,6 +1,6 @@
 from tests.support.fixtures import clear_all_cookies
 from datetime import datetime, timedelta
-from time import sleep
+
 def test_add_domain_cookie(session, url, server_config):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
@@ -51,7 +51,7 @@ def test_add_cookie_for_ip(session, url, server_config, configuration):
             "secure": False
         }
     }
-    sleep(20)
+
     result = session.transport.send("POST", "session/%s/cookie" % session.session_id, create_cookie_request)
     assert result.status == 200
     assert "value" in result.body

--- a/webdriver/tests/cookies/add_cookie.py
+++ b/webdriver/tests/cookies/add_cookie.py
@@ -1,6 +1,6 @@
 from tests.support.fixtures import clear_all_cookies
 from datetime import datetime, timedelta
-
+from time import sleep
 def test_add_domain_cookie(session, url, server_config):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
@@ -39,18 +39,19 @@ def test_add_domain_cookie(session, url, server_config):
     assert cookie["domain"] == ".%s" % server_config["domains"][""]
 
 def test_add_cookie_for_ip(session, url, server_config, configuration):
-    session.url = "http://127.0.0.1:%s/404" % (server_config["ports"]["http"][0])
+    session.url = "http://127.0.0.1:%s/common/blank.html" % (server_config["ports"]["http"][0])
     clear_all_cookies(session)
     create_cookie_request = {
         "cookie": {
             "name": "hello",
             "value": "world",
-            "domain": configuration["host"],
+            "domain": "127.0.0.1",
             "path": "/",
             "httpOnly": False,
             "secure": False
         }
     }
+    sleep(20)
     result = session.transport.send("POST", "session/%s/cookie" % session.session_id, create_cookie_request)
     assert result.status == 200
     assert "value" in result.body
@@ -78,7 +79,7 @@ def test_add_cookie_for_ip(session, url, server_config, configuration):
 def test_add_non_session_cookie(session, url):
     session.url = url("/common/blank.html")
     clear_all_cookies(session)
-    a_year_from_now = int((datetime.utcnow() + timedelta(days=365)).strftime("%s"))
+    a_year_from_now = int((datetime.utcnow() + timedelta(days=365) - datetime.utcfromtimestamp(0)).total_seconds())
     create_cookie_request = {
         "cookie": {
             "name": "hello",


### PR DESCRIPTION
This PR fixes two tests. First, it changes the "domain" field for test_add_cookie_for_ip to match the URL domain used in creating the cookie. Second, it corrects the calculation of the expiration time for the cookie created in test_add_non_session_cookie.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
