### PR TITLE
Pass the binary path of Chrome to wpt run in CI

### DIFF
--- a/tools/ci/ci_stability.sh
+++ b/tools/ci/ci_stability.sh
@@ -8,15 +8,23 @@ cd $WPT_ROOT
 source tools/ci/lib.sh
 
 test_stability() {
-    ./wpt check-stability $PRODUCT --output-bytes $((1024 * 1024 * 3)) --metadata ~/meta/ --install-fonts
+    local extra_arg=$1
+    ./wpt check-stability $PRODUCT $extra_arg --output-bytes $((1024 * 1024 * 3)) --metadata ~/meta/ --install-fonts
 }
 
 main() {
     hosts_fixup
+    local extra_arg=""
     if [ $(echo $PRODUCT | grep '^chrome:') ]; then
-       install_chrome $(echo $PRODUCT | grep --only-matching '\w\+$')
+        local channel=$(echo $PRODUCT | grep --only-matching '\w\+$')
+        if [[ $channel == "dev" ]]; then
+            # The package name for Google Chrome Dev uses "unstable", not "dev".
+            channel="unstable"
+        fi
+        install_chrome $channel
+        extra_arg="--binary=$(which google-chrome-$channel)"
     fi
-    test_stability
+    test_stability $extra_arg
 }
 
 main

--- a/tools/ci/ci_wpt.sh
+++ b/tools/ci/ci_wpt.sh
@@ -10,7 +10,7 @@ source tools/ci/lib.sh
 main() {
     git fetch --unshallow https://github.com/w3c/web-platform-tests.git +refs/heads/*:refs/remotes/origin/*
     hosts_fixup
-    install_chrome dev
+    install_chrome unstable
     pip install -U tox codecov
     cd tools/wpt
     tox

--- a/tools/ci/ci_wptrunner_infrastructure.sh
+++ b/tools/ci/ci_wptrunner_infrastructure.sh
@@ -11,12 +11,14 @@ test_infrastructure() {
     local ARGS="";
     if [ $PRODUCT == "firefox" ]; then
         ARGS="--install-browser"
+    else
+        ARGS=$1
     fi
     ./wpt run --yes --manifest ~/meta/MANIFEST.json --metadata infrastructure/metadata/ --install-fonts $ARGS $PRODUCT infrastructure/
 }
 
 main() {
-    PRODUCTS=( "firefox" )
+    PRODUCTS=( "firefox" "chrome" )
     for PRODUCT in "${PRODUCTS[@]}"; do
         if [ "$PRODUCT" != "firefox" ]; then
             # Firefox is expected to work using pref settings for DNS
@@ -24,9 +26,11 @@ main() {
             hosts_fixup
         fi
         if [ "$PRODUCT" == "chrome" ]; then
-            install_chrome dev
+            install_chrome unstable
+            test_infrastructure "--binary=$(which google-chrome-unstable)"
+        else
+            test_infrastructure
         fi
-        test_infrastructure
     done
 }
 

--- a/tools/ci/lib.sh
+++ b/tools/ci/lib.sh
@@ -15,10 +15,6 @@ hosts_fixup() {
 
 install_chrome() {
     channel=$1
-    # The package name for Google Chrome Dev uses "unstable", not "dev".
-    if [[ $channel == "dev" ]]; then
-        channel="unstable"
-    fi
     deb_archive=google-chrome-${channel}_current_amd64.deb
     wget https://dl.google.com/linux/direct/$deb_archive
 

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -88,7 +88,7 @@ class SeleniumTestharnessProtocolPart(TestharnessProtocolPart):
         for handle in handles:
             try:
                 self.webdriver.switch_to_window(handle)
-                self.webdriver.close_window()
+                self.webdriver.close()
             except exceptions.NoSuchWindowException:
                 pass
         self.webdriver.switch_to_window(exclude)


### PR DESCRIPTION
ChromeDriver doesn't honor PATH and uses /opt/google/chrome/chrome by
default (which is usually the stable channel), so we need to explicitly
pass the desired binary path to wpt run (which in turn passes to
chromedriver via capabilities) in Travis CI (both stability check and
infrastructure test). This fixes #9979 and is one more step closer to #9932.

This PR also fixes a bug introduced in #9391. Due to the issue above, Chrome was disabled in infra integration tests, so the bug wasn't caught back then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10064)
<!-- Reviewable:end -->
