### PR TITLE
Fix ISO-2022-JP reference implementation

### DIFF
--- a/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-decoder.js
+++ b/encoding/legacy-mb-japanese/iso-2022-jp/iso2022jp-decoder.js
@@ -193,8 +193,8 @@ function iso2022jpDecoder(stream) {
                         continue;
                     }
                 }
-                bytes.unshift(lead);
                 bytes.unshift(byte);
+                bytes.unshift(lead);
                 outFlag = false;
                 decState = outState;
                 out += "�";


### PR DESCRIPTION
The relevant step in the Encoding Standard says "Prepend _lead_ and _byte_ to _stream_." However, the two bytes are prepended in the wrong order in the reference implementation.  Note that under the Encoding Standard, "[w]hen one or more tokens are prepended to a stream, those tokens must be inserted, _in given order_, before the first token in the stream."  (Note that the current reference implementation, at the time of this request, moves _lead_ to the front of the array, then moves _byte_ to the front of the array.)

There may be other issues like this elsewhere in the multiple-byte encoder reference implementations.