### PR TITLE
[WIP] Update testing of Request's default credentials mode

### DIFF
--- a/fetch/api/request/request-init-003.sub.html
+++ b/fetch/api/request/request-init-003.sub.html
@@ -44,7 +44,7 @@
                              "referrer" : "about:client",
                              "referrerPolicy" : "",
                              "mode" : "cors",
-                             "credentials" : "omit",
+                             "credentials" : "same-origin",
                              "cache" : "default",
                              "redirect" : "follow",
                              "integrity" : "",

--- a/fetch/api/request/request-structure.html
+++ b/fetch/api/request/request-structure.html
@@ -76,7 +76,7 @@
             break;
 
           case "credentials":
-            defaultValue = "omit";
+            defaultValue = "same-origin";
             newValue = "cors";
             break;
 


### PR DESCRIPTION
This is for https://github.com/whatwg/fetch/pull/585.

I'm a little surprised if only these tests have to be updated, so I'm marking this as a WIP for now. Basically what I did though, was:

 - Ran all of the `/fetch`, `/xor`, `service-workers`, and `/cors` tests on Chromium, and noted failues (none)
 - Modified the Request constructor to use the `same-origin` credentials fallback instead of the previous `omit`
 - Ran all of the previous tests again and noted the failures (only two)
 - Updated the affected tests!

<!-- Reviewable:start -->

<!-- Reviewable:end -->
