### PR TITLE
Fix link to w3c-test.org in the running-tests docs

### DIFF
--- a/docs/_running-tests/index.md
+++ b/docs/_running-tests/index.md
@@ -32,7 +32,7 @@ Additional browser-specific documentation:
   * [Safari][safari]
 
 ## From Inside a Browser
-Tests that have been merged on GitHub are mirrored at [http://w3c-test.org/].
+Tests that have been merged on GitHub are mirrored at [http://w3c-test.org/][w3c-test].
 
 For running multiple tests inside a browser, there is a test runner
 located at `/tools/runner/index.html`.
@@ -74,3 +74,4 @@ documented!
 [public-test-infra]: https://lists.w3.org/Archives/Public/public-test-infra/
 [IRC]: irc://irc.w3.org:6667/testing
 [web irc]: http://irc.w3.org
+[w3c-test]: http://w3c-test.org


### PR DESCRIPTION
http://web-platform-tests.org/running-tests/index.html#from-inside-a-browser

### Before
![screen shot 2018-03-09 at 1 44 53 pm](https://user-images.githubusercontent.com/54056/37224041-50535036-23a0-11e8-9ea8-2216358532f4.png)


### After
![screen shot 2018-03-09 at 1 44 32 pm](https://user-images.githubusercontent.com/54056/37224040-50454afe-23a0-11e8-8f8f-73bd2f2128df.png)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
