### PR TITLE
[mediacapture] Simply test and use standard API

### DIFF
--- a/mediacapture-fromelement/creation.html
+++ b/mediacapture-fromelement/creation.html
@@ -14,15 +14,20 @@ var makeAsyncTest = function(filename, numTracks) {
     var video = document.createElement('video');
     video.src = "/media/" + filename;
     video.onerror = this.unreached_func("<video> error");
-    video.play();
 
     assert_true('captureStream' in video);
 
     var stream = video.captureStream();
     assert_not_equals(stream, null, "error generating stream");
 
-    // onactive event is marked for deprecation (https://crbug.com/649328)
-    stream.onactive = this.step_func_done(function() {
+    stream.onaddtrack = this.step_func_done(function() {
+      var tracks = stream.getTracks();
+      var idx;
+
+      for (idx = 0; idx < tracks.length; idx += 1) {
+        assert_equals(tracks[idx].readyState, 'live')
+      }
+
       // The stream got a (number of) MediaStreamTracks added.
       assert_equals(stream.getVideoTracks().length, numTracks['vid'], 'video');
       assert_equals(stream.getAudioTracks().length, numTracks['aud'], 'audio');

--- a/mediacapture-fromelement/historical.html
+++ b/mediacapture-fromelement/historical.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Historical features</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <script>
+  // https://lists.w3.org/Archives/Public/public-media-capture/2015Nov/0012.html
+  test(function() {
+    assert_false(MediaStream.prototype.hasOwnProperty('onactive'));
+  }, 'the deprecated MediaStream `onactive` event handler property is not available');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
The MediaStream's `active` event was removed from the specification in
December of 2015 [1]. The `addtrack` event offers similar semantics, and
as a standard API, it is expected to be implemented by all browsers
which follow the specification. In addition, because it does not depend
on media playback, its use allows `MediaElement#play` to be removed.
That removal simplifies the process of executing the test because
browsers are beginning to tighten their policies regarding automated
media playback [2].

[1] https://github.com/w3c/mediacapture-main/pull/291
[2] https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

---

@yellowdoge @martinthomson @uysalere More context about autoplay is available [here](https://github.com/web-platform-tests/results-collection/pull/552). Other MediaCapture tests continue to rely on the `active` event and on automatic playback, but those definitely need a more advanced solution. Because a simpler solution seemed possible for this test, I thought I'd propose that first. Is there any reason to continue to us `onactive`?