### PR TITLE
Update serialization of timing functions

### DIFF
--- a/css/css-transitions/transition-001.html
+++ b/css/css-transitions/transition-001.html
@@ -24,26 +24,24 @@
 
         <script>
             var transition = document.getElementById('transition');
-            var ease = 'cubic-bezier(0.25, 0.1, 0.25, 1)';
-            var easeIn = 'cubic-bezier(0.42, 0, 1, 1)';
             // Note that order is important in this property. The first value that can be parsed as a time is assigned to
             // the transition-duration. The second value that can be parsed as a time is assigned to transition-delay.
             // [<‘transition-property’> || <‘transition-duration’> || <‘transition-timing-function’> || <‘transition-delay’> [, [<‘transition-property’> || <‘transition-duration’> || <‘transition-timing-function’> || <‘transition-delay’>]]*
             var values = {
                 // [property, duration, timing, delay]
                 // random order
-                '1s' : ["all", "1s", ease, "0s"],
-                '1s 2s' : ["all", "1s", ease, "2s"],
-                '1s 2s ease-in' : ["all", "1s", easeIn, "2s"],
-                '1s ease-in 2s' : ["all", "1s", easeIn, "2s"],
-                'ease-in 1s 2s' : ["all", "1s", easeIn, "2s"],
-                '1s width' : ["width", "1s", ease, "0s"],
-                'width 1s' : ["width", "1s", ease, "0s"],
-                '1s width 2s' : ["width", "1s", ease, "2s"],
-                '1s 2s width ease-in' : ["width", "1s", easeIn, "2s"],
-                '1s ease-in 2s width' : ["width", "1s", easeIn, "2s"],
-                'width ease-in 1s 2s' : ["width", "1s", easeIn, "2s"],
-                'width .1s ease-in .2s' : ["width", "0.1s", easeIn, "0.2s"]
+                '1s' : ["all", "1s", "ease", "0s"],
+                '1s 2s' : ["all", "1s", "ease", "2s"],
+                '1s 2s ease-in' : ["all", "1s", "ease-in", "2s"],
+                '1s ease-in 2s' : ["all", "1s", "ease-in", "2s"],
+                'ease-in 1s 2s' : ["all", "1s", "ease-in", "2s"],
+                '1s width' : ["width", "1s", "ease", "0s"],
+                'width 1s' : ["width", "1s", "ease", "0s"],
+                '1s width 2s' : ["width", "1s", "ease", "2s"],
+                '1s 2s width ease-in' : ["width", "1s", "ease-in", "2s"],
+                '1s ease-in 2s width' : ["width", "1s", "ease-in", "2s"],
+                'width ease-in 1s 2s' : ["width", "1s", "ease-in", "2s"],
+                'width .1s ease-in .2s' : ["width", "0.1s", "ease-in", "0.2s"]
             };
 
             for (var key in values) {

--- a/css/css-transitions/transition-timing-function-001.html
+++ b/css/css-transitions/transition-timing-function-001.html
@@ -24,15 +24,14 @@
 
         <script>
             var transition = document.getElementById('transition');
-            // "ease"
-            var defaultValue = 'cubic-bezier(0.25, 0.1, 0.25, 1)';
+            var defaultValue = 'ease';
             var values = {
                 // keywords
-                'ease': 'cubic-bezier(0.25, 0.1, 0.25, 1)',
-                'linear': 'cubic-bezier(0, 0, 1, 1)',
-                'ease-in': 'cubic-bezier(0.42, 0, 1, 1)',
-                'ease-out': 'cubic-bezier(0, 0, 0.58, 1)',
-                'ease-in-out': 'cubic-bezier(0.42, 0, 0.58, 1)',
+                'ease': 'ease',
+                'linear': 'linear',
+                'ease-in': 'ease-in',
+                'ease-out': 'ease-out',
+                'ease-in-out': 'ease-in-out',
                 'step-start': 'steps(1, start)',
                 'step-end': 'steps(1)',
                 // cubic bezier


### PR DESCRIPTION
According to https://drafts.csswg.org/css-timing/#serializing-a-timing-function:

> The keyword values `ease`, `linear`, `ease-in`, `ease-out`, and `ease-in-out` are serialized as-is, that-is, they are not converted to the equivalent `cubic-bezier()` function.

Update two tests to match this behavior.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
