### PR TITLE
Match whitespace for custom property serialization

### DIFF
--- a/css/css-variables/variable-invalidation.html
+++ b/css/css-variables/variable-invalidation.html
@@ -43,26 +43,26 @@
 
         // This is a boilerplate to build a testcase and then test the expected outcome
         function testCase(cssStyle, testProperty, testElement, testImportant) {
-            var initialCssText = testProperty + (testImportant ? ": red !important;" : ": red;");
+            var initialCssText = testProperty + (testImportant ? ":red !important;" : ":red;");
 
             testExpectations(testProperty, cssStyle, testElement, "initial", "red", initialCssText, testImportant ? "important" : "", 1, testProperty);
 
             cssStyle.setProperty(testProperty, "blue");
 
             if (!testImportant) {
-                testExpectations(testProperty, cssStyle, testElement, "after setProperty", "blue", testProperty + ": blue;", "", 1, testProperty);
+                testExpectations(testProperty, cssStyle, testElement, "after setProperty", "blue", testProperty + ":blue;", "", 1, testProperty);
             }
 
             if (testProperty) {
                 cssStyle.setProperty(testProperty, "pink", 'important');
-                testExpectations(testProperty, cssStyle, testElement, "after setProperty important", "pink", testProperty + ": pink !important;", "important", 1, testProperty);
+                testExpectations(testProperty, cssStyle, testElement, "after setProperty important", "pink", testProperty + ":pink !important;", "important", 1, testProperty);
             }
 
             cssStyle.removeProperty(testProperty);
             testExpectations(testProperty, cssStyle, testElement, "after removeProperty", "", "", "", 0, "");
 
             var cssText = testProperty + (testImportant ? ":green!important;" : ":green;");
-            var expectedCssText = testProperty + (testImportant ? ": green !important;" : ": green;");
+            var expectedCssText = testProperty + (testImportant ? ":green !important;" : ":green;");
             cssStyle.cssText = cssText;
             testExpectations(testProperty, cssStyle, testElement, "after setting cssText", "green", expectedCssText, testImportant ? "important" : "", 1, testProperty);
         }


### PR DESCRIPTION
When serializing custom properties, they must be preserved exactly as authored (https://crbug.com/661854). variable-invalidation.html added additional whitespace to the expectation, going against this part of the spec. This change makes the test pass in Firefox, Chrome, and Edge.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
