### PR TITLE
Fix flakiness in test order of worker-dedicated.html

### DIFF
--- a/resources/test/tests/functional/worker-2.js
+++ b/resources/test/tests/functional/worker-2.js
@@ -1,0 +1,10 @@
+importScripts("/resources/testharness.js");
+
+test(
+    function(test) {
+        assert_true(true, "True is true");
+    },
+    "Worker test that completes successfully (from worker-2.js)");
+
+// An explicit done() is required for dedicated and shared web workers.
+done();

--- a/resources/test/tests/functional/worker-dedicated-error.html
+++ b/resources/test/tests/functional/worker-dedicated-error.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>Dedicated Worker Error Test</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<h1>Dedicated Web Worker Error Tests</h1>
+<p>Demonstrates running <tt>testharness</tt> based tests inside a dedicated web worker, with an error.
+<div id="log"></div>
+
+<script>
+test(function(t) {
+        assert_true("Worker" in self, "Browser should support Workers");
+    },
+    "Browser supports Workers");
+
+fetch_tests_from_worker(new Worker("worker-error.js"));
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "status_string": "PASS",
+      "name": "Browser supports Workers",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "FAIL",
+      "name": "Untitled",
+      "properties": {},
+      "message": "Error: This failure is expected."
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>

--- a/resources/test/tests/functional/worker-dedicated.html
+++ b/resources/test/tests/functional/worker-dedicated.html
@@ -8,7 +8,7 @@
 <body>
 <h1>Dedicated Web Worker Tests</h1>
 <p>Demonstrates running <tt>testharness</tt> based tests inside a dedicated web worker.
-<p>The test harness is expected to fail due to an uncaught exception in one worker.</p>
+<p>The test harness is expected to time out.</p>
 <div id="log"></div>
 
 <script>
@@ -19,8 +19,6 @@ test(function(t) {
 
 fetch_tests_from_worker(new Worker("worker.js"));
 
-fetch_tests_from_worker(new Worker("worker-error.js"));
-
 test(function(t) {
         assert_false(false, "False is false");
     },
@@ -29,8 +27,8 @@ test(function(t) {
 <script type="text/json" id="expected">
 {
   "summarized_status": {
-    "status_string": "ERROR",
-    "message": "Error: This failure is expected."
+    "status_string": "TIMEOUT",
+    "message": null
   },
   "summarized_tests": [
     {
@@ -44,12 +42,6 @@ test(function(t) {
       "name": "Test running on main document.",
       "properties": {},
       "message": null
-    },
-    {
-      "status_string": "FAIL",
-      "name": "Untitled",
-      "properties": {},
-      "message": "Error: This failure is expected."
     },
     {
       "status_string": "PASS",

--- a/resources/test/tests/functional/worker-dedicated.html
+++ b/resources/test/tests/functional/worker-dedicated.html
@@ -19,6 +19,8 @@ test(function(t) {
 
 fetch_tests_from_worker(new Worker("worker.js"));
 
+fetch_tests_from_worker(new Worker("worker-2.js"));
+
 test(function(t) {
         assert_false(false, "False is false");
     },
@@ -52,6 +54,12 @@ test(function(t) {
     {
       "status_string": "PASS",
       "name": "Worker test that completes successfully",
+      "properties": {},
+      "message": null
+    },
+    {
+      "status_string": "PASS",
+      "name": "Worker test that completes successfully (from worker-2.js)",
       "properties": {},
       "message": null
     },


### PR DESCRIPTION
(An alternative fix may be to make `fetch_tests_from_worker` serialize, like `promise_test`.)