### PR TITLE
Add browser version into run_info (and hence wptreport)

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -371,7 +371,7 @@ class ChromeAndroid(Browser):
         return chrome.install_webdriver(dest)
 
     def version(self, binary):
-        raise NotImplementedError
+        return None
 
 
 class Opera(Browser):
@@ -455,7 +455,7 @@ class Edge(Browser):
         raise NotImplementedError
 
     def version(self, binary):
-        raise NotImplementedError
+        return None
 
 
 class InternetExplorer(Browser):
@@ -477,7 +477,7 @@ class InternetExplorer(Browser):
         raise NotImplementedError
 
     def version(self, binary):
-        raise NotImplementedError
+        return None
 
 
 class Safari(Browser):
@@ -502,7 +502,7 @@ class Safari(Browser):
         raise NotImplementedError
 
     def version(self, binary):
-        raise NotImplementedError
+        return None
 
 
 class Servo(Browser):
@@ -578,6 +578,7 @@ class Sauce(Browser):
 
     def version(self, binary):
         return None
+
 
 class WebKit(Browser):
     """WebKit-specific interface."""

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -422,7 +422,7 @@ def setup_wptrunner(venv, prompt=True, install=False, **kwargs):
 
     venv.install_requirements(os.path.join(wptrunner_path, "requirements.txt"))
 
-    kwargs['browser_version'] = setup_cls.browser.version(None)
+    kwargs['browser_version'] = setup_cls.browser.version(kwargs.get("binary"))
     return kwargs
 
 

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -422,6 +422,7 @@ def setup_wptrunner(venv, prompt=True, install=False, **kwargs):
 
     venv.install_requirements(os.path.join(wptrunner_path, "requirements.txt"))
 
+    kwargs['browser_version'] = setup_cls.browser.version(None)
     return kwargs
 
 

--- a/tools/wptrunner/wptrunner/reduce.py
+++ b/tools/wptrunner/wptrunner/reduce.py
@@ -47,6 +47,7 @@ class Reducer(object):
         self.test_type = kwargs["test_types"][0]
         run_info = wpttest.get_run_info(kwargs["metadata_root"],
                                         kwargs["product"],
+                                        browser_version=kwargs.get("browser_version"),
                                         debug=False)
         test_filter = wptrunner.TestFilter(include=kwargs["include"])
         self.test_loader = wptrunner.TestLoader(kwargs["tests_root"],

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -43,7 +43,9 @@ def get_loader(test_paths, product, ssl_env, debug=None, run_info_extras=None, *
     if run_info_extras is None:
         run_info_extras = {}
 
-    run_info = wpttest.get_run_info(kwargs["run_info"], product, debug=debug,
+    run_info = wpttest.get_run_info(kwargs["run_info"], product,
+                                    browser_version=kwargs.get("browser_version"),
+                                    debug=debug,
                                     extras=run_info_extras)
 
     test_manifests = testloader.ManifestLoader(test_paths, force_manifest_update=kwargs["manifest_update"],
@@ -153,7 +155,9 @@ def run_tests(config, test_paths, product, **kwargs):
             ))
 
         if "test_loader" in kwargs:
-            run_info = wpttest.get_run_info(kwargs["run_info"], product, debug=None,
+            run_info = wpttest.get_run_info(kwargs["run_info"], product,
+                                            browser_version=kwargs.get("browser_version"),
+                                            debug=None,
                                             extras=run_info_extras(**kwargs))
             test_loader = kwargs["test_loader"]
         else:

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -65,7 +65,7 @@ def get_run_info(metadata_root, product, **kwargs):
 
 
 class RunInfo(dict):
-    def __init__(self, metadata_root, product, debug, extras=None):
+    def __init__(self, metadata_root, product, debug, browser_version=None, extras=None):
         import mozinfo
 
         self._update_mozinfo(metadata_root)
@@ -82,6 +82,8 @@ class RunInfo(dict):
             self["stylo"] = True
         if "STYLO_FORCE_DISABLED" in os.environ:
             self["stylo"] = False
+        if browser_version:
+            self["browser_version"] = browser_version
         if extras is not None:
             self.update(extras)
 


### PR DESCRIPTION
Another piece of #10511 

The data flow is:
* `wpt.run` gets `browser_version` from `wpt.browser` during `setup_wptrunner`
* `browser_version` is passed to `wptrunner.start` via `kwargs`
* `wptrunner` then passes `browser_version` to `RunInfo`

As a result, many pieces of code are modified along the code path above. I'm personally not 100% happy with the change in terms of elegance, too much plumbing, but I think generally speaking I'm not making things much worse... Suggestions for less bad solutions are much welcome!

Many of the `version()` methods in `wpt.browser` were actually broken, so I had to fix them as well. AFAIK, these methods weren't called anywhere before. Currently, we don't have version strings for Edge, Safari and Sauce yet.

(@kereliuk helped me to understand some of the code. Thanks! also cc @foolip )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10935)
<!-- Reviewable:end -->
