### PR TITLE
Add test for WebSocket HTTP Authentication

### DIFF
--- a/websockets/basic-auth.any.js
+++ b/websockets/basic-auth.any.js
@@ -1,0 +1,18 @@
+// META: script=websocket.sub.js
+// META: global=sharedworker,serviceworker
+
+async_test(t => {
+  const isSecure = new URL(location.href).scheme === 'https';
+  const scheme = isSecure ? 'wss' : 'ws';
+  const port = isSecure ? __SECURE__PORT : __PORT;
+  const url = scheme + '://' + 'foo:bar@' + __SERVER__NAME + ':' + port + '/basic_auth';
+  const ws = new WebSocket(url);
+  ws.onopen = () => {
+    ws.onclose = ws.onerror = null;
+    ws.close();
+    t.done();
+  };
+  ws.onerror = ws.onclose = t.unreached_func('open should succeed');
+}, 'HTTP basic authentication should work with WebSockets');
+
+done();

--- a/websockets/handlers/basic_auth_wsh.py
+++ b/websockets/handlers/basic_auth_wsh.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+"""A WebSocket handler that enforces basic HTTP authentication. Username is
+'foo' and password is 'bar'."""
+
+
+from mod_pywebsocket.handshake import AbortedByUserException
+
+
+def web_socket_do_extra_handshake(request):
+    authorization = request.headers_in.get('Authorization')
+    if authorization is None or authorization != 'Basic Zm9vOmJhcg==':
+        request.connection.write(
+            'HTTP/1.1 401 Unauthorized\x0d\x0a'
+            'Content-Length: 0\x0d\x0a'
+            'WWW-Authenticate: Basic realm="camelot"\x0d\x0a'
+            '\x0d\x0a')
+        raise AbortedByUserException('Abort the connection')
+
+
+def web_socket_transfer_data(request):
+    pass


### PR DESCRIPTION
User-agents should support HTTP authentication for WebSockets. Add a
test of basic authentication to verify this.

See https://github.com/whatwg/fetch/issues/565.