### PR TITLE
Move input-events IDL to interfaces

### DIFF
--- a/input-events/idlharness.html
+++ b/input-events/idlharness.html
@@ -4,35 +4,26 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/WebIDLParser.js"></script>
 <script src="/resources/idlharness.js"></script>
-
-<pre id="untested_idl">
-interface InputEvent {
-};
-</pre>
-
-<pre id='idl'>
-partial interface InputEvent {
-    readonly attribute DOMString     inputType;
-    readonly attribute DataTransfer? dataTransfer;
-    sequence<StaticRange> getTargetRanges();
-};
-
-partial dictionary InputEventInit {
-    DOMString             inputType = "";
-    DataTransfer?         dataTransfer = null;
-    sequence<StaticRange> targetRanges = [];
-};
-</pre>
-
 <script>
-(function(){
-    "use strict";
+"use strict";
+
+function doTest([input_events]) {
     const idl_array = new IdlArray();
-    idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
-    idl_array.add_idls(document.getElementById("idl").textContent);
+    idl_array.add_untested_idls('interface InputEvent {};');
+    idl_array.add_untested_idls('dictionary InputEventInit {};');
+    idl_array.add_idls(input_events);
     idl_array.add_objects({
-      InputEvent: ['new InputEvent("foo")'],
+        InputEvent: ['new InputEvent("foo")'],
     });
     idl_array.test();
-})();
+}
+
+function fetchText(url) {
+    return fetch(url).then((response) => response.text());
+}
+
+promise_test(() => {
+    return Promise.all(["/interfaces/input-events.idl"].map(fetchText))
+                  .then(doTest);
+}, "Test IDL implementation of Input Events");
 </script>

--- a/interfaces/input-events.idl
+++ b/interfaces/input-events.idl
@@ -1,0 +1,11 @@
+partial interface InputEvent {
+  readonly attribute DOMString inputType;
+  readonly attribute DataTransfer? dataTransfer;
+  sequence<StaticRange> getTargetRanges();
+};
+
+partial dictionary InputEventInit {
+  DOMString inputType = "";
+  DataTransfer? dataTransfer = null;
+  sequence<StaticRange> targetRanges = [];
+};


### PR DESCRIPTION
The input-events IDL was previously directly written in the test. This change moves it to a dedicated file in interfaces.

This change also adds InputEventInit as an untested IDL at the beginning of the test so the test can actually run.