### PR TITLE
[encrypted-media] Correctly call isInitDataTypeSupported.

### DIFF
--- a/encrypted-media/scripts/check-initdata-type.js
+++ b/encrypted-media/scripts/check-initdata-type.js
@@ -2,12 +2,12 @@
  {
     function checkInitDataType(initDataType)
     {
-        return isInitDataTypeSupported(initDataType).then(function(result) {
+        return isInitDataTypeSupported(config.keysystem, initDataType).then(function(result) {
             // If |initDataType| is not supported, simply succeed.
             if (!result)
                 return Promise.resolve('Not supported');
 
-            return navigator.requestMediaKeySystemAccess( config.keysystem, getSimpleConfigurationForInitDataType(initDataType))
+            return navigator.requestMediaKeySystemAccess(config.keysystem, getSimpleConfigurationForInitDataType(initDataType))
                 .then(function(access) {
                     return access.createMediaKeys();
                 }).then(function(mediaKeys) {


### PR DESCRIPTION
This test appears to have been doing no useful testing, since it was
passing invalid keysystem names to all browsers, which were all returning
false in requestMediaKeySystemAccess, and the test lets such a result
pass. The reason for that is because the standard does not impose which
of the init data types a browser must support.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
