### PR TITLE
URL.createObjectURL should not work with MediaStream

### DIFF
--- a/mediacapture-streams/MediaStream-MediaElement-preload-none-manual.https.html
+++ b/mediacapture-streams/MediaStream-MediaElement-preload-none-manual.https.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
-<!-- Copyright © 2016 Chromium authors and World Wide Web Consortium, (Massachusetts Institute of Technology, ERCIM, Keio University, Beihang). -->
 <html>
     <head>
-        <title>Test that the HTMLMediaElement preload 'none' attribute value is ignored for MediaStream used as srcObject and MediaStream object URLs used as src.</title>>
+        <title>Test that the HTMLMediaElement preload 'none' attribute value is ignored for MediaStream used as srcObject and MediaStream object URLs used as src.</title>
         <link rel="author" title="Matthew Wolenetz" href="mailto:wolenetz@chromium.org"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
     </head>
     <body>
         <p class="instructions">When prompted, accept to share your audio and video streams.</p>
-        <h1 class="instructions">Description</h1>
         <p class="instructions">This test checks that the HTMLMediaElement preload 'none' attribute value is ignored for MediaStream used as srcObject and MediaStream object URLs used as src.</p>
+        <div id=log></div>
 
         <audio preload="none"></audio>
         <video preload="none"></video>
@@ -40,14 +39,10 @@
                 navigator.mediaDevices.getUserMedia({audio:true})
                   .then(t.step_func(function(stream)
                   {
-                      testPreloadNone(t, aud, t.step_func(function()
-                      {
-                          aud.src = URL.createObjectURL(stream);
-                          t.add_cleanup(function() { URL.revokeObjectURL(aud.src); });
-                      }));
+                      testPreloadNone(t, aud, t.step_func(function() { aud.srcObject = stream; }));
                   }),
                   t.unreached_func("getUserMedia error callback was invoked."));
-            }, "Test that preload 'none' is ignored for MediaStream object URL used as src");
+            }, "Test that preload 'none' is ignored for MediaStream object URL used as srcObject for audio");
 
             async_test(function(t)
             {
@@ -57,7 +52,7 @@
                   {
                       testPreloadNone(t, vid, t.step_func(function() { vid.srcObject = stream; }));
                   }), t.unreached_func("getUserMedia error callback was invoked."));
-            }, "Test that preload 'none' is ignored for MediaStream used as srcObject");
+            }, "Test that preload 'none' is ignored for MediaStream used as srcObject for video");
         </script>
     </body>
 </html>

--- a/mediacapture-streams/historical.html
+++ b/mediacapture-streams/historical.html
@@ -17,6 +17,7 @@ test(function() {
 }, "navigator.mozGetUserMedia should not exist");
 
 test(() => {
-  assert_throws(new TypeError(), () => URL.createObjectURL(new MediaStream()));
+  const mediaStream = new MediaStream();
+  assert_throws(new TypeError(), () => URL.createObjectURL(mediaStream));
 }, "Passing MediaStream to URL.createObjectURL() should throw");
 </script>

--- a/mediacapture-streams/historical.html
+++ b/mediacapture-streams/historical.html
@@ -15,4 +15,8 @@ test(function() {
 test(function() {
   assert_false("mozGetUserMedia" in navigator);
 }, "navigator.mozGetUserMedia should not exist");
+
+test(() => {
+  assert_throws(new TypeError(), () => URL.createObjectURL(new MediaStream()));
+}, "Passing MediaStream to URL.createObjectURL() should throw");
 </script>


### PR DESCRIPTION
Change the one existing test to no longer rely on it (and clearly mark it as manual) and add an entry to historical.html for it.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
