### PR TITLE
Move entry check before sendBeacon() call

### DIFF
--- a/beacon/headers/header-content-type.html
+++ b/beacon/headers/header-content-type.html
@@ -19,8 +19,8 @@ function testContentTypeHeader(what, contentType, title) {
   promise_test(async t => {
     const id = self.token();
     const testUrl = new Request(RESOURCES_DIR + "content-type.py?cmd=put&id=" + id).url;
-    assert_true(navigator.sendBeacon(testUrl, what), "SendBeacon Succeeded");
     assert_equals(performance.getEntriesByName(testUrl).length, 0);
+    assert_true(navigator.sendBeacon(testUrl, what), "SendBeacon Succeeded");
 
     do {
       await wait(50);


### PR DESCRIPTION
Fixes w3c/beacon#58

See discussion there for details.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
