### PR TITLE
Avoid FutureWarnings in test_sourcefile.py.

### DIFF
--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -395,7 +395,7 @@ def test_testharness_svg():
     assert not s.name_is_worker
     assert not s.name_is_reference
 
-    assert s.root
+    assert s.root is not None
     assert s.content_is_testharness
 
     assert items(s) == [("testharness", "/" + filename)]
@@ -424,7 +424,7 @@ def test_relative_testharness_svg():
     assert not s.name_is_worker
     assert not s.name_is_reference
 
-    assert s.root
+    assert s.root is not None
     assert not s.content_is_testharness
 
     assert items(s) == []


### PR DESCRIPTION
These lines of code triggered the following warning:

> FutureWarning: The behavior of this method will change in future versions.
> Use specific 'len(elem)' or 'elem is not None' test instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10518)
<!-- Reviewable:end -->
