### PR TITLE
Correcting string format for sending WebDriver command

### DIFF
--- a/webdriver/tests/get_element_tag_name/user_prompts.py
+++ b/webdriver/tests/get_element_tag_name/user_prompts.py
@@ -7,9 +7,9 @@ def read_global(session, name):
     return session.execute_script("return %s;" % name)
 
 
-def get_tag_name(session, element_id):
+def get_tag_name(session, webdriver_element_id):
     return session.transport.send("GET", "session/{session_id}/element/{element_id}/name".format(
-        session_id=session.session_id, element_id="foo"))
+        session_id=session.session_id, element_id=webdriver_element_id))
 
 
 def test_handle_prompt_dismiss(new_session, add_browser_capabilites):

--- a/webdriver/tests/get_element_tag_name/user_prompts.py
+++ b/webdriver/tests/get_element_tag_name/user_prompts.py
@@ -7,9 +7,9 @@ def read_global(session, name):
     return session.execute_script("return %s;" % name)
 
 
-def get_tag_name(session, webdriver_element_id):
+def get_tag_name(session, element_id):
     return session.transport.send("GET", "session/{session_id}/element/{element_id}/name".format(
-        session_id=session.session_id, element_id=webdriver_element_id))
+        session_id=session.session_id, element_id=element_id))
 
 
 def test_handle_prompt_dismiss(new_session, add_browser_capabilites):


### PR DESCRIPTION
The get_tag_name function was previously hard-coding the WebDriver element ID to an invalid value.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
