### PR TITLE
[performance-timeline] Reformat tests

### DIFF
--- a/performance-timeline/performanceentry-tojson.any.js
+++ b/performance-timeline/performanceentry-tojson.any.js
@@ -1,12 +1,3 @@
-<!doctype html>
-<html>
-<head>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-</head>
-<body>
-<script>
-
 test(() => {
   performance.mark('markName');
   performance.measure('measureName');
@@ -28,6 +19,3 @@ test(() => {
     }
   }
 }, 'Test toJSON() in PerformanceEntry');
-</script>
-</body>
-</html>

--- a/performance-timeline/po-takeRecords.any.js
+++ b/performance-timeline/po-takeRecords.any.js
@@ -1,11 +1,7 @@
-<!DOCTYPE HTML>
-<meta charset=utf-8>
-<title>PerformanceObserver: takeRecords</title>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-<script src="performanceobservers.js"></script>
-<script>
-  async_test(function (t) {
+// META: title=PerformanceObserver: takeRecords
+// META: script=performanceobservers.js
+
+async_test(function (t) {
     const observer = new PerformanceObserver(function (entryList, observer) {
       assert_unreached('This callback should not have been called.')
     });
@@ -36,4 +32,3 @@
     observer.disconnect();
     t.done();
   }, "Test PerformanceObserver's takeRecords()");
-</script>

--- a/performance-timeline/webtiming-resolution.any.js
+++ b/performance-timeline/webtiming-resolution.any.js
@@ -1,11 +1,3 @@
-<!DOCTYPE HTML>
-<html>
-<head>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
-</head>
-<body>
-<script>
 function testTimeResolution(highResTimeFunc, funcString) {
     test(() => {
         const t0 = highResTimeFunc();
@@ -30,6 +22,3 @@ function timeByUserTiming() {
 
 testTimeResolution(timeByPerformanceNow, 'performance.now()');
 testTimeResolution(timeByUserTiming, 'entry.startTime');
-</script>
-</body>
-</html>


### PR DESCRIPTION
Refactor tests so that they may be consumed by non-browser JavaScript
runtimes which implement the standard (e.g. Node.js [1]). Use WPT's
`.any.js` convention to extend test coverage in browsers by allowing
them to be executed within a Web Worker.

This change is in service of gh-11277 [2]

[1] https://nodejs.org/api/perf_hooks.html
[2] https://github.com/web-platform-tests/wpt/issues/11277