### PR TITLE
URL: correct non-special URL's origin

### DIFF
--- a/url/resources/urltestdata.json
+++ b/url/resources/urltestdata.json
@@ -4035,7 +4035,7 @@
     "input": "notspecial://host/?'",
     "base": "about:blank",
     "href": "notspecial://host/?'",
-    "origin": "notspecial://host",
+    "origin": "null",
     "protocol": "notspecial:",
     "username": "",
     "password": "",


### PR DESCRIPTION
Fixup for 0e084a927078d434bcc1952a2ab99fb541f2c25d.