### PR TITLE
Correct computed value of transform

### DIFF
--- a/css/css-transforms/2d-rotate-js.html
+++ b/css/css-transforms/2d-rotate-js.html
@@ -3,11 +3,12 @@
 	<head>
 		<title>JS test: Rotate via javascript must show the correct computed rotation</title>
 		<link rel="author" title="Rick Hurst" href="http://mrkn.co/axegs">
-		<link rel="help" href="http://www.w3.org/TR/css-transforms-1/#transform-property">
+		<link rel="help" href="https://drafts.csswg.org/css-transforms-1/#serialization-of-the-computed-value">
+		<link rel="help" href="https://drafts.csswg.org/css-transforms-1/#serialization-of-transform-functions">
 		<script src="/resources/testharness.js"></script>
 		<script src="/resources/testharnessreport.js"></script>
 		<meta name="flags" content="svg">
-		<meta name="assert" content="Asserting that you can rotate an element with JS and it show up in CSS computed values not as a matrix but as the rotation">
+		<meta name="assert" content="Asserting that you can rotate an element with JS and it show up in CSS computed values as a matrix">
 		<style>
 			#box{
 				margin-top:30px;
@@ -26,8 +27,9 @@
 			test(function() {
 				var box = document.getElementById("box");
 				box.style.transform = "rotate(30deg)";
+				assert_equals(box.style.transform, "rotate(30deg)");
 				assert_equals(window.getComputedStyle(box).getPropertyValue("transform"),
-				              "rotate(30deg)");
+				              "matrix(0.866025, 0.5, -0.5, 0.866025, 0, 0)");
 			});
 		</script>
     </body>


### PR DESCRIPTION
Per https://drafts.csswg.org/css-transforms-1/#serialization-of-the-computed-value, the computed value of a `<transform-list>` is one `matrix()`. Change this test to bring it in line with the spec, matching the behavior of all major browsers.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
