### PR TITLE
Test vertical tab for base64

### DIFF
--- a/fetch/data-urls/resources/base64.json
+++ b/fetch/data-urls/resources/base64.json
@@ -49,6 +49,7 @@
   ["ab=c=", null],
   ["abc=d", null],
   ["abc=d=", null],
+  ["ab\u000Bcd", null],
   ["ab\tcd", [105, 183, 29]],
   ["ab\ncd", [105, 183, 29]],
   ["ab\fcd", [105, 183, 29]],


### PR DESCRIPTION
Apparently Rust's base64 crate strips this, so it would be good to test. Safari is also an outlier here.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
