### PR TITLE
[css-flex][spec-rec] Test for flex only alignment modes with writing modes

### DIFF
--- a/css/css-flexbox/mix-writing-modes-and-flex-alignment.html
+++ b/css/css-flexbox/mix-writing-modes-and-flex-alignment.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>flexbox | first-letter</title>
+<meta name="assert" content="This test ensures that
+flex only alignment modes (eg: flex-start/end) work as expected in different
+writing modes."/>.
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#placement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta rel="author" title="Benny Ogidan" href="benny.ogidan@andela.com">
+<style>
+  ul {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    writing-mode: vertical-lr;
+  }
+
+.box {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    border: 1px solid black;
+    color: white;
+    margin: 10px;
+  }
+</style>
+
+<ul id="box-list">
+  <li class="box">1</li>
+  <li class="box">2</li>
+  <li class="box">3</li>
+  <li class="box">4</li>
+</ul>
+
+<div id="log"></div>
+<script>
+  test(function () {
+    const boxListComputedStyle = getComputedStyle(document.getElementById('box-list'));
+
+    assert_equals((boxListComputedStyle).getPropertyValue("writing-mode"), "vertical-lr");
+    assert_equals((boxListComputedStyle).getPropertyValue("justify-content"), "flex-end");
+    assert_equals((boxListComputedStyle).getPropertyValue("align-items"), "center");
+  });
+</script>


### PR DESCRIPTION
#### What does this PR do? 
These tests ensure that flex only alignment modes  work as expected in different
writing modes
#### How should this be manually tested?
Pull the current branch
Follow the Readme.md to run the tests
*Testharness.js has been used to write the test cases

#### Screenshots (if appropriate)
<img width="1280" alt="screen shot 2018-04-25 at 12 02 04 am" src="https://user-images.githubusercontent.com/26222856/39219893-61184832-4825-11e8-966c-91c1455057c2.png">

<!-- Reviewable:start -->

<!-- Reviewable:end -->
