### PR TITLE
Don't wrap HTTPExceptions in FunctionHandler.__call__().

### DIFF
--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -260,6 +260,8 @@ class FunctionHandler(object):
     def __call__(self, request, response):
         try:
             rv = self.func(request, response)
+        except HTTPException:
+            raise
         except Exception:
             msg = traceback.format_exc()
             raise HTTPException(500, message=msg)


### PR DESCRIPTION
Extracted from https://github.com/w3c/web-platform-tests/pull/6792.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10505)
<!-- Reviewable:end -->
