### PR TITLE
Add tentative test for what ".." on documentElement returns

### DIFF
--- a/domxpath/document.tentative.html
+++ b/domxpath/document.tentative.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>XPath parent of documentElement</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<body>
+<script>
+test(function() {
+  var result = document.evaluate("..", // expression
+                                document.documentElement, // context node
+                                null, // resolver
+                                XPathResult.ANY_TYPE, // type
+                                null); // result
+  var matched = [];
+  var cur;
+  while ((cur = result.iterateNext()) !== null) {
+    matched.push(cur);
+  }
+  assert_array_equals(matched, [document]);
+});
+</script>


### PR DESCRIPTION
As far as I can tell, from both DOM Level 3 XPath and XPath 1.0, this is undefined. As far as the XPath data model is concerned, documentElement can have no parent, and DOM Level 3 XPath doesn't address this.

However, at least Chrome/Edge/Firefox/Safari all pass this test, so it seems like something we should test.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
