### PR TITLE
Add Console historical test for markTimline

### DIFF
--- a/console/console-tests-historical.any.js
+++ b/console/console-tests-historical.any.js
@@ -1,0 +1,19 @@
+/**
+ * These tests assert the non-existence of certain
+ * legacy Console methods that are not included in
+ * the specification: http://console.spec.whatwg.org/
+ */
+
+"use strict";
+
+test(() => {
+  assert_equals(console.timeline, undefined, "console.timeline should be undefined");
+}, "'timeline' function should not exist on the console object");
+
+test(() => {
+  assert_equals(console.timelineEnd, undefined, "console.timelineEnd should be undefined");
+}, "'timelineEnd' function should not exist on the console object");
+
+test(() => {
+  assert_equals(console.markTimeline, undefined, "console.markTimeline should be undefined");
+}, "'markTimeline' function should not exist on the console object");

--- a/console/console-timeline-timelineEnd-historical.any.js
+++ b/console/console-timeline-timelineEnd-historical.any.js
@@ -1,9 +1,0 @@
-"use strict";
-
-test(() => {
-  assert_equals(console.timeline, undefined, "console.timeline should be undefined");
-}, "'timeline' function should not exist on the console object");
-
-test(() => {
-  assert_equals(console.timelineEnd, undefined, "console.timelineEnd should be undefined");
-}, "'timelineEnd' function should not exist on the console object");


### PR DESCRIPTION
...and also generalize the file already containing historical tests to house any future historical tests asserting the non-existence of certain legacy Console methods.

Part of https://github.com/whatwg/console/issues/27

<!-- Reviewable:start -->

<!-- Reviewable:end -->
