### PR TITLE
[testharness.js] Extend test suite with "variants"

### DIFF
--- a/resources/test/README.md
+++ b/resources/test/README.md
@@ -81,3 +81,10 @@ must include a summary of the expected results as a JSON string within a
       "type": "complete"
     }
     </script>
+
+`testharness.js` is expected to function consistently in a number of
+distinct environments. In order to verify this expectation, each functional
+test may be executed under a number of distinct conditions. These conditions
+are applied using WPT's "test variants" pattern. The available variants are
+defined in the `variants.js` file; this file must be included before
+`testharness.js`. Every test must specify at least one variant.

--- a/resources/test/tests/functional/add_cleanup.html
+++ b/resources/test/tests/functional/add_cleanup.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Test#add_cleanup</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/add_cleanup_count.html
+++ b/resources/test/tests/functional/add_cleanup_count.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="?keep-promise">
 <title>Test#add_cleanup reported count</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/add_cleanup_err.html
+++ b/resources/test/tests/functional/add_cleanup_err.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Test#add_cleanup: error</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/add_cleanup_err_multi.html
+++ b/resources/test/tests/functional/add_cleanup_err_multi.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Test#add_cleanup: multiple functions with one in error</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Sample HTML5 API Tests</title>
+<script src="../../variants.js"></script>
 <meta name="timeout" content="6000">
 </head>
 <body onload="load_test_attr.done()">

--- a/resources/test/tests/functional/api-tests-2.html
+++ b/resources/test/tests/functional/api-tests-2.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Sample HTML5 API Tests</title>
+<script src="../../variants.js"></script>
 </head>
 <body>
 <h1>Sample HTML5 API Tests</h1>

--- a/resources/test/tests/functional/api-tests-3.html
+++ b/resources/test/tests/functional/api-tests-3.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Sample HTML5 API Tests</title>
+<script src="../../variants.js"></script>
 </head>
 <script src="/resources/testharness.js"></script>
 

--- a/resources/test/tests/functional/force_timeout.html
+++ b/resources/test/tests/functional/force_timeout.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="?keep-promise">
 <title>Test#force_timeout</title>
+<script src="../../variants.js"></script>
 </head>
 <body>
 <h1>Test#force_timeout</h1>

--- a/resources/test/tests/functional/generate-callback.html
+++ b/resources/test/tests/functional/generate-callback.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Sample for using generate_tests to create a series of tests that share the same callback.</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -3,7 +3,10 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
   <title>idlharness: Partial dictionary</title>
+  <script src="/resources/test/variants.js"></script>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_immutable_prototype.html
@@ -2,7 +2,10 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
   <title>idlharness: Immutable prototypes</title>
+  <script src="../../../../variants.js"></script>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -3,7 +3,10 @@
 
 <head>
   <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
   <title>idlharness: Partail interface</title>
+  <script src="/resources/test/variants.js"></script>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_primary_interface_of.html
@@ -2,7 +2,10 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
   <title>idlharness: Primary interface</title>
+  <script src="../../../../variants.js"></script>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_to_json_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_to_json_operation.html
@@ -2,7 +2,10 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
   <title>IdlInterface.prototype.test_to_json_operation()</title>
+  <script src="../../../../variants.js"></script>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/resources/test/tests/functional/iframe-callback.html
+++ b/resources/test/tests/functional/iframe-callback.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with iframe that notifies containing document via callbacks</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/iframe-consolidate-errors.html
+++ b/resources/test/tests/functional/iframe-consolidate-errors.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with iframe that consolidates errors via fetch_tests_from_window</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/functional/iframe-consolidate-tests.html
+++ b/resources/test/tests/functional/iframe-consolidate-tests.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with iframe that consolidates tests via fetch_tests_from_window</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
@@ -16,7 +19,7 @@ tests from an <tt>iframe</tt> into the primary document.</p>
 executing</p>
 <div id="log"></div>
 
-<iframe id="childContext" src="promise-async.html" style="display:none"></iframe>
+<iframe id="childContext" src="promise-async.html?keep-promise" style="display:none"></iframe>
 <!-- promise-async.html has async tests with promises -->
 
 <script>

--- a/resources/test/tests/functional/iframe-msg.html
+++ b/resources/test/tests/functional/iframe-msg.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with iframe that notifies containing document via cross document messaging</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/order.html
+++ b/resources/test/tests/functional/order.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Ordering</title>
+<script src="../../variants.js"></script>
 <meta name="timeout" content="6000">
 </head>
 <body>

--- a/resources/test/tests/functional/promise-async.html
+++ b/resources/test/tests/functional/promise-async.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="?keep-promise">
 <title>Async Tests and Promises</title>
+<script src="../../variants.js"></script>
 </head>
 <body>
 <h1>Async Tests and Promises</h1>

--- a/resources/test/tests/functional/promise.html
+++ b/resources/test/tests/functional/promise.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="?keep-promise">
 <title>Promise Tests</title>
+<script src="../../variants.js"></script>
 </head>
 <body>
 <h1>Promise Tests</h1>

--- a/resources/test/tests/functional/single-page-test-fail.html
+++ b/resources/test/tests/functional/single-page-test-fail.html
@@ -1,5 +1,8 @@
 <!DOCTYPE HTML>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with file_is_test (should fail)</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/functional/single-page-test-no-assertions.html
+++ b/resources/test/tests/functional/single-page-test-no-assertions.html
@@ -1,5 +1,8 @@
 <!DOCTYPE HTML>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example single page test with no asserts</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/functional/single-page-test-no-body.html
+++ b/resources/test/tests/functional/single-page-test-no-body.html
@@ -1,5 +1,8 @@
 <!DOCTYPE HTML>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example single page test with no body</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/functional/single-page-test-pass.html
+++ b/resources/test/tests/functional/single-page-test-pass.html
@@ -1,5 +1,8 @@
 <!DOCTYPE HTML>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with file_is_test</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>

--- a/resources/test/tests/functional/uncaught-exception-handle.html
+++ b/resources/test/tests/functional/uncaught-exception-handle.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Harness Handling Uncaught Exception</title>
+<script src="../../variants.js"></script>
 </head>
 <script src="/resources/testharness.js"></script>
 

--- a/resources/test/tests/functional/uncaught-exception-ignore.html
+++ b/resources/test/tests/functional/uncaught-exception-ignore.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Harness Ignoring Uncaught Exception</title>
+<script src="../../variants.js"></script>
 </head>
 <script src="/resources/testharness.js"></script>
 

--- a/resources/test/tests/functional/worker-dedicated.html
+++ b/resources/test/tests/functional/worker-dedicated.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Dedicated Worker Tests</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/worker-service.html
+++ b/resources/test/tests/functional/worker-service.html
@@ -1,7 +1,9 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="?keep-promise">
 <title>Example with a service worker</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/tests/functional/worker-shared.html
+++ b/resources/test/tests/functional/worker-shared.html
@@ -1,7 +1,10 @@
 <!DOCTYPE HTML>
 <html>
 <head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
 <title>Example with a shared worker</title>
+<script src="../../variants.js"></script>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/resources/test/variants.js
+++ b/resources/test/variants.js
@@ -1,0 +1,57 @@
+(function() {
+  'use strict';
+  var variants = {
+    /**
+     * Tests are executed in the absence of the global Promise constructor by
+     * default in order to verify support for the Server browser engine.
+     *
+     * https://github.com/w3c/web-platform-tests/issues/6266
+     */
+    'default': {
+      description: 'Global Promise constructor removed.',
+      apply: function() {
+        delete window.Promise;
+      }
+    },
+    /**
+     * This variant allows for testing functionality that is fundamentally
+     * dependent on Promise support, e.g. the `promise_test` function
+     */
+    'keep-promise': {
+      description: 'No modification of global environment.',
+      apply: function() {}
+    }
+  };
+  var match = window.location.search.match(/\?(.*)$/);
+  var variantName = (match && match[1]) || 'default';
+
+  if (!Object.hasOwnProperty.call(variants, variantName)) {
+    window.location = 'javascript:"Unrecognized variant: ' + variantName + '";';
+    document.close();
+    return;
+  }
+
+  if (typeof test === 'function') {
+    test(function() {
+      assert_unreached('variants.js must be included before testharness.js');
+    });
+  }
+  var variant = variants[variantName];
+
+  var variantNode = document.createElement('div');
+  variantNode.innerHTML = '<p>This testharness.js test was executed with ' +
+    'the variant named, "' + variantName + '". ' + variant.description +
+    '</p><p>Refer to the test harness README file for more information.</p>';
+  function onReady() {
+    if (document.readyState !== 'complete') {
+      return;
+    }
+
+    document.body.insertBefore(variantNode, document.body.firstChild);
+  }
+
+  onReady();
+  document.addEventListener('readystatechange', onReady);
+
+  variant.apply();
+}());


### PR DESCRIPTION
Feature description (from modification to `README.md` file):

> `testharness.js` is expected to function consistently in a number of
> distinct environments. In order to verify this expectation, each
> functional test may be executed under a number of distinct conditions.
> Within this test suite, these alternate configurations are referred to
> as "variants," and defined by the `variants.js` file. This file must
> be included in all functional tests and executed before
> `testharness.js`.
>
> However, not all features are available in all environments, and it is
> not appropriate to execute the corresponding feature tests in the
> unsupported environments. Test files may optionally specify a list of
> variants under which they should *not* be executed via the
> `wpt-test-skip-variant` meta tag, e.g.:
>
>     <meta name="wpt-test-skip-variant" content="no-promise">

Extend test harness for `testharness.js` with additional validation to
ensure that each test is correctly formatted. Introduce a minimal UI to
help future contributors discover this new functionality and its
motivation.

---

@Ms2ger @gsnedders This is in recognition of gh-6266. That consideration is especially important in gh-8748 where we're extending the way `testharness.js` interprets Promise values. This patch will give us more confidence that we're not regressing on the previously-unverified expectation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/web-platform-tests/11150)
<!-- Reviewable:end -->
