### PR TITLE
Fix EUC-JP reference decoder

### DIFF
--- a/encoding/legacy-mb-japanese/euc-jp/eucjp-decoder.js
+++ b/encoding/legacy-mb-japanese/euc-jp/eucjp-decoder.js
@@ -68,6 +68,7 @@ function eucjpDecoder(stream) {
             }
             if (byte >= 0x00 && byte <= 0x7f) bytes.unshift(byte);
             out += "�";
+            continue;
         }
         if (byte >= 0x00 && byte <= 0x7f) {
             out += dec2char(byte);


### PR DESCRIPTION
The relevant step fixed by this pull request says "Return error."; thus, the rest of the process should continue with the next iteration, rather than run the rest of the handler for the given byte.