### PR TITLE
Streams: Modify tests to expect abort reason passthrough

### DIFF
--- a/streams/piping/error-propagation-backward.js
+++ b/streams/piping/error-propagation-backward.js
@@ -548,7 +548,7 @@ promise_test(() => {
   return rs.pipeTo(ws).then(
     () => assert_unreached('the promise must not fulfill'),
     err => {
-      assert_equals(err.name, 'TypeError', 'the promise must reject with a TypeError (_not_ with error1)');
+      assert_equals(err, error1, 'the promise must reject with error1');
 
       assert_array_equals(rs.eventsWithoutPulls, ['cancel', err]);
       assert_array_equals(ws.events, ['abort', error1]);
@@ -575,7 +575,7 @@ promise_test(t => {
       return ws.getWriter().closed.then(
         () => assert_unreached('the promise must not fulfill'),
         err => {
-          assert_equals(err.name, 'TypeError', 'the promise must reject with a TypeError (_not_ with error1)');
+          assert_equals(err, error1, 'the promise must reject with error1');
 
           assert_array_equals(rs.eventsWithoutPulls, ['cancel', err]);
           assert_array_equals(ws.events, ['abort', error1]);
@@ -594,7 +594,7 @@ promise_test(t => {
 
   ws.abort(error1);
 
-  return promise_rejects(t, new TypeError(), rs.pipeTo(ws, { preventCancel: true })).then(() => {
+  return promise_rejects(t, error1, rs.pipeTo(ws, { preventCancel: true })).then(() => {
     assert_array_equals(rs.eventsWithoutPulls, []);
     assert_array_equals(ws.events, ['abort', error1]);
   });

--- a/streams/piping/multiple-propagation.js
+++ b/streams/piping/multiple-propagation.js
@@ -80,10 +80,10 @@ promise_test(t => {
 
     return Promise.all([
       promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1'),
-      promise_rejects(t, new TypeError(), ws.getWriter().closed,
-        'closed must reject with a TypeError indicating the writable stream was aborted'),
-      promise_rejects(t, new TypeError(), closePromise,
-        'close() must reject with a TypeError indicating the writable stream was aborted'),
+      promise_rejects(t, error1, ws.getWriter().closed,
+        'closed must reject with error1'),
+      promise_rejects(t, error1, closePromise,
+        'close() must reject with error1')
     ]);
   });
 

--- a/streams/transform-streams/reentrant-strategies.js
+++ b/streams/transform-streams/reentrant-strategies.js
@@ -317,7 +317,7 @@ promise_test(t => {
   // call to TransformStreamDefaultSink.
   return delay(0).then(() => {
     controller.enqueue('a');
-    return Promise.all([promise_rejects(t, new TypeError(), reader.read(), 'read() should reject'), abortPromise]);
+    return Promise.all([promise_rejects(t, error1, reader.read(), 'read() should reject'), abortPromise]);
   });
 }, 'writer.abort() inside size() should work');
 

--- a/streams/writable-streams/bad-underlying-sinks.js
+++ b/streams/writable-streams/bad-underlying-sinks.js
@@ -189,7 +189,7 @@ promise_test(t => {
   const writer = ws.getWriter();
 
   return promise_rejects(t, error1, writer.abort(abortReason), 'abort should reject with the thrown error')
-  .then(() => promise_rejects(t, new TypeError(), writer.closed, 'closed should reject with a TypeError'));
+  .then(() => promise_rejects(t, abortReason, writer.closed, 'closed should reject with abortReason'));
 }, 'abort: throwing method should cause abort() and closed to reject');
 
 done();

--- a/streams/writable-streams/close.js
+++ b/streams/writable-streams/close.js
@@ -361,8 +361,8 @@ promise_test(t => {
                       'closePromise must reject with the error returned from the sink\'s close method'),
       promise_rejects(t, error1, abortPromise,
                       'abortPromise must reject with the error returned from the sink\'s close method'),
-      promise_rejects(t, new TypeError(), writer.closed,
-                      'writer.closed must reject with a TypeError indicating the stream was aborted')
+      promise_rejects(t, error2, writer.closed,
+                      'writer.closed must reject with error2')
     ]).then(() => {
       assert_array_equals(events, ['closePromise', 'abortPromise', 'closed'],
                           'promises must fulfill/reject in the expected order');

--- a/streams/writable-streams/reentrant-strategy.js
+++ b/streams/writable-streams/reentrant-strategy.js
@@ -114,16 +114,16 @@ promise_test(t => {
   let writer;
   const strategy = {
     size() {
-      writer.abort('nice');
+      writer.abort(error1);
       return 1;
     }
   };
 
   const ws = recordingWritableStream({}, strategy);
   writer = ws.getWriter();
-  return promise_rejects(t, new TypeError(), writer.write('a'), 'write() promise should reject')
+  return promise_rejects(t, error1, writer.write('a'), 'write() promise should reject')
       .then(() => {
-        assert_array_equals(ws.events, ['abort', 'nice'], 'sink.write() should not be called');
+        assert_array_equals(ws.events, ['abort', error1], 'sink.write() should not be called');
       });
 }, 'abort() should work when called from within strategy.size()');
 


### PR DESCRIPTION
This tests the changes in https://github.com/whatwg/streams/pull/903.

Replace expectations that a TypeError will be stored after abort() is
called with with expectations that the reason passed to abort() will be
stored instead.

Also add a test of the stored error on the readable side of a
TransformStream after abort() has been called on the writable size. This
was not explicitly tested.

Also fix a bug in the general.js test: it didn't wrap a call to
assert_unreached properly, so a failure would have shown up as an
unhandled rejection rather than being reported properly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
