### PR TITLE
Readable streams: test no throwing on redundant controller.error()

### DIFF
--- a/streams/readable-streams/bad-underlying-sources.js
+++ b/streams/readable-streams/bad-underlying-sources.js
@@ -332,7 +332,7 @@ promise_test(() => {
 
   return closed.then(() => assert_true(startCalled));
 
-}, 'Underlying source: calling error after close should throw');
+}, 'Underlying source: calling error after close should not throw');
 
 promise_test(() => {
 

--- a/streams/readable-streams/bad-underlying-sources.js
+++ b/streams/readable-streams/bad-underlying-sources.js
@@ -306,7 +306,7 @@ promise_test(() => {
   const closed = new ReadableStream({
     start(c) {
       c.error(theError);
-      assert_throws(new TypeError(), () => c.error(), 'second call to error should throw a TypeError');
+      c.error();
       startCalled = true;
     }
   }).getReader().closed;
@@ -316,7 +316,7 @@ promise_test(() => {
     assert_equals(e, theError, 'closed should reject with the error');
   });
 
-}, 'Underlying source: calling error twice should throw the second time');
+}, 'Underlying source: calling error twice should not throw');
 
 promise_test(() => {
 
@@ -325,7 +325,7 @@ promise_test(() => {
   const closed = new ReadableStream({
     start(c) {
       c.close();
-      assert_throws(new TypeError(), () => c.error(), 'second call to error should throw a TypeError');
+      c.error();
       startCalled = true;
     }
   }).getReader().closed;

--- a/streams/readable-streams/garbage-collection.js
+++ b/streams/readable-streams/garbage-collection.js
@@ -19,7 +19,7 @@ promise_test(() => {
   return delay(50).then(() => {
     controller.close();
     assert_throws(new TypeError(), () => controller.close(), 'close should throw a TypeError the second time');
-    assert_throws(new TypeError(), () => controller.error(), 'error should throw a TypeError on a closed stream');
+    controller.error();
   });
 
 }, 'ReadableStreamController methods should continue working properly when scripts lose their reference to the ' +


### PR DESCRIPTION
Follows https://github.com/whatwg/streams/pull/895.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
