### PR TITLE
test DOM XPath behaviour for root adjacent comments

### DIFF
--- a/domxpath/document-root-comment.html
+++ b/domxpath/document-root-comment.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>Root adjacent comment</title>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+<body>
+<script>
+test(function() {
+  var result = document.evaluate("comment()", // expression
+                                document.documentElement, // context node
+                                null, // resolver
+                                XPathResult.ANY_TYPE, // type
+                                null); // result
+  var matched = [];
+  var cur;
+  while ((cur = result.iterateNext()) !== null) {
+    matched.push(cur);
+  }
+  assert_array_equals(matched, [document]);
+});
+</script>

--- a/domxpath/document-root-comment.html
+++ b/domxpath/document-root-comment.html
@@ -1,11 +1,11 @@
-<!doctype html>
+<!doctype html> <!-- foo -->
 <title>Root adjacent comment</title>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
 <body>
 <script>
 test(function() {
-  var result = document.evaluate("comment()", // expression
+  var result = document.evaluate("//comment()", // comment()
                                 document.documentElement, // context node
                                 null, // resolver
                                 XPathResult.ANY_TYPE, // type


### PR DESCRIPTION
Reference to one of the tests mentioned in #10072 
For now the test fails with the error `assert_array_equals: lengths differ, expected 1 got 0` . I think this is somewhat related to the root adjacent thing. @gsnedders could you please look into this and suggest changes? Thanks a lot !

<!-- Reviewable:start -->

<!-- Reviewable:end -->
