### PR TITLE
[css-text] tests for overflow-wrap with break-word + break-spaces

### DIFF
--- a/css/css-text/overflow-wrap/overflow-wrap-break-word-002.html
+++ b/css/css-text/overflow-wrap/overflow-wrap-break-word-002.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word+break-spaces</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<meta name="flags" content="ahem">
+<link rel="match" href="reference/overflow-wrap-break-word-002-ref.html">
+<meta name="assert" content="break-word + break-spaces do not allow a break
+between the last character of a word and the first space of a sequence of preserved spaces
+if there are other wrapping opportunities earlier in the line">
+<style>
+div {
+  white-space: pre-wrap;
+  overflow-wrap: break-word break-spaces;
+  font-family: monospace;
+  width: 5ch;
+  line-height: 1;
+  overflow: hidden;
+  height: 1em;
+}
+</style>
+
+<p>This test passes if there is nothing below this sentence.
+<div> FAIL <div>
+<!--
+white-space:pre-wrap + overflow:break-spaces should cause the spaces at the end of the line to be preserved.
+Since there is an allowed break point between the first space and the F,
+that's where the line should wrap,
+not between the L and the subsequent space.
+-->

--- a/css/css-text/overflow-wrap/overflow-wrap-break-word-003.html
+++ b/css/css-text/overflow-wrap/overflow-wrap-break-word-003.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word+break-spaces</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-word">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#valdef-overflow-wrap-break-spaces">
+<meta name="flags" content="ahem">
+<link rel="match" href="reference/overflow-wrap-break-word-003-ref.html">
+<meta name="assert" content="break-word + break-spaces do allow a break
+between the last character of a word and the first space of a sequence of preserved spaces
+if there are no other wrapping opportunities earlier in the line">
+<style>
+div {
+  white-space: pre-wrap;
+  overflow-wrap: break-word break-spaces;
+  font-family: monospace;
+  width: 4ch;
+  line-height: 1;
+  overflow: hidden;
+  height: 2em;
+}
+</style>
+
+<p>This test passes if the word FAIL does not appear below.
+<div>PASS FAIL<div>

--- a/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-002-ref.html
+++ b/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-002-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>test reference</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+
+<p>This test passes if there is nothing below this sentence.

--- a/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-003-ref.html
+++ b/css/css-text/overflow-wrap/reference/overflow-wrap-break-word-003-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Text Test: overflow-wrap: break-word+break-spaces</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net/">
+<style>
+div {
+  font-family: monospace;
+  line-height: 1;
+}
+</style>
+
+<p>This test passes if the word FAIL does not appear below.
+<div>PASS<div>


### PR DESCRIPTION
Covers the spec changes made for:
https://github.com/w3c/csswg-drafts/issues/2003

<!-- Reviewable:start -->

<!-- Reviewable:end -->
