### PR TITLE
Update DOMPoint and DOMQuad tests

### DIFF
--- a/css/geometry/DOMPoint-001.html
+++ b/css/geometry/DOMPoint-001.html
@@ -21,7 +21,7 @@
             checkDOMPoint(new DOMPoint(), {x:0, y:0, z:0, w:1});
         },'testConstructor0');
         test(function() {
-            assert_throws(new TypeError(), function() { new DOMPoint(1);})
+            checkDOMPoint(new DOMPoint(1), {x:1, y:0, z:0, w:1});
         },'testConstructor1');
         test(function() {
             checkDOMPoint(new DOMPoint(1, 2), {x:1, y:2, z:0, w:1});
@@ -72,11 +72,11 @@
             checkDOMPoint(new DOMPoint({x:"a", y:"b"}), {x:NaN, y:NaN, z:0, w:1});
         },'testConstructorUndefined2');
         test(function() {
-            assert_throws(new TypeError(), function() { new DOMPointReadOnly();})
-        },'testConstructorIllegal1');
+            checkDOMPoint(new DOMPointReadOnly(), {x:0, y:0, z:0, w:1});
+        },'DOMPointReadOnly constructor with no values');
         test(function() {
-            assert_throws(new TypeError(), function() { new DOMPointReadOnly(1, 2, 3, 4);})
-        },'testConstructorIllegal2');
+            checkDOMPoint(new DOMPointReadOnly(1, 2, 3, 4), {x:1, y:2, z:3, w:4});
+        },'DOMPointReadOnly constructor with 4 values');
         test(function() {
             var p = new DOMPoint(0, 0, 0, 1);
             p.x = undefined;

--- a/css/geometry/DOMQuad-001.html
+++ b/css/geometry/DOMQuad-001.html
@@ -129,15 +129,6 @@
             return q;
         }, initial, 'boundsAttribute0');
 
-        checkDOMQuad(function() {
-            var q = new DOMQuad({}, {}, {}, {});
-            q.bounds.x = 10;
-            q.bounds.y = 10;
-            q.bounds.width = 100;
-            q.bounds.height = 100;
-            return q;
-        }, initial, 'boundsAttribute1');
-
         function checkDOMQuad(createQuad, exp, name) {
             test(function() {
                 var q = createQuad();
@@ -161,10 +152,10 @@
 
             test(function() {
                 var q = createQuad();
-                assert_equals(q.bounds.x, exp.bounds.x, "Expected value for bounds.x is " + exp.bounds.x);
-                assert_equals(q.bounds.y, exp.bounds.y, "Expected value for bounds.y is " + exp.bounds.y);
-                assert_equals(q.bounds.width, exp.bounds.width, "Expected value for bounds.width is " + exp.bounds.width);
-                assert_equals(q.bounds.height, exp.bounds.height, "Expected value for bounds.height is " + exp.bounds.height);
+                assert_equals(q.getBounds().x, exp.bounds.x, "Expected value for getBounds().x is " + exp.bounds.x);
+                assert_equals(q.getBounds().y, exp.bounds.y, "Expected value for getBounds().y is " + exp.bounds.y);
+                assert_equals(q.getBounds().width, exp.bounds.width, "Expected value for getBounds().width is " + exp.bounds.width);
+                assert_equals(q.getBounds().height, exp.bounds.height, "Expected value for getBounds().height is " + exp.bounds.height);
             }, name + ": bounds");
         }
     </script>

--- a/css/geometry/historical.html
+++ b/css/geometry/historical.html
@@ -21,6 +21,8 @@
   ['DOMMatrix', 'rotateAxisAngleBy'],
   ['DOMMatrix', 'skewXBy'],
   ['DOMMatrix', 'skewYBy'],
+  // https://github.com/w3c/fxtf-drafts/commit/555a8c0beb1b7b809ccebd861a0352df31530b56
+  ['DOMQuad', 'bounds'],
 ].forEach(([interf, member]) => {
   test(() => {
     assert_true(interf in self, `${interf} should exist`);


### PR DESCRIPTION
Per https://drafts.fxtf.org/geometry/#DOMPoint, `DOMPoint`'s constructor accepts zero to four values, and `DOMPointReadOnly` has the exact same constructor. Additionally, `DOMQuad` no longer has a live `bounds` attribute per https://drafts.fxtf.org/geometry/#domquad, instead replacing it with `getBounds()` which cannot be set. Fix tests of `DOMPoint` and `DOMQuad `to reflect these changes.

Also add a historical test to make sure that `DOMQuad.bounds` is removed.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
