### PR TITLE
Fix #10741: Call Out-File with an encoding for make-hosts-file on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For example, on most UNIX-like systems, you can setup the hosts file with:
 ./wpt make-hosts-file | sudo tee -a /etc/hosts
 ```
 
-And on Windows (note this requires in PowerShell with Administrator privileges):
+And on Windows (this must be run in a PowerShell session with Administrator privileges):
 
 ```bash
 python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ For example, on most UNIX-like systems, you can setup the hosts file with:
 ./wpt make-hosts-file | sudo tee -a /etc/hosts
 ```
 
-And on Windows (note this requires an Administrator privileged shell):
+And on Windows (note this requires in PowerShell with Administrator privileges):
 
 ```bash
-python wpt make-hosts-file >> %SystemRoot%\System32\drivers\etc\hosts
+python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 
 If you are behind a proxy, you also need to make sure the domains above are

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -114,7 +114,7 @@ For example, on most UNIX-like systems, you can setup the hosts file with:
 ./wpt make-hosts-file | sudo tee -a /etc/hosts
 ```
 
-And on Windows (note this requires in PowerShell with Administrator privileges):
+And on Windows (this must be run in a PowerShell session with Administrator privileges):
 
 ```bash
 python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -114,10 +114,10 @@ For example, on most UNIX-like systems, you can setup the hosts file with:
 ./wpt make-hosts-file | sudo tee -a /etc/hosts
 ```
 
-And on Windows (note this requires an Administrator privileged shell):
+And on Windows (note this requires in PowerShell with Administrator privileges):
 
 ```bash
-python wpt make-hosts-file >> %SystemRoot%\System32\drivers\etc\hosts
+python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 
 If you are behind a proxy, you also need to make sure the domains above are

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -119,9 +119,9 @@ def check_environ(product):
                 else:
                     message = """Missing hosts file configuration. Run
 
-python wpt make-hosts-file >> %s
+python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
 
-from a shell with Administrator privileges.""" % hosts_path
+in PowerShell with Administrator privileges.""" % hosts_path
                 raise WptrunError(message)
 
 


### PR DESCRIPTION
Fixes #10741.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10800)
<!-- Reviewable:end -->
