### PR TITLE
Handle the case when MANIFEST.json is invalid JSON

### DIFF
--- a/tools/manifest/manifest.py
+++ b/tools/manifest/manifest.py
@@ -225,6 +225,9 @@ def load(tests_root, manifest):
                 rv = Manifest.from_json(tests_root, json.load(f))
         except IOError:
             return None
+        except ValueError:
+            logger.warning("%r may be corrupted", manifest)
+            return None
         return rv
 
     return Manifest.from_json(tests_root, json.load(manifest))


### PR DESCRIPTION
I don't know how I got into this situation (probably hit ctrl-C at the wrong time) but I did and it was unclear how to get out. It presents as a ValueError with no useful info.

Update the code to handle ValueError to log a warning and cause a full regen of the manifest.

Also reported in https://crbug.com/822041

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10323)
<!-- Reviewable:end -->
