### PR TITLE
Attempt to fix the font-feature-settings-rendering-2.html test

### DIFF
--- a/css/css-fonts/font-feature-settings-rendering-2-ref.html
+++ b/css/css-fonts/font-feature-settings-rendering-2-ref.html
@@ -4,7 +4,7 @@
 <style>
 @font-face {
     font-family: "FontFeaturesTest";
-    src: url("FontWithFeatures.otf") format("opentype");
+    src: url("support/fonts/FontWithFeatures.otf") format("opentype");
 }
 </style>
 </head>

--- a/css/css-fonts/font-feature-settings-rendering-2.html
+++ b/css/css-fonts/font-feature-settings-rendering-2.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
+<link rel="help" href="https://drafts.csswg.org/css-fonts/#font-rend-desc">
+<link rel="match" href="font-feature-settings-rendering-2-ref.html">
 <style>
 @font-face {
     font-family: "FontFeaturesTest";
-    src: url("resources/FontWithFeatures.otf") format("opentype");
+    src: url("support/fonts/FontWithFeatures.otf") format("opentype");
 }
 </style>
 </head>
@@ -20,7 +22,7 @@ function addElement(feature, c) {
         var element = document.createElement("span");
         element.textContent = c;
         element.style.fontFamily = "FontFeaturesTest";
-        element.style.webkitFontFeatureSettings = '"' + feature + '" ' + state;
+        element.style.fontFeatureSettings = '"' + feature + '" ' + state;
         insertionpoint.appendChild(element);
     });
     insertionpoint.appendChild(document.createTextNode(" "));


### PR DESCRIPTION
Both the test and its ref was in support/fonts/ which doesn't make
sense. Move the test and ref and make some changes in the direction of
fixing it. It still doesn't pass in Chrome or Firefox.

Discovered in https://github.com/w3c/web-platform-tests/pull/11004.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
