### PR TITLE
Correct name of spec in Media Capabilities IDL test

### DIFF
--- a/media-capabilities/idlharness.html
+++ b/media-capabilities/idlharness.html
@@ -30,7 +30,7 @@ function fetchText(url) {
 promise_test(() => {
     return Promise.all(["/interfaces/media-capabilities.idl"].map(fetchText))
                   .then(doTest);
-}, "Test IDL implementation of Media Session");
+}, "Test IDL implementation of Media Capabilities");
 </script>
 <div id="log"></div>
 </body>


### PR DESCRIPTION
My commit adding this test had the incorrect name due to a copy & paste error, this change corrects the name of the spec.