### PR TITLE
Change a const in var in idlharness.js

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -684,7 +684,7 @@ IdlArray.prototype.test = function()
     this["includes"] = {};
 
     // Assert B defined for A : B
-    for (const member of Object.values(this.members).filter(m => m.base)) {
+    for (var member of Object.values(this.members).filter(m => m.base)) {
         const lhs = member.name;
         const rhs = member.base;
         if (!(rhs in this.members)) throw new IdlHarnessError(`${lhs} inherits ${rhs}, but ${rhs} is undefined.`);


### PR DESCRIPTION
See https://github.com/w3c/web-platform-tests/issues/10343#issuecomment-379211826

I know we can't stop progress in WPT just because Servo is stuck in the past,
but let's not make all IDL-related tests fail in it for something that can be
avoided so easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10344)
<!-- Reviewable:end -->
