### PR TITLE
test for iframe sandbox allow-popups-to-escape-sandbox

### DIFF
--- a/html/browsers/sandboxing/inner-iframe-popup.html
+++ b/html/browsers/sandboxing/inner-iframe-popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <title>I can run scripts, but not act as same-origin</title>
+  <script>
+    function pop(){
+      window.open('./popup.html');
+    }
+    window.onload = function() {
+      try{
+        top.calledFromIframe();
+      }catch(e){}
+      pop();
+      document.getElementById('openme').onclick = pop;
+    }
+  </script>
+  </head>
+  <body>
+    <div id="inner">In case you have a popup blocker: <a href="#" id="openme">Pop a popup</a></div>
+  </body>
+</html>

--- a/html/browsers/sandboxing/popup.html
+++ b/html/browsers/sandboxing/popup.html
@@ -5,7 +5,7 @@
   <script>
     window.onload = function() {
       window.opener.parent.calledFromPopUp()
-      setTimeout(function(){window.close();}, 0);
+      window.close();
     }
   </script>
   </head>

--- a/html/browsers/sandboxing/popup.html
+++ b/html/browsers/sandboxing/popup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <title>I should have no sandbox restrictions</title>
+  <script>
+    window.onload = function() {
+      window.opener.parent.calledFromPopUp()
+      setTimeout(function(){window.close();}, 0);
+    }
+  </script>
+  </head>
+  <body>
+    <div id="inner">foo</div>
+  </body>
+</html>

--- a/html/browsers/sandboxing/sandbox-allow-popups-to-escape-sandbox.html
+++ b/html/browsers/sandboxing/sandbox-allow-popups-to-escape-sandbox.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>test allow-popups-to-escape-sandbox</title>
+    <link rel="help" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#sandboxing">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+    <h1>sandbox="allow-popups-to-escape-sandbox" iframe</h1>
+    <script type="text/javascript">
+      var t1 = async_test("ensure iframe can not call as same-origin")
+      var t2 = async_test("allow-popups-to-escape-sandbox able to call as same-origin")
+      function calledFromIframe() {
+        t1.force_timeout(); //not sure how to fail
+      }
+      function calledFromPopUp() {
+        t2.done();
+      }
+      function loaded() {
+        t1.done();
+      }
+    </script>
+
+    <iframe src="/html/browsers/sandboxing/inner-iframe-popup.html" style="" sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox" id="sandboxedframe" onload="loaded();"></iframe>
+
+    <div id="log"></div>
+  </body>
+</html>

--- a/html/browsers/sandboxing/sandbox-allow-popups-to-escape-sandbox.html
+++ b/html/browsers/sandboxing/sandbox-allow-popups-to-escape-sandbox.html
@@ -23,7 +23,7 @@
       }
     </script>
 
-    <iframe src="/html/browsers/sandboxing/inner-iframe-popup.html" style="" sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox" id="sandboxedframe" onload="loaded();"></iframe>
+    <iframe src="./inner-iframe-popup.html" style="" sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox" id="sandboxedframe" onload="loaded();"></iframe>
 
     <div id="log"></div>
   </body>


### PR DESCRIPTION
This will test that a sandboxed iframe limitations won't be transferred to a new window when token `allow-popups-to-escape-sandbox` is present.

The test work by creating a sandboxed iframe that can run script but not act as same-origin (and fails if that is not true). But a link opened from the iframe (`<a target=_blank>` or `window.open`) will be able to (if same domain, of course).