### PR TITLE
URL/Encoding: change query state parsing

### DIFF
--- a/encoding/big5-encoder.html
+++ b/encoding/big5-encoder.html
@@ -15,8 +15,8 @@
 
  encode("ab", "ab", "very basic")
  // edge cases
- encode("\u9EA6", "&%2340614;", "Highest-pointer BMP character excluded from encoder");
- encode("\uD858\uDE6B", "&%23156267;", "Highest-pointer character excluded from encoder");
+ encode("\u9EA6", "%26%2340614%3B", "Highest-pointer BMP character excluded from encoder");
+ encode("\uD858\uDE6B", "%26%23156267%3B", "Highest-pointer character excluded from encoder");
  encode("\u3000", "%A1@", "Lowest-pointer character included in encoder");
  encode("\u20AC", "%A3%E1", "Euro; the highest-pointer character before a range of 30 unmapped pointers");
  encode("\u4E00", "%A4@", "The lowest-pointer character after the range of 30 unmapped pointers");
@@ -24,8 +24,8 @@
  encode("\uFFE2", "%C8%CD", "The lowest-pointer character after the range of 41 unmapped pointers");
  encode("\u79D4", "%FE%FE", "The last character in the index");
  // not in index
- encode("\u2603", "&%239731;", "The canonical BMP test character that is not in the index");
- encode("\uD83D\uDCA9", "&%23128169;", "The canonical astral test character that is not in the index");
+ encode("\u2603", "%26%239731%3B", "The canonical BMP test character that is not in the index");
+ encode("\uD83D\uDCA9", "%26%23128169%3B", "The canonical astral test character that is not in the index");
  // duplicate low bits
  encode("\uD840\uDFB5", "%FDj", "A Plane 2 character whose low 16 bits match a BMP character that has a lower pointer");
  // prefer last

--- a/encoding/gbk-encoder.html
+++ b/encoding/gbk-encoder.html
@@ -17,5 +17,5 @@
  encode("\u4E02", "%81@", "character")
  encode("\uE4C6", "%A1@", "PUA")
  encode("\uE4C5", "%FE%FE", "PUA #2")
- encode("\ud83d\udca9", "&%23128169;", "poo")
+ encode("\ud83d\udca9", "%26%23128169%3B", "poo")
 </script>

--- a/encoding/iso-2022-jp-encoder.html
+++ b/encoding/iso-2022-jp-encoder.html
@@ -15,4 +15,5 @@
  encode("s", "s", "very basic")
  encode("\u00A5\u203Es\\\uFF90\u4F69", "%1B(J\\~s%1B(B\\%1B$B%_PP%1B(B", "basics")
  encode("\x0E\x0F\x1Bx", "%0E%0F%1Bx", "SO/SI ESC")
+ encode("\uFFFD", "%26%2365533%3B", "U+FFFD");
 </script>

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-han.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-han.html
@@ -170,10 +170,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-hangul.html
@@ -135,10 +135,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-misc.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-form-errors-misc.html
@@ -179,10 +179,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-han.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-han.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-hangul.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-encode-href-errors-misc.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-han.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-han.html
@@ -170,10 +170,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-hangul.html
@@ -135,10 +135,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-misc.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-form-errors-misc.html
@@ -179,10 +179,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-han.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-han.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-hangul.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-encode-href-errors-misc.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
         var a = document.createElement("a"); // <a> uses document encoding for URL's query
         a.href = "https://example.com/?" + input;
         result = a.search.substr(1); // remove leading "?"
-        assert_equals(normalizeStr(result), normalizeStr(expected));
+        assert_equals(result, expected);
     }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-han.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-han.html
@@ -165,10 +165,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-hangul.html
@@ -135,10 +135,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-misc.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-form-errors-misc.html
@@ -175,10 +175,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-han.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-han.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-hangul.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-hangul.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
     var a = document.createElement("a"); // <a> uses document encoding for URL's query
     a.href = "https://example.com/?" + input;
     result = a.search.substr(1); // remove leading "?"
-    assert_equals(normalizeStr(result), normalizeStr(expected));
+    assert_equals(result, expected);
   }, desc);
 }
 

--- a/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-japanese/shift_jis/sjis-encode-href-errors-misc.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/encoding/legacy-mb-korean/euc-kr/euckr-encode-form-errors-han.html
+++ b/encoding/legacy-mb-korean/euc-kr/euckr-encode-form-errors-han.html
@@ -166,10 +166,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-korean/euc-kr/euckr-encode-form-errors-misc.html
+++ b/encoding/legacy-mb-korean/euc-kr/euckr-encode-form-errors-misc.html
@@ -175,10 +175,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-korean/euc-kr/euckr-encode-href-errors-han.html
+++ b/encoding/legacy-mb-korean/euc-kr/euckr-encode-href-errors-han.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/encoding/legacy-mb-korean/euc-kr/euckr-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-korean/euc-kr/euckr-encode-href-errors-misc.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-extBa.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-extBa.html
@@ -136,10 +136,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-extBb.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-extBb.html
@@ -136,10 +136,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-han.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-han.html
@@ -178,10 +178,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-hangul.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-hangul.html
@@ -135,10 +135,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-misc.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-misc.html
@@ -175,10 +175,7 @@ function runNext(id) {
     for (var j = 0; j < cplist[i].length; j++) {
       var t = tests[i][j];
       t.step(function() {
-        assert_equals(
-          normalizeStr(results[j]),
-          normalizeStr(cplist[i][j].expected)
-        );
+        assert_equals(results[j], cplist[i][j].expected);
       });
       t.done();
     }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-pua.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-form-errors-pua.html
@@ -135,10 +135,7 @@ function runNext(id) {
         for (var j = 0; j < cplist[i].length; j++) {
             var t = tests[i][j];
             t.step(function() {
-                assert_equals(
-                    normalizeStr(results[j]),
-                    normalizeStr(cplist[i][j].expected)
-                );
+                assert_equals(results[j], cplist[i][j].expected);
             });
             t.done();
         }

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-han.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-han.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-hangul.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-hangul.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
     var a = document.createElement("a"); // <a> uses document encoding for URL's query
     a.href = "https://example.com/?" + input;
     result = a.search.substr(1); // remove leading "?"
-    assert_equals(normalizeStr(result), normalizeStr(expected));
+    assert_equals(result, expected);
   }, desc);
 }
 

--- a/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-misc.html
+++ b/encoding/legacy-mb-tchinese/big5/big5-encode-href-errors-misc.html
@@ -21,7 +21,7 @@ function encode(input, expected, desc) {
 		var a = document.createElement("a"); // <a> uses document encoding for URL's query
 		a.href = "https://example.com/?" + input;
 		result = a.search.substr(1); // remove leading "?"
-		assert_equals(normalizeStr(result), normalizeStr(expected));
+		assert_equals(result, expected);
 	}, desc);
 }
 

--- a/html/infrastructure/urls/resolving-urls/query-encoding/location.sub.html
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/location.sub.html
@@ -9,7 +9,7 @@
 function expected(encoding) {
   return "?" + {
     "UTF-8": "%C3%BF",
-    "windows-1251": "&%23255;",
+    "windows-1251": "%26%23255%3B",
     "windows-1252": "%FF"
   }[encoding];
 }

--- a/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/resources/resolve-url.js
@@ -17,7 +17,7 @@ onload = function() {
     'utf-16be':'%C3%A5',
     'utf-16le':'%C3%A5',
     'windows-1252':'%E5',
-    'windows-1251':'&%23229;'
+    'windows-1251':'%26%23229%3B'
   };
   var expected_current = expected_obj[encoding];
   var expected_utf8 = expected_obj['utf-8'];

--- a/url/README.md
+++ b/url/README.md
@@ -1,3 +1,5 @@
+## urltestdata.json
+
 These tests are for browsers, but the data for
 `a-element.html`, `url-constructor.html`, `a-element-xhtml.xhtml`, and `failure.html`
 is in `urltestdata.json` and can be re-used by non-browser implementations.
@@ -24,6 +26,11 @@ In addition to testing that parsing `input` against `base` gives the result, a t
 true, parsing `about:blank` against `base` must give failure. This tests that the logic for
 converting base URLs into strings properly fails the whole parsing algorithm if the base URL cannot
 be parsed.
+
+## URL parser's encoding argument
+
+Tests in `/encoding` and `/html/infrastructure/urls/resolving-urls/query-encoding/` cover the
+encoding argument to the URL parser.
 
 [parsing]: https://url.spec.whatwg.org/#concept-basic-url-parser
 [API]: https://url.spec.whatwg.org/#api

--- a/xhr/open-url-encoding.htm
+++ b/xhr/open-url-encoding.htm
@@ -5,7 +5,6 @@
     <title>XMLHttpRequest: open() - URL encoding</title>
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
-    <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::ol/li[7] following::ol/li[14]/ul/li[2]" />
   </head>
   <body>
     <div id="log"></div>
@@ -20,7 +19,7 @@
         var client = new XMLHttpRequest()
         client.open("GET", "resources/content.py?\uD83D", false)
         client.send()
-        assert_equals(client.getResponseHeader("x-request-query"), "&%2365533;")
+        assert_equals(client.getResponseHeader("x-request-query"), "%26%2365533%3B");
       }, "lone surrogate");
     </script>
   </body>


### PR DESCRIPTION
See https://github.com/whatwg/encoding/issues/139 for rationale and https://github.com/whatwg/url/pull/386 for the change to the URL Standard.

(I found all these resources in part due to @rakuco's work on trying to align Chrome with the earlier iteration of the specification.)

<!-- Reviewable:start -->

<!-- Reviewable:end -->
