### PR TITLE
Document we wait for web fonts in reftests

### DIFF
--- a/docs/_writing-tests/reftests.md
+++ b/docs/_writing-tests/reftests.md
@@ -99,14 +99,15 @@ leaf nodes.)
 ## Controlling When Comparison Occurs
 
 By default reftest screenshots are taken after the `load` event has
-fired. In some cases it is necessary to delay the screenshot later
-than this, for example because some DOM manipulation is required to
-set up the desired test conditions. To enable this, the test may have
-a `class="reftest-wait"` attribute specified on the root element. This
-will cause the screenshot to be delayed until the `load` event has
-fired and the `reftest-wait` class has been removed from the root
-element. Note that in neither case is exact timing of the screenshot
-guaranteed: it is only guaranteed to be after those events.
+fired, and web fonts (if any) are loaded. In some cases it is
+necessary to delay the screenshot later than this, for example because
+some DOM manipulation is required to set up the desired test
+conditions. To enable this, the test may have a `class="reftest-wait"`
+attribute specified on the root element. This will cause the
+screenshot to be delayed until the `load` event has fired and the
+`reftest-wait` class has been removed from the root element. Note that
+in neither case is exact timing of the screenshot guaranteed: it is
+only guaranteed to be after those events.
 
 ## Fuzzy Matching
 


### PR DESCRIPTION
I added a very simple clause to explain the current behavior of wpt runner (IIUC it isn't clear whether web fonts block load in the specs?). I could add more detailed explanation, or link to the script we inject. WDYT?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
