### PR TITLE
[cssom] Make a test assertion not show the number of CSS properties if it fails.

### DIFF
--- a/css/cssom/getComputedStyle-detached-subtree.html
+++ b/css/cssom/getComputedStyle-detached-subtree.html
@@ -17,7 +17,7 @@ function testNoComputedStyle(element, description) {
     assert_true(!!element);
     let style = getComputedStyle(element);
     assert_true(!!style);
-    assert_equals(style.length, 0);
+    assert_true(style.length === 0);
     assert_equals(style.color, "");
   }, `getComputedStyle returns no style for ${description}`);
 }


### PR DESCRIPTION
That causes unnecessary pain when updating tests across platforms, etc., and also unnecessary test failures when adding new properties for example.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
