### PR TITLE
Fix #10652: resources/test should not rely on Error.stack

### DIFF
--- a/resources/test/conftest.py
+++ b/resources/test/conftest.py
@@ -80,7 +80,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
         if not self.expected:
             assert summarized[u'summarized_status'][u'status_string'] == u'OK', summarized[u'summarized_status'][u'message']
             for test in summarized[u'summarized_tests']:
-                msg = "%s\n%s:\n%s" % (test[u'name'], test[u'message'], test[u'stack'])
+                msg = "%s\n%s" % (test[u'name'], test[u'message'])
                 assert test[u'status_string'] == u'PASS', msg
         else:
             assert summarized == self.expected
@@ -93,12 +93,7 @@ class HTMLItem(pytest.Item, pytest.Collector):
     @staticmethod
     def _scrub_stack(test_obj):
         copy = dict(test_obj)
-
-        assert 'stack' in copy
-
-        if copy['stack'] is not None:
-            copy['stack'] = u'(implementation-defined)'
-
+        del copy['stack']
         return copy
 
     @staticmethod

--- a/resources/test/tests/add_cleanup.html
+++ b/resources/test/tests/add_cleanup.html
@@ -56,37 +56,32 @@ async_test(function(t) {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Cleanup methods are invoked exactly once and in the expected sequence.",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Cleanup methods are invoked following the completion of asynchronous tests",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "probe asynchronous",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "probe synchronous",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/add_cleanup_count.html
+++ b/resources/test/tests/add_cleanup_count.html
@@ -22,14 +22,12 @@ promise_test(function(t) {
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Test named 'test with 3 user-defined cleanup functions' specified 3 'cleanup' functions, and 1 failed.",
-    "stack": null
+    "message": "Test named 'test with 3 user-defined cleanup functions' specified 3 'cleanup' functions, and 1 failed."
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "test with 3 user-defined cleanup functions",
-      "stack": null,
       "message": null,
       "properties": {}
     }

--- a/resources/test/tests/add_cleanup_err.html
+++ b/resources/test/tests/add_cleanup_err.html
@@ -22,23 +22,20 @@ test(function() {}, "This test should not be run.");
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Test named 'Exception in cleanup function causes harness failure.' specified 1 'cleanup' function, and 1 failed.",
-    "stack": null
+    "message": "Test named 'Exception in cleanup function causes harness failure.' specified 1 'cleanup' function, and 1 failed."
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Exception in cleanup function causes harness failure.",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "NOTRUN",
       "name": "This test should not be run.",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/add_cleanup_err_multi.html
+++ b/resources/test/tests/add_cleanup_err_multi.html
@@ -29,23 +29,20 @@ test(function(t) {
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Test named 'Test with multiple cleanup functions' specified 2 'cleanup' functions, and 1 failed.",
-    "stack": null
+    "message": "Test named 'Test with multiple cleanup functions' specified 2 'cleanup' functions, and 1 failed."
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Test with multiple cleanup functions",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "NOTRUN",
       "name": "Verification test",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/api-tests-1.html
+++ b/resources/test/tests/api-tests-1.html
@@ -208,161 +208,138 @@
 {
   "summarized_status": {
     "status_string": "TIMEOUT",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Setup function ran",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "Test assert_throws with non-DOM-exception expected to Fail",
-      "stack": "(implementation-defined)",
       "message": "Test bug: unrecognized DOMException code \"TEST_ERR\" passed to assert_throws()",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test async test with callback",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test async test with callback and `this` obj.",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test step_func",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test that cleanup handlers from previous test ran",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test that defines a global and cleans it up",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Test throw DOM exception",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "Test throw DOM exception expected to fail",
-      "stack": "(implementation-defined)",
       "message": "assert_throws: function \"function () {a.appendChild(b)}\" threw object \"HierarchyRequestError: Node cannot be inserted at the specified point in the hierarchy\" that is not a DOMException NOT_FOUND_ERR: property \"code\" is equal to 3, expected 8",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_array_equals with first param 1",
-      "stack": "(implementation-defined)",
       "message": "assert_array_equals: 1 equals [1]? value is 1, expected array",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_array_equals with first param false",
-      "stack": "(implementation-defined)",
       "message": "assert_array_equals: false equals [1]? value is false, expected array",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_array_equals with first param null",
-      "stack": "(implementation-defined)",
       "message": "assert_array_equals: null equals [1]? value is null, expected array",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_array_equals with first param true",
-      "stack": "(implementation-defined)",
       "message": "assert_array_equals: true equals [1]? value is true, expected array",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_array_equals with first param undefined",
-      "stack": "(implementation-defined)",
       "message": "assert_array_equals: undefined equals [1]? value is undefined, expected array",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "assert_equals tests",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_equals tests expected to fail",
-      "stack": "(implementation-defined)",
       "message": "assert_equals: Zero case expected 0 but got -0",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_greater_than expected to fail",
-      "stack": "(implementation-defined)",
       "message": "assert_greater_than: 10 is not greater than 11 expected a number greater than 11 but got 10",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_less_than_equal expected to fail",
-      "stack": "(implementation-defined)",
       "message": "assert_greater_than_equal: '10' is not a number expected a number but got a \"string\"",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "assert_not_equals tests",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "assert_true expected to fail",
-      "stack": "(implementation-defined)",
       "message": "assert_true: false should not be true expected true got false",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "assert_true expected to pass",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "NOTRUN",
       "name": "async test that is never started, should have status Not Run",
-      "stack": null,
       "message": null,
       "properties": {
         "timeout": 1000
@@ -371,70 +348,60 @@
     {
       "status_string": "PASS",
       "name": "basic assert_approx_equals test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "basic assert_array_approx_equals test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "basic assert_array_equals test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "basic assert_greater_than_equal test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "basic assert_less_than test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "basic assert_object_equals test",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "body element fires the onload event set from the attribute",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "document.body should be the first body element in the document",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "test for assert[_not]_exists and insert_inherits",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "TIMEOUT",
       "name": "test should timeout (fail) with a custom set timeout value of 1 second",
-      "stack": null,
       "message": "Test timed out",
       "properties": {
         "timeout": 1000
@@ -443,14 +410,12 @@
     {
       "status_string": "TIMEOUT",
       "name": "test should timeout (fail) with the default of 2 seconds",
-      "stack": null,
       "message": "Test timed out",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "window onload event fires when set from the handler",
-      "stack": null,
       "message": null,
       "properties": {}
     }

--- a/resources/test/tests/api-tests-2.html
+++ b/resources/test/tests/api-tests-2.html
@@ -21,23 +21,20 @@ done();
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Test defined after onload",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test defined before onload",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/api-tests-3.html
+++ b/resources/test/tests/api-tests-3.html
@@ -17,16 +17,14 @@ timeout();
 {
   "summarized_status": {
     "status_string": "TIMEOUT",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "NOTRUN",
       "name": "This test should give a status of 'Not Run' without a delay",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/force_timeout.html
+++ b/resources/test/tests/force_timeout.html
@@ -31,29 +31,25 @@ promise_test(function(t) {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "TIMEOUT",
       "name": "async_test",
       "message": "Test timed out",
-      "stack": null,
       "properties": {}
     },
     {
       "status_string": "TIMEOUT",
       "name": "promise_test",
       "message": "Test timed out",
-      "stack": null,
       "properties": {}
     },
     {
       "status_string": "TIMEOUT",
       "name": "test (synchronous)",
       "message": "Test timed out",
-      "stack": null,
       "properties": {}
     }
   ],

--- a/resources/test/tests/generate-callback.html
+++ b/resources/test/tests/generate-callback.html
@@ -56,65 +56,56 @@ generate_tests(validate_related_arguments, letters.map(format_as_test));
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Test to map a to 0",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test to map b to 1",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test to map c to 2",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test to map d to 3",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test to map e to 4",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test to map f to 5",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "first test",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "second test",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
@@ -122,8 +113,7 @@ generate_tests(validate_related_arguments, letters.map(format_as_test));
       "properties": {
         "sentinel": true
       },
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
@@ -131,8 +121,7 @@ generate_tests(validate_related_arguments, letters.map(format_as_test));
       "properties": {
         "sentinel": true
       },
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
@@ -140,8 +129,7 @@ generate_tests(validate_related_arguments, letters.map(format_as_test));
       "properties": {
         "sentinel": true
       },
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
@@ -149,15 +137,13 @@ generate_tests(validate_related_arguments, letters.map(format_as_test));
       "properties": {
         "sentinel": false
       },
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "third test",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_immutable_prototype.html
@@ -43,289 +43,248 @@ idlArray.test();
 {
     "summarized_status": {
         "message": null,
-        "status_string": "OK",
-        "stack": null
+        "status_string": "OK"
     },
     "summarized_tests": [
         {
             "name": "Foo interface object length",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface object name",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: existence and properties of interface object",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: existence and properties of interface prototype object",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: existence and properties of interface prototype object's \"constructor\" property",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: existence and properties of interface prototype object's @@unscopables property",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
-            "stack": "(implementation-defined)"
+            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Reflect.setPrototypeOf should return false",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_false: expected false got true",
-            "stack": "(implementation-defined)"
+            "message": "assert_false: expected false got true"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw",
-            "stack": "(implementation-defined)"
+            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Object.setPrototypeOf should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Reflect.setPrototypeOf should return true",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via __proto__ should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw",
-            "stack": "(implementation-defined)"
+            "message": "assert_throws: function \"function() {\n            Object.setPrototypeOf(obj, newValue);\n        }\" did not throw"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Reflect.setPrototypeOf should return false",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_false: expected false got true",
-            "stack": "(implementation-defined)"
+            "message": "assert_false: expected false got true"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "FAIL",
             "properties": {},
-            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw",
-            "stack": "(implementation-defined)"
+            "message": "assert_throws: function \"function() {\n            obj.__proto__ = newValue;\n        }\" did not throw"
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Object.setPrototypeOf should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Reflect.setPrototypeOf should return true",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via __proto__ should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Foo must be primary interface of new Foo()",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Stringification of new Foo()",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Stringification of window",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface object length",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface object name",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: existence and properties of interface object",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: existence and properties of interface prototype object",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: existence and properties of interface prototype object's \"constructor\" property",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: existence and properties of interface prototype object's @@unscopables property",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via Reflect.setPrototypeOf should return false",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Object.setPrototypeOf should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via Reflect.setPrototypeOf should return true",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of global platform object - setting to its original value via __proto__ should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via Reflect.setPrototypeOf should return false",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to a new value via __proto__ should throw a TypeError",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Object.setPrototypeOf should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via Reflect.setPrototypeOf should return true",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window interface: internal [[SetPrototypeOf]] method of interface prototype object - setting to its original value via __proto__ should not throw",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         },
         {
             "name": "Window must be primary interface of window",
             "status_string": "PASS",
             "properties": {},
-            "message": null,
-            "stack": null
+            "message": null
         }
     ],
     "type": "complete"

--- a/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_primary_interface_of.html
@@ -50,65 +50,56 @@ idlArray.test();
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "name": "Foo interface object length",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo interface object name",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo interface: existence and properties of interface object",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo interface: existence and properties of interface prototype object",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo interface: existence and properties of interface prototype object's \"constructor\" property",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo interface: existence and properties of interface prototype object's @@unscopables property",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Foo must be primary interface of new Foo()",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "name": "Stringification of new Foo()",
       "status_string": "PASS",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
+++ b/resources/test/tests/idlharness/IdlInterface/test_to_json_operation.html
@@ -94,7 +94,6 @@
     {
         "summarized_status": {
             "message": null,
-            "stack": null,
             "status_string": "OK"
         },
         "summarized_tests": [
@@ -102,84 +101,72 @@
                 "message": null,
                 "name": "Test default toJSON operation of A",
                 "properties": {},
-                "stack": null,
                 "status_string": "PASS"
             },
             {
                 "message": "assert_equals: expected \"number\" but got \"string\"",
                 "name": "Test default toJSON operation of B",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": null,
                 "name": "Test default toJSON operation of C",
                 "properties": {},
-                "stack": null,
                 "status_string": "PASS"
             },
             {
                 "message": "assert_true: property \"foo\" should be present in the output of D.prototype.toJSON() expected true got false",
                 "name": "Test default toJSON operation of D",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": "assert_true: property foo should be writable expected true got false",
                 "name": "Test default toJSON operation of F",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": "assert_true: property foo should be enumerable expected true got false",
                 "name": "Test default toJSON operation of G",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": "assert_true: property foo should be configurable expected true got false",
                 "name": "Test default toJSON operation of H",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": null,
                 "name": "Test default toJSON operation of I",
                 "properties": {},
-                "stack": null,
                 "status_string": "PASS"
             },
             {
                 "message": null,
                 "name": "Test default toJSON operation of K",
                 "properties": {},
-                "stack": null,
                 "status_string": "PASS"
             },
             {
                 "message": null,
                 "name": "Test toJSON operation of L",
                 "properties": {},
-                "stack": null,
                 "status_string": "PASS"
             },
             {
                 "message": "assert_equals: expected \"string\" but got \"object\"",
                 "name": "Test toJSON operation of M",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             },
             {
                 "message": "assert_true: {\"sequence\":false,\"generic\":null,\"nullable\":false,\"union\":false,\"idlType\":\"DOMException\"} is not an appropriate return value for the toJSON operation of N expected true got false",
                 "name": "Test toJSON operation of N",
                 "properties": {},
-                "stack": "(implementation-defined)",
                 "status_string": "FAIL"
             }
         ],

--- a/resources/test/tests/iframe-callback.html
+++ b/resources/test/tests/iframe-callback.html
@@ -100,16 +100,14 @@ function start_test_in_iframe() {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Example with iframe that notifies containing document via callbacks",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/iframe-consolidate-errors.html
+++ b/resources/test/tests/iframe-consolidate-errors.html
@@ -27,16 +27,14 @@ child context.</p>
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Error in remote: Error: Example Error",
-    "stack": null
+    "message": "Error in remote: Error: Example Error"
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Test executing in parent context",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/iframe-consolidate-tests.html
+++ b/resources/test/tests/iframe-consolidate-tests.html
@@ -27,65 +27,56 @@ executing</p>
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Promise rejection",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Promise resolution",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Promises and test assertion failures (should fail)",
       "properties": {},
-      "message": "assert_true: This failure is expected expected true got false",
-      "stack": "(implementation-defined)"
+      "message": "assert_true: This failure is expected expected true got false"
     },
     {
       "status_string": "PASS",
       "name": "Promises are supported in your browser",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Promises resolution chaining",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test executing in parent context",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Use of step_func with Promises",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Use of unreached_func with Promises (should fail)",
       "properties": {},
-      "message": "assert_unreached: This failure is expected Reached unreachable code",
-      "stack": "(implementation-defined)"
+      "message": "assert_unreached: This failure is expected Reached unreachable code"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/iframe-msg.html
+++ b/resources/test/tests/iframe-msg.html
@@ -68,16 +68,14 @@ on_event(window,
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Containing document receives messages",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/order.html
+++ b/resources/test/tests/order.html
@@ -16,19 +16,16 @@ test(function() {}, 'first');
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [{
     "status_string": "PASS",
     "name": "first",
-    "stack": null,
     "message": null,
     "properties": {}
   }, {
     "status_string": "PASS",
     "name": "second",
-    "stack": null,
     "message": null,
     "properties": {}
   }],

--- a/resources/test/tests/promise-async.html
+++ b/resources/test/tests/promise-async.html
@@ -121,58 +121,50 @@ test(function() {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Promise rejection",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Promise resolution",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Promises and test assertion failures (should fail)",
       "properties": {},
-      "message": "assert_true: This failure is expected expected true got false",
-      "stack": "(implementation-defined)"
+      "message": "assert_true: This failure is expected expected true got false"
     },
     {
       "status_string": "PASS",
       "name": "Promises are supported in your browser",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Promises resolution chaining",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Use of step_func with Promises",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Use of unreached_func with Promises (should fail)",
       "properties": {},
-      "message": "assert_unreached: This failure is expected Reached unreachable code",
-      "stack": "(implementation-defined)"
+      "message": "assert_unreached: This failure is expected Reached unreachable code"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/promise.html
+++ b/resources/test/tests/promise.html
@@ -134,84 +134,72 @@ promise_test(
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "FAIL",
       "name": "Assertion failure in a fulfill reaction (should FAIL with an expected failure)",
-      "stack": "(implementation-defined)",
       "message": "assert_true: Expected failure. expected true got false",
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Chain of promise resolutions",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Promise fulfillment with result",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Promise rejection with result",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "Promises are supported in your browser",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "PASS",
       "name": "promise_test with function that doesn't return a Promise",
-      "stack": null,
       "message": null,
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with function that doesn't return anything",
-      "stack": "(implementation-defined)",
       "message": "assert_not_equals: got disallowed value undefined",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled exception in fulfill reaction (should FAIL)",
-      "stack": "(implementation-defined)",
       "message": "promise_test: Unhandled rejection with value: object \"Error: Expected exception.\"",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled exception in reject reaction (should FAIL)",
-      "stack": "(implementation-defined)",
       "message": "promise_test: Unhandled rejection with value: object \"Error: Expected exception.\"",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "promise_test with unhandled rejection (should FAIL)",
-      "stack": "(implementation-defined)",
       "message": "promise_test: Unhandled rejection with value: \"Expected rejection\"",
       "properties": {}
     },
     {
       "status_string": "FAIL",
       "name": "unreached_func as reactor (should FAIL with an expected failure)",
-      "stack": "(implementation-defined)",
       "message": "assert_unreached: Expected failure. Reached unreachable code",
       "properties": {}
     }

--- a/resources/test/tests/single-page-test-fail.html
+++ b/resources/test/tests/single-page-test-fail.html
@@ -12,16 +12,14 @@ onload = function() {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "FAIL",
       "name": "Example with file_is_test (should fail)",
       "properties": {},
-      "message": "uncaught exception: Error: assert_true: expected true got false",
-      "stack": "(implementation-defined)"
+      "message": "uncaught exception: Error: assert_true: expected true got false"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/single-page-test-no-assertions.html
+++ b/resources/test/tests/single-page-test-no-assertions.html
@@ -9,16 +9,14 @@ done();
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Example single page test with no asserts",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/single-page-test-no-body.html
+++ b/resources/test/tests/single-page-test-no-body.html
@@ -10,16 +10,14 @@ done();
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Example single page test with no body",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/single-page-test-pass.html
+++ b/resources/test/tests/single-page-test-pass.html
@@ -12,16 +12,14 @@ onload = function() {
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Example with file_is_test",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/uncaught-exception-handle.html
+++ b/resources/test/tests/uncaught-exception-handle.html
@@ -16,16 +16,14 @@ throw new Error("Example Error");
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Error: Example Error",
-    "stack": "(implementation-defined)"
+    "message": "Error: Example Error"
   },
   "summarized_tests": [
     {
       "status_string": "NOTRUN",
       "name": "This should show a harness status of 'Error' and a test status of 'Not Run'",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/uncaught-exception-ignore.html
+++ b/resources/test/tests/uncaught-exception-ignore.html
@@ -18,16 +18,14 @@ throw new Error("Example Error");
 {
   "summarized_status": {
     "status_string": "OK",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "setup({allow_uncaught_exception:true}) should allow tests to pass even if there is an exception",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/worker-dedicated.html
+++ b/resources/test/tests/worker-dedicated.html
@@ -30,65 +30,56 @@ test(function(t) {
 {
   "summarized_status": {
     "status_string": "ERROR",
-    "message": "Error: This failure is expected.",
-    "stack": "(implementation-defined)"
+    "message": "Error: This failure is expected."
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Browser supports Workers",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Test running on main document.",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Untitled",
       "properties": {},
-      "message": "Error: This failure is expected.",
-      "stack": "(implementation-defined)"
+      "message": "Error: This failure is expected."
     },
     {
       "status_string": "PASS",
       "name": "Worker async_test that completes successfully",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Worker test that completes successfully",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "NOTRUN",
       "name": "Worker test that doesn't run ('NOT RUN')",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Worker test that fails ('FAIL')",
       "properties": {},
-      "message": "assert_true: Failing test expected true got false",
-      "stack": "(implementation-defined)"
+      "message": "assert_true: Failing test expected true got false"
     },
     {
       "status_string": "TIMEOUT",
       "name": "Worker test that times out ('TIMEOUT')",
       "properties": {},
-      "message": "Test timed out",
-      "stack": null
+      "message": "Test timed out"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/worker-service.html
+++ b/resources/test/tests/worker-service.html
@@ -63,58 +63,50 @@ promise_test(
 {
   "summarized_status": {
     "status_string": "TIMEOUT",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Browser supports ServiceWorker",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Register ServiceWorker",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Worker async_test that completes successfully",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "PASS",
       "name": "Worker test that completes successfully",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "NOTRUN",
       "name": "Worker test that doesn't run ('NOT RUN')",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "status_string": "FAIL",
       "name": "Worker test that fails ('FAIL')",
       "properties": {},
-      "message": "assert_true: Failing test expected true got false",
-      "stack": "(implementation-defined)"
+      "message": "assert_true: Failing test expected true got false"
     },
     {
       "status_string": "TIMEOUT",
       "name": "Worker test that times out ('TIMEOUT')",
       "properties": {},
-      "message": "Test timed out",
-      "stack": null
+      "message": "Test timed out"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/worker-shared.html
+++ b/resources/test/tests/worker-shared.html
@@ -27,50 +27,43 @@ fetch_tests_from_worker(new SharedWorker("worker.js",
 {
   "summarized_status": {
     "status_string": "TIMEOUT",
-    "message": null,
-    "stack": null
+    "message": null
   },
   "summarized_tests": [
     {
       "status_string": "PASS",
       "name": "Browser supports SharedWorkers",
       "properties": {},
-      "message": null,
-      "stack": null
+      "message": null
     },
     {
       "message": null,
       "name": "Worker async_test that completes successfully",
       "properties": {},
-      "stack": null,
       "status_string": "PASS"
     },
     {
       "message": null,
       "name": "Worker test that completes successfully",
       "properties": {},
-      "stack": null,
       "status_string": "PASS"
     },
     {
       "message": null,
       "name": "Worker test that doesn't run ('NOT RUN')",
       "properties": {},
-      "stack": null,
       "status_string": "NOTRUN"
     },
     {
       "message": "assert_true: Failing test expected true got false",
       "name": "Worker test that fails ('FAIL')",
       "properties": {},
-      "stack": "(implementation-defined)",
       "status_string": "FAIL"
     },
     {
       "message": "Test timed out",
       "name": "Worker test that times out ('TIMEOUT')",
       "properties": {},
-      "stack": null,
       "status_string": "TIMEOUT"
     }
   ],


### PR DESCRIPTION
Error.stack is very much undefined and rather weird (e.g., it can vary based on whether you've touched strict-mode code or not, can vary based on whether you've got optimized JITed code on the stack, etc.), and way too fragile for these tests.

Fixes #10652.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10661)
<!-- Reviewable:end -->
