### PR TITLE
Test BigInt as keys and values in IndexedDB

### DIFF
--- a/IndexedDB/bigint_value.htm
+++ b/IndexedDB/bigint_value.htm
@@ -1,65 +1,72 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Values</title>
+<title>IndexedDB: BigInt keys and values</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="support.js"></script>
 
 <script>
-// BigInt and BigInt wrappers are supported in serialization, per
+// BigInt and BigInt objects are supported in serialization, per
 // https://github.com/whatwg/html/pull/3480
 // This support allows them to be used as IndexedDB values.
 
-let i = 0;
-function value(value, test) {
-    var t = async_test(document.title + " - " + (i++));
-    t.step(function() {
-        assert_true(test(value),
-                    "condition does not apply to initial value");
-    });
+function value_test(value, predicate, name) {
+    async_test(t => {
+        t.step(function() {
+            assert_true(predicate(value),
+                        "Predicate should return true for the initial value.");
+        });
 
-    createdb(t).onupgradeneeded = function(e) {
-        e.target.result
-                .createObjectStore("store")
-                .add(value, 1);
-
-        e.target.onsuccess = t.step_func(function(e) {
+        createdb(t).onupgradeneeded = t.step_func(e => {
             e.target.result
-                    .transaction("store")
-                    .objectStore("store")
-                    .get(1)
-                    .onsuccess = t.step_func(function(e)
-            {
-                assert_true(test(e.target.result),
-                            "condition does not apply to deserialized result")
-                t.done();
+                    .createObjectStore("store")
+                    .add(value, 1);
+
+            e.target.onsuccess = t.step_func(e => {
+                e.target.result
+                        .transaction("store")
+                        .objectStore("store")
+                        .get(1)
+                        .onsuccess = t.step_func(e =>
+                {
+                    assert_true(predicate(e.target.result),
+                                "Predicate should return true for the deserialized result.");
+                    t.done();
+                });
             });
         });
-    };
+    }, "BigInts as values in IndexedDB - " + name);
 }
 
-value(1n, x => x === 1n);
-value(Object(1n), x => typeof x === 'object' && x instanceof BigInt
-                                             && x.valueOf() === 1n);
+value_test(1n,
+           x => x === 1n,
+           "primitive BigInt");
+value_test(Object(1n),
+           x => typeof x === 'object' &&
+                x instanceof BigInt &&
+                x.valueOf() === 1n,
+           "BigInt object");
+value_test({val: 1n},
+           x => x.val === 1n,
+           "primitive BigInt inside object");
+value_test({val: Object(1n)},
+           x => x.val.valueOf() === 1n &&
+                x.val instanceof BigInt &&
+                x.val.valueOf() === 1n,
+           "BigInt object inside object");
 
 // However, BigInt is not supported as an IndexedDB key; support
 // has been proposed in the following PR, but that change has not
 // landed at the time this patch was written
 // https://github.com/w3c/IndexedDB/pull/231
 
-function invalidKey(key) {
-    var t = async_test(document.title + " - " + (i++));
-
-    createdb(t).onupgradeneeded = function(e) {
-        let store = e.target.result.createObjectStore("store")
-        assert_throws('DataError', () => store.add(1, key));
-        t.done();
-    };
+function invalidKey(key, name) {
+    test(t => {
+        assert_throws("DataError", () => indexedDB.cmp(0, key));
+    }, "BigInts as keys in IndexedDB - " + name);
 }
 
-invalidKey(1n);
-invalidKey(Object(1n));  // Still an error even if the IndexedDB patch lands
-
+invalidKey(1n, "primitive BigInt");
+// Still an error even if the IndexedDB patch lands
+invalidKey(Object(1n), "BigInt object");
 </script>
-
-<div id="log"></div>

--- a/IndexedDB/bigint_value.htm
+++ b/IndexedDB/bigint_value.htm
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Values</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support.js"></script>
+
+<script>
+// BigInt and BigInt wrappers are supported in serialization, per
+// https://github.com/whatwg/html/pull/3480
+// This support allows them to be used as IndexedDB values.
+
+let i = 0;
+function value(value, test) {
+    var t = async_test(document.title + " - " + (i++));
+    t.step(function() {
+        assert_true(test(value),
+                    "condition does not apply to initial value");
+    });
+
+    createdb(t).onupgradeneeded = function(e) {
+        e.target.result
+                .createObjectStore("store")
+                .add(value, 1);
+
+        e.target.onsuccess = t.step_func(function(e) {
+            e.target.result
+                    .transaction("store")
+                    .objectStore("store")
+                    .get(1)
+                    .onsuccess = t.step_func(function(e)
+            {
+                assert_true(test(e.target.result),
+                            "condition does not apply to deserialized result")
+                t.done();
+            });
+        });
+    };
+}
+
+value(1n, x => x === 1n);
+value(Object(1n), x => typeof x === 'object' && x instanceof BigInt
+                                             && x.valueOf() === 1n);
+
+// However, BigInt is not supported as an IndexedDB key; support
+// has been proposed in the following PR, but that change has not
+// landed at the time this patch was written
+// https://github.com/w3c/IndexedDB/pull/231
+
+function invalidKey(key) {
+    var t = async_test(document.title + " - " + (i++));
+
+    createdb(t).onupgradeneeded = function(e) {
+        let store = e.target.result.createObjectStore("store")
+        assert_throws('DataError', () => store.add(1, key));
+        t.done();
+    };
+}
+
+invalidKey(1n);
+invalidKey(Object(1n));  // Still an error even if the IndexedDB patch lands
+
+</script>
+
+<div id="log"></div>


### PR DESCRIPTION
Test BigInt serialization in IndexedDB values, and check that BigInt values cannot be used as IndexedDB keys. These are @littledan's tests with some changes suggested in reviews; see [PR #9667](https://github.com/w3c/web-platform-tests/pull/9667) for the original version.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
