### PR TITLE
Update the webappsec-csp-embedded IDL file

### DIFF
--- a/content-security-policy/embedded-enforcement/idlharness.window.js
+++ b/content-security-policy/embedded-enforcement/idlharness.window.js
@@ -15,7 +15,7 @@ promise_test(async () => {
   idl_array.add_dependency_idls(html);
   idl_array.add_dependency_idls(dom);
   idl_array.add_objects({
-    HTMLIframeElement: ['document.createElement("iframe")'],
+    HTMLIFrameElement: ['document.createElement("iframe")'],
   });
   idl_array.test();
 }, 'csp-embedded-enforcement IDL');

--- a/content-security-policy/embedded-enforcement/idlharness.window.js
+++ b/content-security-policy/embedded-enforcement/idlharness.window.js
@@ -1,0 +1,21 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://w3c.github.io/webappsec-csp/embedded/
+
+'use strict';
+
+promise_test(async () => {
+  const idl = await fetch('/interfaces/csp-embedded-enforcement.idl').then(r => r.text());
+  const html = await fetch('/interfaces/html.idl').then(r => r.text());
+  const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+
+  const idl_array = new IdlArray();
+  idl_array.add_idls(idl);
+  idl_array.add_dependency_idls(html);
+  idl_array.add_dependency_idls(dom);
+  idl_array.add_objects({
+    HTMLIframeElement: ['document.createElement("iframe")'],
+  });
+  idl_array.test();
+}, 'csp-embedded-enforcement IDL');

--- a/interfaces/csp-embedded-enforcement.idl
+++ b/interfaces/csp-embedded-enforcement.idl
@@ -1,0 +1,8 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Content Security Policy: Embedded Enforcement" spec.
+// See: https://w3c.github.io/webappsec-csp/embedded/
+
+partial interface HTMLIFrameElement {
+  [CEReactions] attribute DOMString csp;
+};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The Spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
