### PR TITLE
Move shadow stuff to its own test in link-rel-attribute.html

### DIFF
--- a/html/semantics/document-metadata/the-link-element/link-rel-attribute.html
+++ b/html/semantics/document-metadata/the-link-element/link-rel-attribute.html
@@ -16,11 +16,6 @@
 </div>
 
 <script>
-var host = document.querySelector("#host");
-var shadow = host.attachShadow({ mode: "open" });
-var tmpl = document.querySelector("template#shadow-dom");
-var clone = document.importNode(tmpl.content, true);
-shadow.appendChild(clone);
 
 function testLinkRelModification(testDiv, testLink) {
   assert_equals(getComputedStyle(testDiv).color, "rgb(0, 128, 0)");
@@ -38,6 +33,11 @@ test (() => {
 }, "Removing stylesheet from link rel attribute should remove the stylesheet for light DOM");
 
 test (() => {
+  var host = document.querySelector("#host");
+  var shadow = host.attachShadow({ mode: "open" });
+  var tmpl = document.querySelector("template#shadow-dom");
+  var clone = document.importNode(tmpl.content, true);
+  shadow.appendChild(clone);
   testLinkRelModification(shadow.querySelector("#shadow-div"),
                           shadow.querySelector("#shadow-link"));
 }, "Removing stylesheet from link rel attribute should remove the stylesheet for shadow DOM");


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/20682 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10731)
<!-- Reviewable:end -->
