### PR TITLE
Make sizes-dynamic-001.html not racy.

### DIFF
--- a/html/semantics/embedded-content/the-img-element/sizes/sizes-dynamic-001.html
+++ b/html/semantics/embedded-content/the-img-element/sizes/sizes-dynamic-001.html
@@ -1,7 +1,20 @@
 <!doctype html>
+<html class="reftest-wait">
 <title>Image intrinsic size specified via sizes attribute reacts properly to media changes</title>
 <link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
 <link rel="match" href="sizes-dynamic-001-ref.html">
 <link rel="help" href="https://html.spec.whatwg.org/#sizes-attributes">
 <link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1149357">
-<iframe onload="this.width = '500'" width="200" height="500" srcdoc='<!doctype html><img srcset="/images/green-256x256.png 100w" style="max-width: 100%" sizes="(min-width: 400px) 10px, 20px">'></iframe>
+<script>
+function frameLoaded(frame) {
+  frame.width = "500";
+  let img = frame.contentDocument.querySelector('img');
+
+  // Trigger the viewport resize, which will trigger the image load task.
+  img.offsetWidth;
+
+  // Wait for the image load task to run.
+  setTimeout(() => document.documentElement.removeAttribute("class"), 0);
+}
+</script>
+<iframe onload="frameLoaded(this)" width="200" height="500" srcdoc='<!doctype html><img srcset="/images/green-256x256.png 100w" style="max-width: 100%" sizes="(min-width: 400px) 10px, 20px">'></iframe>


### PR DESCRIPTION
There's no guarantee the image will be resized before the harness takes the
screenshot.

Indeed, the image is guaranteed to have the old width / offsetWidth if we were
to query it from frameLoaded. We do need to wait for the image load task to run.

This makes the test reliable in both Blink and Gecko at least, afaict.

This was reviewed and landed in mozilla-central in bug 1464392, but the sync bot
seems to have missed it.

MozReview-Commit-ID: 7EDC7jlUScc

<!-- Reviewable:start -->

<!-- Reviewable:end -->
