### PR TITLE
Make set-animation-play-state-to-paused-002 more robust

### DIFF
--- a/css/css-animations/set-animation-play-state-to-paused-002-ref.html
+++ b/css/css-animations/set-animation-play-state-to-paused-002-ref.html
@@ -4,32 +4,33 @@
     <meta charset="utf-8">
     <title>Dynamically set animation-play-state to paused (reference)</title>
     <style>
-      #container {
+      #containerLinear, #containerSteps {
         position: absolute;
-        left: 0;
-        top: 3em;
+        left: 100px;
+      }
+      #containerLinear {
+        top: 100px;
+      }
+      #containerSteps {
+        top: 200px;
       }
       #coveringRectLinear, #coveringRectSteps {
         position: absolute;
         background: lightgreen;
-        width: 40px;
-        height: 70px;
-        left: 80px;
-        transform-origin: 50% 10%;
-        transform: translate(36px, 0) rotate(144deg);
-      }
-      #coveringRectLinear {
-        top: 50px;
-      }
-      #coveringRectSteps {
-        top: 150px;
+        left: -25px;
+        width: 50px;
+        top: -50px;
+        height: 100px;
+        transform: translate(72px, 0) rotate(144deg);
       }
     </style>
   </head>
   <body>
     <p>This test passes if you see two rotated green rectangles and no red.</p>
-    <div id="container">
+    <div id="containerLinear">
       <div id="coveringRectLinear"></div>
+    </div>
+    <div id="containerSteps">
       <div id="coveringRectSteps"></div>
     </div>
   </body>

--- a/css/css-animations/set-animation-play-state-to-paused-002.html
+++ b/css/css-animations/set-animation-play-state-to-paused-002.html
@@ -9,33 +9,32 @@
                                  when animation-play-state is set to paused">
     <link rel="match" href="set-animation-play-state-to-paused-002-ref.html">
     <style>
-      #container {
+      #containerLinear, #containerSteps {
         position: absolute;
-        left: 0;
-        top: 3em;
+        left: 100px;
+      }
+      #containerLinear {
+        top: 100px;
+      }
+      #containerSteps {
+        top: 200px;
       }
       #lineLinear, #lineSteps  {
         position: absolute;
         background: red;
-        width: 10px;
+        left: -1px;
+        width: 2px;
+        top: -25px;
         height: 50px;
-        left: 95px;
-        transform-origin: 50% 0%;
       }
       #coveringRectLinear, #coveringRectSteps {
         position: absolute;
         background: lightgreen;
-        width: 40px;
-        height: 70px;
-        left: 80px;
-        transform-origin: 50% 10%;
-        transform: translate(36px, 0) rotate(144deg);
-      }
-      #coveringRectLinear, #lineLinear {
-        top: 50px;
-      }
-      #coveringRectSteps, #lineSteps {
-        top: 150px;
+        left: -25px;
+        width: 50px;
+        top: -50px;
+        height: 100px;
+        transform: translate(72px, 0) rotate(144deg);
       }
       #lineLinear {
         animation: rotate 2s linear;
@@ -50,31 +49,34 @@
       @keyframes rotate
       {
         100% {
-          transform: translate(90px, 0) rotate(360deg);
+          transform: translate(180px, 0) rotate(360deg);
         }
       }
     </style>
     <script>
       var start = null;
       var animationDuration = 2000;
-      var coveringRectAngle = 144;
-      var rectFinalAngle = 360;
+      function shift(id)
+      {
+        var transform = window.getComputedStyle(document.getElementById(id)).transform;
+        if (transform === "none")
+          return 0;
+        // See https://drafts.csswg.org/css-transforms-2/#serialization-of-the-computed-value
+        return parseFloat(transform.split(/,\s*/)[4]);
+      }
       function step(timestamp) {
+        // For each line, pause the animation when it is close enough to the middle of the corresponding covering rect.
+        var epsilon = 10;
+        ["Linear", "Steps"].forEach((id) => {
+          if (Math.abs(shift(`coveringRect${id}`) - shift(`line${id}`)) < epsilon)
+            document.getElementById(`line${id}`).classList.add("pause");
+        });
+
+        // Stop the reftest after the time when the animations would have stop.
+        // If pausing failed for some reason, the lines will be visible.
         if (!start) start = timestamp;
-        var progress = timestamp - start;
-
-        // Pause the animations when the squares pass under the covering rect.
-        var targetProgress = animationDuration * coveringRectAngle / rectFinalAngle;
-        if (progress >= targetProgress) {
-          document.getElementById("lineLinear").classList.add("pause");
-          document.getElementById("lineSteps").classList.add("pause");
-        }
-
-        // Wait a bit so that the squares pass the covering rect if the
-        // animation fails to be paused.
-        var delta = 200;
-        if (progress < targetProgress + delta)
-          window.requestAnimationFrame(step)
+        if (timestamp - start < animationDuration)
+          window.requestAnimationFrame(step);
         else
           document.documentElement.classList.remove("reftest-wait");
       }
@@ -85,9 +87,11 @@
   </head>
   <body onload="runTest()">
     <p>This test passes if you see two rotated green rectangles and no red.</p>
-    <div id="container">
+    <div id="containerLinear">
       <div id="lineLinear"></div>
       <div id="coveringRectLinear"></div>
+    </div>
+    <div id="containerSteps">
       <div id="lineSteps"></div>
       <div id="coveringRectSteps"></div>
     </div>


### PR DESCRIPTION
This is a follow-up of https://github.com/web-platform-tests/wpt/pull/11200, trying to make it more robust after review comments on another PR.

        - Increase the height of covering rect to avoid anti-aliasing issue with the red lines.
        - Instead of waiting a delay, use the shift returned by getComputedStyle() to know when animated lines are supposed to be hidden by the green rect.
        - Instead of waiting an additional amount of time to ensure red lines will show up again if they were not paused, just use the animation duration to decide when the screenshot should be taken.
