### PR TITLE
[svg 2 text] add scripted tests for length and indexed access

### DIFF
--- a/svg/scripted/text-attrs-dxdy-have-length.svg
+++ b/svg/scripted/text-attrs-dxdy-have-length.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="dx and dy attributes on text elements are lists that support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+    y="150"
+    x="120"
+    dx="60 90 -30 120 60 -257"
+    dy="0 12 24 12 0 -12 -24 -12 0"
+    >His socks are black.</text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var text = document.getElementById('text');
+      assert_equals(text.dx.baseVal.length, 6);
+      assert_equals(text.dy.baseVal.length, 9);
+    });
+  ]]></script>
+</svg>

--- a/svg/scripted/text-attrs-xyrotate-have-length.svg
+++ b/svg/scripted/text-attrs-xyrotate-have-length.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="x y and rotate attributes on text elements are lists that support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+    y="150 130 160"
+    x="120 160 200 240"
+    rotate="0 0 10, -10, 0"
+    >My socks are blue.</text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    /* The SVG spec requires (at least) readonly support for length */
+    test(function() {
+      var text = document.getElementById('text');
+      assert_equals(text.y.baseVal.length, 3);
+      assert_equals(text.x.baseVal.length, 4);
+      assert_equals(text.rotate.baseVal.length, 5);
+    });
+  ]]></script>
+</svg>

--- a/svg/scripted/text-tspan-attrs-have-length.svg
+++ b/svg/scripted/text-tspan-attrs-have-length.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="x y dx dy and rotate attributes on text and tspan elements are lists that support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+  y="150 130 160" x="120 160 200 240" rotate="0 0 10, -10, 0">
+    My <tspan id="tspan" x="280 325" y="150 155 160 165 170" rotate="-30,0,30">socks</tspan>
+    are blue.
+  </text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      /* Make sure that text.y is a list, (presumably
+       * SVGAnimatedLengthList) and that the list has a
+       * length() method and that it returns the right thing.
+       *
+       * This test is for a change in SVG for 2.0, since 1.x, to add
+       * a length property.
+       */
+      var text = document.getElementById('text');
+      assert_equals(text.y.baseVal.length, 3);
+      assert_equals(text.x.baseVal.length, 4);
+      assert_equals(text.rotate.baseVal.length, 5);
+
+      /* same for tspan */
+      var tspan = document.getElementById('tspan');
+      assert_equals(tspan.x.baseVal.length, 2);
+      assert_equals(tspan.y.baseVal.length, 5);
+      assert_equals(tspan.rotate.baseVal.length, 3);
+
+      /* Note, we only have to test that the length property
+       * is there (and interoperable) when there is a list given;
+       * in practice it's there with value 0 when the attributes are
+       * absent, but that's not required, the attribute could be implemented
+       * as a plain string in that case, or absent entirely, I think
+       * - Liam Quin 2018
+       */
+     });
+  ]]></script>
+</svg>

--- a/svg/scripted/text-tspan-attrs-indexed-access.svg
+++ b/svg/scripted/text-tspan-attrs-indexed-access.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="x y dx dy and rotate attributes on text and tspan elements are lists that support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+  y="150 130 160" x="120 160 200 240" rotate="0 0 10, -10, 0">
+    My <tspan id="tspan" x="280 325" y="150 155 160 165 170" rotate="-30,0,30">socks</tspan>
+    are blue.
+  </text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      /* Make sure that we can get at list items with indexed access.
+       */
+      var text = document.getElementById('text');
+      assert_equals(text.x.baseVal[0].value, 120);
+      assert_equals(text.y.baseVal[2].value, 160);
+      assert_equals(text.rotate.baseVal[3].value, -10);
+      assert_equals(text.rotate.baseVal[0].value, 0);
+
+      /* same for tspan */
+      var tspan = document.getElementById('tspan');
+      assert_equals(tspan.x.baseVal[1].value, 325);
+      assert_equals(tspan.y.baseVal[4].value, 170);
+      assert_equals(tspan.rotate.baseVal[0].value, -30);
+    });
+
+  ]]></script>
+</svg>

--- a/svg/scripted/tspan-attrs-dxdy-have-length.svg
+++ b/svg/scripted/tspan-attrs-dxdy-have-length.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="dx, dy attrs on tspan support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+    y="150"
+    x="120"
+    >His socks are <tspan id="tsp"
+    dx="60 90 -30 120 60 -257"
+    dy="0 12 24 12 0 -12 -24 -12 0"
+    >very</tspan> clean.</text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var tspan = document.getElementById('tsp');
+      assert_equals(tspan.dx.baseVal.length, 6);
+      assert_equals(tspan.dy.baseVal.length, 9);
+    });
+  ]]></script>
+</svg>

--- a/svg/scripted/tspan-attrs-xyrotate-have-length.svg
+++ b/svg/scripted/tspan-attrs-xyrotate-have-length.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/single-page.html#text-TSpanNotes"/>
+    <h:meta name="assert" content="dx and dy attributes on text elements are lists that support length()"/>
+</metadata>
+  <text id="text" font-family="Verdana" font-size="55" fill="blue"
+    y="150"
+    x="120"
+    >Her socks were <tspan id="tsp"
+    x="280 325" y="150 155 160 165 170" rotate="-30,0,30"
+    >stained</tspan> with blood.</text>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    test(function() {
+      var tspan = document.getElementById('tsp');
+      assert_equals(tspan.x.baseVal.length, 2);
+      assert_equals(tspan.y.baseVal.length, 5);
+      assert_equals(tspan.rotate.baseVal.length, 3);
+    });
+  ]]></script>
+</svg>


### PR DESCRIPTION
The text and tspan elements seem to be the only ones in SVG itself affected by this change. The spec only demands read-only access so that's all that's tested here.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
