### PR TITLE
Prevent redirect loop in fetch/api/redirect/redirect-location.html

### DIFF
--- a/fetch/api/redirect/redirect-location.js
+++ b/fetch/api/redirect/redirect-location.js
@@ -32,7 +32,7 @@ function redirectLocation(desc, redirectUrl, redirectLocation, redirectStatus, r
 
 var redirUrl = RESOURCES_DIR + "redirect.py";
 var locationUrl = "top.txt";
-var invalidLocationUrl = "#invalidurl:";
+var invalidLocationUrl = "invalidurl:";
 var dataLocationUrl = "data:,data%20url";
 // FIXME: We may want to mix redirect-mode and cors-mode.
 // FIXME: Add tests for "error" redirect-mode.


### PR DESCRIPTION
The value of invalidLocationUrl, "#invalidurl:" is actually treated as a valid
URL by redirect.py, leading to a redirect loop. This makes the test take over 6
seconds in Chrome, causing it to time out. Change invalidLocationUrl to
"invalidurl:" to avoid the redirect loop and make the test faster.

See Chrome issue http://crbug.com/815286 about the test timing out.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
