### PR TITLE
HTML: Test hidden attribute on table elements

### DIFF
--- a/html/rendering/non-replaced-elements/tables/hidden-attr.html
+++ b/html/rendering/non-replaced-elements/tables/hidden-attr.html
@@ -4,6 +4,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <table hidden></table>
+<table><caption hidden></caption></table>
 <table><colgroup hidden></table>
 <table><col hidden></table>
 <table><thead hidden></table>
@@ -15,6 +16,7 @@
 <script>
 const expectedDisplay = {
   'table': 'none',
+  'caption': 'none',
   'colgroup': 'table-column-group',
   'col': 'table-column',
   'thead': 'table-header-group',
@@ -28,7 +30,8 @@ for (const el of document.querySelectorAll("[hidden]")) {
   test(function() {
     const style = getComputedStyle(el);
     assert_equals(style.display, expectedDisplay[el.localName]);
-    if (el instanceof HTMLTableElement) {
+    if (el instanceof HTMLTableElement ||
+        el instanceof HTMLTableCaptionElement) {
       assert_equals(style.visibility, 'visible');
     } else {
       assert_equals(style.visibility, 'collapse');

--- a/html/rendering/non-replaced-elements/tables/hidden-attr.html
+++ b/html/rendering/non-replaced-elements/tables/hidden-attr.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<title>UA style for hidden attribute on table elements</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<table hidden></table>
+<table><colgroup hidden></table>
+<table><col hidden></table>
+<table><thead hidden></table>
+<table><tbody hidden></table>
+<table><tfoot hidden></table>
+<table><tr hidden></table>
+<table><tr><td hidden></table>
+<table><tr><th hidden></table>
+<script>
+const expectedDisplay = {
+  'table': 'none',
+  'colgroup': 'table-column-group',
+  'col': 'table-column',
+  'thead': 'table-header-group',
+  'tbody': 'table-row-group',
+  'tfoot': 'table-footer-group',
+  'tr': 'table-row',
+  'td': 'table-cell',
+  'th': 'table-cell',
+};
+for (const el of document.querySelectorAll("[hidden]")) {
+  test(function() {
+    const style = getComputedStyle(el);
+    assert_equals(style.display, expectedDisplay[el.localName]);
+    if (el instanceof HTMLTableElement) {
+      assert_equals(style.visibility, 'visible');
+    } else {
+      assert_equals(style.visibility, 'collapse');
+    }
+  }, `Computed display and visibility of ${el.localName}`);
+}
+</script>


### PR DESCRIPTION
(I found this when adding the "Filter" feature in https://bocoup.github.io/wpt-disabled-tests-report/ -- typing something should not change the column widths of the tables.)