### PR TITLE
[css-multicol] column-gap normal is 1em per spec now

### DIFF
--- a/css/css-multicol/multicol-gap-001.xht
+++ b/css/css-multicol/multicol-gap-001.xht
@@ -6,8 +6,8 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-08-05 -->
   <link rel="help" href="http://www.w3.org/TR/css3-multicol/#column-gap" title="4.1. 'column-gap'" />
   <link rel="match" href="multicol-gap-001-ref.xht" />
-  <meta name="flags" content="ahem may" />
-  <meta name="assert" content="This test checks that the 'normal' column gap is 1em, which is suggested -- and not prescribed -- by the specification." />
+  <meta name="flags" content="ahem" />
+  <meta name="assert" content="This test checks that the 'normal' column gap is 1em." />
   <style type="text/css"><![CDATA[
   div
   {

--- a/css/css-multicol/multicol-gap-003.xht
+++ b/css/css-multicol/multicol-gap-003.xht
@@ -6,7 +6,7 @@
   <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2013-08-05 -->
   <link rel="help" href="http://www.w3.org/TR/css3-multicol/#column-gap" title="4.1. 'column-gap'" />
   <link rel="match" href="multicol-gap-002-ref.xht" />
-  <meta name="flags" content="ahem may" />
+  <meta name="flags" content="ahem" />
   <style type="text/css"><![CDATA[
   div
   {


### PR DESCRIPTION
The CSSWG resolved to make it explicit in the spec in issue w3c/csswg-drafts#2145.
The reason is that there's interop between all UAs regarding this.

These 2 tests were marked as optional "may" but they're not optional anymore.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
