### PR TITLE
Ignore some new PNG files in ci_built_diff.sh

### DIFF
--- a/tools/ci/ci_built_diff.sh
+++ b/tools/ci/ci_built_diff.sh
@@ -15,6 +15,10 @@ main() {
         '2dcontext/drawing-text-to-the-canvas/2d.text.draw.fill.maxWidth.large.png'
         '2dcontext/drawing-text-to-the-canvas/2d.text.draw.fill.rtl.png'
         '2dcontext/drawing-text-to-the-canvas/2d.text.draw.stroke.basic.png'
+        'offscreen-canvas/text/2d.text.draw.fill.basic.png'
+        'offscreen-canvas/text/2d.text.draw.fill.maxWidth.large.png'
+        'offscreen-canvas/text/2d.text.draw.fill.rtl.png'
+        'offscreen-canvas/text/2d.text.draw.stroke.basic.png'
     )
 
     ./update-built-tests.sh


### PR DESCRIPTION
PR #11362 introduces some new PNG files similar to their counterparts in 2dcontext (also font-rendering specific), so we need to ignore these files in tools/ci/ci_built_diff.sh, too.

@jgraham PTAL, this is blocking #11362 from landing. Thanks!