### PR TITLE
Testdriver API to get current window handle

### DIFF
--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -51,3 +51,7 @@ For example, to send the tab key you would send "\uE004".
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}
 
 ### `test_driver.current_window_handle()`
+
+This function grabs the associated window handle `string` that identifies
+the current open window. It returns a `Promise` that contains the `string`
+window handle or it rejects if it cannot get the handle.

--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -49,3 +49,5 @@ To send special keys, one must send the respective key's codepoint. Since this u
 For example, to send the tab key you would send "\uE004".
 
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}
+
+### `test_driver.current_window_handle()`

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -119,6 +119,15 @@
             }
 
             return window.test_driver_internal.send_keys(element, keys);
+        },
+
+        /**
+         * Gets the handle for the current window
+         *
+         * @returns {Promise} fulfilled after getting window handle or rejected if that fails
+         */
+        current_window_handle: function() {
+            return Promise.reject(new Error("unimplemented"));
         }
     };
 
@@ -142,6 +151,15 @@
          * @returns {Promise} fulfilled after keys are sent or rejected if click fails
          */
         send_keys: function(element, keys) {
+            return Promise.reject(new Error("unimplemented"));
+        },
+
+        /**
+         * Gets the handle for the current window
+         *
+         * @returns {Promise} fulfilled after getting window handle or rejected if that fails
+         */
+        current_window_handle: function() {
             return Promise.reject(new Error("unimplemented"));
         }
     };


### PR DESCRIPTION
This is a PR to add an API to get the current window handle. It depends on #10716 and shouldn't be merged until it is resolved.

(It also needs some docs and a test)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10747)
<!-- Reviewable:end -->
