### PR TITLE
[css-box] Parsing tests for CSS Box properties

### DIFF
--- a/css/css-box/parsing/clear-invalid.html
+++ b/css/css-box/parsing/clear-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing clear with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-clear">
+<meta name="assert" content="clear supports only the grammar 'none | left | right | both'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("clear", "auto");
+test_invalid_value("clear", "left right");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/clear-valid.html
+++ b/css/css-box/parsing/clear-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing clear with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-clear">
+<meta name="assert" content="clear supports the full grammar 'none | left | right | both'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("clear", "none");
+test_valid_value("clear", "left");
+test_valid_value("clear", "right");
+test_valid_value("clear", "both");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/float-invalid.html
+++ b/css/css-box/parsing/float-invalid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing float with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-float">
+<meta name="assert" content="float supports only the grammar 'left | right | top | bottom | start | end | none | <page-floats>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("float", "auto");
+test_invalid_value("float", "right bottom");
+test_invalid_value("float", "top, left");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/float-valid.html
+++ b/css/css-box/parsing/float-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing float with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-float">
+<meta name="assert" content="float supports the full grammar 'left | right | top | bottom | start | end | none | <page-floats>'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("float", "left");
+test_valid_value("float", "right");
+test_valid_value("float", "none");
+
+// The following are not yet supported by browsers:
+// test_valid_value("float", "top");
+// test_valid_value("float", "bottom");
+// test_valid_value("float", "start"); // not permitted in https://drafts.csswg.org/css-page-floats/#float-property
+// test_valid_value("float", "end"); // not permitted in https://drafts.csswg.org/css-page-floats/#float-property
+
+// Page floats are now defined in
+// https://drafts.csswg.org/css-page-floats/#float-property
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/height-invalid.html
+++ b/css/css-box/parsing/height-invalid.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing height with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-height">
+<meta name="assert" content="height supports only the grammar '[<length> | <percentage>] | available | min-content | max-content | fit-content | complex | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("height", "none");
+
+test_invalid_value("height", "min-content available");
+test_invalid_value("height", "max-content 10px");
+test_invalid_value("height", "20% available");
+
+test_invalid_value("height", "-10px");
+test_invalid_value("height", "-20%");
+test_invalid_value("height", "60");
+test_invalid_value("height", "10px 20%");
+
+test_invalid_value("height", "10px border-box");
+test_invalid_value("height", "content-box 20%");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/height-valid.html
+++ b/css/css-box/parsing/height-valid.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing height with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-height">
+<meta name="assert" content="height supports the full grammar '[<length> | <percentage>] | available | min-content | max-content | fit-content | complex | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("height", "auto");
+
+test_valid_value("height", "10px");
+test_valid_value("height", "20%");
+test_valid_value("height", "calc(2em + 3ex)");
+
+test_valid_value("height", "min-content");
+test_valid_value("height", "max-content");
+test_valid_value("height", "fit-content");
+
+// The following are not yet supported by browsers:
+// test_valid_value("height", "available");
+// test_valid_value("height", "complex");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/margin-invalid.html
+++ b/css/css-box/parsing/margin-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing margin with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-margin">
+<meta name="assert" content="margin supports only the grammar '[ <length> | <percentage> | auto]{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("margin", "available");
+test_invalid_value("margin", "10px border-box");
+test_invalid_value("margin", "1% 2% 3% 4% 5%");
+
+test_invalid_value("margin-top", "calc(2em + 3ex) auto");
+test_invalid_value("margin-right", "auto calc(2em + 3ex) 20%");
+test_invalid_value("margin-bottom", "10px 20% calc(2em + 3ex) auto");
+test_invalid_value("margin-bottom-left", "none");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/margin-valid.html
+++ b/css/css-box/parsing/margin-valid.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing margin with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-margin">
+<meta name="assert" content="margin supports the full grammar '[ <length> | <percentage> | auto]{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("margin", "10px");
+test_valid_value("margin", "20%");
+test_valid_value("margin", "calc(2em + 3ex)");
+test_valid_value("margin", "auto");
+test_valid_value("margin", "-10px");
+test_valid_value("margin", "-20%");
+
+test_valid_value("margin", "calc(2em + 3ex) auto");
+test_valid_value("margin", "auto calc(2em + 3ex) 20%");
+test_valid_value("margin", "10px 20% calc(2em + 3ex) auto");
+
+test_valid_value("margin-top", "10px");
+test_valid_value("margin-right", "20%");
+test_valid_value("margin-bottom", "calc(2em + 3ex)");
+test_valid_value("margin-left", "auto");
+test_valid_value("margin-top", "-10px");
+test_valid_value("margin-right", "-20%");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/max-height-invalid.html
+++ b/css/css-box/parsing/max-height-invalid.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing max-height with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-max-height">
+<meta name="assert" content="max-height supports only the grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("max-height", "complex");
+test_invalid_value("max-height", "auto");
+test_invalid_value("max-height", "none available");
+test_invalid_value("max-height", "max-content 10px");
+test_invalid_value("max-height", "20% available");
+
+test_invalid_value("max-height", "-10px");
+test_invalid_value("max-height", "-20%");
+test_invalid_value("max-height", "60");
+test_invalid_value("max-height", "10px 20%");
+test_invalid_value("max-height", "content-box border-box");
+test_invalid_value("max-height", "10px border-box 20%");
+test_invalid_value("max-height", "content-box 20% border-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/max-height-valid.html
+++ b/css/css-box/parsing/max-height-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing max-height with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-max-height">
+<meta name="assert" content="max-height supports the full grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("max-height", "none");
+
+test_valid_value("max-height", "10px");
+test_valid_value("max-height", "20%");
+test_valid_value("max-height", "calc(2em + 3ex)");
+
+test_valid_value("max-height", "min-content");
+test_valid_value("max-height", "max-content");
+test_valid_value("max-height", "fit-content");
+
+// The following are not yet supported by browsers:
+// test_valid_value("max-height", "available");
+// test_valid_value("max-height", "10px border-box");
+// test_valid_value("max-height", "content-box 20%", "20% content-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/max-width-invalid.html
+++ b/css/css-box/parsing/max-width-invalid.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing max-width with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-max-width">
+<meta name="assert" content="max-width supports only the grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("max-width", "complex");
+test_invalid_value("max-width", "auto");
+test_invalid_value("max-width", "none available");
+test_invalid_value("max-width", "max-content 10px");
+test_invalid_value("max-width", "20% available");
+
+test_invalid_value("max-width", "-10px");
+test_invalid_value("max-width", "-20%");
+test_invalid_value("max-width", "60");
+test_invalid_value("max-width", "10px 20%");
+test_invalid_value("max-width", "content-box border-box");
+test_invalid_value("max-width", "10px border-box 20%");
+test_invalid_value("max-width", "content-box 20% border-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/max-width-valid.html
+++ b/css/css-box/parsing/max-width-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing max-width with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-max-width">
+<meta name="assert" content="max-width supports the full grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content | none'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("max-width", "none");
+
+test_valid_value("max-width", "10px");
+test_valid_value("max-width", "20%");
+test_valid_value("max-width", "calc(2em + 3ex)");
+
+test_valid_value("max-width", "min-content");
+test_valid_value("max-width", "max-content");
+test_valid_value("max-width", "fit-content");
+
+// The following are not yet supported by browsers:
+// test_valid_value("max-width", "available");
+// test_valid_value("max-width", "10px border-box");
+// test_valid_value("max-width", "content-box 20%", "20% content-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/min-height-invalid.html
+++ b/css/css-box/parsing/min-height-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing min-height with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-min-height">
+<meta name="assert" content="min-height supports only the grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("min-height", "complex");
+test_invalid_value("min-height", "none");
+test_invalid_value("min-height", "none available");
+test_invalid_value("min-height", "max-content 10px");
+test_invalid_value("min-height", "20% available");
+
+test_invalid_value("min-height", "-10px");
+test_invalid_value("min-height", "-20%");
+test_invalid_value("min-height", "60");
+test_invalid_value("min-height", "10px 20%");
+test_invalid_value("min-height", "content-box border-box");
+test_invalid_value("min-height", "10px border-box 20%");
+test_invalid_value("min-height", "content-box 20% border-box");
+
+// The following is not yet rejected by browsers:
+test_invalid_value("min-height", "auto");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/min-height-valid.html
+++ b/css/css-box/parsing/min-height-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing min-height with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-min-height">
+<meta name="assert" content="min-height supports the full grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("min-height", "10px");
+test_valid_value("min-height", "20%");
+test_valid_value("min-height", "calc(2em + 3ex)");
+
+test_valid_value("min-height", "min-content");
+test_valid_value("min-height", "max-content");
+test_valid_value("min-height", "fit-content");
+
+// The following are not yet supported by browsers:
+// test_valid_value("min-height", "available");
+// test_valid_value("min-height", "10px border-box");
+// test_valid_value("min-height", "content-box 20%", "20% content-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/min-width-invalid.html
+++ b/css/css-box/parsing/min-width-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing min-width with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-min-width">
+<meta name="assert" content="min-width supports only the grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("min-width", "complex");
+test_invalid_value("min-width", "none");
+test_invalid_value("min-width", "none available");
+test_invalid_value("min-width", "max-content 10px");
+test_invalid_value("min-width", "20% available");
+
+test_invalid_value("min-width", "-10px");
+test_invalid_value("min-width", "-20%");
+test_invalid_value("min-width", "60");
+test_invalid_value("min-width", "10px 20%");
+test_invalid_value("min-width", "content-box border-box");
+test_invalid_value("min-width", "10px border-box 20%");
+test_invalid_value("min-width", "content-box 20% border-box");
+
+// The following is not yet rejected by browsers:
+test_invalid_value("min-width", "auto");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/min-width-valid.html
+++ b/css/css-box/parsing/min-width-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing min-width with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-min-width">
+<meta name="assert" content="min-width supports the full grammar '[ [<length> | <percentage>] && [border-box | content-box]? ] | available | min-content | max-content | fit-content'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("min-width", "10px");
+test_valid_value("min-width", "20%");
+test_valid_value("min-width", "calc(2em + 3ex)");
+
+test_valid_value("min-width", "min-content");
+test_valid_value("min-width", "max-content");
+test_valid_value("min-width", "fit-content");
+
+// The following are not yet supported by browsers:
+// test_valid_value("min-width", "available");
+// test_valid_value("min-width", "10px border-box");
+// test_valid_value("min-width", "content-box 20%", "20% content-box");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/overflow-invalid.html
+++ b/css/css-box/parsing/overflow-invalid.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing overflow with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-overflow">
+<meta name="assert" content="overflow supports only the grammar '[ visible | hidden | scroll | auto | no-display | no-content ]{1,2}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("overflow", "none");
+test_invalid_value("overflow", "visible hidden scroll");
+test_invalid_value("overflow", "no-display, no-content");
+
+test_invalid_value("overflow-x", "none");
+test_invalid_value("overflow-y", "visible hidden");
+test_invalid_value("overflow-y", "no-display, no-content");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/overflow-valid.html
+++ b/css/css-box/parsing/overflow-valid.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing overflow with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-overflow">
+<meta name="assert" content="overflow supports the full grammar '[ visible | hidden | scroll | auto | no-display | no-content ]{1,2}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("overflow", "visible");
+test_valid_value("overflow", "hidden");
+test_valid_value("overflow", "scroll");
+test_valid_value("overflow", "auto");
+
+test_valid_value("overflow-x", "visible");
+test_valid_value("overflow-x", "hidden");
+test_valid_value("overflow-x", "scroll");
+test_valid_value("overflow-y", "auto");
+
+// The following are not yet supported by browsers:
+// test_valid_value("overflow", "no-display");
+// test_valid_value("overflow", "no-content");
+// test_valid_value("overflow", "visible hidden");
+// test_valid_value("overflow", "auto scroll");
+// test_valid_value("overflow", "no-display no-content");
+// test_valid_value("overflow-y", "no-display");
+// test_valid_value("overflow-y", "no-content");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/padding-invalid.html
+++ b/css/css-box/parsing/padding-invalid.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing padding with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-padding">
+<meta name="assert" content="padding supports only the grammar '<length>{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("padding", "auto");
+test_invalid_value("padding", "available");
+test_invalid_value("padding", "10px border-box");
+test_invalid_value("padding", "calc(2em + 3ex) auto");
+test_invalid_value("padding", "10px 20px 30px 40px 50px");
+
+test_invalid_value("padding-top", "auto");
+test_invalid_value("padding-bottom", "10px 20px calc(2em + 3ex) auto");
+test_invalid_value("padding-bottom-left", "10px 20px");
+
+test_invalid_value("padding-top", "-10px");
+
+// The following are not yet rejected by browsers:
+test_invalid_value("padding", "20%");
+test_invalid_value("padding", "10px 20% 30% 40px");
+test_invalid_value("padding-right", "20%");
+test_invalid_value("padding-right", "calc(2em + 3%)");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/padding-valid.html
+++ b/css/css-box/parsing/padding-valid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing padding with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-padding">
+<meta name="assert" content="padding supports the full grammar '<length>{1,4}'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("padding", "10px");
+test_valid_value("padding", "10px 20px 30px 40px");
+test_valid_value("padding", "calc(2em + 3ex)");
+
+test_valid_value("padding-top", "10px");
+test_valid_value("padding-right", "20px");
+test_valid_value("padding-bottom", "30px");
+test_valid_value("padding-left", "40px");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/resources/parsing-testcommon.js
+++ b/css/css-box/parsing/resources/parsing-testcommon.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// serializedValue can be the expected serialization of value,
+// or an array of permitted serializations,
+// or omitted if value should serialize as value.
+function test_valid_value(property, value, serializedValue) {
+    if (arguments.length < 3)
+        serializedValue = value;
+
+    var stringifiedValue = JSON.stringify(value);
+
+    test(function(){
+        var div = document.createElement('div');
+        div.style[property] = value;
+        assert_not_equals(div.style.getPropertyValue(property), "", "property should be set");
+
+        var div = document.createElement('div');
+        div.style[property] = value;
+        var readValue = div.style.getPropertyValue(property);
+        if (serializedValue instanceof Array)
+            assert_in_array(readValue, serializedValue, "serialization should be sound");
+        else
+            assert_equals(readValue, serializedValue, "serialization should be canonical");
+
+        div.style[property] = readValue;
+        assert_equals(div.style.getPropertyValue(property), readValue, "serialization should round-trip");
+
+    }, "e.style['" + property + "'] = " + stringifiedValue + " should set the property value");
+}
+
+function test_invalid_value(property, value) {
+    var stringifiedValue = JSON.stringify(value);
+
+    test(function(){
+        var div = document.createElement('div');
+        div.style[property] = value;
+        assert_equals(div.style.getPropertyValue(property), "");
+    }, "e.style['" + property + "'] = " + stringifiedValue + " should not set the property value");
+}

--- a/css/css-box/parsing/visibility-invalid.html
+++ b/css/css-box/parsing/visibility-invalid.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing visibility with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-visibility">
+<meta name="assert" content="visibility supports only the grammar 'visible | hidden | collapse'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("visibility", "auto");
+test_invalid_value("visibility", "hidden collapse");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/visibility-valid.html
+++ b/css/css-box/parsing/visibility-valid.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing visibility with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-visibility">
+<meta name="assert" content="visibility supports the full grammar 'visible | hidden | collapse'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("visibility", "visible");
+test_valid_value("visibility", "hidden");
+test_valid_value("visibility", "collapse");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/width-invalid.html
+++ b/css/css-box/parsing/width-invalid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing width with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-width">
+<meta name="assert" content="width supports only the grammar '[<length> | <percentage>] | available | min-content | max-content | fit-content | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("width", "complex");
+test_invalid_value("width", "none");
+
+test_invalid_value("width", "min-content available");
+test_invalid_value("width", "max-content 10px");
+test_invalid_value("width", "20% available");
+
+test_invalid_value("width", "-10px");
+test_invalid_value("width", "-20%");
+test_invalid_value("width", "60");
+test_invalid_value("width", "10px 20%");
+
+test_invalid_value("width", "10px border-box");
+test_invalid_value("width", "content-box 20%");
+</script>
+</body>
+</html>

--- a/css/css-box/parsing/width-valid.html
+++ b/css/css-box/parsing/width-valid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS basic box model: parsing width with valid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-box-3/#propdef-width">
+<meta name="assert" content="width supports the full grammar '[<length> | <percentage>] | available | min-content | max-content | fit-content | auto'.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("width", "auto");
+
+test_valid_value("width", "10px");
+test_valid_value("width", "20%");
+test_valid_value("width", "calc(2em + 3ex)");
+
+test_valid_value("width", "min-content");
+test_valid_value("width", "max-content");
+test_valid_value("width", "fit-content");
+
+// The following is not yet supported by browsers:
+// test_valid_value("width", "available");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Spec:
https://drafts.csswg.org/css-box-3/
    
Omits properties and values that are not yet supported by browsers.
