### PR TITLE
[testharness.js] Report error for worker errors

### DIFF
--- a/resources/test/tests/functional/worker-dedicated-uncaught-single.html
+++ b/resources/test/tests/functional/worker-dedicated-uncaught-single.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta name="variant" content="">
+<meta name="variant" content="?keep-promise">
+<title>Dedicated Worker Tests - Uncaught Exception in Single-Page Test</title>
+<script src="../../variants.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<h1>Dedicated Web Worker Tests - Uncaught Exception in Single-Page Test</h1>
+<p>Demonstrates running <tt>testharness</tt> based tests inside a dedicated web worker.
+<p>The test harness is expected to pass despite an uncaught exception in a worker because that worker is a single-page test.</p>
+<div id="log"></div>
+
+<script>
+test(function(t) {
+        assert_true("Worker" in self, "Browser should support Workers");
+    },
+    "Browser supports Workers");
+
+fetch_tests_from_worker(new Worker("worker-uncaught-single.js"));
+
+test(function(t) {
+        assert_false(false, "False is false");
+    },
+    "Test running on main document.");
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Browser supports Workers",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Test running on main document.",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "FAIL",
+      "name": "worker-uncaught-single",
+      "properties": {},
+      "message": "Error: This failure is expected."
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>

--- a/resources/test/tests/functional/worker-dedicated.html
+++ b/resources/test/tests/functional/worker-dedicated.html
@@ -49,12 +49,6 @@ test(function(t) {
       "message": null
     },
     {
-      "status_string": "FAIL",
-      "name": "worker-error",
-      "properties": {},
-      "message": "Error: This failure is expected."
-    },
-    {
       "status_string": "PASS",
       "name": "Worker async_test that completes successfully",
       "properties": {},
@@ -63,6 +57,12 @@ test(function(t) {
     {
       "status_string": "PASS",
       "name": "Worker test that completes successfully",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "worker test that completes successfully before exception",
       "properties": {},
       "message": null
     },

--- a/resources/test/tests/functional/worker-error.js
+++ b/resources/test/tests/functional/worker-error.js
@@ -1,3 +1,8 @@
 importScripts("/resources/testharness.js");
 
+// The following sub-test ensures that the worker is not interpreted as a
+// single-page test.  The subsequent uncaught exception should therefore be
+// interpreted as a harness error rather than a single-page test failure.
+test(function() {}, "worker test that completes successfully before exception");
+
 throw new Error("This failure is expected.");

--- a/resources/test/tests/functional/worker-uncaught-single.js
+++ b/resources/test/tests/functional/worker-uncaught-single.js
@@ -1,0 +1,6 @@
+importScripts("/resources/testharness.js");
+
+// Because this script does not define any sub-tests, it should be interpreted
+// as a single-page test, and the uncaught exception should be reported as a
+// test failure (harness status: OK).
+throw new Error("This failure is expected.");

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1833,6 +1833,15 @@ policies and contribution forms [3].
         }
         this.message_target.removeEventListener("message", this.message_handler);
         this.running = false;
+
+        // If remote context is cross origin assigning to onerror is not
+        // possible, so silently catch those errors.
+        try {
+          this.remote.onerror = null;
+        } catch (e) {
+          // Ignore.
+        }
+
         this.remote = null;
         this.message_target = null;
         if (this.doneResolve) {


### PR DESCRIPTION
In resources/test/tests/functional/worker-dedicated.html remote_done
ends up being called twice, and the second time message_target is
null, which causes an exception to be thrown.