### PR TITLE
Properly switching window focus after close of window

### DIFF
--- a/webdriver/tests/close_window/user_prompts.py
+++ b/webdriver/tests/close_window/user_prompts.py
@@ -32,6 +32,9 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
     response = close(session)
     assert response.status == 200
+
+    # Asserting that the dialog was handled requires valid top-level browsing
+    # context, so we must switch to the original window.
     session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #1")
 
@@ -41,6 +44,9 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
     response = close(session)
     assert response.status == 200
+
+    # Asserting that the dialog was handled requires valid top-level browsing
+    # context, so we must switch to the original window.
     session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #2")
 
@@ -50,6 +56,9 @@ def test_handle_prompt_accept(new_session, add_browser_capabilites):
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
     response = close(session)
     assert response.status == 200
+
+    # Asserting that the dialog was handled requires valid top-level browsing
+    # context, so we must switch to the original window.
     session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #3")
 

--- a/webdriver/tests/close_window/user_prompts.py
+++ b/webdriver/tests/close_window/user_prompts.py
@@ -3,7 +3,7 @@
 from tests.support.asserts import assert_error, assert_dialog_handled
 from tests.support.fixtures import create_dialog, create_window
 from tests.support.inline import inline
-from time import sleep
+
 
 def close(session):
     return session.transport.send("DELETE", "session/%s/window" % session.session_id)

--- a/webdriver/tests/close_window/user_prompts.py
+++ b/webdriver/tests/close_window/user_prompts.py
@@ -3,7 +3,7 @@
 from tests.support.asserts import assert_error, assert_dialog_handled
 from tests.support.fixtures import create_dialog, create_window
 from tests.support.inline import inline
-
+from time import sleep
 
 def close(session):
     return session.transport.send("DELETE", "session/%s/window" % session.session_id)
@@ -24,23 +24,33 @@ def test_handle_prompt_ignore():
 def test_handle_prompt_accept(new_session, add_browser_capabilites):
     _, session = new_session({"capabilities": {
         "alwaysMatch": add_browser_capabilites({"unhandledPromptBehavior": "accept"})}})
-    session.window_handle = create_window(session)()
+    original_handle = session.window_handle
 
+    session.window_handle = create_window(session)()
     session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("alert", text="dismiss #1", result_var="dismiss1")
     response = close(session)
     assert response.status == 200
+    session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #1")
+
+    session.window_handle = create_window(session)()
+    session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("confirm", text="dismiss #2", result_var="dismiss2")
     response = close(session)
     assert response.status == 200
+    session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #2")
+
+    session.window_handle = create_window(session)()
+    session.url = inline("<title>WD doc title</title>")
 
     create_dialog(session)("prompt", text="dismiss #3", result_var="dismiss3")
     response = close(session)
     assert response.status == 200
+    session.window_handle = original_handle
     assert_dialog_handled(session, "dismiss #3")
 
 


### PR DESCRIPTION
The test_handle_prompt_accept test for closing a window tests to see if an
alert was handled. It does so by calling the Get Alert Text end point.
However, the Get Alert Text end point requires an active, valid top-level
browsing context to have the focus. The test now switches focus back to
the previous window before checking that an alert was handled. In between
checking the alert, confirm, and prompt cases, it recreates the new window
required so it can be closed.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
