### PR TITLE
prevent harness timeout after calling window.stop()

### DIFF
--- a/xhr/abort-after-stop.htm
+++ b/xhr/abort-after-stop.htm
@@ -20,8 +20,11 @@
         client.open("GET", "resources/delay.py?ms=3000", true);
         client.send(null);
         test.step_timeout(() => {
-          assert_equals(abortFired, true);
+          test.step(t => assert_equals(abortFired, true));
           test.done();
+
+          // Prevent harness timeout caused by window.stop() preventing "load" event
+          window.dispatchEvent(new Event('load'));
         }, 200);
         window.stop();
       });


### PR DESCRIPTION
window.stop() prevents window.onload from firing, which causes a harness timeout
This fixes that, and the natural flow of things returns after window.stop().

Relates to https://github.com/w3c/web-platform-tests/pull/9959

<!-- Reviewable:start -->

<!-- Reviewable:end -->
