### PR TITLE
Updating browser version retrieval for Chrome to return None on Windows

### DIFF
--- a/tools/wpt/browser.py
+++ b/tools/wpt/browser.py
@@ -345,16 +345,19 @@ class Chrome(Browser):
 
     def version(self, binary=None):
         binary = binary or self.binary
-        try:
-            version_string = call(binary, "--version").strip()
-        except subprocess.CalledProcessError:
-            logger.warn("Failed to call %s", binary)
-            return None
-        m = re.match(r"Google Chrome (.*)", version_string)
-        if not m:
-            logger.warn("Failed to extract version from: s%", version_string)
-            return None
-        return m.group(1)
+        if uname[0] != "Windows":
+            try:
+                version_string = call(binary, "--version").strip()
+            except subprocess.CalledProcessError:
+                logger.warn("Failed to call %s", binary)
+                return None
+            m = re.match(r"Google Chrome (.*)", version_string)
+            if not m:
+                logger.warn("Failed to extract version from: s%", version_string)
+                return None
+            return m.group(1)
+        logger.warn("Unable to extract version from binary on Windows.")
+        return None
 
 
 class ChromeAndroid(Browser):


### PR DESCRIPTION
The test framework attempts to retrieve the version of Chrome by executing
`chrome --version` and parsing the result. On Windows, this command simply
launches the browser. There may be tehcniques that can be used on Windows
to get this information, including, but not limited to, reading the value
from the Windows registry. This commit simply returns None for the browser
version, which is a valid return value for this method, and will not
adversely affect the execution of the test framework.