### PR TITLE
No longer allow Chrome stability check to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,9 +87,6 @@ matrix:
     - env:  # exclude empty env from the top-level above
   allow_failures:
     - env: JOB=build_css SCRIPT=css/build-css-testsuites.sh
-    - env:
-        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
-        - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=chrome:dev
 script:
   - ./tools/ci/run.sh
 cache:


### PR DESCRIPTION
After #10064, Chrome jobs run successfully on Travis, so we can turn the
stability check back on.

Fixes #9932.

Note: I'm not planning to land this immediately. Just sending this out now, and I'll wait for some more Travis builds and see how they go next week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10082)
<!-- Reviewable:end -->
