### PR TITLE
Handle options for add_untested_idls

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -177,7 +177,7 @@ IdlArray.prototype.add_idls = function(raw_idls, options)
 };
 
 //@}
-IdlArray.prototype.add_untested_idls = function(raw_idls)
+IdlArray.prototype.add_untested_idls = function(raw_idls, options)
 //@{
 {
     /** Entry point.  See documentation at beginning of file. */
@@ -193,7 +193,7 @@ IdlArray.prototype.add_untested_idls = function(raw_idls)
             }
         }
     }
-    this.internal_add_idls(parsed_idls);
+    this.internal_add_idls(parsed_idls, options);
 };
 
 //@}
@@ -274,13 +274,13 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
         }
 
         parsed_idl.array = this;
-        if (parsed_idl.name in this.members)
-        {
-            throw "Duplicate identifier " + parsed_idl.name;
-        }
         if (should_skip(parsed_idl.name))
         {
             return;
+        }
+        if (parsed_idl.name in this.members)
+        {
+            throw "Duplicate identifier " + parsed_idl.name;
         }
         switch(parsed_idl.type)
         {


### PR DESCRIPTION
Currently, no way to import a subset of an IDL snippet as untested interfaces.

Note that the order of checking for `should_skip` needs to change for a case such as:
IDL:

    interface A {}
    interface B {}

    let text = await fetch('interfaces/foo.idl').then(r => r.text());
    idlArray.add_untested_idls(text, {only: ['A'] });
    idlArray.add_idls(text, {only: ['B'] });

The `add_idls` encounters 'A' for a second time, and throws `Duplicate identifier`, in spite of the fact that it will be skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10100)
<!-- Reviewable:end -->
