### PR TITLE
Add tests to verify that animated translation and rotation freeze as …

### DIFF
--- a/css/css-animations/set-animation-play-state-to-paused-001-ref.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused (reference)</title>
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #coveringRect {
+        position: absolute;
+        background: lightgreen;
+        width: 150px;
+        height: 250px;
+        left: -75px;
+        top: 0px;
+        transform: translate(150px);
+      }
+    </style>
+  </head>
+  <body>
+    <p>This test passes if you see a green rectangle and no red.</p>
+    <div id="container">
+      <div id="coveringRect"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-001.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused</title>
+    <link rel="author" title="Igalia S.L." href="https://www.igalia.com/">
+    <link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-play-state">
+    <meta name="flags" content="animated">
+    <meta name="assert" content="Visually check that transform animations stop
+                                 when animation-play-state is set to paused">
+    <link rel="match" href="set-animation-play-state-to-paused-001-ref.html">
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #squareLinear, #squareSteps  {
+        width: 100px;
+        height: 100px;
+        background: red;
+        position: absolute;
+        left: -50px;
+      }
+      #squareLinear {
+        top: 0px;
+        animation: move 1s linear;
+      }
+      #squareSteps {
+        top: 150px;
+        animation: move 1s steps(1000, end);
+      }
+      #coveringRect {
+        position: absolute;
+        background: lightgreen;
+        width: 150px;
+        height: 250px;
+        left: -75px;
+        top: 0px;
+        transform: translate(150px);
+      }
+      .pause {
+        opacity: 0.6;
+        animation-play-state: paused !important;
+      }
+      @keyframes move
+      {
+        100% {
+          transform: translate(500px);
+        }
+      }
+    </style>
+    <script>
+      var start = null;
+      var animationDuration = 1000;
+      var coveringRectShift = 150;
+      var rectFinalShift = 500;
+      function step(timestamp) {
+        if (!start) start = timestamp;
+        var progress = timestamp - start;
+        // Pause the animations when the squares pass under the covering rect.
+        var targetProgress = animationDuration * coveringRectShift / rectFinalShift;
+        if (progress > targetProgress) {
+          document.getElementById("squareLinear").classList.add("pause");
+          document.getElementById("squareSteps").classList.add("pause");
+        }
+
+        // Wait a bit so that the squares pass the covering rect if the
+        // animation fails to be paused.
+        var delta = 200;
+        if (progress < targetProgress + delta)
+          window.requestAnimationFrame(step)
+        else
+          document.documentElement.classList.remove("reftest-wait");
+      }
+      function runTest() {
+        window.requestAnimationFrame(step);
+      }
+    </script>
+  </head>
+  <body onload="runTest()">
+    <p>This test passes if you see a green rectangle and no red.</p>
+    <div id="container">
+      <div id="squareLinear"></div>
+      <div id="squareSteps"></div>
+      <div id="coveringRect"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-001.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001.html
@@ -5,7 +5,6 @@
     <title>Dynamically set animation-play-state to paused</title>
     <link rel="author" title="Igalia S.L." href="https://www.igalia.com/">
     <link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-play-state">
-    <meta name="flags" content="animated">
     <meta name="assert" content="Visually check that transform animations stop
                                  when animation-play-state is set to paused">
     <link rel="match" href="set-animation-play-state-to-paused-001-ref.html">

--- a/css/css-animations/set-animation-play-state-to-paused-002-ref.html
+++ b/css/css-animations/set-animation-play-state-to-paused-002-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused (reference)</title>
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #coveringRectLinear, #coveringRectSteps {
+        position: absolute;
+        background: lightgreen;
+        width: 40px;
+        height: 70px;
+        left: 80px;
+        transform-origin: 50% 10%;
+        transform: translate(36px, 0) rotate(144deg);
+      }
+      #coveringRectLinear {
+        top: 50px;
+      }
+      #coveringRectSteps {
+        top: 150px;
+      }
+    </style>
+  </head>
+  <body>
+    <p>This test passes if you see two rotated green rectangles and no red.</p>
+    <div id="container">
+      <div id="coveringRectLinear"></div>
+      <div id="coveringRectSteps"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-002.html
+++ b/css/css-animations/set-animation-play-state-to-paused-002.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused</title>
+    <link rel="author" title="Igalia S.L." href="https://www.igalia.com/">
+    <link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-play-state">
+    <meta name="flags" content="animated">
+    <meta name="assert" content="Visually check that complex animations stop
+                                 when animation-play-state is set to paused">
+    <link rel="match" href="set-animation-play-state-to-paused-002-ref.html">
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #lineLinear, #lineSteps  {
+        position: absolute;
+        background: red;
+        width: 10px;
+        height: 50px;
+        left: 95px;
+        transform-origin: 50% 0%;
+      }
+      #coveringRectLinear, #coveringRectSteps {
+        position: absolute;
+        background: lightgreen;
+        width: 40px;
+        height: 70px;
+        left: 80px;
+        transform-origin: 50% 10%;
+        transform: translate(36px, 0) rotate(144deg);
+      }
+      #coveringRectLinear, #lineLinear {
+        top: 50px;
+      }
+      #coveringRectSteps, #lineSteps {
+        top: 150px;
+      }
+      #lineLinear {
+        animation: rotate 2s linear;
+      }
+      #lineSteps {
+        animation: rotate 2s steps(360, end);
+      }
+      .pause {
+        opacity: 0.6;
+        animation-play-state: paused !important;
+      }
+      @keyframes rotate
+      {
+        100% {
+          transform: translate(90px, 0) rotate(360deg);
+        }
+      }
+    </style>
+    <script>
+      var start = null;
+      var animationDuration = 2000;
+      var coveringRectAngle = 144;
+      var rectFinalAngle = 360;
+      function step(timestamp) {
+        if (!start) start = timestamp;
+        var progress = timestamp - start;
+
+        // Pause the animations when the squares pass under the covering rect.
+        var targetProgress = animationDuration * coveringRectAngle / rectFinalAngle;
+        if (progress >= targetProgress) {
+          document.getElementById("lineLinear").classList.add("pause");
+          document.getElementById("lineSteps").classList.add("pause");
+        }
+
+        // Wait a bit so that the squares pass the covering rect if the
+        // animation fails to be paused.
+        var delta = 200;
+        if (progress < targetProgress + delta)
+          window.requestAnimationFrame(step)
+        else
+          document.documentElement.classList.remove("reftest-wait");
+      }
+      function runTest() {
+        window.requestAnimationFrame(step);
+      }
+    </script>
+  </head>
+  <body onload="runTest()">
+    <p>This test passes if you see two rotated green rectangles and no red.</p>
+    <div id="container">
+      <div id="lineLinear"></div>
+      <div id="coveringRectLinear"></div>
+      <div id="lineSteps"></div>
+      <div id="coveringRectSteps"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-002.html
+++ b/css/css-animations/set-animation-play-state-to-paused-002.html
@@ -5,7 +5,6 @@
     <title>Dynamically set animation-play-state to paused</title>
     <link rel="author" title="Igalia S.L." href="https://www.igalia.com/">
     <link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-play-state">
-    <meta name="flags" content="animated">
     <meta name="assert" content="Visually check that complex animations stop
                                  when animation-play-state is set to paused">
     <link rel="match" href="set-animation-play-state-to-paused-002-ref.html">


### PR DESCRIPTION
…expected when animation-play-state is set to 'paused'.

This covers iOS bugs reported by users in https://bugs.webkit.org/show_bug.cgi?id=170784#c0