### PR TITLE
Add CEReactions tests for HTMLButtonElement

### DIFF
--- a/custom-elements/reactions/HTMLButtonElement.html
+++ b/custom-elements/reactions/HTMLButtonElement.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<title>Custom Elements: CEReactions on HTMLButtonElement interface</title>
+<meta name="author" title="Zhang Xiaoyu" href="xiaoyux.zhang@intel.com">
+<meta name="assert" content=" autofocus, disabled, formAction, formEnctype, formMethod, formNoValidate, formTarget, name, type, value of HTMLButtonElement interface must have CEReactions">
+<meta name="help" content="https://html.spec.whatwg.org/#htmlbuttonelement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/custom-elements-helpers.js"></script>
+<script src="./resources/reactions.js"></script>
+<body>
+<script>
+
+testReflectAttributeWithContentValues('autofocus', 'autofocus', true, 'true', false, 'false', 'autofocus on HTMLButtonElement', 'button', HTMLButtonElement);
+testReflectAttributeWithContentValues('disabled', 'disabled', true, 'true', false, 'false', 'disabled on HTMLButtonElement', 'button', HTMLButtonElement);
+testReflectAttribute('name', 'name', 'intel', 'intel1', 'name on HTMLButtonElement', 'button', HTMLButtonElement);
+testReflectAttribute('value', 'value', 'HTML', 'CSS', 'value on HTMLButtonElement', 'button', HTMLButtonElement);
+testReflectAttrWithPNode('type', 'type', 'submit', 'reset', 'type on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithDepAttr('formAction', 'formaction', 'type', 'intel.asp', 'intel1.asp', 'submit', 'formAction on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithDepAttr('formEnctype', 'formenctype', 'type', 'text/plain', 'multipart/form-data', 'submit', 'formEnctype on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithDepAttr('formMethod', 'formmethod', 'type', 'get', 'post', 'submit', 'formMethod on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithContentValuesAndDepAttr('formNoValidate', 'formnoValidate', 'type', true, 'true', false, 'false', 'submit', 'formNoValidate on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithDepAttr('formTarget', 'formtarget', 'type', '_blank', '_self', 'submit', 'formTarget on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+
+//In parent node, sub node's observeAttribute can enqueue by changing attribute value 
+//Test reflect attribute with content values and parent node
+function testReflectAttrWithContentValuesAndPNode(jsAtName, coAtName, jsAtValue1, coAtValue1, jsAtValue2, coAtValue2, name, elementName, pElementName, interfaceName) {
+    var parentElement = document.createElement(pElementName);
+    document.body.appendChild(parentElement);
+
+    test(() => {
+        var element = define_build_in_custom_element([coAtName], interfaceName, elementName);
+        var instance = document.createElement(elementName, { is: element.name });
+
+        assert_array_equals(element.takeLog().types(), ['constructed']);
+        parentElement.appendChild(instance);
+        assert_array_equals(element.takeLog().types(), ['connected']);
+        instance[jsAtName] = jsAtValue1;
+        var logEntries = element.takeLog();
+        assert_array_equals(logEntries.types(), ['attributeChanged']);
+        assert_attribute_log_entry(logEntries.last(), { name: coAtName, oldValue: null, newValue: coAtValue1, namespace: null });
+
+    }, name + ' must enqueue an attributeChanged reaction when adding a new attribute');
+
+    test(() => {
+        var element = define_build_in_custom_element([coAtName], interfaceName, elementName);
+        var instance = document.createElement(elementName, { is: element.name });
+        parentElement.appendChild(instance);
+
+        assert_array_equals(element.takeLog().types(), ['constructed', 'connected']);
+        instance[jsAtName] = jsAtValue1;
+        assert_array_equals(element.takeLog().types(), ['attributeChanged']);
+        instance[jsAtName] = jsAtValue2;
+        var logEntries = element.takeLog();
+        assert_array_equals(logEntries.types(), ['attributeChanged']);
+        assert_attribute_log_entry(logEntries.last(), { name: coAtName, oldValue: coAtValue1, newValue: coAtValue2, namespace: null });
+
+    }, name + ' must enqueue an attributeChanged reaction when replacing an existing attribute');
+
+    parentElement.parentNode.removeChild(parentElement);
+}
+
+//Package refect attribute with parent node
+function testReflectAttrWithPNode(jsAtName, coAtName, jsAtValue1, jsAtValue2, name, elementName, pElementName, interfaceName) {
+    testReflectAttrWithContentValuesAndPNode(jsAtName, coAtName, jsAtValue1, jsAtValue1, jsAtValue2, jsAtValue2, name, elementName, pElementName, interfaceName);
+}
+
+//In parent node, sub node's observeAttribute which depends another attribute can enqueue by changing attribute value
+//Test reflect attribute with content values and dependent attribute 
+function testReflectAttrWithContentValuesAndDepAttr(jsAtName, coAtName, deAtName, jsAtValue1, coAtValue1, jsAtValue2, coAtValue2, deAtValue, name, elementName, pElementName, interfaceName) {
+    var parentElement = document.createElement(pElementName);
+    document.body.appendChild(parentElement);
+
+    test(() => {
+        var element = define_build_in_custom_element([coAtName], interfaceName, elementName);
+        var instance = document.createElement(elementName, { is: element.name });
+
+        assert_array_equals(element.takeLog().types(), ['constructed']);
+        parentElement.appendChild(instance);
+        assert_array_equals(element.takeLog().types(), ['connected']);
+        instance.setAttribute(deAtName, deAtValue);
+        instance[jsAtName] = jsAtValue1;
+        var logEntries = element.takeLog();
+        assert_array_equals(logEntries.types(), ['attributeChanged']);
+        assert_attribute_log_entry(logEntries.last(), { name: coAtName, oldValue: null, newValue: coAtValue1, namespace: null });
+
+    }, name + ' must enqueue an attributeChanged reaction when adding a new attribute');
+
+    test(() => {
+        var element = define_build_in_custom_element([coAtName], interfaceName, elementName);
+        var instance = document.createElement(elementName, { is: element.name });
+        parentElement.appendChild(instance);
+        instance.setAttribute(deAtName, deAtValue);
+        instance[jsAtName] = jsAtValue1;
+
+        assert_array_equals(element.takeLog().types(), ['constructed', 'connected', 'attributeChanged']);
+        instance[jsAtName] = jsAtValue2;
+        var logEntries = element.takeLog();
+        assert_array_equals(logEntries.types(), ['attributeChanged']);
+        assert_attribute_log_entry(logEntries.last(), { name: coAtName, oldValue: coAtValue1, newValue: coAtValue2, namespace: null });
+
+    }, name + ' must enqueue an attributeChanged reaction when replacing an existing attribute');
+
+    parentElement.parentNode.removeChild(parentElement);
+}
+
+//Package reflect attribute with dependent attribute
+function testReflectAttrWithDepAttr(jsAtName, coAtName, deAtName, jsAtValue1, jsAtValue2, deAtValue, name, elementName, pElementName, interfaceName) {
+    testReflectAttrWithContentValuesAndDepAttr(jsAtName, coAtName, deAtName, jsAtValue1, jsAtValue1, jsAtValue2, jsAtValue2, deAtValue, name, elementName, pElementName, interfaceName);
+}
+
+</script>
+</body>

--- a/custom-elements/reactions/HTMLButtonElement.html
+++ b/custom-elements/reactions/HTMLButtonElement.html
@@ -14,16 +14,16 @@ testReflectAttributeWithContentValues('autofocus', 'autofocus', true, 'true', fa
 testReflectAttributeWithContentValues('disabled', 'disabled', true, 'true', false, 'false', 'disabled on HTMLButtonElement', 'button', HTMLButtonElement);
 testReflectAttribute('name', 'name', 'intel', 'intel1', 'name on HTMLButtonElement', 'button', HTMLButtonElement);
 testReflectAttribute('value', 'value', 'HTML', 'CSS', 'value on HTMLButtonElement', 'button', HTMLButtonElement);
-testReflectAttrWithPNode('type', 'type', 'submit', 'reset', 'type on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithParentNode('type', 'type', 'submit', 'submit', 'reset', 'reset', 'type on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
 testReflectAttrWithDepAttr('formAction', 'formaction', 'type', 'intel.asp', 'intel1.asp', 'submit', 'formAction on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
 testReflectAttrWithDepAttr('formEnctype', 'formenctype', 'type', 'text/plain', 'multipart/form-data', 'submit', 'formEnctype on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
 testReflectAttrWithDepAttr('formMethod', 'formmethod', 'type', 'get', 'post', 'submit', 'formMethod on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
-testReflectAttrWithContentValuesAndDepAttr('formNoValidate', 'formnoValidate', 'type', true, 'true', false, 'false', 'submit', 'formNoValidate on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
+testReflectAttrWithContentValuesAndDepAttr('formNoValidate', 'formnovalidate', 'type', true, 'true', false, 'false', 'submit', 'formNoValidate on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
 testReflectAttrWithDepAttr('formTarget', 'formtarget', 'type', '_blank', '_self', 'submit', 'formTarget on HTMLButtonElement', 'button', 'form', HTMLButtonElement);
 
 //In parent node, sub node's observeAttribute can enqueue by changing attribute value 
 //Test reflect attribute with content values and parent node
-function testReflectAttrWithContentValuesAndPNode(jsAtName, coAtName, jsAtValue1, coAtValue1, jsAtValue2, coAtValue2, name, elementName, pElementName, interfaceName) {
+function testReflectAttrWithParentNode(jsAtName, coAtName, jsAtValue1, coAtValue1, jsAtValue2, coAtValue2, name, elementName, pElementName, interfaceName) {
     var parentElement = document.createElement(pElementName);
     document.body.appendChild(parentElement);
 
@@ -57,11 +57,6 @@ function testReflectAttrWithContentValuesAndPNode(jsAtName, coAtName, jsAtValue1
     }, name + ' must enqueue an attributeChanged reaction when replacing an existing attribute');
 
     parentElement.parentNode.removeChild(parentElement);
-}
-
-//Package refect attribute with parent node
-function testReflectAttrWithPNode(jsAtName, coAtName, jsAtValue1, jsAtValue2, name, elementName, pElementName, interfaceName) {
-    testReflectAttrWithContentValuesAndPNode(jsAtName, coAtName, jsAtValue1, jsAtValue1, jsAtValue2, jsAtValue2, name, elementName, pElementName, interfaceName);
 }
 
 //In parent node, sub node's observeAttribute which depends another attribute can enqueue by changing attribute value

--- a/custom-elements/reactions/resources/reactions.js
+++ b/custom-elements/reactions/resources/reactions.js
@@ -126,32 +126,42 @@ function testCloner(testFunction, name) {
     }, name + ' must enqueue an attributeChanged reaction when cloning an element only for observed attributes');
 }
 
-function testReflectAttributeWithContentValues(jsAttributeName, contentAttributeName, validValue1, contentValue1, validValue2, contentValue2, name) {
+function testReflectAttributeWithContentValues(jsAttributeName, contentAttributeName, validValue1, contentValue1, validValue2, contentValue2, name, elementName, interfaceName) {
     test(function () {
-        var element = define_new_custom_element([contentAttributeName]);
-        var instance = document.createElement(element.name);
+        if(elementName === undefined) {
+            var element = define_new_custom_element([contentAttributeName]);
+            var instance = document.createElement(element.name);
+        } else {
+            var element = define_build_in_custom_element([contentAttributeName], interfaceName, elementName);
+            var instance = document.createElement(elementName, { is: element.name });
+        }
         assert_array_equals(element.takeLog().types(), ['constructed']);
         instance[jsAttributeName] = validValue1;
         var logEntries = element.takeLog();
         assert_array_equals(logEntries.types(), ['attributeChanged']);
 
-        assert_attribute_log_entry(logEntries.last(), {name: contentAttributeName, oldValue: null, newValue: contentValue1, namespace: null});
+        assert_attribute_log_entry(logEntries.last(), { name: contentAttributeName, oldValue: null, newValue: contentValue1, namespace: null });
     }, name + ' must enqueue an attributeChanged reaction when adding ' + contentAttributeName + ' content attribute');
 
     test(function () {
-        var element = define_new_custom_element([contentAttributeName]);
-        var instance = document.createElement(element.name);
+        if(elementName === undefined) {
+            var element = define_new_custom_element([contentAttributeName]);
+            var instance = document.createElement(element.name);
+        } else {
+            var element = define_build_in_custom_element([contentAttributeName], interfaceName, elementName);
+            var instance = document.createElement(elementName, { is: element.name });
+        }
         instance[jsAttributeName] = validValue1;
         assert_array_equals(element.takeLog().types(), ['constructed', 'attributeChanged']);
         instance[jsAttributeName] = validValue2;
         var logEntries = element.takeLog();
         assert_array_equals(logEntries.types(), ['attributeChanged']);
-        assert_attribute_log_entry(logEntries.last(), {name: contentAttributeName, oldValue: contentValue1, newValue: contentValue2, namespace: null});
+        assert_attribute_log_entry(logEntries.last(), { name: contentAttributeName, oldValue: contentValue1, newValue: contentValue2, namespace: null });
     }, name + ' must enqueue an attributeChanged reaction when replacing an existing attribute');
 }
 
-function testReflectAttribute(jsAttributeName, contentAttributeName, validValue1, validValue2, name) {
-    testReflectAttributeWithContentValues(jsAttributeName, contentAttributeName, validValue1, validValue1, validValue2, validValue2, name);
+function testReflectAttribute(jsAttributeName, contentAttributeName, validValue1, validValue2, name, elementName, interfaceName) {
+    testReflectAttributeWithContentValues(jsAttributeName, contentAttributeName, validValue1, validValue1, validValue2, validValue2, name, elementName, interfaceName);
 }
 
 function testReflectBooleanAttribute(jsAttributeName, contentAttributeName, name) {

--- a/custom-elements/reactions/resources/reactions.js
+++ b/custom-elements/reactions/resources/reactions.js
@@ -128,7 +128,7 @@ function testCloner(testFunction, name) {
 
 function testReflectAttributeWithContentValues(jsAttributeName, contentAttributeName, validValue1, contentValue1, validValue2, contentValue2, name, elementName, interfaceName) {
     test(function () {
-        if(elementName === undefined) {
+        if (elementName === undefined) {
             var element = define_new_custom_element([contentAttributeName]);
             var instance = document.createElement(element.name);
         } else {
@@ -140,11 +140,11 @@ function testReflectAttributeWithContentValues(jsAttributeName, contentAttribute
         var logEntries = element.takeLog();
         assert_array_equals(logEntries.types(), ['attributeChanged']);
 
-        assert_attribute_log_entry(logEntries.last(), { name: contentAttributeName, oldValue: null, newValue: contentValue1, namespace: null });
+        assert_attribute_log_entry(logEntries.last(), {name: contentAttributeName, oldValue: null, newValue: contentValue1, namespace: null});
     }, name + ' must enqueue an attributeChanged reaction when adding ' + contentAttributeName + ' content attribute');
 
     test(function () {
-        if(elementName === undefined) {
+        if (elementName === undefined) {
             var element = define_new_custom_element([contentAttributeName]);
             var instance = document.createElement(element.name);
         } else {
@@ -156,7 +156,7 @@ function testReflectAttributeWithContentValues(jsAttributeName, contentAttribute
         instance[jsAttributeName] = validValue2;
         var logEntries = element.takeLog();
         assert_array_equals(logEntries.types(), ['attributeChanged']);
-        assert_attribute_log_entry(logEntries.last(), { name: contentAttributeName, oldValue: contentValue1, newValue: contentValue2, namespace: null });
+        assert_attribute_log_entry(logEntries.last(), {name: contentAttributeName, oldValue: contentValue1, newValue: contentValue2, namespace: null});
     }, name + ' must enqueue an attributeChanged reaction when replacing an existing attribute');
 }
 


### PR DESCRIPTION
- Verify attributes of HTMLButtonElement interface have CEReactions.
- Adjust functions ‘testReflectAttribute’ and ‘testReflectAttributeWithContentValues’  in the reactions.js to compatible customized built-in element

<!-- Reviewable:start -->

<!-- Reviewable:end -->
