### PR TITLE
Sync Mozilla tests as of 2018-06-14

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/color-stop-currentcolor-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/color-stop-currentcolor-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Reftest Reference</title>
+    <link rel="author" title="Dan Glastonbury" href="mailto:dglastonbury@mozilla.com" />
+    <style type="text/css">
+     body {
+         background: linear-gradient(to right, currentcolor, limegreen);
+     }
+
+     div {
+         width: 100vw;
+         height: 100vh;
+         background: linear-gradient(to right, limegreen, limegreen);
+     }
+    </style>
+  </head>
+  <body>
+    <!-- content of test -->
+    <div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/color-stop-currentcolor.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/color-stop-currentcolor.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>CSS Test: 'color-stop' on linear-gradient respects 'currentcolor'</title>
+    <link rel="author" title="Dan Glastonbury" href="mailto:dglastonbury@mozilla.com" />
+    <link rel="help" href="https://www.w3.org/TR/css3-images/#color-stop-syntax" />
+    <link rel="help" href="https://www.w3.org/TR/css-color-3/#currentcolor" />
+    <link rel="match" href="color-stop-currentcolor-ref.html" />
+    <style type="text/css">
+     body {
+         background: linear-gradient(to right, currentcolor, limegreen);
+     }
+
+     div {
+         width: 100vw;
+         height: 100vh;
+         color: limegreen;
+         background: inherit;
+     }
+    </style>
+  </head>
+  <body>
+    <!-- content of test -->
+    <div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/images3/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/images3/reftest.list
@@ -189,3 +189,6 @@
 == object-position-svg-002i.html object-position-svg-002-ref.html
 == object-position-svg-002o.html object-position-svg-002-ref.html
 == object-position-svg-002p.html object-position-svg-002-ref.html
+
+# Tests for gradient color stops with 'currentcolor'
+== color-stop-currentcolor.html color-stop-currentcolor-ref.html


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/91db0c695f0272f00bf92c81c471a85101056d96 .

This contains a single change, from [bug 1467379](https://bugzilla.mozilla.org/show_bug.cgi?id=1467379), by @djg, already reviewed by @upsuper.