### PR TITLE
Fixed lint checking directories it shouldn't be

### DIFF
--- a/tools/gitignore/gitignore.py
+++ b/tools/gitignore/gitignore.py
@@ -84,7 +84,7 @@ def parse_line(line):
     if dir_only:
         line = line[:-1]
 
-    return invert, dir_only, fnmatch_translate(line, "/" in line)
+    return invert, dir_only, fnmatch_translate(line, dir_only)
 
 
 class PathFilter(object):

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -60,7 +60,7 @@ you could add the following line to the lint.whitelist file.
 %s: %s"""
 
 def all_filesystem_paths(repo_root, subdir=None):
-    path_filter = PathFilter(repo_root, extras=[".git/*"])
+    path_filter = PathFilter(repo_root, extras=[".git/"])
     if subdir:
         expanded_path = subdir
     else:
@@ -72,8 +72,7 @@ def all_filesystem_paths(repo_root, subdir=None):
                 yield path
         dirnames[:] = [item for item in dirnames if
                        path_filter(os.path.relpath(os.path.join(dirpath, item) + "/",
-                                                   repo_root))]
-
+                                                   repo_root)+"/")]
 
 def _all_files_equal(paths):
     """


### PR DESCRIPTION
Lint earlier checked _venv/ and .git/ which it shouldn't be checking.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10147)
<!-- Reviewable:end -->
