### PR TITLE
HTML: document.open()'s readiness step

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
@@ -1,0 +1,17 @@
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  frame.src = "/common/blank.html";
+  frame.onload = t.step_func_done(() => {
+    const states = [];
+    assert_equals(frame.contentDocument.readyState, "complete");
+    frame.contentDocument.open();
+    // open() removes event listeners so adding one now
+    frame.contentDocument.onreadystatechange = t.step_func(() => {
+      states.push(frame.contentDocument.readyState);
+    });
+    assert_equals(frame.contentDocument.readyState, "loading");
+    frame.contentDocument.close();
+    assert_equals(frame.contentDocument.readyState, "complete");
+    assert_array_equals(states, ["interactive", "complete"]);
+  });
+}, "document.open() and readiness");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/readiness.window.js
@@ -3,12 +3,14 @@ async_test(t => {
   frame.src = "/common/blank.html";
   frame.onload = t.step_func_done(() => {
     const states = [];
-    assert_equals(frame.contentDocument.readyState, "complete");
-    frame.contentDocument.open();
-    // open() removes event listeners so adding one now
-    frame.contentDocument.onreadystatechange = t.step_func(() => {
+    const onreadystatechange = t.step_func(() => {
       states.push(frame.contentDocument.readyState);
     });
+    frame.contentDocument.onreadystatechange = onreadystatechange;
+    assert_equals(frame.contentDocument.readyState, "complete");
+    frame.contentDocument.open();
+    // open() removes event listeners so adding another one
+    frame.contentDocument.onreadystatechange = onreadystatechange;
     assert_equals(frame.contentDocument.readyState, "loading");
     frame.contentDocument.close();
     assert_equals(frame.contentDocument.readyState, "complete");


### PR DESCRIPTION
The main thing not explained by the HTML Standard that's tested here is how close() ends up with "complete", but non-Firefox exhibits this behavior.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
