### PR TITLE
Fix the unit test for affected tests

### DIFF
--- a/tools/wpt/tests/test_wpt.py
+++ b/tools/wpt/tests/test_wpt.py
@@ -183,13 +183,14 @@ def test_files_changed_ignore_rules():
 def test_tests_affected(capsys, manifest_dir):
     # This doesn't really work properly for random commits because we test the files in
     # the current working directory for references to the changed files, not the ones at
-    # that specific commit. But we can at least test it returns something sensible
-    commit = "9047ac1d9f51b1e9faa4f9fad9c47d109609ab09"
+    # that specific commit. But we can at least test it returns something sensible.
+    # The test will fail if the file we assert is renamed, so we choose a stable one.
+    commit = "3a055e818218f548db240c316654f3cc1aeeb733"
     with pytest.raises(SystemExit) as excinfo:
         wpt.main(argv=["tests-affected", "--metadata", manifest_dir, "%s~..%s" % (commit, commit)])
     assert excinfo.value.code == 0
     out, err = capsys.readouterr()
-    assert "html/browsers/offline/appcache/workers/appcache-worker.html" in out
+    assert "infrastructure/reftest-wait.html" in out
 
 
 @pytest.mark.slow


### PR DESCRIPTION
The root cause is that we use the up-to-date manifest and rely on the
files on the head of master, so the test will fail whenever the file we
are asserting is renamed (which unfortunately happened at
bf17459a71ff4d1ea280bae54dd046ecf86e0628).

This PR doesn't fix the root cause, but instead switches to a relatively
stable test file (`infrastructure/reftest-wait.html`). Hopefully this
will hold in the forseeable future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10335)
<!-- Reviewable:end -->
