### PR TITLE
Change how invalid base URLs are tested

### DIFF
--- a/url/README.md
+++ b/url/README.md
@@ -1,10 +1,10 @@
 These tests are for browsers, but the data for
-`a-element.html`, `url-constructor.html`, and `a-element-xhtml.xhtml`
+`a-element.html`, `url-constructor.html`, `a-element-xhtml.xhtml`, and `failure.html`
 is in `urltestdata.json` and can be re-used by non-browser implementations.
 This file contains a JSON array of comments as strings and test cases as objects.
 The keys for each test case are:
 
-* `base`: an absolute URL as a string whose [parsing] without a base of its own should succeed.
+* `base`: an absolute URL as a string whose [parsing] without a base of its own must succeed.
   This key is always present,
   and may have a value like `"about:blank"` when `input` is an absolute URL.
 * `input`: an URL as a string to be [parsed][parsing] with `base` as its base URL.
@@ -18,6 +18,12 @@ The keys for each test case are:
 
     The `origin` key may be missing.
     In that case, the API’s `origin` attribute is not tested.
+
+In addition to testing that parsing `input` against `base` gives the result, a test harness for the
+`URL` constructor (or similar APIs) should additionally test the following pattern: if `failure` is
+true, parsing `about:blank` against `base` must give failure. This tests that the logic for
+converting base URLs into strings properly fails the whole parsing algorithm if the base URL cannot
+be parsed.
 
 [parsing]: https://url.spec.whatwg.org/#concept-basic-url-parser
 [API]: https://url.spec.whatwg.org/#api

--- a/url/failure.html
+++ b/url/failure.html
@@ -16,7 +16,13 @@ function runTests(testData) {
 
     const name = test.input + " should throw"
 
-    self.test(() => { // new URL itself is already tested by url-constructor.html
+    self.test(() => { // URL's constructor's first argument is tested by url-constructor.html
+      // If a URL fails to parse with any valid base, it must also fail to parse with no base, i.e.
+      // when used as a base URL itself.
+      assert_throws(new TypeError(), () => new URL("about:blank", test.input));
+    }, "URL's constructor's base argument: " + name)
+
+    self.test(() => {
       const url = new URL("about:blank")
       assert_throws(new TypeError, () => url.href = test.input)
     }, "URL's href: " + name)

--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -6521,27 +6521,34 @@
     "search": "?a",
     "hash": "#%GH"
   },
-  "Bad bases",
+  "URLs that require a non-about:blank base. (Also serve as invalid base tests.)"
   {
-    "input": "test-a.html",
-    "base": "a",
+    "input": "a",
+    "base": "about:blank",
     "failure": true
   },
   {
-    "input": "test-a-slash.html",
-    "base": "a/",
+    "input": "a/",
+    "base": "about:blank",
     "failure": true
   },
   {
-    "input": "test-a-slash-slash.html",
-    "base": "a//",
+    "input": "a//",
+    "base": "about:blank",
     "failure": true
   },
+  "Bases that don't fail to parse but fail to be bases",
   {
     "input": "test-a-colon.html",
     "base": "a:",
     "failure": true
   },
+  {
+    "input": "test-a-colon-b.html",
+    "base": "a:b",
+    "failure": true
+  },
+  "Other base URL tests, that must succeed"
   {
     "input": "test-a-colon-slash.html",
     "base": "a:/",
@@ -6569,11 +6576,6 @@
     "pathname": "/test-a-colon-slash-slash.html",
     "search": "",
     "hash": ""
-  },
-  {
-    "input": "test-a-colon-b.html",
-    "base": "a:b",
-    "failure": true
   },
   {
     "input": "test-a-colon-slash-b.html",

--- a/url/urltestdata.json
+++ b/url/urltestdata.json
@@ -6521,7 +6521,7 @@
     "search": "?a",
     "hash": "#%GH"
   },
-  "URLs that require a non-about:blank base. (Also serve as invalid base tests.)"
+  "URLs that require a non-about:blank base. (Also serve as invalid base tests.)",
   {
     "input": "a",
     "base": "about:blank",
@@ -6548,7 +6548,7 @@
     "base": "a:b",
     "failure": true
   },
-  "Other base URL tests, that must succeed"
+  "Other base URL tests, that must succeed",
   {
     "input": "test-a-colon-slash.html",
     "base": "a:/",


### PR DESCRIPTION
Fixes #8707. Supercedes #10917, which it is based on.

This keeps the tests inside urltestdata.json, but adds a new requirement on consumers of that file that they should also test their base URL parsing logic by reusing the data in a different way.

It also rearranges the various cases from 90efdbecfe3c457b36c71cf3e01a72cd5301c163 under several different headings.

/cc @GPHemsley and @TimothyGu especially to review the changes to the README to see if they're clear on how to maintain and improve coverage. Existing harnesses will _lose_ coverage from this change, since urltestdata.json no longer tests the `a`, `a/`, and `a//` base URLs directly. But if they implement the tweak suggested in the README, they will gain coverage, testing not only those URLs as bases but also lots of others already in the file.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
