### PR TITLE
Fixed config.json not being used in TestEnvironment

### DIFF
--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -135,6 +135,7 @@ class TestEnvironment(object):
 
     def load_config(self):
         default_config_path = os.path.join(serve_path(self.test_paths), "config.default.json")
+        override_path = os.path.join(serve_path(self.test_paths), "config.json")
 
         with open(default_config_path) as f:
             default_config = json.load(f)
@@ -146,6 +147,12 @@ class TestEnvironment(object):
             "https": [8443],
             "ws": [8888]
         }
+
+        if os.path.exists(override_path):
+            with open(override_path) as f:
+                override_obj = json.load(f)
+            config.update(override_obj)
+
         config.check_subdomains = False
         config.ssl = {}
 


### PR DESCRIPTION
Added a check in the TestEnvironment load_config so the config.json overrides the
default config when present.

Closes https://github.com/w3c/web-platform-tests/issues/8181

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10494)
<!-- Reviewable:end -->
