### PR TITLE
Fix DOM interface test

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -116,6 +116,7 @@ dictionary FocusOptions {
 HTMLElement includes GlobalEventHandlers;
 HTMLElement includes DocumentAndElementEventHandlers;
 HTMLElement includes ElementContentEditable;
+HTMLElement includes HTMLOrSVGElement;
 
 // Note: intentionally not [HTMLConstructor]
 interface HTMLUnknownElement : HTMLElement { };
@@ -128,8 +129,6 @@ interface mixin HTMLOrSVGElement {
   void focus(optional FocusOptions options);
   void blur();
 };
-HTMLElement includes HTMLOrSVGElement;
-SVGElement includes HTMLOrSVGElement;
 
 [Exposed=Window,
  OverrideBuiltins]


### PR DESCRIPTION
...by removing SVGElement. This should be included in the SVG interface test (SVG needs further updates that will be handled separately)

Fixes https://w3c-test.org/dom/interfaces.html

<!-- Reviewable:start -->

<!-- Reviewable:end -->
