### PR TITLE
gyroscope: Rename LocalCoordinateSystem to GyroscopeLocalCoordinateSystem

### DIFF
--- a/interfaces/gyroscope.idl
+++ b/interfaces/gyroscope.idl
@@ -5,8 +5,8 @@ interface Gyroscope : Sensor {
   readonly attribute double? z;
 };
 
-enum LocalCoordinateSystem { "device", "screen" };
+enum GyroscopeLocalCoordinateSystem { "device", "screen" };
 
 dictionary GyroscopeSensorOptions : SensorOptions {
-  LocalCoordinateSystem referenceFrame = "device";
+  GyroscopeLocalCoordinateSystem referenceFrame = "device";
 };


### PR DESCRIPTION
Adapt to w3c/gyroscope#34.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
