### PR TITLE
Add backwards compatibility for external_host and host_ip

### DIFF
--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -14,6 +14,8 @@ from .utils import get_port
 _renamed_props = {
     "host": "browser_host",
     "bind_hostname": "bind_address",
+    "external_host": "server_host",
+    "host_ip": "server_host",
 }
 
 


### PR DESCRIPTION
Now we're strict about rejecting invalid configs, we need to add more explicit backwards compatibility to avoid breakage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10409)
<!-- Reviewable:end -->
