### PR TITLE
Add two screen-orientation tests and replace async by promise_test

### DIFF
--- a/screen-orientation/lock-bad-argument.html
+++ b/screen-orientation/lock-bad-argument.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
@@ -11,6 +9,8 @@ promise_test(t => {
     undefined,
     123,
     window,
+    "",
+    true,
     ["portrait-primary", "landscape-primary"],
   ];
   const promisesToReject = invalid_lock_types.map(type =>
@@ -23,6 +23,4 @@ promise_test(t => {
   return promise_rejects(t, new TypeError(), screen.orientation.lock());
 }, "screen.orientation.lock() must throw when the input is missing.");
 </script>
-</body>
-</html>
 

--- a/screen-orientation/lock-basic.html
+++ b/screen-orientation/lock-basic.html
@@ -19,6 +19,7 @@ promise_test(async t => {
 promise_test(async t => {
   const orientations = [
     'any',
+    'natural',
     'portrait',
     'landscape',
     'portrait-secondary',
@@ -27,25 +28,36 @@ promise_test(async t => {
     'portrait-primary',
   ];
   for (const orientation of orientations) {
-    const returnType = screen.orientation.lock(orientation);
-    assert_true(returnType instanceof Promise);
-    await returnType;
+    const promiseToChange = screen.orientation.lock(orientation);
+    assert_true(promiseToChange instanceof Promise, "Expected an instance of Promise");
+    await promiseToChange;
+    const type = screen.orientation.type;
+    switch (orientation) {
+    case 'any':
+      break;
+    case 'natural':
+      assert_true(type == "portrait-primary" || type == "landscape-primary");
+      break;
+    case 'portrait':
+      assert_true(type == "portrait-primary" || type == "portrait-secondary");
+      break;
+    case 'landscape':
+      assert_true(type == "landscape-primary" || type == "landscape-secondary");
+      break;
+    default:
+      assert_equals(type, orientation, "Expected orientation to change");
+      break;
+    }
   }
   screen.orientation.unlock();
 }, "Test that screen.orientation.lock returns a pending promise.");
 
 promise_test(async t => {
   const preType = screen.orientation.type;
-  let newType = "";
-
-  if (preType.indexOf("portrait") != -1) {
-    newType = "landscape-primary";
-  } else {
-    newType = "portrait-primary";
-  }
-
+  const isPortrait = preType.includes("portrait");
+  const newType = `${ isPortrait ? "portrait" : "landscape" }-primary`;
   const p = screen.orientation.lock(newType);
-  assert_equals(screen.orientation.type, preType);
+  assert_equals(screen.orientation.type, preType, "Must not change orientation until next spin of event loop");
   await p;
   assert_equals(screen.orientation.type, newType);
 }, "Test that screen.orientation.lock() is actually async");

--- a/screen-orientation/lock-basic.html
+++ b/screen-orientation/lock-basic.html
@@ -1,41 +1,43 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-
-var previousOrientation = screen.orientation;
-
-test(function() {
-    screen.orientation.unlock();
+test(() => {
+  screen.orientation.unlock();
 }, "Test that screen.orientation.unlock() doesn't throw when there is no lock");
 
-async_test(function(t) {
-    var orientations = ['any', 'portrait', 'landscape', 'portrait-secondary',
-                        'landscape-primary', 'landscape-secondary', 'portrait-primary'];
+test(() => {
+  const value = screen.orientation.unlock();
+  assert_equals(value, undefined);
+}, "Test that screen.orientation.unlock() returns a void value");
 
-    setOrientation = function(idx) {
-        if( idx == orientations.length) {
-            screen.orientation.unlock();
-            t.done();
-            return;
-        }
-        (function(i) {
-            screen.orientation.lock(orientations[i]).then(function() {
-                setOrientation(i+1);
-            },function() {});
-        })(idx);
-    };
+promise_test(t => {
+  return screen.orientation.lock('any').then(value => {
+    assert_equals(value, undefined);
+  });
+}, "Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.");
 
-    setOrientation(0);
-
+promise_test(t => {
+  const orientations = [
+    'any',
+    'portrait',
+    'landscape',
+    'portrait-secondary',
+    'landscape-primary',
+    'landscape-secondary',
+    'portrait-primary',
+  ];
+  const promises = orientations.map(type => {
+    const returnType = screen.orientation.lock(type);
+    assert_true(returnType instanceof Promise);
+  });
+  return Promise.all(promises).finally(() => {
+    screen.orientation.unlock();
+  });
 }, "Test that screen.orientation.lock returns a pending promise.");
 
-test(function() {
-    assert_equals(screen.orientation, previousOrientation);
+test(() => {
+  const previousOrientation = screen.orientation;
+  assert_equals(screen.orientation, previousOrientation);
 }, "Test that screen.orientation.lock() is actually async");
-
 </script>
-</body>
-</html>

--- a/screen-orientation/lock-basic.html
+++ b/screen-orientation/lock-basic.html
@@ -55,7 +55,7 @@ promise_test(async t => {
 promise_test(async t => {
   const preType = screen.orientation.type;
   const isPortrait = preType.includes("portrait");
-  const newType = `${ isPortrait ? "portrait" : "landscape" }-primary`;
+  const newType = `${ isPortrait ? "landscape" : "portrait" }-primary`;
   const p = screen.orientation.lock(newType);
   assert_equals(screen.orientation.type, preType, "Must not change orientation until next spin of event loop");
   await p;

--- a/screen-orientation/lock-basic.html
+++ b/screen-orientation/lock-basic.html
@@ -11,13 +11,12 @@ test(() => {
   assert_equals(value, undefined);
 }, "Test that screen.orientation.unlock() returns a void value");
 
-promise_test(t => {
-  return screen.orientation.lock('any').then(value => {
-    assert_equals(value, undefined);
-  });
+promise_test(async t => {
+  const value = await screen.orientation.lock('any');
+  assert_equals(value, undefined);
 }, "Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.");
 
-promise_test(t => {
+promise_test(async t => {
   const orientations = [
     'any',
     'portrait',
@@ -27,17 +26,27 @@ promise_test(t => {
     'landscape-secondary',
     'portrait-primary',
   ];
-  const promises = orientations.map(type => {
-    const returnType = screen.orientation.lock(type);
+  for (const orientation of orientations) {
+    const returnType = screen.orientation.lock(orientation);
     assert_true(returnType instanceof Promise);
-  });
-  return Promise.all(promises).finally(() => {
-    screen.orientation.unlock();
-  });
+    await returnType;
+  }
+  screen.orientation.unlock();
 }, "Test that screen.orientation.lock returns a pending promise.");
 
-test(() => {
-  const previousOrientation = screen.orientation;
-  assert_equals(screen.orientation, previousOrientation);
+promise_test(async t => {
+  const preType = screen.orientation.type;
+  let newType = "";
+
+  if (preType.indexOf("portrait") != -1) {
+    newType = "landscape-primary";
+  } else {
+    newType = "portrait-primary";
+  }
+
+  const p = screen.orientation.lock(newType);
+  assert_equals(screen.orientation.type, preType);
+  await p;
+  assert_equals(screen.orientation.type, newType);
 }, "Test that screen.orientation.lock() is actually async");
 </script>

--- a/screen-orientation/lock-sandboxed-iframe.html
+++ b/screen-orientation/lock-sandboxed-iframe.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
@@ -10,29 +8,21 @@
 <iframe id="disallowedIframe" sandbox="allow-scripts allow-same-origin" style="display:none">
 </iframe>
 <script>
-    var testNotAllowed = async_test("Test without 'allow-orientation-lock' sandboxing directive");
-    var testAllowed = async_test("Test with 'allow-orientation-lock' sandboxing directive");
+promise_test(async t => {
+  const messageWatcher = new EventWatcher(t, window, "message");
+  const disallowedIframe = document.getElementById("disallowedIframe");
+  disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
 
-    function runTestAllowed() {
-        window.onmessage = testAllowed.step_func(function (ev) {
-            assert_equals(ev.data, "portrait-primary", "screen.orientation lock to portrait-primary");
-            screen.orientation.unlock();
-            testAllowed.done();
-        });
-        var allowedIframe = document.getElementById("allowedIframe");
-        allowedIframe.src = "resources/sandboxed-iframe-locking.html";
-    }
+  const message = await messageWatcher.wait_for("message");
+  assert_equals(message.data, "SecurityError", "screen.lockOrientation() throws a SecurityError");
+}, "Test without 'allow-orientation-lock' sandboxing directive");
 
-    function runTestNotAllowed() {
-        window.onmessage = testNotAllowed.step_func(function (ev) {
-            assert_equals(ev.data, "SecurityError", "screen.lockOrientation() throws a SecurityError");
-            testNotAllowed.done();
-            runTestAllowed();
-        });
-        var disallowedIframe = document.getElementById("disallowedIframe");
-        disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
-    }
-    runTestNotAllowed();
+promise_test(async t => {
+  const messageWatcher = new EventWatcher(t, window, "message");
+  const disallowedIframe = document.getElementById("allowedIframe");
+  disallowedIframe.src = "resources/sandboxed-iframe-locking.html";
+
+  const message = await messageWatcher.wait_for("message");
+  assert_equals(message.data, "portrait-primary", "screen.orientation lock to portrait-primary");
+}, "Test with 'allow-orientation-lock' sandboxing directive");
 </script>
-</body>
-</html>

--- a/screen-orientation/onchange-event-subframe.html
+++ b/screen-orientation/onchange-event-subframe.html
@@ -8,23 +8,21 @@
 
 <script>
 promise_test(async t => {
-  const orientations = [
+  let orientations = [
     'portrait-primary',
     'portrait-secondary',
     'landscape-primary',
     'landscape-secondary'
   ];
+  if (screen.orientation.type.includes('portrait')) {
+    orientations = orientations.reverse();
+  }
   const messageWatcher = new EventWatcher(t, window, "message");
 
-  let currentIndex = orientations.indexOf(screen.orientation.type);
-  let nextIndex;
-  let message;
-  for (let i = 0; i < orientations.length; i++) {
-    nextIndex = (currentIndex + 1) % orientations.length;
-    screen.orientation.lock(orientations[nextIndex]);
-    currentIndex = nextIndex;
-    message = await messageWatcher.wait_for("message");
-    assert_equals(message.data, orientations[currentIndex], "subframe receives orientation change event");
+  for (const orientation of orientations) {
+    screen.orientation.lock(orientation);
+    const message = await messageWatcher.wait_for("message");
+    assert_equals(message.data, orientation, "subframe receives orientation change event");
   }
   screen.orientation.unlock();
 }, "Test subframes receive orientation change events");

--- a/screen-orientation/onchange-event-subframe.html
+++ b/screen-orientation/onchange-event-subframe.html
@@ -20,7 +20,7 @@ promise_test(async t => {
   const messageWatcher = new EventWatcher(t, window, "message");
 
   for (const orientation of orientations) {
-    screen.orientation.lock(orientation);
+    await screen.orientation.lock(orientation);
     const message = await messageWatcher.wait_for("message");
     assert_equals(message.data, orientation, "subframe receives orientation change event");
   }

--- a/screen-orientation/onchange-event-subframe.html
+++ b/screen-orientation/onchange-event-subframe.html
@@ -1,46 +1,31 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<iframe id="testIframe" sandbox="allow-scripts allow-same-origin" style="display:none">
+<iframe id="testIframe" sandbox="allow-scripts allow-same-origin"
+  style="display:none" src="resources/iframe-listen-orientation-change.html">
 </iframe>
 
 <script>
-    var test = async_test("Test subframes receive orientation change events");
+promise_test(async t => {
+  const orientations = [
+    'portrait-primary',
+    'portrait-secondary',
+    'landscape-primary',
+    'landscape-secondary'
+  ];
+  const messageWatcher = new EventWatcher(t, window, "message");
 
-    var orientations = [
-        'portrait-primary',
-        'portrait-secondary',
-        'landscape-primary',
-        'landscape-secondary'
-    ];
-
-    var currentIndex = orientations.indexOf(window.screen.orientation.type);
-    var eventsReceived = 0;
-
-    function getNextIndex() {
-        return (currentIndex + 1) % orientations.length;
-    }
-
-    function changeOrientation() {
-        screen.orientation.lock(orientations[getNextIndex()]).then(function () {}, function () {});
-        currentIndex = getNextIndex();
-    }
-
-    window.onmessage = test.step_func(function (ev) {
-        assert_equals(ev.data, orientations[currentIndex], "subframe receives orientation change event");
-        ++eventsReceived;
-        if (eventsReceived < orientations.length)
-            changeOrientation()
-        else
-            test.done();
-    });
-
-    var testIframe = document.getElementById("testIframe");
-    testIframe.src = "resources/iframe-listen-orientation-change.html";
-    testIframe.onload = changeOrientation;
+  let currentIndex = orientations.indexOf(screen.orientation.type);
+  let nextIndex;
+  let message;
+  for (let i = 0; i < orientations.length; i++) {
+    nextIndex = (currentIndex + 1) % orientations.length;
+    screen.orientation.lock(orientations[nextIndex]);
+    currentIndex = nextIndex;
+    message = await messageWatcher.wait_for("message");
+    assert_equals(message.data, orientations[currentIndex], "subframe receives orientation change event");
+  }
+  screen.orientation.unlock();
+}, "Test subframes receive orientation change events");
 </script>
-</body>
-</html>

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -15,7 +15,7 @@ promise_test(t => {
       reject(e);
     }
     assert_equals(screen.orientation.type, type);
-    setTimeout(resolve);
+    resolve();
   });
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -4,12 +4,14 @@
 <script>
 promise_test(t => {
   const type = screen.orientation.type;
-  //wrap onchange listener in new promise to catch unreached assertion
+  // wrap onchange listener in new promise to catch unreached assertion
   return new Promise(async (resolve, reject) => {
-    screen.orientation.onchange = () => { reject("change event should not be fired"); }
+    screen.orientation.onchange = () => { 
+      reject(new Error("change event should not be fired"));
+    }
     await screen.orientation.lock(type);
     assert_equals(screen.orientation.type, type);
-    setTimeout(() => { resolve(); }, 1000);
+    setTimeout(resolve, 1000);
   });
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -4,29 +4,31 @@
 <script>
 promise_test(t => {
   const type = screen.orientation.type;
-  screen.orientation.addEventListener('change', t.unreached_func("change event should not be fired"));
-  return screen.orientation.lock(type).then(() => {
+  //wrap onchange listener in new promise to catch unreached assertion
+  return new Promise(async (resolve, reject) => {
+    screen.orientation.onchange = () => { reject("change event should not be fired"); }
+    await screen.orientation.lock(type);
     assert_equals(screen.orientation.type, type);
+    setTimeout(() => { resolve(); }, 1000);
   });
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 
 promise_test(async t => {
-  const orientations = [
+  let orientations = [
     'portrait-primary',
     'portrait-secondary',
     'landscape-primary',
     'landscape-secondary'
   ];
+  if (screen.orientation.type.includes('portrait')) {
+    orientations = orientations.reverse();
+  }
   const orientationWatcher = new EventWatcher(t, screen.orientation, 'change');
 
-  let currentIndex = orientations.indexOf(screen.orientation.type);
-  let nextIndex;
-  for (let i = 0; i < orientations.length; i++) {
-    nextIndex = (currentIndex + 1) % orientations.length;
-    screen.orientation.lock(orientations[nextIndex]);
-    currentIndex = nextIndex;
+  for (const orientation of orientations) {
+    screen.orientation.lock(orientation);
     await orientationWatcher.wait_for('change');
-    assert_equals(screen.orientation.type, orientations[currentIndex]);
+    assert_equals(screen.orientation.type, orientation);
   }
   screen.orientation.unlock();
 }, "Test that orientationchange event is fired when the orientation changes.");

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -11,11 +11,11 @@ promise_test(t => {
         reject(new Error("change event should not be fired"));
       }
       await screen.orientation.lock(type);
+      assert_equals(screen.orientation.type, type);
+      resolve();
     } catch (e) {
       reject(e);
     }
-    assert_equals(screen.orientation.type, type);
-    resolve();
   });
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -6,10 +6,14 @@ promise_test(t => {
   const type = screen.orientation.type;
   // wrap onchange listener in new promise to catch unreached assertion
   return new Promise(async (resolve, reject) => {
-    screen.orientation.onchange = () => {
-      reject(new Error("change event should not be fired"));
+    try {
+      screen.orientation.onchange = () => {
+        reject(new Error("change event should not be fired"));
+      }
+      await screen.orientation.lock(type);
+    } catch (e) {
+      reject(e);
     }
-    await screen.orientation.lock(type);
     assert_equals(screen.orientation.type, type);
     setTimeout(resolve);
   });
@@ -28,7 +32,7 @@ promise_test(async t => {
   const orientationWatcher = new EventWatcher(t, screen.orientation, 'change');
 
   for (const orientation of orientations) {
-    screen.orientation.lock(orientation);
+    await screen.orientation.lock(orientation);
     await orientationWatcher.wait_for('change');
     assert_equals(screen.orientation.type, orientation);
   }

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -11,7 +11,7 @@ promise_test(t => {
     }
     await screen.orientation.lock(type);
     assert_equals(screen.orientation.type, type);
-    setTimeout(resolve, 1000);
+    setTimeout(resolve);
   });
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -1,80 +1,33 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-
-var changeTest = async_test("Test that orientationchange event is fired when the orientation changes.");
-var noChangeTest = async_test("Test that orientationchange event is not fired when the orientation does not change.");
-
-var orientations = [
-  'portrait-primary',
-  'portrait-secondary',
-  'landscape-primary',
-  'landscape-secondary'
-];
-
-var currentIndex = orientations.indexOf(window.screen.orientation.type);
-// Count the number of calls received from the EventHandler set on screen.orientation.onchange.
-var orientationChangeEventHandlerCalls = 0;
-// Count the number of calls received from the listener set with screen.orientation.addEventListene().
-var orientationChangeEventListenerCalls = 0;
-
-var orientationChangeContinuation = null;
-
-function getNextIndex() {
-  return (currentIndex + 1) % orientations.length;
-}
-
-window.screen.orientation.onchange = function() {
-  orientationChangeEventHandlerCalls++;
-  if (orientationChangeEventContinuation) {
-    setTimeout(orientationChangeEventContinuation);
-    orientationChangeEventContinuation = null;
-  }
-};
-
-window.screen.orientation.addEventListener('change', function() {
-  orientationChangeEventListenerCalls++;
-});
-
-function runNoChangeTest() {
-  screen.orientation.lock(orientations[currentIndex]).then(function() {}, function() {});
-
-  noChangeTest.step(function() {
-    assert_equals(screen.orientation.type, orientations[currentIndex]);
-    assert_equals(orientationChangeEventHandlerCalls, orientations.length);
-    assert_equals(orientationChangeEventListenerCalls, orientations.length);
+promise_test(t => {
+  const type = screen.orientation.type;
+  screen.orientation.addEventListener('change', t.unreached_func("change event should not be fired"));
+  return screen.orientation.lock(type).then(() => {
+    assert_equals(screen.orientation.type, type);
   });
+}, "Test that orientationchange event is not fired when the orientation does not change.");
 
-  noChangeTest.done();
-}
+promise_test(async t => {
+  const orientations = [
+    'portrait-primary',
+    'portrait-secondary',
+    'landscape-primary',
+    'landscape-secondary'
+  ];
+  const orientationWatcher = new EventWatcher(t, screen.orientation, 'change');
 
-var i = 0;
-function runChangeTest() {
-  screen.orientation.lock(orientations[getNextIndex()]).then(function() {}, function() {});
-  currentIndex = getNextIndex();
-
-  orientationChangeEventContinuation = function() {
-    changeTest.step(function() {
-      assert_equals(screen.orientation.type, orientations[currentIndex]);
-      assert_equals(orientationChangeEventHandlerCalls, i + 1);
-      assert_equals(orientationChangeEventListenerCalls, i + 1);
-    });
-
-    ++i;
-    if (i == orientations.length) {
-      changeTest.done();
-      runNoChangeTest();
-    } else {
-      runChangeTest();
-    }
-  };
-}
-
-runChangeTest();
-
+  let currentIndex = orientations.indexOf(screen.orientation.type);
+  let nextIndex;
+  for (let i = 0; i < orientations.length; i++) {
+    nextIndex = (currentIndex + 1) % orientations.length;
+    screen.orientation.lock(orientations[nextIndex]);
+    currentIndex = nextIndex;
+    await orientationWatcher.wait_for('change');
+    assert_equals(screen.orientation.type, orientations[currentIndex]);
+  }
+  screen.orientation.unlock();
+}, "Test that orientationchange event is fired when the orientation changes.");
 </script>
-</body>
-</html>

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -6,7 +6,7 @@ promise_test(t => {
   const type = screen.orientation.type;
   // wrap onchange listener in new promise to catch unreached assertion
   return new Promise(async (resolve, reject) => {
-    screen.orientation.onchange = () => { 
+    screen.orientation.onchange = () => {
       reject(new Error("change event should not be fired"));
     }
     await screen.orientation.lock(type);

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -2,21 +2,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-promise_test(t => {
+promise_test(async t => {
   const type = screen.orientation.type;
-  // wrap onchange listener in new promise to catch unreached assertion
-  return new Promise(async (resolve, reject) => {
-    try {
-      screen.orientation.onchange = () => {
-        reject(new Error("change event should not be fired"));
-      }
-      await screen.orientation.lock(type);
-      assert_equals(screen.orientation.type, type);
-      resolve();
-    } catch (e) {
-      reject(e);
-    }
-  });
+  screen.orientation.onchange = t.unreached_func("change event should not be fired");
+  await screen.orientation.lock(type);
+  assert_equals(screen.orientation.type, type);
 }, "Test that orientationchange event is not fired when the orientation does not change.");
 
 promise_test(async t => {

--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -42,9 +42,9 @@ promise_test(async t => {
   const orientationWatcher = new EventWatcher(t, orientation, "change");
 
   if (orientationType.includes("portrait")) {
-    orientation.lock("landscape-primary");
+    await orientation.lock("landscape-primary");
   } else {
-    orientation.lock("portrait-primary");
+    await orientation.lock("portrait-primary");
   }
 
   await orientationWatcher.wait_for("change");

--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -1,61 +1,58 @@
 <!DOCTYPE html>
-<html>
-<body>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-
-test(function() {
-    assert_true('type' in screen.orientation);
-    assert_true('angle' in screen.orientation);
+test(() => {
+  assert_true('type' in screen.orientation);
+  assert_true('angle' in screen.orientation);
 }, "Test screen.orientation properties");
 
-test(function() {
-    assert_equals(screen.orientation.type, "portrait-primary");
-    assert_equals(screen.orientation.angle, 0);
+test(() => {
+  const type = screen.orientation.type;
+  const angle = screen.orientation.angle;
+
+  if (screen.width > screen.height) {
+    assert_true(type == "landscape-primary" || type == "landscape-secondary");
+  } else if (screen.width < screen.height) {
+    assert_true(type == "portrait-primary" || type == "portrait-secondary");
+  }
+
+  assert_true(angle == 0 || angle == 90 || angle == 180 || angle == 270);
 }, "Test screen.orientation default values.");
 
-test(function() {
-    var type = screen.orientation.type;
-    var angle = screen.orientation.angle;
+test(() => {
+  const type = screen.orientation.type;
+  const angle = screen.orientation.angle;
 
-    screen.orientation.type = 'foo';
-    screen.orientation.angle = 42;
+  screen.orientation.type = 'foo';
+  screen.orientation.angle = 42;
 
-    assert_equals(screen.orientation.type, type);
-    assert_equals(screen.orientation.angle, angle);
+  assert_equals(screen.orientation.type, type);
+  assert_equals(screen.orientation.angle, angle);
 }, "Test that screen.orientation properties are not writable");
 
-test(function() {
-    assert_equals(screen.orientation, screen.orientation);
+test(() => {
+  assert_equals(screen.orientation, screen.orientation);
 }, "Test that screen.orientation is always the same object");
 
-async_test(function(t) {
-    var orientation = screen.orientation;
-    var orientationType = screen.orientation.type;
-    var orientationAngle = screen.orientation.angle;
+promise_test(async t => {
+  const orientation = screen.orientation;
+  const orientationType = screen.orientation.type;
+  const orientationAngle = screen.orientation.angle;
+  const orientationWatcher = new EventWatcher(t, orientation, "change");
 
-    screen.orientation.unlock();
-    screen.orientation.lock('landscape-primary').then(function () {
-        t.step(function () {
-            assert_equals(screen.orientation, orientation);
-            assert_equals(screen.orientation.type, orientation.type);
-            assert_equals(screen.orientation.angle, orientation.angle);
-            assert_not_equals(screen.orientation.type, orientationType);
-            assert_not_equals(screen.orientation.angle, orientationAngle);
-        });
-        t.done();
-        screen.orientation.unlock();
-    }, function () {
-        t.step(function () {
-            assert_unreached('Unexpected orientation change');
-        });
-        t.done();
-        screen.orientation.unlock();
-    });
+  if (orientationType.indexOf("portrait") != -1) {
+    orientation.lock("landscape-primary");
+  } else {
+    orientation.lock("portrait-primary");
+  }
 
+  await orientationWatcher.wait_for("change");
+  assert_equals(screen.orientation, orientation);
+  assert_equals(screen.orientation.type, orientation.type);
+  assert_equals(screen.orientation.angle, orientation.angle);
+  assert_not_equals(screen.orientation.type, orientationType);
+  assert_not_equals(screen.orientation.angle, orientationAngle);
+  screen.orientation.unlock();
 }, "Test that screen.orientation values change if the orientation changes");
-
 </script>
-</body>
-</html>

--- a/screen-orientation/orientation-reading.html
+++ b/screen-orientation/orientation-reading.html
@@ -41,7 +41,7 @@ promise_test(async t => {
   const orientationAngle = screen.orientation.angle;
   const orientationWatcher = new EventWatcher(t, orientation, "change");
 
-  if (orientationType.indexOf("portrait") != -1) {
+  if (orientationType.includes("portrait")) {
     orientation.lock("landscape-primary");
   } else {
     orientation.lock("portrait-primary");

--- a/screen-orientation/resources/iframe-listen-orientation-change.html
+++ b/screen-orientation/resources/iframe-listen-orientation-change.html
@@ -1,6 +1,5 @@
-<!DOCTYPE html>
 <script>
-    window.screen.orientation.addEventListener('change', function() {
-        parent.window.postMessage(screen.orientation.type, "*");
-    });
+window.screen.orientation.addEventListener('change', () => {
+  parent.window.postMessage(screen.orientation.type, "*");
+});
 </script>

--- a/screen-orientation/resources/sandboxed-iframe-locking.html
+++ b/screen-orientation/resources/sandboxed-iframe-locking.html
@@ -1,13 +1,11 @@
-<!DOCTYPE html>
-<html>
 <script>
-    var msg = "";
-    screen.orientation.lock("portrait-primary").then(function() {
-        msg = screen.orientation.type;
-    }, function(error) {
-        msg = error.name;
-    }).then(function() {
-        parent.window.postMessage(msg, "*");
-    });
+let msg = "";
+screen.orientation.lock("portrait-primary")
+.then(() => {
+  msg = screen.orientation.type;
+}).catch(error => {
+  msg = error.name;
+}).finally(() => {
+  parent.window.postMessage(msg, "*");
+});
 </script>
-</html>


### PR DESCRIPTION
- Add test that screen.orientation.unlock() returns a void value.
- Add test that screen.orientation.lock returns a promise which will be fulfilled with a void value.
- Add "" and true types in test (screen.orientation.lock() must throw given invalid input).
- Update test (Test screen.orientation default values).
- Replace async by promise_test.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
