### PR TITLE
[encrypted-media] Add segmented clear-to-encrypted test.

### DIFF
--- a/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html
+++ b/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted-segmented.https.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset=utf-8>
+    <title>Encrypted Media Extensions: Successful Playback, Temporary session with Clear Key, mp4, clear then encrypted using segmented media</title>
+    <link rel="help" href="https://w3c.github.io/encrypted-media/">
+
+    <!-- Web Platform Test Harness scripts -->
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
+
+    <!-- Helper scripts for Encrypted Media Extensions tests  -->
+    <script src=/encrypted-media/util/utils.js></script>
+    <script src=/encrypted-media/util/fetch.js></script>
+    <script src=/encrypted-media/util/testmediasource.js></script>
+    <script src=/encrypted-media/util/utf8.js></script>
+
+    <!-- Content metadata -->
+    <script src=/encrypted-media/content/content-metadata.js></script>
+
+    <!-- Message handler for Clear Key keysystem -->
+    <script src=/encrypted-media/util/clearkey-messagehandler.js></script>
+
+    <!-- The script for this specific test -->
+    <script src=/encrypted-media/scripts/playback-temporary-encrypted-clear-segmented-sources.js></script>
+
+  </head>
+  <body>
+    <div id='log'></div>
+
+    <div id='video'>
+      <video id="videoelement" width="200px"></video>
+    </div>
+
+    <script>
+        var encryptedcontentitem = content['mp4-basic'],
+            clearcontentitem = content['mp4-clear'],
+            handler = new MessageHandler('org.w3.clearkey', encryptedcontentitem),
+            configEncrypted = { video:              document.getElementById('videoelement'),
+                                keysystem:          'org.w3.clearkey',
+                                messagehandler:     handler.messagehandler,
+                                audioPath:          encryptedcontentitem.audio.path,
+                                videoPath:          encryptedcontentitem.video.path,
+                                audioType:          encryptedcontentitem.audio.type,
+                                videoType:          encryptedcontentitem.video.type,
+                                duration:           4,
+                                initDataType:       'keyids',
+                                initData:           getInitData(encryptedcontentitem, 'keyids'),
+                            },
+            configClear = { audioPath:          clearcontentitem.audio.path,
+                            videoPath:          clearcontentitem.video.path,
+                            audioType:          clearcontentitem.audio.type,
+                            videoType:          clearcontentitem.video.type,
+                            duration:           4,
+                            };
+
+        runTest(configEncrypted,configClear);
+    </script>
+  </body>
+</html>

--- a/encrypted-media/scripts/playback-temporary-encrypted-clear-segmented-sources.js
+++ b/encrypted-media/scripts/playback-temporary-encrypted-clear-segmented-sources.js
@@ -1,0 +1,109 @@
+function runTest(configEncrypted,configClear,qualifier) {
+
+    var testname = testnamePrefix(qualifier, configEncrypted.keysystem)
+                                    + ', temporary, '
+                                    + /video\/([^;]*)/.exec(configEncrypted.videoType)[1]
+                                    + ', playback, encrypted and clear sources in separate segments';
+
+    var configuration = {   initDataTypes: [ configEncrypted.initDataType ],
+                            audioCapabilities: [ { contentType: configEncrypted.audioType } ],
+                            videoCapabilities: [ { contentType: configEncrypted.videoType } ],
+                            sessionTypes: [ 'temporary' ] };
+
+    async_test(function(test) {
+        var didAppendEncrypted = false,
+            _video = configEncrypted.video,
+            _mediaKeys,
+            _mediaKeySession,
+            _mediaSource,
+            _sourceBuffer;
+
+        function onFailure(error) {
+            forceTestFailureFromPromise(test, error);
+        }
+
+        function onVideoError(event) {
+            var message = (_video.error || {}).message || 'Got unknown error from <video>';
+            forceTestFailureFromPromise(test, new Error(message));
+        }
+
+        function onMessage(event) {
+            assert_equals(event.target, _mediaKeySession);
+            assert_true(event instanceof window.MediaKeyMessageEvent);
+            assert_equals(event.type, 'message');
+            assert_in_array(event.messageType, ['license-request', 'individualization-request']);
+
+            configEncrypted.messagehandler(event.messageType, event.message).then(function(response) {
+                return _mediaKeySession.update(response);
+            }).catch(onFailure);
+        }
+
+        function onEncrypted(event) {
+            assert_equals(event.target, _video);
+            assert_true(event instanceof window.MediaEncryptedEvent);
+            assert_equals(event.type, 'encrypted');
+
+            var initDataType = configEncrypted.initDataType || event.initDataType;
+            var initData = configEncrypted.initData || event.initData;
+
+            _mediaKeySession = _mediaKeys.createSession('temporary');
+            waitForEventAndRunStep('message', _mediaKeySession, onMessage, test);
+            _mediaKeySession.generateRequest(initDataType, initData).catch(onFailure);
+        }
+
+        function onPlaying(event) {
+            // Not using waitForEventAndRunStep() to avoid too many
+            // EVENT(onTimeUpdate) logs.
+            _video.addEventListener('timeupdate', onTimeupdate, true);
+        }
+
+        function onTimeupdate(event) {
+            if (_video.currentTime > (configEncrypted.duration || 1) + (configClear.duration || 1)) {
+                _video.pause();
+                test.done();
+            }
+            if (_video.currentTime > 1 && !didAppendEncrypted) {
+                didAppendEncrypted = true;
+                _sourceBuffer.timestampOffset = configClear.duration;
+                fetchAndAppend(configEncrypted.videoPath).then(function() {
+                  _mediaSource.endOfStream();
+                }).catch(onFailure);
+            }
+        }
+
+        function fetchAndAppend(path) {
+            return fetch(path).then(function(response) {
+                if (!response.ok) throw new Error('Resource fetch failed');
+                return response.arrayBuffer();
+            }).then(function(data) {
+                return new Promise(function(resolve, reject) {
+                    _sourceBuffer.appendBuffer(data);
+                    _sourceBuffer.addEventListener('updateend', resolve);
+                    _sourceBuffer.addEventListener('error', reject);
+                });
+            });
+        }
+
+        _video.addEventListener('error', onVideoError);
+        navigator.requestMediaKeySystemAccess(configEncrypted.keysystem, [configuration]).then(function(access) {
+            return access.createMediaKeys();
+        }).then(function(mediaKeys) {
+            _mediaKeys = mediaKeys;
+            return _video.setMediaKeys(_mediaKeys);
+        }).then(function(){
+            waitForEventAndRunStep('encrypted', _video, onEncrypted, test);
+            waitForEventAndRunStep('playing', _video, onPlaying, test);
+
+            return new Promise(function(resolve, reject) {
+                _mediaSource = new MediaSource();
+                _mediaSource.addEventListener('sourceopen', resolve);
+                _video.src = URL.createObjectURL(_mediaSource);
+            });
+        }).then(function() {
+            _sourceBuffer = _mediaSource.addSourceBuffer(configEncrypted.videoType);
+            return fetchAndAppend(configClear.videoPath);
+        }).then(function() {
+            _video.play();
+        }).catch(onFailure);
+    }, testname);
+}


### PR DESCRIPTION
This adds a test that tests transitioning from clear to encrypted content when it appears in different segments.  This can happen when streaming and the first content is a clear ad and the encrypted content
will be appended later.

This kind of content wasn't playable on Firefox until recently and I think this won't work on Edge if they supported clear-key (similar tests with PlayReady don't work).
See https://bugzilla.mozilla.org/show_bug.cgi?id=1454630