### PR TITLE
HTML: fix joint session history test to not time out

### DIFF
--- a/html/browsers/history/the-history-interface/joint_session_history/001.html
+++ b/html/browsers/history/the-history-interface/joint_session_history/001.html
@@ -4,7 +4,6 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-setup({timeout:10000});
 var t = async_test("Session history length on initial load");
 var t1 = async_test("Session history length on adding new iframe");
 var t2 = async_test("Navigating second iframe");
@@ -13,6 +12,6 @@ var t4 = async_test("Navigating first iframe");
 var t5 = async_test("Traversing history back (2)");
 var t6 = async_test("Traversing history forward");
 var w = window.open("001-1.html");
-//add_completion_callback(function() {w.close()});
+add_completion_callback(function() {w.close()});
 </script>
 

--- a/html/browsers/history/the-history-interface/joint_session_history/002-1.html
+++ b/html/browsers/history/the-history-interface/joint_session_history/002-1.html
@@ -18,13 +18,13 @@ onload = function () {
     document.body.appendChild(iframe);
     o.assert_equals(history.length, 1);
     frameloaded = o.t2.step_func(function() {
-      iframe.contentDocument.open();
-      iframe.contentDocument.write("3<script>onpageshow = function() {alert('pageshow'); parent.frameloaded()}<\/script>");
-      iframe.contentDocument.close();
       frameloaded = o.t2.step_func(function () {
         o.assert_equals(history.length, 2);
         o.t2.done();
       });
+      iframe.contentDocument.open();
+      iframe.contentDocument.write("3<script>parent.frameloaded();<\/script>");
+      iframe.contentDocument.close();
     });
     o.t1.done();
   });

--- a/html/browsers/history/the-history-interface/joint_session_history/002.html
+++ b/html/browsers/history/the-history-interface/joint_session_history/002.html
@@ -4,15 +4,14 @@
 <script src="/resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-setup({timeout:10000});
 var t = async_test("Session history length on initial load");
 var t1 = async_test("Session history length on adding new iframe");
 var t2 = async_test("Navigating second iframe");
-<!-- var t3 = async_test("Traversing history back (1)"); -->
-<!-- var t4 = async_test("Navigating first iframe"); -->
-<!-- var t5 = async_test("Traversing history back (2)"); -->
-<!-- var t6 = async_test("Traversing history forward"); -->
+// var t3 = async_test("Traversing history back (1)");
+// var t4 = async_test("Navigating first iframe");
+// var t5 = async_test("Traversing history back (2)");
+// var t6 = async_test("Traversing history forward");
 var w = window.open("002-1.html");
-//add_completion_callback(function() {w.close()});
+add_completion_callback(function() {w.close()});
 </script>
 


### PR DESCRIPTION
Part of #11269.

---

The `t2` test in 002.html fails in Firefox and Chrome, and still times out in Safari. I'm not sure what the spec-correct behavior is for this test.