### PR TITLE
Avoid using diff to figure out files that changed in a revision.

### DIFF
--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -96,10 +96,8 @@ def compile_ignore_rule(rule):
 
 def repo_files_changed(revish, include_uncommitted=False, include_new=False):
     git = get_git_cmd(wpt_root)
-    files = git("diff", "--name-only", "-z", revish).split("\0")
-    assert not files[-1]
-    files = set(files[:-1])
-
+    files = set(git("log", "--first-parent", "-z", "--format=", "--name-only", revish)
+                .split("\0")[:-1])
     if include_uncommitted:
         entries = git("status", "-z").split("\0")
         assert not entries[-1]


### PR DESCRIPTION
In a history with a complex merge structure, trying to figure out
which files changed using git diff appears to be fraught with peril,
since it tends to show changes on both sides of the merge. With
e.g. PR 7579 where the branch was long-lived this ends up considering
most of the repository as changed and causes the command to fail. A
simple approach that seems to be reliable is to use git log
--name-only, with --first-parent to handle merges in a predicatable
way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10948)
<!-- Reviewable:end -->
