### PR TITLE
Editing expectations of domain attribute of returned cookie

### DIFF
--- a/webdriver/tests/cookies/add_cookie.py
+++ b/webdriver/tests/cookies/add_cookie.py
@@ -36,7 +36,7 @@ def test_add_domain_cookie(session, url, server_config):
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
-    assert cookie["domain"] == ".%s" % server_config["domains"][""]
+    assert cookie["domain"] == ".%s" % server_config["domains"][""] or cookie["domain"] == "%s" % server_config["domains"][""]
 
 def test_add_cookie_for_ip(session, url, server_config, configuration):
     session.url = "http://127.0.0.1:%s/common/blank.html" % (server_config["ports"]["http"][0])
@@ -175,4 +175,4 @@ def test_add_session_cookie_with_leading_dot_character_in_domain(session, url, s
 
     assert cookie["name"] == "hello"
     assert cookie["value"] == "world"
-    assert cookie["domain"] == ".%s" % server_config["domains"][""]
+    assert cookie["domain"] == ".%s" % server_config["domains"][""] or cookie["domain"] == "%s" % server_config["domains"][""]


### PR DESCRIPTION
For the domain attribute of a returned cookie, if the attribute value
conatains a domain with a single dot ('.'), some user agents prepend a
leading dot onto the beginning of the attribute value. This is consistent
with RFC 2965. Some user agents expressly omit the leading dot, which is
consistent with the later RFC 6265. This commit allows both values as the
returned value of the domain attribute.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
