### PR TITLE
webkit: GTK port should enable acceptInsecureCerts capability

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -30,7 +30,7 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
             "webdriver_args": kwargs.get("webdriver_args")}
 
 
-def capabilities_for_port(webkit_port, binary, binary_args):
+def capabilities_for_port(test_type, webkit_port, binary, binary_args):
     from selenium.webdriver import DesiredCapabilities
 
     if webkit_port == "gtk":
@@ -39,6 +39,8 @@ def capabilities_for_port(webkit_port, binary, binary_args):
             "binary": binary,
             "args": binary_args
         }
+        if test_type in ("testharness", "reftest"):
+            capabilities["acceptInsecureCerts"] = True
         return capabilities
 
     return {}
@@ -49,7 +51,7 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs = base_executor_kwargs(test_type, server_config,
                                            cache_manager, **kwargs)
     executor_kwargs["close_after_done"] = True
-    capabilities = capabilities_for_port(kwargs["webkit_port"],
+    capabilities = capabilities_for_port(test_type, kwargs["webkit_port"],
                                          kwargs["binary"],
                                          kwargs.get("binary_args", []))
     executor_kwargs["capabilities"] = capabilities


### PR DESCRIPTION
When using the WebKit product to run the WPT tests, the GTK port of WebKit has
to properly handle the temporary testing-purpose certificate that's used for
loads over SSL/TLS and which can't be validated otherwise.

To allow running tests served over HTTPS, the acceptInsecureCerts capability is
set in the capabilities dict that's then used for the Selenium-based executor.
This is only done for the tesharness tests and reftests but not for the wdspec
tests as that would collide with the tests that are testing this capability.