### PR TITLE
[css-flex][spec-rec] Test for flex only alignment modes with writing modes (vertical-lr)

### DIFF
--- a/css/css-flexbox/mix-writing-modes-vertical-lr-and-flex-alignment.html
+++ b/css/css-flexbox/mix-writing-modes-vertical-lr-and-flex-alignment.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<title>flexbox | flex alignment mode | writing mode (vertical-lr) </title>
+<meta name="assert" content="This test ensures that
+flex only alignment modes (eg: flex-start/end) work as expected in
+writing-mode: vertical-lr. "/>.
+<link rel="help" href="http://www.w3.org/TR/css-flexbox-1/#placement">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<meta rel="author" title="Benny Ogidan" href="benny.ogidan@andela.com">
+<style>
+  ul {
+    list-style: none;
+    width: 200px;
+    height: 200px;
+    writing-mode: vertical-lr;
+  }
+
+  #box-container {
+    display: flex;
+    justify-content: flex-end;
+    background-color: yellow;
+  }
+
+  #second-box-container {
+    margin-top: 10px;
+    display: flex;
+    align-items: flex-end;
+    background-color: limegreen;
+  }
+
+  #box, #second-box {
+    width: 100px;
+    height: 100px;
+    background: blue;
+    border: 1px solid black;
+    color: white;
+  }
+</style>
+
+<ul id="box-container">
+  <li id="box">1st Box</li>
+</ul>
+
+<ul id="second-box-container">
+  <li id="second-box">2nd Box</li>
+</ul>
+
+<div id="log"></div>
+<script>
+  test(function () {
+    const boxContainer = document.getElementById('box-container')
+    const secondBoxContainer = document.getElementById('second-box-container')
+
+    const box = document.getElementById('box')
+    const secondBox = document.getElementById('second-box')
+
+    const boxContainerBR = boxContainer.getBoundingClientRect();
+    const secondBoxContainerBR = secondBoxContainer.getBoundingClientRect();
+    const boxBR = box.getBoundingClientRect();
+    const secondBoxBr = secondBox.getBoundingClientRect();
+
+    assert_equals(boxBR.bottom,boxContainerBR.bottom)
+    assert_equals(secondBoxBr.right, boxContainerBR.right)
+  });
+</script>


### PR DESCRIPTION
#### What does this PR do? 
These tests ensure that flex only alignment modes work as expected in different
writing modes. 
The tests use the writing-mode: vertical-lr with the flex alignment modes 
(justify-content and align-items)

#### How should this be manually tested?
Pull the current branch
Follow the Readme.md to run the tests
*Testharness.js has been used to write the test cases*

#### Screenshots (if appropriate)
<img width="1280" alt="screen shot 2018-05-03 at 12 37 53 pm" src="https://user-images.githubusercontent.com/26222856/39574476-4cab6842-4ecf-11e8-8401-0c80e3fa3da1.png">

<!-- Reviewable:start -->

<!-- Reviewable:end -->
