### PR TITLE
Accept variation in serialization of 'background'

### DIFF
--- a/css/css-backgrounds/parsing/background-valid.html
+++ b/css/css-backgrounds/parsing/background-valid.html
@@ -12,9 +12,17 @@
 </head>
 <body>
 <script>
-// For <final-bg-layer>, implementations serialize <‘background-color’> after <bg-image>, contrary to spec.
-// Safari removes quotes.
-test_valid_value("background", '1px 2px / 3px 4px space round fixed border-box padding-box, red url("https://example.com/")', ['1px 2px / 3px 4px space round fixed border-box padding-box, url("https://example.com/") red', '1px 2px / 3px 4px space round fixed border-box padding-box, url(https://example.com/) red']);
+// Background serialization varies across browsers. https://github.com/w3c/csswg-drafts/issues/418
+
+test_valid_value("background",
+  'url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box', [
+  'url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box, rgb(5, 6, 7) url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box', // spec
+  'url("https://example.com/") local space round 1px 2px / 3px 4px padding-box content-box, url("https://example.com/") local space round 1px 2px / 3px 4px padding-box content-box rgb(5, 6, 7)', // Edge
+  'url("https://example.com/") space round local 1px 2px / 3px 4px padding-box content-box, rgb(5, 6, 7) url("https://example.com/") space round local 1px 2px / 3px 4px padding-box content-box', // Firefox
+  'url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box, url("https://example.com/") 1px 2px / 3px 4px space round local padding-box content-box rgb(5, 6, 7)', // Blink
+  'url(https://example.com/) 1px 2px / 3px 4px space round local padding-box content-box, url(https://example.com/) 1px 2px / 3px 4px space round local padding-box content-box rgb(5, 6, 7)' // WebKit omits quotes - https://bugs.webkit.org/show_bug.cgi?id=28869
+]);
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Serialization of the CSS property 'background' varies across browsers.

There is an open spec issue:
https://github.com/w3c/csswg-drafts/issues/418

Until the issue is resolved, we accept a variety of serializations.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
