### PR TITLE
SVG: transform properties affect rendering

### DIFF
--- a/svg/styling/render/transform-box-ref.svg
+++ b/svg/styling/render/transform-box-ref.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <style>
+    rect {
+      fill: cyan;
+      stroke: cyan;
+      stroke-width: 16px;
+    }
+  </style>
+  <g transform="translate(140, 130)">
+    <rect id="r" x="-30" y="-10" width="80" height="20" />
+  </g>
+</svg>

--- a/svg/styling/render/transform-box.svg
+++ b/svg/styling/render/transform-box.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="match" href="transform-box-ref.svg"/>
+    <h:meta name="assert" content="The transform-box property impacts SVG rendering."/>
+  </metadata>
+
+  <style>
+    #r {
+      fill: cyan;
+      stroke: cyan;
+      stroke-width: 8px;
+      transform-box: fill-box;
+      transform-origin: 75% 100%;
+      transform: scale(2, 2);
+    }
+  </style>
+  <g transform="translate(140, 130)">
+    <rect id="r" x="0" y="0" width="40" height="10" />
+  </g>
+</svg>

--- a/svg/styling/render/transform-origin-ref.svg
+++ b/svg/styling/render/transform-origin-ref.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <style>
+    rect {
+      fill: cyan;
+    }
+  </style>
+  <g transform="translate(140, 130)">
+    <rect x="-30" y="-20" width="80" height="30" />
+  </g>
+</svg>

--- a/svg/styling/render/transform-origin.svg
+++ b/svg/styling/render/transform-origin.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="match" href="transform-origin-ref.svg"/>
+    <h:meta name="assert" content="The transform-origin property impacts SVG rendering."/>
+  </metadata>
+
+  <style>
+    rect {
+      fill: cyan;
+      transform-origin: 30px 10px;
+      transform: scale(2, 3);
+    }
+  </style>
+  <g transform="translate(140, 130)">
+    <rect x="0" y="0" width="40" height="10" />
+  </g>
+</svg>

--- a/svg/styling/render/transform-ref.svg
+++ b/svg/styling/render/transform-ref.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <style>
+    rect {
+      fill: cyan;
+    }
+  </style>
+  <rect x="169" y="141" width="40" height="10" />
+</svg>

--- a/svg/styling/render/transform.svg
+++ b/svg/styling/render/transform.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="300" height="200" viewBox="0 0 300 200">
+  <metadata>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/styling.html#RequiredProperties"/>
+    <h:link rel="match" href="transform-ref.svg"/>
+    <h:meta name="assert" content="The transform property impacts SVG rendering."/>
+  </metadata>
+
+  <style>
+    rect {
+      fill: cyan;
+      transform: translate(29px, 11px);
+    }
+  </style>
+  <rect x="140" y="130" width="40" height="10" />
+</svg>


### PR DESCRIPTION
Test that transform, transform-box and transform-origin
affect rendering of SVG elements.
https://svgwg.org/svg2-draft/styling.html#RequiredProperties