### PR TITLE
wptrunner: Always restart on test error

### DIFF
--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -254,6 +254,8 @@ RunnerManagerState = _RunnerManagerState()
 
 
 class TestRunnerManager(threading.Thread):
+    statuses_requiring_restart = ("CRASH", "ERROR", "EXTERNAL-TIMEOUT")
+
     def __init__(self, suite_name, test_queue, test_source_cls, browser_cls, browser_kwargs,
                  executor_cls, executor_kwargs, stop_flag, rerun=1, pause_after_test=False,
                  pause_on_unexpected=False, restart_on_unexpected=True, debug_info=None):
@@ -585,7 +587,7 @@ class TestRunnerManager(threading.Thread):
                              extra=file_result.extra)
 
         restart_before_next = (test.restart_after or
-                               file_result.status in ("CRASH", "EXTERNAL-TIMEOUT") or
+                               file_result.status in self.statuses_requiring_restart or
                                ((subtest_unexpected or is_unexpected) and
                                 self.restart_on_unexpected))
 


### PR DESCRIPTION
Because a harness error may describe an unrecoverable browser state, the
browser should always be restarted when such an error is encountered
(even in the presence of the `--no-restart-on-unexpected` flag).

---

@jgraham @gsnedders If `wpt run --no-restart-on-unexpected` is used to execute
a test file like this:

```html
<script>
window.opener.close();
</script>
```

Then after that test fails with the status "ERROR", all subsequent tests fail
for the same reason. By interpreting the error as unrecoverable, we can avoid
invalidating test runs in these cases.

That's a contrived example, though. As an alternative, we might be able to
address it by detecting a missing window and applying the status "CRASH". I
started researching this possibility, but it started to look like this logic
would be dependent on the browser, executor, and/or transport. I'm also
thinking that there are many more subtle ways the environment could become
corrupted, and we'd probably never be able to detect them all.

In contrast, what I'm proposing here is much more heavy-handed. There are many
kinds of harness errors that don't require full restarts, so this patch will
make running WPT with `--no-restart-on-unexpected` slower. My inclination is to
prefer correctness and completeness over speed since test execution time
(unlike correctness) can be improved by consumers by using more machines. I
also get the sense that not many consumers have a use for this particular flag,
so I'm guessing that we wouldn't want to take on the complexity overhead of a
more nuanced solution.

What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10186)
<!-- Reviewable:end -->
