### PR TITLE
Fix ignoring changes under resources in the stability checking script

### DIFF
--- a/check_stability.ini
+++ b/check_stability.ini
@@ -6,5 +6,5 @@ skip_tests: conformance-checkers docs tools
 # Exhaustively validating such changes is highly resource intensive
 # (particularly in terms of execution time), making it impractical in most
 # cases.
-ignore_changes: resources
+ignore_changes: resources/**
 results_url: https://pulls.web-platform-tests.org/api/stability


### PR DESCRIPTION
It turns out that this uses different input for excludes than the wpt
tests-affected script. The config file input is turned into a regexp
that tries to match the entire path, so "resources" would just match a
file called "resources" and "resources/**" is needed to match the
entire path.

Fixes #10928.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10929)
<!-- Reviewable:end -->