### PR TITLE
ReadableStream: Readable byte stream must call pull if needed after receiving new chunk

### DIFF
--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -693,7 +693,7 @@ promise_test(() => {
     },
     type: 'bytes'
   }, {
-    highWaterMark: 256
+    highWaterMark: 0
   });
 
   const reader = stream.getReader();
@@ -717,9 +717,9 @@ promise_test(() => {
     assert_equals(result[2].done, false, 'result[2].done');
     assert_equals(result[2].value.byteLength, 1, 'result[2].value.byteLength');
     assert_equals(byobRequest, undefined, 'byobRequest should be undefined');
-    assert_equals(desiredSizes[0], 256, 'desiredSize on pull should be 256');
-    assert_equals(desiredSizes[1], 256, 'desiredSize after 1st enqueue() should be 256');
-    assert_equals(desiredSizes[2], 256, 'desiredSize after 2nd enqueue() should be 256');
+    assert_equals(desiredSizes[0], 0, 'desiredSize on pull should be 0');
+    assert_equals(desiredSizes[1], 0, 'desiredSize after 1st enqueue() should be 0');
+    assert_equals(desiredSizes[2], 0, 'desiredSize after 2nd enqueue() should be 0');
     assert_equals(pullCount, 1, 'pull() should only be called once');
   });
 }, 'ReadableStream with byte source: Respond to pull() by enqueue() asynchronously');

--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -351,12 +351,13 @@ promise_test(() => {
     return p0;
   }).then(result => {
     assert_equals(pullCount, 2, 'pull() must have been invoked twice');
-    assert_not_equals(result.value, undefined);
-    assert_equals(result.value.constructor, Uint8Array);
-    assert_equals(result.value.buffer.byteLength, 16);
-    assert_equals(result.value.byteOffset, 0);
-    assert_equals(result.value.byteLength, 1);
-    assert_equals(result.value[0], 0x01);
+    const value = result.value;
+    assert_not_equals(value, undefined);
+    assert_equals(value.constructor, Uint8Array);
+    assert_equals(value.buffer.byteLength, 16);
+    assert_equals(value.byteOffset, 0);
+    assert_equals(value.byteLength, 1);
+    assert_equals(value[0], 0x01);
     const byobRequest = byobRequests[1];
     assert_true(byobRequest.defined, 'second byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'second byobRequest.view must not be undefined');
@@ -369,13 +370,14 @@ promise_test(() => {
     return p1;
   }).then(result => {
     assert_equals(pullCount, 2, 'pull() should only be invoked twice');
-    assert_not_equals(result.value, undefined);
-    assert_equals(result.value.constructor, Uint8Array);
-    assert_equals(result.value.buffer.byteLength, 16);
-    assert_equals(result.value.byteOffset, 0);
-    assert_equals(result.value.byteLength, 2);
-    assert_equals(result.value[0], 0x02);
-    assert_equals(result.value[1], 0x03);
+    const value = result.value;
+    assert_not_equals(value, undefined);
+    assert_equals(value.constructor, Uint8Array);
+    assert_equals(value.buffer.byteLength, 16);
+    assert_equals(value.byteOffset, 0);
+    assert_equals(value.byteLength, 2);
+    assert_equals(value[0], 0x02);
+    assert_equals(value[1], 0x03);
   });
 }, 'ReadableStream with byte source: autoAllocateChunkSize');
 
@@ -415,12 +417,13 @@ promise_test(() => {
 
   const reader = stream.getReader();
   return reader.read().then(result => {
-    assert_not_equals(result.value, undefined);
-    assert_equals(result.value.constructor, Uint8Array);
-    assert_equals(result.value.buffer.byteLength, 16);
-    assert_equals(result.value.byteOffset, 0);
-    assert_equals(result.value.byteLength, 1);
-    assert_equals(result.value[0], 0x01);
+    const value = result.value;
+    assert_not_equals(value, undefined);
+    assert_equals(value.constructor, Uint8Array);
+    assert_equals(value.buffer.byteLength, 16);
+    assert_equals(value.byteOffset, 0);
+    assert_equals(value.byteLength, 1);
+    assert_equals(value[0], 0x01);
     const byobRequest = byobRequests[0];
     assert_true(byobRequest.defined, 'first byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'first byobRequest.view must not be undefined');
@@ -434,13 +437,14 @@ promise_test(() => {
     const byobReader = stream.getReader({ mode: 'byob' });
     return byobReader.read(new Uint8Array(32));
   }).then(result => {
-    assert_not_equals(result.value, undefined);
-    assert_equals(result.value.constructor, Uint8Array);
-    assert_equals(result.value.buffer.byteLength, 32);
-    assert_equals(result.value.byteOffset, 0);
-    assert_equals(result.value.byteLength, 2);
-    assert_equals(result.value[0], 0x02);
-    assert_equals(result.value[1], 0x03);
+    const value = result.value;
+    assert_not_equals(value, undefined);
+    assert_equals(value.constructor, Uint8Array);
+    assert_equals(value.buffer.byteLength, 32);
+    assert_equals(value.byteOffset, 0);
+    assert_equals(value.byteLength, 2);
+    assert_equals(value[0], 0x02);
+    assert_equals(value[1], 0x03);
     const byobRequest = byobRequests[1];
     assert_true(byobRequest.defined, 'second byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'second byobRequest.view must not be undefined');

--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -300,7 +300,7 @@ function extractViewInfo(view) {
 promise_test(() => {
   let pullCount = 0;
   let controller;
-  let byobRequests = [];
+  const byobRequests = [];
 
   const stream = new ReadableStream({
     start(c) {

--- a/streams/readable-byte-streams/general.js
+++ b/streams/readable-byte-streams/general.js
@@ -352,12 +352,12 @@ promise_test(() => {
   }).then(result => {
     assert_equals(pullCount, 2, 'pull() must have been invoked twice');
     const value = result.value;
-    assert_not_equals(value, undefined);
-    assert_equals(value.constructor, Uint8Array);
-    assert_equals(value.buffer.byteLength, 16);
-    assert_equals(value.byteOffset, 0);
-    assert_equals(value.byteLength, 1);
-    assert_equals(value[0], 0x01);
+    assert_not_equals(value, undefined, 'first read should have a value');
+    assert_equals(value.constructor, Uint8Array, 'first value should be a Uint8Array');
+    assert_equals(value.buffer.byteLength, 16, 'first value.buffer.byteLength should be 16');
+    assert_equals(value.byteOffset, 0, 'first value.byteOffset should be 0');
+    assert_equals(value.byteLength, 1, 'first value.byteLength should be 1');
+    assert_equals(value[0], 0x01, 'first value[0] should be 0x01');
     const byobRequest = byobRequests[1];
     assert_true(byobRequest.defined, 'second byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'second byobRequest.view must not be undefined');
@@ -371,13 +371,13 @@ promise_test(() => {
   }).then(result => {
     assert_equals(pullCount, 2, 'pull() should only be invoked twice');
     const value = result.value;
-    assert_not_equals(value, undefined);
-    assert_equals(value.constructor, Uint8Array);
-    assert_equals(value.buffer.byteLength, 16);
-    assert_equals(value.byteOffset, 0);
-    assert_equals(value.byteLength, 2);
-    assert_equals(value[0], 0x02);
-    assert_equals(value[1], 0x03);
+    assert_not_equals(value, undefined, 'second read should have a value');
+    assert_equals(value.constructor, Uint8Array, 'second value should be a Uint8Array');
+    assert_equals(value.buffer.byteLength, 16, 'second value.buffer.byteLength should be 16');
+    assert_equals(value.byteOffset, 0, 'second value.byteOffset should be 0');
+    assert_equals(value.byteLength, 2, 'second value.byteLength should be 2');
+    assert_equals(value[0], 0x02, 'second value[0] should be 0x02');
+    assert_equals(value[1], 0x03, 'second value[1] should be 0x03');
   });
 }, 'ReadableStream with byte source: autoAllocateChunkSize');
 
@@ -418,12 +418,12 @@ promise_test(() => {
   const reader = stream.getReader();
   return reader.read().then(result => {
     const value = result.value;
-    assert_not_equals(value, undefined);
-    assert_equals(value.constructor, Uint8Array);
-    assert_equals(value.buffer.byteLength, 16);
-    assert_equals(value.byteOffset, 0);
-    assert_equals(value.byteLength, 1);
-    assert_equals(value[0], 0x01);
+    assert_not_equals(value, undefined, 'first read should have a value');
+    assert_equals(value.constructor, Uint8Array, 'first value should be a Uint8Array');
+    assert_equals(value.buffer.byteLength, 16, 'first value.buffer.byteLength should be 16');
+    assert_equals(value.byteOffset, 0, 'first value.byteOffset should be 0');
+    assert_equals(value.byteLength, 1, 'first value.byteLength should be 1');
+    assert_equals(value[0], 0x01, 'first value[0] should be 0x01');
     const byobRequest = byobRequests[0];
     assert_true(byobRequest.defined, 'first byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'first byobRequest.view must not be undefined');
@@ -438,13 +438,13 @@ promise_test(() => {
     return byobReader.read(new Uint8Array(32));
   }).then(result => {
     const value = result.value;
-    assert_not_equals(value, undefined);
-    assert_equals(value.constructor, Uint8Array);
-    assert_equals(value.buffer.byteLength, 32);
-    assert_equals(value.byteOffset, 0);
-    assert_equals(value.byteLength, 2);
-    assert_equals(value[0], 0x02);
-    assert_equals(value[1], 0x03);
+    assert_not_equals(value, undefined, 'second read should have a value');
+    assert_equals(value.constructor, Uint8Array, 'second value should be a Uint8Array');
+    assert_equals(value.buffer.byteLength, 32, 'second value.buffer.byteLength should be 32');
+    assert_equals(value.byteOffset, 0, 'second value.byteOffset should be 0');
+    assert_equals(value.byteLength, 2, 'second value.byteLength should be 2');
+    assert_equals(value[0], 0x02, 'second value[0] should be 0x02');
+    assert_equals(value[1], 0x03, 'second value[1] should be 0x03');
     const byobRequest = byobRequests[1];
     assert_true(byobRequest.defined, 'second byobRequest must not be undefined');
     assert_true(byobRequest.viewDefined, 'second byobRequest.view must not be undefined');


### PR DESCRIPTION
This adds a test for the new behavior to be introduced by whatwg/streams#904. More tests will follow later.

This also changes two other tests:
* _ReadableStream with byte source: autoAllocateChunkSize_  
This test previously expected `pull()` to only be called once, although `read()` is called twice. This was incorrect: `pull()` should have been called again to fulfill the second `read()`. The fixed test verifies that the second `read` is correctly fulfilled.
* _ReadableStream with byte source: Respond to pull() by enqueue() asynchronously_  
This test previously expected `pull()` to only be called once, but the amount of data enqueued by one `pull()` is not sufficient to fill the stream's queue up to its `highWaterMark` of `256`. This is now incorrect: the stream would need to repeatedly call pull until it has reached the `highWaterMark`. The fixed test sets the `highWaterMark` to `0` such that `pull()` does not get called repeatedly.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
