### PR TITLE
Added note about using special keys in send_keys to testdriver docs

### DIFF
--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -45,5 +45,7 @@ Note that if the element that's keys need to be send to does not have
 a unique ID, the document must not have any DOM mutations made
 between the function being called and the promise settling.
 
+To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a list for code points to special keys in the spec (here)[https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions].
+For example, to send the tab key you would send "\uE004".
 
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}


### PR DESCRIPTION
Linked the WebDriver spec showing the codepoints.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
