### PR TITLE
HTML: Use a URL that is more likely to fail to parse in img test

### DIFF
--- a/html/semantics/embedded-content/the-img-element/invalid-src.html
+++ b/html/semantics/embedded-content/the-img-element/invalid-src.html
@@ -8,7 +8,7 @@
 <script>
 async_test(function(t) {
     var img = document.getElementById("brokenurl");
-    img.src = "http://also a broken url";
+    img.src = "http://[";
     var errorevent = false;
 
     // The errors should be queued in the event loop, so they should only trigger
@@ -17,7 +17,7 @@ async_test(function(t) {
     img.addEventListener('loadend', t.step_func_done(function() {
         assert_true(errorevent, "error event fired");
     }));
-}, 'src="http://also a broken url"');
+}, 'src="http://["');
 
 async_test(function(t) {
     var img = document.getElementById("emptysrc");


### PR DESCRIPTION
Part of #1126.

---

Note that this doesn't seem to fix the timeout in browsers, but per spec it should fire an 'error' event. Will file bugs.

https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:parse-a-url-2