### PR TITLE
Use Referrer Policy IDL as dependency for fetch

### DIFF
--- a/fetch/api/idl.any.js
+++ b/fetch/api/idl.any.js
@@ -4,11 +4,12 @@
 
 promise_test(async() => {
   const text = await (await fetch("/interfaces/fetch.idl")).text();
+  const referrer_policy = await (await fetch("/interfaces/webappsec-referrer-policy.idl")).text();
   const idl_array = new IdlArray();
   idl_array.add_idls(text);
   idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface AbortSignal {};");
   idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ReadableStream {};");
-  idl_array.add_untested_idls("enum ReferrerPolicy {};");
+  idl_array.add_dependency_idls(referrer_policy);
   idl_array.add_objects({
     Headers: ["new Headers()"],
     Request: ["new Request('about:blank')"],


### PR DESCRIPTION
In newer versions of webidl2.js, empty enums are not allowed. We can easily switch to using the actual definition in the Referrer Policy spec to avoid running into any problems when upgrading webidl2.js.

This change leads to the same number of passing/failing tests on Chrome.