### PR TITLE
Add MouseEvent/MouseEventInit as untested DOM IDLs

### DIFF
--- a/dom/interfaces.html
+++ b/dom/interfaces.html
@@ -19,10 +19,7 @@ element.setAttribute("bar", "baz");
 var idlArray = new IdlArray();
 
 function doTest([html, dom]) {
-  // HTML is needed for EventHandler. Provide a dummy interface for
-  // LinkStyle which HTML depends on but we're not testing.
-  idlArray.add_untested_idls('interface LinkStyle {};');
-  idlArray.add_untested_idls(html);
+  idlArray.add_dependency_idls(html);
   idlArray.add_idls(dom);
   idlArray.add_objects({
     EventTarget: ['new EventTarget()'],


### PR DESCRIPTION
The DOM idlharness test would not run as `MouseEvent`/`MouseEventInit` were not declared within any IDL files parsed. Add these in as untested IDLs.