### PR TITLE
Test short regionCode

### DIFF
--- a/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
+++ b/payment-request/PaymentAddress/attributes-and-toJSON-method-manual.https.html
@@ -68,7 +68,7 @@ function runManualTest(button, expected = {}) {
     <button onclick="
     const expectedAddress = {
       country: 'AU',
-      regionCode: 'AU-QLD',
+      regionCode: 'QLD',
       addressLine: '55 test st',
       city: 'Chapel Hill',
       dependentLocality: '',
@@ -90,8 +90,10 @@ function runManualTest(button, expected = {}) {
       <dd>55 test st</dd>
       <dt>Country</dt>
       <dd>Australia</dd>
-      <dt>Suburb</dt>
+      <dt>City</dt>
       <dd>Chapel Hill</dd>
+      <dd>State/Region</dd>
+      <dd>Queensland</dd>
       <dt>postal code </dt>
       <dd>6095</dd>
       <dt>organization</dt>


### PR DESCRIPTION
With https://github.com/w3c/payment-request/pull/690 the payment request spec now requires `regionCode` to be a "code element" of an [[!ISO3166-2]] country subdivision name (e.g., "CA" for California).

<!-- Reviewable:start -->

<!-- Reviewable:end -->
