### PR TITLE
Correct serialization of counter()

### DIFF
--- a/css/cssom/serialize-values.html
+++ b/css/cssom/serialize-values.html
@@ -90,6 +90,7 @@
 
     function counter() {
       var values = ['counter(par-num)',
+                    { actual: 'counter(par-num, decimal)', serialized: 'counter(par-num)' },
                     'counter(par-num, upper-roman)'];
       return iterable(values);
     }

--- a/css/cssom/serialize-values.html
+++ b/css/cssom/serialize-values.html
@@ -89,8 +89,7 @@
     }
 
     function counter() {
-      var values = [{actual: 'counter(par-num)',
-                     serialized: 'counter(par-num, decimal)'},
+      var values = ['counter(par-num)',
                     'counter(par-num, upper-roman)'];
       return iterable(values);
     }


### PR DESCRIPTION
As discussed in https://github.com/w3c/csswg-drafts/issues/670, the spec states that if the "the last CSS component value if it is "decimal"", it should be omitted when serializing. Correct the test to match the spec.

Fixes https://github.com/w3c/csswg-drafts/issues/670.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
