### PR TITLE
Update Firefox prefs path for upstream changes.

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -205,7 +205,11 @@ class Firefox(Browser):
                 # can get if we have an application.ini file
                 tag = "tip"
 
-        return "%s/raw-file/%s/testing/profiles/prefs_general.js" % (repo, tag)
+        if int(version.split(".")[0]) < 61:
+            path = "prefs_general.js"
+        else:
+            path = "common/user.js"
+        return "%s/raw-file/%s/testing/profiles/%s" % (repo, tag, path)
 
     def install_prefs(self, binary, dest=None):
         version, channel = self.get_version_number(binary)
@@ -216,7 +220,7 @@ class Firefox(Browser):
         dest = os.path.join(dest, "profiles")
         if not os.path.exists(dest):
             os.makedirs(dest)
-        prefs_file = os.path.join(dest, "prefs_general.js")
+        prefs_file = os.path.join(dest, "user.js")
         cache_file = os.path.join(dest,
                                   "%s-%s.cache" % (version, channel)
                                   if channel != "nightly"

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -245,7 +245,7 @@ class FirefoxBrowser(Browser):
     def load_prefs(self):
         prefs = Preferences()
 
-        prefs_path = os.path.join(self.prefs_root, "prefs_general.js")
+        prefs_path = os.path.join(self.prefs_root, "user.js")
         if os.path.exists(prefs_path):
             prefs.add(Preferences.read_prefs(prefs_path))
         else:


### PR DESCRIPTION
Firefox changed the prefs path from testing/profiles/prefs_general.js to testing/profiles/config/user.js
Therefore for versions of firefox from currently nightly onwards we need to use the new path to download
the appropriate prefs files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10855)
<!-- Reviewable:end -->
