### PR TITLE
Update variable-presentation-attribute.html per specs

### DIFF
--- a/css/css-variables/variable-presentation-attribute.html
+++ b/css/css-variables/variable-presentation-attribute.html
@@ -52,37 +52,34 @@
 
         let testproperties = [
             { property: "alignment-baseline", valuesToTest:["auto", "baseline", "before-edge", "text-before-edge", "middle", "central", "after-edge", "text-after-edge", "ideographic", "alphabetic", "hanging", "mathematical"], default: "auto" },
-            { property: "baseline-shift", valuesToTest:["baseline", "sub", "super", "13%", "28px"], default: "baseline" },
+            { property: "baseline-shift", valuesToTest:["baseline", "sub", "super", "13%", "28px"], default: "0px" },
             { property: "clip-rule", valuesToTest:["nonzero", "evenodd"], default: "nonzero" },
             { property: "color", valuesToTest:["rgb(128, 0, 128)"], default: "rgb(0, 0, 0)" },
-            { property: "color-interpolation-filters", valuesToTest:["auto", "sRGB", "linearRGB"], default: "" },
+            { property: "color-interpolation-filters", valuesToTest:["auto", "sRGB", "linearRGB"], default: "linearRGB" },
             { property: "cursor", valuesToTest:["auto", "crosshair", "default", "pointer", "move", "e-resize", "ne-resize", "nw-resize", "n-resize", "se-resize", "sw-resize", "s-resize", "w-resize", "text", "wait", "help"], default: "auto" },
             { property: "direction", valuesToTest:["ltr", "rtl"], default: "ltr" },
             { property: "display", valuesToTest:["inline", "block", "list-item", "table", "inline-table", "table-row-group", "table-header-group", "table-footer-group", "table-row", "table-column-group", "table-column", "table-cell", "table-caption", "none"], default: "inline" },
             { property: "dominant-baseline", valuesToTest:["auto", "use-script", "no-change", "reset-size", "ideographic", "alphabetic", "hanging", "mathematical", "central", "middle", "text-after-edge", "text-before-edge"], default: "auto" },
-            { property: "fill", valuesToTest:["red", "url(#gradient) black"], default: "black" },
+            { property: "fill", valuesToTest:["red", "url(#gradient) black"], default: "rgb(0, 0, 0)" },
             { property: "fill-opacity", valuesToTest:["0.8"], default: "1" },
             { property: "fill-rule", valuesToTest:["nonzero", "evenodd"], default: "nonzero" },
             { property: "filter", valuesToTest:["none"], default: "none" },
-            { property: "flood-color", valuesToTest:["currentColor", "green"], default: "" },
+            { property: "flood-color", valuesToTest:["currentColor", "green"], default: "rgb(0, 0, 0)" },
             { property: "flood-opacity", valuesToTest:["0.7"], default: "1" },
-            { property: "font-family", valuesToTest:["Arial", "Times New Roman"], default: "Times New Roman" },
+            { property: "font-family", valuesToTest:["Arial", "Times New Roman"] },
             { property: "font-size", valuesToTest:["31px"], default: "16px" },
             { property: "font-size-adjust", valuesToTest:["22", "none"], default: "none" },
             { property: "font-stretch", valuesToTest:["normal", "ultra-condensed", "extra-condensed", "condensed", "semi-condensed", "semi-expanded", "expanded", "extra-expanded", "ultra-expanded"], default: "normal" },
             { property: "font-style", valuesToTest:["normal", "italic"], default: "normal" },
             { property: "font-weight", valuesToTest:["100", "200", "300", "400", "500", "600", "700", "800", "900"], default: "400" },
-            { property: "glyph-orientation-horizontal", valuesToTest:["13deg"], default: "0deg" },
-            { property: "glyph-orientation-vertical", valuesToTest:["auto", "19deg"], default: "auto" },
-            { property: "kerning", valuesToTest:["auto", "15"], default: "auto" },
             { property: "letter-spacing", valuesToTest:["normal", "21px"], default: "normal" },
-            { property: "lighting-color", valuesToTest:["currentColor", "pink"], default: "" },
+            { property: "lighting-color", valuesToTest:["currentColor", "pink"], default: "rgb(255, 255, 255)" },
             { property: "opacity", valuesToTest:["0.11"], default: "1" },
             { property: "overflow", valuesToTest:["visible", "hidden", "scroll", "auto"], default: "visible" },
             { property: "pointer-events", valuesToTest:["visiblePainted", "visibleFill", "visibleStroke", "visible", "painted", "fill", "stroke", "all", "none"], default: "visiblePainted" },
-            { property: "stop-color", valuesToTest:["currentColor", "maroon"], default: "" },
+            { property: "stop-color", valuesToTest:["currentColor", "maroon"], default: "rgb(0, 0, 0)" },
             { property: "stop-opacity", valuesToTest:["0.225"], default: "1" },
-            { property: "stroke", valuesToTest:["green", "url(#gradient)"], default: "" },
+            { property: "stroke", valuesToTest:["green", "url(#gradient)"], default: "none" },
             { property: "stroke-dasharray", valuesToTest:["none", "2px"], default: "none" },
             { property: "stroke-dashoffset", valuesToTest:["14%", "98px"], default: "0px" },
             { property: "stroke-linecap", valuesToTest:["butt", "round", "square"], default: "butt" },
@@ -94,7 +91,7 @@
             { property: "text-decoration", valuesToTest:["none", "underline", "overline", "line-through"], default: "none" },
             { property: "visibility", valuesToTest:["visible", "hidden", "collapse"], default: "visible" },
             { property: "word-spacing", valuesToTest:["31px"], default: "0px" },
-            { property: "writing-mode", valuesToTest:["lr-tb", "rl-tb"], default: "lr-tb" },
+            { property: "writing-mode", valuesToTest:["lr-tb", "rl-tb"], default: "horizontal-tb" },
         ];
 
         testproperties.forEach(function (testcase) {
@@ -103,9 +100,10 @@
                 let rect = document.createElement("rect");
                 svg.appendChild(rect);
                 let computedStyle = window.getComputedStyle(rect);
-                let expectedDefaultValue = testcase.default ? testcase.default : "";
-                let actualValue = computedStyle.getPropertyValue(testcase.property);
-                assert_equals(actualValue, expectedDefaultValue, "Default value.");
+                if ("default" in testcase) {
+                    let actualValue = computedStyle.getPropertyValue(testcase.property);
+                    assert_equals(actualValue, testcase.default, "Default value.");
+                }
                 rect.style.cssText = testcase.property + ":var(--prop);";
 
                 for (var value of testcase.valuesToTest)


### PR DESCRIPTION
Many tests in variable-presentation-attribute.html went against their relative specs. For most attributes, this change corrects their default values. This change also removes the default value test for `font-family`, since the default value is implementation-dependent.

This change also removes the tests for `glyph-orientation-horizontal`, `glyph-orientation-vertical`, and `kerning`, as these properties have been removed by Chrome and Firefox as they are obsolete.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
