### PR TITLE
Added dictionary WebGLContextAttributes to avoid no original dictionary error

### DIFF
--- a/webxr/interfaces.https.html
+++ b/webxr/interfaces.https.html
@@ -17,6 +17,7 @@ promise_test(async () => {
   idl_array.add_untested_idls(dom_idl);
   idl_array.add_untested_idls("interface Navigator {};");
   idl_array.add_idls(webxr_idl);
+  idl_array.add_idls("dictionary WebGLContextAttributes {};");
   idl_array.add_objects({
     Navigator:['navigator'],
   });


### PR DESCRIPTION
This PR fixed "Partial dictionary WebGLContextAttributes with no
original dictionary" error in webxr idlharness test

<!-- Reviewable:start -->

<!-- Reviewable:end -->
