### PR TITLE
Wait until window load before calling window.stop() in XHR test

### DIFF
--- a/xhr/abort-after-stop.htm
+++ b/xhr/abort-after-stop.htm
@@ -10,7 +10,7 @@
     <div id="log"></div>
     <script>
       var test = async_test();
-      test.step(function() {
+      window.onload = test.step_func(function() {
         var client = new XMLHttpRequest();
         var abortFired = false;
         client.onabort = test.step_func(function (e) {


### PR DESCRIPTION
https://wpt.fyi/xhr/abort-after-stop.htm is broken in 3/4 browsers and
it appears this is because calling window.stop() causes the window
load event to never be fired, and testharness.js depends on that.

There is no harness timeout in Edge, because Edge fires the load
event. Tested with https://jsbin.com/tufepag/edit?js,console and filed
https://github.com/w3c/web-platform-tests/issues/11090 for the lack of
tests for this.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
