### PR TITLE
HTML: remove autofocused element before its task runs

### DIFF
--- a/html/semantics/forms/autofocus/once-per-document-2.window.js
+++ b/html/semantics/forms/autofocus/once-per-document-2.window.js
@@ -1,0 +1,13 @@
+async_test(t => {
+  const input = document.createElement("input");
+  input.autofocus = true;
+  document.body.appendChild(input);
+  input.remove();
+  const input2 = document.createElement("input");
+  input2.autofocus = true;
+  document.body.appendChild(input2);
+  t.step_timeout(() => {
+    assert_equals(document.activeElement, document.body);
+    t.done();
+  }, 100);
+}, "autofocus should only work for the first inserted element matching the conditions???");

--- a/html/semantics/forms/autofocus/once-per-document.window.js
+++ b/html/semantics/forms/autofocus/once-per-document.window.js
@@ -1,0 +1,20 @@
+async_test(t => {
+  const input = document.createElement("input");
+  input.autofocus = true;
+  document.body.appendChild(input);
+  t.step_timeout(() => {
+    assert_equals(document.activeElement, input);
+    document.body.appendChild(input);
+    t.step_timeout(() => {
+      assert_equals(document.activeElement, document.body);
+      input.remove();
+      const input2 = document.createElement("input");
+      input2.autofocus = true;
+      document.body.appendChild(input2);
+      t.step_timeout(() => {
+        assert_equals(document.activeElement, document.body);
+        t.done();
+      }, 100)
+    }, 100)
+  }, 100);
+}, "autofocus should work once per document");


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1463563 for context.

We'll need to update -2 to figure out the correct pass condition. Given Chrome and Safari, I guess we should expect input2 and then we should update the specification to note that if the element is no longer connected you just abort the algorithm, meaning no flags get set.