### PR TITLE
Move and simplify element.matches("*") test so that it works

### DIFF
--- a/dom/nodes/selectors.js
+++ b/dom/nodes/selectors.js
@@ -70,7 +70,7 @@ var validSelectors = [
   {name: "Type selector, matching body element", selector: "body", expect: [] /*no matches*/, exclude: ["document"],                        level: 1, testType: TEST_QSA},
 
   // Universal Selector
-  // Testing "*" for entire an entire context node is handled separately.
+  {name: "Universal selector, matching all elements",                                    selector: "*",              expect: ["universal", "universal-p1", "universal-code1", "universal-hr1", "universal-pre1", "universal-span1", "universal-p2", "universal-a1", "universal-address1", "universal-code2", "universal-a2"], level: 2, testType: TEST_MATCH},
   {name: "Universal selector, matching all children of element with specified ID",       selector: "#universal>*",   expect: ["universal-p1", "universal-hr1", "universal-pre1", "universal-p2", "universal-address1"], level: 2, testType: TEST_QSA | TEST_MATCH},
   {name: "Universal selector, matching all grandchildren of element with specified ID",  selector: "#universal>*>*", expect: ["universal-code1", "universal-span1", "universal-a1", "universal-code2"],                 level: 2, testType: TEST_QSA | TEST_MATCH},
   {name: "Universal selector, matching all children of empty element with specified ID", selector: "#empty>*",       expect: [] /*no matches*/,                                                                         level: 2, testType: TEST_QSA},
@@ -448,10 +448,6 @@ var validSelectors = [
 
 var scopedSelectors = [
   //{name: "", selector: "", ctx: "", ref: "", expect: [], level: 1, testType: TEST_FIND | TEST_MATCH},
-
-  // Universal Selector
-  {name: "Universal selector, matching all descendants of the specified reference element",    selector: "*",    ctx: "#universal", expect: ["universal-p1", "universal-code1", "universal-hr1", "universal-pre1", "universal-span1",
-                                                                                                                                             "universal-p2", "universal-a1", "universal-address1", "universal-code2", "universal-a2"], unexpected: ["universal", "empty"], level: 2, testType: TEST_FIND | TEST_MATCH},
 
   // Attribute Selectors
   // - presence                  [att]


### PR DESCRIPTION
The reason it didn't work before was because in Element-matches.js,
it's always `someElement.matches("*")` being tested, which is the only
thing that could be tested as there's not other "context" or
"reference node" involved in the API surface.

All of TEST_FIND is actually dead code, so dropping that is harmless.

Fixes https://github.com/web-platform-tests/wpt/issues/11212.