### PR TITLE
Correct edge case for background color clip

### DIFF
--- a/css/css-backgrounds/background-color-clip.html
+++ b/css/css-backgrounds/background-color-clip.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Background Color Clip</title>
+<link rel="match" href="reference/background-color-clip.html">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#background-color">
+<meta name="assert" content="Check that the background color is clipped according to the background-clip value associated with the bottom-most background image layer.">
+<style>
+    div {
+        width: 120px;
+        height: 100px;
+        background-color: green;
+        background-clip: border-box, content-box, border-box;
+        background-image: none, none;
+        border-style: solid;
+        border-width: 10px;
+        border-color: transparent;
+    }
+</style>
+<div></div>

--- a/css/css-backgrounds/reference/background-color-clip.html
+++ b/css/css-backgrounds/reference/background-color-clip.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Green Rectangle</title>
+<style>
+    div {
+        width: 120px;
+        height: 100px;
+        background-color: green;
+        background-clip: content-box;
+        border-style: solid;
+        border-width: 10px;
+        border-color: transparent;
+    }
+</style>
+<div></div>


### PR DESCRIPTION

Use the color clip corresponding to the last background-image instead
of the last background-clip. (There may be more clips than images and
clips are repeated if there are less clips than images.)

Add a test.

Upstreamed from https://github.com/servo/servo/pull/20744 [ci skip]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10849)
<!-- Reviewable:end -->
