### PR TITLE
Correcting expected error response in WebDriver element_click test

### DIFF
--- a/webdriver/tests/element_click/interactability.py
+++ b/webdriver/tests/element_click/interactability.py
@@ -59,4 +59,4 @@ def test_element_not_visible_overflow_hidden(session):
 
     element = session.find.css("input", all=False)
     response = element_click(session, element)
-    assert_error(response, "element not visible")
+    assert_error(response, "element not interactable")


### PR DESCRIPTION
Test should expect the "element not interactable" error state, not the nonexistent "element not visible".