### PR TITLE
[presentation-api] check if a URL with an unsupported scheme is ignored

### DIFF
--- a/presentation-api/controlling-ua/PresentationRequest_error.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_error.https.html
@@ -21,16 +21,16 @@
       new PresentationRequest('http://@');
     }, 'Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.');
 
-    assert_throws('NotFoundError', () => {
+    assert_throws('NotSupportedError', () => {
         new PresentationRequest('unsupported://example.com');
-    }, 'Call PresentationRequest constructor with an unsupported URL. NotFoundError expected.');
+    }, 'Call PresentationRequest constructor with an unsupported URL. NotSupportedError expected.');
 
     assert_throws('SyntaxError', function() {
       new PresentationRequest(['presentation.html', 'http://@']);
     }, 'Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.');
 
-    assert_throws('NotFoundError', function() {
+    assert_throws('NotSupportedError', function() {
       new PresentationRequest(['unsupported://example.com', 'invalid://example.com']);
-    }, 'Call PresentationRequest constructor only with a sequence of unsupported URLs. NotFoundError Exception expected.');
+    }, 'Call PresentationRequest constructor only with a sequence of unsupported URLs. NotSupportedError Exception expected.');
   });
 </script>

--- a/presentation-api/controlling-ua/PresentationRequest_error.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_error.https.html
@@ -1,33 +1,36 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Presentation API PresentationRequest for Controlling User Agent (Error)</title>
+<title>Constructing a PresentationRequest (Error)</title>
 <link rel="author" title="Franck William Taffo" href="http://www.fokus.fraunhofer.de">
-<link rel="help" href="http://w3c.github.io/presentation-api/#dfn-controlling-user-agent">
+<link rel="author" title="Tomoyuki Shimizu" href="https://github.com/tomoyukilabs">
+<link rel="help" href="http://w3c.github.io/presentation-api/#constructing-a-presentationrequest">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
 
-    test(function() {
-        assert_throws(new TypeError(), function() {
-            new PresentationRequest();
-        });
+  test(() => {
+    assert_throws(new TypeError(), () => {
+      new PresentationRequest();
     }, 'Call PresentationRequest() constructor without presentation URL. TypeError Exception expected.');
 
-    test(function() {
-        assert_throws('NotSupportedError', function() {
-            new PresentationRequest([]);
-        });
+    assert_throws('NotSupportedError', () => {
+      new PresentationRequest([]);
     }, 'Call PresentationRequest constructor with an empty sequence. NotSupportedError Exception expected.');
 
-    test(function() {
-        assert_throws('SyntaxError', function() {
-            new PresentationRequest('http://@');
-        });
+    assert_throws('SyntaxError', () => {
+      new PresentationRequest('http://@');
     }, 'Call PresentationRequest constructor with an invalid URL. SyntaxError Exception expected.');
 
-    test(function() {
-        assert_throws('SyntaxError', function() {
-            new PresentationRequest(['presentation.html', 'http://@']);
-        });
+    assert_throws('NotFoundError', () => {
+        new PresentationRequest('unsupported://example.com');
+    }, 'Call PresentationRequest constructor with an unsupported URL. NotFoundError expected.');
+
+    assert_throws('SyntaxError', function() {
+      new PresentationRequest(['presentation.html', 'http://@']);
     }, 'Call PresentationRequest constructor with a sequence of URLs, one of them invalid. SyntaxError Exception expected.');
+
+    assert_throws('NotFoundError', function() {
+      new PresentationRequest(['unsupported://example.com', 'invalid://example.com']);
+    }, 'Call PresentationRequest constructor only with a sequence of unsupported URLs. NotFoundError Exception expected.');
+  });
 </script>

--- a/presentation-api/controlling-ua/PresentationRequest_success.https.html
+++ b/presentation-api/controlling-ua/PresentationRequest_success.https.html
@@ -8,17 +8,24 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <script>
-    test(() => {
-        let request = new PresentationRequest('presentation.html');
-        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with a relative presentation URL is constructed successfully.');
+  test(() => {
+    let request = new PresentationRequest('presentation.html');
+    assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with a relative presentation URL is constructed successfully.');
 
-        request = new PresentationRequest('https://example.org/');
-        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an absolute presentation URL is constructed successfully.');
+    request = new PresentationRequest('https://example.org/');
+    assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an absolute presentation URL is constructed successfully.');
 
-        request = new PresentationRequest([
-            'presentation.html',
-            'https://example.org/presentation/'
-        ]);
-        assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an array of presentation URLs is constructed successfully.');
-    });
+    request = new PresentationRequest([
+      'presentation.html',
+      'https://example.org/presentation/'
+    ]);
+    assert_true(request instanceof PresentationRequest, 'An instance of PresentationRequest with an array of presentation URLs is constructed successfully.');
+
+    request = new PresentationRequest([
+      'unsupported://example.com',
+      'presentation.html',
+      'https://example.org/presentation/'
+    ]);
+    assert_true(request instanceof PresentationRequest, 'An unsupported URL in an array of presentation URLs is ignored successfully.');
+  });
 </script>


### PR DESCRIPTION
This PR is based on the suggested change on Presentation API, addressed by https://github.com/w3c/presentation-api/pull/447. In detail, the following tests are added:

- To check if an instance of PresentationRequest with URLs including one with an unsupported scheme is successfully constructed
- To check if `NotSupportedError` is thrown when only single or multiple URLs with unsupported schemes are specified

<!-- Reviewable:start -->

<!-- Reviewable:end -->
