### PR TITLE
Add filtering support to ManifestLoader.

### DIFF
--- a/tools/manifest/tests/test_manifest.py
+++ b/tools/manifest/tests/test_manifest.py
@@ -294,6 +294,35 @@ def test_iterpath():
     assert set(m.iterpath("missing")) == set()
 
 
+def test_filter():
+    m = manifest.Manifest()
+
+    sources = [SourceFileWithTest("test1", "0"*40, item.RefTest, [("/test1-ref", "==")]),
+               SourceFileWithTest("test2", "0"*40, item.RefTest, [("/test2-ref", "==")]),
+               SourceFileWithTests("test2", "0"*40, item.TestharnessTest, [("/test2-1.html",),
+                                                                           ("/test2-2.html",)]),
+               SourceFileWithTest("test3", "0"*40, item.TestharnessTest)]
+    m.update(sources)
+
+    json = m.to_json()
+
+    def filter(it):
+        for test in it:
+            if test[0] in ["/test2-2.html", "/test3"]:
+                yield test
+
+    filtered_manifest = manifest.Manifest.from_json("/", json, types=["testharness"], meta_filters=[filter])
+
+    actual = [
+        (ty, path, [test.id for test in tests])
+        for (ty, path, tests) in filtered_manifest
+    ]
+    assert actual == [
+        ("testharness", "test2", ["/test2-2.html"]),
+        ("testharness", "test3", ["/test3"]),
+    ]
+
+
 def test_reftest_node_by_url():
     m = manifest.Manifest()
 

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -378,11 +378,13 @@ class TagFilter(object):
 
 
 class ManifestLoader(object):
-    def __init__(self, test_paths, force_manifest_update=False, manifest_download=False):
+    def __init__(self, test_paths, force_manifest_update=False, manifest_download=False, types=None, meta_filters=None):
         do_delayed_imports()
         self.test_paths = test_paths
         self.force_manifest_update = force_manifest_update
         self.manifest_download = manifest_download
+        self.types = types
+        self.meta_filters = meta_filters or []
         self.logger = structured.get_default_logger()
         if self.logger is None:
             self.logger = structured.structuredlog.StructuredLogger("ManifestLoader")
@@ -437,7 +439,7 @@ class ManifestLoader(object):
         if (not os.path.exists(manifest_path) or
             self.force_manifest_update):
             self.update_manifest(manifest_path, tests_path, url_base, download=self.manifest_download)
-        manifest_file = manifest.load(tests_path, manifest_path)
+        manifest_file = manifest.load(tests_path, manifest_path, types=self.types, meta_filters=self.meta_filters)
         if manifest_file.url_base != url_base:
             self.logger.info("Updating url_base in manifest from %s to %s" % (manifest_file.url_base,
                                                                               url_base))


### PR DESCRIPTION
In some use cases, the overhead of creating data structures for all tests in
the manifest, and then filtering them, is too big. This change allows users
to filter tests when initially creating the manifest.