### PR TITLE
Parameterize domain and port references

### DIFF
--- a/clear-site-data/support/test_utils.sub.js
+++ b/clear-site-data/support/test_utils.sub.js
@@ -267,7 +267,7 @@ var TestUtils = (function() {
         throw "Unsupported scheme: " + page_scheme;
       if (resource_scheme != "https" && resource_scheme != "http")
         throw "Unsupported scheme: " + resource_scheme;
-      return page_scheme + "://web-platform.test:" +
+      return page_scheme + "://{{domains[]}}:" +
           (page_scheme == "https" ? {{ports[https][0]}} : {{ports[http][0]}}) +
           "/clear-site-data/support/page_with_resource.sub.html?scheme=" +
           resource_scheme;

--- a/content-security-policy/base-uri/report-uri-does-not-respect-base-uri.sub.html
+++ b/content-security-policy/base-uri/report-uri-does-not-respect-base-uri.sub.html
@@ -5,7 +5,7 @@
   <script src='/resources/testharness.js'></script>
   <script src='/resources/testharnessreport.js'></script>
   <!-- if base is used for resolving the URL to report to then we will not get a report -->
-  <base href="http://nonexistent.web-platform.test">
+  <base href="http://nonexistent.{{domains[]}}">
 </head>
 <body>
   <script>

--- a/content-security-policy/generic/generic-0_8.sub.html
+++ b/content-security-policy/generic/generic-0_8.sub.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <title>test wildcard host name matching (*.web-platform.test is good)</title>
+    <title>test wildcard host name matching (asterisk as a subdomain of the current domain)</title>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' *.{{host}}:{{ports[http][0]}} 'unsafe-inline';">
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
@@ -22,7 +22,7 @@
     </script>    
 </head>
 <body>
-    <h1>test wildcard host name matching (*.web-platform.test is good)</h1>
+    <h1>test wildcard host name matching (asterisk as a subdomain of the current domain)</h1>
     <div id='log'></div>
 </body>
 </html>

--- a/content-security-policy/generic/generic-0_8_1.sub.html
+++ b/content-security-policy/generic/generic-0_8_1.sub.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <title>test wildcard host name matching (www*.web-platform.test is bad, *www.web-platform.test is bad)</title>
+    <title>test wildcard host name matching (asterisk as part of a subdomain is not accepted)</title>
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' *w.{{host}}:{{ports[http][0]}} w*.{{host}}:{{ports[http][0]}} 'unsafe-inline';">
     <script src='/resources/testharness.js'></script>
     <script src='/resources/testharnessreport.js'></script>
@@ -20,7 +20,7 @@
     </script>
 </head>
 <body>
-    <h1>test wildcard host name matching (www*.web-platform.test is bad, *www.web-platform.test is bad)</h1>
+    <h1>test wildcard host name matching (asterisk as part of a subdomain is not accepted)</h1>
     <div id='log'></div>
 </body>
 </html>

--- a/content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.sub.html
+++ b/content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.sub.html
@@ -124,7 +124,7 @@
         var script = document.querySelector('#cssTest');
         var style = getComputedStyle(script);
         assert_equals(style['display'], 'block');
-        assert_equals(style['background-image'], "url(\"http://web-platform.test:8001/security/resources/abe.png\")");
+        assert_equals(style['background-image'], "url(\"http://{{domains[]}}:8001/security/resources/abe.png\")");
       }));
     }, "Nonces leak via CSS side-channels.");
 </script>

--- a/content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.sub.html
+++ b/content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.sub.html
@@ -124,7 +124,7 @@
         var script = document.querySelector('#cssTest');
         var style = getComputedStyle(script);
         assert_equals(style['display'], 'block');
-        assert_equals(style['background-image'], "url(\"http://{{domains[]}}:8001/security/resources/abe.png\")");
+        assert_equals(style['background-image'], "url(\"http://{{domains[]}}:{{ports[http][0]}}/security/resources/abe.png\")");
       }));
     }, "Nonces leak via CSS side-channels.");
 </script>

--- a/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.sub.html
+++ b/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.sub.html
@@ -109,7 +109,7 @@
           var script = document.querySelector('#cssTest');
           var style = getComputedStyle(script);
           assert_equals(style['display'], 'block');
-          assert_equals(style['background-image'], "url(\"http://{{domains[]}}:8001/security/resources/abe.png\")");
+          assert_equals(style['background-image'], "url(\"http://{{domains[]}}:{{ports[http][0]}}/security/resources/abe.png\")");
         }));
       }, "Nonces don't leak via CSS side-channels.");
   </script>

--- a/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.sub.html
+++ b/content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.sub.html
@@ -109,7 +109,7 @@
           var script = document.querySelector('#cssTest');
           var style = getComputedStyle(script);
           assert_equals(style['display'], 'block');
-          assert_equals(style['background-image'], "url(\"http://web-platform.test:8001/security/resources/abe.png\")");
+          assert_equals(style['background-image'], "url(\"http://{{domains[]}}:8001/security/resources/abe.png\")");
         }));
       }, "Nonces don't leak via CSS side-channels.");
   </script>

--- a/fetch/api/request/request-structure.html
+++ b/fetch/api/request/request-structure.html
@@ -45,7 +45,7 @@
 
           case "url":
             //default value is base url
-            //i.e http://web-platform.test:8000/fetch/api/request-structure.html
+            //i.e http://example.com/fetch/api/request-structure.html
             newValue = "http://url.test";
             break;
 

--- a/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
+++ b/html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
@@ -11,17 +11,17 @@
     <script>
       var host_info = get_host_info();
       var HTTP_PORT = host_info.HTTP_PORT;
-      var ORIGINAL_HOST = host_info.ORIGINAL_HOST; // e.g. "web-platform.test"
+      var ORIGINAL_HOST = host_info.ORIGINAL_HOST;
       var SUFFIX_HOST = ORIGINAL_HOST.substring(ORIGINAL_HOST.lastIndexOf('.') + 1); // e.g. "test"
-      var PREFIX_HOST = "www1." + ORIGINAL_HOST; // e.g. "www1.web-platform.test"
+      var REMOTE_HOST = host_info.REMOTE_HOST;
       var iframe = document.getElementById("iframe");
       var iframe_url = new URL("support/document_domain_setter_iframe.html", document.location);
-      iframe_url.hostname = PREFIX_HOST;
+      iframe_url.hostname = REMOTE_HOST;
       iframe.src = iframe_url;
       test(function() {
         assert_throws("SecurityError", function() { document.domain = SUFFIX_HOST; });
         assert_throws("SecurityError", function() { document.domain = "." + SUFFIX_HOST; });
-        assert_throws("SecurityError", function() { document.domain = PREFIX_HOST; });
+        assert_throws("SecurityError", function() { document.domain = REMOTE_HOST; });
         assert_throws("SecurityError", function() { document.domain = "example.com"; });
       }, "failed setting of document.domain");
       async_test(function(t) {

--- a/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.sub.html
+++ b/html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.sub.html
@@ -5,7 +5,7 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="iframe_harness.js"></script>
 <body>
-  <iframe src="http://www1.web-platform.test:8000/html/semantics/embedded-content/the-iframe-element/cross_origin_child.html"></iframe>
+  <iframe src="http://{{domains[www1]}}:{{ports[http][0]}}/html/semantics/embedded-content/the-iframe-element/cross_origin_child.html"></iframe>
 </body>
 <script>
     get_test_results('bffa23ee-b45a-4e9a-9405-87ab437d5cfa');

--- a/html/semantics/forms/the-label-element/label-attributes.sub.html
+++ b/html/semantics/forms/the-label-element/label-attributes.sub.html
@@ -222,7 +222,7 @@
                     "The number of labels should be 2 after the labelable element is moved to iframe.");
     });
 
-    iframe.setAttribute('src', 'http://web-platform.test:8000/html/semantics/forms/the-label-element/iframe-label-attributes.html');
+    iframe.setAttribute('src', 'http://{{domains[]}}:{{ports[http][0]}}/html/semantics/forms/the-label-element/iframe-label-attributes.html');
     document.body.appendChild(iframe);
   }, "A labelable element is moved to iframe.");
 

--- a/lint.whitelist
+++ b/lint.whitelist
@@ -772,19 +772,3 @@ MISSING-LINK: css/filter-effects/*.any.js
 # Tests that use WebKit/Blink testing APIs
 LAYOUTTESTS APIS: css/css-regions/interactivity/*
 LAYOUTTESTS APIS: resources/chromium/generic_sensor_mocks.js
-
-# Existing use of WEB-PLATFORM.TEST
-WEB-PLATFORM.TEST: clear-site-data/support/test_utils.sub.js
-WEB-PLATFORM.TEST: content-security-policy/base-uri/report-uri-does-not-respect-base-uri.sub.html
-WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8.sub.html
-WEB-PLATFORM.TEST: content-security-policy/generic/generic-0_8_1.sub.html
-WEB-PLATFORM.TEST: content-security-policy/nonce-hiding/script-nonces-hidden-meta.tentative.html
-WEB-PLATFORM.TEST: content-security-policy/nonce-hiding/svgscript-nonces-hidden-meta.tentative.html
-WEB-PLATFORM.TEST: fetch/api/request/request-structure.html
-WEB-PLATFORM.TEST: html/browsers/origin/relaxing-the-same-origin-restriction/document_domain_setter.html
-WEB-PLATFORM.TEST: html/semantics/embedded-content/the-iframe-element/cross_origin_parentage.html
-WEB-PLATFORM.TEST: html/semantics/forms/the-label-element/label-attributes.html
-WEB-PLATFORM.TEST: navigation-timing/nav2_test_attributes_values.html
-WEB-PLATFORM.TEST: navigation-timing/nav2_test_instance_accessors.html
-WEB-PLATFORM.TEST: webrtc/RTCPeerConnection-getIdentityAssertion.html
-WEB-PLATFORM.TEST: webrtc/identity-helper.js

--- a/navigation-timing/nav2_test_attributes_values.html
+++ b/navigation-timing/nav2_test_attributes_values.html
@@ -7,12 +7,23 @@
         <link rel="help" href="http://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
+        <script src="/common/get-host-info.sub.js"></script>
     </head>
     <body>
         <h1>Description</h1>
         <p>This test validates that the values of nav timing 2 instance's timing-related attributes are in certain order and the others are of expected values.</p>
 
         <script>
+        // Host names and ports may be configured at test execution time. The
+        // web-platform-tests server offers two mechanisms for retrieving these
+        // values dynamically: direct text substitution and the `get-host-info`
+        // script. The former is inapproprate for this test because it
+        // influences the size of the document, and this test includes static
+        // assertions for that value.
+        var host_info = get_host_info();
+        var expectedUrl = "http://" + host_info.ORIGINAL_HOST + ":" +
+            host_info.HTTP_PORT +
+            "/navigation-timing/nav2_test_attributes_values.html";
         var navTiming2EventOrder1 = [
             'startTime',
             'redirectStart',
@@ -81,7 +92,7 @@
                     var entries = entryList.getEntries();
                     assert_equals(entries[0].entryType, "navigation",
                         "Expected entryType to be: navigation.");
-                    assert_equals(entries[0].name, "http://web-platform.test:8001/navigation-timing/nav2_test_attributes_values.html");
+                    assert_equals(entries[0].name, expectedUrl);
                     assert_equals(entries[0].startTime, 0,
                         "Expected startTime to be: 0.");
                     assert_equals(entries[0].duration, entries[0].loadEventEnd,
@@ -93,8 +104,8 @@
                     // running this test.
                     assert_true(entries[0].transferSize > entries[0].encodedBodySize,
                         "Expected transferSize to be greater than encodedBodySize in uncached navigation.");
-                    assert_equals(entries[0].encodedBodySize, 5328);
-                    assert_equals(entries[0].decodedBodySize, 5328);
+                    assert_equals(entries[0].encodedBodySize, 5955);
+                    assert_equals(entries[0].decodedBodySize, 5955);
                     verifyTimingEventOrder(entries[0], navTiming2EventOrder1);
                     // Verify if the reported timing is not that different
                     // from what is reported by Navigation Timing 1.

--- a/navigation-timing/nav2_test_instance_accessors.html
+++ b/navigation-timing/nav2_test_instance_accessors.html
@@ -7,12 +7,16 @@
         <link rel="help" href="http://www.w3.org/TR/navigation-timing-2/#sec-PerformanceNavigationTiming"/>
         <script src="/resources/testharness.js"></script>
         <script src="/resources/testharnessreport.js"></script>
+        <script src="/common/get-host-info.sub.js"></script>
     </head>
     <body>
         <h1>Description</h1>
         <p>This test validates that nav timing 2 instance can be accessed by three different accessors once available: window.performance.getEntries()/getEntriesByType("navigation")/getEntriesByName("document")</p>
 
         <script>
+        var host_info = get_host_info();
+        var expectedUrl = "http://" + host_info.ORIGINAL_HOST + ":" +
+            host_info.HTTP_PORT + "/navigation-timing/nav2_test_instance_accessors.html";
         var navTiming2Attributes = [
             'connectEnd',
             'connectStart',
@@ -50,10 +54,10 @@
                 t.step_func(function (entryList) {
                     var instance1 = performance.getEntries()[0];
                     var instance2 = performance.getEntriesByType("navigation")[0];
-                    var instance3 = performance.getEntriesByName("http://web-platform.test:8001/navigation-timing/nav2_test_instance_accessors.html")[0];
+                    var instance3 = performance.getEntriesByName(expectedUrl)[0];
 
                     assert_equals(performance.getEntriesByType("navigation").length, 1, "Expected there is only one navigation timing instance.");
-                    assert_equals(performance.getEntriesByName("http://web-platform.test:8001/navigation-timing/nav2_test_instance_accessors.html").length, 1, "Expected there is only one navigation timing instance.");
+                    assert_equals(performance.getEntriesByName(expectedUrl).length, 1, "Expected there is only one navigation timing instance.");
 
                     for (var i = 0; i < navTiming2Attributes.length; i++) {
                         assert_equals(instance1[navTiming2Attributes[i]], instance2[navTiming2Attributes[i]]);

--- a/webrtc/RTCPeerConnection-getIdentityAssertion.sub.html
+++ b/webrtc/RTCPeerConnection-getIdentityAssertion.sub.html
@@ -3,7 +3,7 @@
 <title>RTCPeerConnection.prototype.getIdentityAssertion</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="identity-helper.js"></script>
+<script src="identity-helper.sub.js"></script>
 <script>
   'use strict';
 
@@ -13,7 +13,7 @@
   // The tests here interacts with the mock identity provider located at
   //   /.well-known/idp-proxy/mock-idp.js
 
-  // The following helper functions are called from identity-helper.js
+  // The following helper functions are called from identity-helper.sub.js
   //   parseAssertionResult
   //   getIdpDomains
   //   assert_rtcerror_rejection
@@ -217,7 +217,7 @@
   promise_test(t => {
     const pc = new RTCPeerConnection();
 
-    pc.setIdentityProvider('nonexistent.web-platform.test', {
+    pc.setIdentityProvider('nonexistent.{{domains[]}}', {
       protocol: `non-existent`,
       usernameHint: `alice@example.org`,
     });

--- a/webrtc/RTCPeerConnection-peerIdentity.html
+++ b/webrtc/RTCPeerConnection-peerIdentity.html
@@ -3,7 +3,7 @@
 <title>RTCPeerConnection.prototype.peerIdentity</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="identity-helper.js"></script>
+<script src="identity-helper.sub.js"></script>
 <script>
   'use strict';
 
@@ -13,7 +13,7 @@
   // The tests here interacts with the mock identity provider located at
   //   /.well-known/idp-proxy/mock-idp.js
 
-  // The following helper functions are called from identity-helper.js
+  // The following helper functions are called from identity-helper.sub.js
   //   parseAssertionResult
   //   getIdpDomains
   //   assert_rtcerror_rejection

--- a/webrtc/identity-helper.sub.js
+++ b/webrtc/identity-helper.sub.js
@@ -1,14 +1,10 @@
 'use strict';
 
 /*
-  In web-platform-test, the following domains are required to be set up locally:
-    127.0.0.1   web-platform.test
-    127.0.0.1   www.web-platform.test
-    127.0.0.1   www1.web-platform.test
-    127.0.0.1   www2.web-platform.test
-    127.0.0.1   xn--n8j6ds53lwwkrqhv28a.web-platform.test
-    127.0.0.1   xn--lve-6lad.web-platform.test
-    0.0.0.0     nonexistent.web-platform.test
+  In web-platform-test, a number of domains are required to be set up locally.
+  The list is available at docs/_writing-tests/server-features.md. The
+  appropriate hosts file entries can be generated with the WPT CLI via the
+  following command: `wpt make-hosts-file`.
  */
 
 /*
@@ -34,12 +30,16 @@ function parseAssertionResult(assertionResultStr) {
 
 // Return two distinct IdP domains that are different from current domain
 function getIdpDomains() {
-  if(window.location.hostname === 'www1.web-platform.test') {
-    return ['www.web-platform.test', 'www2.web-platform.test'];
-  } else if(window.location.hostname === 'www2.web-platform.test') {
-    return ['www.web-platform.test', 'www1.web-platform.test'];
+  const domainA = '{{domains[www]}}';
+  const domainB = '{{domains[www1]}}';
+  const domainC = '{{domains[www2]}}';
+
+  if(window.location.hostname === domainA) {
+    return [domainB, domainC];
+  } else if(window.location.hostname === domainB) {
+    return [domainA, domainC];
   } else {
-    return ['www1.web-platform.test', 'www2.web-platform.test'];
+    return [domainA, domainB];
   }
 }
 

--- a/webrtc/tools/.eslintrc.js
+++ b/webrtc/tools/.eslintrc.js
@@ -72,7 +72,7 @@ module.exports = {
     assert_optional_dict_field: true,
     assert_optional_enum_field: true,
 
-    // identity-helper.js
+    // identity-helper.sub.js
     parseAssertionResult: true,
     getIdpDomains: true,
     assert_rtcerror_rejection: true,


### PR DESCRIPTION
The web-platform-tests server may be configured to run from any host name and any TCP/IP port number. It offers a text substitution feature so that tests can be written to account for this variability.

Update tests which previously referenced the default host name and port number (i.e. `web-platform.test` and 8000) to instead reference parameterized values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11011)
<!-- Reviewable:end -->
