### PR TITLE
Remove HTMLIFrameElement.allowvr test

### DIFF
--- a/webvr/idlharness.https.html
+++ b/webvr/idlharness.https.html
@@ -203,10 +203,6 @@ partial interface Window {
   attribute EventHandler onvrdisplaypresentchange;
 };
 
-partial interface HTMLIFrameElement {
-  attribute boolean allowvr;
-};
-
 partial interface Gamepad {
   readonly attribute unsigned long displayId;
 };


### PR DESCRIPTION

This attribute was unshipped.

Upstreamed from https://github.com/servo/servo/pull/20287 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10011)
<!-- Reviewable:end -->
