### PR TITLE
Clean up FileAPI idlharness tests

### DIFF
--- a/FileAPI/idlharness-manual.html
+++ b/FileAPI/idlharness-manual.html
@@ -27,117 +27,6 @@
 
     <div id="log"></div>
 
-    <pre id="untested_idl" style="display: none">
-      interface ArrayBuffer {
-      };
-
-      interface ArrayBufferView {
-      };
-
-      interface URL {
-      };
-
-      interface EventTarget {
-      };
-
-      interface Event {
-      };
-
-      [TreatNonCallableAsNull]
-      callback EventHandlerNonNull = any (Event event);
-      typedef EventHandlerNonNull? EventHandler;
-    </pre>
-
-    <pre id="idl" style="display: none">
-[Constructor,
- Constructor(sequence<(ArrayBuffer or ArrayBufferView or Blob or DOMString)> blobParts, optional BlobPropertyBag options), Exposed=Window,Worker]
-interface Blob {
-
-  readonly attribute unsigned long long size;
-  readonly attribute DOMString type;
-
-  //slice Blob into byte-ranged chunks
-
-  Blob slice([Clamp] optional long long start,
-             [Clamp] optional long long end,
-             optional DOMString contentType);
-};
-
-dictionary BlobPropertyBag {
-  DOMString type = "";
-};
-
-[Constructor(sequence<(Blob or DOMString or ArrayBufferView or ArrayBuffer)> fileBits,
-[EnsureUTF16] DOMString fileName, optional FilePropertyBag options), Exposed=Window,Worker]
-interface File : Blob {
-
-  readonly attribute DOMString name;
-  readonly attribute long long lastModified;
-
-};
-
-dictionary FilePropertyBag {
-
-  DOMString type = "";
-  long long lastModified;
-
-};
-
-[Exposed=Window,Worker] interface FileList {
-  getter File? item(unsigned long index);
-  readonly attribute unsigned long length;
-};
-
-[Constructor, Exposed=Window,Worker]
-interface FileReader: EventTarget {
-
-  // async read methods
-  void readAsArrayBuffer(Blob blob);
-  void readAsText(Blob blob, optional DOMString label);
-  void readAsDataURL(Blob blob);
-
-  void abort();
-
-  // states
-  const unsigned short EMPTY = 0;
-  const unsigned short LOADING = 1;
-  const unsigned short DONE = 2;
-
-  readonly attribute unsigned short readyState;
-
-  // File or Blob data
-  readonly attribute (DOMString or ArrayBuffer)? result;
-
-  readonly attribute DOMException? error;
-
-  // event handler attributes
-  attribute EventHandler onloadstart;
-  attribute EventHandler onprogress;
-  attribute EventHandler onload;
-  attribute EventHandler onabort;
-  attribute EventHandler onerror;
-  attribute EventHandler onloadend;
-
-};
-
-[Constructor, Exposed=Worker]
-interface FileReaderSync {
-
-  // Synchronously return strings
-
-  ArrayBuffer readAsArrayBuffer(Blob blob);
-  DOMString readAsText(Blob blob, optional DOMString label);
-  DOMString readAsDataURL(Blob blob);
-};
-
-partial interface URL {
-
-  static DOMString createObjectURL(Blob blob);
-  static void revokeObjectURL(DOMString url);
-
-};
-    </pre>
-
     <script>
       var fileInput;
 
@@ -145,10 +34,18 @@ partial interface URL {
         fileInput = document.querySelector("#fileChooser")
       }, {explicit_done: true, explicit_timeout: true});
 
-      on_event(fileInput, "change", function(evt) {
-        var idl_array = new IdlArray();
-        idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
-        idl_array.add_idls(document.getElementById("idl").textContent);
+      on_event(fileInput, "change", async function(evt) {
+        const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
+        const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+        const html = await fetch('/interfaces/html.idl').then(r => r.text());
+        const url = await fetch('/interfaces/url.idl').then(r => r.text());
+
+        const idl_array = new IdlArray();
+        idl_array.add_idls(idl);
+        idl_array.add_dependency_idls(url);
+        idl_array.add_dependency_idls(html);
+        idl_array.add_dependency_idls(dom);
+        idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
 
         idl_array.add_objects({
           FileList: [fileInput.files],

--- a/FileAPI/idlharness.html
+++ b/FileAPI/idlharness.html
@@ -20,37 +20,30 @@
     </form>
 
     <script>
-var file_input;
-setup(function() {
-    var idl_array = new IdlArray();
+      'use strict';
 
-    var request = new XMLHttpRequest();
-    request.open("GET", "/interfaces/FileAPI.idl");
-    request.send();
-    request.onload = function() {
-        var idls = request.responseText;
+      promise_test(async () => {
+        const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
+        const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+        const html = await fetch('/interfaces/html.idl').then(r => r.text());
+        const url = await fetch('/interfaces/url.idl').then(r => r.text());
 
+        const idl_array = new IdlArray();
+        idl_array.add_idls(idl);
+        idl_array.add_dependency_idls(url);
+        idl_array.add_dependency_idls(html);
+        idl_array.add_dependency_idls(dom);
         idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
-        idl_array.add_untested_idls("interface URL {};");
-        idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface EventTarget {};");
-        idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface Event {};");
-        idl_array.add_untested_idls("[TreatNonCallableAsNull] callback EventHandlerNonNull = any (Event event);");
-        idl_array.add_untested_idls("typedef EventHandlerNonNull? EventHandler;");
 
-        idl_array.add_idls(idls);
-
-        file_input = document.querySelector("#fileChooser");
         idl_array.add_objects({
-            Blob: ['new Blob(["TEST"])'],
-            File: ['new File(["myFileBits"], "myFileName")'],
-            FileList: ['file_input.files'],
-            FileReader: ['new FileReader()']
+          Blob: ['new Blob(["TEST"])'],
+          File: ['new File(["myFileBits"], "myFileName")'],
+          FileList: [document.querySelector("#fileChooser")],
+          FileReader: ['new FileReader()']
         });
 
         idl_array.test();
-        done();
-  };
-}, {explicit_done: true});
+      }, 'Test FileAPI IDL implementation');
     </script>
 
   </body>

--- a/FileAPI/idlharness.html
+++ b/FileAPI/idlharness.html
@@ -38,7 +38,7 @@
         idl_array.add_objects({
           Blob: ['new Blob(["TEST"])'],
           File: ['new File(["myFileBits"], "myFileName")'],
-          FileList: [document.querySelector("#fileChooser")],
+          FileList: ['document.querySelector("#fileChooser").files'],
           FileReader: ['new FileReader()']
         });
 

--- a/FileAPI/idlharness.worker.js
+++ b/FileAPI/idlharness.worker.js
@@ -4,12 +4,12 @@ importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
 'use strict';
 
 promise_test(async () => {
-const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
-const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
-const html = await fetch('/interfaces/html.idl').then(r => r.text());
-const url = await fetch('/interfaces/url.idl').then(r => r.text());
+  const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
+  const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+  const html = await fetch('/interfaces/html.idl').then(r => r.text());
+  const url = await fetch('/interfaces/url.idl').then(r => r.text());
 
-const idl_array = new IdlArray();
+  const idl_array = new IdlArray();
   idl_array.add_idls(idl);
   idl_array.add_dependency_idls(url);
   idl_array.add_dependency_idls(html);

--- a/FileAPI/idlharness.worker.js
+++ b/FileAPI/idlharness.worker.js
@@ -1,8 +1,6 @@
 importScripts("/resources/testharness.js");
 importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
 
-'use strict';
-
 promise_test(async () => {
   const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
   const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
@@ -11,9 +9,9 @@ promise_test(async () => {
 
   const idl_array = new IdlArray();
   idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(url);
-  idl_array.add_dependency_idls(html);
   idl_array.add_dependency_idls(dom);
+  idl_array.add_dependency_idls(html);
+  idl_array.add_dependency_idls(url);
   idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
   idl_array.add_objects({
     Blob: ['new Blob(["TEST"])'],
@@ -24,3 +22,4 @@ promise_test(async () => {
 
   idl_array.test();
 }, 'Test FileAPI IDL implementation');
+done();

--- a/FileAPI/idlharness.worker.js
+++ b/FileAPI/idlharness.worker.js
@@ -1,31 +1,26 @@
 importScripts("/resources/testharness.js");
 importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
 
-var request = new XMLHttpRequest();
-request.open("GET", "/interfaces/FileAPI.idl");
-request.send();
-request.onload = function() {
-    var idl_array = new IdlArray();
-    var idls = request.responseText;
+'use strict';
 
-    idl_array.add_untested_idls("[Global] interface Window { };");
+promise_test(async () => {
+const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
+const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+const html = await fetch('/interfaces/html.idl').then(r => r.text());
+const url = await fetch('/interfaces/url.idl').then(r => r.text());
 
-    idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
-    idl_array.add_untested_idls("interface URL {};");
-    idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface EventTarget {};");
-    idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface Event {};");
-    idl_array.add_untested_idls("[TreatNonCallableAsNull] callback EventHandlerNonNull = any (Event event);");
-    idl_array.add_untested_idls("typedef EventHandlerNonNull? EventHandler;");
+const idl_array = new IdlArray();
+  idl_array.add_idls(idl);
+  idl_array.add_dependency_idls(url);
+  idl_array.add_dependency_idls(html);
+  idl_array.add_dependency_idls(dom);
+  idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
+  idl_array.add_objects({
+    Blob: ['new Blob(["TEST"])'],
+    File: ['new File(["myFileBits"], "myFileName")'],
+    FileReader: ['new FileReader()'],
+    FileReaderSync: ['new FileReaderSync()']
+  });
 
-    idl_array.add_idls(idls);
-
-    idl_array.add_objects({
-        Blob: ['new Blob(["TEST"])'],
-        File: ['new File(["myFileBits"], "myFileName")'],
-        FileReader: ['new FileReader()'],
-        FileReaderSync: ['new FileReaderSync()']
-    });
-
-    idl_array.test();
-    done();
-};
+  idl_array.test();
+}, 'Test FileAPI IDL implementation');


### PR DESCRIPTION
After fixing https://github.com/web-platform-tests/wpt/issues/10338, we can leverage `add_dependency_idls` to import the 'real' untested idl from sources cleanly.