### PR TITLE
Require mozdownload and mozinstall when running wpt install.

### DIFF
--- a/tools/wpt/commands.json
+++ b/tools/wpt/commands.json
@@ -9,6 +9,7 @@
                       "help": "Get a list of files that have changed", "virtualenv": false},
     "tests-affected": {"path": "testfiles.py", "script": "run_tests_affected", "parser": "get_parser_affected",
                        "help": "Get a list of tests affected by changes", "virtualenv": false},
-    "install": {"path": "install.py", "script": "run", "parser": "get_parser", "help": "Install browser components"},
+    "install": {"path": "install.py", "script": "run", "parser": "get_parser", "help": "Install browser components",
+                "install": ["mozdownload", "mozinstall"]},
     "branch-point": {"path": "testfiles.py", "script": "display_branch_point", "parser": null, "help": "Print branch point from master", "virtualenv": false}
 }


### PR DESCRIPTION
mozdownload and mozinstall are now used to install Firefox. Therefore
they are required to run the |wpt install| command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9875)
<!-- Reviewable:end -->
