### PR TITLE
Testdriver API to switch to a window

### DIFF
--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -51,7 +51,11 @@ For example, to send the tab key you would send "\uE004".
 ### `test_driver.switch_to_window(window_handle)`
 #### `window_handle: string that is associated with a window`
 
-This function causes the browser to switch to make the current window the one with associated window handle string `window_handle`.
-Here we mean window handle as the identifier you get when invoking the `test_driver.get_window_handle` command.
+This function causes the browser to switch to make the current window
+the one with associated window handle string `window_handle`. Here we
+mean window handle as the identifier you get when invoking the 
+`test_driver.get_window_handle` command. It returns a `Promise` that 
+resolves after the window is minimized or rejects if the window 
+cannot be minimized.
 
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}

--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -48,6 +48,10 @@ between the function being called and the promise settling.
 To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a list for code points to special keys in the spec (here)[https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions].
 For example, to send the tab key you would send "\uE004".
 
-### `test_driver.switch_to_window()`
+### `test_driver.switch_to_window(window_handle)`
+#### `window_handle: string that is associated with a window`
+
+This function causes the browser to switch to make the current window the one with associated window handle string `window_handle`.
+Here we mean window handle as the identifier you get when invoking the `test_driver.get_window_handle` command.
 
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}

--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -48,4 +48,6 @@ between the function being called and the promise settling.
 To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a list for code points to special keys in the spec (here)[https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions].
 For example, to send the tab key you would send "\uE004".
 
+### `test_driver.switch_to_window()`
+
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -119,6 +119,20 @@
             }
 
             return window.test_driver_internal.send_keys(element, keys);
+        },
+
+        /**
+         * Switch to a window
+         *
+         * This matches the behaviour of the {@link
+         * https://w3c.github.io/webdriver/#switch-to-window|WebDriver
+         * Switch to Window command}.
+         *
+         * @returns {Promise} fulfilled window is switched, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        switch_to_window: function(window_handle) {
+            return window.test_driver_internal.switch_to_window(window_handle);
         }
     };
 
@@ -143,6 +157,20 @@
          */
         send_keys: function(element, keys) {
             return Promise.reject(new Error("unimplemented"));
+        },
+
+        /**
+         * Switch to a window
+         *
+         * This matches the behaviour of the {@link
+         * https://w3c.github.io/webdriver/#switch-to-window|WebDriver
+         * Switch to Window command}.
+         *
+         * @returns {Promise} fulfilled window is switched, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        switch_to_window: function(window_handle) {
+            return window.test_driver_internal.switch_to_window(window_handle);
         }
     };
 })();

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -502,7 +502,8 @@ class CallbackHandler(object):
 
         self.actions = {
             "click": ClickAction(self.logger, self.protocol),
-            "send_keys": SendKeysAction(self.logger, self.protocol)
+            "send_keys": SendKeysAction(self.logger, self.protocol),
+            "switch_to_window": SwitchToWindowAction(self.logger, self.protocol)
         }
 
     def __call__(self, result):
@@ -575,3 +576,13 @@ class SendKeysAction(object):
             raise ValueError("Selector matches multiple elements")
         self.logger.debug("Sending keys to element: %s" % selector)
         self.protocol.send_keys.send_keys(elements[0], keys)
+
+class SwitchToWindowAction(object):
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        window_handle = payload["window_handle"]
+        self.logger.debug("Switching to window with handle: %s" % handle)
+        self.protocol.switch_to_window.switch_to_window(handle)

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -584,5 +584,5 @@ class SwitchToWindowAction(object):
 
     def __call__(self, payload):
         window_handle = payload["window_handle"]
-        self.logger.debug("Switching to window with handle: %s" % handle)
-        self.protocol.switch_to_window.switch_to_window(handle)
+        self.logger.debug("Switching to window with handle: %s" % window_handle)
+        self.protocol.switch_to_window.switch_to_window(window_handle)

--- a/tools/wptrunner/wptrunner/executors/executorselenium.py
+++ b/tools/wptrunner/wptrunner/executors/executorselenium.py
@@ -20,6 +20,7 @@ from .protocol import (BaseProtocolPart,
                        SelectorProtocolPart,
                        ClickProtocolPart,
                        SendKeysProtocolPart,
+                       SwitchToWindowProtocolPart,
                        TestDriverProtocolPart)
 from ..testrunner import Stop
 
@@ -142,6 +143,13 @@ class SeleniumSendKeysProtocolPart(SendKeysProtocolPart):
     def send_keys(self, element, keys):
         return element.send_keys(keys)
 
+class SeleniumSwitchToWindowProtocolPart(SwitchToWindowProtocolPart):
+    def setup(self):
+        self.webdriver = self.parent.webdriver
+
+    def send_keys(self, element, keys):
+        return element.send_keys(keys)
+
 
 class SeleniumTestDriverProtocolPart(TestDriverProtocolPart):
     def setup(self):
@@ -163,6 +171,7 @@ class SeleniumProtocol(Protocol):
                   SeleniumSelectorProtocolPart,
                   SeleniumClickProtocolPart,
                   SeleniumSendKeysProtocolPart,
+                  SeleniumSwitchToWindowProtocolPart,
                   SeleniumTestDriverProtocolPart]
 
     def __init__(self, executor, browser, capabilities, **kwargs):

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -273,6 +273,19 @@ class SendKeysProtocolPart(ProtocolPart):
         :param keys: A protocol-specific handle to a string of input keys."""
         pass
 
+class SwitchToWindowProtocolPart(ProtocolPart):
+    """Protocol part for performing trusted clicks"""
+    __metaclass__ = ABCMeta
+
+    name = "switch_to_window"
+
+    @abstractmethod
+    def switch_to_window(self, handle):
+        """Send keys to a specific element.
+
+        :param handle: A protocol-specific handle to a window."""
+        pass
+
 
 class TestDriverProtocolPart(ProtocolPart):
     """Protocol part that implements the basic functionality required for

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -70,4 +70,13 @@
         window.opener.postMessage({"type": "action", "action": "send_keys", "selector": selector, "keys": keys}, "*");
         return pending_promise;
     };
+
+    window.test_driver_internal.switch_to_window = function(window_handle) {
+        const pending_promise = new Promise(function(resolve, reject) {
+            pending_resolve = resolve;
+            pending_reject = reject;
+        });
+        window.opener.postMessage({"type": "action", "action": "switch_to_window", "window_handle": window_handle}, "*");
+        return pending_promise;
+    };
 })();


### PR DESCRIPTION
This is a PR that adds a testdriver APi to switch to a window given a handle. There needs to be a way to get the required handle name so this feature depends on #10749 and #10747 for now.

(It also needs some docs and an infra test)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10752)
<!-- Reviewable:end -->
