### PR TITLE
Correct serialization of URL in background-332.html

### DIFF
--- a/css/css-backgrounds/background-332.html
+++ b/css/css-backgrounds/background-332.html
@@ -22,8 +22,8 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-image"),
-                'url("' + new URL("support/60x60-green.png", window.location.href).href + '")', "background specified value for background-image");
-        }, "background_specified_image");
+                'url("' + new URL("support/60x60-green.png", window.location.href).href + '")');
+        }, "Computed value for background-image after setting background shorthand");
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-position"),

--- a/css/css-backgrounds/background-332.html
+++ b/css/css-backgrounds/background-332.html
@@ -22,7 +22,7 @@
 
         test(function() {
             assert_equals(cs.getPropertyValue("background-image"),
-                "url(support/60x60-green.png)", "background specified value for background-image");
+                'url("' + new URL("support/60x60-green.png", window.location.href).href + '")', "background specified value for background-image");
         }, "background_specified_image");
 
         test(function() {


### PR DESCRIPTION
According to https://drafts.csswg.org/cssom/#serialize-a-url, the serialization of a URL always includes double-quotes, and per https://drafts.csswg.org/css-values/#relative-urls, if a URL appears in a computed style, it is resolved to an absolute URL. Adjust `background-332.html` to match the spec.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
