### PR TITLE
Fix RequestHeaders to proper concat repeats

### DIFF
--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -348,12 +348,22 @@ class Request(object):
 class RequestHeaders(dict):
     """Dictionary-like API for accessing request headers."""
     def __init__(self, items):
-        for key, value in zip(items.keys(), items.values()):
-            key = key.lower()
-            if key in self:
-                self[key].append(value)
+        for header in items.keys():
+            key = header.lower()
+            # get all headers with the same name
+            values = items.getallmatchingheaders(header)
+            if len(values) > 1:
+                # collect the multiple variations of the current header
+                multiples = []
+                # loop through the values from getallmatchingheaders
+                for value in values:
+                    # getallmatchingheaders returns raw header lines, so
+                    # split to get name, value
+                    multiples.append(value.split(':', 1)[1].strip())
+                dict.__setitem__(self, key, multiples)
             else:
-                dict.__setitem__(self, key, [value])
+                dict.__setitem__(self, key, [items[header]])
+
 
     def __getitem__(self, key):
         """Get all headers of a certain (case-insensitive) name. If there is


### PR DESCRIPTION
Previously RequestHeaders only provided the last instance of a repeated header.

Reapplies the changes from https://github.com/w3c/wptserve/pull/87 to fix #8367.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10562)
<!-- Reviewable:end -->
