### PR TITLE
Make dynamic-import tests fail early instead of time out

### DIFF
--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
@@ -96,7 +96,7 @@ promise_test(t => {
     "onclick",
     `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
   );
-  assert_equals(typeof dummyDiv.onclick, "function");
+  assert_equals(typeof dummyDiv.onclick, "function", "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
   return promise.then(assertSuccessful);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-classic.html
@@ -96,6 +96,7 @@ promise_test(t => {
     "onclick",
     `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
   );
+  assert_equals(typeof dummyDiv.onclick, "function");
   dummyDiv.click(); // different from **on**click()
 
   return promise.then(assertSuccessful);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
@@ -95,7 +95,7 @@ promise_test(t => {
     "onclick",
     `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
   );
-  assert_equals(typeof dummyDiv.onclick, 'function');
+  assert_equals(typeof dummyDiv.onclick, 'function', "the browser must be able to parse a string containing the import() syntax into a function");
   dummyDiv.click(); // different from **on**click()
 
   return promise.then(assertSuccessful);

--- a/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
+++ b/html/semantics/scripting-1/the-script-element/module/dynamic-import/string-compilation-nonce-module.html
@@ -95,6 +95,7 @@ promise_test(t => {
     "onclick",
     `import('../imports-a.js?label=inline event handlers triggered via UA code').then(window.continueTest, window.errorTest)`
   );
+  assert_equals(typeof dummyDiv.onclick, 'function');
   dummyDiv.click(); // different from **on**click()
 
   return promise.then(assertSuccessful);


### PR DESCRIPTION
Part of #11269.