### PR TITLE
Correct order of serialized media list values

### DIFF
--- a/css/cssom/medialist-interfaces-001.html
+++ b/css/cssom/medialist-interfaces-001.html
@@ -57,7 +57,7 @@
       assert_equals(mediaList.mediaText, "all, screen");
 
     }, "mediatest_medialist_serialize_comma",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"],
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"],
       assert: ["To serialize a comma-separated list concatenate all items of the list in list order while separating them by \",\" (U+002C), followed by a space (U+0020)."] });
 
     test(function() {
@@ -75,11 +75,11 @@
 
       mediaList.appendMedium('screen');
       mediaList.appendMedium('print');
-      assert_equals(mediaList.mediaText, "all, print, screen");
+      assert_equals(mediaList.mediaText, "all, screen, print");
 
-    }, "mediatest_medialist_serialize_lexicographical",
-    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serializing-media-queries"],
-      assert: ["Each media query in the list of media queries should be sorted in lexicographical order."] });
+    }, "mediatest_medialist_serialize_order",
+    { help: ["http://www.w3.org/TR/cssom-1/#the-medialist-interface", "http://www.w3.org/TR/cssom-1/#serialize-a-media-query-list"],
+      assert: ["Each media query should be sorted in the same order as they appear in the list of media queries."] });
 
   </script>
  </body>

--- a/css/cssom/medialist-interfaces-004.html
+++ b/css/cssom/medialist-interfaces-004.html
@@ -55,7 +55,7 @@
       assert_equals(media_list.length, 2);
       assert_equals(media_list.item(0), "screen");
       assert_equals(media_list.item(1), "all");
-      assert_equals(media_list.mediaText, "all, screen");
+      assert_equals(media_list.mediaText, "screen, all");
     }, "appendMedium_correctly_appends_medium_to_nonempty_MediaList",
     { assert: "MediaList.appendMedium correctly adds medium to a MediaList that already has a medium." });
 


### PR DESCRIPTION
According to the spec (https://drafts.csswg.org/cssom/#serialize-a-media-query-list), each media query should be serialized in the same order as they appear in the media query list. Media *features* are sorted in lexicographical order in a single media query, but media queries are not sorted in the same manner. Fix two tests to reflect the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
