### PR TITLE
lint.py: Adds a lint for files with the same basename in the same dir…

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -624,6 +624,29 @@ def check_script_metadata(repo_root, path, f):
     return errors
 
 
+def check_multiple_identical_values(repo_root, paths):
+    """
+    Runs lints that check for multiple identical paths
+    in all_paths_lints.
+
+    :param repo_root: the repository root
+    :param paths: a list of all the paths within the repository
+    :returns: a list of errors found in ``path``
+    """
+
+    file_dict = dict()
+    errors = []
+    file_dict = defaultdict(list)
+    for path in paths:
+        file_name, file_extension =  os.path.splitext(path)
+        file_dict[file_name].append(file_extension)
+    for f in file_dict.keys():
+        if len(file_dict[f]) > 1:
+            msg = "Got files for path %s with extensions %s" % (f, file_dict[f])
+            errors.append(("DUPLICATE-EXTENSIONLESS-PATH", msg, f, None))
+    return []
+
+
 def check_path(repo_root, path):
     """
     Runs lints that check the file path.
@@ -837,7 +860,7 @@ def lint(repo_root, paths, output_format):
     return sum(itervalues(error_count))
 
 path_lints = [check_path_length, check_worker_collision, check_ahem_copy]
-all_paths_lints = [check_css_globally_unique]
+all_paths_lints = [check_css_globally_unique, check_multiple_identical_values]
 file_lints = [check_regexp_line, check_parsed, check_python_ast, check_script_metadata]
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a lint to the `all_paths_lints`
set in `tools/lint/lint.py` that checks if
there are any paths in which 'os.path.splitext(paths)[0]`
has multiple identical values.

Closes https://github.com/w3c/web-platform-tests/issues/7570