### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=170784

### DIFF
--- a/css/css-animations/set-animation-play-state-to-paused-001-ref.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001-ref.html
@@ -13,7 +13,7 @@
         position: absolute;
         background: lightgreen;
         width: 150px;
-        height: 250px;
+        height: 300px;
         left: -75px;
         top: 0px;
         transform: translate(150px);

--- a/css/css-animations/set-animation-play-state-to-paused-001-ref.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused (reference)</title>
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #coveringRect {
+        position: absolute;
+        background: lightgreen;
+        width: 150px;
+        height: 250px;
+        left: -75px;
+        top: 0px;
+        transform: translate(150px);
+      }
+    </style>
+  </head>
+  <body>
+    <p>This test passes if you see a green rectangle and no red.</p>
+    <div id="container">
+      <div id="coveringRect"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-001.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically set animation-play-state to paused</title>
+    <link rel="author" title="Igalia S.L." href="https://www.igalia.com/">
+    <link rel="help" href="https://drafts.csswg.org/css-animations-1/#animation-play-state">
+    <meta name="assert" content="Visually check that transform animations stop
+                                 when animation-play-state is set to paused">
+    <link rel="match" href="set-animation-play-state-to-paused-001-ref.html">
+    <style>
+      #container {
+        position: absolute;
+        left: 0;
+        top: 3em;
+      }
+      #squareLinear, #squareSteps  {
+        width: 100px;
+        height: 100px;
+        background: red;
+        position: absolute;
+        left: -50px;
+      }
+      #squareLinear {
+        top: 0px;
+        animation: move 2s linear;
+      }
+      #squareSteps {
+        top: 150px;
+        animation: move 2s steps(1000, end);
+      }
+      #coveringRect {
+        position: absolute;
+        background: lightgreen;
+        width: 150px;
+        height: 250px;
+        left: -75px;
+        top: 0px;
+        transform: translate(150px);
+      }
+      .pause {
+        opacity: 0.6;
+        animation-play-state: paused !important;
+      }
+      @keyframes move
+      {
+        100% {
+          transform: translate(500px);
+        }
+      }
+    </style>
+    <script>
+      var start = null;
+      var animationDuration = 2000;
+      var coveringRectShift = 150;
+      var rectFinalShift = 500;
+      function step(timestamp) {
+        if (!start) start = timestamp;
+        var progress = timestamp - start;
+        // Pause the animations when the squares pass under the covering rect.
+        var targetProgress = animationDuration * coveringRectShift / rectFinalShift;
+        if (progress > targetProgress) {
+          document.getElementById("squareLinear").classList.add("pause");
+          document.getElementById("squareSteps").classList.add("pause");
+        }
+
+        // Wait a bit so that the squares pass the covering rect if the
+        // animation fails to be paused.
+        var delta = 200;
+        if (progress < targetProgress + delta)
+          window.requestAnimationFrame(step)
+        else
+          document.documentElement.classList.remove("reftest-wait");
+      }
+      function runTest() {
+        window.requestAnimationFrame(step);
+      }
+    </script>
+  </head>
+  <body onload="runTest()">
+    <p>This test passes if you see a green rectangle and no red.</p>
+    <div id="container">
+      <div id="squareLinear"></div>
+      <div id="squareSteps"></div>
+      <div id="coveringRect"></div>
+    </div>
+  </body>
+</html>

--- a/css/css-animations/set-animation-play-state-to-paused-001.html
+++ b/css/css-animations/set-animation-play-state-to-paused-001.html
@@ -22,18 +22,18 @@
         left: -50px;
       }
       #squareLinear {
-        top: 0px;
+        top: 25px;
         animation: move 2s linear;
       }
       #squareSteps {
-        top: 150px;
+        top: 175px;
         animation: move 2s steps(1000, end);
       }
       #coveringRect {
         position: absolute;
         background: lightgreen;
         width: 150px;
-        height: 250px;
+        height: 300px;
         left: -75px;
         top: 0px;
         transform: translate(150px);
@@ -52,23 +52,30 @@
     <script>
       var start = null;
       var animationDuration = 2000;
-      var coveringRectShift = 150;
-      var rectFinalShift = 500;
+      function halfWidth(id)
+      {
+        return document.getElementById(id).scrollWidth / 2;
+      }
+      function shift(id)
+      {
+        var transform = window.getComputedStyle(document.getElementById(id)).transform;
+        if (transform === "none")
+          return 0;
+        // See https://drafts.csswg.org/css-transforms-2/#serialization-of-the-computed-value
+        return parseFloat(transform.split(/,\s*/)[4]);
+      }
       function step(timestamp) {
-        if (!start) start = timestamp;
-        var progress = timestamp - start;
-        // Pause the animations when the squares pass under the covering rect.
-        var targetProgress = animationDuration * coveringRectShift / rectFinalShift;
-        if (progress > targetProgress) {
-          document.getElementById("squareLinear").classList.add("pause");
-          document.getElementById("squareSteps").classList.add("pause");
-        }
+        // For each square, pause the animation as soon as it passes under the covering rect.
+        ["squareLinear", "squareSteps"].forEach((id) => {
+          if (Math.abs(shift("coveringRect") - shift(id)) < halfWidth("coveringRect") - halfWidth(id))
+            document.getElementById(id).classList.add("pause");
+        });
 
-        // Wait a bit so that the squares pass the covering rect if the
-        // animation fails to be paused.
-        var delta = 200;
-        if (progress < targetProgress + delta)
-          window.requestAnimationFrame(step)
+        // Stop the reftest after the time when the animations would have stop.
+        // If pausing failed for some reason, the squares will be visible.
+        if (!start) start = timestamp;
+        if (timestamp - start < animationDuration)
+          window.requestAnimationFrame(step);
         else
           document.documentElement.classList.remove("reftest-wait");
       }


### PR DESCRIPTION
WebKit export from bug: [\[iOS\] Animations with Bézier timing function not suspended on UI process when animation-play-state is set to "paused"](https://bugs.webkit.org/show_bug.cgi?id=170784)