### PR TITLE
Use force flag on git add operations during syncing

### DIFF
--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -178,9 +178,9 @@ class GitTree(object):
                        add all files under that path.
         """
         if prefix is None:
-            args = ("-a",)
+            args = ("-f", "-a",)
         else:
-            args = ("--no-ignore-removal", prefix)
+            args = ("-f", "--no-ignore-removal", prefix)
         self.git("add", *args)
 
     def list_refs(self, ref_filter=None):


### PR DESCRIPTION
This ensures that files that belong in the tree but match .gitignore filters are still synced appropriately (like payment-handler/manifest.json, which matches MANIFEST.json).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9901)
<!-- Reviewable:end -->
