### PR TITLE
Removed extension capability tests

### DIFF
--- a/webdriver/tests/new_session/support/create.py
+++ b/webdriver/tests/new_session/support/create.py
@@ -11,5 +11,4 @@ valid_data = [
                   {"script": 500},
                   {}]),
     ("unhandledPromptBehavior", ["dismiss", "accept", None]),
-    ("test:extension", [True, "abc", 123, [], {"key": "value"}, None]),
 ]


### PR DESCRIPTION
Remove the extension capability tests referenced by #10881. The core issue is that to pass these tests browsers must add support for a fake capability, which doesn't even test the specific browsers capability extension but rather it's ability to parse a ":" in the capability name.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
