### PR TITLE
Add tests for mathematical functions in <img sizes="">

### DIFF
--- a/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute.html
@@ -14,7 +14,7 @@ setup({explicit_done:true});
 function check(p, iframe) {
   var current = p.firstElementChild;
   var ref_sizes = current.getAttribute('sizes');
-  var expect = p.firstElementChild.currentSrc;
+  var expect = current.currentSrc;
   if (expect) {
     expect = expect.split('?')[0];
   }

--- a/html/semantics/embedded-content/the-img-element/sizes/sizes-iframed.sub.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/sizes-iframed.sub.html
@@ -52,8 +52,14 @@
 <img srcset='/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w' sizes='\[,1px'>
 <img srcset='/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w' sizes='1\p\x'>
 <img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='calc(1px)'>
+<img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='min(1px, 100px)'>
+<img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='min(-100px, 1px)'>
 <img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) calc(1px)'>
+<img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) min(1px, 100px)'>
+<img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) max(-100px, 1px)'>
 <img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:calc(0)) 1px'>
+<img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:min(0, 200vw)) 1px'>
+<img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:max(-200vw, 0)) 1px'>
 <img srcset='/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w' sizes='(min-width:0) 1px, 100vw'>
 <img srcset='/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w' sizes='(min-width:0) 1px, (min-width:0) 100vw, 100vw'>
 <img srcset='/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w' sizes='(min-width:0) 1px'>
@@ -126,7 +132,11 @@
 <img srcset='/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w' sizes='(max-width:0) or (unknown-general-enclosed !) 100vw, 1px'>
 <img srcset='/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w' sizes='not ((max-width:0) or (unknown "general-enclosed")) 100vw, 1px'>
 <img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='calc(1px'>
+<img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='min(1px, 200vw'>
+<img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='max(-200vw, 1px'>
 <img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) calc(1px'>
+<img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) min(1px, 200vw'>
+<img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) max(-200vw, 1px'>
 
 <p>
 <img srcset='/images/green-1x1.png?f1 50w, /images/green-16x16.png?f1 51w' sizes='100vw'>

--- a/html/semantics/embedded-content/the-img-element/sizes/sizes-iframed.sub.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/sizes-iframed.sub.html
@@ -52,14 +52,14 @@
 <img srcset='/images/green-1x1.png?e34 50w, /images/green-16x16.png?e34 51w' sizes='\[,1px'>
 <img srcset='/images/green-1x1.png?e35 50w, /images/green-16x16.png?e35 51w' sizes='1\p\x'>
 <img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='calc(1px)'>
-<img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='min(1px, 100px)'>
-<img srcset='/images/green-1x1.png?e36 50w, /images/green-16x16.png?e36 51w' sizes='min(-100px, 1px)'>
+<img srcset='/images/green-1x1.png?e36a 50w, /images/green-16x16.png?e36a 51w' sizes='min(1px, 100px)'>
+<img srcset='/images/green-1x1.png?e36b 50w, /images/green-16x16.png?e36b 51w' sizes='min(-100px, 1px)'>
 <img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) calc(1px)'>
-<img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) min(1px, 100px)'>
-<img srcset='/images/green-1x1.png?e37 50w, /images/green-16x16.png?e37 51w' sizes='(min-width:0) max(-100px, 1px)'>
+<img srcset='/images/green-1x1.png?e37a 50w, /images/green-16x16.png?e37a 51w' sizes='(min-width:0) min(1px, 100px)'>
+<img srcset='/images/green-1x1.png?e37b 50w, /images/green-16x16.png?e37b 51w' sizes='(min-width:0) max(-100px, 1px)'>
 <img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:calc(0)) 1px'>
-<img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:min(0, 200vw)) 1px'>
-<img srcset='/images/green-1x1.png?e38 50w, /images/green-16x16.png?e38 51w' sizes='(min-width:max(-200vw, 0)) 1px'>
+<img srcset='/images/green-1x1.png?e38a 50w, /images/green-16x16.png?e38a 51w' sizes='(min-width:min(0, 200vw)) 1px'>
+<img srcset='/images/green-1x1.png?e38b 50w, /images/green-16x16.png?e38b 51w' sizes='(min-width:max(-200vw, 0)) 1px'>
 <img srcset='/images/green-1x1.png?e39 50w, /images/green-16x16.png?e39 51w' sizes='(min-width:0) 1px, 100vw'>
 <img srcset='/images/green-1x1.png?e40 50w, /images/green-16x16.png?e40 51w' sizes='(min-width:0) 1px, (min-width:0) 100vw, 100vw'>
 <img srcset='/images/green-1x1.png?e41 50w, /images/green-16x16.png?e41 51w' sizes='(min-width:0) 1px'>
@@ -132,11 +132,11 @@
 <img srcset='/images/green-1x1.png?e108 50w, /images/green-16x16.png?e108 51w' sizes='(max-width:0) or (unknown-general-enclosed !) 100vw, 1px'>
 <img srcset='/images/green-1x1.png?e109 50w, /images/green-16x16.png?e109 51w' sizes='not ((max-width:0) or (unknown "general-enclosed")) 100vw, 1px'>
 <img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='calc(1px'>
-<img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='min(1px, 200vw'>
-<img srcset='/images/green-1x1.png?f48 50w, /images/green-16x16.png?f48 51w' sizes='max(-200vw, 1px'>
+<img srcset='/images/green-1x1.png?f48a 50w, /images/green-16x16.png?f48a 51w' sizes='min(1px, 200vw'>
+<img srcset='/images/green-1x1.png?f48b 50w, /images/green-16x16.png?f48b 51w' sizes='max(-200vw, 1px'>
 <img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) calc(1px'>
-<img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) min(1px, 200vw'>
-<img srcset='/images/green-1x1.png?f49 50w, /images/green-16x16.png?f49 51w' sizes='(min-width:0) max(-200vw, 1px'>
+<img srcset='/images/green-1x1.png?f49a 50w, /images/green-16x16.png?f49a 51w' sizes='(min-width:0) min(1px, 200vw'>
+<img srcset='/images/green-1x1.png?f49b 50w, /images/green-16x16.png?f49b 51w' sizes='(min-width:0) max(-200vw, 1px'>
 
 <p>
 <img srcset='/images/green-1x1.png?f1 50w, /images/green-16x16.png?f1 51w' sizes='100vw'>


### PR DESCRIPTION
This should be enough to test all of the `math functions` here, for https://github.com/whatwg/html/pull/3084

## Edit

Also, I'm curious about the tests here. Currently we seem to be trying to test that various, sometimes media-condition adorned `sizes` attribute values resolve to the same computed value. We test this by checking that `currentSrc` for each image (in a particular group) is the same (since the computed value of `sizes` can affect the choice of image), however this is a little incomplete right?

I tested in Chrome and Firefox, and sometimes vastly different `sizes` attribute values have no effect on the chosen image. Doesn't this mean that even if the parsing of a particular `sizes` attribute failed (and we either chose some very wrong value, or fell back on the default `100vw`) we could still be choosing the correct image just based on how a particular user agent decides to choose an image? So we might fail parsing `sizes` properly, yet still pass a bunch of tests.

If this is the case, I'm wondering if it might be more beneficial to instead not have multiple sources in the `srcset`, and choose a particular non-100vw `sizes` value so we can reliably see if the actual computed width (maybe `clientWidth`?) of an image is what it should be after the [width descriptor](https://html.spec.whatwg.org/multipage/images.html#width-descriptor) is factored in with the *expected* `sizes` value?

<!-- Reviewable:start -->

<!-- Reviewable:end -->
