### PR TITLE
Check for circular interface deps in idlharness.js

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -694,6 +694,8 @@ IdlArray.prototype.test = function()
             if (!lhs_is_interface) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${lhs} is not an interface.`);
             if (!rhs_is_interface) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${rhs} is not an interface.`);
         }
+        // Check for circular dependencies.
+        member.get_inheritance_stack();
     }
 
     Object.getOwnPropertyNames(this.members).forEach(function(memberName) {
@@ -1124,6 +1126,10 @@ IdlInterface.prototype.get_inheritance_stack = function() {
         var base = this.array.members[idl_interface.base];
         if (!base) {
             throw new Error(idl_interface.type + " " + idl_interface.base + " not found (inherited by " + idl_interface.name + ")");
+        } else if (stack.indexOf(base) > -1) {
+            stack.push(base);
+            let dep_chain = stack.map(i => i.name).join(',');
+            throw new IdlHarnessError(`${this.name} has a circular dependency: ${dep_chain}`);
         }
         idl_interface = base;
         stack.push(idl_interface);
@@ -1684,7 +1690,6 @@ IdlInterface.prototype.test_self = function()
                           this.name + '.prototype should not have @@unscopables');
         }
     }.bind(this), this.name + ' interface: existence and properties of interface prototype object\'s @@unscopables property');
-
 };
 
 //@}

--- a/resources/test/tests/idlharness/IdlInterface/get_inheritance_stack.html
+++ b/resources/test/tests/idlharness/IdlInterface/get_inheritance_stack.html
@@ -29,6 +29,13 @@
         var A = idl.members["A"];
         assert_array_equals(A.get_inheritance_stack().map(i => i.name), ["A", "B", "C"]);
     }, 'should return an array of inherited interfaces in order of inheritance, starting with itself.');
+
+    test(function () {
+        var idl = new IdlArray();
+        idl.add_untested_idls('interface A : B { };');
+        idl.add_untested_idls('interface B : A { };');
+        idl.assert_throws('A has a circular dependency: A,B,A', i => i.test());
+    }, 'should throw when inheritance is circular');
 </script>
 </body>
 </html>


### PR DESCRIPTION
Related to https://github.com/w3c/web-platform-tests/pull/10285 and https://github.com/w3c/web-platform-tests/issues/10214

Throws an exception when a circular dep is encountered while building the inheritance stack (previously just looped infinitely 😩) and explicitly calls the `get_inheritance_stack` method to test for this as part of `IdlArray.test()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10334)
<!-- Reviewable:end -->
