### PR TITLE
webkit: GTK port should whitelist the web-platform.test host certificate

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -39,8 +39,8 @@ def capabilities_for_port(server_config, **kwargs):
             "binary": kwargs["binary"],
             "args": kwargs.get("binary_args", []),
             "certificates": [
-                { "host": server_config["browser_host"],
-                  "certificateFile": kwargs["host_cert_path"] }
+                {"host": server_config["browser_host"],
+                 "certificateFile": kwargs["host_cert_path"]}
             ]
         }
         return capabilities

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -30,14 +30,18 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
             "webdriver_args": kwargs.get("webdriver_args")}
 
 
-def capabilities_for_port(webkit_port, binary, binary_args):
+def capabilities_for_port(server_config, **kwargs):
     from selenium.webdriver import DesiredCapabilities
 
-    if webkit_port == "gtk":
+    if kwargs["webkit_port"] == "gtk":
         capabilities = dict(DesiredCapabilities.WEBKITGTK.copy())
         capabilities["webkitgtk:browserOptions"] = {
-            "binary": binary,
-            "args": binary_args
+            "binary": kwargs["binary"],
+            "args": kwargs.get("binary_args", []),
+            "certificates": [
+                { "host": server_config["browser_host"],
+                  "certificateFile": kwargs["host_cert_path"] }
+            ]
         }
         return capabilities
 
@@ -49,10 +53,8 @@ def executor_kwargs(test_type, server_config, cache_manager, run_info_data,
     executor_kwargs = base_executor_kwargs(test_type, server_config,
                                            cache_manager, **kwargs)
     executor_kwargs["close_after_done"] = True
-    capabilities = capabilities_for_port(kwargs["webkit_port"],
-                                         kwargs["binary"],
-                                         kwargs.get("binary_args", []))
-    executor_kwargs["capabilities"] = capabilities
+    executor_kwargs["capabilities"] = capabilities_for_port(server_config,
+                                                            **kwargs)
     return executor_kwargs
 
 


### PR DESCRIPTION
For testing purposes, the TLS certificate for the web-platform.test
host should be whitelisted for the GTK port of WebKit in order to
avoid TLS errors when loading test cases via HTTPS.

This is done by listing the host and certificate file path pair in
the port-specific capabilities. This pair is then used for
whitelisting the certificate for the given host in the
WebDriver-automated browsing session.