### PR TITLE
WebDriver: add more WebKit workarounds to detect whether a window is fullscreen

### DIFF
--- a/webdriver/tests/contexts/maximize_window.py
+++ b/webdriver/tests/contexts/maximize_window.py
@@ -12,6 +12,12 @@ def maximize(session):
     return session.transport.send("POST", "session/%s/window/maximize" % session.session_id)
 
 
+def is_fullscreen(session):
+    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
+    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
+    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
+
+
 # 10.7.3 Maximize Window
 
 
@@ -137,11 +143,11 @@ def test_fully_exit_fullscreen(session):
 
     """
     session.window.fullscreen()
-    assert session.execute_script("return window.fullScreen") is True
+    assert is_fullscreen(session) is True
 
     response = maximize(session)
     assert_success(response)
-    assert session.execute_script("return window.fullScreen") is False
+    assert is_fullscreen(session) is False
 
 
 def test_restore_the_window(session):

--- a/webdriver/tests/fullscreen_window.py
+++ b/webdriver/tests/fullscreen_window.py
@@ -16,6 +16,12 @@ def fullscreen(session):
     return session.transport.send("POST", "session/%s/window/fullscreen" % session.session_id)
 
 
+def is_fullscreen(session):
+    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
+    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
+    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
+
+
 # 10.7.5 Fullscreen Window
 
 
@@ -134,11 +140,6 @@ def test_handle_prompt_missing_value(session, create_dialog):
     assert_dialog_handled(session, "dismiss #3")
     assert read_global(session, "dismiss3") == None
 
-
-def is_fullscreen(session):
-    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
-    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
-    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
 
 def test_fullscreen(session):
     """

--- a/webdriver/tests/minimize_window.py
+++ b/webdriver/tests/minimize_window.py
@@ -10,6 +10,11 @@ def minimize(session):
     return session.transport.send("POST", "session/%s/window/minimize" % session.session_id)
 
 
+def is_fullscreen(session):
+    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
+    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
+    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
+
 # 10.7.4 Minimize Window
 
 
@@ -135,11 +140,11 @@ def test_fully_exit_fullscreen(session):
 
     """
     session.window.fullscreen()
-    assert session.execute_script("return window.fullScreen") is True
+    assert is_fullscreen(session) is True
 
     response = minimize(session)
     assert_success(response)
-    assert session.execute_script("return window.fullScreen") is False
+    assert is_fullscreen(session) is False
     assert session.execute_script("return document.hidden") is True
 
 

--- a/webdriver/tests/set_window_rect.py
+++ b/webdriver/tests/set_window_rect.py
@@ -13,6 +13,11 @@ alert_doc = inline("<script>window.alert()</script>")
 def set_window_rect(session, rect):
     return session.transport.send("POST", "session/%s/window/rect" % session.session_id, rect)
 
+def is_fullscreen(session):
+    # At the time of writing, WebKit does not conform to the Fullscreen API specification.
+    # Remove the prefixed fallback when https://bugs.webkit.org/show_bug.cgi?id=158125 is fixed.
+    return session.execute_script("return !!(window.fullScreen || document.webkitIsFullScreen)")
+
 
 # 10.7.2 Set Window Rect
 
@@ -293,14 +298,14 @@ def test_fully_exit_fullscreen(session):
       3. Exit fullscreen document.
     """
     session.window.fullscreen()
-    assert session.execute_script("return window.fullScreen") is True
+    assert is_fullscreen(session) is True
 
     response = set_window_rect(session, {"width": 400, "height": 400})
     value = assert_success(response)
     assert value["width"] == 400
     assert value["height"] == 400
 
-    assert session.execute_script("return window.fullScreen") is False
+    assert is_fullscreen(session) is False
 
 
 def test_restore_from_minimized(session):


### PR DESCRIPTION
WebKit doesn't conform to the Fullscreen API yet, so we need to use
the vendor prefixed property to check whether the window is fullscreen.

This workaround was previously applied to fullscreen_window.py, but it
needs to happen in other places as well.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
