### PR TITLE
Allow cookie-store IDL test to run even if objects not defined

### DIFF
--- a/cookie-store/idlharness.tentative.html
+++ b/cookie-store/idlharness.tentative.html
@@ -54,8 +54,8 @@ promise_test(async t => {
   idl_array.add_idls(cookie_store);
 
   idl_array.add_objects({
-    CookieStore: [self.cookieStore],
-    CookieChangeEvent: [new CookieChangeEvent('change')],
+    CookieStore: ["self.cookieStore"],
+    CookieChangeEvent: ["new CookieChangeEvent('change')"],
   });
   idl_array.test();
 }, 'Interface test');

--- a/cookie-store/idlharness_serviceworker.js
+++ b/cookie-store/idlharness_serviceworker.js
@@ -35,9 +35,9 @@ promise_test(async t => {
   idl_array.add_idls(cookie_store);
 
   idl_array.add_objects({
-    CookieStore: [self.cookieStore],
+    CookieStore: ["self.cookieStore"],
     ExtendableCookieChangeEvent: [
-        new ExtendableCookieChangeEvent('cookiechange')],
+        "new ExtendableCookieChangeEvent('cookiechange')"],
   });
   idl_array.test();
 }, 'Interface test');


### PR DESCRIPTION
By quoting the object constructors/references, we prevent the test from erroring out prior to running and instead allow all of the tests to run. This means that if an implementation only defines one interface but not the other, it will make sure there is test coverage of that interface without having to implement the other.