### PR TITLE
Changing WebDriver test_parent_htmldocument to expect error

### DIFF
--- a/webdriver/tests/element_retrieval/find_element_from_element.py
+++ b/webdriver/tests/element_retrieval/find_element_from_element.py
@@ -79,4 +79,4 @@ def test_parent_htmldocument(session):
     from_element = session.execute_script("return document.documentElement")
 
     response = find_element(session, from_element.id, "xpath", "..")
-    assert_success(response)
+    assert_error(response, "invalid selector")

--- a/webdriver/tests/element_retrieval/find_element_from_element.py
+++ b/webdriver/tests/element_retrieval/find_element_from_element.py
@@ -76,6 +76,16 @@ def test_xhtml_namespace(session, using, value):
 
 def test_parent_htmldocument(session):
     session.url = inline("")
+    from_element = session.execute_script("""return document.querySelector("body")""")
+    expected = session.execute_script("return document.documentElement")
+
+    response = find_element(session, from_element.id, "xpath", "..")
+    value = assert_success(response)
+    assert_same_element(session, value, expected)
+
+
+def test_parent_of_document_node_errors(session):
+    session.url = inline("")
     from_element = session.execute_script("return document.documentElement")
 
     response = find_element(session, from_element.id, "xpath", "..")

--- a/webdriver/tests/element_retrieval/find_elements_from_element.py
+++ b/webdriver/tests/element_retrieval/find_elements_from_element.py
@@ -82,6 +82,4 @@ def test_parent_htmldocument(session):
     from_element = session.execute_script("return document.documentElement")
 
     response = find_elements(session, from_element.id, "xpath", "..")
-    value = assert_success(response)
-    assert isinstance(value, list)
-    assert len(value) == 1
+    value = assert_error(response, "invalid selector")

--- a/webdriver/tests/element_retrieval/find_elements_from_element.py
+++ b/webdriver/tests/element_retrieval/find_elements_from_element.py
@@ -79,7 +79,21 @@ def test_xhtml_namespace(session, using, value):
 
 def test_parent_htmldocument(session):
     session.url = inline("")
+    from_element = session.execute_script("""return document.querySelector("body")""")
+    expected = session.execute_script("return document.documentElement")
+
+    response = find_elements(session, from_element.id, "xpath", "..")
+    value = assert_success(response)
+    assert isinstance(value, list)
+    assert len(value) == 1
+
+    found_element = value[0]
+    assert_same_element(session, found_element, expected)
+
+
+def test_parent_of_document_node_errors(session):
+    session.url = inline("")
     from_element = session.execute_script("return document.documentElement")
 
     response = find_elements(session, from_element.id, "xpath", "..")
-    value = assert_error(response, "invalid selector")
+    assert_error(response, "invalid selector")


### PR DESCRIPTION
When the context element is `document.documentElement`, and an attempt is
made to find elements from that context element using an XPath of `..`, a
snapshot is returned containing the `document` object. While this is
apparently the correct behavior for XPath, the WebDriver spec says that if
the object in the snapshot is not an element, we should return an error
with error code "invalid selector." The test_parent_htmldocument test in
both find_element_from_element.py and find_elements_from_element.py expect
a success in this case. This commit changes the tests to correctly expect
an error from the driver.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
