### PR TITLE
Run apt-get update before installing Chrome

### DIFF
--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -28,7 +28,7 @@ then
     deb_archive=google-chrome-unstable_current_amd64.deb
     wget https://dl.google.com/linux/direct/$deb_archive
 
-    sudo gdebi -n $deb_archive
+    sudo apt-get -qqy update && gdebi -n $deb_archive
 fi
 
 sudo Xvfb $DISPLAY -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &


### PR DESCRIPTION
There might have been new package releases since the Docker image was
built, and the old packages may no longer exist on the
mirror; therefore, update the package lists before installing Chrome.

Note all Taskcluster jobs have failed recently, due to Chrome installation failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11148)
<!-- Reviewable:end -->
