### PR TITLE
[wptrunner] Install Ahem in Sauce Labs Windows VM

### DIFF
--- a/fonts/README.md
+++ b/fonts/README.md
@@ -1,2 +1,6 @@
 This directory only contains auxiliary font files used by other tests. See
 /css-fonts for tests covering the CSS Fonts Module specification.
+
+The font named `Ahem.ttf` is referenced from the project documentation and the
+CLI's scripts for provisioning virtual machines provided by Sauce Labs. If that
+file is re-located, the references should be updated accordingly.

--- a/tools/wptrunner/wptrunner/browsers/sauce_setup/edge-prerun.bat
+++ b/tools/wptrunner/wptrunner/browsers/sauce_setup/edge-prerun.bat
@@ -1,2 +1,9 @@
 @echo off
 reg add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge\New Windows" /v "PopupMgr" /t REG_SZ /d no
+
+
+REM Download and install the Ahem font
+REM - https://wiki.saucelabs.com/display/DOCS/Downloading+Files+to+a+Sauce+Labs+Virtual+Machine+Prior+to+Testing
+REM - https://superuser.com/questions/201896/how-do-i-install-a-font-from-the-windows-command-prompt
+bitsadmin.exe /transfer "JobName" https://github.com/w3c/web-platform-tests/raw/master/fonts/Ahem.ttf "%WINDIR%\Fonts\Ahem.ttf"
+reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts" /v "Ahem (TrueType)" /t REG_SZ /d Ahem.ttf /f

--- a/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
+++ b/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically -bool true

--- a/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
+++ b/tools/wptrunner/wptrunner/browsers/sauce_setup/safari-prerun.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+defaults write com.apple.Safari com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically -bool true


### PR DESCRIPTION
In gh-10491, @gsnedders [suggested](https://github.com/w3c/web-platform-tests/pull/10491#discussion_r181912073):

> Can we download files over the tunnel? Does the tunnel already exist at the point the prerun script runs? Because if it does, then we could just download http://web-platform.test:8000/fonts/Ahem.ttf, which would be the right version for the revision being run?

That sounded like a great idea ([although we would have to construct the URL based on the relevant `env_config` values](https://github.com/w3c/web-platform-tests/commit/0fdf04d1a851e7717d03512533a9f9548c29a8aa)), and I almost included it here. However, the "prerun" script is currently uploaded with the same file name for every test execution. That would cause confusing problems if two test execution tasks used different configurations but the same Sauce Labs account. That might seem unlikely, but it may actually occur on a regular basis in http://builds.wpt.fyi fairly soon.

I have some thoughts on how we can address that problem, but I recommend we move forward with this simple solution for now because it can only improve result accuracy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10499)
<!-- Reviewable:end -->
