### PR TITLE
Fix #11454: Set --verify-log-full to False for ci/check_stability.py

### DIFF
--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -270,7 +270,7 @@ def run(venv, wpt_args, **kwargs):
         wpt_kwargs["install"] = wpt_kwargs["product"].split(":")[0] == "firefox"
 
         wpt_kwargs["pause_after_test"] = False
-        wpt_kwargs["verify_log_full"] = True
+        wpt_kwargs["verify_log_full"] = False
         if wpt_kwargs["repeat"] == 1:
             wpt_kwargs["repeat"] = 10
 


### PR DESCRIPTION
I'm not entirely sure why #10988 made this default to on, given that was a change of behaviour from before, so let's turn it back off given it's causing breakage, as documented in #11454.