### PR TITLE
[css-align] tests for row-gap / column-gap normal

### DIFF
--- a/css/css-align/gaps/gap-normal-computed-001.html
+++ b/css/css-align/gaps/gap-normal-computed-001.html
@@ -14,7 +14,7 @@
      and there are implementations that support column-gap without supporting the shorthand */
   colum-gap: normal;
   row-gap: normal;
-  float: right; /* for shrinwrap*/
+  float: right; /* for shrinkwrap*/
 }
 #col {
   column-count: 2;

--- a/css/css-align/gaps/gap-normal-computed-001.html
+++ b/css/css-align/gaps/gap-normal-computed-001.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment Test: computed value of normal on *-gap properties</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#column-row-gap">
+<meta assert="The computed value of [row-|column-]?gap is normal for all elements it applies to. Checking explicitely because earlier version of the spec called for 0px in some cases.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#col,
+#grid,
+#flex {
+  /* Not using the shorthand because that's not what we're interested in,
+     and there are implementations that support column-gap without supporting the shorthand */
+  colum-gap: normal;
+  row-gap: normal;
+  float: right; /* for shrinwrap*/
+}
+#col {
+  column-count: 2;
+  column-width: 50px;
+}
+#grid {
+  display: grid;
+  grid-template-columns: 50px 50px;
+  grid-template-rows: 50px 50px;
+}
+#flex {
+  display: flex;
+}
+#flex * { width: 50px; height: 50px;}
+</style>
+<body>
+  <div id="log"></div>
+
+  <div id=col></div>
+  <div id=grid></div>
+  <div id=flex><span></span><span></span></div>
+
+  <script>
+    test(
+      function(){
+        var target = document.getElementById("col");
+        assert_equals(getComputedStyle(target).columnGap, "normal");
+      }, "colum-gap:normal computes to normal on multicol elements");
+    test(
+      function(){
+        var target = document.getElementById("col");
+        assert_equals(getComputedStyle(target).rowGap, "normal");
+      }, "row-gap:normal computes to normal on multicol elements");
+    test(
+      function(){
+        var target = document.getElementById("grid");
+        assert_equals(getComputedStyle(target).columnGap, "normal");
+      }, "colum-gap:normal computes to normal on grid");
+    test(
+      function(){
+        var target = document.getElementById("grid");
+        assert_equals(getComputedStyle(target).rowGap, "normal");
+      }, "row-gap:normal computes to normal on grid");
+    test(
+      function(){
+        var target = document.getElementById("flex");
+        assert_equals(getComputedStyle(target).columnGap, "normal");
+      }, "colum-gap:normal (main axis) computes to normal on flexbox");
+    test(
+      function(){
+        var target = document.getElementById("flex");
+        assert_equals(getComputedStyle(target).rowGap, "normal");
+      }, "row-gap:normal (cross axis) computes to normal on flexbox");
+  </script>
+</body>

--- a/css/css-align/gaps/gap-normal-used-001.html
+++ b/css/css-align/gaps/gap-normal-used-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment Test: used value of *-gap:normal on grid</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#column-row-gap">
+<meta assert="The used value of row-gap and column-gap normal for grids is 0">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<style>
+#grid {
+  colum-gap: normal;
+  row-gap: normal;
+  display: grid;
+  grid-template-columns: 50px 50px;
+  grid-template-rows: 50px 50px;
+
+  position: absolute;
+}
+#grid * { background: green; }
+#red {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+  <div id=grid><span></span><span></span><span></span><span></span></div>
+  <div id=red></div>
+
+

--- a/css/css-align/gaps/gap-normal-used-001.html
+++ b/css/css-align/gaps/gap-normal-used-001.html
@@ -22,10 +22,8 @@
   background: red;
 }
 </style>
-<body>
-  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-  <div id=grid><span></span><span></span><span></span><span></span></div>
-  <div id=red></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-
+<div id=grid><span></span><span></span><span></span><span></span></div>
+<div id=red></div>

--- a/css/css-align/gaps/gap-normal-used-002.html
+++ b/css/css-align/gaps/gap-normal-used-002.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Box Alignment Test: used value of *-gap:normal on flexbox</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://www.w3.org/TR/css-align-3/#column-row-gap">
+<meta assert="The used value row-gap:normal and column:normal normal is 0px in flexbox">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht" />
+<style>
+#flex {
+  colum-gap: normal;
+  row-gap: normal;
+  display: flex;
+  flex-flow: wrap;
+  max-width: 145px; /* more than 100, less than 150, to force wrapping and get 2 items per line*/
+
+  position: absolute;
+}
+#flex * {
+  width: 50px;
+  height: 50px;
+  background: green
+}
+#red {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+</style>
+<body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+  <div id=flex><span></span><span></span><span></span><span></span></div>
+  <div id=red></div>

--- a/css/css-align/gaps/gap-normal-used-002.html
+++ b/css/css-align/gaps/gap-normal-used-002.html
@@ -26,8 +26,8 @@
   background: red;
 }
 </style>
-<body>
-  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
 
-  <div id=flex><span></span><span></span><span></span><span></span></div>
-  <div id=red></div>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id=flex><span></span><span></span><span></span><span></span></div>
+<div id=red></div>


### PR DESCRIPTION
Matching the https://github.com/w3c/csswg-drafts/issues/2294 spec change

Not including tests for used value in multicol, because (so far) it is
UA defined.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
