### PR TITLE
sensors: Yield to the event loop in GenericSensorTestChromium.reset()

### DIFF
--- a/resources/chromium/generic_sensor_mocks.js
+++ b/resources/chromium/generic_sensor_mocks.js
@@ -167,23 +167,13 @@ var GenericSensorTest = (() => {
               initParams: initParams};
     }
 
-    async reset() {
+    reset() {
       if (this.activeSensor_ !== null) {
         this.activeSensor_.reset();
         this.activeSensor_ = null;
       }
-      // Wait for an event loop iteration to let
-      // the pending mojo commands pass.
-      function schedule(func) {
-        return new Promise(resolve => {
-          setTimeout(() => {
-            func();
-            resolve();
-          }, 0);
-        });
-      }
-      await schedule(this.binding_.close.bind(this.binding_));
-      await schedule(this.interceptor_.stop.bind(this.interceptor_));
+      this.binding_.close();
+      this.interceptor_.stop();
     }
   }
 
@@ -216,9 +206,13 @@ var GenericSensorTest = (() => {
     async reset() {
       if (!testInternal.initialized)
         throw new Error('Call initialize() before reset().');
-      await testInternal.sensorProvider.reset();
+      testInternal.sensorProvider.reset();
       testInternal.sensorProvider = null;
       testInternal.initialized = false;
+
+      // Wait for an event loop iteration to let any pending mojo commands in
+      // the sensor provider finish.
+      await new Promise(resolve => setTimeout(resolve, 0));
     }
   }
 


### PR DESCRIPTION
Do so there instead of in `MockSensorProvider.reset()`, which is now a
regular function.

This brings the code more in line with Blink's own `sensor-helpers.js`, and
fixes one of the issues described in #10906: when a test failed, we'd end up
with the following code path

1. `sensor_tests()`'s calls `GenericSensorTestChromium.reset()`
2. `GenericSensorTestChromium.reset()` calls `MockSensorProvider.reset()`
3. This function `await`s on a promise that resolves inside `setTimeout()`
   and yields control back to the event loop
4. The next test is run, and it fails because
   `GenericSensorTest.testInternal` hasn't been reset yet.
5. After all tests run, we go back to the `setTimeout()` callbacks and
   finish running `GenericSensorTest.reset()`.

which essentially caused all subsequent tests to failure because
`1initialize()` would complain `reset()` had not been run.

We now simplify things, and a test failure results in:

1. `sensor_tests()`'s calls `GenericSensorTestChromium.reset()`
2. `GenericSensorTestChromium.reset()` calls `MockSensorProvider.reset()`,
   which runs synchronously and where we close the mojo binding and stop the
   mojo interceptor
3. This function `await`s on a promise that resolves inside `setTimeout()`
   and yields control back to the event loop to let the mojo shutdown
   process finish. The next test may start running before this `sensor_test`
   fully finishes, but it's not a problem since we're not running anything
   after calling `GenericSensorTestChromium.reset()`
4. The next test runs as expected because `testInternal` has already been
   reset

With this change, running `wpt run` with a recent Chromium master build on
accelerometer, generic-sensor, geolocation-sensor, gyroscope, magnetometer
and orientation-sensor yields 249 failures, down from 286.