### PR TITLE
testcase fixes in css/CSS2/borders

### DIFF
--- a/css/CSS2/bidi-text/bidi-003.xht
+++ b/css/CSS2/bidi-text/bidi-003.xht
@@ -41,7 +41,7 @@
     <span class="control b end">   mmm nnn ooo </span>
    </p>
    <p>
-    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj </span> iii hhh ggg <span class="test b"> fff eee ddd &#x202C; mmm nnn ooo </span>
+    <span class="test a"> aaa bbb ccc &#x202E; lll kkk jjj </span> iii hhh ggg <span class="test b"> fff eee ddd &#x202C;mmm nnn ooo </span>
    </p>
   </div>
  </body>

--- a/css/CSS2/borders/border-bottom-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-bottom-width-applies-to-008.xht
@@ -3,23 +3,27 @@
     <head>
         <title>CSS Test: Border-bottom-width applied to element with display inline</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Mike Bremford" href="http://bfo.com/" /> <!-- modified 2018-05-02 -->
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-05-24 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-bottom-width" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-width-properties" />
+	<link rel="match" href="border-n-width-applies-to-008-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'border-bottom-width' property applies to elements with a display of inline." />
         <style type="text/css">
-            div
+            img
             {
                 border-bottom-style: solid;
                 border-bottom-width: 1in;
                 display: inline;
-                font-size: 1in;
+                width: 1in;
+                height: 1px;
+                margin-top: -1px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is a black filled rectangle.</p>
-        <div>&nbsp;&nbsp;&nbsp;&nbsp;</div>
+        <p>Test passes if there is a filled black rectangle.</p>
+        <img src="support/1x1-white.png" />
     </body>
 </html>

--- a/css/CSS2/borders/border-bottom-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-bottom-width-applies-to-008.xht
@@ -15,7 +15,6 @@
             {
                 border-bottom-style: solid;
                 border-bottom-width: 1in;
-                display: inline;
                 width: 1in;
                 height: 1px;
                 margin-top: -1px;
@@ -23,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black rectangle.</p>
-        <img src="support/1x1-white.png" />
+        <p>Test passes if there is a filled black square.</p>
+        <div><img src="support/1x1-white.png" alt="Image download support must be enabled" /></div>
     </body>
 </html>

--- a/css/CSS2/borders/border-color-011-ref.xht
+++ b/css/CSS2/borders/border-color-011-ref.xht
@@ -19,7 +19,10 @@
 
  <body>
 
-  <div>This should have a green border, because the computed value of 'border-color' set to its initial value is the computed value of 'color', which is then inherited as a color.</div>
-
+  <div>
+    This should have a green border, because the computed value of
+    'border-color' set to its initial value is 'currentColor', which
+    refers to the color on the current element.
+  </div>
  </body>
 </html>

--- a/css/CSS2/borders/border-color-011.xht
+++ b/css/CSS2/borders/border-color-011.xht
@@ -6,11 +6,17 @@
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.html" type="text/html"/>
   <link rel="alternate" href="http://www.hixie.ch/tests/adhoc/css/inheritance/border-color/001.xml" type="application/xhtml+xml"/>
   <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-color-properties" />
+  <link rel="help" href="https://drafts.csswg.org/css-color/#resolving-color-values" />
+  <!--
+  Note this test was originally reversed, but was updated to reflect the introduction of the the
+  "currentColor" keyword, and in particular the rule that it is inherited as a keyword, not as
+  the value of the 'color' property.
+  -->
   <link rel="match" href="border-color-011-ref.xht" />
 
   <style type="text/css">
-   .test { display: block; color: green; border: none; }
-   .test .inner { border-color: inherit; border-style: solid; color: red; }
+   .test { display: block; color: red; border: none; }
+   .test .inner { border-color: inherit; border-style: solid; color: green; }
    .test .inner .text { color: green; }
   </style>
  </head>
@@ -19,8 +25,8 @@
    <div class="inner">
     <div class="text">
      This should have a green border, because the computed value of
-     'border-color' set to its initial value is the computed value
-     of 'color', which is then inherited as a color.
+     'border-color' set to its initial value is 'currentColor', which
+     refers to the color on the current element.
     </div>
    </div>
   </div>

--- a/css/CSS2/borders/border-left-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-left-width-applies-to-008.xht
@@ -15,14 +15,13 @@
             {
                 border-left-style: solid;
                 border-left-width: 1in;
-                display: inline;
                 height: 1in;
                 width: 1px;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black rectangle.</p>
-        <img src="support/1x1-white.png" />
+        <p>Test passes if there is a filled black square.</p>
+        <div><img src="support/1x1-white.png" alt="Image download support must be enabled" /></div>
     </body>
 </html>

--- a/css/CSS2/borders/border-left-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-left-width-applies-to-008.xht
@@ -3,23 +3,26 @@
     <head>
         <title>CSS Test: Border-left-width applied to element with display inline</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Mike Bremford" href="http://bfo.com/" /> <!-- modified 2018-05-02 -->
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-12-06 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-left-width" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-width-properties" />
+	<link rel="match" href="border-n-width-applies-to-008-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'border-left-width' properties applies to elements with a display of inline." />
         <style type="text/css">
-            div
+            img
             {
                 border-left-style: solid;
                 border-left-width: 1in;
                 display: inline;
-                font-size: 1in;
+                height: 1in;
+                width: 1px;
             }
         </style>
     </head>
     <body>
         <p>Test passes if there is a filled black rectangle.</p>
-        <div>&nbsp;</div>
+        <img src="support/1x1-white.png" />
     </body>
 </html>

--- a/css/CSS2/borders/border-n-width-applies-to-008-ref.xht
+++ b/css/CSS2/borders/border-n-width-applies-to-008-ref.xht
@@ -7,7 +7,7 @@
     </style>
   </head>
   <body>
-    <p>Test passes if there is a filled black rectangle.</p>
-    <img src="support/black15x15.png" />
+    <p>Test passes if there is a filled black square.</p>
+    <div><img src="support/black15x15.png" alt="Image download support must be enabled" /></div>
   </body>
 </html>

--- a/css/CSS2/borders/border-n-width-applies-to-008-ref.xht
+++ b/css/CSS2/borders/border-n-width-applies-to-008-ref.xht
@@ -1,0 +1,13 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Reference Test</title>
+    <link rel="author" title="Mike Bremford" href="http://bfo.com/" />
+    <style type="text/css">
+    img { width: 1in; height: 1in; }
+    </style>
+  </head>
+  <body>
+    <p>Test passes if there is a filled black rectangle.</p>
+    <img src="support/black15x15.png" />
+  </body>
+</html>

--- a/css/CSS2/borders/border-right-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-right-width-applies-to-008.xht
@@ -15,7 +15,6 @@
             {
                 border-right-style: solid;
                 border-right-width: 1in;
-                display: inline;
                 height: 1in;
                 width: 1px;
                 margin-left: -1px;
@@ -23,7 +22,7 @@
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black rectangle.</p>
-        <img src="support/1x1-white.png" />
+        <p>Test passes if there is a filled black square.</p>
+        <div><img src="support/1x1-white.png" alt="Image download support must be enabled" /></div>
     </body>
 </html>

--- a/css/CSS2/borders/border-right-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-right-width-applies-to-008.xht
@@ -3,23 +3,27 @@
     <head>
         <title>CSS Test: Border-right-width applied to element with display inline</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Mike Bremford" href="http://bfo.com/" /> <!-- modified 2018-05-02 -->
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-24 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-right-width" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-width-properties" />
+        <link rel="match" href="border-n-width-applies-to-008-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'border-right-width' property applies to elements with a display of inline." />
         <style type="text/css">
-            div
+            img
             {
                 border-right-style: solid;
                 border-right-width: 1in;
                 display: inline;
-                font-size: 1in;
+                height: 1in;
+                width: 1px;
+                margin-left: -1px;
             }
         </style>
     </head>
     <body>
         <p>Test passes if there is a filled black rectangle.</p>
-        <div>&nbsp;</div>
+        <img src="support/1x1-white.png" />
     </body>
 </html>

--- a/css/CSS2/borders/border-top-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-top-width-applies-to-008.xht
@@ -3,27 +3,26 @@
     <head>
         <title>CSS Test: Border-top-width applied to element with display inline</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
+        <link rel="author" title="Mike Bremford" href="http://bfo.com/" /> <!-- modified 2018-05-02 -->
         <link rel="reviewer" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" /> <!-- 2012-06-25 -->
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-border-top-width" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/box.html#border-width-properties" />
+        <link rel="match" href="border-n-width-applies-to-008-ref.xht" />
         <meta name="flags" content="" />
         <meta name="assert" content="The 'border-top-width' property applies to elements with a display of inline." />
         <style type="text/css">
-            div
+            img
             {
                 border-top-style: solid;
                 border-top-width: 1in;
                 display: inline;
-                font-size: 1in;
-            }
-            p
-            {
-                margin-bottom: 1.5in;
+                height: 1px;
+                width: 1in;
             }
         </style>
     </head>
     <body>
         <p>Test passes if there is a filled black rectangle.</p>
-        <div>&nbsp;&nbsp;&nbsp;&nbsp;</div>
+        <img src="support/1x1-white.png" />
     </body>
 </html>

--- a/css/CSS2/borders/border-top-width-applies-to-008.xht
+++ b/css/CSS2/borders/border-top-width-applies-to-008.xht
@@ -15,14 +15,13 @@
             {
                 border-top-style: solid;
                 border-top-width: 1in;
-                display: inline;
                 height: 1px;
                 width: 1in;
             }
         </style>
     </head>
     <body>
-        <p>Test passes if there is a filled black rectangle.</p>
-        <img src="support/1x1-white.png" />
+        <p>Test passes if there is a filled black square.</p>
+        <div><img src="support/1x1-white.png" alt="Image download support must be enabled" /></div>
     </body>
 </html>

--- a/css/css-backgrounds/css3-background-origin-padding-box.html
+++ b/css/css-backgrounds/css3-background-origin-padding-box.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>CSS Backgrounds Test:background origin property with value content-box</title>
+    <title>CSS Backgrounds Test:background origin property with value padding-box</title>
     <link rel="author" title="yanshasha" href="mailto:yanshasha133@gmail.com" />
     <link rel="reviewer" title="Dayang Shen" href="mailto:shendayang@baidu.com" /> <!-- 2013-08-26 -->
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-origin" />
-    <link rel="match" href="reference/css3-background-origin-content-box-ref.html" />
+    <link rel="match" href="reference/css3-background-origin-padding-box-ref.html" />
     <style type="text/css">
             div {
                 width: 100px;

--- a/css/css-backgrounds/css3-background-size-001.html
+++ b/css/css-backgrounds/css3-background-size-001.html
@@ -6,7 +6,7 @@
     <link rel="author" title="yanshasha" href="mailto:yanshasha133@gmail.com" />
     <link rel="reviewer" title="Dayang Shen" href="mailto:shendayang@baidu.com" /><!-- 2013-08-26 -->
     <link rel="help" href="http://www.w3.org/TR/css3-background/#the-background-size" />
-    <link rel="match" href="reference/css3-background-size-ref.html" />
+    <link rel="match" href="reference/css3-background-size-001-ref.html" />
     <style type="text/css">
             div {
                 width: 150px;


### PR DESCRIPTION
Two changes:

1. border-*N*-width-applies-to-008.xht tests did not have a reftest and were slightly dependent on default font-metrics (specifically, nbsp being 0.25em wide). Redid to use an image, although they're still testing the same thing. Added a matching reftest

2. border-color-011.xht was incorrect, result of test has reversed since the rules regarding "currentColor" inheritance were clarified in css-color-4

3. additional whitespace in bidi-003.xht was causing reftest mismatch
<!-- Reviewable:start -->

<!-- Reviewable:end -->
