### PR TITLE
Add a lint to catch adding files that would otherwise be ignored by git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.sw[po]
 *~
 MANIFEST.json
+!content-security-policy/support/manifest.json
+!payment-handler/manifest.json
 \#*
 _certs
 .virtualenv

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 
 from collections import defaultdict
 
@@ -132,6 +133,28 @@ def check_ahem_copy(repo_root, path):
     if "ahem" in lpath and lpath.endswith(".ttf"):
         return [("AHEM COPY", "Don't add extra copies of Ahem, use /fonts/Ahem.ttf", path, None)]
     return []
+
+
+def check_git_ignore(repo_root, paths):
+    errors = []
+    with tempfile.TemporaryFile('w+') as f:
+        f.write('\n'.join(paths))
+        f.seek(0)
+        try:
+            matches = subprocess.check_output(
+                ["git", "check-ignore", "--verbose", "--no-index", "--stdin"], stdin=f)
+            for match in matches.strip().split('\n'):
+                match_filter, path = match.split()
+                _, _, filter_string = match_filter.split(':')
+                # If the matching filter reported by check-ignore is a special-case exception,
+                # that's fine. Otherwise, it requires a new special-case exception.
+                if filter_string != '!' + path:
+                    errors += [("IGNORED PATH", "%s matches an ignore filter in .gitignore - "
+                                "please add a .gitignore exception" % path, path, None)]
+        except subprocess.CalledProcessError as e:
+            # Nonzero return code means that no match exists.
+            pass
+    return errors
 
 
 drafts_csswg_re = re.compile(r"https?\:\/\/drafts\.csswg\.org\/([^/?#]+)")
@@ -278,7 +301,9 @@ def filter_whitelist_errors(data, errors):
 
     for i, (error_type, msg, path, line) in enumerate(errors):
         normpath = os.path.normcase(path)
-        if error_type in data:
+        # Allow whitelisting all lint errors except the IGNORED PATH lint,
+        # which explains how to fix it correctly and shouldn't be ignored.
+        if error_type in data and error_type != "IGNORED PATH":
             wl_files = data[error_type]
             for file_match, allowed_lines in iteritems(wl_files):
                 if None in allowed_lines or line in allowed_lines:
@@ -839,6 +864,13 @@ def lint(repo_root, paths, output_format):
 path_lints = [check_path_length, check_worker_collision, check_ahem_copy]
 all_paths_lints = [check_css_globally_unique]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata]
+
+# Don't break users of the lint that don't have git installed.
+try:
+    subprocess.check_output(["git", "--version"])
+    all_paths_lints += [check_git_ignore]
+except subprocess.CalledProcessError:
+    print('No git present; skipping .gitignore lint.')
 
 if __name__ == "__main__":
     args = create_parser().parse_args()


### PR DESCRIPTION
This addresses the case where downstream syncing breaks because the sync operation excludes the ignored files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9902)
<!-- Reviewable:end -->
