### PR TITLE
[cssom] Add a test for mutation records when CSSStyleDeclaration.setPropertyValue is invoked.

### DIFF
--- a/css/cssom/cssstyledeclaration-mutationrecord-001.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-001.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: CSSStyleDeclaration.setPropertyValue queues a mutation record when not actually mutated</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setpropertyvalue">
+<link rel="help" href="https://drafts.csswg.org/cssom/#update-style-attribute-for">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  document.documentElement.style.top = "0px";
+
+  let test = async_test("CSSStyleDeclaration.setPropertyValue queues a mutation record, even if not mutated");
+  let m = new MutationObserver(function(r) {
+    assert_equals(r.length, 1);
+    test.done();
+  });
+
+  m.observe(document.documentElement,  { attributes: true });
+  document.documentElement.style.top = "0px";
+</script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-002.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-002.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: CSSStyleDeclaration.setPropertyValue doesn't queue a mutation record for invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setpropertyvalue">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  let test = async_test("CSSStyleDeclaration.setPropertyValue doesn't queue a mutation record when setting invalid values");
+  let m = new MutationObserver(test.unreached_func("shouldn't queue a mutation record"));
+  m.observe(document.documentElement,  { attributes: true });
+
+  document.documentElement.style.width = "-100px";
+  setTimeout(() => test.done(), 0);
+</script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-002.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-002.html
@@ -11,5 +11,5 @@
   m.observe(document.documentElement,  { attributes: true });
 
   document.documentElement.style.width = "-100px";
-  setTimeout(() => test.done(), 0);
+  requestAnimationFrame(() => test.done());
 </script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-003.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-003.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed, invoked from setPropertyValue</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setpropertyvalue">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  let test = async_test("CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed, invoked from setPropertyValue");
+  document.documentElement.style.top = "0";
+  let m = new MutationObserver(test.unreached_func("shouldn't queue a mutation record"));
+  m.observe(document.documentElement,  { attributes: true });
+
+  document.documentElement.style.width = "";
+  setTimeout(() => test.done(), 0);
+</script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-003.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-003.html
@@ -12,5 +12,5 @@
   m.observe(document.documentElement,  { attributes: true });
 
   document.documentElement.style.width = "";
-  setTimeout(() => test.done(), 0);
+  requestAnimationFrame(() => test.done());
 </script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-004.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-004.html
@@ -12,5 +12,5 @@
   m.observe(document.documentElement,  { attributes: true });
 
   document.documentElement.style.removeProperty("width");
-  setTimeout(() => test.done(), 0);
+  requestAnimationFrame(() => test.done());
 </script>

--- a/css/cssom/cssstyledeclaration-mutationrecord-004.html
+++ b/css/cssom/cssstyledeclaration-mutationrecord-004.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSSOM: CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setpropertyvalue">
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  let test = async_test("CSSStyleDeclaration.removeProperty doesn't queue a mutation record when not actually removed");
+  document.documentElement.style.top = "0";
+  let m = new MutationObserver(test.unreached_func("shouldn't queue a mutation record"));
+  m.observe(document.documentElement,  { attributes: true });
+
+  document.documentElement.style.removeProperty("width");
+  setTimeout(() => test.done(), 0);
+</script>


### PR DESCRIPTION
Even if it doesn't mutate the block.

https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setpropertyvalue always
ends up in https://drafts.csswg.org/cssom/#update-style-attribute-for (step 8),
which calls https://dom.spec.whatwg.org/#concept-element-attributes-set-value,
which does queue a mutation record even if the value doesn't change.

This makes this consistent with `setAttribute("style", getAttribute("style"))`,
for example.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
