### PR TITLE
Throw IdlHarnessError outside try

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -603,7 +603,6 @@ IdlArray.prototype.assert_throws = function(error, idlArrayFunc)
 {
     try {
         idlArrayFunc.call(this, this);
-        throw new IdlHarnessError(`${idlArrayFunc} did not throw the expected IdlHarnessError`);
     } catch (e) {
         if (e instanceof AssertionError) {
             throw e;
@@ -613,9 +612,11 @@ IdlArray.prototype.assert_throws = function(error, idlArrayFunc)
             error = error.message;
         }
         if (e.message !== error) {
-            throw new IdlHarnessError(`${idlArrayFunc} threw ${e}, not the expected IdlHarnessError`);
+            throw new IdlHarnessError(`${idlArrayFunc} threw "${e}", not the expected IdlHarnessError "${error}"`);
         }
+        return;
     }
+    throw new IdlHarnessError(`${idlArrayFunc} did not throw the expected IdlHarnessError`);
 }
 
 //@}


### PR DESCRIPTION
Extracted from the reverted https://github.com/w3c/web-platform-tests/pull/10240.

Improves the error message for unexpected outcomes in idlharness.js tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10280)
<!-- Reviewable:end -->
