### PR TITLE
Use sha:<SHA> in tag_master.py instead of just <SHA>

### DIFF
--- a/tools/ci/tag_master.py
+++ b/tools/ci/tag_master.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_pr(repo, owner, sha):
-    url = ("https://api.github.com/search/issues?q=type:pr+is:merged+repo:%s/%s+%s" %
+    url = ("https://api.github.com/search/issues?q=type:pr+is:merged+repo:%s/%s+sha:%s" %
            (repo, owner, sha))
     try:
         resp = urllib2.urlopen(url)


### PR DESCRIPTION
This is to avoid finding PRs where commit SHAs have been mentioned,
for example reverts, or just in PR comments.

Example of search which had 2 results before and 1 after:
https://api.github.com/search/issues?q=type:pr+is:merged+repo:w3c/web-platform-tests+280005efe04503f14891d73c6ceab1077a59a735
https://api.github.com/search/issues?q=type:pr+is:merged+repo:w3c/web-platform-tests+sha:280005efe04503f14891d73c6ceab1077a59a735

Kudos to @lukebjerring for pointing out the problem/solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10687)
<!-- Reviewable:end -->
