### PR TITLE
add url host test: Port number is removed if new port is scheme default

### DIFF
--- a/url/setters_tests.json
+++ b/url/setters_tests.json
@@ -968,6 +968,17 @@
                 "hostname": "test",
                 "port": "12"
             }
+        },
+        {
+            "comment": "Port number is removed if new port is scheme default",
+            "href": "http://example.net:8080",
+            "new_value": "example.com:80",
+            "expected": {
+                "href": "http://example.com/",
+                "host": "example.com",
+                "hostname": "example.com",
+                "port": ""
+            }
         }
     ],
     "hostname": [

--- a/url/setters_tests.json
+++ b/url/setters_tests.json
@@ -720,6 +720,17 @@
             }
         },
         {
+            "comment": "Port number is removed if new port is scheme default and existing URL has a non-default port",
+            "href": "http://example.net:8080",
+            "new_value": "example.com:80",
+            "expected": {
+                "href": "http://example.com/",
+                "host": "example.com",
+                "hostname": "example.com",
+                "port": ""
+            }
+        },
+        {
             "comment": "Stuff after a / delimiter is ignored",
             "href": "http://example.net/path",
             "new_value": "example.com/stuff",
@@ -967,17 +978,6 @@
                 "host": "test:12",
                 "hostname": "test",
                 "port": "12"
-            }
-        },
-        {
-            "comment": "Port number is removed if new port is scheme default",
-            "href": "http://example.net:8080",
-            "new_value": "example.com:80",
-            "expected": {
-                "href": "http://example.com/",
-                "host": "example.com",
-                "hostname": "example.com",
-                "port": ""
             }
         }
     ],


### PR DESCRIPTION
This commit adds a test for a bug found with the `node.js` implementation of URL, which was not covered by the existing test cases.

Refs: https://github.com/nodejs/node/pull/20479

<!-- Reviewable:start -->

<!-- Reviewable:end -->
