### PR TITLE
Mute wget when downloading chrome deb

### DIFF
--- a/tools/ci/lib.sh
+++ b/tools/ci/lib.sh
@@ -20,7 +20,7 @@ install_chrome() {
         channel="unstable"
     fi
     deb_archive=google-chrome-${channel}_current_amd64.deb
-    wget https://dl.google.com/linux/direct/$deb_archive
+    wget -q https://dl.google.com/linux/direct/$deb_archive
 
     # If the environment provides an installation of Google Chrome, the
     # existing binary may take precedence over the one introduced in this


### PR DESCRIPTION
A quick fix to clean up Travis logs for Chrome jobs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10080)
<!-- Reviewable:end -->
