### PR TITLE
[testharness.js][docs] Support assert_throws without name property

### DIFF
--- a/docs/_writing-tests/testharness-api.md
+++ b/docs/_writing-tests/testharness-api.md
@@ -762,7 +762,8 @@ assert that property `property_name` on object is readonly
              name, e.g., "TimeoutError" (for compatibility with existing
              tests, a constant is also supported, e.g., "TIMEOUT_ERR")
   * object - the thrown exception must have a property called "name" that
-             matches code.name
+             matches `code.name`, or if `code.name` is not given, must have
+             the same `constructor.name` as code
 
 `func` - a function that should throw
 

--- a/resources/test/tests/functional/api-tests-1.html
+++ b/resources/test/tests/functional/api-tests-1.html
@@ -173,6 +173,19 @@
         assert_throws("TEST_ERR", function() {throw e});
     }, "Test assert_throws with non-DOM-exception expected to Fail");
 
+    function FooError() {
+      return this;
+    }
+    test(function()
+    {
+        assert_throws(new FooError(), function() {throw new FooError()});
+    }, "Test assert_throws with custom exception without name property");
+
+    test(function()
+    {
+        assert_throws(new FooError(), function() {throw {name: "FooError"}});
+    }, "Test assert_throws with custom exception without name property, expected to fail");
+
     var t = async_test("Test step_func")
     setTimeout(
       t.step_func(
@@ -266,6 +279,18 @@
       "status_string": "FAIL",
       "name": "Test throw DOM exception expected to fail",
       "message": "assert_throws: function \"function () {a.appendChild(b)}\" threw object \"HierarchyRequestError: Node cannot be inserted at the specified point in the hierarchy\" that is not a DOMException NOT_FOUND_ERR: property \"code\" is equal to 3, expected 8",
+      "properties": {}
+    },
+    {
+      "status_string": "PASS",
+      "name": "Test assert_throws with custom exception without name property",
+      "message": null,
+      "properties": {}
+    },
+    {
+      "status_string": "FAIL",
+      "name": "Test assert_throws with custom exception without name property, expected to fail",
+      "message": "assert_throws: function \"function() {throw {name: \"FooError\"}}\" threw object \"[object Object]\" (\"Object\") expected object \"[object Object]\" (\"FooError\")",
       "properties": {}
     },
     {

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1313,12 +1313,21 @@ policies and contribution forms [3].
                 throw new AssertionError('Test bug: need to pass exception to assert_throws()');
             }
             if (typeof code === "object") {
-                assert("name" in e && e.name == code.name,
-                       "assert_throws", description,
-                       "${func} threw ${actual} (${actual_name}) expected ${expected} (${expected_name})",
-                                    {func:func, actual:e, actual_name:e.name,
-                                     expected:code,
-                                     expected_name:code.name});
+                if (!("name" in code)) {
+                    assert(e.constructor.name == code.constructor.name,
+                           "assert_throws", description,
+                           "${func} threw ${actual} (${actual_name}) expected ${expected} (${expected_name})",
+                                        {func:func, actual:e, actual_name:e.constructor.name,
+                                         expected:code,
+                                         expected_name:code.constructor.name});
+                } else {
+                    assert("name" in e && e.name == code.name,
+                           "assert_throws", description,
+                           "${func} threw ${actual} (${actual_name}) expected ${expected} (${expected_name})",
+                                        {func:func, actual:e, actual_name:e.name,
+                                         expected:code,
+                                         expected_name:code.name});
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixes #11556.