### PR TITLE
Fix the TemporaryFile mode to prevent crashing.

### DIFF
--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -58,15 +58,11 @@ class TestInputFile(TestUsingServer):
 
         try:
             resp = self.request(route[1], method="POST", body="1"*20)
-        except HTTPError:
-            # Cleanup and fail test
+            self.assertEqual(200, resp.getcode())
+            self.assertEqual(["11", "7", "0", "0"],
+                            resp.read().split(" "))
+        finally:
             InputFile.max_buffer_size = old_max_buf
-            self.assertTrue(False, 'This should not be reached. Server failed.')
-
-        self.assertEqual(200, resp.getcode())
-        self.assertEqual(["11", "7", "0", "0"],
-                         resp.read().split(" "))
-        InputFile.max_buffer_size = old_max_buf
 
     def test_iter(self):
         @wptserve.handlers.handler
@@ -94,14 +90,10 @@ class TestInputFile(TestUsingServer):
 
         try:
             resp = self.request(route[1], method="POST", body="12345\nabcdef\r\nzyxwv")
-        except HTTPError:
-            # Cleanup and fail test
+            self.assertEqual(200, resp.getcode())
+            self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
+        finally:
             InputFile.max_buffer_size = old_max_buf
-            self.assertTrue(False, 'This should not be reached. Server failed.')
-
-        self.assertEqual(200, resp.getcode())
-        self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
-        InputFile.max_buffer_size = old_max_buf
 
 class TestRequest(TestUsingServer):
     def test_body(self):

--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -62,7 +62,7 @@ class TestInputFile(TestUsingServer):
             # Cleanup and fail test
             InputFile.max_buffer_size = old_max_buf
             self.assertTrue(False, 'This should not be reached. Server failed.')
-        
+
         self.assertEqual(200, resp.getcode())
         self.assertEqual(["11", "7", "0", "0"],
                          resp.read().split(" "))
@@ -98,7 +98,7 @@ class TestInputFile(TestUsingServer):
             # Cleanup and fail test
             InputFile.max_buffer_size = old_max_buf
             self.assertTrue(False, 'This should not be reached. Server failed.')
-        
+
         self.assertEqual(200, resp.getcode())
         self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
         InputFile.max_buffer_size = old_max_buf

--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -4,6 +4,8 @@ import pytest
 
 wptserve = pytest.importorskip("wptserve")
 from .base import TestUsingServer
+from wptserve.request import InputFile
+from urllib2 import HTTPError
 
 
 class TestInputFile(TestUsingServer):
@@ -35,6 +37,37 @@ class TestInputFile(TestUsingServer):
                           "12345ab\ncdef", "12345ab\n", "cdef"],
                          resp.read().split(" "))
 
+    def test_seek_input_longer_than_buffer(self):
+        old_max_buf = InputFile.max_buffer_size
+        InputFile.max_buffer_size = 10
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            rv = []
+            f = request.raw_input
+            f.seek(5)
+            rv.append(f.read(2))
+            rv.append(f.tell())
+            f.seek(0)
+            rv.append(f.tell())
+            rv.append(f.tell())
+            return " ".join(str(item) for item in rv)
+
+        route = ("POST", "/test/test_seek", handler)
+        self.server.router.register(*route)
+
+        try:
+            resp = self.request(route[1], method="POST", body="1"*20)
+        except HTTPError:
+            # Cleanup and fail test
+            InputFile.max_buffer_size = old_max_buf
+            self.assertTrue(False, 'This should not be reached. Server failed.')
+        
+        self.assertEqual(200, resp.getcode())
+        self.assertEqual(["11", "7", "0", "0"],
+                         resp.read().split(" "))
+        InputFile.max_buffer_size = old_max_buf
+
     def test_iter(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -46,6 +79,29 @@ class TestInputFile(TestUsingServer):
         resp = self.request(route[1], method="POST", body="12345\nabcdef\r\nzyxwv")
         self.assertEqual(200, resp.getcode())
         self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
+
+    def test_iter_input_longer_than_buffer(self):
+        old_max_buf = InputFile.max_buffer_size
+        InputFile.max_buffer_size = 10
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            f = request.raw_input
+            return " ".join(line for line in f)
+
+        route = ("POST", "/test/test_iter", handler)
+        self.server.router.register(*route)
+
+        try:
+            resp = self.request(route[1], method="POST", body="12345\nabcdef\r\nzyxwv")
+        except HTTPError:
+            # Cleanup and fail test
+            InputFile.max_buffer_size = old_max_buf
+            self.assertTrue(False, 'This should not be reached. Server failed.')
+        
+        self.assertEqual(200, resp.getcode())
+        self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
+        InputFile.max_buffer_size = old_max_buf
 
 class TestRequest(TestUsingServer):
     def test_body(self):

--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -38,8 +38,6 @@ class TestInputFile(TestUsingServer):
                          resp.read().split(" "))
 
     def test_seek_input_longer_than_buffer(self):
-        old_max_buf = InputFile.max_buffer_size
-        InputFile.max_buffer_size = 10
 
         @wptserve.handlers.handler
         def handler(request, response):
@@ -56,6 +54,8 @@ class TestInputFile(TestUsingServer):
         route = ("POST", "/test/test_seek", handler)
         self.server.router.register(*route)
 
+        old_max_buf = InputFile.max_buffer_size
+        InputFile.max_buffer_size = 10
         try:
             resp = self.request(route[1], method="POST", body="1"*20)
             self.assertEqual(200, resp.getcode())
@@ -77,8 +77,6 @@ class TestInputFile(TestUsingServer):
         self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
 
     def test_iter_input_longer_than_buffer(self):
-        old_max_buf = InputFile.max_buffer_size
-        InputFile.max_buffer_size = 10
 
         @wptserve.handlers.handler
         def handler(request, response):
@@ -88,6 +86,8 @@ class TestInputFile(TestUsingServer):
         route = ("POST", "/test/test_iter", handler)
         self.server.router.register(*route)
 
+        old_max_buf = InputFile.max_buffer_size
+        InputFile.max_buffer_size = 10
         try:
             resp = self.request(route[1], method="POST", body="12345\nabcdef\r\nzyxwv")
             self.assertEqual(200, resp.getcode())

--- a/tools/wptserve/wptserve/request.py
+++ b/tools/wptserve/wptserve/request.py
@@ -50,7 +50,7 @@ class InputFile(object):
         self._file_position = 0
 
         if length > self.max_buffer_size:
-            self._buf = tempfile.TemporaryFile(mode="rw+b")
+            self._buf = tempfile.TemporaryFile()
         else:
             self._buf = StringIO.StringIO()
 


### PR DESCRIPTION
In `request.py`, if a remote file is bigger than the given `max_buffer_size`, it will use a [TemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryFile). The mode for this tempfile caused an error `IOError: [Errno 9] Bad file descriptor` to happen on line 84. Removing this mode and using the default `w+b` fixes this. 