### PR TITLE
Check if a type is a sequence through idlType.generic

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -884,7 +884,7 @@ IdlArray.prototype.assert_type_is = function(value, type)
         return;
     }
 
-    if (type.sequence)
+    if (type.generic === "sequence")
     {
         assert_true(Array.isArray(value), "should be an Array");
         if (!value.length)


### PR DESCRIPTION
`idlType.sequence` was removed in https://github.com/w3c/webidl2.js/pull/175, as the same check can be achieved through `idlType.generic === "sequence"`. Move to this more updated syntax so that updating webidl2.js will require less work the next time we do it.