### PR TITLE
fix `python wpt make-hosts-file` command in README for PowerShell on Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For example, on most UNIX-like systems, you can setup the hosts file with:
 And on Windows (this must be run in a PowerShell session with Administrator privileges):
 
 ```bash
-python wpt make-hosts-file | Out-File %SystemRoot%\System32\drivers\etc\hosts -Encoding ascii -Append
+python wpt make-hosts-file | Out-File $env:systemroot\System32\drivers\etc\hosts -Encoding ascii -Append
 ```
 
 If you are behind a proxy, you also need to make sure the domains above are


### PR DESCRIPTION
on my Windows 10 machine, `%SystemRoot%` did not work in PowerShell (run as administrator).

see this screenshot of when I called the command using `%SystemRoot%` vs. `$env:systemroot`:

![screenshot of PowerShell commands](https://user-images.githubusercontent.com/203725/41017141-6de7753e-6908-11e8-89c9-fa872f040311.png)
