### PR TITLE
Comment out SVGElement dependency from html.idl

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -129,7 +129,7 @@ interface mixin HTMLOrSVGElement {
   void blur();
 };
 HTMLElement includes HTMLOrSVGElement;
-SVGElement includes HTMLOrSVGElement;
+// SVGElement includes HTMLOrSVGElement;
 
 [Exposed=Window,
  OverrideBuiltins]


### PR DESCRIPTION
Fixes regression caused by #10110.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
