### PR TITLE
 [testdriver] Prevent protocol interference

### DIFF
--- a/infrastructure/testdriver/click.html
+++ b/infrastructure/testdriver/click.html
@@ -16,4 +16,27 @@ async_test(t => {
     .then(() => t.done())
     .catch(t.unreached_func("click failed"));
 });
+
+async_test((t) => {
+  const counts = {
+    button1: 0,
+    button2: 0
+  };
+  const button1 = document.createElement("button");
+  const button2 = document.createElement("button");
+  button1.id = "button-1";
+  button2.id = "button-2";
+  button1.addEventListener("click", t.step_func(() => counts.button1 += 1));
+  button2.addEventListener("click", t.step_func(() => counts.button2 += 1));
+  document.body.appendChild(button1);
+  document.body.appendChild(button2);
+
+  Promise.all([test_driver.click(button1), test_driver.click(button2)])
+    .then(() => {
+      assert_equals(counts.button1, 1, "firist button received one click");
+      assert_equals(counts.button2, 1, "second button received one click");
+      t.done();
+    })
+    .catch(t.unreached_func("click failed"));
+}, "Supports parallel invocations");
 </script>

--- a/infrastructure/testdriver/send_keys.html
+++ b/infrastructure/testdriver/send_keys.html
@@ -20,4 +20,24 @@ async_test(t => {
     })
     .catch(t.unreached_func("send keys failed"));
 });
+
+async_test((t) => {
+  const input1 = document.createElement("input");
+  const input2 = document.createElement("input");
+  input1.id = "input-1";
+  input2.id = "input-2";
+  document.body.appendChild(input1);
+  document.body.appendChild(input2);
+
+  Promise.all([
+      test_driver.send_keys(input1, "first"),
+	  test_driver.send_keys(input2, "second")
+    ])
+    .then(() => {
+      assert_equals(input1.value, "first", "firist input received keys");
+      assert_equals(input2.value, "second", "second input received keys");
+      t.done();
+    })
+    .catch(t.unreached_func("send keys failed"));
+}, "supports parallel invocations");
 </script>

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -6,7 +6,7 @@
     window.addEventListener("message", function(event) {
         const data = event.data;
 
-        if (typeof data !== "object" && data !== null) {
+        if (typeof data !== "object" || data === null) {
             return;
         }
 


### PR DESCRIPTION
Prevent interference between parallel invocations of the testdriver.js
API by scheduling messages in a queue.

Interference could be avoided by extending the communication protocol
with a request/response identifier, but such an extension would be of
little practical benefit because the WebDriver processing model does not
support concurrency.