### PR TITLE
Add back the style for font install warning

### DIFF
--- a/css/WOFF2/support/index.css
+++ b/css/WOFF2/support/index.css
@@ -29,6 +29,17 @@ h1 {
 	padding: 0px 0px 20px 0px;
 }
 
+p.installFontsNote {
+	font-weight: bold;
+	color: white;
+	background-color: red;
+	padding: 5px 10px 5px 10px;
+}
+
+p.installFontsNote a {
+	color: white;
+}
+
 .mainNote {
 	margin: 0px;
 	padding: 15px 0px 15px 0px;


### PR DESCRIPTION
This is no longer used for the WPT tests but other generators from woff2-tests still require it, so let's
just keep it to make things easier.