### PR TITLE
[idlharness.js] Clean up media-capabilities idl test

### DIFF
--- a/media-capabilities/idlharness.any.js
+++ b/media-capabilities/idlharness.any.js
@@ -14,10 +14,10 @@ promise_test(async () => {
   idl_array.add_idls(idl);
   idl_array.add_dependency_idls(html);
   idl_array.add_dependency_idls(cssomView);
-  
+
   idl_array.add_objects({
     Navigator: ['navigator']
   });
-  
+
   idl_array.test();
 }, 'Test IDL implementation of Media Capabilities');

--- a/media-capabilities/idlharness.any.js
+++ b/media-capabilities/idlharness.any.js
@@ -1,17 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>Media Capabilities IDL tests</title>
-<link rel="help" href="https://wicg.github.io/media-capabilities/"/>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="/resources/WebIDLParser.js"></script>
-<script src="/resources/idlharness.js"></script>
-</head>
-<body>
-<h1>Media Session IDL tests</h1>
-<script>
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://wicg.github.io/media-capabilities/
+
 'use strict';
 
 promise_test(async () => {
@@ -30,7 +21,3 @@ promise_test(async () => {
   
   idl_array.test();
 }, 'Test IDL implementation of Media Capabilities');
-</script>
-<div id="log"></div>
-</body>
-</html>

--- a/media-capabilities/idlharness.html
+++ b/media-capabilities/idlharness.html
@@ -12,25 +12,24 @@
 <body>
 <h1>Media Session IDL tests</h1>
 <script>
-"use strict";
-function doTest([media_capabilities]) {
-    var idl_array = new IdlArray();
-    idl_array.add_untested_idls('interface Navigator {};');
-    idl_array.add_untested_idls('interface WorkerNavigator {};');
-    idl_array.add_untested_idls('interface Screen {};');
-    idl_array.add_idls(media_capabilities);
-    idl_array.add_objects({
-      Navigator: ["navigator"]
-    });
-    idl_array.test();
-}
-function fetchText(url) {
-    return fetch(url).then((response) => response.text());
-}
-promise_test(() => {
-    return Promise.all(["/interfaces/media-capabilities.idl"].map(fetchText))
-                  .then(doTest);
-}, "Test IDL implementation of Media Capabilities");
+'use strict';
+
+promise_test(async () => {
+  const idl = await fetch('/interfaces/media-capabilities.idl').then(r => r.text());
+  const html = await fetch('/interfaces/html.idl').then(r => r.text());
+  const cssomView = await fetch('/interfaces/cssom-view.idl').then(r => r.text());
+
+  var idl_array = new IdlArray();
+  idl_array.add_idls(idl);
+  idl_array.add_dependency_idls(html);
+  idl_array.add_dependency_idls(cssomView);
+  
+  idl_array.add_objects({
+    Navigator: ['navigator']
+  });
+  
+  idl_array.test();
+}, 'Test IDL implementation of Media Capabilities');
 </script>
 <div id="log"></div>
 </body>


### PR DESCRIPTION
Follow up for https://github.com/web-platform-tests/wpt/pull/11255 which was unable to use `add_dependency_idls` because of #10338.