### PR TITLE
Make screen-orientation tests fail early if orientation is unsupported

### DIFF
--- a/screen-orientation/onchange-event-subframe.html
+++ b/screen-orientation/onchange-event-subframe.html
@@ -4,11 +4,11 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<iframe id="testIframe" sandbox="allow-scripts allow-same-origin" style="display:none">
+<iframe id="testIframe" sandbox="allow-scripts allow-same-origin">
 </iframe>
 
 <script>
-    var test = async_test("Test subframes receive orientation change events");
+async_test(test => {
 
     var orientations = [
         'portrait-primary',
@@ -41,6 +41,7 @@
     var testIframe = document.getElementById("testIframe");
     testIframe.src = "resources/iframe-listen-orientation-change.html";
     testIframe.onload = changeOrientation;
+}, "Test subframes receive orientation change events");
 </script>
 </body>
 </html>

--- a/screen-orientation/onchange-event.html
+++ b/screen-orientation/onchange-event.html
@@ -8,73 +8,80 @@
 var changeTest = async_test("Test that orientationchange event is fired when the orientation changes.");
 var noChangeTest = async_test("Test that orientationchange event is not fired when the orientation does not change.");
 
-var orientations = [
-  'portrait-primary',
-  'portrait-secondary',
-  'landscape-primary',
-  'landscape-secondary'
-];
+test(() => {
+  add_result_callback(test => {
+    if (test.name === "Setup" && test.status !== 0) {
+      changeTest.unreached_func("Setup failed")();
+      noChangeTest.unreached_func("Setup failed")();
+    }
+  })
+  var orientations = [
+    'portrait-primary',
+    'portrait-secondary',
+    'landscape-primary',
+    'landscape-secondary'
+  ];
 
-var currentIndex = orientations.indexOf(window.screen.orientation.type);
-// Count the number of calls received from the EventHandler set on screen.orientation.onchange.
-var orientationChangeEventHandlerCalls = 0;
-// Count the number of calls received from the listener set with screen.orientation.addEventListene().
-var orientationChangeEventListenerCalls = 0;
+  var currentIndex = orientations.indexOf(window.screen.orientation.type);
+  // Count the number of calls received from the EventHandler set on screen.orientation.onchange.
+  var orientationChangeEventHandlerCalls = 0;
+  // Count the number of calls received from the listener set with screen.orientation.addEventListene().
+  var orientationChangeEventListenerCalls = 0;
 
-var orientationChangeContinuation = null;
+  var orientationChangeContinuation = null;
 
-function getNextIndex() {
-  return (currentIndex + 1) % orientations.length;
-}
-
-window.screen.orientation.onchange = function() {
-  orientationChangeEventHandlerCalls++;
-  if (orientationChangeEventContinuation) {
-    setTimeout(orientationChangeEventContinuation);
-    orientationChangeEventContinuation = null;
+  function getNextIndex() {
+    return (currentIndex + 1) % orientations.length;
   }
-};
 
-window.screen.orientation.addEventListener('change', function() {
-  orientationChangeEventListenerCalls++;
-});
-
-function runNoChangeTest() {
-  screen.orientation.lock(orientations[currentIndex]).then(function() {}, function() {});
-
-  noChangeTest.step(function() {
-    assert_equals(screen.orientation.type, orientations[currentIndex]);
-    assert_equals(orientationChangeEventHandlerCalls, orientations.length);
-    assert_equals(orientationChangeEventListenerCalls, orientations.length);
-  });
-
-  noChangeTest.done();
-}
-
-var i = 0;
-function runChangeTest() {
-  screen.orientation.lock(orientations[getNextIndex()]).then(function() {}, function() {});
-  currentIndex = getNextIndex();
-
-  orientationChangeEventContinuation = function() {
-    changeTest.step(function() {
-      assert_equals(screen.orientation.type, orientations[currentIndex]);
-      assert_equals(orientationChangeEventHandlerCalls, i + 1);
-      assert_equals(orientationChangeEventListenerCalls, i + 1);
-    });
-
-    ++i;
-    if (i == orientations.length) {
-      changeTest.done();
-      runNoChangeTest();
-    } else {
-      runChangeTest();
+  window.screen.orientation.onchange = function() {
+    orientationChangeEventHandlerCalls++;
+    if (orientationChangeEventContinuation) {
+      setTimeout(orientationChangeEventContinuation);
+      orientationChangeEventContinuation = null;
     }
   };
-}
 
-runChangeTest();
+  window.screen.orientation.addEventListener('change', function() {
+    orientationChangeEventListenerCalls++;
+  });
 
+  function runNoChangeTest() {
+    screen.orientation.lock(orientations[currentIndex]).then(function() {}, function() {});
+
+    noChangeTest.step(function() {
+      assert_equals(screen.orientation.type, orientations[currentIndex]);
+      assert_equals(orientationChangeEventHandlerCalls, orientations.length);
+      assert_equals(orientationChangeEventListenerCalls, orientations.length);
+    });
+
+    noChangeTest.done();
+  }
+
+  var i = 0;
+  function runChangeTest() {
+    screen.orientation.lock(orientations[getNextIndex()]).then(function() {}, function() {});
+    currentIndex = getNextIndex();
+
+    orientationChangeEventContinuation = function() {
+      changeTest.step(function() {
+        assert_equals(screen.orientation.type, orientations[currentIndex]);
+        assert_equals(orientationChangeEventHandlerCalls, i + 1);
+        assert_equals(orientationChangeEventListenerCalls, i + 1);
+      });
+
+      ++i;
+      if (i == orientations.length) {
+        changeTest.done();
+        runNoChangeTest();
+      } else {
+        runChangeTest();
+      }
+    };
+  }
+
+  runChangeTest();
+}, "Setup");
 </script>
 </body>
 </html>


### PR DESCRIPTION
Part of #11269.

---

The tests still time out if orientation is supported but the event is not fired or so; not sure if anything can be done about that, assuming the tests are correct.