### PR TITLE
[wptrunner] Re-enable secure WebSocket server

### DIFF
--- a/infrastructure/assumptions/wpt-server-http.sub.html
+++ b/infrastructure/assumptions/wpt-server-http.sub.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html>
+  <head>
+    <title>WPT Server checker</title>
+    <meta charset="utf-8" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+</body>
+<body>
+<script>
+function check(protocol, domain, port, done) {
+  var url = protocol + '://' + domain + ':' + port + '/media/1x1-green.png';
+  var img = document.createElement('img');
+  img.setAttribute('src', url);
+  img.style.display = 'none';
+  img.onerror = function() {
+    done(false);
+  };
+  img.onload = function() {
+    done(true);
+  };
+
+  document.body.appendChild(img);
+}
+
+async_test(function(t) {
+  check('http', '{{browser_host}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, no subdomain, port #1');
+
+async_test(function(t) {
+  check('http', '{{browser_host}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, no subdomain, port #2');
+
+async_test(function(t) {
+  check('http', '{{domains[www]}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #1, port #1');
+
+async_test(function(t) {
+  check('http', '{{domains[www]}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #1, port #2');
+
+async_test(function(t) {
+  check('http', '{{domains[www1]}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #2, port #1');
+
+async_test(function(t) {
+  check('http', '{{domains[www1]}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #2, port #2');
+
+async_test(function(t) {
+  check('http', '{{domains[www2]}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #3, port #1');
+
+async_test(function(t) {
+  check('http', '{{domains[www2]}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, www subdomain #3, port #2');
+
+async_test(function(t) {
+  check('http', '{{domains[élève]}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, punycode subdomain #1, port #1');
+
+async_test(function(t) {
+  check('http', '{{domains[élève]}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, punycode subdomain #1, port #2');
+
+async_test(function(t) {
+  check('http', '{{domains[天気の良い日]}}', {{ports[http][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, punycode subdomain #2, port #1');
+
+async_test(function(t) {
+  check('http', '{{domains[天気の良い日]}}', {{ports[http][1]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTP protocol, punycode subdomain #2, port #2');
+
+async_test(function(t) {
+  check('https', '{{browser_host}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, no subdomain');
+
+async_test(function(t) {
+  check('https', '{{domains[www]}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, www subdomain #1');
+
+async_test(function(t) {
+  check('https', '{{domains[www1]}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, www subdomain #2');
+
+async_test(function(t) {
+  check('https', '{{domains[www2]}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, www subdomain #3');
+
+async_test(function(t) {
+  check('https', '{{domains[élève]}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, punycode subdomain #1');
+
+async_test(function(t) {
+  check('https', '{{domains[天気の良い日]}}', {{ports[https][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'HTTPS protocol, punycode subdomain #2');
+</script>
+</body>
+</html>

--- a/infrastructure/assumptions/wpt-server-websocket.sub.html
+++ b/infrastructure/assumptions/wpt-server-websocket.sub.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html>
+  <head>
+    <title>WPT Server checker</title>
+    <meta charset="utf-8" />
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+</body>
+<body>
+<script>
+function check(protocol, domain, port, done) {
+  var url = protocol + '://' + domain + ':' + port + '/echo';
+  var ws = new WebSocket(url);
+
+  ws.addEventListener('error', function() {
+    done(false);
+  });
+
+  ws.addEventListener('open', function() {
+    done(true);
+  });
+}
+
+async_test(function(t) {
+  check('ws', '{{browser_host}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, no subdomain');
+
+async_test(function(t) {
+  check('ws', '{{domains[www1]}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, www subdomain #1');
+
+async_test(function(t) {
+  check('ws', '{{domains[www1]}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, www subdomain #2');
+
+async_test(function(t) {
+  check('ws', '{{domains[www2]}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, www subdomain #3');
+
+async_test(function(t) {
+  check('ws', '{{domains[élève]}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, punycode subdomain #1');
+
+async_test(function(t) {
+  check('ws', '{{domains[天気の良い日]}}', {{ports[ws][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WS protocol, punycode subdomain #2');
+
+async_test(function(t) {
+  check('wss', '{{browser_host}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, no subdomain');
+
+async_test(function(t) {
+  check('wss', '{{domains[www1]}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, www subdomain #1');
+
+async_test(function(t) {
+  check('wss', '{{domains[www1]}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, www subdomain #2');
+
+async_test(function(t) {
+  check('wss', '{{domains[www2]}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, www subdomain #3');
+
+async_test(function(t) {
+  check('wss', '{{domains[élève]}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, punycode subdomain #1');
+
+async_test(function(t) {
+  check('wss', '{{domains[天気の良い日]}}', {{ports[wss][0]}}, t.step_func(function(result) {
+    assert_true(result);
+
+    t.done();
+  }));
+}, 'WSS protocol, punycode subdomain #2');
+</script>
+</body>
+</html>

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -142,11 +142,10 @@ class TestEnvironment(object):
 
         config = serve.Config(override_ssl_env=self.ssl_env, **default_config)
 
-        config.ports = {
-            "http": [8000, 8001],
-            "https": [8443],
-            "ws": [8888]
-        }
+        config.server_host = self.options.get("server_host", None)
+        config.ports["http"] = [8000, 8001]
+        config.ports["https"] = [8443]
+        config.ports["ws"] = [8888]
 
         if os.path.exists(override_path):
             with open(override_path) as f:
@@ -162,7 +161,6 @@ class TestEnvironment(object):
         if "bind_address" in self.options:
             config.bind_address = self.options["bind_address"]
 
-        config.server_host = self.options.get("server_host", None)
         config.ssl["encrypt_after_connect"] = self.options.get("encrypt_after_connect", False)
         config.doc_root = serve_path(self.test_paths)
 


### PR DESCRIPTION
Commit bfef1f20a419d24633e48d24c14e6a7503e1d48c organized WPT
configuration management into a dedicated class. As part of this change,
it modified the way certain properties were initialized. The original
implementation included the following code:

    config = serve.merge_json(default_config, local_config)

The `merge_json` method operated on object values recursively. Any
properties in `default_config["ports"]` that were *not* present in
`local_config["ports"]` were persisted.

The commit referenced above translated that code to:

    config = serve.Config(override_ssl_env=self.ssl_env, **default_config)
    config.ports = {
        "http": [8000, 8001],
        "https": [8443],
        "ws": [8888]
    }

In this factoring, the `config.ports` property is completely
overwritten.  Because the `default_config` object contains a "wss"
property that is not present in the override, this new approach disables
the default secure WebSocket server.

Re-implement the original behavior by selectively overwriting only the
specified configuration properties and persisting any
previously-existing properties.

---

As an alternative, it might make sense to remove the `config.ports =` statement from `environment.py` and instead declaratively set those values in `config.default.json`. That could be easier to follow (fewer sources of configuration), but I'm not sure where else `config.default.json` is used. The file currently demonstrates the use of the special value `"auto"`. Users are encouraged to copy the file and make local modifications, so the illustrative purpose may be a good reason to leave it as is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10544)
<!-- Reviewable:end -->
