### PR TITLE
[css-fonts] Avoid race condition

### DIFF
--- a/css/css-fonts/variations/at-font-face-font-matching.html
+++ b/css/css-fonts/variations/at-font-face-font-matching.html
@@ -87,7 +87,7 @@
                 return once_fonts_are_ready
                     .then(() => verifyFont("descriptorPriorityTest", testCase.weight, testCase.style, testCase.stretch, testCase.expectedFamily));
                 },
-                "Descriptor mathcing priority: " + testCase.description
+                "Descriptor matching priority: " + testCase.description
             );
         });
 

--- a/css/css-fonts/variations/at-font-face-font-matching.html
+++ b/css/css-fonts/variations/at-font-face-font-matching.html
@@ -3,6 +3,7 @@
 <head>
     <title>Testing @font-face font matching logic introduced in CSS Fonts level 4</title>
     <link rel="help" href="https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm" />
+    <meta name="timeout" content="long">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <style>
@@ -33,6 +34,9 @@
         <span style="font-family: 'W100';">A</span>
         <span style="font-family: 'W200';">A</span>
         <span style="font-family: 'W300';">A</span>
+        <span style="font-family: 'descriptorPriorityTest'; font-stretch: 125%;">A</span>
+        <span style="font-family: 'descriptorPriorityTest'; font-style: italic;">A</span>
+        <span style="font-family: 'descriptorPriorityTest'; font-weight: 350;">A</span>
     </span>
 
     <div id="master" class="test">A1 A2 A2 A3 A3 A3</div>
@@ -79,19 +83,59 @@
         ];
 
         descriptorPriorityCases.forEach(function (testCase) {
-            promise_test(
-                assert => once_fonts_are_ready.then(assert => {
-                    verifyFont("descriptorPriorityTest", testCase.weight, testCase.style, testCase.stretch, testCase.expectedFamily);
-                }),
+            promise_test(() => {
+                return once_fonts_are_ready
+                    .then(() => verifyFont("descriptorPriorityTest", testCase.weight, testCase.style, testCase.stretch, testCase.expectedFamily));
+                },
                 "Descriptor mathcing priority: " + testCase.description
             );
         });
 
+        function load(family, name, value) {
+            const el1 = document.createElement("span");
+            const el2 = document.createElement("span");
+            el1.innerText = "A";
+            el2.innerText = "A";
+            let value1, value2;
+            if (value.indexOf("deg") > 0) {
+                value1 = "oblique " + value.split(" ")[1];
+                value2 = "oblique " + (value.split(" ")[2] || value.split(" ")[1]);
+            } else {
+                value1 = value.split(" ")[0];
+                value2 = value.split(" ")[1] || value1;
+            }
+            el1.style[name] = value1;
+            el2.style[name] = value2;
+            document.body.appendChild(el1);
+            document.body.appendChild(el2);
+            const initialWidth1 = el1.offsetWidth;
+            const initialWidth2 = el2.offsetWidth;
+            return new Promise((resolve) => {
+                el1.style.fontFamily = family;
+                el2.style.fontFamily = family;
+                (function check() {
+                    if (el1.offsetWidth !== initialWidth1 && el2.offsetWidth !== initialWidth2) {
+                        el1.remove();
+                        el2.remove();
+                        resolve();
+                    } else {
+                        requestAnimationFrame(check);
+                    }
+                }());
+            });
+        }
         function createFontFaceRules(fontFaceFamily, descriptorName, expectedMatch, unexpectedMatch) {
             dynamicStyles.innerHTML =
                 "@font-face { font-family: " + fontFaceFamily + "; src: url('./resources/csstest-weights-100-kerned.ttf'); "+ descriptorName + ": " + expectedMatch   + "; }" +
                 "@font-face { font-family: " + fontFaceFamily + "; src: url('./resources/csstest-weights-200-kerned.ttf'); " + descriptorName + ": " + unexpectedMatch + "; }";
+
+            return Promise.all([
+                load(fontFaceFamily, descriptorName, expectedMatch),
+                load(fontFaceFamily, descriptorName, unexpectedMatch)
+            ]);
         }
+
+        let familyId = 0;
 
         function testDescriptor(descriptorName, testCases) {
             testCases.forEach(function (testCase) {
@@ -99,16 +143,20 @@
                     for(let i = 0; i < testCase.testDescriptors.length - 1; i++) {
                         let expectedMatch   = testCase.testDescriptors[i];
                         let unexpectedMatch = testCase.testDescriptors[i + 1];
+                        familyId += 1;
+                        const family = "MatchTestFamily" + familyId;
+
                         promise_test(
-                            assert => once_fonts_are_ready.then(assert => {
-                                createFontFaceRules("MatchTestFamily", descriptorName, expectedMatch, unexpectedMatch);
+                            () => {
+                                return createFontFaceRules(family, descriptorName, expectedMatch, unexpectedMatch)
+                                    .then(() => {
+                                        let testWeight  = (descriptorName == "font-weight")  ? testCase.value : "normal";
+                                        let testStyle   = (descriptorName == "font-style")   ? testCase.value : "normal";
+                                        let testStretch = (descriptorName == "font-stretch") ? testCase.value : "normal";
 
-                                let testWeight  = (descriptorName == "font-weight")  ? testCase.value : "normal";
-                                let testStyle   = (descriptorName == "font-style")   ? testCase.value : "normal";
-                                let testStretch = (descriptorName == "font-stretch") ? testCase.value : "normal";
-
-                                verifyFont("MatchTestFamily", testWeight, testStyle, testStretch, "'W100'");
-                            }),
+                                        verifyFont(family, testWeight, testStyle, testStretch, "'W100'");
+                                    });
+                            },
                             "Matching " + descriptorName + ": '" + testCase.value + "' should prefer '" + expectedMatch + "' over '" + unexpectedMatch + "'");
                     }
             });


### PR DESCRIPTION
@gsnedders @Ms2ger I'm not certain that my rationale is sound, so I've over-explained a bit to help you show me if/where I've gone wrong.

---

The modified test primes the document's font source by declaring a
`font-face` rule and deferring tests until the font has been loaded. The
sub-tests are expressed in terms of a FontFace which is dynamically
generated via a `<style>` tag but which shares the same URL.

Prior to this patch, the test assumed that the declaration of the second
FontFace would be reflected in a synchronously-triggered reflow (via
access of the `offsetWidth` property). This is not guaranteed because
each parse of a `<style>` element creates a new FontFace object [1] which
must be loaded [2] with the potentially CORS-enabled fetch method of the
HTML specification [3].

Practically speaking, this caused the Firefox and Chrome browsers to
consistently fail the sub-tests.

Update the test to define a unique FontFace for every subtest and to
explicitly wait for it to be available for rendering. Annotate the test
as "long" to accomodate the additional time spent waiting.

[1] > A CSS @font-face rule automatically defines a corresponding
    > FontFace object, which is automatically placed in the document’s
    > font source when the rule is parsed.

    https://www.w3.org/TR/css-font-loading-3/#font-face-css-connection

[2] > When a user-agent needs to load a font face, it must do so by
    > calling the load() method of the corresponding FontFace object.

    https://www.w3.org/TR/css-font-loading-3/#font-face-set-css

[3] > For font loads, user agents must use the potentially CORS-enabled
    > fetch method defined by the [HTML5] specification for URL's
    > defined within @font-face rules.

    https://www.w3.org/TR/css-fonts-3/#font-fetching-requirements

<!-- Reviewable:start -->

<!-- Reviewable:end -->
