### PR TITLE
HTML: document.write() and reloading

### DIFF
--- a/html/dom/dynamic-markup-insertion/document-write/reload.window.js
+++ b/html/dom/dynamic-markup-insertion/document-write/reload.window.js
@@ -1,35 +1,43 @@
-async_test(t => {
-  const frame = document.body.appendChild(document.createElement("iframe"));
-  let reloaded = false;
-  frame.src = "/common/blank.html";
-  frame.onload = t.step_func(() => {
-    if (reloaded) {
+[false, true].forEach(callClose => {
+  async_test(t => {
+    const frame = document.body.appendChild(document.createElement("iframe"));
+    let reloaded = false;
+    frame.src = "/common/blank.html";
+    frame.onload = t.step_func(() => {
+      if (reloaded) {
         assert_equals(frame.contentDocument.body.textContent, "");
         t.done();
         return;
-    }
-    assert_false(reloaded);
+      }
+      assert_false(reloaded);
+      assert_equals(frame.contentDocument.body.textContent, "");
+      frame.contentDocument.write("Hey");
+      assert_equals(frame.contentDocument.body.textContent, "Hey");
+      if (callClose) {
+        frame.contentDocument.close();
+      }
+      reloaded = true;
+      frame.contentWindow.location.reload();
+    });
+  }, "document.write() and reloading" + (callClose ? " (and close()d)" : ""));
+
+  async_test(t => {
+    const frame = document.body.appendChild(document.createElement("iframe"));
+    let reloaded = false;
+    frame.onload = t.step_func(() => {
+      if (reloaded) {
+        assert_equals(frame.contentDocument.body.textContent, "");
+        t.done();
+        return;
+      }
+    });
     assert_equals(frame.contentDocument.body.textContent, "");
     frame.contentDocument.write("Hey");
     assert_equals(frame.contentDocument.body.textContent, "Hey");
+    if (callClose) {
+      frame.contentDocument.close();
+    }
     reloaded = true;
     frame.contentWindow.location.reload();
-  });
-}, "document.write() and reloading");
-
-async_test(t => {
-  const frame = document.body.appendChild(document.createElement("iframe"));
-  let reloaded = false;
-  frame.onload = t.step_func(() => {
-    if (reloaded) {
-        assert_equals(frame.contentDocument.body.textContent, "");
-        t.done();
-        return;
-    }
-  });
-  assert_equals(frame.contentDocument.body.textContent, "");
-  frame.contentDocument.write("Hey");
-  assert_equals(frame.contentDocument.body.textContent, "Hey");
-  reloaded = true;
-  frame.contentWindow.location.reload();
-}, "document.write() and reloading, part 2");
+  }, "document.write() and reloading, part 2" + (callClose ? " (and close()d)" : ""));
+});

--- a/html/dom/dynamic-markup-insertion/document-write/reload.window.js
+++ b/html/dom/dynamic-markup-insertion/document-write/reload.window.js
@@ -1,0 +1,35 @@
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  let reloaded = false;
+  frame.src = "/common/blank.html";
+  frame.onload = t.step_func(() => {
+    if (reloaded) {
+        assert_equals(frame.contentDocument.body.textContent, "");
+        t.done();
+        return;
+    }
+    assert_false(reloaded);
+    assert_equals(frame.contentDocument.body.textContent, "");
+    frame.contentDocument.write("Hey");
+    assert_equals(frame.contentDocument.body.textContent, "Hey");
+    reloaded = true;
+    frame.contentWindow.location.reload();
+  });
+}, "document.write() and reloading");
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  let reloaded = false;
+  frame.onload = t.step_func(() => {
+    if (reloaded) {
+        assert_equals(frame.contentDocument.body.textContent, "");
+        t.done();
+        return;
+    }
+  });
+  assert_equals(frame.contentDocument.body.textContent, "");
+  frame.contentDocument.write("Hey");
+  assert_equals(frame.contentDocument.body.textContent, "Hey");
+  reloaded = true;
+  frame.contentWindow.location.reload();
+}, "document.write() and reloading, part 2");


### PR DESCRIPTION
For https://github.com/whatwg/html/pull/3651 or possibly a standalone patch.

It seems that Firefox only supports the reload override flag for about:blank resources. Edge always supports it. Safari overrides the URL and therefore ends up in a loop. Chrome doesn't support it, which seems most desirable as it's a rather hairy feature.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
