### PR TITLE
Use version-specific prefs files when running Firefox

### DIFF
--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -201,8 +201,7 @@ Consider installing certutil via your OS package manager or directly.""")
                 kwargs["test_types"].remove("wdspec")
 
         if kwargs["prefs_root"] is None:
-            print("Downloading gecko prefs")
-            prefs_root = self.browser.install_prefs(self.venv.path)
+            prefs_root = self.browser.install_prefs(kwargs["binary"], self.venv.path)
             kwargs["prefs_root"] = prefs_root
 
 


### PR DESCRIPTION
Firefox requires a prefs file to be loaded to ensure that it doesn't
make external network connections, and to make sure that other
settings are appropriate for testing. Previously we always used the
version of the prefs file from master, which is usually fine for
nightly builds, but doesn't work with release builds if it happens
that a pref changed.

This change uses the correct release version of the prefs file for
firefox releases and beta versions. It continues to use the master
version for any nightly build; this could be fixed in some cases if we
are able to access the actual commit hash used to build Firefox, but
probably isn't too bad an approximation.

The caching algorithm was changed so that release versions of the
prefs are cached forever, and the nightly version is updated once per
day (although this doesn't quite match the nightly release cadence,
it's only going to fail in edge cases where the prefs were changed in
the file, but the nightly version was not yet updated, of vice-versa.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10443)
<!-- Reviewable:end -->
