### PR TITLE
Add tests to check that the User-Agent header is set for XHR requests

### DIFF
--- a/xhr/header-user-agent-async.htm
+++ b/xhr/header-user-agent-async.htm
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that async requests (both OPTIONS preflight and regular) are sent with the User-Agent header</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script type="text/javascript">
+  async_test((test) => {
+    let xhr = new XMLHttpRequest;
+    xhr.open("GET", get_host_info().HTTP_REMOTE_ORIGIN + "/xhr/resources/header-user-agent.py");
+    xhr.setRequestHeader("x-test", "foobar");
+
+    xhr.onerror = test.unreached_func("Unexpected error");
+
+    xhr.onload = test.step_func_done(() => {
+      assert_equals(xhr.responseText, "PASS");
+    });
+
+    xhr.send();
+  }, "Async request has User-Agent header");
+</script>
+</body>
+</html>

--- a/xhr/header-user-agent-sync.htm
+++ b/xhr/header-user-agent-sync.htm
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that sync requests (both OPTIONS preflight and regular) are sent with the User-Agent header</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
+</head>
+<body>
+<script type="text/javascript">
+  test(function() {
+    let xhr = new XMLHttpRequest;
+    xhr.open("post", get_host_info().HTTP_REMOTE_ORIGIN + "/xhr/resources/header-user-agent.py", false);
+    xhr.setRequestHeader("x-test", "foobar");
+    xhr.send();
+    assert_equals(xhr.responseText, "PASS");
+  }, "Sync request has User-Agent header");
+</script>
+</body>
+</html>

--- a/xhr/resources/header-user-agent.py
+++ b/xhr/resources/header-user-agent.py
@@ -1,0 +1,15 @@
+def main(request, response):
+    response.headers.set("Access-Control-Allow-Origin", "*")
+    response.headers.set("Access-Control-Max-Age", 0)
+    response.headers.set('Access-Control-Allow-Headers', "x-test")
+
+    if request.method == "OPTIONS":
+        if not request.headers.get("User-Agent"):
+            response.content = "FAIL: User-Agent header missing in preflight request."
+            response.status = 400
+    else:
+        if request.headers.get("User-Agent"):
+            response.content = "PASS"
+        else:
+            response.content = "FAIL: User-Agent header missing in request"
+            response.status = 400


### PR DESCRIPTION
The spec for [HTTP-network-or-cache fetch](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch)  (Step 11) specifies that the `User-Agent` header should be set by the user agent. These tests check that this header exists.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
