### PR TITLE
Call done() in websockets/opening-handshake/003-sets-origin.worker.js

### DIFF
--- a/websockets/opening-handshake/003-sets-origin.worker.js
+++ b/websockets/opening-handshake/003-sets-origin.worker.js
@@ -15,3 +15,4 @@ async_test(function(t) {
   })
   ws.onerror = ws.onclose = t.unreached_func();
 }, "W3C WebSocket API - origin set in a Worker");
+done();


### PR DESCRIPTION
This prevents the test harness to time out.