### PR TITLE
Add console timing manual tests

### DIFF
--- a/console/console-timing-logging-manual.html
+++ b/console/console-timing-logging-manual.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Console Timing Methods - Logging Manual Test</title>
+<meta name="author" title="Dominic Farolino" href="mailto:domfarolino@gmail.com">
+<meta name="assert" content="Console timing methods">
+<link rel="help" href="https://console.spec.whatwg.org/#timing">
+</head>
+<body>
+<p>Open the console inside the developer tools. It should contain entries whose contents are:</p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time> extra data</code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time> extra data</code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>default: &lt;some time> extra data</code></p>
+<p><code>default: &lt;some time></code></p>
+<p><code>a label: &lt;some time></code></p>
+<p><code>a label: &lt;some time> extra data</code></p>
+<p><code>a label: &lt;some time></code></p>
+<p style="color:grey;">[some warning message indicating that a timer for label "b" does not exist]</p>
+
+<script>
+console.time();
+console.timeLog();
+console.timeEnd();
+
+console.time(undefined);
+console.timeLog(undefined);
+console.timeLog(undefined, "extra data");
+console.timeEnd(undefined);
+
+console.time("default");
+console.timeLog("default");
+console.timeLog("default", "extra data");
+console.timeEnd("default");
+
+console.time({toString() {return "default"}});
+console.timeLog({toString() {return "default"}});
+console.timeLog({toString() {return "default"}}, "extra data");
+console.timeEnd({toString() {return "default"}});
+
+console.time("a label");
+console.timeLog("a label");
+console.timeLog("a label", "extra data");
+console.timeEnd("a label");
+
+console.timeEnd("b"); // should produce a warning
+</script>
+</body>
+</html>

--- a/console/console-timing-logging-manual.html
+++ b/console/console-timing-logging-manual.html
@@ -10,18 +10,27 @@
 <p>Open the console inside the developer tools. It should contain entries whose contents are:</p>
 <p><code>default: &lt;some time></code></p>
 <p><code>default: &lt;some time></code></p>
+
 <p><code>default: &lt;some time></code></p>
 <p><code>default: &lt;some time> extra data</code></p>
 <p><code>default: &lt;some time></code></p>
+
 <p><code>default: &lt;some time></code></p>
 <p><code>default: &lt;some time> extra data</code></p>
 <p><code>default: &lt;some time></code></p>
+
 <p><code>default: &lt;some time></code></p>
 <p><code>default: &lt;some time> extra data</code></p>
 <p><code>default: &lt;some time></code></p>
+
+<p><code>custom toString(): &lt;some time></code></p>
+<p><code>custom toString(): &lt;some time> extra data</code></p>
+<p><code>custom toString(): &lt;some time></code></p>
+
 <p><code>a label: &lt;some time></code></p>
 <p><code>a label: &lt;some time> extra data</code></p>
 <p><code>a label: &lt;some time></code></p>
+
 <p style="color:grey;">[some warning message indicating that a timer for label "b" does not exist]</p>
 
 <script>
@@ -44,11 +53,17 @@ console.timeLog({toString() {return "default"}});
 console.timeLog({toString() {return "default"}}, "extra data");
 console.timeEnd({toString() {return "default"}});
 
+console.time({toString() {return "custom toString()"}});
+console.timeLog({toString() {return "custom toString()"}});
+console.timeLog({toString() {return "custom toString()"}}, "extra data");
+console.timeEnd({toString() {return "custom toString()"}});
+
 console.time("a label");
 console.timeLog("a label");
 console.timeLog("a label", "extra data");
 console.timeEnd("a label");
 
+console.timeLog("b"); // should produce a warning
 console.timeEnd("b"); // should produce a warning
 </script>
 </body>


### PR DESCRIPTION
Adds console timing manual tests. This, as well as https://github.com/web-platform-tests/wpt/blob/master/console/console-label-conversion.any.js should be enough to cover https://github.com/whatwg/console/pull/138.