### PR TITLE
Remove redundant importScript bits from a .any.js test

### DIFF
--- a/payment-handler/interfaces.https.any.js
+++ b/payment-handler/interfaces.https.any.js
@@ -3,11 +3,6 @@
 
 'use strict';
 
-if (self.importScripts) {
-  importScripts('/resources/testharness.js');
-  importScripts('/resources/WebIDLParser.js', '/resources/idlharness.js');
-}
-
 // https://w3c.github.io/payment-handler/
 
 promise_test(async () => {


### PR DESCRIPTION
The test results do not change as a result of these changes.

See http://web-platform-tests.org/writing-tests/testharness.html#multi-global-tests

<!-- Reviewable:start -->

<!-- Reviewable:end -->
