### PR TITLE
Stop using wpt test-jobs --include.

### DIFF
--- a/tools/ci/before_install.sh
+++ b/tools/ci/before_install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-if [[ -z ${RUN_JOB+x} && $(./wpt test-jobs --includes $JOB; echo $?) -eq 0 ]] || [[ $RUN_JOB -eq 1 ]]; then
+RELEVANT_JOBS=$(./wpt test-jobs)
+RELEVANT_CHANGES=$(echo "$RELEVANT_JOBS" | grep $JOB || true)
+if [[ -z ${RUN_JOB+x} && ! -z $RELEVANT_CHANGES ]] || [[ $RUN_JOB -eq 1 ]]; then
     export RUN_JOB=1
     git submodule update --init --recursive 1>&2
     export DISPLAY=:99.0

--- a/tools/ci/ci_tools_unittest.sh
+++ b/tools/ci/ci_tools_unittest.sh
@@ -18,8 +18,10 @@ run_applicable_tox () {
     export TOXENV="$OLD_TOXENV"
 }
 
+RELEVANT_JOBS=$(./wpt test-jobs)
 
-if [[ $(./wpt test-jobs --includes tools_unittest; echo $?) -eq 0 ]]; then
+RELEVANT_CHANGES_TOOLS=$(echo "$RELEVANT_JOBS" | grep "tools_unittest" || true)
+if [[ ! -z $RELEVANT_CHANGES_TOOLS ]]; then
     pip install -U tox codecov
     cd tools
     run_applicable_tox
@@ -28,7 +30,8 @@ else
     echo "Skipping tools unittest"
 fi
 
-if [[ $(./wpt test-jobs --includes wptrunner_unittest; echo $?) -eq 0 ]]; then
+RELEVANT_CHANGES_WPTRUNNER=$(echo "$RELEVANT_JOBS" | grep "wptrunner_unittest" || true)
+if [[ ! -z $RELEVANT_CHANGES_WPTRUNNER ]]; then
     cd tools/wptrunner
     run_applicable_tox
     cd $WPT_ROOT


### PR DESCRIPTION
This ensures we fail on exceptions rather than continuing silently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11139)
<!-- Reviewable:end -->
