### PR TITLE
Use a non-zero exit code if tag_master.py fails

### DIFF
--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -63,12 +63,14 @@ def tag(repo, owner, sha, tag):
         resp = opener.open(req)
     except Exception as e:
         logger.error("Tag creation failed:\n%s" % e)
-        return
+        return False
 
     if resp.code != 201:
         logger.error("Got HTTP status %s" % resp.code)
-    else:
-        logger.info("Tagged master as %s" % tag)
+        return False
+
+    logger.info("Tagged master as %s" % tag)
+    return True
 
 
 def main():
@@ -84,8 +86,11 @@ def main():
     head_rev = git("rev-parse", "HEAD")
 
     pr = get_pr(owner, repo, head_rev)
-    if pr is not None:
-        tag(owner, repo, head_rev, "merge_pr_%s" % pr)
+    if pr is None:
+        sys.exit(1)
+    tagged = tag(owner, repo, head_rev, "merge_pr_%s" % pr)
+    if not tagged:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -17,9 +17,9 @@ logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 
-def get_pr(repo, owner, rev):
+def get_pr(repo, owner, sha):
     url = ("https://api.github.com/search/issues?q=type:pr+is:merged+repo:%s/%s+%s" %
-           (repo, owner, rev))
+           (repo, owner, sha))
     try:
         resp = urllib2.urlopen(url)
     except Exception as e:
@@ -38,10 +38,10 @@ def get_pr(repo, owner, rev):
 
     items = data["items"]
     if len(items) == 0:
-        logger.error("No PR found for master")
+        logger.error("No PR found for %s" % sha)
         return None
     if len(items) > 1:
-        logger.warning("Found multiple PRs for master")
+        logger.warning("Found multiple PRs for %s" % sha)
 
     pr = items[0]
 
@@ -69,7 +69,7 @@ def tag(repo, owner, sha, tag):
         logger.error("Got HTTP status %s" % resp.code)
         return False
 
-    logger.info("Tagged master as %s" % tag)
+    logger.info("Tagged %s as %s" % (sha, tag))
     return True
 
 


### PR DESCRIPTION
This way, the Travis job will fail, and ci_manifest.sh will not
continue to upload a manifest for an untagged-* tag.

Related to https://github.com/w3c/web-platform-tests/issues/10572 but
doesn't fix it, rather it'll make the Travis jobs fail when this
problem happens, making it easier to notice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10673)
<!-- Reviewable:end -->
