### PR TITLE
WebDriver: XSS Auditor errors prevent WebKit from running scripts loaded via inline.py

### DIFF
--- a/webdriver/tests/support/inline.py
+++ b/webdriver/tests/support/inline.py
@@ -40,5 +40,9 @@ def main(request, response):
     if doc is None:
         rv = 404, [("Content-Type", "text/plain")], "Missing doc parameter in query"
     else:
-        rv = [("Content-Type", content_type)], doc
+        response.headers.update([
+          ("Content-Type", content_type),
+          ("X-XSS-Protection", "0")
+        ])
+        rv = doc
     return rv


### PR DESCRIPTION
Sending 'X-XSS-Protection: 0' in the response headers for the main document will opt
out of the XSS Auditor and allow inline event handlers (i.e., onmousemove) to run.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
