### PR TITLE
Fix python gitignore for directories.

### DIFF
--- a/tools/gitignore/gitignore.py
+++ b/tools/gitignore/gitignore.py
@@ -17,6 +17,12 @@ def fnmatch_translate(pat, path_name=False):
     else:
         any_char = "."
         parts.append("^(?:.*/)?")
+    if pat[-1] == "/":
+        # If the last character is / match this directory or any subdirectory
+        pat = pat[:-1]
+        suffix = "(?:/|$)"
+    else:
+        suffix = "$"
     while i < len(pat):
         c = pat[i]
         if c == "\\":
@@ -63,7 +69,7 @@ def fnmatch_translate(pat, path_name=False):
 
     if seq:
         raise ValueError
-    parts.append("$")
+    parts.append(suffix)
     try:
         return re.compile("".join(parts))
     except Exception:

--- a/tools/gitignore/tests/test_gitignore.py
+++ b/tools/gitignore/tests/test_gitignore.py
@@ -11,7 +11,8 @@ match_data = [
     ("/*.c", False, ["a.c", ".c"]),
     ("**/b", False, ["a/b", "a/c/b"]),
     ("*b", True, ["ab"]),
-    ("**/b", True, ["a/b"])
+    ("**/b", True, ["a/b"]),
+    ("a/", True, ["a", "a/b", "a/b/c"])
 ]
 
 mismatch_data = [
@@ -23,6 +24,7 @@ mismatch_data = [
     ("**b", True, ["a/b"]),
     ("a[/]b", True, ["a/b"]),
     ("**/b", True, ["a/c/b"]),
+    ("a", True, ["ab"])
 ]
 
 invalid_data = [
@@ -40,20 +42,24 @@ filter_data = [
     ("c/b", True)
 ]
 
+
 def expand_data(compact_data):
     for pattern, path_name, inputs in compact_data:
         for input in inputs:
             yield pattern, input, path_name
+
 
 @pytest.mark.parametrize("pattern, input, path_name", expand_data(match_data))
 def tests_match(pattern, input, path_name):
     regexp = fnmatch_translate(pattern, path_name)
     assert regexp.match(input) is not None
 
+
 @pytest.mark.parametrize("pattern, input, path_name", expand_data(mismatch_data))
 def tests_no_match(pattern, input, path_name):
     regexp = fnmatch_translate(pattern, path_name)
     assert regexp.match(input) is None
+
 
 @pytest.mark.parametrize("pattern", invalid_data)
 def tests_invalid(pattern):
@@ -61,6 +67,7 @@ def tests_invalid(pattern):
         fnmatch_translate(pattern, False)
     with pytest.raises(ValueError):
         fnmatch_translate(pattern, True)
+
 
 @pytest.mark.parametrize("path, expected", filter_data)
 def test_path_filter(path, expected):


### PR DESCRIPTION
For top level directories like _venv/ we were creating the regexp
^\_venv/$, which we were then feeding paths like _venv/bin/foo which
it fails to match. Since we are matching against full paths, we
certainly want to allow matching _venv/* and probably also bare _venv,
so add a special case for paths with a trailing slash to allow these
options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10131)
<!-- Reviewable:end -->
