### PR TITLE
Attempt to fix ci_resources_unittest (#10114)

### DIFF
--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -1,4 +1,6 @@
 [tox]
+# wptserve etc. are Python2-only.
+envlist = py27
 skipsdist=True
 
 [testenv]
@@ -9,5 +11,6 @@ deps =
   pytest>=2.9
   pyvirtualdisplay
   selenium
+  requests
 
 commands = pytest {posargs} -vv tests

--- a/tools/ci/ci_resources_unittest.sh
+++ b/tools/ci/ci_resources_unittest.sh
@@ -8,13 +8,12 @@ cd $WPT_ROOT
 main() {
     cd $WPT_ROOT
     pip install -U tox
-    pip install --requirement tools/wpt/requirements.txt
     ./wpt install firefox browser --destination $HOME
     ./wpt install firefox webdriver --destination $HOME/firefox
     export PATH=$HOME/firefox:$PATH
 
     cd $WPT_ROOT/resources/test
-    tox
+    tox -- --binary=$HOME/browsers/firefox/firefox
 }
 
 main


### PR DESCRIPTION
The test wasn't running against the downloaded Firefox Nightly but
system Firefox instead, which is fixed by passing the binary path to
tox (which then passes it to pytest conftest.py).

The pip requirements should be managed by tox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10116)
<!-- Reviewable:end -->
