### PR TITLE
Remove desiredCapabilities

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -43,7 +43,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs["timeout_multiplier"] = get_timeout_multiplier(test_type,
                                                                    run_info_data,
                                                                    **kwargs)
-    executor_kwargs["capabilities"] = dict(DesiredCapabilities.EDGE.items())
+    executor_kwargs["capabilities"] = {}
     return executor_kwargs
 
 def env_extras(**kwargs):


### PR DESCRIPTION
Removing the Selenium desiredCapabilities from our default. The issue was that the response body ended up containing desiredCapabilities inside of the capabilities object which wasn't good.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11111)
<!-- Reviewable:end -->
