### PR TITLE
Use add_dependency_idls in gamepad idlharness test

### DIFF
--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -9,21 +9,22 @@
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
 <script>
-"use strict";
+  "use strict";
 
-promise_test(async () => {
-  const idl_array = new IdlArray();
-  const gamepad_idl = await fetch("/interfaces/gamepad.idl").then(r => r.text());
-  const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
+  promise_test(async () => {
+    const idl_array = new IdlArray();
+    const gamepad_idl = await fetch("/interfaces/gamepad.idl").then(r => r.text());
+    const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
+    const html = await fetch("/interfaces/html.idl").then(r => r.text());
 
-  idl_array.add_untested_idls(dom, {only: ['Event', 'EventInit']});
-  idl_array.add_untested_idls('interface Navigator {};');
-  idl_array.add_idls(gamepad_idl);
+    idl_array.add_idls(gamepad_idl);
+    idl_array.add_dependency_idls(dom);
+    idl_array.add_dependency_idls(html);
 
-  idl_array.add_objects({
-    GamepadEvent: [new GamepadEvent("something")],
-    Navigator: ["navigator"]
-  });
-  idl_array.test();
-}, "Test IDL implementation of Gamepad API");
+    idl_array.add_objects({
+      GamepadEvent: [new GamepadEvent("something")],
+      Navigator: ["navigator"]
+    });
+    idl_array.test();
+  }, "Test IDL implementation of Gamepad API");
 </script>


### PR DESCRIPTION
To test, copied the same file to Chromium and ran 

    python third_party/blink/tools/run_web_tests.py -t Default external/wpt/gamepad/idlharness.html

    
>    Found 1 test; running 1, skipping 0.               
>    Running 1 content_shell.                                                                              

>    The test ran as expected.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
