### PR TITLE
magnetometer: Rename LocalCoordinateSystem enum.

### DIFF
--- a/interfaces/magnetometer.idl
+++ b/interfaces/magnetometer.idl
@@ -6,10 +6,10 @@ interface Magnetometer : Sensor {
   readonly attribute double? z;
 };
 
-enum LocalCoordinateSystem { "device", "screen" };
+enum MagnetometerLocalCoordinateSystem { "device", "screen" };
 
 dictionary MagnetometerSensorOptions : SensorOptions {
-  LocalCoordinateSystem referenceFrame = "device";
+  MagnetometerLocalCoordinateSystem referenceFrame = "device";
 };
 
 [Constructor(optional MagnetometerSensorOptions sensorOptions), SecureContext,


### PR DESCRIPTION
Call it `MagnetometerLocalCoordinateSystem` after w3c/magnetometer#45.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
