### PR TITLE
Allow for exception to occur if medium not found

### DIFF
--- a/css/cssom/medialist-interfaces-002.html
+++ b/css/cssom/medialist-interfaces-002.html
@@ -58,7 +58,7 @@
 
       media_list.appendMedium("all");
 
-      media_list.deleteMedium("screen");
+      assert_throws("NotFoundError", () => media_list.deleteMedium("screen"));
 
       assert_equals(media_list.length, 1);
       assert_equals(media_list.item(0), "all");


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom/#dom-medialist-deletemedium, "If nothing was removed, then throw a NotFoundError exception." Throwing an exception in this step stops the test with an error. Assert that the correct exception is thrown, and allow the test to continue.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
