### PR TITLE
add Response test for propagating underlying ReadableStream error

### DIFF
--- a/fetch/api/response/response-error-from-stream.html
+++ b/fetch/api/response/response-error-from-stream.html
@@ -8,19 +8,16 @@
   </head>
   <body>
     <script>
-      /*************************************************************************
-       *
-       *  These tests originate from issue https://github.com/whatwg/fetch/issues/676
-       *
-       ************************************************************************/
-      const errorThrown = new Error('ReadableStream error');
+      function CustomTestError() {
+        const error = Error();
+        error.name = 'custom-test-error';
+        return error;
+      }
 
       function newStreamWithStartError() {
         return new ReadableStream({
           start(controller) {
-            // controller.close();
-            // controller.error(Error('Test 1 Error'));
-            controller.error(errorThrown);
+            controller.error(CustomTestError());
           }
         })
       }
@@ -28,37 +25,29 @@
       function newStreamWithPullError() {
         return new ReadableStream({
           pull(controller) {
-            // controller.close();
-            // controller.error(Error('Test 1 Error'));
-            controller.error(errorThrown);
+            controller.error(CustomTestError());
           }
         })
       }
 
       function runRequestPromiseTest(stream, responseReaderMethod, testDescription) {
-        promise_test(_ => {
-          return new Response(stream)[responseReaderMethod]()
-          .then(
-            ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
-            error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
+        promise_test(test => {
+          return promise_rejects(
+            test,
+            CustomTestError(),
+            new Response(stream)[responseReaderMethod](),
+            'CustomTestError should propagate'
           )
         }, testDescription)
       }
 
-      promise_test(_ => {
-        return newStreamWithStartError().getReader().read()
-        .then(
-          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
-          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Promise")
-        )
+
+      promise_test(test => {
+        return promise_rejects(test, CustomTestError(), newStreamWithStartError().getReader().read(), 'CustomTestError should propagate')
       }, "ReadableStreamDefaultReader Promise receives ReadableStream start() Error")
 
-      promise_test(_ => {
-        return newStreamWithPullError().getReader().read()
-        .then(
-          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
-          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Promise")
-        )
+      promise_test(test => {
+        return promise_rejects(test, CustomTestError(), newStreamWithPullError().getReader().read(), 'CustomTestError should propagate')
       }, "ReadableStreamDefaultReader Promise receives ReadableStream pull() Error")
 
 

--- a/fetch/api/response/response-error-from-stream.html
+++ b/fetch/api/response/response-error-from-stream.html
@@ -35,6 +35,16 @@
         })
       }
 
+      function runRequestPromiseTest(stream, responseReaderMethod, testDescription) {
+        promise_test(_ => {
+          return new Response(stream)[responseReaderMethod]()
+          .then(
+            ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
+            error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
+          )
+        }, testDescription)
+      }
+
       promise_test(_ => {
         return newStreamWithStartError().getReader().read()
         .then(
@@ -51,23 +61,20 @@
         )
       }, "ReadableStreamDefaultReader Promise receives ReadableStream pull() Error")
 
-      promise_test(_ => {
-        return new Response(newStreamWithStartError())
-        .text()
-        .then(
-          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
-          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
-        )
-      }, "Response Promise receives ReadableStream start() Error")
 
-      promise_test(_ => {
-        return new Response(newStreamWithPullError())
-        .text()
-        .then(
-          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
-          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
-        )
-      }, "Response Promise receives ReadableStream pull() Error")
+      // test start() errors for all Body reader methods
+      runRequestPromiseTest(newStreamWithStartError(), 'arrayBuffer', 'ReadableStream start() Error propagates to Response.arrayBuffer() Promise');
+      runRequestPromiseTest(newStreamWithStartError(), 'blob',        'ReadableStream start() Error propagates to Response.blob() Promise');
+      runRequestPromiseTest(newStreamWithStartError(), 'formData',    'ReadableStream start() Error propagates to Response.formData() Promise');
+      runRequestPromiseTest(newStreamWithStartError(), 'json',        'ReadableStream start() Error propagates to Response.json() Promise');
+      runRequestPromiseTest(newStreamWithStartError(), 'text',        'ReadableStream start() Error propagates to Response.text() Promise');
+
+      // test pull() errors for all Body reader methods
+      runRequestPromiseTest(newStreamWithPullError(), 'arrayBuffer', 'ReadableStream pull() Error propagates to Response.arrayBuffer() Promise');
+      runRequestPromiseTest(newStreamWithPullError(), 'blob',        'ReadableStream pull() Error propagates to Response.blob() Promise');
+      runRequestPromiseTest(newStreamWithPullError(), 'formData',    'ReadableStream pull() Error propagates to Response.formData() Promise');
+      runRequestPromiseTest(newStreamWithPullError(), 'json',        'ReadableStream pull() Error propagates to Response.json() Promise');
+      runRequestPromiseTest(newStreamWithPullError(), 'text',        'ReadableStream pull() Error propagates to Response.text() Promise');
     </script>
   </body>
 </html>

--- a/fetch/api/response/response-error-from-stream.html
+++ b/fetch/api/response/response-error-from-stream.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Response Receives Propagated Error from ReadableStream</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      /*************************************************************************
+       *
+       *  These tests originate from issue https://github.com/whatwg/fetch/issues/676
+       *
+       ************************************************************************/
+      const errorThrown = new Error('ReadableStream error');
+
+      function newStreamWithStartError() {
+        return new ReadableStream({
+          start(controller) {
+            // controller.close();
+            // controller.error(Error('Test 1 Error'));
+            controller.error(errorThrown);
+          }
+        })
+      }
+
+      function newStreamWithPullError() {
+        return new ReadableStream({
+          pull(controller) {
+            // controller.close();
+            // controller.error(Error('Test 1 Error'));
+            controller.error(errorThrown);
+          }
+        })
+      }
+
+      promise_test(_ => {
+        return newStreamWithStartError().getReader().read()
+        .then(
+          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
+          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Promise")
+        )
+      }, "ReadableStreamDefaultReader Promise receives ReadableStream start() Error")
+
+      promise_test(_ => {
+        return newStreamWithPullError().getReader().read()
+        .then(
+          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
+          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Promise")
+        )
+      }, "ReadableStreamDefaultReader Promise receives ReadableStream pull() Error")
+
+      promise_test(_ => {
+        return new Response(newStreamWithStartError())
+        .text()
+        .then(
+          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
+          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
+        )
+      }, "Response Promise receives ReadableStream start() Error")
+
+      promise_test(_ => {
+        return new Response(newStreamWithPullError())
+        .text()
+        .then(
+          ok => assert_false(true, 'ReadableStream Promise should throw error and not resolve'),
+          error => assert_equals(error, errorThrown, "ReadableStream error does not propagate to Response Promise rejection")
+        )
+      }, "Response Promise receives ReadableStream pull() Error")
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
When a Response is constructed with ReadableStream, errors originating in that
ReadableStream are not propagated to the Response during a Promise rejection.
Tests throw errors in start() and pull() methods.

https://github.com/whatwg/fetch/issues/676

<!-- Reviewable:start -->

<!-- Reviewable:end -->
