### PR TITLE
ReadableStream: getReader() should call ToString() on mode

### DIFF
--- a/streams/readable-streams/default-reader.js
+++ b/streams/readable-streams/default-reader.js
@@ -485,4 +485,17 @@ promise_test(t => {
 
 }, 'Reading twice on a stream that gets errored');
 
+test(() => {
+  const rs = new ReadableStream();
+  let toStringCalled = false;
+  const mode = {
+    toString() {
+      toStringCalled = true;
+      return '';
+    }
+  };
+  assert_throws(new RangeError(), () => rs.getReader({ mode }), 'getReader() should throw');
+  assert_true(toStringCalled, 'toString() should be called');
+}, 'getReader() should call ToString() on mode');
+
 done();


### PR DESCRIPTION
When the "mode" option is not undefined, getReader({mode}) algorithm
calls ToString() on it before checking whether or not it is "blob". Add
a test to ensure this conversion is done.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
