### PR TITLE
[wptrunner] Re-enable return code

### DIFF
--- a/infrastructure/browsers/firefox/prefs.html
+++ b/infrastructure/browsers/firefox/prefs.html
@@ -3,5 +3,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <script>
 assert_equals(getComputedStyle(document.documentElement).color, "rgb(0, 255, 0)")
+done();
 </script>
 <p>This should be green</p>

--- a/tools/ci/ci_taskcluster.sh
+++ b/tools/ci/ci_taskcluster.sh
@@ -5,5 +5,5 @@
 if [ $1 == "firefox" ]; then
     ./wpt run firefox --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y --install-browser --no-pause --no-restart-on-unexpected --reftest-internal --install-fonts
 elif [ $1 == "chrome" ]; then
-    ./wpt run chrome --log-tbpl==../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected --install-fonts
+    ./wpt run chrome --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected --install-fonts
 fi

--- a/tools/ci/ci_taskcluster.sh
+++ b/tools/ci/ci_taskcluster.sh
@@ -3,7 +3,7 @@
 ./wpt manifest-download
 
 if [ $1 == "firefox" ]; then
-    ./wpt run firefox --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y --install-browser --no-pause --no-restart-on-unexpected --reftest-internal --install-fonts
+    ./wpt run firefox --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y --install-browser --no-pause --no-restart-on-unexpected --reftest-internal --install-fonts --no-fail-on-unexpected
 elif [ $1 == "chrome" ]; then
-    ./wpt run chrome --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected --install-fonts
+    ./wpt run chrome --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected --install-fonts --no-fail-on-unexpected
 fi

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -455,8 +455,7 @@ def run(venv, **kwargs):
 
 def run_single(venv, **kwargs):
     from wptrunner import wptrunner
-    wptrunner.start(**kwargs)
-    return
+    return wptrunner.start(**kwargs)
 
 
 def main():

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -66,6 +66,10 @@ scheme host and port.""")
 
     parser.add_argument("--no-capture-stdio", action="store_true", default=False,
                         help="Don't capture stdio and write to logging")
+    parser.add_argument("--no-fail-on-unexpected", action="store_false",
+                        default=True,
+                        dest="fail_on_unexpected",
+                        help="Exit with status code 0 when test expectations are violated")
 
     mode_group = parser.add_argument_group("Mode")
     mode_group.add_argument("--list-test-groups", action="store_true",

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -289,6 +289,10 @@ def run_tests(config, test_paths, product, **kwargs):
         logger.error("No tests ran")
         return False
 
+    if unexpected_total and not kwargs["fail_on_unexpected"]:
+        logger.info("Tolerating %s unexpected results" % unexpected_total)
+        return True
+
     return unexpected_total == 0
 
 


### PR DESCRIPTION
In a previous commit [1] the WPT CLI was modified to ignore the return
value of the `wptrunner.start` method. Although this behavior is
convenient in cases where there is no expectation data, it obscures
errors that are relevant in any context.

Specifically, the `start` method returns a non-zero value when no tests
are run, but this is a reliable indicator of an erroneous configuration.
Because the `wpt run` command is used to validate the infrastructure of
the web-platform-tests project, ignoring this case allows
mis-configurations to go unnoticed [2].

Re-enable observance of the value returned by `wptrunner.start` and
update the code generated for the TaskCluster service to ignore this
value.

[1] 5a1b0365267b540c7f4feac3e0a85e9146997fcd
[2] https://github.com/w3c/web-platform-tests/pull/10721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10742)
<!-- Reviewable:end -->
