### PR TITLE
add "short" harness timeout value

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -20,6 +20,7 @@ policies and contribution forms [3].
     var settings = {
         output:true,
         harness_timeout:{
+            "short":2000,
             "normal":10000,
             "long":60000
         },
@@ -239,7 +240,9 @@ policies and contribution forms [3].
         var metas = document.getElementsByTagName("meta");
         for (var i = 0; i < metas.length; i++) {
             if (metas[i].name == "timeout") {
-                if (metas[i].content == "long") {
+                if (metas[i].content == "short") {
+                    return settings.harness_timeout.short;
+                } else if (metas[i].content == "long") {
                     return settings.harness_timeout.long;
                 }
                 break;


### PR DESCRIPTION
This would allow tests that explicitly call `window.stop()` to exit after 2s instead of waiting the full 10s to timeout by adding `<meta name="timeout" content="short">`.  For example, the "short" value could be applied to the tests below:

* https://w3c-test.org/xhr/abort-after-stop.htm
* https://github.com/w3c/web-platform-tests/pull/9933

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9959)
<!-- Reviewable:end -->
