### PR TITLE
Make lint run when directories are passed in

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -816,7 +816,7 @@ def lint(repo_root, paths, output_format):
     last = None
 
     with open(os.path.join(repo_root, "lint.whitelist")) as f:
-        whitelist, ignored_files = parse_whitelist(f)
+        whitelist, ignored_files=parse_whitelist(f)
 
     output_errors = {"json": output_errors_json,
                      "markdown": output_errors_markdown,

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -59,9 +59,13 @@ you could add the following line to the lint.whitelist file.
 
 %s: %s"""
 
-def all_filesystem_paths(repo_root, extended_path):
+def all_filesystem_paths(repo_root, subdir = None):
     path_filter = PathFilter(repo_root, extras=[".git/*"])
-    for dirpath, dirnames, filenames in os.walk(extended_path):
+    if subdir:
+        expanded_path = subdir
+    else:
+        expanded_path = repo_root
+    for dirpath, dirnames, filenames in os.walk(expanded_path):
         for filename in filenames:
             path = os.path.relpath(os.path.join(dirpath, filename), repo_root)
             if path_filter(path):
@@ -754,10 +758,10 @@ def lint_paths(kwargs, wpt_root):
             # create extension for called directory and merge it with the existing path
                 new_path = os.path.realpath(os.path.join(wpt_root, path))
                 # get all files from new path
-                path_dir = list(all_filesystem_paths(wpt_root, new_Path))
+                path_dir = list(all_filesystem_paths(wpt_root, new_path))
              
                 # add all files from a given directory to our master list of files to check
-                paths = paths + path_dir
+                paths.extend(path_dir)
 
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -754,8 +754,7 @@ def lint_paths(kwargs, wpt_root):
         paths = []
         for path in kwargs.get("paths"):
             if os.path.isdir(path):
-                new_path = os.path.realpath(os.path.join(wpt_root, path))
-                path_dir = list(all_filesystem_paths(wpt_root, new_path))
+                path_dir = list(all_filesystem_paths(wpt_root, path))
                 paths.extend(path_dir)
             elif os.path.isfile(path):
                 paths.extend(path)

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -27,7 +27,7 @@ import logging
 
 logger = None
 
-def setup_logging(prefix = False):
+def setup_logging(prefix=False):
     global logger
     if logger is None:
         logger = logging.getLogger(os.path.basename(os.path.splitext(__file__)[0]))
@@ -59,7 +59,7 @@ you could add the following line to the lint.whitelist file.
 
 %s: %s"""
 
-def all_filesystem_paths(repo_root, subdir = None):
+def all_filesystem_paths(repo_root, subdir=None):
     path_filter = PathFilter(repo_root, extras = [".git/*"])
     if subdir:
         expanded_path = subdir

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -60,7 +60,7 @@ you could add the following line to the lint.whitelist file.
 %s: %s"""
 
 def all_filesystem_paths(repo_root, subdir=None):
-    path_filter = PathFilter(repo_root, extras = [".git/*"])
+    path_filter = PathFilter(repo_root, extras=[".git/*"])
     if subdir:
         expanded_path = subdir
     else:
@@ -744,8 +744,8 @@ def output_error_count(error_count):
 
 
 def changed_files(wpt_root):
-    revish = testfiles.get_revish(revish = None)
-    changed, _ = testfiles.files_changed(revish, set(), include_uncommitted = True, include_new = True)
+    revish = testfiles.get_revish(revish=None)
+    changed, _ = testfiles.files_changed(revish, set(), include_uncommitted=True, include_new=True)
     return [os.path.relpath(item, wpt_root) for item in changed]
 
 
@@ -816,7 +816,7 @@ def lint(repo_root, paths, output_format):
     last = None
 
     with open(os.path.join(repo_root, "lint.whitelist")) as f:
-        whitelist, ignored_files = parse_whitelist(f)
+        whitelist, ignored_files=parse_whitelist(f)
 
     output_errors = {"json": output_errors_json,
                      "markdown": output_errors_markdown,

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -748,19 +748,19 @@ def changed_files(wpt_root):
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
         #make new list in case there are multiple added directories
-        all_Paths=[]
+        paths=[]
         for path in kwargs.get("paths"):
             if os.path.isdir(path):
             # create extension for called directory and merge it with the existing path
                 new_Path = os.path.realpath(os.path.join(wpt_root, path))
                 extension = path+'/'
                 # get all files from new path
-                paths = list(all_filesystem_paths(new_Path))
+                path_dir = list(all_filesystem_paths(new_Path))
                 # add the extension to the strings for all files from the new path,
                 # so they may be called from the current directory
-                paths = [extension + path for path in paths]
+                paths = [extension + extended_path for extended_path in path_dir]
                 # add all files from a given directory to our master list of files to check
-                all_Paths=paths+all_Paths
+                paths=paths+path_dir
 
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -756,8 +756,9 @@ def lint_paths(kwargs, wpt_root):
             if os.path.isdir(path):
                 path_dir = list(all_filesystem_paths(wpt_root, path))
                 paths.extend(path_dir)
-            else:
-                paths.extend(path)
+            elif os.path.isfile(path):
+                paths.append(os.path.relpath(os.path.abspath(path), wpt_root))
+
 
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -751,24 +751,20 @@ def changed_files(wpt_root):
 
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
-        #make new list in case there are multiple added directories
         paths = []
         for path in kwargs.get("paths"):
             if os.path.isdir(path):
-            # create extension for called directory and merge it with the existing path
                 new_path = os.path.realpath(os.path.join(wpt_root, path))
-                # get all files from new path
                 path_dir = list(all_filesystem_paths(wpt_root, new_path))
-             
-                # add all files from a given directory to our master list of files to check
                 paths.extend(path_dir)
+            elif os.path.isfile(path):
+                paths.extend(path)
 
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
     else:
         changed_paths = changed_files(wpt_root)
         force_all = False
-        # If we changed the lint itself ensure that we retest everything
         for path in changed_paths:
             path = path.replace(os.path.sep, "/")
             if path == "lint.whitelist" or path.startswith("tools/lint/"):

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -756,7 +756,7 @@ def lint_paths(kwargs, wpt_root):
             if os.path.isdir(path):
                 path_dir = list(all_filesystem_paths(wpt_root, path))
                 paths.extend(path_dir)
-            elif os.path.isfile(path):
+            else:
                 paths.extend(path)
 
     elif kwargs["all"]:

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -748,18 +748,20 @@ def changed_files(wpt_root):
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
         #make new list in case there are multiple added directories
-        AllPaths=[]
+        all_Paths=[]
         for path in kwargs.get("paths"):
+            if os.path.isdir(path):
             # create extension for called directory and merge it with the existing path
-            extension= path+'/'
-            newPath=(str(os.path.realpath(wpt_root))+'/'+ extension)
-            # get all files from new path
-            paths = list(all_filesystem_paths(newPath))
-            # add the extension to the strings for all files from the new path,
-            # so they may be called from the current directory
-            paths=list(map(lambda path : extension + path, paths))
-            # add all files from a given directory to our master list of files to check
-            AllPaths=paths+AllPaths
+                new_Path = os.path.realpath(os.path.join(wpt_root, path))
+                extension = path+'/'
+                # get all files from new path
+                paths = list(all_filesystem_paths(new_Path))
+                # add the extension to the strings for all files from the new path,
+                # so they may be called from the current directory
+                paths = [extension + path for path in paths]
+                # add all files from a given directory to our master list of files to check
+                all_Paths=paths+all_Paths
+
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
     else:

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -747,8 +747,19 @@ def changed_files(wpt_root):
 
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
-        r = os.path.realpath(wpt_root)
-        paths = [os.path.relpath(os.path.realpath(x), r) for x in kwargs["paths"]]
+        #make new list in case there are multiple added directories
+        AllPaths=[]
+        for path in kwargs.get("paths"):
+            # create extension for called directory and merge it with the existing path
+            extension= path+'/'
+            newPath=(str(os.path.realpath(wpt_root))+'/'+ extension)
+            # get all files from new path
+            paths = list(all_filesystem_paths(newPath))
+            # add the extension to the strings for all files from the new path,
+            # so they may be called from the current directory
+            paths=list(map(lambda path : extension + path, paths))
+            # add all files from a given directory to our master list of files to check
+            AllPaths=paths+AllPaths
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))
     else:

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -59,9 +59,9 @@ you could add the following line to the lint.whitelist file.
 
 %s: %s"""
 
-def all_filesystem_paths(repo_root):
+def all_filesystem_paths(repo_root, extended_path):
     path_filter = PathFilter(repo_root, extras=[".git/*"])
-    for dirpath, dirnames, filenames in os.walk(repo_root):
+    for dirpath, dirnames, filenames in os.walk(extended_path):
         for filename in filenames:
             path = os.path.relpath(os.path.join(dirpath, filename), repo_root)
             if path_filter(path):
@@ -754,10 +754,8 @@ def lint_paths(kwargs, wpt_root):
             # create extension for called directory and merge it with the existing path
                 new_path = os.path.realpath(os.path.join(wpt_root, path))
                 # get all files from new path
-                path_dir = list(all_filesystem_paths(new_Path))
-                # add the extension to the strings for all files from the new path,
-                # so they may be called from the current directory
-                path_dir = [os.path.join(path+os.path.sep,extended_path) for extended_path in path_dir]
+                path_dir = list(all_filesystem_paths(wpt_root, new_Path))
+             
                 # add all files from a given directory to our master list of files to check
                 paths = paths + path_dir
 

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -816,7 +816,7 @@ def lint(repo_root, paths, output_format):
     last = None
 
     with open(os.path.join(repo_root, "lint.whitelist")) as f:
-        whitelist, ignored_files=parse_whitelist(f)
+        whitelist, ignored_files = parse_whitelist(f)
 
     output_errors = {"json": output_errors_json,
                      "markdown": output_errors_markdown,

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -748,19 +748,18 @@ def changed_files(wpt_root):
 def lint_paths(kwargs, wpt_root):
     if kwargs.get("paths"):
         #make new list in case there are multiple added directories
-        paths=[]
+        paths = []
         for path in kwargs.get("paths"):
             if os.path.isdir(path):
             # create extension for called directory and merge it with the existing path
-                new_Path = os.path.realpath(os.path.join(wpt_root, path))
-                extension = path+'/'
+                new_path = os.path.realpath(os.path.join(wpt_root, path))
                 # get all files from new path
                 path_dir = list(all_filesystem_paths(new_Path))
                 # add the extension to the strings for all files from the new path,
                 # so they may be called from the current directory
-                paths = [extension + extended_path for extended_path in path_dir]
+                path_dir = [os.path.join(path+os.path.sep,extended_path) for extended_path in path_dir]
                 # add all files from a given directory to our master list of files to check
-                paths=paths+path_dir
+                paths = paths + path_dir
 
     elif kwargs["all"]:
         paths = list(all_filesystem_paths(wpt_root))

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -27,7 +27,7 @@ import logging
 
 logger = None
 
-def setup_logging(prefix=False):
+def setup_logging(prefix = False):
     global logger
     if logger is None:
         logger = logging.getLogger(os.path.basename(os.path.splitext(__file__)[0]))
@@ -60,7 +60,7 @@ you could add the following line to the lint.whitelist file.
 %s: %s"""
 
 def all_filesystem_paths(repo_root, subdir = None):
-    path_filter = PathFilter(repo_root, extras=[".git/*"])
+    path_filter = PathFilter(repo_root, extras = [".git/*"])
     if subdir:
         expanded_path = subdir
     else:
@@ -744,8 +744,8 @@ def output_error_count(error_count):
 
 
 def changed_files(wpt_root):
-    revish = testfiles.get_revish(revish=None)
-    changed, _ = testfiles.files_changed(revish, set(), include_uncommitted=True, include_new=True)
+    revish = testfiles.get_revish(revish = None)
+    changed, _ = testfiles.files_changed(revish, set(), include_uncommitted = True, include_new = True)
     return [os.path.relpath(item, wpt_root) for item in changed]
 
 

--- a/tools/lint/tests/test_lint.py
+++ b/tools/lint/tests/test_lint.py
@@ -398,12 +398,14 @@ def test_main_with_args():
     orig_argv = sys.argv
     try:
         sys.argv = ['./lint', 'a', 'b', 'c']
-        with _mock_lint('lint', return_value=True) as m:
-            lint_mod.main(**vars(create_parser().parse_args()))
-            m.assert_called_once_with(repo_root,
-                                      [os.path.relpath(os.path.join(os.getcwd(), x), repo_root)
-                                       for x in ['a', 'b', 'c']],
-                                      "normal")
+        with mock.patch(lint_mod.__name__ + ".os.path.isfile") as mock_isfile:
+            mock_isfile.return_value = True
+            with _mock_lint('lint', return_value=True) as m:
+                lint_mod.main(**vars(create_parser().parse_args()))
+                m.assert_called_once_with(repo_root,
+                                          [os.path.relpath(os.path.join(os.getcwd(), x), repo_root)
+                                           for x in ['a', 'b', 'c']],
+                                          "normal")
     finally:
         sys.argv = orig_argv
 


### PR DESCRIPTION
Response to issue https://github.com/w3c/web-platform-tests/issues/9879

Allows tester to pass command line arguments to lint specifying directories they want checked

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/9995)
<!-- Reviewable:end -->
