### PR TITLE
Add tests for some logical border shorthand properties

### DIFF
--- a/css/css-logical/logical-box-border-shorthands.html
+++ b/css/css-logical/logical-box-border-shorthands.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>CSS Logical Properties: Flow-Relative Border Shorthands</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com" />
+<link rel="help" href="https://drafts.csswg.org/css-logical/#border-shorthands">
+<meta name="assert" content="This test checks the interaction of the flow-relative border-* shorthand properties with the physical ones in different writing modes." />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<script src="./resources/test-box-properties.js"></script>
+<script>
+runTests(createBoxPropertyGroup("border-*", {type: ["length", "border-style", "color"]}));
+</script>


### PR DESCRIPTION
#11324 only tested logical longhands.

This adds tests for `border-block-start`, `border-block-end`, `border-inline-start` and `border-inline-end`. The other logical border shorthands are not covered.

Cc @mrego 