### PR TITLE
[idlharness.js] Test exposure set of partial interfaces

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -695,18 +695,15 @@ function exposed_in(globals) {
     }
     if ('DedicatedWorkerGlobalScope' in self &&
         self instanceof DedicatedWorkerGlobalScope) {
-        return globals.has("Worker") ||
-               globals.has("DedicatedWorker");
+        return globals.has("DedicatedWorker");
     }
     if ('SharedWorkerGlobalScope' in self &&
         self instanceof SharedWorkerGlobalScope) {
-        return globals.has("Worker") ||
-               globals.has("SharedWorker");
+        return globals.has("SharedWorker");
     }
     if ('ServiceWorkerGlobalScope' in self &&
         self instanceof ServiceWorkerGlobalScope) {
-        return globals.has("Worker") ||
-               globals.has("ServiceWorker");
+        return globals.has("ServiceWorker");
     }
     throw new IdlHarnessError("Unexpected global object");
 }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -668,36 +668,45 @@ function exposure_set(object, default_set) {
             `Multiple 'Exposed' extended attributes on ${object.name}`);
     }
 
-    if (exposed.length === 0) {
-        return default_set;
+    let result = default_set;
+    if (result && !(result instanceof Set)) {
+        result = new Set(result);
     }
-
-    var set = exposed[0].rhs.value;
-    // Could be a list or a string.
-    if (typeof set == "string") {
-        set = [ set ];
+    if (exposed.length !== 0) {
+        var set = exposed[0].rhs.value;
+        // Could be a list or a string.
+        if (typeof set == "string") {
+            set = [ set ];
+        }
+        result = new Set(set);
     }
-    return set;
+    if (result.has("Worker")) {
+        result.delete("Worker");
+        result.add("DedicatedWorker");
+        result.add("ServiceWorker");
+        result.add("SharedWorker");
+    }
+    return result;
 }
 
 function exposed_in(globals) {
     if ('document' in self) {
-        return globals.indexOf("Window") >= 0;
+        return globals.has("Window");
     }
     if ('DedicatedWorkerGlobalScope' in self &&
         self instanceof DedicatedWorkerGlobalScope) {
-        return globals.indexOf("Worker") >= 0 ||
-               globals.indexOf("DedicatedWorker") >= 0;
+        return globals.has("Worker") ||
+               globals.has("DedicatedWorker");
     }
     if ('SharedWorkerGlobalScope' in self &&
         self instanceof SharedWorkerGlobalScope) {
-        return globals.indexOf("Worker") >= 0 ||
-               globals.indexOf("SharedWorker") >= 0;
+        return globals.has("Worker") ||
+               globals.has("SharedWorker");
     }
     if ('ServiceWorkerGlobalScope' in self &&
         self instanceof ServiceWorkerGlobalScope) {
-        return globals.indexOf("Worker") >= 0 ||
-               globals.indexOf("ServiceWorker") >= 0;
+        return globals.has("Worker") ||
+               globals.has("ServiceWorker");
     }
     throw new IdlHarnessError("Unexpected global object");
 }
@@ -737,27 +746,7 @@ IdlArray.prototype.test = function()
 
     // First merge in all the partial interfaces and implements statements we
     // encountered.
-    this.partials.forEach(function(parsed_idl)
-    {
-        if (!(parsed_idl.name in this.members)
-            || !(this.members[parsed_idl.name] instanceof IdlInterface
-                 || this.members[parsed_idl.name] instanceof IdlDictionary))
-        {
-            throw new IdlHarnessError(`Partial ${parsed_idl.type} ${parsed_idl.name} with no original ${parsed_idl.type}`);
-        }
-        if (parsed_idl.extAttrs)
-        {
-            parsed_idl.extAttrs.forEach(function(extAttr)
-            {
-                this.members[parsed_idl.name].extAttrs.push(extAttr);
-            }.bind(this));
-        }
-        parsed_idl.members.forEach(function(member)
-        {
-            this.members[parsed_idl.name].members.push(new IdlInterfaceMember(member));
-        }.bind(this));
-    }.bind(this));
-    this.partials = [];
+    this.collapse_partial_interfaces();
 
     for (var lhs in this["implements"])
     {
@@ -832,6 +821,72 @@ IdlArray.prototype.test = function()
         }
     }
 };
+
+//@}
+IdlArray.prototype.collapse_partial_interfaces = function(value, type)
+//@{
+{
+    const testedPartials = new Map();
+    this.partials.forEach(function(parsed_idl)
+    {
+        // Ensure unique test name in case of multiple partials.
+        let partialTestName = parsed_idl.name;
+        let partialTestCount = 1;
+        if (testedPartials.has(parsed_idl.name)) {
+            partialTestCount += testedPartials.get(parsed_idl.name);
+            partialTestName = `${partialTestName} (${partialTestCount})`;
+        }
+        testedPartials.set(parsed_idl.name, partialTestCount);
+
+        test(function () {
+            if (!(parsed_idl.name in this.members)
+                || !(this.members[parsed_idl.name] instanceof IdlInterface
+                     || this.members[parsed_idl.name] instanceof IdlDictionary))
+            {
+                if (!parsed_idl.untested) {
+                    throw new IdlHarnessError(`Found partial ${parsed_idl.type} ${parsed_idl.name}, but no original ${parsed_idl.type} ${parsed_idl.name}`);
+                }
+                return;
+            }
+            if (parsed_idl.extAttrs)
+            {
+                // Special-case "Exposed". Must be a subset of original interface's exposure.
+                // Exposed on a partial is the equivalent of having the same Exposed on all nested members.
+                const exposureAttr = parsed_idl.extAttrs.find(a => a.name === "Exposed");
+                if (exposureAttr) {
+                    if (!parsed_idl.untested) {
+                        test(function () {
+                            const partialExposure = exposure_set(parsed_idl);
+                            const memberExposure = exposure_set(this.members[parsed_idl.name]);
+                            partialExposure.forEach(name => {
+                                if (!memberExposure || !memberExposure.has(name)) {
+                                    throw new IdlHarnessError(`Partial ${parsed_idl.name} interface is exposed to '${name}', the original interface is not.`);
+                                }
+                            });
+                        }.bind(this), `Partial interface ${partialTestName}: valid exposure set`);
+                    }
+                    parsed_idl.members.forEach(function (member) {
+                        member.extAttrs.push(exposureAttr);
+                    }.bind(this));
+                }
+
+                parsed_idl.extAttrs.forEach(function(extAttr)
+                {
+                    // "Exposed" already handled above.
+                    if (extAttr.name === "Exposed") {
+                        return;
+                    }
+                    this.members[parsed_idl.name].extAttrs.push(extAttr);
+                }.bind(this));
+            }
+            parsed_idl.members.forEach(function(member)
+            {
+                this.members[parsed_idl.name].members.push(new IdlInterfaceMember(member));
+            }.bind(this));
+        }.bind(this), `Partial interface ${partialTestName}`);
+    }.bind(this));
+    this.partials = [];
+}
 
 //@}
 IdlArray.prototype.assert_type_is = function(value, type)
@@ -1529,7 +1584,7 @@ IdlInterface.prototype.test_self = function()
             if (this.is_callback()) {
                 throw new IdlHarnessError("Invalid IDL: LegacyWindowAlias extended attribute on non-interface " + this.name);
             }
-            if (this.exposureSet.indexOf("Window") === -1) {
+            if (!this.exposureSet.has("Window")) {
                 throw new IdlHarnessError("Invalid IDL: LegacyWindowAlias extended attribute on " + this.name + " which is not exposed in Window");
             }
             // TODO: when testing of [NoInterfaceObject] interfaces is supported,

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -681,6 +681,7 @@ function exposure_set(object, default_set) {
         result = new Set(set);
     }
     if (result && result.has("Worker")) {
+        result.delete("Worker");
         result.add("DedicatedWorker");
         result.add("ServiceWorker");
         result.add("SharedWorker");

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -662,8 +662,8 @@ IdlArray.prototype.is_json_type = function(type)
 };
 
 function exposure_set(object, default_set) {
-    var exposed = object.extAttrs.filter(function(a) { return a.name == "Exposed" });
-    if (exposed.length > 1) {
+    var exposed = object.extAttrs && object.extAttrs.filter(a => a.name === "Exposed");
+    if (exposed && exposed.length > 1) {
         throw new IdlHarnessError(
             `Multiple 'Exposed' extended attributes on ${object.name}`);
     }
@@ -672,7 +672,7 @@ function exposure_set(object, default_set) {
     if (result && !(result instanceof Set)) {
         result = new Set(result);
     }
-    if (exposed.length !== 0) {
+    if (exposed && exposed.length) {
         var set = exposed[0].rhs.value;
         // Could be a list or a string.
         if (typeof set == "string") {
@@ -745,7 +745,7 @@ IdlArray.prototype.test = function()
 
     // First merge in all the partial interfaces and implements statements we
     // encountered.
-    this.collapse_partial_interfaces();
+    this.collapse_partials();
 
     for (var lhs in this["implements"])
     {
@@ -822,7 +822,7 @@ IdlArray.prototype.test = function()
 };
 
 //@}
-IdlArray.prototype.collapse_partial_interfaces = function(value, type)
+IdlArray.prototype.collapse_partials = function()
 //@{
 {
     const testedPartials = new Map();
@@ -859,10 +859,11 @@ IdlArray.prototype.collapse_partial_interfaces = function(value, type)
                             const memberExposure = exposure_set(this.members[parsed_idl.name]);
                             partialExposure.forEach(name => {
                                 if (!memberExposure || !memberExposure.has(name)) {
-                                    throw new IdlHarnessError(`Partial ${parsed_idl.name} interface is exposed to '${name}', the original interface is not.`);
+                                    throw new IdlHarnessError(
+                                        `Partial ${parsed_idl.name} ${parsed_idl.type} is exposed to '${name}', the original ${parsed_idl.type} is not.`);
                                 }
                             });
-                        }.bind(this), `Partial interface ${partialTestName}: valid exposure set`);
+                        }.bind(this), `Partial ${parsed_idl.type} ${partialTestName}: valid exposure set`);
                     }
                     parsed_idl.members.forEach(function (member) {
                         member.extAttrs.push(exposureAttr);
@@ -882,7 +883,7 @@ IdlArray.prototype.collapse_partial_interfaces = function(value, type)
             {
                 this.members[parsed_idl.name].members.push(new IdlInterfaceMember(member));
             }.bind(this));
-        }.bind(this), `Partial interface ${partialTestName}`);
+        }.bind(this), `Partial ${parsed_idl.type} ${partialTestName}`);
     }.bind(this));
     this.partials = [];
 }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -828,20 +828,20 @@ IdlArray.prototype.collapse_partials = function()
     const testedPartials = new Map();
     this.partials.forEach(function(parsed_idl)
     {
-        // Ensure unique test name in case of multiple partials.
-        let partialTestName = parsed_idl.name;
-        let partialTestCount = 1;
-        if (testedPartials.has(parsed_idl.name)) {
-            partialTestCount += testedPartials.get(parsed_idl.name);
-            partialTestName = `${partialTestName} (${partialTestCount})`;
-        }
-        testedPartials.set(parsed_idl.name, partialTestCount);
-
         const originalExists = parsed_idl.name in this.members
             && (this.members[parsed_idl.name] instanceof IdlInterface
                 || this.members[parsed_idl.name] instanceof IdlDictionary);
 
+        let partialTestName = parsed_idl.name;
         if (!parsed_idl.untested) {
+            // Ensure unique test name in case of multiple partials.
+            let partialTestCount = 1;
+            if (testedPartials.has(parsed_idl.name)) {
+                partialTestCount += testedPartials.get(parsed_idl.name);
+                partialTestName = `${partialTestName}[${partialTestCount}]`;
+            }
+            testedPartials.set(parsed_idl.name, partialTestCount);
+            
             test(function () {
                 assert_true(originalExists, `Original ${parsed_idl.type} should be defined`);
             }.bind(this), `Partial ${parsed_idl.type} ${partialTestName}: original ${parsed_idl.type} defined`);

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -841,7 +841,7 @@ IdlArray.prototype.collapse_partials = function()
                 partialTestName = `${partialTestName}[${partialTestCount}]`;
             }
             testedPartials.set(parsed_idl.name, partialTestCount);
-            
+
             test(function () {
                 assert_true(originalExists, `Original ${parsed_idl.type} should be defined`);
             }.bind(this), `Partial ${parsed_idl.type} ${partialTestName}: original ${parsed_idl.type} defined`);

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -668,7 +668,7 @@ function exposure_set(object, default_set) {
             `Multiple 'Exposed' extended attributes on ${object.name}`);
     }
 
-    let result = default_set;
+    let result = default_set || ["Window"];
     if (result && !(result instanceof Set)) {
         result = new Set(result);
     }
@@ -680,8 +680,7 @@ function exposure_set(object, default_set) {
         }
         result = new Set(set);
     }
-    if (result.has("Worker")) {
-        result.delete("Worker");
+    if (result && result.has("Worker")) {
         result.add("DedicatedWorker");
         result.add("ServiceWorker");
         result.add("SharedWorker");
@@ -803,7 +802,7 @@ IdlArray.prototype.test = function()
             return;
         }
 
-        var globals = exposure_set(member, ["Window"]);
+        var globals = exposure_set(member);
         member.exposed = exposed_in(globals);
         member.exposureSet = globals;
     }.bind(this));

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -855,6 +855,8 @@ IdlArray.prototype.collapse_partials = function()
         {
             // Special-case "Exposed". Must be a subset of original interface's exposure.
             // Exposed on a partial is the equivalent of having the same Exposed on all nested members.
+            // See https://github.com/heycam/webidl/issues/154 for discrepency between Exposed and
+            // other extended attributes on partial interfaces.
             const exposureAttr = parsed_idl.extAttrs.find(a => a.name === "Exposed");
             if (exposureAttr) {
                 if (!parsed_idl.untested) {

--- a/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -1,0 +1,44 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>idlharness: Partial dictionary</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+</head>
+
+<body>
+  <p>Verify the series of sub-tests that are executed for "partial" dictionary objects.</p>
+  <script>
+    "use strict";
+
+    // No original existence
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls('partial dictionary A {};');
+      idlArray.test();
+    })();
+  </script>
+  <script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "name": "Partial dictionary A",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "Found partial dictionary A, but no original dictionary A"
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+
+</html>

--- a/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -21,6 +21,17 @@
       idlArray.add_idls('partial dictionary A {};');
       idlArray.test();
     })();
+
+    // Multiple partials existence
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_untested_idls('partial dictionary B {};');
+      idlArray.add_idls('partial dictionary B {};');
+      idlArray.add_idls('partial dictionary B {};');
+      idlArray.add_idls('partial dictionary B {};');
+      idlArray.add_idls('dictionary B {};');
+      idlArray.test();
+    })();
   </script>
   <script type="text/json" id="expected">
 {
@@ -34,6 +45,24 @@
       "status_string": "FAIL",
       "properties": {},
       "message": "assert_true: Original dictionary should be defined expected true got false"
+    },
+    {
+      "name": "Partial dictionary B: original dictionary defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial dictionary B[2]: original dictionary defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial dictionary B[3]: original dictionary defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
     }
   ],
   "type": "complete"

--- a/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -30,10 +30,10 @@
   },
   "summarized_tests": [
     {
-      "name": "Partial dictionary A",
+      "name": "Partial dictionary A: original dictionary defined",
       "status_string": "FAIL",
       "properties": {},
-      "message": "Found partial dictionary A, but no original dictionary A"
+      "message": "assert_true: Original dictionary should be defined expected true got false"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -27,10 +27,16 @@
       const idlArray = new IdlArray();
       idlArray.add_untested_idls(`
         [Exposed=(Worker)]
-        interface B {};`);
+        interface B {};
+
+        [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
+        interface C {};`);
       idlArray.add_idls(`
         [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
-        partial interface B {};`);
+        partial interface B {};
+
+        [Exposed=(Worker)]
+        partial interface C {};`);
       idlArray.collapse_partials();
     })();
 
@@ -39,10 +45,10 @@
       const idlArray = new IdlArray();
       idlArray.add_untested_idls(`
         [Exposed=(Window, ServiceWorker)]
-        interface C {};`);
+        interface D {};`);
       idlArray.add_idls(`
         [Exposed=(DedicatedWorker)]
-        partial interface C {};`);
+        partial interface D {};`);
       idlArray.collapse_partials();
     })();
   </script>
@@ -79,9 +85,21 @@
     },
     {
       "name": "Partial interface C: valid exposure set",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial interface D: original interface defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial interface D: valid exposure set",
       "status_string": "FAIL",
       "properties": {},
-      "message": "Partial C interface is exposed to 'DedicatedWorker', the original interface is not."
+      "message": "Partial D interface is exposed to 'DedicatedWorker', the original interface is not."
     }
   ],
   "type": "complete"

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -54,13 +54,13 @@
   },
   "summarized_tests": [
     {
-      "name": "Partial interface A",
+      "name": "Partial interface A: original interface defined",
       "status_string": "FAIL",
       "properties": {},
-      "message": "Found partial interface A, but no original interface A"
+      "message": "assert_true: Original interface should be defined expected true got false"
     },
     {
-      "name": "Partial interface B",
+      "name": "Partial interface B: original interface defined",
       "status_string": "PASS",
       "properties": {},
       "message": null
@@ -72,7 +72,7 @@
       "message": null
     },
     {
-      "name": "Partial interface C",
+      "name": "Partial interface C: original interface defined",
       "status_string": "PASS",
       "properties": {},
       "message": null

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -1,0 +1,92 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>idlharness: Primary interface</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+</head>
+
+<body>
+  <p>Verify the series of sub-tests that are executed for "partial" interface objects.</p>
+  <script>
+    "use strict";
+
+    // No original existence
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls('partial interface A {};');
+      idlArray.test();
+    })();
+
+    // Valid exposure (Note: Worker -> {Shared,Dedicated,Service}Worker)
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_untested_idls(`
+        [Exposed=(Worker)]
+        interface B {};`);
+      idlArray.add_idls(`
+        [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
+        partial interface B {};`);
+      idlArray.collapse_partial_interfaces();
+    })();
+
+    // Invalid exposure
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_untested_idls(`
+        [Exposed=(Window, ServiceWorker)]
+        interface C {};`);
+      idlArray.add_idls(`
+        [Exposed=(DedicatedWorker)]
+        partial interface C {};`);
+      idlArray.collapse_partial_interfaces();
+    })();
+  </script>
+  <script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "name": "Partial interface A",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "Found partial interface A, but no original interface A"
+    },
+    {
+      "name": "Partial interface B",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial interface B: valid exposure set",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial interface C",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial interface C: valid exposure set",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "Partial C interface is exposed to 'DedicatedWorker', the original interface is not."
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+
+</html>

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>idlharness: Primary interface</title>
+  <title>idlharness: Partail interface</title>
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>
@@ -31,7 +31,7 @@
       idlArray.add_idls(`
         [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
         partial interface B {};`);
-      idlArray.collapse_partial_interfaces();
+      idlArray.collapse_partials();
     })();
 
     // Invalid exposure
@@ -43,7 +43,7 @@
       idlArray.add_idls(`
         [Exposed=(DedicatedWorker)]
         partial interface C {};`);
-      idlArray.collapse_partial_interfaces();
+      idlArray.collapse_partials();
     })();
   </script>
   <script type="text/json" id="expected">

--- a/resources/test/tests/unit/IdlDictionary/test_partial_dictionary.html
+++ b/resources/test/tests/unit/IdlDictionary/test_partial_dictionary.html
@@ -33,12 +33,6 @@ test(() => {
   let members = idlArray.members["A"].members.map(m => m.name);
   assert_array_equals(members, ["B", "C"], 'A should contain B, C');
 }, 'Partial dictionaries');
-
-test(() => {
-  let idlArray = new IdlArray();
-  idlArray.add_idls('partial dictionary D {};');
-  idlArray.assert_throws('Partial dictionary D with no original dictionary', i => i.test());
-}, 'Partial-only dictionary definition')
 </script>
 
 </body>

--- a/resources/test/tests/unit/basic.html
+++ b/resources/test/tests/unit/basic.html
@@ -29,28 +29,15 @@
     test(function() {
         assert_equals(typeof WebIDL2.parse("interface Foo {};"), "object");
     }, 'WebIDL2 parse method should produce an AST for correct WebIDL');
-    for (let type of ['dictionary', 'interface']) {
-        test(function() {
+    test(function () {
+        try {
             let i = new IdlArray();
-            i.add_untested_idls(`partial ${type} A {};`);
-            i.assert_throws(new IdlHarnessError(`Partial ${type} A with no original ${type}`), i => i.test());
-        }, `assert_throws should handle ${type} IdlHarnessError`);
-        test(function() {
-            let i = new IdlArray();
-            i.add_untested_idls(`partial ${type} A {};`);
-            i.assert_throws(`Partial ${type} A with no original ${type}`, i => i.test());
-        }, `assert_throws should handle ${type} IdlHarnessError from message`);
-        test(function () {
-            try {
-                let i = new IdlArray();
-                i.add_untested_idls(`${type} A {};`);
-                i.assert_throws(`Partial ${type} A with no original ${type}`, i => i.test());
-            } catch (e) {
-                assert_true(e instanceof IdlHarnessError);
-            }
-        }, `assert_throws should throw if no ${type} IdlHarnessError thrown`);
-    }
+            i.add_untested_idls(`interface C {};`);
+            i.assert_throws('Anything', i => i.test());
+        } catch (e) {
+            assert_true(e instanceof IdlHarnessError);
+        }
+    }, `assert_throws should throw if no IdlHarnessError thrown`);
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
Resolves https://github.com/web-platform-tests/wpt/issues/10338
Equivalent Chromium CL: https://chromium-review.googlesource.com/c/chromium/src/+/1091210

- Converts the `exposure_set` return value to be a `Set`
- Extracts the 'collapse `partial interface` definitions into original interfaces' code into a method `collapse_partial_interfaces`
- Adds a new `test` for each partial interface with `Exposed`, asserting that its values are a subset of the original interfaces
- Wraps each individual 'partial interface collapse' loop in a test, so that if it's invalid, the remaining setup + testing of the `IdlArray` continues.