### PR TITLE
Replace assert_own_property with assert_idl_attribute

### DIFF
--- a/css/cssom/inline-style-001.html
+++ b/css/cssom/inline-style-001.html
@@ -16,15 +16,14 @@
  <script type="text/javascript">
     test(function() {
         var test = document.getElementById("test");
-        assert_own_property(test, "style");
-        assert_readonly(test, "style");
+        assert_idl_attribute(test, "style");
         declaration = test.style;
     }, "CSSStyleDeclaration_accessible", {
         assert: "Can access CSSStyleDeclaration through style property"
     });
 
     test(function() {
-        assert_regexp_match(declaration.cssText, /margin-left: 5px;\s*/);
+        assert_equals(declaration.cssText, "margin-left: 5px;");
         assert_equals(declaration.getPropertyValue("margin-left"), "5px");
     }, "read", {
         assert: "initial property values are correct"
@@ -32,7 +31,7 @@
 
     test(function() {
         declaration.cssText = "margin-left: 10px; padding-left: 10px;";
-        assert_regexp_match(declaration.cssText, /margin-left: 10px;\s+padding-left: 10px;\s+/);
+        assert_equals(declaration.cssText, "margin-left: 10px; padding-left: 10px;");
         assert_equals(declaration.length, 2);
         assert_equals(declaration.item(0), "margin-left");
         assert_equals(declaration.item(1), "padding-left");

--- a/css/cssom/style-sheet-interfaces-001.html
+++ b/css/cssom/style-sheet-interfaces-001.html
@@ -24,11 +24,11 @@
     var styleSheet;
     var linkSheet;
     test(function() {
-        assert_own_property(styleElement, "sheet");
+        assert_idl_attribute(styleElement, "sheet");
         assert_readonly(styleElement, "sheet");
         styleSheet = styleElement.sheet;
         assert_true(styleSheet instanceof CSSStyleSheet);
-        assert_own_property(linkElement, "sheet");
+        assert_idl_attribute(linkElement, "sheet");
         linkSheet = linkElement.sheet;
         assert_true(linkSheet instanceof CSSStyleSheet);
     }, "sheet_property",
@@ -48,8 +48,8 @@
       assert: "The sheet property on LinkStyle should always return the current associated style sheet." });
 
     test(function() {
-        assert_own_property(styleSheet, "ownerRule");
-        assert_own_property(styleSheet, "cssRules");
+        assert_idl_attribute(styleSheet, "ownerRule");
+        assert_idl_attribute(styleSheet, "cssRules");
         assert_inherits(styleSheet, "insertRule");
         assert_inherits(styleSheet, "deleteRule");
 
@@ -71,13 +71,13 @@
       assert: "CSSStyleSheet initial property values are correct" });
 
     test(function() {
-        assert_own_property(styleSheet, "type");
-        assert_own_property(styleSheet, "disabled");
-        assert_own_property(styleSheet, "ownerNode");
-        assert_own_property(styleSheet, "parentStyleSheet");
-        assert_own_property(styleSheet, "href");
-        assert_own_property(styleSheet, "title");
-        assert_own_property(styleSheet, "media");
+        assert_idl_attribute(styleSheet, "type");
+        assert_idl_attribute(styleSheet, "disabled");
+        assert_idl_attribute(styleSheet, "ownerNode");
+        assert_idl_attribute(styleSheet, "parentStyleSheet");
+        assert_idl_attribute(styleSheet, "href");
+        assert_idl_attribute(styleSheet, "title");
+        assert_idl_attribute(styleSheet, "media");
 
         assert_readonly(styleSheet, "type");
         assert_readonly(styleSheet, "ownerNode");


### PR DESCRIPTION
CSSOM objects do not implement attributes as their own properties; they are IDL attributes. Switch to use assert_idl_attribute instead of assert_own_property. Also make inline-style-001.html pass by removing assert_readonly (it resets the attribute, making future tests fail) and use assert_equals instead of assert_regexp_match.

Fixes #6203.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
