### PR TITLE
Add alternate_hosts

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,7 @@
 {"browser_host": "web-platform.test",
+ "alternate_hosts": {
+     "alt": "not-web-platform.test"
+ },
  "doc_root": null,
  "ws_doc_root": null,
  "server_host": null,

--- a/docs/_writing-tests/server-features.md
+++ b/docs/_writing-tests/server-features.md
@@ -14,15 +14,18 @@ generation. This is supported through the
 
 ### Tests Involving Multiple Origins
 
-In the test environment, five subdomains are available: `www`, `www1`,
-`www2`, `天気の良い日`, and `élève`; there is also
-`nonexistent-origin` which is guaranteed not to resolve. In addition,
-the HTTP server listens on two ports, and the WebSockets server on
-one. These subdomains and ports must be used for cross-origin
-tests. Tests must not hardcode the hostname of the server that they
-expect to be running on or the port numbers, as these are not
-guaranteed by the test environment. Instead they can get this
-information in one of two ways:
+Our test servers are guaranteed to be accessible through two domains
+and five subdomains under each. The 'main' domain is unnamed; the
+other is called 'alt'. These subdomains are: `www`, `www1`, `www2`,
+`天気の良い日`, and `élève`; there is also `nonexistent-origin` which
+is guaranteed not to resolve. In addition, the HTTP server listens on
+two ports, and the WebSockets server on one. These subdomains and
+ports must be used for cross-origin tests.
+
+Tests must not hardcode the hostname of the server that they expect to
+be running on or the port numbers, as these are not guaranteed by the
+test environment. Instead they can get this information in one of two
+ways:
 
 * From script, using the `location` API.
 
@@ -33,15 +36,19 @@ form `{name}.sub.{ext}` e.g. `example-test.sub.html` or be referenced
 through a URL containing `pipe=sub` in the query string
 e.g. `example-test.html?pipe=sub`. The substitution syntax uses `{%
 raw %}{{ }}{% endraw %}` to delimit items for substitution. For
-example to substitute in the host name on which the tests are running,
-one would write: `{% raw %}{{host}}{% endraw %}`.
+example to substitute in the main host name, one would write:
+`{% raw %}{{host}}{% endraw %}`.
 
+To get full domains, including subdomains, there is the `hosts`
+dictionary, where the first dimension is the name of the domain, and
+the second the subdomain. For example, `{% raw %}{{hosts[][www]}}{%
+endraw %}` would give the `www` subdomain under the main (unnamed)
+domain, and `{% raw %}{{hosts[alt][élève]}}{% endraw %}` would give
+the `élève` subdomain under the alt domain.
 
-As well as the host, one can get full domains, including subdomains
-using the `domains` dictionary. For example, `{% raw
-%}{{domains[www]}}{% endraw %}` or `{% raw %}{{domains[élève]}}{%
-endraw %}` would be replaced by the full qualified domain name of the
-respective subdomains.
+For mostly historic reasons, the subdomains of the main domain are
+also available under the `domains` dictionary; this is identical to
+`hosts[]`.
 
 Ports are also available on a per-protocol basis. For example, `{% raw
 %}{{ports[ws][0]}}{% endraw %}` is replaced with the first (and only)

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -437,13 +437,11 @@ def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
 def make_hosts_file(config, host):
     rv = []
 
-    for per_host_domains in config["domains"].values():
-        for domain in per_host_domains.values():
-            rv.append("%s\t%s\n" % (host, domain))
+    for domain in config.domains_set:
+        rv.append("%s\t%s\n" % (host, domain))
 
-    for per_host_domains in config["not_domains"].values():
-        for not_domain in per_host_domains.values():
-            rv.append("0.0.0.0\t%s\n" % not_domain)
+    for not_domain in config.not_domains_set:
+        rv.append("0.0.0.0\t%s\n" % not_domain)
 
     return "".join(rv)
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -423,7 +423,10 @@ def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
                         "You may need to edit /etc/hosts or similar, see README.md." % (host, port))
         sys.exit(1)
 
-    for domain in domains.itervalues():
+    for domain in domains_set.itervalues():
+        if domain == host:
+            continue
+
         try:
             urllib2.urlopen("http://%s:%d/" % (domain, port))
         except Exception as e:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -401,7 +401,7 @@ class ServerProc(object):
 
 def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
     domains = domains.copy()
-    host = domains.pop("")
+    host = domains.pop("main_")
     port = get_port(host)
     logger.debug("Going to use port %d to check subdomains" % port)
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -437,11 +437,13 @@ def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
 def make_hosts_file(config, host):
     rv = []
 
-    for domain in config["domains"].values():
-        rv.append("%s\t%s\n" % (host, domain))
+    for per_host_domains in config["domains"].values():
+        for domain in per_host_domains.values():
+            rv.append("%s\t%s\n" % (host, domain))
 
-    for not_domain in config.get("not_domains", {}).values():
-        rv.append("0.0.0.0\t%s\n" % not_domain)
+    for per_host_domains in config["not_domains"].values():
+        for not_domain in per_host_domains.values():
+            rv.append("0.0.0.0\t%s\n" % not_domain)
 
     return "".join(rv)
 

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -399,9 +399,13 @@ class ServerProc(object):
         return self.proc.is_alive()
 
 
-def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
-    domains = domains.copy()
-    host = domains[""][""]
+def check_subdomains(config):
+    paths = config.paths
+    bind_address = config.bind_address
+    ssl_config = config.ssl_config
+    aliases = config.aliases
+
+    host = config.server_host
     port = get_port(host)
     logger.debug("Going to use port %d to check subdomains" % port)
 
@@ -423,7 +427,7 @@ def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
                         "You may need to edit /etc/hosts or similar, see README.md." % (host, port))
         sys.exit(1)
 
-    for domain in domains_set.itervalues():
+    for domain in config.domains_set:
         if domain == host:
             continue
 
@@ -698,9 +702,7 @@ def run(**kwargs):
     bind_address = config["bind_address"]
 
     if config["check_subdomains"]:
-        paths = config.paths
-        ssl_config = config.ssl_config
-        check_subdomains(config.domains, paths, bind_address, ssl_config, config["aliases"])
+        check_subdomains(config)
 
     stash_address = None
     if bind_address:

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -401,7 +401,7 @@ class ServerProc(object):
 
 def check_subdomains(domains, paths, bind_address, ssl_config, aliases):
     domains = domains.copy()
-    host = domains.pop("main_")
+    host = domains[""][""]
     port = get_port(host)
     logger.debug("Going to use port %d to check subdomains" % port)
 

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -1,12 +1,22 @@
 from . import serve
 
 def test_make_hosts_file():
-    hosts = serve.make_hosts_file({
-        "domains": {"www": "www.foo.bar.test", "www1": "www1.foo.bar.test"},
-        "not_domains": {"aaa": "aaa.foo.bar.test", "bbb": "bbb.foo.bar.test"}
-    }, "127.1.1.1")
+    c = serve.Config(browser_host="foo.bar", alternate_hosts={"alt": "foo2.bar"})
+    hosts = serve.make_hosts_file(c, "192.168.42.42")
     lines = hosts.split("\n")
-    assert "127.1.1.1\twww.foo.bar.test" in lines
-    assert "127.1.1.1\twww1.foo.bar.test" in lines
-    assert "0.0.0.0\taaa.foo.bar.test" in lines
-    assert "0.0.0.0\tbbb.foo.bar.test" in lines
+    assert set(lines) == {"",
+                          "0.0.0.0\tnonexistent-origin.foo.bar",
+                          "0.0.0.0\tnonexistent-origin.foo2.bar",
+                          "192.168.42.42\tfoo.bar",
+                          "192.168.42.42\tfoo2.bar",
+                          "192.168.42.42\twww.foo.bar",
+                          "192.168.42.42\twww.foo2.bar",
+                          "192.168.42.42\twww1.foo.bar",
+                          "192.168.42.42\twww1.foo2.bar",
+                          "192.168.42.42\twww2.foo.bar",
+                          "192.168.42.42\twww2.foo2.bar",
+                          "192.168.42.42\txn--lve-6lad.foo.bar",
+                          "192.168.42.42\txn--lve-6lad.foo2.bar",
+                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo.bar",
+                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo2.bar"}
+    assert lines[-1] == ""

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -98,8 +98,7 @@ def check_environ(product):
     if product not in ("firefox", "servo"):
         config = serve.load_config(os.path.join(wpt_root, "config.default.json"),
                                    os.path.join(wpt_root, "config.json"))
-        expected_hosts = (set(config["domains"].itervalues()) ^
-                          set(config["not_domains"].itervalues()))
+        expected_hosts = set(config.all_domains_set)
         missing_hosts = set(expected_hosts)
         if platform.uname()[0] != "Windows":
             hosts_path = "/etc/hosts"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -98,7 +98,7 @@ def check_environ(product):
     if product not in ("firefox", "servo"):
         config = serve.load_config(os.path.join(wpt_root, "config.default.json"),
                                    os.path.join(wpt_root, "config.json"))
-        expected_hosts = set(config.all_domains_set)
+        expected_hosts = set(config.all_domains.itervalues())
         missing_hosts = set(expected_hosts)
         if platform.uname()[0] != "Windows":
             hosts_path = "/etc/hosts"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -98,7 +98,9 @@ def check_environ(product):
     if product not in ("firefox", "servo"):
         config = serve.load_config(os.path.join(wpt_root, "config.default.json"),
                                    os.path.join(wpt_root, "config.json"))
-        expected_hosts = set(config.all_domains.itervalues())
+        expected_hosts = set(domain
+                             for per_host_domains in config.all_domains.itervalues()
+                             for domain in per_host_domains.itervalues())
         missing_hosts = set(expected_hosts)
         if platform.uname()[0] != "Windows":
             hosts_path = "/etc/hosts"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -98,9 +98,7 @@ def check_environ(product):
     if product not in ("firefox", "servo"):
         config = serve.load_config(os.path.join(wpt_root, "config.default.json"),
                                    os.path.join(wpt_root, "config.json"))
-        expected_hosts = set(domain
-                             for per_host_domains in config.all_domains.itervalues()
-                             for domain in per_host_domains.itervalues())
+        expected_hosts = set(config.all_domains_set)
         missing_hosts = set(expected_hosts)
         if platform.uname()[0] != "Windows":
             hosts_path = "/etc/hosts"

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -102,7 +102,10 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         if kwargs["binary_args"]:
             options["args"] = kwargs["binary_args"]
         options["prefs"] = {
-            "network.dns.localDomains": ",".join(server_config.domains.itervalues())
+            "network.dns.localDomains": ",".join(
+                domain
+                for per_host_domains in server_config.domains.itervalues()
+                for domain in per_host_domains.itervalues())
         }
         capabilities["moz:firefoxOptions"] = options
     if kwargs["certutil_binary"] is None:
@@ -198,7 +201,10 @@ class FirefoxBrowser(Browser):
         self.profile = FirefoxProfile(preferences=preferences)
         self.profile.set_preferences({"marionette.port": self.marionette_port,
                                       "dom.disable_open_during_load": False,
-                                      "network.dns.localDomains": ",".join(self.config.domains.itervalues()),
+                                      "network.dns.localDomains": ",".join(
+                                          domain
+                                          for per_host_domains in self.config.domains.itervalues()
+                                          for domain in per_host_domains.itervalues()),
                                       "network.proxy.type": 0,
                                       "places.history.enabled": False,
                                       "dom.send_after_paint_to_content": True,

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -102,10 +102,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
         if kwargs["binary_args"]:
             options["args"] = kwargs["binary_args"]
         options["prefs"] = {
-            "network.dns.localDomains": ",".join(
-                domain
-                for per_host_domains in server_config.domains.itervalues()
-                for domain in per_host_domains.itervalues())
+            "network.dns.localDomains": ",".join(server_config.domains_set)
         }
         capabilities["moz:firefoxOptions"] = options
     if kwargs["certutil_binary"] is None:
@@ -201,10 +198,7 @@ class FirefoxBrowser(Browser):
         self.profile = FirefoxProfile(preferences=preferences)
         self.profile.set_preferences({"marionette.port": self.marionette_port,
                                       "dom.disable_open_during_load": False,
-                                      "network.dns.localDomains": ",".join(
-                                          domain
-                                          for per_host_domains in self.config.domains.itervalues()
-                                          for domain in per_host_domains.itervalues()),
+                                      "network.dns.localDomains": ",".join(self.config.domains_set),
                                       "network.proxy.type": 0,
                                       "places.history.enabled": False,
                                       "dom.send_after_paint_to_content": True,

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -166,7 +166,7 @@ class SauceConnect():
             "--metrics-address=0.0.0.0:9876",
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
-            ",".join(self.env_config['domains'].values())
+            ",".join(self.env_config.domains_set)
         ])
 
         # Timeout config vars

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -166,7 +166,9 @@ class SauceConnect():
             "--metrics-address=0.0.0.0:9876",
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
-            ",".join(self.env_config.domains.itervalues())
+            ",".join(domain
+                     for per_host_domains in self.env_config.domains.itervalues()
+                     for domain in per_host_domains.itervalues())
         ])
 
         # Timeout config vars

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -166,9 +166,7 @@ class SauceConnect():
             "--metrics-address=0.0.0.0:9876",
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
-            ",".join(domain
-                     for per_host_domains in self.env_config.domains.itervalues()
-                     for domain in per_host_domains.itervalues())
+            ",".join(self.env_config.domains_set)
         ])
 
         # Timeout config vars

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -166,7 +166,7 @@ class SauceConnect():
             "--metrics-address=0.0.0.0:9876",
             "--readyfile=./sauce_is_ready",
             "--tunnel-domains",
-            ",".join(self.env_config.domains_set)
+            ",".join(self.env_config.domains.itervalues())
         ])
 
         # Timeout config vars

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -126,4 +126,7 @@ def test_sauceconnect_tunnel_domains():
                 assert rest[1].startswith("-"), "--tunnel-domains takes a comma separated list (not a space separated list)"
             assert set(rest[0].split(",")) == {'example.net',
                                                'a.example.net',
-                                               'b.example.net'}
+                                               'b.example.net',
+                                               'example.org',
+                                               'a.example.org',
+                                               'b.example.org'}

--- a/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
+++ b/tools/wptrunner/wptrunner/tests/browsers/test_sauce.py
@@ -110,6 +110,7 @@ def test_sauceconnect_tunnel_domains():
             sauce_connect_binary="ddd")
 
         env_config = Config(browser_host="example.net",
+                            alternate_hosts={"alt": "example.org"},
                             subdomains={"a", "b"},
                             not_subdomains={"x", "y"})
         sauce_connect(None, env_config)

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -272,29 +272,37 @@ def test_set_server_host():
 
 def test_domains():
     c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
                       subdomains={"a", "b"},
                       not_subdomains={"x", "y"})
     domains = c.domains
     assert domains == {
-        "": "foo.bar",
-        "a": "a.foo.bar",
-        "b": "b.foo.bar",
+        "main_": "foo.bar",
+        "main_a": "a.foo.bar",
+        "main_b": "b.foo.bar",
+        "alt_": "foo2.bar",
+        "alt_a": "a.foo2.bar",
+        "alt_b": "b.foo2.bar",
     }
 
 
 def test_not_domains():
     c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
                       subdomains={"a", "b"},
                       not_subdomains={"x", "y"})
     not_domains = c.not_domains
     assert not_domains == {
-        "x": "x.foo.bar",
-        "y": "y.foo.bar",
+        "main_x": "x.foo.bar",
+        "main_y": "y.foo.bar",
+        "alt_x": "x.foo2.bar",
+        "alt_y": "y.foo2.bar",
     }
 
 
 def test_domains_not_domains_intersection():
     c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
                       subdomains={"a", "b"},
                       not_subdomains={"x", "y"})
     domains = c.domains
@@ -305,15 +313,21 @@ def test_domains_not_domains_intersection():
 
 def test_all_domains():
     c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
                       subdomains={"a", "b"},
                       not_subdomains={"x", "y"})
     all_domains = c.all_domains
     assert all_domains == {
-        "": "foo.bar",
-        "a": "a.foo.bar",
-        "b": "b.foo.bar",
-        "x": "x.foo.bar",
-        "y": "y.foo.bar",
+        "main_": "foo.bar",
+        "main_a": "a.foo.bar",
+        "main_b": "b.foo.bar",
+        "main_x": "x.foo.bar",
+        "main_y": "y.foo.bar",
+        "alt_": "foo2.bar",
+        "alt_a": "a.foo2.bar",
+        "alt_b": "b.foo2.bar",
+        "alt_x": "x.foo2.bar",
+        "alt_y": "y.foo2.bar",
     }
 
 

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -277,12 +277,16 @@ def test_domains():
                       not_subdomains={"x", "y"})
     domains = c.domains
     assert domains == {
-        "main_": "foo.bar",
-        "main_a": "a.foo.bar",
-        "main_b": "b.foo.bar",
-        "alt_": "foo2.bar",
-        "alt_a": "a.foo2.bar",
-        "alt_b": "b.foo2.bar",
+        "": {
+            "": "foo.bar",
+            "a": "a.foo.bar",
+            "b": "b.foo.bar",
+        },
+        "alt": {
+            "": "foo2.bar",
+            "a": "a.foo2.bar",
+            "b": "b.foo2.bar",
+        },
     }
 
 
@@ -293,10 +297,14 @@ def test_not_domains():
                       not_subdomains={"x", "y"})
     not_domains = c.not_domains
     assert not_domains == {
-        "main_x": "x.foo.bar",
-        "main_y": "y.foo.bar",
-        "alt_x": "x.foo2.bar",
-        "alt_y": "y.foo2.bar",
+        "": {
+            "x": "x.foo.bar",
+            "y": "y.foo.bar",
+        },
+        "alt": {
+            "x": "x.foo2.bar",
+            "y": "y.foo2.bar",
+        },
     }
 
 
@@ -307,8 +315,12 @@ def test_domains_not_domains_intersection():
                       not_subdomains={"x", "y"})
     domains = c.domains
     not_domains = c.not_domains
-    assert len(set(domains.iterkeys()) & set(not_domains.iterkeys())) == 0
-    assert len(set(domains.itervalues()) & set(not_domains.itervalues())) == 0
+    assert len(set(domains.iterkeys()) ^ set(not_domains.iterkeys())) == 0
+    for host in domains.iterkeys():
+        host_domains = domains[host]
+        host_not_domains = not_domains[host]
+        assert len(set(host_domains.iterkeys()) & set(host_not_domains.iterkeys())) == 0
+        assert len(set(host_domains.itervalues()) & set(host_not_domains.itervalues())) == 0
 
 
 def test_all_domains():
@@ -318,16 +330,20 @@ def test_all_domains():
                       not_subdomains={"x", "y"})
     all_domains = c.all_domains
     assert all_domains == {
-        "main_": "foo.bar",
-        "main_a": "a.foo.bar",
-        "main_b": "b.foo.bar",
-        "main_x": "x.foo.bar",
-        "main_y": "y.foo.bar",
-        "alt_": "foo2.bar",
-        "alt_a": "a.foo2.bar",
-        "alt_b": "b.foo2.bar",
-        "alt_x": "x.foo2.bar",
-        "alt_y": "y.foo2.bar",
+        "": {
+            "": "foo.bar",
+            "a": "a.foo.bar",
+            "b": "b.foo.bar",
+            "x": "x.foo.bar",
+            "y": "y.foo.bar",
+        },
+        "alt": {
+            "": "foo2.bar",
+            "a": "a.foo2.bar",
+            "b": "b.foo2.bar",
+            "x": "x.foo2.bar",
+            "y": "y.foo2.bar",
+        },
     }
 
 

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -347,6 +347,56 @@ def test_all_domains():
     }
 
 
+def test_domains_set():
+    c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
+                      subdomains={"a", "b"},
+                      not_subdomains={"x", "y"})
+    domains_set = c.domains_set
+    assert domains_set == {
+        "foo.bar",
+        "a.foo.bar",
+        "b.foo.bar",
+        "foo2.bar",
+        "a.foo2.bar",
+        "b.foo2.bar",
+    }
+
+
+def test_not_domains_set():
+    c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
+                      subdomains={"a", "b"},
+                      not_subdomains={"x", "y"})
+    not_domains_set = c.not_domains_set
+    assert not_domains_set == {
+        "x.foo.bar",
+        "y.foo.bar",
+        "x.foo2.bar",
+        "y.foo2.bar",
+    }
+
+
+def test_all_domains_set():
+    c = config.Config(browser_host="foo.bar",
+                      alternate_hosts={"alt": "foo2.bar"},
+                      subdomains={"a", "b"},
+                      not_subdomains={"x", "y"})
+    all_domains_set = c.all_domains_set
+    assert all_domains_set == {
+        "foo.bar",
+        "a.foo.bar",
+        "b.foo.bar",
+        "x.foo.bar",
+        "y.foo.bar",
+        "foo2.bar",
+        "a.foo2.bar",
+        "b.foo2.bar",
+        "x.foo2.bar",
+        "y.foo2.bar",
+    }
+
+
 def test_ssl_env_override():
     c = config.Config(override_ssl_env="foobar")
     assert c.ssl_env == "foobar"

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -205,6 +205,22 @@ class Config(Mapping):
         return rv
 
     @property
+    def domains_set(self):
+        return {domain
+                for per_host_domains in self.domains.itervalues()
+                for domain in per_host_domains.itervalues()}
+
+    @property
+    def not_domains_set(self):
+        return {domain
+                for per_host_domains in self.not_domains.itervalues()
+                for domain in per_host_domains.itervalues()}
+
+    @property
+    def all_domains_set(self):
+        return self.domains_set | self.not_domains_set
+
+    @property
     def ssl_env(self):
         try:
             if self.override_ssl_env is not None:

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -173,24 +173,34 @@ class Config(Mapping):
 
     @property
     def domains(self):
-        assert self.browser_host.encode("idna") == self.browser_host
-        domains = {subdomain: (subdomain.encode("idna") + u"." + self.browser_host)
-                   for subdomain in self.subdomains}
-        domains[""] = self.browser_host
-        return domains
+        hosts = self.alternate_hosts.copy()
+        assert "main" not in hosts
+        hosts["main"] = self.browser_host
+
+        rv = {}
+        for name, host in hosts.iteritems():
+            rv.update({(name + "_" + subdomain): (subdomain.encode("idna") + u"." + host)
+                       for subdomain in self.subdomains})
+            rv[name + "_"] = host
+        return rv
 
     @property
     def not_domains(self):
-        assert self.browser_host.encode("idna") == self.browser_host
-        domains = {subdomain: (subdomain.encode("idna") + u"." + self.browser_host)
-                   for subdomain in self.not_subdomains}
-        return domains
+        hosts = self.alternate_hosts.copy()
+        assert "main" not in hosts
+        hosts["main"] = self.browser_host
+
+        rv = {}
+        for name, host in hosts.iteritems():
+            rv.update({(name + "_" + subdomain): (subdomain.encode("idna") + u"." + host)
+                       for subdomain in self.not_subdomains})
+        return rv
 
     @property
     def all_domains(self):
-        domains = self.domains.copy()
-        domains.update(self.not_domains)
-        return domains
+        rv = self.domains.copy()
+        rv.update(self.not_domains)
+        return rv
 
     @property
     def ssl_env(self):

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -174,32 +174,34 @@ class Config(Mapping):
     @property
     def domains(self):
         hosts = self.alternate_hosts.copy()
-        assert "main" not in hosts
-        hosts["main"] = self.browser_host
+        assert "" not in hosts
+        hosts[""] = self.browser_host
 
         rv = {}
         for name, host in hosts.iteritems():
-            rv.update({(name + "_" + subdomain): (subdomain.encode("idna") + u"." + host)
-                       for subdomain in self.subdomains})
-            rv[name + "_"] = host
+            rv[name] = {subdomain: (subdomain.encode("idna") + u"." + host)
+                        for subdomain in self.subdomains}
+            rv[name][""] = host
         return rv
 
     @property
     def not_domains(self):
         hosts = self.alternate_hosts.copy()
-        assert "main" not in hosts
-        hosts["main"] = self.browser_host
+        assert "" not in hosts
+        hosts[""] = self.browser_host
 
         rv = {}
         for name, host in hosts.iteritems():
-            rv.update({(name + "_" + subdomain): (subdomain.encode("idna") + u"." + host)
-                       for subdomain in self.not_subdomains})
+            rv[name] = {subdomain: (subdomain.encode("idna") + u"." + host)
+                        for subdomain in self.not_subdomains}
         return rv
 
     @property
     def all_domains(self):
         rv = self.domains.copy()
-        rv.update(self.not_domains)
+        nd = self.not_domains
+        for host in rv:
+            rv[host].update(nd[host])
         return rv
 
     @property

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -1,4 +1,5 @@
 from cgi import escape
+from collections import deque
 import gzip as gzip_module
 import hashlib
 import os
@@ -420,17 +421,18 @@ def template(request, content, escape_type="html"):
         content, = match.groups()
 
         tokens = tokenizer.tokenize(content)
+        tokens = deque(tokens)
 
-        if tokens[0][0] == "var":
-            variable = tokens[0][1]
-            tokens = tokens[1:]
+        token_type, field = tokens.popleft()
+
+        if token_type == "var":
+            variable = field
+            token_type, field = tokens.popleft()
         else:
             variable = None
 
-        assert tokens[0][0] == "ident", tokens
-        assert all(item[0] in ("index", "arguments") for item in tokens[1:]), tokens
-
-        field = tokens[0][1]
+        if token_type != "ident":
+            raise Exception("unexpected token type %s (token '%r'), expected ident" % (token_type, field))
 
         if field in variables:
             value = variables[field]
@@ -441,15 +443,20 @@ def template(request, content, escape_type="html"):
         elif field == "GET":
             value = FirstWrapper(request.GET)
         elif field == "domains":
-            if ('not_domains' in request.server.config and
-                    tokens[1][1] in request.server.config['not_domains']):
-                value = request.server.config['not_domains']
+            value = request.server.config.all_domains
+            ttype, field = tokens.popleft()
+            if ttype != "index":
+                raise Exception(
+                    "unexpected token type %s (token '%r'), expected ident" % (ttype, field)
+                )
+            if field in value:
+                value = value[field]
             else:
-                value = request.server.config['domains']
+                value = value["main_" + field]
         elif field == "host":
             value = request.server.config["browser_host"]
         elif field in request.server.config:
-            value = request.server.config[tokens[0][1]]
+            value = request.server.config[field]
         elif field == "location":
             value = {"server": "%s://%s:%s" % (request.url_parts.scheme,
                                                request.url_parts.hostname,
@@ -467,11 +474,16 @@ def template(request, content, escape_type="html"):
         else:
             raise Exception("Undefined template variable %s" % field)
 
-        for item in tokens[1:]:
-            if item[0] == "index":
-                value = value[item[1]]
+        while tokens:
+            ttype, field = tokens.popleft()
+            if ttype == "index":
+                value = value[field]
+            elif ttype == "arguments":
+                value = value(request, *field)
             else:
-                value = value(request, *item[1])
+                raise Exception(
+                    "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
+                )
 
         assert isinstance(value, (int,) + types.StringTypes), tokens
 

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -442,17 +442,10 @@ def template(request, content, escape_type="html"):
             value = request.headers
         elif field == "GET":
             value = FirstWrapper(request.GET)
-        elif field == "domains":
+        elif field == "hosts":
             value = request.server.config.all_domains
-            ttype, field = tokens.popleft()
-            if ttype != "index":
-                raise Exception(
-                    "unexpected token type %s (token '%r'), expected ident" % (ttype, field)
-                )
-            if field in value:
-                value = value[field]
-            else:
-                value = value["main_" + field]
+        elif field == "domains":
+            value = request.server.config.all_domains[""]
         elif field == "host":
             value = request.server.config["browser_host"]
         elif field in request.server.config:

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -170,7 +170,6 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         else:
             self.logger.debug("Using default configuration")
             Server.config = Config(browser_host=server_address[0],
-                                   server_host=server_address[0],
                                    ports={"http": [self.server_address[1]]})
 
 

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -13,6 +13,7 @@ import types
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
 from . import routes as default_routes
+from .config import Config
 from .logger import get_logger
 from .request import Server, Request
 from .response import Response
@@ -168,10 +169,9 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
             Server.config = config
         else:
             self.logger.debug("Using default configuration")
-            Server.config = {"browser_host": server_address[0],
-                             "server_host": server_address[0],
-                             "domains": {"": server_address[0]},
-                             "ports": {"http": [self.server_address[1]]}}
+            Server.config = Config(browser_host=server_address[0],
+                                   server_host=server_address[0],
+                                   ports={"http": [self.server_address[1]]})
 
 
         self.key_file = key_file


### PR DESCRIPTION
Fixes #2669.

Note this doesn't yet do #8581, but adding a new host at this point is adding a string to the config file, and adding new subdomains is just editing the list in `tools/serve/serve.py`.

@mikewest: This gives us `alt_domains[0]` and `alt_domains[1]`, which isn't quite what we were talking about in #8581 (given there's nowhere to put 'this-is-mikes-domain-go-away'). I think giving them names is going to be a fair bit of extra complexity, but let me know what you think?

Also, FWIW, I'm pretty sure this will fail CI. But opening the PR so people can look at it if they want before I touch it again on Monday.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10166)
<!-- Reviewable:end -->
