### PR TITLE
Correct importScripts() behavior test

### DIFF
--- a/service-workers/service-worker/import-scripts-updated-flag.https.html
+++ b/service-workers/service-worker/import-scripts-updated-flag.https.html
@@ -75,7 +75,7 @@ promise_test(t => {
           return post_and_wait_for_reply(worker, 'message');
         })
       .then(result => {
-          assert_equals(result.error, 'TypeError');
+          assert_equals(result.error, 'NetworkError');
           assert_equals(result.value, null);
         });
   }, 'import script not previously imported');

--- a/service-workers/service-worker/resources/import-scripts-updated-flag-worker.js
+++ b/service-workers/service-worker/resources/import-scripts-updated-flag-worker.js
@@ -4,6 +4,7 @@ let echo_output = null;
 
 // Tests importing a script that sets |echo_output| to the query string.
 function test_import(str) {
+  echo_output = null;
   importScripts('import-scripts-echo.py?msg=' + str);
   assert_equals(echo_output, str);
 }
@@ -18,6 +19,7 @@ self.addEventListener('install', () => {
 
 self.addEventListener('message', e => {
     var error = null;
+    echo_output = null;
 
     try {
       importScripts('import-scripts-echo.py?msg=' + e.data);


### PR DESCRIPTION
- Update the after-install call to expect NetworkError instead of TypeError.
- Initialize echo_output before calling importScripts().