### PR TITLE
Make a check for the initial value of selectionDirection less strict.

### DIFF
--- a/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -75,7 +75,7 @@
     }, `selectionEnd on an input[type=${type}] returns a value`);
 
     test(() => {
-      assert_in_array(el.selectionDirection, ["forward", "backward", "none"]);
+      assert_in_array(el.selectionDirection, ["forward", "none"]);
     }, `selectionDirection on an input[type=${type}] returns a value`);
 
     test(() => {

--- a/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -14,6 +14,11 @@
     var el = document.createElement("input");
     el.type = type;
 
+    if (el.type != type) {
+      // Type is not supported - don't bother with the following checks.
+      return;
+    }
+
     test(() => {
       assert_equals(el.selectionStart, null);
     }, `selectionStart on an input[type=${type}] returns null`);

--- a/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -70,7 +70,7 @@
     }, `selectionEnd on an input[type=${type}] returns a value`);
 
     test(() => {
-      assert_equals(el.selectionDirection, "none");
+      assert_any(assert_equals, el.selectionDirection, ["forward", "backward", "none"]);
     }, `selectionDirection on an input[type=${type}] returns a value`);
 
     test(() => {

--- a/html/semantics/forms/textfieldselection/selection-not-application.html
+++ b/html/semantics/forms/textfieldselection/selection-not-application.html
@@ -75,7 +75,7 @@
     }, `selectionEnd on an input[type=${type}] returns a value`);
 
     test(() => {
-      assert_any(assert_equals, el.selectionDirection, ["forward", "backward", "none"]);
+      assert_in_array(el.selectionDirection, ["forward", "backward", "none"]);
     }, `selectionDirection on an input[type=${type}] returns a value`);
 
     test(() => {


### PR DESCRIPTION
The standard does not define an initial value.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
