### PR TITLE
Removing ES6 constructs from WebDriver element clear tests

### DIFF
--- a/webdriver/tests/interaction/element_clear.py
+++ b/webdriver/tests/interaction/element_clear.py
@@ -9,13 +9,13 @@ from tests.support.asserts import (
 )
 from tests.support.inline import inline
 
-
 def add_event_listeners(element):
     element.session.execute_script("""
-        let [target] = arguments;
+        var target = arguments[0];
         window.events = [];
-        for (let expected of ["focus", "blur", "change"]) {
-          target.addEventListener(expected, ({type}) => window.events.push(type));
+        var expectedEvents = ["focus", "blur", "change"];
+        for (var i = 0; i < expectedEvents.length; i++) {
+          target.addEventListener(expectedEvents[i], function (eventObject) { window.events.push(eventObject.type) });
         }
         """, args=(element,))
 
@@ -272,7 +272,6 @@ def test_contenteditable(session):
     assert_element_has_focus(session.execute_script("return document.body"))
 
 
-
 def test_designmode(session):
     session.url = inline("foobar")
     element = session.find.css("body", all=False)
@@ -323,7 +322,7 @@ def test_resettable_element_does_not_satisfy_validation_constraints(session, typ
 
     def is_valid(element):
         return session.execute_script("""
-            let [input] = arguments;
+            var input = arguments[0];
             return input.validity.valid;
             """, args=(element,))
 
@@ -361,12 +360,12 @@ def test_scroll_into_view(session):
         """)
     element = session.find.css("input", all=False)
     assert element.property("value") == "foobar"
-    assert session.execute_script("return window.scrollY") == 0
+    assert session.execute_script("return window.pageYOffset") == 0
 
     # scroll to the bottom right of the page
     session.execute_script("""
-        let {scrollWidth, scrollHeight} = document.body;
-        window.scrollTo(scrollWidth, scrollHeight);
+        var body = document.body;
+        window.scrollTo(body.scrollWidth, body.scrollHeight);
         """)
 
     # clear and scroll back to the top of the page
@@ -376,12 +375,18 @@ def test_scroll_into_view(session):
 
     # check if element cleared is scrolled into view
     rect = session.execute_script("""
-        let [input] = arguments;
-        return input.getBoundingClientRect();
+        var input = arguments[0];
+        var rect = input.getBoundingClientRect();
+        return {"top": rect.top,
+                "left": rect.left,
+                "height": rect.height,
+                "width": rect.width};
         """, args=(element,))
     window = session.execute_script("""
-        let {innerHeight, innerWidth, pageXOffset, pageYOffset} = window;
-        return {innerHeight, innerWidth, pageXOffset, pageYOffset};
+        return {"innerHeight": window.innerHeight,
+                "innerWidth": window.innerWidth,
+                "pageXOffset": window.pageXOffset,
+                "pageYOffset": window.pageYOffset};
         """)
 
     assert rect["top"] < (window["innerHeight"] + window["pageYOffset"]) and \


### PR DESCRIPTION
This will allow the tests to be run against browsers that do not support
ES6 JavaScript constructs like Internet Explorer.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
