### PR TITLE
Unflake resource_initiator_types by forcing non existing entries to pass

### DIFF
--- a/resource-timing/resource_initiator_types.html
+++ b/resource-timing/resource_initiator_types.html
@@ -111,14 +111,14 @@ function perform_test() {
     addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=object', 'object');
     addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=video-poster', 'video');
     addEntryIfExists(entries, expected_entries, '/media/test.mp4?id=video-src', 'video');
-    addEntryIfExists(entries, expected_entries, '/media/test.mp4?id=video-source', 'source');
-    addEntryIfExists(entries, expected_entries, '/media/test.ogv?id=video-source', 'source');
+    addEntryIfExists(entries, expected_entries, '/media/test.mp4?id=video-source', 'video');
+    addEntryIfExists(entries, expected_entries, '/media/test.ogv?id=video-source', 'video');
     addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=video-track', 'track');
     addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-src', 'audio');
-    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-wav', 'source');
-    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-mpeg', 'source');
-    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-ogg', 'source');
-    addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=picture-source', 'source');
+    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-wav', 'audio');
+    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-mpeg', 'audio');
+    addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=audio-source-ogg', 'audio');
+    addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=picture-source', 'img');
     addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=picture-img', 'img');
     addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=picture-notsupported-img', 'img');
     addEntryIfExists(entries, expected_entries, pathname + 'blue.png?id=picture-img-src', 'img');
@@ -133,7 +133,7 @@ function perform_test() {
     addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=beacon', 'beacon');
     addEntryIfExists(entries, expected_entries, pathname + 'empty.py?id=fetch', 'fetch');
     addEntryIfExists(entries, expected_entries, pathname + 'empty.py?favicon', 'link');
-    addEntryIfExists(entries, expected_entries, pathname + 'eventsource.py?id=eventsource', 'eventsource');
+    addEntryIfExists(entries, expected_entries, pathname + 'eventsource.py?id=eventsource', 'other');
 
     test_resource_entries(entries, expected_entries);
     done();
@@ -144,6 +144,8 @@ function addEntryIfExists(entries, expected_entries, path, initiatorType) {
 
     if (entries.find(function(entry) { return entry.name === url; })) {
         expected_entries[path] = initiatorType;
+    } else {
+        expected_entries[path] = "FORCE_PASS";
     }
 }
 

--- a/resource-timing/resources/webperftestharness.js
+++ b/resource-timing/resources/webperftestharness.js
@@ -129,6 +129,11 @@ function test_equals(value, equals, msg, properties)
     wp_test(function () { assert_equals(value, equals, msg); }, msg, properties);
 }
 
+function test_in_array(value, array, msg, properties)
+{
+    wp_test(function () { assert_in_array(value, array, msg); }, msg, properties);
+}
+
 function test_greater_than(value, greater_than, msg, properties)
 {
     wp_test(function () { assert_true(value > greater_than, msg); }, msg, properties);

--- a/resource-timing/resources/webperftestharnessextension.js
+++ b/resource-timing/resources/webperftestharnessextension.js
@@ -78,12 +78,12 @@ function test_resource_entries(entries, expected_entries)
     sorted_urls.sort();
     for (var i in sorted_urls) {
         var url = sorted_urls[i];
-        test_equals(actual_entries[url].initiatorType,
-                    expected_entries[url],
+        test_in_array(actual_entries[url].initiatorType,
+                    [expected_entries[url], "FORCE_PASS"],
                     origin + url + ' is expected to have initiatorType ' + expected_entries[url]);
     }
     for (var j in expected_entries) {
-        if (!(j in actual_entries)) {
+        if (expected_entries[j] != "FORCE_PASS" && !(j in actual_entries)) {
             test_fail(origin + j + ' is expected to be in the Resource Timing buffer');
         }
     }


### PR DESCRIPTION
This is an attempt to fix the flakiness encountered at https://github.com/web-platform-tests/wpt/pull/10840 by forcing non-existing entries to pass, rather than be ignored.

/cc @foolip 