### PR TITLE
Do not print logs twice when running wpt lint

### DIFF
--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -32,7 +32,10 @@ def setup_logging(prefix=False):
     if logger is None:
         logger = logging.getLogger(os.path.basename(os.path.splitext(__file__)[0]))
         handler = logging.StreamHandler(sys.stdout)
-        logger.addHandler(handler)
+        # Only add a handler if the parent logger is missing a handler
+        if logger.parent and len(logger.parent.handlers) == 0:
+            handler = logging.StreamHandler(sys.stdout)
+            logger.addHandler(handler)
     if prefix:
         format = logging.BASIC_FORMAT
     else:


### PR DESCRIPTION
Running `wpt lint` appears to print a duplicate line to the console for each line the logger module prints.


### Before
```
$ ./wpt lint cors/allow-headers.htm 
cors/allow-headers.htm:87: Whitespace at EOL (TRAILING WHITESPACE)
ERROR:lint:cors/allow-headers.htm:87: Whitespace at EOL (TRAILING WHITESPACE)

INFO:lint:
There was 1 error (TRAILING WHITESPACE: 1)
INFO:lint:There was 1 error (TRAILING WHITESPACE: 1)
You must fix all errors; for details on how to fix them, see
INFO:lint:You must fix all errors; for details on how to fix them, see
http://web-platform-tests.org/writing-tests/lint-tool.html
INFO:lint:http://web-platform-tests.org/writing-tests/lint-tool.html

INFO:lint:
However, instead of fixing a particular error, it's sometimes
INFO:lint:However, instead of fixing a particular error, it's sometimes
OK to add a line to the lint.whitelist file in the root of the
INFO:lint:OK to add a line to the lint.whitelist file in the root of the
web-platform-tests directory to make the lint tool ignore it.
INFO:lint:web-platform-tests directory to make the lint tool ignore it.

INFO:lint:
For example, to make the lint tool ignore all 'TRAILING WHITESPACE'
INFO:lint:For example, to make the lint tool ignore all 'TRAILING WHITESPACE'
errors in the cors/allow-headers.htm file,
INFO:lint:errors in the cors/allow-headers.htm file,
you could add the following line to the lint.whitelist file.
INFO:lint:you could add the following line to the lint.whitelist file.

INFO:lint:
TRAILING WHITESPACE: cors/allow-headers.htm
INFO:lint:TRAILING WHITESPACE: cors/allow-headers.htm
```

### After
```
$ ./wpt lint cors/allow-headers.htm 
cors/allow-headers.htm:87: Whitespace at EOL (TRAILING WHITESPACE)

There was 1 error (TRAILING WHITESPACE: 1)
You must fix all errors; for details on how to fix them, see
http://web-platform-tests.org/writing-tests/lint-tool.html

However, instead of fixing a particular error, it's sometimes
OK to add a line to the lint.whitelist file in the root of the
web-platform-tests directory to make the lint tool ignore it.

For example, to make the lint tool ignore all 'TRAILING WHITESPACE'
errors in the cors/allow-headers.htm file,
you could add the following line to the lint.whitelist file.

TRAILING WHITESPACE: cors/allow-headers.htm
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10148)
<!-- Reviewable:end -->
