### PR TITLE
Rewrite access-control-and-redirects-async test to use promise_test to…

### DIFF
--- a/cors/basic.htm
+++ b/cors/basic.htm
@@ -22,13 +22,14 @@ function cors(desc, scheme, subdomain, port) {
         }
         var url = scheme + "://" + (subdomain ? subdomain + "." : "") + location.hostname + ":" + port + dirname(location.pathname)
     }
-    async_test(desc).step(function() {
+    promise_test(function(t) {
         var client = new XMLHttpRequest();
-        this.count = counter++;
+        t.count = counter++;
 
-        client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&origin=none&" + this.count);
+        client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&origin=none&" + t.count);
 
-        client.onreadystatechange = this.step_func(function(e) {
+        return new Promise(resolve => {
+          client.onreadystatechange = t.step_func(function(e) {
             // First request, test that it fails with no origin
             if (client.readyState < 4) return;
             if (!url)
@@ -37,17 +38,18 @@ function cors(desc, scheme, subdomain, port) {
                 assert_false(!!client.response, "Got CORS-disallowed response");
 
             client = new XMLHttpRequest();
-            client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&" + this.count);
-            client.onreadystatechange = this.step_func(function(e) {
+            client.open("GET", url + "resources/cors-makeheader.py?get_value=hest_er_best&" + t.count);
+            client.onreadystatechange = t.step_func(function(e) {
                 // Second request, test that it passes with the allowed-origin
                 if (client.readyState < 4) return;
                 assert_true(client.response.indexOf("hest_er_best") != -1, "Got CORS-allowed response");
-                this.done();
+                resolve();
             });
             client.send();
+          });
+          client.send();
         });
-        client.send();
-    });
+    }, desc);
 }
 
 cors("Same domain basic usage");

--- a/cors/credentials-flag.htm
+++ b/cors/credentials-flag.htm
@@ -24,99 +24,109 @@ test(function () {
     client.withCredentials = true;
 }, 'Setting withCredentials on a sync XHR object should not throw')
 
-async_test(function () {
-    var id = new Date().getTime() + '_1',
-        client = new XMLHttpRequest()
-    client.open("GET", url + id, true)
-    client.onload = this.step_func(function() {
-        assert_equals(client.response, "NO_COOKIE")
+promise_test(function (t) {
+    return new Promise((resolve, reject) => {
+        var id = new Date().getTime() + '_1',
+          client = new XMLHttpRequest()
         client.open("GET", url + id, true)
-        client.onload = this.step_func(function() {
+        client.onerror = reject
+        client.onload = t.step_func(function() {
             assert_equals(client.response, "NO_COOKIE")
-            this.done()
+            client.open("GET", url + id, true)
+            client.onload = t.step_func(function() {
+                assert_equals(client.response, "NO_COOKIE")
+                resolve();
+            })
+            client.send(null)
         })
         client.send(null)
-    })
-    client.send(null)
-
+    });
 }, "Don't send cookie by default");
 
-async_test(function () {
-    var id = new Date().getTime() + '_2',
-        client = new XMLHttpRequest()
+promise_test(function (t) {
+    return new Promise((resolve, reject) => {
+        var id = new Date().getTime() + '_2',
+            client = new XMLHttpRequest()
 
-    client.open("GET", url + id, true)
-    client.withCredentials = true
-    client.onload = this.step_func(function() {
-        assert_equals(client.response, "NO_COOKIE", "No cookie in initial request");
-
-        /* We have cookie, but the browser shouldn't send */
-        client.open("GET", url + id, true)
-        client.withCredentials = false
-        client.onload = this.step_func(function() {
-            assert_equals(client.response, "NO_COOKIE", "No cookie after withCredentials=false sync request")
-
-            /* Reads and deletes the cookie */
-            client.open("GET", url + id, true)
-            client.withCredentials = true
-            client.onload = this.step_func(function() {
-                assert_equals(client.response, "COOKIE", "Cookie sent in withCredentials=true sync request")
-                this.done()
-            })
-            client.send(null)
-        })
-        client.send(null)
-    })
-    client.send(null)
-}, "Don't send cookie part 2");
-
-async_test(function () {
-    var id = new Date().getTime() + '_3',
-        client = new XMLHttpRequest()
-
-    /* Shouldn't set the response cookie */
-    client.open("GET", url + id, true)
-    client.withCredentials = false
-    client.onload = this.step_func(function() {
-        assert_equals(client.response, "NO_COOKIE", "first");
-
-        /* Sets the cookie */
         client.open("GET", url + id, true)
         client.withCredentials = true
-        client.onload = this.step_func(function() {
-            assert_equals(client.response, "NO_COOKIE", "second")
+        client.onerror = reject
+        client.onload = t.step_func(function() {
+            assert_equals(client.response, "NO_COOKIE", "No cookie in initial request");
 
-            /* Reads and deletes the cookie */
+            /* We have cookie, but the browser shouldn't send */
             client.open("GET", url + id, true)
-            client.withCredentials = true
-            client.onload = this.step_func(function() {
-                assert_equals(client.response, "COOKIE", "third")
-                this.done()
+            client.withCredentials = false
+            client.onload = t.step_func(function() {
+                assert_equals(client.response, "NO_COOKIE", "No cookie after withCredentials=false sync request")
+
+                /* Reads and deletes the cookie */
+                client.open("GET", url + id, true)
+                client.withCredentials = true
+                client.onload = t.step_func(function() {
+                    assert_equals(client.response, "COOKIE", "Cookie sent in withCredentials=true sync request")
+                    resolve()
+                })
+                client.send(null)
             })
             client.send(null)
         })
         client.send(null)
     })
-    client.send(null)
+}, "Don't send cookie part 2");
+
+promise_test(function (t) {
+    return new Promise((resolve, reject) => {
+        var id = new Date().getTime() + '_3',
+            client = new XMLHttpRequest()
+
+        /* Shouldn't set the response cookie */
+        client.open("GET", url + id, true)
+        client.withCredentials = false
+        client.onerror = reject
+        client.onload = t.step_func(function() {
+            assert_equals(client.response, "NO_COOKIE", "first");
+
+            /* Sets the cookie */
+            client.open("GET", url + id, true)
+            client.withCredentials = true
+            client.onload = t.step_func(function() {
+                assert_equals(client.response, "NO_COOKIE", "second")
+
+                /* Reads and deletes the cookie */
+                client.open("GET", url + id, true)
+                client.withCredentials = true
+                client.onload = t.step_func(function() {
+                    assert_equals(client.response, "COOKIE", "third")
+                    resolve()
+                })
+                client.send(null)
+            })
+            client.send(null)
+        })
+        client.send(null)
+    })
 }, "Don't obey Set-Cookie when withCredentials=false");
 
 function test_response_header(allow) {
-    var resp_test = async_test('Access-Control-Allow-Credentials: ' + allow + ' should be disallowed (async)')
-    resp_test.step(function() {
-        var client = new XMLHttpRequest()
-        client.open('GET',
-            CROSSDOMAIN + 'resources/cors-makeheader.py?credentials=' + allow,
-            true)
-        client.withCredentials = true;
-        client.onload = resp_test.step_func(function() {
-            assert_unreached("onload")
+    promise_test(function(resp_test) {
+        return new Promise((resolve, reject) => {
+            var client = new XMLHttpRequest()
+            client.open('GET',
+                        CROSSDOMAIN + 'resources/cors-makeheader.py?credentials=' + allow,
+                        true)
+            client.withCredentials = true;
+            client.onload = resp_test.step_func(function() {
+                assert_unreached("onload")
+                reject()
+            })
+            client.onerror = resp_test.step_func(function () {
+                assert_equals(client.readyState, client.DONE, 'readyState')
+                resolve()
+            })
+            client.send()
         })
-        client.onerror = resp_test.step_func(function () {
-            assert_equals(client.readyState, client.DONE, 'readyState')
-            resp_test.done()
-        })
-        client.send()
-    })
+    }, 'Access-Control-Allow-Credentials: ' + allow + ' should be disallowed (async)')
 }
 
 test_response_header('TRUE')

--- a/cors/preflight-failure.htm
+++ b/cors/preflight-failure.htm
@@ -25,31 +25,33 @@ function preflight_failure(code) {
   var isCodeOK = code >= 200 && code <= 299,
       descOK = isCodeOK ? 'succeed' : 'throw error',
       desc = 'Should ' + descOK + ' if preflight has status ' + code;
-  async_test(desc).step(function() {
-    var client = new XMLHttpRequest();
-    var redirect =
-      encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
+  promise_test(function(t) {
+    return new Promise(resolve => {
+      var client = new XMLHttpRequest();
+      var redirect =
+        encodeURIComponent(CROSSDOMAIN_URL + 'headers=x-test&' + req_c++);
 
-    client.open('GET',
-        CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
-        + '&code=' + code + '&preflight=' + code
-        + '&' + req_c++,
-        true /* async */);
-    client.setRequestHeader('x-test', 'test');
-    client.onerror = this.step_func(function() {
-      assert_false(isCodeOK);
-      this.done();
+      client.open('GET',
+          CROSSDOMAIN_URL + 'headers=x-test&location=' + redirect
+          + '&code=' + code + '&preflight=' + code
+          + '&' + req_c++,
+          true /* async */);
+      client.setRequestHeader('x-test', 'test');
+      client.onerror = t.step_func(function() {
+        assert_false(isCodeOK);
+        resolve();
+      });
+      client.onreadystatechange = t.step_func(function() {
+        if (!isCodeOK)
+          assert_equals(client.status, 0);
+      });
+      client.onload = t.step_func(function() {
+        assert_true(isCodeOK);
+        resolve();
+      });
+      client.send(null);
     });
-    client.onreadystatechange = this.step_func(function() {
-      if (!isCodeOK)
-        assert_equals(client.status, 0);
-    });
-    client.onload = this.step_func(function() {
-      assert_true(isCodeOK);
-      this.done();
-    });
-    client.send(null);
-  });
+  }, desc);
 }
 [200, 299,
  300, 301, 302, 303, 304, 305, 306, 307, 308,

--- a/cors/status-async.htm
+++ b/cors/status-async.htm
@@ -14,30 +14,31 @@
 <script>
 
 function statusRequest(method, code, text, content, type) {
-    async_test("Status on " + method + " " + code, { timeout: 15000 })
-    .step(function() {
-        var client = new XMLHttpRequest()
-        client.open(method, CROSSDOMAIN + "resources/status.py?code="
-            + code + "&text=" + text + "&content=" + content + "&type=" + type, true)
-        client.onreadystatechange = this.step_func(function() {
-            if (client.readyState != client.DONE)
-                return
+    promise_test(function(t) {
+        return new Promise(resolve => {
+            var client = new XMLHttpRequest()
+            client.open(method, CROSSDOMAIN + "resources/status.py?code="
+                + code + "&text=" + text + "&content=" + content + "&type=" + type, true)
+            client.onreadystatechange = t.step_func(function() {
+                if (client.readyState != client.DONE)
+                    return
 
-            assert_equals(client.status, code, 'response status')
-            assert_equals(client.statusText, text, 'response status text')
-            assert_equals(client.getResponseHeader("X-Request-Method"), method, 'method')
-            if(method != "HEAD") {
-                if(type == "text/xml") {
-                    assert_equals(client.responseXML.documentElement.localName,
+                assert_equals(client.status, code, 'response status')
+                assert_equals(client.statusText, text, 'response status text')
+                assert_equals(client.getResponseHeader("X-Request-Method"), method, 'method')
+                if(method != "HEAD") {
+                    if(type == "text/xml") {
+                        assert_equals(client.responseXML.documentElement.localName,
                                 "x", 'responseXML')
+                    }
+                    assert_equals(client.response, content, 'response content')
                 }
-                assert_equals(client.response, content, 'response content')
-            }
-            this.done()
-        })
+                resolve()
+            })
 
-        client.send(null)
-    })
+            client.send(null)
+        })
+    }, "Status on " + method + " " + code, { timeout: 15000 })
 }
 
   /*            method     code text  content        type */
@@ -60,36 +61,37 @@ function statusRequestFail(method, code, expect_code, nonsimple) {
     if (expect_code === undefined)
         expect_code = code
 
-    async_test("Status on " + method + " " + code + (nonsimple?' (nonsimple)':''), { timeout: 15000 })
-    .step(function() {
-        var client = new XMLHttpRequest()
+    async_test(function() {
+        return new Promise(resolve => {
+            var client = new XMLHttpRequest()
 
-        client.open(method, CROSSDOMAIN + "resources/status.py?code="
-          + code + '&headers=x-nonsimple&text=OHAI', true)
+            client.open(method, CROSSDOMAIN + "resources/status.py?code="
+              + code + '&headers=x-nonsimple&text=OHAI', true)
 
-        if (nonsimple)
-            client.setRequestHeader('x-nonsimple', true)
+            if (nonsimple)
+                client.setRequestHeader('x-nonsimple', true)
 
-        client.onreadystatechange = this.step_func(function() {
-            if (client.readyState < client.HEADERS_RECEIVED)
-                return
-            assert_equals(client.response, "", "response data")
-            assert_equals(client.status, expect_code, "response status")
-            /* Response code 200 forces webserver to send OK(?) */
-            if(expect_code == 200)
-                assert_equals(client.statusText, "OK", "response statusText")
-            else
-                assert_equals(client.statusText, (expect_code == 0 ? "" : "OHAI"), "response statusText")
-            if (client.readyState == client.DONE)
-                this.done()
+            client.onreadystatechange = this.step_func(function() {
+                if (client.readyState < client.HEADERS_RECEIVED)
+                    return
+                assert_equals(client.response, "", "response data")
+                assert_equals(client.status, expect_code, "response status")
+                /* Response code 200 forces webserver to send OK(?) */
+                if(expect_code == 200)
+                    assert_equals(client.statusText, "OK", "response statusText")
+                else
+                    assert_equals(client.statusText, (expect_code == 0 ? "" : "OHAI"), "response statusText")
+                if (client.readyState == client.DONE)
+                    this.done()
+            })
+
+            client.onerror = this.step_func(function(e) {
+                assert_unreached("Got error event.")
+            })
+
+            client.send()
         })
-
-        client.onerror = this.step_func(function(e) {
-            assert_unreached("Got error event.")
-        })
-
-        client.send()
-    })
+    }, "Status on " + method + " " + code + (nonsimple?' (nonsimple)':''), { timeout: 15000 })
 }
 
   /*                                 expect

--- a/cors/status-preflight.htm
+++ b/cors/status-preflight.htm
@@ -16,29 +16,31 @@ var counter = 0
 function statusAfterPreflight(method, code) {
     counter++
 
-    async_test(document.title + " on " + method + " " + code).step(function() {
-        var client = new XMLHttpRequest()
-        client.open(method, CROSSDOMAIN + "resources/status.py?" + counter
-            +"&code=" + code + '&headers=x-nonsimple&preflight=200', true)
+    promise_test(function(t) {
+        return new Promise(resolve => {
+            var client = new XMLHttpRequest()
+            client.open(method, CROSSDOMAIN + "resources/status.py?" + counter
+                +"&code=" + code + '&headers=x-nonsimple&preflight=200', true)
 
-        client.setRequestHeader('x-nonsimple', true)
-        client.onreadystatechange = this.step_func(function() {
-            if (client.readyState < client.HEADERS_RECEIVED)
-                return
-            assert_equals(client.response, "", "response data")
-            assert_equals(client.status, code, "response status")
-            if (client.readyState == client.DONE) {
-                /* Wait for spurious error events */
-                this.step_timeout(() => { this.done() }, 10)
-            }
+            client.setRequestHeader('x-nonsimple', true)
+            client.onreadystatechange = t.step_func(function() {
+                if (client.readyState < client.HEADERS_RECEIVED)
+                    return
+                assert_equals(client.response, "", "response data")
+                assert_equals(client.status, code, "response status")
+                if (client.readyState == client.DONE) {
+                    /* Wait for spurious error events */
+                    t.step_timeout(resolve, 10)
+                }
+            })
+
+            client.onerror = t.step_func(function() {
+                assert_unreached("Shouldn't throw no error event!")
+            })
+
+            client.send()
         })
-
-        client.onerror = this.step_func(function() {
-            assert_unreached("Shouldn't throw no error event!")
-        })
-
-        client.send()
-    })
+    }, document.title + " on " + method + " " + code)
 }
 
 /*                   method     code */

--- a/xhr/access-control-and-redirects-async-same-origin.htm
+++ b/xhr/access-control-and-redirects-async-same-origin.htm
@@ -8,24 +8,26 @@
   </head>
   <body>
     <script>
-    function runTest(test, path, credentials, expectSuccess) {
-      return new Promise(resolve => {
-        const xhr = new XMLHttpRequest();
-        xhr.withCredentials = credentials;
-        xhr.open("GET", "resources/redirect.py?location=" + get_host_info().HTTP_REMOTE_ORIGIN + path, true);
+    function runTest(testName, path, credentials, expectSuccess) {
+      return promise_test(test => {
+          return new Promise(resolve => {
+              const xhr = new XMLHttpRequest();
+              xhr.withCredentials = credentials;
+              xhr.open("GET", "resources/redirect.py?location=" + get_host_info().HTTP_REMOTE_ORIGIN + path, true);
 
-        xhr.onload = test.step_func(function() {
-          assert_true(expectSuccess);
-          assert_equals(xhr.responseText, "PASS: Cross-domain access allowed.");
-          resolve();
-        });
-        xhr.onerror = test.step_func(function() {
-          assert_false(expectSuccess);
-          assert_equals(xhr.status, 0);
-          resolve();
-        });
-        xhr.send(null);
-      });
+              xhr.onload = test.step_func(function() {
+                  assert_true(expectSuccess);
+                  assert_equals(xhr.responseText, "PASS: Cross-domain access allowed.");
+                  resolve();
+              });
+              xhr.onerror = test.step_func(function() {
+                  assert_false(expectSuccess);
+                  assert_equals(xhr.status, 0);
+                  resolve();
+              });
+              xhr.send(null);
+          });
+      }, testName);
     }
 
     const withoutCredentials = false;
@@ -36,40 +38,34 @@
     // Test simple same origin requests that receive cross origin redirects.
 
     // The redirect response passes the access check.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
-          withoutCredentials, succeeds)
-    }, "Request without credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)");
+    runTest("Request without credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)",
+            "/xhr/resources/access-control-basic-allow-star.py",
+            withoutCredentials, succeeds);
 
     // The redirect response fails the access check because credentials were sent.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
-          withCredentials, fails)
-    }, "Request with credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)");
+    runTest("Request with credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)",
+            "/xhr/resources/access-control-basic-allow-star.py",
+            withCredentials, fails);
 
     // The redirect response passes the access check.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow.py",
-          withoutCredentials, succeeds)
-    }, "Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin");
+    runTest("Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin",
+            "/xhr/resources/access-control-basic-allow.py",
+            withoutCredentials, succeeds);
 
     // The redirect response passes the access check.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow.py",
-          withCredentials, succeeds)
-    }, "Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin");
+    runTest("Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin",
+            "/xhr/resources/access-control-basic-allow.py",
+            withCredentials, succeeds);
 
     // forbidding credentials. The redirect response passes the access check.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
-          withoutCredentials, succeeds)
-    }, "Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)");
+    runTest("Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)",
+            "/xhr/resources/access-control-basic-allow-no-credentials.py",
+            withoutCredentials, succeeds);
 
     // forbidding credentials. The redirect response fails the access check.
-    promise_test(t => {
-      return runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
-          withCredentials, fails)
-    }, "Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)");
+    runTest("Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)",
+            "/xhr/resources/access-control-basic-allow-no-credentials.py",
+            withCredentials, fails);
     </script>
   </body>
 </html>

--- a/xhr/access-control-and-redirects-async-same-origin.htm
+++ b/xhr/access-control-and-redirects-async-same-origin.htm
@@ -9,19 +9,23 @@
   <body>
     <script>
     function runTest(test, path, credentials, expectSuccess) {
-      const xhr = new XMLHttpRequest();
-      xhr.withCredentials = credentials;
-      xhr.open("GET", "resources/redirect.py?location=" + get_host_info().HTTP_REMOTE_ORIGIN + path, true);
+      return new Promise(resolve => {
+        const xhr = new XMLHttpRequest();
+        xhr.withCredentials = credentials;
+        xhr.open("GET", "resources/redirect.py?location=" + get_host_info().HTTP_REMOTE_ORIGIN + path, true);
 
-      xhr.onload = test.step_func_done(function() {
-        assert_true(expectSuccess);
-        assert_equals(xhr.responseText, "PASS: Cross-domain access allowed.");
+        xhr.onload = test.step_func(function() {
+          assert_true(expectSuccess);
+          assert_equals(xhr.responseText, "PASS: Cross-domain access allowed.");
+          resolve();
+        });
+        xhr.onerror = test.step_func(function() {
+          assert_false(expectSuccess);
+          assert_equals(xhr.status, 0);
+          resolve();
+        });
+        xhr.send(null);
       });
-      xhr.onerror = test.step_func_done(function() {
-        assert_false(expectSuccess);
-        assert_equals(xhr.status, 0);
-      });
-      xhr.send(null);
     }
 
     const withoutCredentials = false;
@@ -32,38 +36,38 @@
     // Test simple same origin requests that receive cross origin redirects.
 
     // The redirect response passes the access check.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
           withoutCredentials, succeeds)
     }, "Request without credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)");
 
     // The redirect response fails the access check because credentials were sent.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow-star.py",
           withCredentials, fails)
     }, "Request with credentials is redirected to a cross-origin response with Access-Control-Allow-Origin=* (with star)");
 
     // The redirect response passes the access check.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow.py",
           withoutCredentials, succeeds)
     }, "Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin");
 
     // The redirect response passes the access check.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow.py",
           withCredentials, succeeds)
     }, "Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin");
 
     // forbidding credentials. The redirect response passes the access check.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
           withoutCredentials, succeeds)
     }, "Request without credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)");
 
     // forbidding credentials. The redirect response fails the access check.
-    async_test(t => {
-      runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
+    promise_test(t => {
+      return runTest(t, "/xhr/resources/access-control-basic-allow-no-credentials.py",
           withCredentials, fails)
     }, "Request with credentials is redirected to a cross-origin response with a specific Access-Control-Allow-Origin (no credentials)");
     </script>

--- a/xhr/access-control-and-redirects-async.htm
+++ b/xhr/access-control-and-redirects-async.htm
@@ -9,24 +9,30 @@
   <body>
     <script>
     function runTest(test, destination, parameters, customHeader, local, expectSuccess) {
-      const xhr = new XMLHttpRequest();
-      const url = (local ? get_host_info().HTTP_ORIGIN : get_host_info().HTTP_REMOTE_ORIGIN) +
-        "/xhr/resources/redirect-cors.py?location=" + destination + "&" +  parameters;
+      return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        const url = (local ? get_host_info().HTTP_ORIGIN : get_host_info().HTTP_REMOTE_ORIGIN) +
+          "/xhr/resources/redirect-cors.py?location=" + destination + "&" +  parameters;
 
-      xhr.open("GET", url, true);
+        xhr.open("GET", url, true);
 
-      if (customHeader)
-        xhr.setRequestHeader("x-test", "test");
+        if (customHeader) {
+          xhr.setRequestHeader("x-test", "test");
+        }
 
-      xhr.onload = test.step_func_done(function() {
-        assert_true(expectSuccess);
-        assert_true(xhr.responseText.startsWith("PASS"));
+        xhr.onload = test.step_func(function() {
+          assert_true(expectSuccess);
+          assert_true(xhr.responseText.startsWith("PASS"));
+          resolve();
+        });
+
+        xhr.onerror = test.step_func(function() {
+          assert_false(expectSuccess);
+          assert_equals(xhr.status, 0);
+          resolve();
+        });
+        xhr.send();
       });
-      xhr.onerror = test.step_func_done(function() {
-        assert_false(expectSuccess);
-        assert_equals(xhr.status, 0);
-      });
-      xhr.send();
     }
 
     const withCustomHeader = true;
@@ -39,49 +45,49 @@
     // Test simple cross origin requests that receive redirects.
 
     // The redirect response fails the access check because the redirect lacks a CORS header.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
           "/xhr/resources/access-control-basic-allow-star.py", "",
           withoutCustomHeader, remote, fails)
     }, "Request is redirected without CORS headers to a response with Access-Control-Allow-Origin=*");
 
     // The redirect response passes the access check.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
           "/xhr/resources/access-control-basic-allow-star.py", "allow_origin=true",
           withoutCustomHeader, remote, succeeds)
     }, "Request is redirected to a response with Access-Control-Allow-Origin=*");
 
     // The redirect response fails the access check because user info was sent.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_REMOTE_ORIGIN.replace("http://", "http://username:password@") +
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_REMOTE_ORIGIN.replace("http://", "http://username:password@") +
           "/xhr/resources/access-control-basic-allow-star.py", "allow_origin=true",
           withoutCustomHeader, remote, fails)
     }, "Request with user info is redirected to a response with Access-Control-Allow-Origin=*");
 
     // The redirect response fails the access check because the URL scheme is unsupported.
-    async_test(t => {
-      runTest(t, "foo://bar.cgi", "allow_origin=true", withoutCustomHeader, remote, fails)
+    promise_test(t => {
+      return runTest(t, "foo://bar.cgi", "allow_origin=true", withoutCustomHeader, remote, fails)
     }, "Request is redirect to a bad URL");
 
     // The preflighted redirect response fails the access check because of preflighting.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
           "/xhr/resources/access-control-basic-allow-star.py",
           "allow_origin=true&redirect_preflight=true", withCustomHeader, remote, fails)
     }, "Preflighted request is redirected to a response with Access-Control-Allow-Origin=*");
 
     // The preflighted redirect response fails the access check after successful preflighting.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_REMOTE_ORIGIN +
           "/xhr/resources/access-control-basic-allow-star.py",
           "allow_origin=true&allow_header=x-test&redirect_preflight=true",
           withCustomHeader, remote, fails)
     }, "Preflighted request is redirected to a response with Access-Control-Allow-Origin=* and header allowed");
 
     // The same-origin redirect response passes the access check.
-    async_test(t => {
-      runTest(t, get_host_info().HTTP_ORIGIN + "/xhr/resources/pass.txt",
+    promise_test(t => {
+      return runTest(t, get_host_info().HTTP_ORIGIN + "/xhr/resources/pass.txt",
           "", withCustomHeader, local, succeeds)
     }, "Request is redirected to a same-origin resource file");
     </script>


### PR DESCRIPTION
…ensure consistent results in WebKit

This test is marked as flaky in WebKit's [test expectation file](https://github.com/WebKit/webkit/blob/f415af3483f4f9136e45a93f69e9d7a511d6018c/LayoutTests/TestExpectations#L286) because the order of results are reported inconsistently. Changing `async_test ` to `promise_test` ensures the tests are run (and reported) in a consistent order. Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=179607.