### PR TITLE
idlharness.js: Distinguish instance toJSON is being executed against when it's inherited

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2069,6 +2069,7 @@ IdlInterface.prototype.add_iterable_members = function(member)
 };
 
 IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, member) {
+    var instanceName = memberHolderObject.constructor.name;
     if (member.has_extended_attribute("Default")) {
         var map = this.default_to_json_operation();
         test(function() {
@@ -2082,12 +2083,12 @@ IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, mem
                 this.array.assert_type_is(json[k], type);
                 delete json[k];
             }, this);
-        }.bind(this), "Test default toJSON operation of " + this.name);
+        }.bind(this), "Test default toJSON operation of " + instanceName);
     } else {
         test(function() {
-            assert_true(this.array.is_json_type(member.idlType), JSON.stringify(member.idlType) + " is not an appropriate return value for the toJSON operation of " + this.name);
+            assert_true(this.array.is_json_type(member.idlType), JSON.stringify(member.idlType) + " is not an appropriate return value for the toJSON operation of " + instanceName);
             this.array.assert_type_is(memberHolderObject.toJSON(), member.idlType);
-        }.bind(this), "Test toJSON operation of " + this.name);
+        }.bind(this), "Test toJSON operation of " + instanceName);
     }
 };
 

--- a/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
@@ -12,7 +12,7 @@
 <body>
 <script>
     "use strict";
-    function wrap(obj) {
+    function wrap(member, obj) {
         function F(obj) {
             this._obj = obj;
         }
@@ -20,25 +20,25 @@
         F.prototype.toJSON = function() {
             return this._obj;
         }
-
+        Object.defineProperty(F, 'name', { value: member.name });
         return new F(obj);
     }
 
     var i, obj;
     i = interfaceFrom("interface A { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap({ foo: 123 }), i.members[0]);
+    i.test_to_json_operation(wrap(i, { foo: 123 }), i.members[0]);
 
     // should fail (wrong type)
     i = interfaceFrom("interface B { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap({ foo: "a value" }), i.members[0]);
+    i.test_to_json_operation(wrap(i, { foo: "a value" }), i.members[0]);
 
     // should handle extraneous attributes (e.g. from an extension specification)
     i = interfaceFrom("interface C { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap({ foo: 123, bar: 456 }), i.members[0]);
+    i.test_to_json_operation(wrap(i, { foo: 123, bar: 456 }), i.members[0]);
 
     // should fail (missing property)
     i = interfaceFrom("interface D { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap({ }), i.members[0]);
+    i.test_to_json_operation(wrap(i, { }), i.members[0]);
 
     // should fail (should be writable)
     obj = Object.defineProperties({}, { foo: {
@@ -48,7 +48,7 @@
         value: 123
     }});
     i = interfaceFrom("interface F { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap(obj), i.members[0]);
+    i.test_to_json_operation(wrap(i, obj), i.members[0]);
 
     // should fail (should be enumerable)
     obj = Object.defineProperties({}, { foo: {
@@ -58,7 +58,7 @@
         value: 123
     }});
     i = interfaceFrom("interface G { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap(obj), i.members[0]);
+    i.test_to_json_operation(wrap(i, obj), i.members[0]);
 
     // should fail (should be configurable)
     obj = Object.defineProperties({}, { foo: {
@@ -68,27 +68,27 @@
         value: 123
     }});
     i = interfaceFrom("interface H { [Default] object toJSON(); attribute long foo; };");
-    i.test_to_json_operation(wrap(obj), i.members[0]);
+    i.test_to_json_operation(wrap(i, obj), i.members[0]);
 
     var idl = new IdlArray();
     idl.add_idls("interface I : J { [Default] object toJSON(); attribute long foo; };");
     idl.add_idls("interface J { [Default] object toJSON(); attribute DOMString foo;};");
     var i = idl.members.I;
-    i.test_to_json_operation(wrap({ foo: 123 }), i.members[0]);
+    i.test_to_json_operation(wrap(i, { foo: 123 }), i.members[0]);
 
     i = interfaceFrom("interface K { [Default] object toJSON(); };");
-    i.test_to_json_operation(wrap({}), i.members[0]);
+    i.test_to_json_operation(wrap(i, {}), i.members[0]);
 
     i = interfaceFrom("interface L { DOMString toJSON(); };");
-    i.test_to_json_operation(wrap("a string"), i.members[0]);
+    i.test_to_json_operation(wrap(i, "a string"), i.members[0]);
 
     // should fail (wrong output type)
     i = interfaceFrom("interface M { DOMString toJSON(); };");
-    i.test_to_json_operation(wrap({}), i.members[0]);
+    i.test_to_json_operation(wrap(i, {}), i.members[0]);
 
     // should fail (not an IDL type)
     i = interfaceFrom("interface N { DOMException toJSON(); };");
-    i.test_to_json_operation(wrap({}), i.members[0]);
+    i.test_to_json_operation(wrap(i, {}), i.members[0]);
 </script>
 <script type="text/json" id="expected">
     {


### PR DESCRIPTION
The specific 'bug' that I am attempting to fix is outlined in https://github.com/w3c/web-platform-tests/pull/9787 - also fixes #7492

I am unsure why changing `[Default] toJSON();` to `[Default] object toJSON();` suddenly results in the new error:

    3 duplicate test names: "Test default toJSON operation of DOMPointReadOnly", "Test default toJSON 
    operation of DOMRectReadOnly", "Test default toJSON operation of DOMMatrixReadOnly"

I _have_ clarified that the duplication occurs from running the test on both `DOMMatrix` and `DOMMatrixReadOnly`, where `DOMMatrix : DOMMatrixReadOnly`.
`this.name` is `DOMMatrixReadOnly` in both cases, in spite of the idlArray object instance being DOMMatrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10029)
<!-- Reviewable:end -->
