### PR TITLE
font-variant descriptor was moved to Fonts 4 

### DIFF
--- a/css/css-fonts/font-variant-05.xht
+++ b/css/css-fonts/font-variant-05.xht
@@ -4,9 +4,9 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>CSS Test:  font-variant descriptor in @font-face rule is overriden by equivalent style rules</title>
 <link rel="author" title="Mike Bremford" href="mike@bfo.com" />
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-variant-prop" />
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-rend-desc" />
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop" />
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-variant-prop" />
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-rend-desc" />
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-feature-settings-prop" />
 <link rel="match" href="font-variant-05-ref.xht" />
 <meta name="assert" content="Setting ‘font-variant-ligatures’ properties will override the same properties set in the @font-face rule. But properties set there and not explicitly turned off or on later remain set." />
 <style>

--- a/css/css-fonts/font-variant-descriptor-01.html
+++ b/css/css-fonts/font-variant-descriptor-01.html
@@ -3,9 +3,9 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <title>CSS Test:  font-variant: normal; low level equivalence</title>
 <link rel="author" title="Chris Lilley" href="chris@w3.org">
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-variant-prop">
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop">
-<link rel="help" href="https://www.w3.org/TR/css-fonts-3/#font-rend-desc">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-variant-prop">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-feature-settings-prop">
+<link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-rend-desc">
 <link rel="match" href="font-variant-descriptor-01-ref.html">
 <meta name="assert" content="These descriptors define initial settings that apply when the font defined by an @font-face rule is rendered">
 <style>


### PR DESCRIPTION
See CSS WG issue https://github.com/w3c/csswg-drafts/issues/2531
the font-variant *descriptor* was moved from Fonts 3 to Fonts 4. Spec links updated, test and ref unchanged.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
