### PR TITLE
Update serialization of drop-shadow

### DIFF
--- a/css/filter-effects/parsing/filter-parsing-invalid.html
+++ b/css/filter-effects/parsing/filter-parsing-invalid.html
@@ -34,8 +34,6 @@ test_invalid_value("filter", "drop-shadow(10% 20%)");
 test_invalid_value("filter", "drop-shadow(1px)");
 test_invalid_value("filter", "drop-shadow(1px 2px 3px 4px)");
 test_invalid_value("filter", "drop-shadow(rgb(4, 5, 6))");
-// https://github.com/w3c/fxtf-drafts/issues/231
-test_invalid_value("filter", "drop-shadow(rgb(4, 5, 6) 1px 2px)"); // Fails in Blink/WebKit "drop-shadow(rgb(4, 5, 6) 1px 2px)" and Firefox "drop-shadow(1px 2px rgb(4, 5, 6))".
 test_invalid_value("filter", "drop-shadow()");
 
 test_invalid_value("filter", "grayscale(-20)");

--- a/css/filter-effects/parsing/filter-parsing-valid.html
+++ b/css/filter-effects/parsing/filter-parsing-valid.html
@@ -26,9 +26,9 @@ test_valid_value("filter", "contrast(300%)");
 test_valid_value("filter", "drop-shadow(1px 2px)");
 test_valid_value("filter", "drop-shadow(1px 2px 3px)");
 test_valid_value("filter", "drop-shadow(0 0 0)", "drop-shadow(0px 0px 0px)");
-// https://github.com/w3c/fxtf-drafts/issues/231
-test_valid_value("filter", "drop-shadow(1px 2px rgb(4, 5, 6))"); // Blink/WebKit serialize as "drop-shadow(rgb(4, 5, 6) 1px 2px)"
-test_valid_value("filter", "drop-shadow(1px 2px 3px rgba(4, 5, 6, 0.75))"); // Blink/WebKit serialize as "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)"
+// https://github.com/w3c/fxtf-drafts/issues/240
+test_valid_value("filter", "drop-shadow(rgb(4, 5, 6) 1px 2px)");
+test_valid_value("filter", "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)");
 
 test_valid_value("filter", "grayscale(0)");
 test_valid_value("filter", "grayscale(300%)", "grayscale(100%)");

--- a/css/filter-effects/parsing/filter-parsing-valid.html
+++ b/css/filter-effects/parsing/filter-parsing-valid.html
@@ -28,6 +28,7 @@ test_valid_value("filter", "drop-shadow(1px 2px 3px)");
 test_valid_value("filter", "drop-shadow(0 0 0)", "drop-shadow(0px 0px 0px)");
 // https://github.com/w3c/fxtf-drafts/issues/240
 test_valid_value("filter", "drop-shadow(rgb(4, 5, 6) 1px 2px)");
+test_valid_value("filter", "drop-shadow(1px 2px rgb(4, 5, 6))", "drop-shadow(rgb(4, 5, 6) 1px 2px)");
 test_valid_value("filter", "drop-shadow(rgba(4, 5, 6, 0.75) 1px 2px 3px)");
 
 test_valid_value("filter", "grayscale(0)");


### PR DESCRIPTION
After https://github.com/w3c/fxtf-drafts/issues/240, the serialization order of `drop-shadow()` was changed to be the color (if specified), then the length values. This matches the behavior of Firefox/Chrome/WebKit. Update the test to match this change to the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
