### PR TITLE
Add git revision to run_info (and wptreport)

### DIFF
--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -1,4 +1,5 @@
 import os
+import subproccess
 from collections import defaultdict
 
 from wptmanifest.parser import atoms
@@ -71,7 +72,11 @@ class RunInfo(dict):
         self.update(mozinfo.info)
 
         from update.tree import GitTree
-        rev = GitTree().rev
+        try:
+            # GitTree.__init__ throws if we are not in a git tree.
+            rev = GitTree().rev
+        except subprocess.CalledProcessError:
+            rev = None
         if rev:
             self["revision"] = rev
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -67,9 +67,15 @@ def get_run_info(metadata_root, product, **kwargs):
 class RunInfo(dict):
     def __init__(self, metadata_root, product, debug, browser_version=None, extras=None):
         import mozinfo
-
         self._update_mozinfo(metadata_root)
         self.update(mozinfo.info)
+
+        from update.tree import GitTree
+        self._gittree = GitTree()
+        rev = self._gittree.rev
+        if rev:
+            self["revision"] = rev
+
         self["product"] = product
         if debug is not None:
             self["debug"] = debug

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -71,8 +71,7 @@ class RunInfo(dict):
         self.update(mozinfo.info)
 
         from update.tree import GitTree
-        self._gittree = GitTree()
-        rev = self._gittree.rev
+        rev = GitTree().rev
         if rev:
             self["revision"] = rev
 

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -1,5 +1,5 @@
 import os
-import subproccess
+import subprocess
 from collections import defaultdict
 
 from wptmanifest.parser import atoms


### PR DESCRIPTION
One more step towards #10511 

I know `GitTree` is already instantiated somewhere else (`update.py`), but it's hard to get info from there to here, and `GitTree` is a rather lean object. The only part I don't like is the delayed import, which has to be done for the same as reason `mozinfo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/10971)
<!-- Reviewable:end -->
