### PR TITLE
Fix c563-list-type-000-ref to match the test

### DIFF
--- a/css/CSS2/css1/c563-list-type-000-ref.xht
+++ b/css/CSS2/css1/c563-list-type-000-ref.xht
@@ -9,7 +9,7 @@
   <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
 
   <style type="text/css"><![CDATA[
-  div, li {color: navy;}
+  body {color: navy;}
 
   div
   {


### PR DESCRIPTION
Currently the introductory text in the ref isn't navy, unlike in the test.