### PR TITLE
Add used body replacement test for Request constructor

### DIFF
--- a/fetch/api/request/request-disturbed.html
+++ b/fetch/api/request/request-disturbed.html
@@ -69,7 +69,7 @@
         assert_not_equals(originalBody, undefined, "body should not be undefined");
         assert_not_equals(originalBody, null, "body should not be null");
         assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
-        return requestFromRequest.text(text => {
+        return requestFromRequest.text().then(text => {
           assert_equals(text, "Request's body");
         });
       }, "Input request used for creating new request became disturbed");
@@ -85,7 +85,7 @@
         assert_not_equals(originalBody, null, "body should not be null");
         assert_not_equals(requestFromRequest.body, originalBody, "new request's body is new");
 
-        return requestFromRequest.text(text => {
+        return requestFromRequest.text().then(text => {
           assert_equals(text, "init body");
         });
       }, "Input request used for creating new request became disturbed even if body is not used");

--- a/fetch/api/request/request-disturbed.html
+++ b/fetch/api/request/request-disturbed.html
@@ -49,6 +49,17 @@
       }, "Check creating a new request from a disturbed request");
 
       promise_test(function() {
+        assert_true(bodyConsumed.bodyUsed , "bodyUsed is true when request is disturbed");
+        const originalBody = bodyConsumed.body;
+        const bodyReplaced = new Request(bodyConsumed, { body: "Replaced body" });
+        assert_not_equals(bodyReplaced.body, originalBody, "new request's body is new");
+        assert_false(bodyReplaced.bodyUsed, "bodyUsed is false when request is not disturbed");
+        return bodyReplaced.text().then(text => {
+          assert_equals(text, "Replaced body");
+        });
+      }, "Check creating a new request with a new body from a disturbed request");
+
+      promise_test(function() {
         var bodyRequest = new Request("", initValuesDict);
         const originalBody = bodyRequest.body;
         assert_false(bodyRequest.bodyUsed , "bodyUsed is false when request is not disturbed");


### PR DESCRIPTION
This is a WPT companion PR for a Fetch spec change: https://github.com/whatwg/fetch/pull/675. That change allows this currently throwy code snippet to function as expected:

```js
let request = new Request(url, { method: "POST", body: "foo" })
await request.text()  // disturb the body

// currently throws because request is disturbed,
// even thought we're providing a new body
request = new Request(request, { body: "bar" })
```

I tested this on Chrome and Epiphany Tech Preview. As expected, it fails on both because: Chrome does not implement `request.body`, and EPT implements the spec as currently written.

/cc @yutakahirano, @annevk

<!-- Reviewable:start -->

<!-- Reviewable:end -->
