### PR TITLE
Automatically setting session to None for new session tests

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -182,7 +182,8 @@ def new_session(configuration, request):
         global _current_session
         if _current_session is not None and _current_session.session_id:
             _current_session.end()
-            _current_session = None
+
+        _current_session = None
 
     def create_session(body):
         global _current_session


### PR DESCRIPTION
There is an edge case in the current implementation where a "new session"
test can create a new session and expressly close the created session by
calling `end()`, but the next test that is not a "new session" test sees the
"current session" object as not `None`, and failing to create a new
session. This change fixes that issue. If the session is not None and has
a valid session ID, the `end()` method still gets called. If the current
session is not `None`, but has an invalid session ID, it cannot be
terminated any other way, so setting the current session to `None` at that
point is not a negative side effect. Finally, if the current session is
already `None`, setting the variable to `None` again does no harm.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
