### PR TITLE
Improve idlharness error message for exposure test

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2442,6 +2442,7 @@ IdlInterface.prototype.test_interface_of = function(desc, obj, exception, expect
         }
         if (!exposed_in(exposure_set(member, this.exposureSet))) {
             test(function() {
+                assert_equals(exception, null, "Unexpected exception when evaluating object");
                 assert_false(member.name in obj);
             }.bind(this), this.name + " interface: " + desc + ' must not have property "' + member.name + '"');
             continue;


### PR DESCRIPTION
When `obj` is not created successfully, there's an error like

> Cannot use 'in' operator to search for [member.name] in undefined

NB: I'm not a fan of having each sub-test re-test the same thing, but this is at least _consistent_ with the other code..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10336)
<!-- Reviewable:end -->
