### PR TITLE
accname: Updated tests

### DIFF
--- a/accname/description_1.0_combobox-focusable-manual.html
+++ b/accname/description_1.0_combobox-focusable-manual.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Description from content of describedby element</title>
+    <title>Description 1.0 combobox-focusable</title>
     <meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
     <link rel="stylesheet" href="/resources/testharness.css">
     <link rel="stylesheet" href="/wai-aria/scripts/manual.css">
@@ -22,7 +22,7 @@
                   "property",
                   "description",
                   "is",
-                  "My name is Eli the weird. (QED) Where are my marbles?"
+                  ""
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXHelp",
                   "is",
-                  "My name is Eli the weird. (QED) Where are my marbles?"
+                  ""
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accDescription",
                   "is",
-                  "My name is Eli the weird. (QED) Where are my marbles?"
+                  ""
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Description",
                   "is",
-                  "My name is Eli the weird. (QED) Where are my marbles?"
+                  ""
                ]
             ]
          },
@@ -54,38 +54,16 @@
          "type" : "test"
       }
    ],
-   "title" : "Description from content of describedby element"
+   "title" : "Description 1.0 combobox-focusable"
 }
 
     ) ;
     </script>
   </head>
   <body>
-  <p>This test examines the ARIA properties for Description from content of describedby element.</p>
-    <style>
-    .hidden { display: none; }
-  </style>
-  <input id="test" type="text" aria-label="Important stuff" aria-describedby="descId" />
-  <div>
-    <div id="descId">
-      <span aria-hidden="true"><i> Hello, </i></span>
-      <span>My</span> name is
-      <div><img src="file.jpg" title="Bryan" alt="" role="presentation" /></div>
-      <span role="presentation" aria-label="Eli">
-        <span aria-label="Garaventa">Zambino</span>
-      </span>
-      <span>the weird.</span>
-      (<span>Q</span><span>E</span><span>D</span>)
-      <span class="hidden"><i><b>and don't you forget it.</b></i></span>
-      <table>
-        <tr>
-          <td>Where</td>
-          <td style="visibility:hidden;"><div>in</div></td>
-          <td><div style="display:none;">the world</div></td>
-          <td>are my marbles?</td>
-        </tr>
-      </table>
-    </div>
+  <p>This test examines the ARIA properties for Description 1.0 combobox-focusable.</p>
+    <div id="test" role="combobox" tabindex="0" title="Choose your language.">
+    <span> English </span>
   </div>
 
   <div id="manualMode"></div>

--- a/accname/description_from_content_of_describedby_element_which_is_hidden-manual.html
+++ b/accname/description_from_content_of_describedby_element_which_is_hidden-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "description",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXHelp",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accDescription",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Description",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ]
          },
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Description from content of describedby element which is hidden.</p>
-    <div>
+    <style>
+    .hidden { display: none; }
+  </style>
+  <div>
     <input id="test" type="text" aria-labelledby="lbl1 lbl2" aria-describedby="descId" />
     <span>
       <span aria-hidden="true" id="lbl1">Important</span>

--- a/accname/name_1.0_combobox-focusable-manual.html
+++ b/accname/name_1.0_combobox-focusable-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "Choose your language. English"
+                  "Choose your language."
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "Choose your language. English"
+                  "Choose your language."
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "Choose your language. English"
+                  "Choose your language."
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "Choose your language. English"
+                  "Choose your language."
                ]
             ]
          },

--- a/accname/name_file-label-inline-hidden-elements-manual.html
+++ b/accname/name_file-label-inline-hidden-elements-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "246810"
+                  "2 4 6 8 10"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "246810"
+                  "2 4 6 8 10"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "246810"
+                  "2 4 6 8 10"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "246810"
+                  "2 4 6 8 10"
                ]
             ]
          },

--- a/accname/name_from_content-manual.html
+++ b/accname/name_from_content-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ]
          },
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Name from content.</p>
-    <div id="test" role="link" tabindex="0">
+    <style>
+    .hidden { display: none; }
+  </style>
+  <div id="test" role="link" tabindex="0">
     <span aria-hidden="true"><i> Hello, </i></span>
     <span>My</span> name is
     <div><img src="file.jpg" title="Bryan" alt="" role="presentation" /></div>

--- a/accname/name_from_content_of_label-manual.html
+++ b/accname/name_from_content_of_label-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ]
          },
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Name from content of label.</p>
-    <input type="text" id="test" />
+    <style>
+    .hidden { display: none; }
+  </style>
+  <input type="text" id="test" />
   <label for="test" id="label">
     <span aria-hidden="true"><i> Hello, </i></span>
     <span>My</span> name is

--- a/accname/name_from_content_of_labelledby_element-manual.html
+++ b/accname/name_from_content_of_labelledby_element-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "My name is Garaventa the weird. (QED) Where are my marbles?"
+                  "My name is Eli the weird. (QED) Where are my marbles?"
                ]
             ]
          },
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Name from content of labelledby element.</p>
-    <input id="test" type="text" aria-labelledby="lblId" />
+    <style>
+    .hidden { display: none; }
+  </style>
+  <input id="test" type="text" aria-labelledby="lblId" />
   <div id="lblId" >
     <span aria-hidden="true"><i> Hello, </i></span>
     <span>My</span> name is

--- a/accname/name_from_content_of_labelledby_elements_one_of_which_is_hidden-manual.html
+++ b/accname/name_from_content_of_labelledby_elements_one_of_which_is_hidden-manual.html
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Name from content of labelledby elements one of which is hidden.</p>
-    <div>
+    <style>
+    .hidden { display: none; }
+  </style>
+  <div>
     <input id="test" type="text" aria-labelledby="lbl1 lbl2" aria-describedby="descId" />
     <span>
       <span aria-hidden="true" id="lbl1">Important</span>

--- a/accname/name_link-mixed-content-manual.html
+++ b/accname/name_link-mixed-content-manual.html
@@ -22,7 +22,7 @@
                   "property",
                   "name",
                   "is",
-                  "My name is Garaventa the weird. (QED)"
+                  "My name is Eli the weird. (QED)"
                ]
             ],
             "AXAPI" : [
@@ -30,7 +30,7 @@
                   "property",
                   "AXDescription",
                   "is",
-                  "My name is Garaventa the weird. (QED)"
+                  "My name is Eli the weird. (QED)"
                ]
             ],
             "IAccessible2" : [
@@ -38,7 +38,7 @@
                   "property",
                   "accName",
                   "is",
-                  "My name is Garaventa the weird. (QED)"
+                  "My name is Eli the weird. (QED)"
                ]
             ],
             "UIA" : [
@@ -46,7 +46,7 @@
                   "property",
                   "Name",
                   "is",
-                  "My name is Garaventa the weird. (QED)"
+                  "My name is Eli the weird. (QED)"
                ]
             ]
          },
@@ -62,7 +62,10 @@
   </head>
   <body>
   <p>This test examines the ARIA properties for Name link-mixed-content.</p>
-    <div id="test" role="link" tabindex="0">
+    <style>
+    .hidden { display: none; }
+  </style>
+  <div id="test" role="link" tabindex="0">
     <span aria-hidden="true"><i> Hello, </i></span>
     <span>My</span> name is
     <div><img src="file.jpg" title="Bryan" alt="" role="presentation" /></div>


### PR DESCRIPTION
* Add missing "hidden" style from several tests
* Fix expectations for several tests with presentation role used on img
* Fix bogus expectations on name and description calculations with combobox
* Fix incorrect whitespace in expectations for name from content with spans
* Add test for which coverage was missing

<!-- Reviewable:start -->

<!-- Reviewable:end -->
