### PR TITLE
 Updating WebDriver execute[Async]Script tests for unhandled user prompts 

### DIFF
--- a/webdriver/tests/execute_async_script/user_prompts.py
+++ b/webdriver/tests/execute_async_script/user_prompts.py
@@ -7,52 +7,60 @@ from webdriver import error
 
 def test_handle_prompt_accept(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
-    session.execute_async_script("window.alert('Hello');")
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
+    title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.accept()
 
 
 def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
-    session.execute_async_script("window.alert('Hello');")
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
+    title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.dismiss()
 
 
 def test_handle_prompt_dismiss_and_notify(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss and notify"})}})
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_async_script("window.alert('Hello');")
-    with pytest.raises(error.NoSuchAlertException):
-        session.alert.dismiss()
+        title = session.title
 
 
 def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept and notify"})}})
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_async_script("window.alert('Hello');")
-    with pytest.raises(error.NoSuchAlertException):
-        session.alert.accept()
+        title = session.title
 
 
 def test_handle_prompt_ignore(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "ignore"})}})
-    with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_async_script("window.alert('Hello');")
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
     session.alert.dismiss()
 
 
 def test_handle_prompt_default(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
+    value = session.execute_async_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_async_script("window.alert('Hello');")
+        title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.dismiss()
 
 
 def test_handle_prompt_twice(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
-    session.execute_async_script("window.alert('Hello');window.alert('Bye');")
+    value = session.execute_async_script("window.alert('Hello');window.alert('Bye');")
+    assert value is None
+    session.alert.dismiss()
     # The first alert has been accepted by the user prompt handler, the second one remains.
     # FIXME: this is how browsers currently work, but the spec should clarify if this is the
     #        expected behavior, see https://github.com/w3c/webdriver/issues/1153.

--- a/webdriver/tests/execute_async_script/user_prompts.py
+++ b/webdriver/tests/execute_async_script/user_prompts.py
@@ -29,6 +29,8 @@ def test_handle_prompt_dismiss_and_notify(new_session, add_browser_capabilites):
     assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
         title = session.title
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.dismiss()
 
 
 def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
@@ -37,12 +39,16 @@ def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
     assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
         title = session.title
+    with pytest.raises(error.NoSuchAlertException):
+        session.alert.accept()
 
 
 def test_handle_prompt_ignore(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "ignore"})}})
     value = session.execute_async_script("window.alert('Hello');")
     assert value is None
+    with pytest.raises(error.UnexpectedAlertOpenException):
+        title = session.title
     session.alert.dismiss()
 
 

--- a/webdriver/tests/execute_script/user_prompts.py
+++ b/webdriver/tests/execute_script/user_prompts.py
@@ -7,52 +7,66 @@ from webdriver import error
 
 def test_handle_prompt_accept(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
-    session.execute_script("window.alert('Hello');")
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
+    title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.accept()
 
 
 def test_handle_prompt_dismiss(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss"})}})
-    session.execute_script("window.alert('Hello');")
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
+    title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.dismiss()
 
 
 def test_handle_prompt_dismiss_and_notify(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "dismiss and notify"})}})
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_script("window.alert('Hello');")
+        title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.dismiss()
 
 
 def test_handle_prompt_accept_and_notify(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept and notify"})}})
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_script("window.alert('Hello');")
+        title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.accept()
 
 
 def test_handle_prompt_ignore(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "ignore"})}})
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_script("window.alert('Hello');")
+        title = session.title
     session.alert.dismiss()
 
 
 def test_handle_prompt_default(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({})}})
+    value = session.execute_script("window.alert('Hello');")
+    assert value is None
     with pytest.raises(error.UnexpectedAlertOpenException):
-        session.execute_script("window.alert('Hello');")
+        title = session.title
     with pytest.raises(error.NoSuchAlertException):
         session.alert.dismiss()
 
 
 def test_handle_prompt_twice(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {"alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
-    session.execute_script("window.alert('Hello');window.alert('Bye');")
+    value = session.execute_script("window.alert('Hello');window.alert('Bye');")
+    assert value is None
+    session.alert.dismiss()
     # The first alert has been accepted by the user prompt handler, the second one remains.
     # FIXME: this is how browsers currently work, but the spec should clarify if this is the
     #        expected behavior, see https://github.com/w3c/webdriver/issues/1153.


### PR DESCRIPTION
When the WebDriver specification is modified with the contents of PR 1248
(https://github.com/w3c/webdriver/pull/1248), the behavior of
implementations changes to handle user prompts on the next command after
an executeScript or executeAsyncScript command. This PR modifies the
tests for user prompts for those commands to match the spec behavior.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
