### PR TITLE
Add CODEOWNERS to prevent submodule issues

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Prevent accidentially touching CSS submodules
+/css/tools/ @plinss @kojiishi @jgraham @gsnedders


### PR DESCRIPTION
b8ef676615e230a09023e02ce4f0b0f8b1f6c2a1 accidentially touched a submodule. This would greatly diminish the chance of that happening and it landing on master again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11070)
<!-- Reviewable:end -->
