### PR TITLE
Move add_dependency_idls after add_idls

### DIFF
--- a/dom/interfaces.html
+++ b/dom/interfaces.html
@@ -19,8 +19,8 @@ element.setAttribute("bar", "baz");
 var idlArray = new IdlArray();
 
 function doTest([html, dom]) {
-  idlArray.add_dependency_idls(html);
   idlArray.add_idls(dom);
+  idlArray.add_dependency_idls(html);
   idlArray.add_objects({
     EventTarget: ['new EventTarget()'],
     Event: ['document.createEvent("Event")', 'new Event("foo")'],


### PR DESCRIPTION
Per #11280, the order in which you call these methods matters to execution. Flip the order in order to prevent `Unrecognized type EventHandler`.