### PR TITLE
Fetch: expand Response.redirect() assertions

### DIFF
--- a/fetch/api/response/response-static-redirect.html
+++ b/fetch/api/response/response-static-redirect.html
@@ -14,16 +14,24 @@
       var url = "http://test.url:1234/";
       test(function() {
         redirectResponse = Response.redirect(url);
+        assert_equals(redirectResponse.type, "default");
+        assert_false(redirectResponse.redirected);
+        assert_false(redirectResponse.ok);
         assert_equals(redirectResponse.status, 302, "Default redirect status is 302");
         assert_equals(redirectResponse.headers.get("Location"), url,
           "redirected response has Location header with the correct url");
+        assert_equals(redirectResponse.statusText, "");
       }, "Check default redirect response");
 
-      var redirectStatus = [301, 302, 303, 307, 308];
-      redirectStatus.forEach(function(status) {
+      [301, 302, 303, 307, 308].forEach(function(status) {
         test(function() {
           redirectResponse = Response.redirect(url, status);
+          assert_equals(redirectResponse.type, "default");
+          assert_false(redirectResponse.redirected);
+          assert_false(redirectResponse.ok);
           assert_equals(redirectResponse.status, status, "Redirect status is " + status);
+          assert_equals(redirectResponse.headers.get("Location"), url);
+          assert_equals(redirectResponse.statusText, "");
         }, "Check response returned by static method redirect(), status = " + status);
       });
 


### PR DESCRIPTION
Needed for https://github.com/whatwg/fetch/issues/664 and https://github.com/whatwg/fetch/pull/600.

Safari already passes these. Chrome and Firefox have `statusText` returning `OK`.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
