### PR TITLE
[docs] Add instruction for specifying test title

### DIFF
--- a/docs/_writing-tests/testharness.md
+++ b/docs/_writing-tests/testharness.md
@@ -146,6 +146,10 @@ be made available by the framework:
     self.GLOBAL.isWindow()
     self.GLOBAL.isWorker()
 
+### Specifying a test title in auto-generated boilerplate tests
+
+Use `// META: title=This is the title of the test` at the beginning of the resource.
+
 ### Including other JavaScript resources in auto-generated boilerplate tests
 
 Use `// META: script=link/to/resource.js` at the beginning of the resource. For example,


### PR DESCRIPTION
This feature was originally introduced via https://github.com/web-platform-tests/wpt/pull/11251