### PR TITLE
Make manifest's parsers quicker

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -133,7 +133,7 @@ def global_variant_url(url, suffix):
 
 
 class SourceFile(object):
-    parsers = {"html":lambda x:html5lib.parse(x, treebuilder="etree"),
+    parsers = {"html":lambda x:html5lib.parse(x, treebuilder="etree", useChardet=False),
                "xhtml":lambda x:ElementTree.parse(x, XMLParser.XMLParser()),
                "svg":lambda x:ElementTree.parse(x, XMLParser.XMLParser())}
 

--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -132,10 +132,20 @@ def global_variant_url(url, suffix):
     return replace_end(url, ".js", suffix)
 
 
+def _parse_xml(f):
+    try:
+        # raises ValueError with an unsupported encoding,
+        # ParseError when there's an undefined entity
+        return ElementTree.parse(f)
+    except (ValueError, ElementTree.ParseError):
+        f.seek(0)
+        return ElementTree.parse(f, XMLParser.XMLParser())
+
+
 class SourceFile(object):
     parsers = {"html":lambda x:html5lib.parse(x, treebuilder="etree", useChardet=False),
-               "xhtml":lambda x:ElementTree.parse(x, XMLParser.XMLParser()),
-               "svg":lambda x:ElementTree.parse(x, XMLParser.XMLParser())}
+               "xhtml":_parse_xml,
+               "svg":_parse_xml}
 
     root_dir_non_test = set(["common"])
 


### PR DESCRIPTION
This disables chardet for HTML, and tries the built-in XML parser before falling back to ours (which, with cElementTree, gains a lot). Overall this makes no-cache manifest 23% faster, though obviously the specific gain depend on I/O performance.