### PR TITLE
Fixed firefox binary path for Windows and Mac in browser.py

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -163,7 +163,7 @@ class Firefox(BrowserSetup):
 
     def setup_kwargs(self, kwargs):
         if kwargs["binary"] is None:
-            binary = self.browser.find_binary()
+            binary = self.browser.find_binary(self.venv.path)
             if binary is None:
                 raise WptrunError("""Firefox binary not found on $PATH.
 

--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -65,8 +65,6 @@ def test_help():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "darwin",
-                   reason="https://github.com/w3c/web-platform-tests/issues/9090")
 @pytest.mark.xfail(sys.platform == "win32",
                    reason="Tests currently don't work on Windows for path reasons")
 def test_run_firefox(manifest_dir):
@@ -77,7 +75,10 @@ def test_run_firefox(manifest_dir):
 
     os.environ["MOZ_HEADLESS"] = "1"
     try:
-        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
+        if sys.platform == "darwin":
+            fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "Firefox Nightly.app")
+        else:
+            fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "firefox")
         if os.path.exists(fx_path):
             shutil.rmtree(fx_path)
         with pytest.raises(SystemExit) as excinfo:
@@ -122,12 +123,14 @@ def test_install_chromedriver():
 
 @pytest.mark.slow
 @pytest.mark.remote_network
-@pytest.mark.xfail(sys.platform == "darwin",
-                   reason="https://github.com/w3c/web-platform-tests/issues/9090")
 @pytest.mark.xfail(sys.platform == "win32",
                    reason="Tests currently don't work on Windows for path reasons")
 def test_install_firefox():
-    fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "firefox")
+
+    if sys.platform == "darwin":
+        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "Firefox Nightly.app")
+    else:
+        fx_path = os.path.join(wpt.localpaths.repo_root, "_venv", "browsers", "firefox")
     if os.path.exists(fx_path):
         shutil.rmtree(fx_path)
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
find_executable() earlier returned None for non-linux systems, causing
firefox browser install to fail. Added the different binary paths for each OS.
Also removed platform_string() which used to be called in install() before nightly
download depended on mozdownload, and is now dead code.
Removed xfail for firefox install and run on MacOS in test_wpt.py as it will work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9900)
<!-- Reviewable:end -->
