### PR TITLE
[wptrunner] Reject tests that almost time out in stability check

### DIFF
--- a/tools/ci/check_stability.py
+++ b/tools/ci/check_stability.py
@@ -20,7 +20,7 @@ from tools.wpt import markdown
 from tools import localpaths  # noqa: F401
 
 logger = None
-run_step, write_inconsistent, write_results = None, None, None
+run_step, write_inconsistent, write_slow_tests, write_results = None, None, None, None
 wptrunner = None
 
 def setup_logging():
@@ -35,9 +35,9 @@ def setup_logging():
 
 
 def do_delayed_imports():
-    global wptrunner, run_step, write_inconsistent, write_results
+    global wptrunner, run_step, write_inconsistent, write_slow_tests, write_results
     from wptrunner import wptrunner
-    from wptrunner.stability import run_step, write_inconsistent, write_results
+    from wptrunner.stability import run_step, write_inconsistent, write_slow_tests, write_results
 
 
 class TravisFold(object):
@@ -283,11 +283,14 @@ def run(venv, wpt_args, **kwargs):
         logger.info("Starting tests")
 
         wpt_logger = wptrunner.logger
-        results, inconsistent, iterations = run_step(wpt_logger, wpt_kwargs["repeat"], True, {}, **wpt_kwargs)
+        results, inconsistent, slow, iterations = run_step(wpt_logger, wpt_kwargs["repeat"], True, {}, **wpt_kwargs)
 
     if results:
         if inconsistent:
             write_inconsistent(logger.error, inconsistent, iterations)
+            retcode = 2
+        elif slow:
+            write_slow_tests(logger.error, slow)
             retcode = 2
         else:
             logger.info("All results were stable\n")

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -87,8 +87,10 @@ class LogHandler(reader.LogHandler):
         test = self.find_or_create_test(data)
         test["status"][data["status"]] += 1
         start_time = test.pop("start_time")
+        # Timestamps are in ms since epoch.
         test["duration"] = data["time"] - start_time
-        test["timeout"] = data["extra"]["test_timeout"]
+        # test_timeout is in seconds; convert it to ms.
+        test["timeout"] = data["extra"]["test_timeout"] * 1000
 
 
 def is_inconsistent(results_dict, iterations):
@@ -287,7 +289,7 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
             write_duration(logger, longest_duration)
             return 1
 
-        max_duration = timeout * 1000 * 0.8
+        max_duration = timeout * 0.8
         if longest_duration > max_duration:
             step_results.append((desc, "FAIL"))
             logger.info('::: Test results were consistent but longest duration was %sms (expected < %sms).' % (longest_duration,

--- a/tools/wptrunner/wptrunner/stability.py
+++ b/tools/wptrunner/wptrunner/stability.py
@@ -330,7 +330,7 @@ def check_stability(logger, repeat_loop=10, repeat_restart=5, chaos_mode=True, m
             write_summary(logger, step_results, "FAIL")
             return 1
 
-        if len(slow) > 0:
+        if slow:
             step_results.append((desc, "FAIL"))
             write_slow_tests(logger.info, slow)
             write_summary(logger, step_results, "FAIL")

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -589,6 +589,7 @@ class TestRunnerManager(threading.Thread):
                                             int(assertion_count),
                                             test.min_assertion_count,
                                             test.max_assertion_count)
+        file_result.extra["test_timeout"] = test.timeout
 
         self.logger.test_end(test.id,
                              status,

--- a/tools/wptrunner/wptrunner/testrunner.py
+++ b/tools/wptrunner/wptrunner/testrunner.py
@@ -589,7 +589,8 @@ class TestRunnerManager(threading.Thread):
                                             int(assertion_count),
                                             test.min_assertion_count,
                                             test.max_assertion_count)
-        file_result.extra["test_timeout"] = test.timeout
+
+        file_result.extra["test_timeout"] = test.timeout * self.executor_kwargs['timeout_multiplier']
 
         self.logger.test_end(test.id,
                              status,

--- a/tools/wptrunner/wptrunner/tests/test_stability.py
+++ b/tools/wptrunner/wptrunner/tests/test_stability.py
@@ -5,8 +5,27 @@ sys.path.insert(0, join(dirname(__file__), "..", ".."))
 
 from wptrunner import stability
 
+
 def test_is_inconsistent():
     assert stability.is_inconsistent({"PASS": 10}, 10) is False
     assert stability.is_inconsistent({"PASS": 9}, 10) is True
     assert stability.is_inconsistent({"PASS": 9, "FAIL": 1}, 10) is True
     assert stability.is_inconsistent({"PASS": 8, "FAIL": 1}, 10) is True
+
+
+def test_find_slow_status():
+    assert stability.find_slow_status({
+        "longest_duration": {"TIMEOUT": 10},
+        "timeout": 10}) is None
+    assert stability.find_slow_status({
+        "longest_duration": {"CRASH": 10},
+        "timeout": 10}) is None
+    assert stability.find_slow_status({
+        "longest_duration": {"PASS": 1},
+        "timeout": 10}) is None
+    assert stability.find_slow_status({
+        "longest_duration": {"PASS": 81},
+        "timeout": 100}) == "PASS"
+    assert stability.find_slow_status({
+        "longest_duration": {"TIMEOUT": 10, "FAIL": 81},
+        "timeout": 100}) == "FAIL"


### PR DESCRIPTION
Fixes #9972.

~TODO: allow longer time for timeout=long tests.~