### PR TITLE
Fix typo in documentation of SourceFile.content_is_css_visual().

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -560,7 +560,7 @@ class SourceFile(object):
     @cached_property
     def content_is_css_visual(self):
         """Boolean indicating whether the file content represents a
-        CSS WG-style manual test"""
+        CSS WG-style visual test"""
         if self.root is None:
             return None
         return bool(self.ext in {'.xht', '.html', '.xhtml', '.htm', '.xml', '.svg'} and


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10786)
<!-- Reviewable:end -->
