### PR TITLE
Expose done promise on Test

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -89,7 +89,7 @@ Assertions can be added to the test by calling the step method of the test
 object with a function containing the test assertions:
 
 ```js
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function(e) {
   t.step(function() {
     assert_true(e.bubbles, "bubbles should be true");
   });
@@ -108,7 +108,7 @@ first argument. The above example can be rewritten as:
 
 ```js
 async_test(function(t) {
-  document.addEventListener("DOMContentLoaded", function() {
+  document.addEventListener("DOMContentLoaded", function(e) {
     t.step(function() {
       assert_true(e.bubbles, "bubbles should be true");
     });
@@ -127,7 +127,7 @@ callback. A convenient method of doing this is through the `step_func` method
 which returns a function that, when called runs a test step. For example:
 
 ```js
-document.addEventListener("DOMContentLoaded", t.step_func(function() {
+document.addEventListener("DOMContentLoaded", t.step_func(function(e) {
   assert_true(e.bubbles, "bubbles should be true");
   t.done();
 }));
@@ -137,7 +137,7 @@ As a further convenience, the `step_func` that calls `done()` can instead
 use `step_func_done`, as follows:
 
 ```js
-document.addEventListener("DOMContentLoaded", t.step_func_done(function() {
+document.addEventListener("DOMContentLoaded", t.step_func_done(function(e) {
   assert_true(e.bubbles, "bubbles should be true");
 }));
 ```
@@ -249,6 +249,30 @@ resolve after that specific series of events has been fired at the watched node.
 created Promise waiting to be fulfilled, or if the event is of a different type
 to the type currently expected. This ensures that only the events that are
 expected occur, in the correct order, and with the correct timing.
+
+If you cannot or do not want to use `EventWatcher` for a test case,
+`promise_test` allows you to mix traditional callback handling and promises by
+exposing the `done_promise` on the `Test` instance.
+
+An example:
+
+```js
+function foo() {
+  return Promise.resolve("foo");
+}
+
+promise_test(function(t) {
+  someObject.addEventListener("someevent", t.step_func(function() {
+    t.done();
+  }));
+  
+  return foo()
+    .then(function(result) {
+      assert_equals(result, "foo", "foo should return 'foo'");
+      return t.done_promise;
+    });
+}, "Promise example + some event");
+```
 
 ## Single Page Tests ##
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -526,7 +526,7 @@ policies and contribution forms [3].
             tests.promise_tests = Promise.resolve();
         }
         tests.promise_tests = tests.promise_tests.then(function() {
-            var donePromise = new Promise(function(resolve) {
+            test.done_promise = new Promise(function(resolve) {
                 test._add_cleanup(resolve);
             });
             var promise = test.step(func, test, test);
@@ -545,7 +545,7 @@ policies and contribution forms [3].
                         assert(false, "promise_test", null,
                                "Unhandled rejection with value: ${value}", {value:value});
                     }));
-            return donePromise;
+            return test.done_promise;
         });
     }
 


### PR DESCRIPTION
Expose the *done* promise as `Test.done_promise` when using a `promise_test`. Allows to mix event callback handling with promise-based tests.

Real world examples: https://gist.github.com/lgrahl/de4101dc0276f28975a028a595ce05d7 and #10468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10933)
<!-- Reviewable:end -->
