### PR TITLE
New MIME type parsing tests

### DIFF
--- a/mimesniff/mime-types/resources/mime-types.json
+++ b/mimesniff/mime-types/resources/mime-types.json
@@ -57,6 +57,12 @@
     "navigable": true,
     "encoding": "GBK"
   },
+  {
+    "input": "text/html;charset= \"gbk\"",
+    "output": "text/html;charset=\" \\\"gbk\\\"\"",
+    "navigable": true,
+    "encoding": null
+  },
   "Single quotes are a token, not a delimiter",
   {
     "input": "text/html;charset='gbk'",
@@ -73,6 +79,12 @@
   {
     "input": "text/html;charset=gbk'",
     "output": "text/html;charset=gbk'",
+    "navigable": true,
+    "encoding": null
+  },
+  {
+    "input": "text/html;charset=';charset=GBK",
+    "output": "text/html;charset=';charset=GBK",
     "navigable": true,
     "encoding": null
   },
@@ -113,6 +125,12 @@
     "navigable": true,
     "encoding": "GBK"
   },
+  {
+    "input": "text/html;charset=();charset=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
   "Double quotes",
   {
     "input": "text/html;charset=\"gbk\"",
@@ -139,6 +157,12 @@
     "encoding": "GBK"
   },
   {
+    "input": "text/html;charset=\"gbk \"",
+    "output": "text/html;charset=\"gbk \"",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
     "input": "text/html;charset=\"\\ gbk\"",
     "output": "text/html;charset=\" gbk\"",
     "navigable": true,
@@ -153,6 +177,12 @@
   {
     "input": "text/html;charset=\"gbk\"x",
     "output": "text/html;charset=gbk",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\";charset=GBK",
+    "output": "text/html;charset=GBK",
     "navigable": true,
     "encoding": "GBK"
   },

--- a/mimesniff/mime-types/resources/mime-types.json
+++ b/mimesniff/mime-types/resources/mime-types.json
@@ -186,6 +186,12 @@
     "navigable": true,
     "encoding": "GBK"
   },
+  {
+    "input": "text/html;charset=\";charset=GBK",
+    "output": "text/html;charset=\";charset=GBK\"",
+    "navigable": true,
+    "encoding": null
+  },
   "Unexpected code points",
   {
     "input": "text/html;charset={gbk}",

--- a/mimesniff/mime-types/resources/mime-types.json
+++ b/mimesniff/mime-types/resources/mime-types.json
@@ -32,6 +32,12 @@
     "navigable": true,
     "encoding": "GBK"
   },
+  {
+    "input": "text/html;charset=();charset=GBK",
+    "output": "text/html;charset=\"()\"",
+    "navigable": true,
+    "encoding": null
+  },
   "Spaces",
   {
     "input": "text/html;charset =gbk",
@@ -122,12 +128,6 @@
   {
     "input": "text/html;;;;charset=gbk",
     "output": "text/html;charset=gbk",
-    "navigable": true,
-    "encoding": "GBK"
-  },
-  {
-    "input": "text/html;charset=();charset=GBK",
-    "output": "text/html;charset=GBK",
     "navigable": true,
     "encoding": "GBK"
   },

--- a/mimesniff/mime-types/resources/mime-types.json
+++ b/mimesniff/mime-types/resources/mime-types.json
@@ -84,7 +84,7 @@
   },
   {
     "input": "text/html;charset=';charset=GBK",
-    "output": "text/html;charset=';charset=GBK",
+    "output": "text/html;charset='",
     "navigable": true,
     "encoding": null
   },
@@ -127,6 +127,18 @@
   },
   {
     "input": "text/html;charset=();charset=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset= \"\u007F;charset=GBK",
+    "output": "text/html;charset=GBK",
+    "navigable": true,
+    "encoding": "GBK"
+  },
+  {
+    "input": "text/html;charset=\"\u007F;charset=foo\";charset=GBK",
     "output": "text/html;charset=GBK",
     "navigable": true,
     "encoding": "GBK"


### PR DESCRIPTION
Tests suggested at https://github.com/w3c/web-platform-tests/issues/1851#issuecomment-378032606.

Co-Authored-By: Matt Menke <mmenke@google.com>

I didn't add these for now:

> text/html;charset=" gbk"

Already tested.

> text/html;charset= ";charset=GBK

I didn't see why this would end up as GBK. We'd have `" \""` as charset parameter value and that would simply not result in an encoding. Why would we consult the second parameter?

> text/html;charset=";charset=GBK";charset=GBK

Semi-colons are allowed, so this would not parse as GBK.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
