### PR TITLE
Invert (fix) the order of `wpt make-hosts-file` instructions

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -117,13 +117,13 @@ def check_environ(product):
                 if platform.uname()[0] != "Windows":
                     message = """Missing hosts file configuration. Run
 
-python wpt make-hosts-file >> %s
-
-from a shell with Administrator privileges.""" % hosts_path
+./wpt make-hosts-file | sudo tee -a %s""" % hosts_path
                 else:
                     message = """Missing hosts file configuration. Run
 
-./wpt make-hosts-file | sudo tee -a %s""" % hosts_path
+python wpt make-hosts-file >> %s
+
+from a shell with Administrator privileges.""" % hosts_path
                 raise WptrunError(message)
 
 


### PR DESCRIPTION
This was inverted so that the Windows instructions were printed on
Linux. Rather than just changing the condition, switch the messages,
to match the order of some preceding code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10237)
<!-- Reviewable:end -->
