### PR TITLE
Move mediasession IDL to interfaces

### DIFF
--- a/interfaces/mediasession.idl
+++ b/interfaces/mediasession.idl
@@ -1,0 +1,49 @@
+[Exposed=Window]
+partial interface Navigator {
+  [SameObject] readonly attribute MediaSession mediaSession;
+};
+
+enum MediaSessionPlaybackState {
+  "none",
+  "paused",
+  "playing"
+};
+
+enum MediaSessionAction {
+  "play",
+  "pause",
+  "seekbackward",
+  "seekforward",
+  "previoustrack",
+  "nexttrack",
+};
+
+callback MediaSessionActionHandler = void();
+
+[Exposed=Window]
+interface MediaSession {
+  attribute MediaMetadata? metadata;
+  attribute MediaSessionPlaybackState playbackState;
+  void setActionHandler(MediaSessionAction action, MediaSessionActionHandler? handler);
+};
+
+[Constructor(optional MediaMetadataInit init), Exposed=Window]
+interface MediaMetadata {
+  attribute DOMString title;
+  attribute DOMString artist;
+  attribute DOMString album;
+  attribute FrozenArray<MediaImage> artwork;
+};
+
+dictionary MediaMetadataInit {
+  DOMString title = "";
+  DOMString artist = "";
+  DOMString album = "";
+  sequence<MediaImage> artwork = [];
+};
+
+dictionary MediaImage {
+  required USVString src;
+  DOMString sizes = "";
+  DOMString type = "";
+};

--- a/mediasession/idlharness.html
+++ b/mediasession/idlharness.html
@@ -11,78 +11,28 @@
 </head>
 <body>
 <h1>Media Session IDL tests</h1>
-
-<pre id='untested_idl' style='display:none'>
-[Global=Window, Exposed=Global]
-interface Window {
-};
-
-interface Navigator {
-};
-</pre>
-
-<pre id='idl'>
-[Exposed=Window]
-partial interface Navigator {
-  [SameObject] readonly attribute MediaSession mediaSession;
-};
-
-enum MediaSessionPlaybackState {
-  "none",
-  "paused",
-  "playing"
-};
-
-enum MediaSessionAction {
-  "play",
-  "pause",
-  "seekbackward",
-  "seekforward",
-  "previoustrack",
-  "nexttrack",
-};
-
-callback MediaSessionActionHandler = void();
-
-[Exposed=Window]
-interface MediaSession {
-  attribute MediaMetadata? metadata;
-
-  attribute MediaSessionPlaybackState playbackState;
-
-  void setActionHandler(MediaSessionAction action, MediaSessionActionHandler? handler);
-};
-
-[Constructor(optional MediaMetadataInit init), Exposed=Window]
-interface MediaMetadata {
-  attribute DOMString title;
-  attribute DOMString artist;
-  attribute DOMString album;
-  attribute FrozenArray<MediaImage> artwork;
-};
-
-dictionary MediaMetadataInit {
-  DOMString title = "";
-  DOMString artist = "";
-  DOMString album = "";
-  sequence<MediaImage> artwork = [];
-};
-
-dictionary MediaImage {
-  required USVString src;
-  DOMString sizes = "";
-  DOMString type = "";
-};
-</pre>
 <script>
-var idl_array = new IdlArray();
-idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
-idl_array.add_idls(document.getElementById("idl").textContent);
-idl_array.add_objects({
-  MediaMetadata: [new MediaMetadata()],
-  Navigator: ["navigator"]
-});
-idl_array.test();
+"use strict";
+
+function doTest([mediasession]) {
+    var idl_array = new IdlArray();
+    idl_array.add_untested_idls('interface Navigator {};');
+    idl_array.add_idls(mediasession);
+    idl_array.add_objects({
+      MediaMetadata: ["new MediaMetadata()"],
+      Navigator: ["navigator"]
+    });
+    idl_array.test();
+}
+
+function fetchText(url) {
+    return fetch(url).then((response) => response.text());
+}
+
+promise_test(() => {
+    return Promise.all(["/interfaces/mediasession.idl"].map(fetchText))
+                  .then(doTest);
+}, "Test IDL implementation of Media Session");
 </script>
 <div id="log"></div>
 </body>


### PR DESCRIPTION
The mediasession IDL was defined directly in the idlharness test. This change moves the IDL definitions into its own file in interfaces. This change also makes the construction of `MediaMetadata` be quoted, so the test can proceed even if it is not defined.