### PR TITLE
Improve error message for exposure_set test

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -554,8 +554,9 @@ IdlArray.prototype.is_json_type = function(type)
 
 function exposure_set(object, default_set) {
     var exposed = object.extAttrs.filter(function(a) { return a.name == "Exposed" });
-    if (exposed.length > 1 || exposed.length < 0) {
-        throw new IdlHarnessError("Unexpected Exposed extended attributes on " + memberName + ": " + exposed);
+    if (exposed.length > 1) {
+        throw new IdlHarnessError(
+            `Multiple 'Exposed' extended attributes on ${object.name}`);
     }
 
     if (exposed.length === 0) {


### PR DESCRIPTION
`memberName` is undefined; error message is (was) `ReferenceError: memberName is not defined`.
Clearly supposed to be a check for duplication - `array.length < 0` was a really weird thing to see, though. Spec says it's always non-negative, so deleted that.

Error I see now is 

    "Multiple 'Exposed' extended attributes on Navigator"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10337)
<!-- Reviewable:end -->
