### PR TITLE
Check inherited interfaces exist

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -603,7 +603,6 @@ IdlArray.prototype.assert_throws = function(error, idlArrayFunc)
 {
     try {
         idlArrayFunc.call(this, this);
-        throw new IdlHarnessError(`${idlArrayFunc} did not throw the expected IdlHarnessError`);
     } catch (e) {
         if (e instanceof AssertionError) {
             throw e;
@@ -613,9 +612,11 @@ IdlArray.prototype.assert_throws = function(error, idlArrayFunc)
             error = error.message;
         }
         if (e.message !== error) {
-            throw new IdlHarnessError(`${idlArrayFunc} threw ${e}, not the expected IdlHarnessError`);
+            throw new IdlHarnessError(`${idlArrayFunc} threw "${e}", not the expected IdlHarnessError "${error}"`);
         }
+        return;
     }
+    throw new IdlHarnessError(`${idlArrayFunc} did not throw the expected IdlHarnessError`);
 }
 
 //@}
@@ -681,6 +682,16 @@ IdlArray.prototype.test = function()
         }.bind(this));
     }
     this["includes"] = {};
+
+    // Assert B defined for A : B
+    for (var member of Array.from(Object.values(this.members)).filter(m => m.base)) {
+        let lhs = member.name;
+        let rhs = member.base;
+        if (!(lhs in this.members)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${lhs} is undefined.`);
+        if (!(this.members[lhs] instanceof IdlInterface)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${lhs} is not an interface.`);
+        if (!(rhs in this.members)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${rhs} is undefined.`);
+        if (!(this.members[rhs] instanceof IdlInterface)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${rhs} is not an interface.`);
+    }
 
     Object.getOwnPropertyNames(this.members).forEach(function(memberName) {
         var member = this.members[memberName];

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -684,7 +684,7 @@ IdlArray.prototype.test = function()
     this["includes"] = {};
 
     // Assert B defined for A : B
-    for (var member of Array.from(Object.values(this.members)).filter(m => m.base)) {
+    for (var member of Object.values(this.members).filter(m => m.base)) {
         let lhs = member.name;
         let rhs = member.base;
         if (!(lhs in this.members)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${lhs} is undefined.`);

--- a/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of_undefined.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of_undefined.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <title>idlharness test_primary_interface_of_undefined</title>
+</head>
+
+<body>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+  <script>
+    'use strict';
+
+    test(function () {
+      let i = new IdlArray();
+      i.add_untested_idls('interface A : B {};');
+      i.assert_throws(new IdlHarnessError('A inherits B, but B is undefined.'), i => i.test());
+    }, 'A : B with B undeclared should throw IdlHarnessError');
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Ensures that `B` exists if you `add_[untested_]idl('interface A : B {};')`
See https://www.w3.org/TR/WebIDL-1/#idl-interfaces for definition of interface inheritance.

Fixes https://github.com/w3c/web-platform-tests/issues/10214

Note:
Side-stepping the `Cannot read property 'has_extended_attribute' of undefined` message at its source would involve non-null checks in several places (e.g. l1318, l1524, ...).
This change is consistent with the other early existence checks, and is a fail-fast (before testing each member), which is likely to change the number of executed tests for any IDL tests which have undefined inherits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10240)
<!-- Reviewable:end -->
