### PR TITLE
Don't assume file_is_test when there's a top-level non-assert error

### DIFF
--- a/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
+++ b/infrastructure/metadata/infrastructure/expected-fail/uncaught-exception.html.ini
@@ -1,4 +1,3 @@
 [uncaught-exception.html]
-  [Uncaught exception]
-    expected: FAIL
+  expected: ERROR
 

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -770,7 +770,7 @@ policies and contribution forms [3].
     }
 
     function done() {
-        if (tests.tests.length === 0) {
+        if (tests.tests.length === 0 && tests.status.status === tests.status.OK) {
             tests.set_file_is_test();
         }
         if (tests.file_is_test) {
@@ -3366,10 +3366,6 @@ policies and contribution forms [3].
 
     if (global_scope.addEventListener) {
         var error_handler = function(e) {
-            if (tests.tests.length === 0 && !tests.allow_uncaught_exception) {
-                tests.set_file_is_test();
-            }
-
             var stack;
             if (e.error && e.error.stack) {
                 stack = e.error.stack;
@@ -3391,6 +3387,9 @@ policies and contribution forms [3].
                 tests.status.status = tests.status.ERROR;
                 tests.status.message = e.message;
                 tests.status.stack = stack;
+                if (!tests.length) {
+                    tests.phase = tests.phases.ABORTED;
+                }
             }
             done();
         };


### PR DESCRIPTION
Previously, if we got an unexpected error before any asserts ran, we
would assume that the file represented a single-test file and imply a
subtest. However this is confusing in the case that the assumptions
are wrong because we see different subtests in browsers that have an
early error vs those that do not.

Instead of this, we only set file_is_test when we call assert()
outside a test, and in other cases set the overall status to ERROR and
leave the list of subtests empty.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
