### PR TITLE
Accname: Remove unspecified behavior from test cases

### DIFF
--- a/accname/description_from_content_of_describedby_element-manual.html
+++ b/accname/description_from_content_of_describedby_element-manual.html
@@ -75,7 +75,7 @@
         <span aria-label="Garaventa">Zambino</span>
       </span>
       <span>the weird.</span>
-      (<span>Q</span><span>E</span><span>D</span>)
+      (QED)
       <span class="hidden"><i><b>and don't you forget it.</b></i></span>
       <table>
         <tr>

--- a/accname/description_from_content_of_describedby_element_which_is_hidden-manual.html
+++ b/accname/description_from_content_of_describedby_element_which_is_hidden-manual.html
@@ -83,7 +83,7 @@
         <span aria-label="Garaventa">Zambino</span>
       </span>
       <span>the weird.</span>
-      (<span>Q</span><span>E</span><span>D</span>)
+      (QED)
       <span class="hidden"><i><b>and don't you forget it.</b></i></span>
       <table>
         <tr>

--- a/accname/name_from_content-manual.html
+++ b/accname/name_from_content-manual.html
@@ -73,7 +73,7 @@
       <span aria-label="Garaventa">Zambino</span>
     </span>
     <span>the weird.</span>
-    (<span>Q</span><span>E</span><span>D</span>)
+    (QED)
     <span class="hidden"><i><b>and don't you forget it.</b></i></span>
     <table>
       <tr>

--- a/accname/name_from_content_of_label-manual.html
+++ b/accname/name_from_content_of_label-manual.html
@@ -74,7 +74,7 @@
       <span aria-label="Garaventa">Zambino</span>
    </span>
    <span>the weird.</span>
-   (<span>Q</span><span>E</span><span>D</span>)
+   (QED)
    <span class="hidden"><i><b>and don't you forget it.</b></i></span>
    <table>
      <tr>

--- a/accname/name_from_content_of_labelledby_element-manual.html
+++ b/accname/name_from_content_of_labelledby_element-manual.html
@@ -74,7 +74,7 @@
       <span aria-label="Garaventa">Zambino</span>
     </span>
     <span>the weird.</span>
-    (<span>Q</span><span>E</span><span>D</span>)
+    (QED)
     <span class="hidden"><i><b>and don't you forget it.</b></i></span>
     <table>
       <tr>

--- a/accname/name_from_content_of_labelledby_elements_one_of_which_is_hidden-manual.html
+++ b/accname/name_from_content_of_labelledby_elements_one_of_which_is_hidden-manual.html
@@ -83,7 +83,7 @@
         <span aria-label="Garaventa">Zambino</span>
       </span>
       <span>the weird.</span>
-      (<span>Q</span><span>E</span><span>D</span>)
+      (QED)
       <span class="hidden"><i><b>and don't you forget it.</b></i></span>
       <table>
         <tr>

--- a/accname/name_link-mixed-content-manual.html
+++ b/accname/name_link-mixed-content-manual.html
@@ -71,7 +71,7 @@
     <div><img src="file.jpg" title="Bryan" alt="" role="presentation" /></div>
     <span role="presentation" aria-label="Eli"><span aria-label="Garaventa">Zambino</span></span>
     <span>the weird.</span>
-    (<span>Q</span><span>E</span><span>D</span>)
+    (QED)
     <span class="hidden"><i><b>and don't you forget it.</b></i></span>
   </div>
 


### PR DESCRIPTION
The accname spec doesn't describe exactly what should happen with respect
to whitespace insertion when inline elements are being concatenated in
a name-from-contents calculation. This will be addressed in Accname 1.2.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
