### PR TITLE
Add python handler directory to Python path in wptserve

### DIFF
--- a/tools/wptserve/tests/functional/docroot/subdir/example_module.py
+++ b/tools/wptserve/tests/functional/docroot/subdir/example_module.py
@@ -1,0 +1,2 @@
+def module_function():
+    return [("Content-Type", "text/plain")], "PASS"

--- a/tools/wptserve/tests/functional/docroot/subdir/import_handler.py
+++ b/tools/wptserve/tests/functional/docroot/subdir/import_handler.py
@@ -1,0 +1,5 @@
+import example_module
+
+
+def main(request, response):
+    return example_module.module_function()

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import unittest
 import uuid
 
@@ -228,6 +229,7 @@ class TestJSONHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual({"data": "test data"}, json.load(resp))
 
+
 class TestPythonHandler(TestUsingServer):
     def test_string(self):
         resp = self.request("/test_string.py")
@@ -248,6 +250,17 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("Giraffe", resp.msg)
         self.assertEqual("text/html", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.info()["X-Test"])
+        self.assertEqual("PASS", resp.read())
+
+    def test_import(self):
+        dir_name = os.path.join(doc_root, "subdir")
+        assert dir_name not in sys.path
+        assert "test_module" not in sys.modules
+        resp = self.request("/subdir/import_handler.py")
+        assert dir_name not in sys.path
+        assert "test_module" not in sys.modules
+        self.assertEqual(200, resp.getcode())
+        self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.read())
 
     def test_no_main(self):

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -1,6 +1,7 @@
 import cgi
 import json
 import os
+import sys
 import traceback
 
 from six.moves.urllib.parse import parse_qs, quote, unquote, urljoin
@@ -231,8 +232,11 @@ class PythonScriptHandler(object):
     def __call__(self, request, response):
         path = filesystem_path(self.base_path, request, self.url_base)
 
+        sys_path = sys.path[:]
+        sys_modules = sys.modules.copy()
         try:
             environ = {"__file__": path}
+            sys.path.insert(0, os.path.dirname(path))
             execfile(path, environ, environ)
             if "main" in environ:
                 handler = FunctionHandler(environ["main"])
@@ -242,6 +246,10 @@ class PythonScriptHandler(object):
                 raise HTTPException(500, "No main function in script %s" % path)
         except IOError:
             raise HTTPException(404)
+        finally:
+            sys.path = sys_path
+            sys.modules = sys_modules
+
 
 python_script_handler = PythonScriptHandler()
 


### PR DESCRIPTION
Currently making import of files relative to the handler is tricky
because, unlike in normal Python, the script directory isn't on the
path.

This patch adds it to the path when executing the handler. It also
ensures that any modifications made to the path or to sys.modules are
rolled back after the handler has run.

Fixes #10378


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10397)
<!-- Reviewable:end -->
