### PR TITLE
Test removed interfaces and SVG* -> DOM* in Types chapter

### DIFF
--- a/svg/historical.html
+++ b/svg/historical.html
@@ -12,6 +12,7 @@ var removedInterfaces = [
   "SVGICCColor",
   "SVGLangSpace",
   "SVGLocatable",
+  "SVGTransformable",
   "SVGPaint",
   "SVGPathSeg",
   "SVGStylable",

--- a/svg/types/elements/SVGGeometryElement-rect.svg
+++ b/svg/types/elements/SVGGeometryElement-rect.svg
@@ -14,9 +14,9 @@
   <h:script src="/resources/testharness.js"/>
   <h:script src="/resources/testharnessreport.js"/>
   <script><![CDATA[
-  test(function() {
-    var box = document.getElementById('box');
+  var box = document.getElementById('box');
 
+  test(function() {
     assert_equals(box.pathLength.baseVal, 6);
 
     assert_equals(box.getTotalLength(), 600);
@@ -24,5 +24,9 @@
     assert_equals(box.getPointAtLength(210).x, 250);
     assert_equals(box.getPointAtLength(210).y, 60);
   }, 'getTotalLength and getPointAtLength do not take pathLength into account');
+
+  test(function() {
+    assert_true(box.getPointAtLength(210) instanceof DOMPoint);
+  }, 'getPointAtLength() returns instance of DOMPoint');
   ]]></script>
 </svg>

--- a/svg/types/scripted/SVGAnimatedRect.html
+++ b/svg/types/scripted/SVGAnimatedRect.html
@@ -10,8 +10,9 @@ test(function() {
 
   // Check initial viewBox value.
   assert_true(svgElement.viewBox instanceof SVGAnimatedRect);
-  assert_true(svgElement.viewBox.baseVal instanceof SVGRect);
+  assert_true(svgElement.viewBox.baseVal instanceof DOMRect);
   assert_equals(svgElement.viewBox.baseVal.x, 0);
+  assert_true(svgElement.viewBox.animVal instanceof DOMRectReadOnly);
 
   // Check that rects are dynamic, caching value in a local variable and modifying it, should take effect.
   var numRef = svgElement.viewBox.baseVal;
@@ -28,6 +29,6 @@ test(function() {
   assert_equals(svgElement.viewBox.baseVal.x, 100);
 
   // Check that the viewBox baseVal type has not been changed.
-  assert_true(svgElement.viewBox.baseVal instanceof SVGRect);
+  assert_true(svgElement.viewBox.baseVal instanceof DOMRect);
 });
 </script>

--- a/svg/types/scripted/SVGGraphicsElement.svg
+++ b/svg/types/scripted/SVGGraphicsElement.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <title>SVGGraphicsElement</title>
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement"/>
+  </metadata>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+    var el = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+
+    test(function() {
+        assert_true(el.getBBox() instanceof DOMRect);
+    }, 'getBBox() returns instance of DOMRect');
+
+    test(function() {
+        assert_true(el.getCTM() instanceof DOMMatrix);
+    }, 'getCTM() returns instance of DOMMatrix');
+
+    test(function() {
+        assert_true(el.getScreenCTM() instanceof DOMMatrix);
+    }, 'getScreenCTM() returns instance of DOMMatrix');
+  ]]></script>
+</svg>


### PR DESCRIPTION
This is the first round of tests for updates in SVG2 to the types chapter:

* Adds missing test for removal of SVGTransformable. All other removed interfaces/members are included
* Adds or updates tests for returning DOMPoint/DOMRect/DOMMatrix instead of SVGPoint, SVGRect/SVGMatrix. All browsers fail these even though all browsers but Edge support the new interfaces for CSS.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
