### PR TITLE
Adjust MathML tests to Workaround WebKit's bug with document.fonts.ready

### DIFF
--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -63,7 +63,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/fractions/frac-parameters-1.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-1.html
@@ -62,7 +62,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -50,7 +50,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/fractions/frac-parameters-2.html
+++ b/mathml/presentation-markup/fractions/frac-parameters-2.html
@@ -51,7 +51,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -26,7 +26,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/operators/mo-axis-height-1.html
+++ b/mathml/presentation-markup/operators/mo-axis-height-1.html
@@ -27,7 +27,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -50,7 +50,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/radicals/root-parameters-1.html
+++ b/mathml/presentation-markup/radicals/root-parameters-1.html
@@ -51,7 +51,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -63,7 +63,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/subsup-parameters-1.html
+++ b/mathml/presentation-markup/scripts/subsup-parameters-1.html
@@ -62,7 +62,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -39,7 +39,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-1.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-1.html
@@ -38,7 +38,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -39,7 +39,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-2.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-2.html
@@ -38,7 +38,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -41,7 +41,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => {   document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-3.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-3.html
@@ -42,7 +42,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => {   document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => {   document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-4.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.html
@@ -41,7 +41,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => {   document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/scripts/underover-parameters-4.html
+++ b/mathml/presentation-markup/scripts/underover-parameters-4.html
@@ -42,7 +42,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => {   document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => {   document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -26,7 +26,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/presentation-markup/tables/table-axis-height.html
+++ b/mathml/presentation-markup/tables/table-axis-height.html
@@ -27,7 +27,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -32,7 +32,8 @@
   }
 
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/relations/css-styling/displaystyle-1.html
+++ b/mathml/relations/css-styling/displaystyle-1.html
@@ -33,7 +33,7 @@
 
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {

--- a/mathml/relations/css-styling/lengths-3.html
+++ b/mathml/relations/css-styling/lengths-3.html
@@ -26,7 +26,8 @@
 
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
-    document.fonts.ready.then(runTests);
+    // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
+    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
   });
 
   function runTests() {

--- a/mathml/relations/css-styling/lengths-3.html
+++ b/mathml/relations/css-styling/lengths-3.html
@@ -27,7 +27,7 @@
   setup({ explicit_done: true });
   window.addEventListener("load", function() {
     // Delay the check to workaround WebKit's bug https://webkit.org/b/174030.
-    setTimeout(() => { document.fonts.ready.then(runTests); }, 0);
+    requestAnimationFrame(() => { document.fonts.ready.then(runTests); });
   });
 
   function runTests() {


### PR DESCRIPTION
cc @mrego cc @youennf 

That seems to be an acceptable work around to me. WDYT?

See also https://bugs.webkit.org/show_bug.cgi?id=183628

<!-- Reviewable:start -->

<!-- Reviewable:end -->
