### PR TITLE
WebDriver: REGRESSION(86d68c3198c): missing 'sys' import in fixtures.py

### DIFF
--- a/webdriver/tests/support/fixtures.py
+++ b/webdriver/tests/support/fixtures.py
@@ -4,6 +4,7 @@ import json
 import os
 import urlparse
 import re
+import sys
 
 import webdriver
 


### PR DESCRIPTION
This adds extra [Error] results whenever there's a problem during teardown.
I can't debug the actual failure if the test runner itself raises an exception.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
