### PR TITLE
Removing ES6 constructs from WebDriver tests for IE support

### DIFF
--- a/webdriver/tests/element_click/navigate.py
+++ b/webdriver/tests/element_click/navigate.py
@@ -44,11 +44,12 @@ def test_link_unload_event(session, server_config):
             <a href={url}>click here</a>
             <input type=checkbox>
             <script>
-                function checkUnload() {
+                function checkUnload() {{
                     document.getElementsByTagName("input")[0].checked = true;
-                }
+                }}
             </script>
         </body>""".format(url=link))
+
     element = session.find.css("a", all=False)
     response = element_click(session, element)
     assert_success(response)
@@ -61,7 +62,7 @@ def test_link_unload_event(session, server_config):
 
     element = session.find.css("input", all=False)
     response = session.execute_script("""
-        let [input] = arguments;
+        let input = arguments[0];
         return input.checked;
         """, args=(element,))
     assert response is True
@@ -84,7 +85,7 @@ def test_link_hash(session):
 
     element = session.find.css("p", all=False)
     assert session.execute_script("""
-        let [input] = arguments;
+        let input = arguments[0];
         rect = input.getBoundingClientRect();
         return rect["top"] >= 0 && rect["left"] >= 0 &&
             (rect["top"] + rect["height"]) <= window.innerHeight &&

--- a/webdriver/tests/element_click/scroll_into_view.py
+++ b/webdriver/tests/element_click/scroll_into_view.py
@@ -21,7 +21,7 @@ def test_scroll_into_view(session):
 
     # Check if element clicked is scrolled into view
     assert session.execute_script("""
-        let [input] = arguments;
+        let input = arguments[0];
         rect = input.getBoundingClientRect();
         return rect["top"] >= 0 && rect["left"] >= 0 &&
             (rect["top"] + rect["height"]) <= window.innerHeight &&


### PR DESCRIPTION
IE does not support array destructuring in a `let` statement. This commit
allows the newly added element_click tests to run on IE 11.

Also fixes a minor string template format issue.