### PR TITLE
Fix test for Event.returnValue

### DIFF
--- a/dom/events/Event-returnValue.html
+++ b/dom/events/Event-returnValue.html
@@ -53,7 +53,7 @@ test(function() {
   assert_true(ev.returnValue, "returnValue");
 }, "initEvent should unset returnValue.");
 test(function() {
-  var ev = new Event("foo");
+  var ev = new Event("foo", {"cancelable": true});
   ev.preventDefault();
   ev.returnValue = true;// no-op
   assert_true(ev.defaultPrevented);


### PR DESCRIPTION
The last test requires the event to be cancelable. This was discovered as part of https://github.com/jsdom/jsdom/pull/2197.

Two tests from this file don't pass in current browsers even with this change, but this appears to be due to changes made to the setter in the specification which will be implemented soon.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
