### PR TITLE
Add support for // META: spec=url to satisfy MISSING-LINK

### DIFF
--- a/css/geometry/DOMMatrix-css-string.worker.js
+++ b/css/geometry/DOMMatrix-css-string.worker.js
@@ -1,4 +1,4 @@
-// https://drafts.fxtf.org/geometry/#DOMMatrix
+// META: spec=https://drafts.fxtf.org/geometry/#DOMMatrix
 
 importScripts("/resources/testharness.js");
 

--- a/css/geometry/WebKitCSSMatrix.worker.js
+++ b/css/geometry/WebKitCSSMatrix.worker.js
@@ -1,4 +1,4 @@
-// https://drafts.fxtf.org/geometry/#DOMMatrix
+// META: spec=https://drafts.fxtf.org/geometry/#DOMMatrix
 
 importScripts('/resources/testharness.js');
 

--- a/css/geometry/interfaces.worker.js
+++ b/css/geometry/interfaces.worker.js
@@ -1,8 +1,9 @@
+// META: spec=https://drafts.fxtf.org/geometry/#DOMPoint
+// META: spec=https://drafts.fxtf.org/geometry/#DOMRect
+// META: spec=https://drafts.fxtf.org/geometry/#DOMQuad
+// META: spec=https://drafts.fxtf.org/geometry/#DOMMatrix
+
 "use strict";
-// https://drafts.fxtf.org/geometry/#DOMPoint
-// https://drafts.fxtf.org/geometry/#DOMRect
-// https://drafts.fxtf.org/geometry/#DOMQuad
-// https://drafts.fxtf.org/geometry/#DOMMatrix
 
 importScripts("/resources/testharness.js");
 importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -919,9 +919,6 @@ MISSING-LINK: css/cssom-view/scrollTop-display-change.html
 CSS-COLLIDING-TEST-NAME: css/cssom-view/interfaces.html
 CSS-COLLIDING-TEST-NAME: css/cssom/interfaces.html
 
-# TODO https://github.com/w3c/web-platform-tests/issues/5770
-MISSING-LINK: css/geometry/*.worker.js
-
 WEBIDL2.JS: .gitmodules
 
 # Manual test that uses console.logs for feedback

--- a/tools/lint/lint.py
+++ b/tools/lint/lint.py
@@ -636,6 +636,8 @@ def check_script_metadata(repo_root, path, f):
                     errors.append(("UNKNOWN-TIMEOUT-METADATA", "Unexpected value for timeout metadata", path, idx + 1))
             elif key == b"script":
                 pass
+            elif key == b"spec":
+                pass
             else:
                 errors.append(("UNKNOWN-METADATA", "Unexpected kind of metadata", path, idx + 1))
         else:

--- a/tools/lint/tests/test_file_lints.py
+++ b/tools/lint/tests/test_file_lints.py
@@ -525,6 +525,7 @@ def test_css_missing_file_manual():
     (b"""// META: timeout=long\n""", None),
     (b"""//  META: timeout=long\n""", None),
     (b"""// META: script=foo.js\n""", None),
+    (b"""// META: spec=foo.html\n""", None),
     (b"""# META:\n""", None),
     (b"""\n// META: timeout=long\n""", (2, "STRAY-METADATA")),
     (b""" // META: timeout=long\n""", (1, "INDENTED-METADATA")),

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -466,6 +466,9 @@ class SourceFile(object):
         for item in self.spec_link_nodes:
             if "href" in item.attrib:
                 rv.add(item.attrib["href"].strip(space_chars))
+        if self.script_metadata:
+            for item in filter(lambda x: x[0] == b"spec", self.script_metadata):
+                rv.add(item[1].strip(space_chars))
         return rv
 
     @cached_property

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -263,6 +263,18 @@ test()"""
         assert item.timeout == "long"
 
 
+def test_spec_meta_tag():
+    contents = b"""// META: spec=foo.html
+importScripts('/resources/testharness.js')
+test()"""
+
+    metadata = list(read_script_metadata(BytesIO(contents), js_meta_re))
+    assert metadata == [(b"spec", b"foo.html")]
+
+    s = create("html/test.any.js", contents=contents)
+    assert "foo.html" in s.spec_links
+
+
 @pytest.mark.parametrize("input,expected", [
     (b"""//META: foo=bar\n""", [(b"foo", b"bar")]),
     (b"""// META: foo=bar\n""", [(b"foo", b"bar")]),
@@ -395,7 +407,7 @@ def test_testharness_svg():
     assert not s.name_is_worker
     assert not s.name_is_reference
 
-    assert s.root
+    assert len(s.root)
     assert s.content_is_testharness
 
     assert items(s) == [("testharness", "/" + filename)]
@@ -424,7 +436,7 @@ def test_relative_testharness_svg():
     assert not s.name_is_worker
     assert not s.name_is_reference
 
-    assert s.root
+    assert len(s.root)
     assert not s.content_is_testharness
 
     assert items(s) == []


### PR DESCRIPTION
Fixes https://github.com/w3c/web-platform-tests/issues/5770.

- Whitelists `// META: spec=url` as a valid `META` tag (stops `UNKNOWN-METADATA`)
- Surfaces `url` from the above expression in the set of `SourceFile.spec_links`

Note that this does not affect what is considered a valid link; opened https://github.com/w3c/web-platform-tests/issues/10288 to cover that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10289)
<!-- Reviewable:end -->
