### PR TITLE
Fix resources/test (when running locally)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 _venv/
 .cache/
 .pytest_cache/
+.tox/
 
 # Node
 node_modules/

--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -24,8 +24,8 @@ def pytest_configure(config):
     config.driver = webdriver.Firefox(firefox_binary=config.getoption("--binary"))
     config.server = WPTServer(WPT_ROOT)
     config.server.start()
-    config.add_cleanup(lambda: config.server.stop())
-    config.add_cleanup(lambda: config.driver.quit())
+    config.add_cleanup(config.server.stop)
+    config.add_cleanup(config.driver.quit)
 
 class HTMLItem(pytest.Item, pytest.Collector):
     def __init__(self, filename, parent):

--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -1,48 +1,49 @@
 import json
 import os
-import ssl
 import subprocess
+import time
 import urllib2
 
 _CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'config.test.json')
 
-with open(_CONFIG_FILE, 'r') as config_handle:
-    config = json.loads(config_handle.read())
-    host = config["host"]
-    port = config["ports"]["https"][0]
 
 class WPTServer(object):
-    base_url = 'https://%s:%s' % (host, port)
 
     def __init__(self, wpt_root):
         self.wpt_root = wpt_root
+        with open(_CONFIG_FILE, 'r') as config_handle:
+            config = json.load(config_handle)
+        self.host = config["host"]
+        self.http_port = config["ports"]["http"][0]
+        self.https_port = config["ports"]["https"][0]
+        self.base_url = 'http://%s:%s' % (self.host, self.http_port)
+        self.https_base_url = 'https://%s:%s' % (self.host, self.https_port)
 
     def start(self):
         self.devnull = open(os.devnull, 'w')
         self.proc = subprocess.Popen(
             [os.path.join(self.wpt_root, 'wpt'), 'serve', '--config=' + _CONFIG_FILE],
-            stdout=self.devnull,
             stderr=self.devnull,
             cwd=self.wpt_root)
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-        context.verify_mode = ssl.CERT_NONE
-        context.check_hostname = False
 
-        while True:
+        for retry in range(5):
+            # Exponential backoff.
+            time.sleep(2 ** retry)
             if self.proc.poll() != None:
-                raise Exception('Could not start wptserve.')
-
-            try:
-                urllib2.urlopen(self.base_url, timeout=1, context=context)
                 break
-            except urllib2.URLError as e:
+            try:
+                urllib2.urlopen(self.base_url, timeout=1)
+                return
+            except urllib2.URLError:
                 pass
 
+        raise Exception('Could not start wptserve.')
+
     def stop(self):
-        self.proc.kill()
+        self.proc.terminate()
         self.proc.wait()
         self.devnull.close()
 
     def url(self, abs_path):
-        return self.base_url + '/' + os.path.relpath(abs_path, self.wpt_root)
+        return self.https_base_url + '/' + os.path.relpath(abs_path, self.wpt_root)

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -3,7 +3,6 @@
 .coverage.*
 htmlcov/
 coverage.xml
-.tox/
 .cache/
 .hypothesis/
 *.py[co]


### PR DESCRIPTION
1. Check the HTTP port of wptserve instead of HTTPS to avoid the
   unnecessary complexities of setting up SSL context (which may fail in
   some environments, depending on the system OpenSSL version).
2. Use exponential backoff when waiting for wptserve and specify a
   maximum retry to avoid indefinite hang.
3. Use `terminate` instead of `kill` to give wptserve a chance to clean
   up, which is especially useful when running locally.

Fixes #10114.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10127)
<!-- Reviewable:end -->
