### PR TITLE
Verify sync XHR does not fire progress event

### DIFF
--- a/xhr/sync-no-progress.any.js
+++ b/xhr/sync-no-progress.any.js
@@ -1,6 +1,12 @@
 test(t => {
   let xhr = new XMLHttpRequest();
+  let loadEventFired = false;
   xhr.onprogress = t.unreached_func('progress event should not be fired');
-  xhr.open('GET', 'resources/trickle.py?count=4&delay=150');
+  xhr.onload = () => {
+    loadEventFired = true;
+  };
+  xhr.open('GET', 'resources/trickle.py?count=4&delay=150', false);
   xhr.send();
+  // Check the load event as a sanity check that the test is working.
+  assert_true(loadEventFired, 'load event should have fired');
 }, 'progress event should not be fired by sync XHR');

--- a/xhr/sync-no-progress.any.js
+++ b/xhr/sync-no-progress.any.js
@@ -1,0 +1,6 @@
+test(t => {
+  let xhr = new XMLHttpRequest();
+  xhr.onprogress = t.unreached_func('progress event should not be fired');
+  xhr.open('GET', 'resources/trickle.py?count=4&delay=150');
+  xhr.send();
+}, 'progress event should not be fired by sync XHR');


### PR DESCRIPTION
Sync XHR should not fire a "progress" event. Add a test to verify that
it does not.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
