### PR TITLE
Escape attributes named 'required' in HTML IDL

### DIFF
--- a/interfaces/html.idl
+++ b/interfaces/html.idl
@@ -825,7 +825,7 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions] attribute DOMString pattern;
   [CEReactions] attribute DOMString placeholder;
   [CEReactions] attribute boolean readOnly;
-  [CEReactions] attribute boolean required;
+  [CEReactions] attribute boolean _required;
   [CEReactions] attribute unsigned long size;
   [CEReactions] attribute USVString src;
   [CEReactions] attribute DOMString step;
@@ -893,7 +893,7 @@ interface HTMLSelectElement : HTMLElement {
   readonly attribute HTMLFormElement? form;
   [CEReactions] attribute boolean multiple;
   [CEReactions] attribute DOMString name;
-  [CEReactions] attribute boolean required;
+  [CEReactions] attribute boolean _required;
   [CEReactions] attribute unsigned long size;
 
   readonly attribute DOMString type;
@@ -963,7 +963,7 @@ interface HTMLTextAreaElement : HTMLElement {
   [CEReactions] attribute DOMString name;
   [CEReactions] attribute DOMString placeholder;
   [CEReactions] attribute boolean readOnly;
-  [CEReactions] attribute boolean required;
+  [CEReactions] attribute boolean _required;
   [CEReactions] attribute unsigned long rows;
   [CEReactions] attribute DOMString wrap;
 


### PR DESCRIPTION
Since `required` is a reserved name in WebIDL, it should be escaped with an underscore when used as an attribute name.

Change for https://github.com/whatwg/html/pull/3721, should be merged when that PR is merged.