### PR TITLE
[infra] Remove unnecessary configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
           packages:
             - libnss3-tools
       env:
-        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
         - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=firefox:nightly
     - os: linux
       sudo: required
@@ -58,7 +57,6 @@ matrix:
             - libappindicator1
             - fonts-liberation
       env:
-        - secure: "YTSXPwI0DyCA1GhYrLT9KMEV6b7QQKuEeaQgeFDP38OTzJ1+cIj3CC4SRNqbnJ/6SJwPGcdqSxLuV8m4e5HFFnyCcQnJe6h8EMsTehZ7W3j/fP9UYrJqYqvGpe3Vj3xblO5pwBYmq7sg3jAmmuCgAgOW6VGf7cRMucrsmFeo7VM="
         - JOB=stability SCRIPT=tools/ci/ci_stability.sh PRODUCT=chrome:dev
     - python: 2.7
       env: JOB=tools_unittest TOXENV=py27 HYPOTHESIS_PROFILE=ci SCRIPT=tools/ci/ci_tools_unittest.sh


### PR DESCRIPTION
This encrypted value was introduced to authorized the continuous
integration server to post comments to GitHub.com [1]. That
functionality was later relocated to an external application, but the
value was not removed from this project's configuration file [2].

Remove the value as it is no longer necessary.

[1] 50075bf587ceff5608e9a7d3297fdbc5cea35750
[2] 1ba7507b2f364c947b34ea43290573b759fef72f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10937)
<!-- Reviewable:end -->
