### PR TITLE
[feature-policy] Avoid timeouts in absence of API

### DIFF
--- a/feature-policy/resources/feature-policy-allowedfeatures.html
+++ b/feature-policy/resources/feature-policy-allowedfeatures.html
@@ -2,6 +2,14 @@
 'use strict';
 
 window.onload = function() {
-  parent.postMessage(document.policy.allowedFeatures(), '*');
+  var value;
+
+  try {
+    value = document.policy.allowedFeatures();
+  } catch (error) {
+    value = [error && error.message];
+  }
+
+  parent.postMessage(value, '*');
 }
 </script>


### PR DESCRIPTION
Many tests written for the `document.policy.allowedFeatures` method
reference the API without first ensuring its availability. The method is
a new addition to the web platform, so this pattern produces a
ReferenceError in many browsers (i.e. all major browsers at the time of
this writing). Because the error occurs in the context of an iframe, the
test harness is unable to detect it, and the affected tests report an
error only following an extended delay.

Guard the reference with a `try`/`catch` block so that failures are
detected and reported immediately.

---

Here are the results of the command `./wpt run --include feature-policy
chrome` before applying this patch:

>     Ran 343 checks (29 tests, 314 subtests)
>     Expected results: 48
>     Unexpected results: 295
>       test: 17 (14 timeout, 3 error)
>       subtest: 278 (222 fail, 28 notrun, 28 timeout)

And after:

>     Ran 343 checks (29 tests, 314 subtests)
>     Expected results: 76
>     Unexpected results: 267
>       test: 10 (7 timeout, 3 error)
>       subtest: 257 (236 fail, 21 timeout)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
