### PR TITLE
Cleanup CSSOM View interfaces test

### DIFF
--- a/css/cssom-view/interfaces.html
+++ b/css/cssom-view/interfaces.html
@@ -3,7 +3,7 @@
 <!-- WARNING: These tests are preliminary and probably partly incorrect.  -->
 <title>CSSOM View automated IDL tests</title>
 <link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com">
-<link rel="help" href="https://drafts.csswg.org/cssom-1/#idl-index">
+<link rel="help" href="https://drafts.csswg.org/cssom-view-1/#idl-index">
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
 <script src=/resources/WebIDLParser.js></script>
@@ -17,11 +17,11 @@
 <script>
 "use strict";
 
-function doTest([html, dom, uievents, cssom, geometry, cssom_view]) {
+function doTest([html, dom, uievents, cssom, cssom_view]) {
 
   var idlArray = new IdlArray();
   var svg = "interface SVGElement : Element {};";
-  idlArray.add_untested_idls(html + dom + svg + cssom + geometry);
+  idlArray.add_untested_idls(html + dom + svg + cssom);
   idlArray.add_untested_idls(uievents, { only: [
     'UIEvent',
     'UIEventInit',
@@ -45,7 +45,6 @@ function doTest([html, dom, uievents, cssom, geometry, cssom_view]) {
     // "MouseEvent": ["new MouseEvent('foo')"],
     "Text": ["document.createTextNode('x')"],
     // "CSSPseudoElement": [],
-    "Document": ["document"],
   });
   idlArray.test();
 };
@@ -66,7 +65,6 @@ promise_test(function() {
                       fetchData("/interfaces/dom.idl"),
                       fetchData("/interfaces/uievents.idl"),
                       fetchData("/interfaces/cssom.idl"),
-                      fetchData("/interfaces/geometry.idl"),
                       fetchData("/interfaces/cssom-view.idl"),
                       waitForLoad()])
                 .then(doTest);


### PR DESCRIPTION
The CSSOM View interfaces test added the Geometry IDL as untested, but it is never needed (at least as far as I can tell, since removing it does not affect test results, but someone with more knowledge about idlharness should verify that). Removing it means that less IDL needs to be parsed, speeding up the test.

The test also adds Document as an object twice, and refers to the CSSOM spec instead of the CSSOM View spec. This change fixes both of these issues as well.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
