### PR TITLE
[css-contain] Add alt on image at contain-size-013.html

### DIFF
--- a/css/css-contain/contain-size-013.html
+++ b/css/css-contain/contain-size-013.html
@@ -14,4 +14,4 @@ img {
 </style>
 
 <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
-<img src="/css/support/60x60-red.png" />
+<img src="/css/support/60x60-red.png" alt="Image download support must be enabled" />


### PR DESCRIPTION
Adding `alt` attribute on image in test `contain-size-013.html` as suggested by @gtalbot.