### PR TITLE
Add tests for notification inline reply idl properties

### DIFF
--- a/interfaces/notifications.idl
+++ b/interfaces/notifications.idl
@@ -1,27 +1,9 @@
-<!doctype html>
-<meta charset=utf-8>
-<title>Notification interface IDL tests</title>
-<div id=log></div>
-<script src=/resources/testharness.js></script>
-<script src=/resources/testharnessreport.js></script>
-<script src=/resources/WebIDLParser.js></script>
-<script src=/resources/idlharness.js></script>
-<script type=text/plain class=untested>
-interface EventTarget {
-  void addEventListener(DOMString type, EventListener? callback, optional boolean capture /* = false */);
-  void removeEventListener(DOMString type, EventListener? callback, optional boolean capture /* = false */);
-  boolean dispatchEvent(Event event);
-};
-[TreatNonCallableAsNull]
-callback EventHandlerNonNull = any (Event event);
-typedef EventHandlerNonNull? EventHandler;
-</script>
-<script type=text/plain>
 [Constructor(DOMString title, optional NotificationOptions options),
  Exposed=(Window,Worker)]
 interface Notification : EventTarget {
   static readonly attribute NotificationPermission permission;
-  [Exposed=Window] static Promise<NotificationPermission> requestPermission(optional NotificationPermissionCallback deprecatedCallback);
+  [Exposed=Window] static Promise<NotificationPermission> requestPermission(
+      optional NotificationPermissionCallback deprecatedCallback);
 
   static readonly attribute unsigned long maxActions;
 
@@ -79,25 +61,39 @@ enum NotificationDirection {
 };
 
 dictionary NotificationAction {
+  NotificationActionType type = "button";
   required DOMString action;
   required DOMString title;
   USVString icon;
+  DOMString? placeholder = null;
 };
 
 callback NotificationPermissionCallback = void (NotificationPermission permission);
-</script>
-<script>
-"use strict";
-var idlArray = new IdlArray();
-[].forEach.call(document.querySelectorAll("script[type=text\\/plain]"), function(node) {
-  if (node.className == "untested") {
-    idlArray.add_untested_idls(node.textContent);
-  } else {
-    idlArray.add_idls(node.textContent);
-  }
-});
-idlArray.add_objects({
-  Notification: ['new Notification("Running idlharness.")'],
-});
-idlArray.test();
-</script>
+
+dictionary GetNotificationOptions {
+  DOMString tag = "";
+};
+
+partial interface ServiceWorkerRegistration {
+  Promise<void> showNotification(DOMString title, optional NotificationOptions options);
+  Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter);
+};
+
+[Constructor(DOMString type, NotificationEventInit eventInitDict),
+ Exposed=ServiceWorker]
+interface NotificationEvent : ExtendableEvent {
+  readonly attribute Notification notification;
+  readonly attribute DOMString action;
+  readonly attribute DOMString? reply;
+};
+
+dictionary NotificationEventInit : ExtendableEventInit {
+  required Notification notification;
+  DOMString action = "";
+  DOMString? reply = null;
+};
+
+partial interface ServiceWorkerGlobalScope {
+  attribute EventHandler onnotificationclick;
+  attribute EventHandler onnotificationclose;
+};

--- a/notifications/interfaces.any.js
+++ b/notifications/interfaces.any.js
@@ -1,0 +1,41 @@
+// META: global=worker
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// See https://notifications.spec.whatwg.org/
+
+// This file's contents are duplicated in notifications/interfaces.https.any.js
+// as a workaround for https://github.com/w3c/web-platform-tests/issues/11105
+
+"use strict";
+
+promise_test(async () => {
+  const sw_idl = await fetch('/interfaces/ServiceWorker.idl').then(r => r.text());
+  const dedicated_workers_idl = await fetch('/interfaces/dedicated-workers.idl').then(r => r.text());
+  const dom_idl = await fetch('/interfaces/dom.idl').then(r => r.text());
+
+  const notifications_idl = await fetch('/interfaces/notifications.idl').then(r => r.text());
+
+  var idlArray = new IdlArray();
+
+  idlArray.add_untested_idls(sw_idl, { only: [
+    'ServiceWorkerRegistration',
+    'ServiceWorkerGlobalScope',
+    'ExtendableEvent',
+    'ExtendableEventInit',
+  ] });
+
+  idlArray.add_untested_idls(dedicated_workers_idl);
+  idlArray.add_untested_idls(dom_idl, { only: [ 'Event', 'EventInit' ] });
+
+  idlArray.add_idls(notifications_idl);
+
+  if (!self.GLOBAL.isWorker()) {
+    idlArray.add_objects({
+      Notification: ['new Notification("Running idlharness.")'],
+    });
+  }
+
+  idlArray.test();
+  done();
+}, 'notifications interfaces.');

--- a/notifications/interfaces.https.any.js
+++ b/notifications/interfaces.https.any.js
@@ -1,0 +1,40 @@
+// META: global=worker
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// See https://notifications.spec.whatwg.org/
+
+// The contents of this file are duplicated in notifications/interfaces.any.js
+// as a workaround for https://github.com/w3c/web-platform-tests/issues/11105
+"use strict";
+
+promise_test(async () => {
+  const sw_idl = await fetch('/interfaces/ServiceWorker.idl').then(r => r.text());
+  const dedicated_workers_idl = await fetch('/interfaces/dedicated-workers.idl').then(r => r.text());
+  const dom_idl = await fetch('/interfaces/dom.idl').then(r => r.text());
+
+  const notifications_idl = await fetch('/interfaces/notifications.idl').then(r => r.text());
+
+  var idlArray = new IdlArray();
+
+  idlArray.add_untested_idls(sw_idl, { only: [
+    'ServiceWorkerRegistration',
+    'ServiceWorkerGlobalScope',
+    'ExtendableEvent',
+    'ExtendableEventInit',
+  ] });
+
+  idlArray.add_untested_idls(dedicated_workers_idl);
+  idlArray.add_untested_idls(dom_idl, { only: [ 'Event', 'EventInit' ] });
+
+  idlArray.add_idls(notifications_idl);
+
+  if (!self.GLOBAL.isWorker()) {
+    idlArray.add_objects({
+      Notification: ['new Notification("Running idlharness.")'],
+    });
+  }
+
+  idlArray.test();
+  done();
+}, 'notifications interfaces.');


### PR DESCRIPTION
- Migrated existing html test to .any.js test + .idl interface
to allow testing the new properties from a service worker scope.

- See https://github.com/whatwg/notifications/pull/132 for the
spec change this tests.

- See https://github.com/anitawoodruff/inline-notification-replies
for an Explainer.

<!-- Reviewable:start -->

<!-- Reviewable:end -->
