### PR TITLE
Remove CSSStyleDeclaration#setPropertyPriority/setPropertyValue from CSSOM IDL

### DIFF
--- a/interfaces/cssom.idl
+++ b/interfaces/cssom.idl
@@ -118,8 +118,6 @@ interface CSSStyleDeclaration {
   CSSOMString getPropertyValue(CSSOMString property);
   CSSOMString getPropertyPriority(CSSOMString property);
   [CEReactions] void setProperty(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value, [TreatNullAs=EmptyString] optional CSSOMString priority = "");
-  [CEReactions] void setPropertyValue(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString value);
-  [CEReactions] void setPropertyPriority(CSSOMString property, [TreatNullAs=EmptyString] CSSOMString priority);
   [CEReactions] CSSOMString removeProperty(CSSOMString property);
   readonly attribute CSSRule? parentRule;
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString cssFloat;


### PR DESCRIPTION
These were removed from the spec in https://github.com/w3c/csswg-drafts/commit/02daf7f7204d57b0034205e88d695592e821117e.

@emilio

<!-- Reviewable:start -->

<!-- Reviewable:end -->
