### PR TITLE
Add run_info and timestamps to wptreport

### DIFF
--- a/tools/wptrunner/wptrunner/formatters.py
+++ b/tools/wptrunner/wptrunner/formatters.py
@@ -8,15 +8,20 @@ class WptreportFormatter(BaseFormatter):
 
     def __init__(self):
         self.raw_results = {}
+        self.results = {}
+
+    def suite_start(self, data):
+        self.results['run_info'] = data['run_info']
+        self.results['time_start'] = data['time']
 
     def suite_end(self, data):
-        results = {}
-        results["results"] = []
+        self.results['time_end'] = data['time']
+        self.results["results"] = []
         for test_name in self.raw_results:
             result = {"test": test_name}
             result.update(self.raw_results[test_name])
-            results["results"].append(result)
-        return json.dumps(results)
+            self.results["results"].append(result)
+        return json.dumps(self.results)
 
     def find_or_create_test(self, data):
         test_name = data["test"]


### PR DESCRIPTION
The first stab at #10511 , adding the simplest fields to make sure I understand correctly @jgraham 

Meanwhile, how shall I pass the version of the browser? Via `run_info`? FWIW, there's `run_info['version']` which is the version of my OS (and it seems to overlap with `run_info['os_version']` a bit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10811)
<!-- Reviewable:end -->
