### PR TITLE
Additional fixes to DOMQuad-001.html

### DIFF
--- a/css/geometry/DOMQuad-001.html
+++ b/css/geometry/DOMQuad-001.html
@@ -44,31 +44,31 @@
         },'testConstructor4');
 
         checkDOMQuad(
-                function() { return new DOMQuad(new DOMRect(10, 20, 100, 200)); },
+                function() { return DOMQuad.fromRect(new DOMRect(10, 20, 100, 200)); },
                 {   p1: { x: 10, y: 20, z: 0, w: 1 },
                     p2: { x: 110, y: 20, z: 0, w: 1 },
                     p3: { x: 110, y: 220, z: 0, w: 1 },
                     p4: { x: 10, y: 220, z: 0, w: 1 },
                     bounds: { x: 10, y: 20, width: 100, height: 200 } },
-                'testConstructor5');
+                'fromRect() method on DOMQuad');
 
         checkDOMQuad(
-                function() { return new DOMQuad(new DOMRect(10, 20, -100, -200)) },
+                function() { return DOMQuad.fromRect(new DOMRect(10, 20, -100, -200)) },
                 {   p1: { x: 10, y: 20, z: 0, w: 1 },
                     p2: { x: -90, y: 20, z: 0, w: 1 },
                     p3: { x: -90, y: -180, z: 0, w: 1 },
                     p4: { x: 10, y: -180, z: 0, w: 1 },
                     bounds: { x: -90, y: -180, width: 100, height: 200 } },
-                'testConstructor6');
+                'fromRect() method on DOMQuad with negatives');
 
         checkDOMQuad(
-                function() { return new DOMQuad(new DOMRect(-Infinity, -Infinity, Infinity, Infinity)) },
+                function() { return DOMQuad.fromRect(new DOMRect(-Infinity, -Infinity, Infinity, Infinity)) },
                 {   p1: { x: -Infinity, y: -Infinity, z: 0, w: 1 },
                     p2: { x: NaN, y: -Infinity, z: 0, w: 1 },
                     p3: { x: NaN, y: NaN, z: 0, w: 1 },
                     p4: { x: -Infinity, y: NaN, z: 0, w: 1 },
                     bounds: { x: -Infinity, y: -Infinity, width: NaN, height: NaN } },
-                'testConstructor7');
+                'fromRect() method on DOMQuad with Infinity');
 
         checkDOMQuad(function() { return new DOMQuad(new DOMRect()); }, initial, 'testConstructor8');
 
@@ -120,14 +120,8 @@
             p2: { x: 2, y: 0, z: 0, w: 1 },
             p3: { x: 2, y: 0, z: 0, w: 1 },
             p4: { x: 2, y: 0, z: 0, w: 1 },
-            bounds: { x: 2, y: 0, width: 0, height: 0 } },
+            bounds: { x: 0, y: 0, width: 0, height: 0 } },
         'p1Top4Attributes1');
-
-        checkDOMQuad(function() {
-            var q = new DOMQuad({}, {}, {}, {});
-            q.bounds = new DOMRect(10, 10, 100, 100);
-            return q;
-        }, initial, 'boundsAttribute0');
 
         function checkDOMQuad(createQuad, exp, name) {
             test(function() {


### PR DESCRIPTION
`DOMQuad` no longer has an explicit constructor from a `DOMRect`, this was replaced with `fromRect()` in https://github.com/w3c/fxtf-drafts/commit/62b9cb9d5be4982d2a9cbf314e3a59efb8a68dd6. Additionally, there was a test for the `bounds` attribute being read-only, which was replaced with `getBounds()`, so the test no longer makes sense. Update the tests to reflect these changes.

Also fix a typo for the bounds in `p1Top4Attributes1` as all values should be 0 since it was the original value for each.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
