### PR TITLE
Remove tests for the crop property

### DIFF
--- a/css/css-transitions/support/properties.js
+++ b/css/css-transitions/support/properties.js
@@ -221,8 +221,6 @@ var properties = {
     'outline-width': ['length'],
 
     'clip': ['rectangle'],
-    // Note: doesn't seem implemented anywhere
-    'crop': ['rectangle'],
 
     'vertical-align': ['length', 'percentage'],
     'opacity': ['number[0,1]'],


### PR DESCRIPTION
There is a comment in the test that it wasn't implemented in anywhere, and it seems to have been removed from the spec (per https://github.com/w3c/csswg-drafts/commit/7f3fb42152f3110f5581901797f6d34c9300cf4b). Remove the reference to the property from the testcases.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
