### PR TITLE
Exit check_stability with an error when no tests run

### DIFF
--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -250,16 +250,13 @@ def main():
     venv.install("requests")
 
     args, wpt_args = get_parser().parse_known_args()
-    return run(venv, wpt_args, **vars(args))
+    return setup_and_run(venv, wpt_args, **vars(args))
 
 
-def run(venv, wpt_args, **kwargs):
-    global logger
-
+def setup_and_run(venv, wpt_args, **kwargs):
     do_delayed_imports()
 
     retcode = 0
-    parser = get_parser()
 
     wpt_args = create_parser().parse_args(wpt_args)
 
@@ -353,16 +350,15 @@ def run(venv, wpt_args, **kwargs):
                              status="failed" if inconsistent else "passed")
     else:
         logger.info("No tests run.")
+        retcode = 3
 
     return retcode
 
 
 if __name__ == "__main__":
     try:
-        retcode = main()
+        sys.exit(main())
     except Exception:
         import traceback
         traceback.print_exc()
         sys.exit(1)
-    else:
-        sys.exit(retcode)


### PR DESCRIPTION
Similar to #10030 (which was for `wpt run`), this commit makes `wpt
check-stability` return a non-zero exit code when no tests run.

Also fix some code smells:

* `run` was redefined by `do_delayed_imports` to a different function.
  Rename the other `run` method in this module to `setup_and_run`.
* `retcode` was unnecessarily defined in the top scope. Remove it to
  avoid redefinition.
* `global logger` and the call to `get_parser` were extraneous in `run`
  (now `setup_and_run`) and hence are removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10098)
<!-- Reviewable:end -->
