### PR TITLE
Update expectation for promise resource tests

### DIFF
--- a/resources/test/tests/iframe-consolidate-tests.html
+++ b/resources/test/tests/iframe-consolidate-tests.html
@@ -85,7 +85,7 @@ executing</p>
       "name": "Use of unreached_func with Promises (should fail)",
       "properties": {},
       "message": "assert_unreached: This failure is expected Reached unreachable code",
-      "stack": "(implementation-defined)"
+      "stack": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/promise-async.html
+++ b/resources/test/tests/promise-async.html
@@ -172,7 +172,7 @@ test(function() {
       "name": "Use of unreached_func with Promises (should fail)",
       "properties": {},
       "message": "assert_unreached: This failure is expected Reached unreachable code",
-      "stack": "(implementation-defined)"
+      "stack": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/promise.html
+++ b/resources/test/tests/promise.html
@@ -190,21 +190,21 @@ promise_test(
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled exception in fulfill reaction (should FAIL)",
-      "stack": "(implementation-defined)",
+      "stack": null,
       "message": "promise_test: Unhandled rejection with value: object \"Error: Expected exception.\"",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled exception in reject reaction (should FAIL)",
-      "stack": "(implementation-defined)",
+      "stack": null,
       "message": "promise_test: Unhandled rejection with value: object \"Error: Expected exception.\"",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled rejection (should FAIL)",
-      "stack": "(implementation-defined)",
+      "stack": null,
       "message": "promise_test: Unhandled rejection with value: \"Expected rejection\"",
       "properties": {}
     },


### PR DESCRIPTION
5 tests were expecting a non-null stack but did not receive one. Update the expectations to match current behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10660)
<!-- Reviewable:end -->
