### PR TITLE
Prevent GitTree logging errors if git fails.

### DIFF
--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -131,11 +131,11 @@ class HgTree(object):
 class GitTree(object):
     name = "git"
 
-    def __init__(self, root=None):
+    def __init__(self, root=None, log_error=True):
         if root is None:
-            root = git("rev-parse", "--show-toplevel").strip()
+            root = git("rev-parse", "--show-toplevel", log_error=log_error).strip()
         self.root = root
-        self.git = vcs.bind_to_repo(git, self.root)
+        self.git = vcs.bind_to_repo(git, self.root, log_error=log_error)
         self.message = None
         self.commit_cls = Commit
 

--- a/tools/wptrunner/wptrunner/vcs.py
+++ b/tools/wptrunner/wptrunner/vcs.py
@@ -37,13 +37,13 @@ git = vcs("git")
 hg = vcs("hg")
 
 
-def bind_to_repo(vcs_func, repo):
-    return partial(vcs_func, repo=repo)
+def bind_to_repo(vcs_func, repo, log_error=True):
+    return partial(vcs_func, repo=repo, log_error=log_error)
 
 
-def is_git_root(path):
+def is_git_root(path, log_error=True):
     try:
-        rv = git("rev-parse", "--show-cdup", repo=path)
+        rv = git("rev-parse", "--show-cdup", repo=path, log_error=log_error)
     except subprocess.CalledProcessError:
         return False
     return rv == "\n"

--- a/tools/wptrunner/wptrunner/wpttest.py
+++ b/tools/wptrunner/wptrunner/wpttest.py
@@ -74,7 +74,7 @@ class RunInfo(dict):
         from update.tree import GitTree
         try:
             # GitTree.__init__ throws if we are not in a git tree.
-            rev = GitTree().rev
+            rev = GitTree(log_error=False).rev
         except subprocess.CalledProcessError:
             rev = None
         if rev:


### PR DESCRIPTION
The errors logged when failing to get a git revision cause issues in the gecko infrastructure.
Fix this by passing throught the log_error=False flag to suppress printing the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11036)
<!-- Reviewable:end -->
