### PR TITLE
expand tests to test in reverse direction

### DIFF
--- a/html/webappapis/scripting/events/event-handler-attributes-body-window.html
+++ b/html/webappapis/scripting/events/event-handler-attributes-body-window.html
@@ -22,6 +22,13 @@ handlers.forEach(function(handler) {
 });
 
 handlers.forEach(function(handler) {
+  test(function() {
+    window['on' + handler] = f;
+    assert_equals(document.body['on' + handler], f);
+  }, handler);
+});
+
+handlers.forEach(function(handler) {
     document.body['on' + handler] = null;
 });
 

--- a/html/webappapis/scripting/events/event-handler-attributes-window-body.html
+++ b/html/webappapis/scripting/events/event-handler-attributes-window-body.html
@@ -16,19 +16,8 @@ var handlers = ['blur','error','focus','load','resize','scroll',
                 'pageshow','popstate','storage','unload'];
 handlers.forEach(function(handler) {
   test(function() {
-    document.body['on' + handler] = f;
-    assert_equals(window['on' + handler], f);
+    window['on' + handler] = f;
+    assert_equals(document.body['on' + handler], f);
   }, handler);
-});
-
-handlers.forEach(function(handler) {
-    document.body['on' + handler] = null;
-});
-
-handlers.forEach(function(handler) {
-  test(function() {
-    assert_equals(document.body['on' + handler], null);
-    assert_equals(window['on' + handler], null);
-  }, handler + " removal");
 });
 </script>

--- a/html/webappapis/scripting/events/event-handler-attributes-window-body.html
+++ b/html/webappapis/scripting/events/event-handler-attributes-window-body.html
@@ -20,4 +20,15 @@ handlers.forEach(function(handler) {
     assert_equals(document.body['on' + handler], f);
   }, handler);
 });
+
+handlers.forEach(function(handler) {
+    window['on' + handler] = null;
+});
+
+handlers.forEach(function(handler) {
+  test(function() {
+    assert_equals(window['on' + handler], null);
+    assert_equals(document.body['on' + handler], null);
+  }, handler + " removal");
+});
 </script>


### PR DESCRIPTION
Reference to issue #2314. 
The tests can now test in the opposite direction too as suggested by @Ms2ger . 
However, there is a minor fix required regarding the duplicacy of handlers. Please review and suggest any changes required. Thanks :)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
