### PR TITLE
[Fetch] Fix tests for isHistoryNavigation

### DIFF
--- a/fetch/api/request/request-reset-attributes.https.html
+++ b/fetch/api/request/request-reset-attributes.https.html
@@ -39,7 +39,7 @@ promise_test(async (t) => {
   }, 'Request.isReloadNavigation is reset with non-empty RequestInit');
 
 promise_test(async (t) => {
-    const scope = '../resources/blank.html?name=isHistoryNavigation';
+    const scope = 'resources/hello.html?name=isHistoryNavigation';
     let frame;
     let reg;
 
@@ -48,13 +48,13 @@ promise_test(async (t) => {
       await wait_for_state(t, reg.installing, 'activated');
       frame = await with_iframe(scope);
       assert_equals(frame.contentDocument.body.textContent,
-                    'original: false, stored: false');
+                    'old: false, new: false');
       // Use step_timeout(0) to ensure the history entry is created for Blink
       // and WebKit. See https://bugs.webkit.org/show_bug.cgi?id=42861.
       await wait(0);
       await new Promise((resolve) => {
         frame.onload = resolve;
-        frame.src = '../resources/blank.html?ignore';
+        frame.src = 'resources/hello.html?ignore';
       });
       await wait(0);
       await new Promise((resolve) => {
@@ -62,7 +62,7 @@ promise_test(async (t) => {
         frame.contentWindow.history.go(-1);
       });
       assert_equals(frame.contentDocument.body.textContent,
-                    'original: true, stored: true');
+                    'old: true, new: false');
     } finally {
       if (frame) {
         frame.remove();

--- a/fetch/api/request/request-reset-attributes.https.html
+++ b/fetch/api/request/request-reset-attributes.https.html
@@ -71,7 +71,7 @@ promise_test(async (t) => {
         await reg.unregister();
       }
     }
-}, 'Request.IsHistoryNavigation should persist.');
+}, 'Request.isHistoryNavigation is reset with non-empty RequestInit');
 
 promise_test(async (t) => {
     const scope = 'resources/hello.txt?name=mode';

--- a/service-workers/service-worker/fetch-event.https.html
+++ b/service-workers/service-worker/fetch-event.https.html
@@ -1074,7 +1074,7 @@ promise_test(async (t) => {
         await reg.unregister();
       }
     }
-  }, 'FetchEvent#request.isReloadNavigation is true (POST + history.go(-1))');
+  }, 'FetchEvent#request.isHistoryNavigation is true (POST + history.go(-1))');
 
 </script>
 </body>


### PR DESCRIPTION
This is a followup for https://github.com/web-platform-tests/wpt/commit/8f805ef0b6a3ddb06c0266cc56557d05e36f3a3d.

fetch/api/request/request-reset-attributes.https.html:
I was confused by the test case and another test case in service-workers/cache-storage/serviceworker/cache-keys-attributes-for-service-worker.https.html. This change fixes the test case.

service-workers/service-worker/fetch-event.https.html
This change fixes a test description.
