### PR TITLE
Fix TaskCluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -15,7 +15,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 1 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -32,7 +32,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 2 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -49,7 +49,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 3 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -66,7 +66,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 4 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -83,7 +83,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 5 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -100,7 +100,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 6 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -117,7 +117,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 7 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -134,7 +134,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 8 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -151,7 +151,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 9 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -168,7 +168,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome reftest 10 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -185,7 +185,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome wdspec 1 1"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -202,7 +202,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 1 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -219,7 +219,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 2 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -236,7 +236,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 3 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -253,7 +253,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 4 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -270,7 +270,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 5 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -287,7 +287,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 6 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -304,7 +304,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 7 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -321,7 +321,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 8 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -338,7 +338,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 9 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -355,7 +355,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 10 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -372,7 +372,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 11 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -389,7 +389,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 12 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -406,7 +406,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 13 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -423,7 +423,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 14 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -440,7 +440,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} chrome-dev &&\n        \
         \    cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ chrome testharness 15 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -457,7 +457,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 1 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -474,7 +474,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 2 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -491,7 +491,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 3 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -508,7 +508,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 4 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -525,7 +525,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 5 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -542,7 +542,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 6 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -559,7 +559,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 7 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -576,7 +576,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 8 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -593,7 +593,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 9 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -610,7 +610,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox reftest 10 10"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -627,7 +627,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox wdspec 1 1"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -644,7 +644,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 1 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -661,7 +661,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 2 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -678,7 +678,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 3 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -695,7 +695,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 4 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -712,7 +712,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 5 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -729,7 +729,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 6 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -746,7 +746,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 7 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -763,7 +763,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 8 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -780,7 +780,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 9 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -797,7 +797,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 10 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -814,7 +814,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 11 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -831,7 +831,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 12 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -848,7 +848,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 13 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -865,7 +865,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 14 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker
@@ -882,7 +882,7 @@ tasks:
         \ {{ event.head.repo.branch }} {{event.head.sha}} firefox-nightly &&\n   \
         \         cd ~/web-platform-tests &&\n            ./tools/ci/ci_taskcluster.sh\
         \ firefox testharness 15 15"]
-    image: harjgam/web-platform-tests:0.12
+    image: gsnedders/web-platform-tests:0.13
     maxRunTime: 7200
   provisionerId: aws-provisioner-v1
   workerType: wpt-docker-worker

--- a/tools/ci/taskgraph.py
+++ b/tools/ci/taskgraph.py
@@ -9,7 +9,7 @@ import yaml
 here = os.path.dirname(__file__)
 wpt_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
 
-docker_image = "harjgam/web-platform-tests:0.12"
+docker_image = "gsnedders/web-platform-tests:0.13"
 
 task_template = {
     "provisionerId": "aws-provisioner-v1",

--- a/tools/docker/start.sh
+++ b/tools/docker/start.sh
@@ -41,7 +41,7 @@ then
     deb_archive=google-chrome-unstable_current_amd64.deb
     wget https://dl.google.com/linux/direct/$deb_archive
 
-    sudo apt-get -qqy update && gdebi -n $deb_archive
+    sudo apt-get -qqy update && sudo gdebi -n $deb_archive
 fi
 
 sudo Xvfb $DISPLAY -screen 0 ${SCREEN_WIDTH}x${SCREEN_HEIGHT}x${SCREEN_DEPTH} &


### PR DESCRIPTION
a8a5dc635dc73e3ebb10c1162bc3488bfec6ea4d broke the Chrome install; this fixes it

Note the documentation in start.sh didn't quite suffice: `docker ps` didn't output the image ID (because no container based on it was running, and `--all` doesn't show it because there's no container based on it), and `docker login` is needed.