### PR TITLE
Prevent abort error from breaking test in FF (fixes #10792)

### DIFF
--- a/IndexedDB/idbdatabase-createObjectStore-exception-order.htm
+++ b/IndexedDB/idbdatabase-createObjectStore-exception-order.htm
@@ -8,8 +8,12 @@
 <script>
 
 indexeddb_test(
-  (t, db, txn) => {
+  (t, db, txn, rq) => {
     db.createObjectStore('s');
+
+    // Acknowledge the error, to prevent window.error from firing in
+    // browsers that implement that.
+    rq.onerror = e => { e.preventDefault(); };
 
     txn.onabort = () => {
       setTimeout(t.step_func(() => {


### PR DESCRIPTION
The test intentionally aborts a versionchange transaction, which results in an AbortError being fired at the IDBOpenDBRequest. In browsers that bubble event errors up to `window.error` (i.e. Firefox) this will cause the harness to fail.

Call preventDefault() on the error since it's expected.