### PR TITLE
WebKit export of https://bugs.webkit.org/show_bug.cgi?id=186939

### DIFF
--- a/cors/resources/cache-304.py
+++ b/cors/resources/cache-304.py
@@ -1,0 +1,10 @@
+def main(request, response):
+    match = request.headers.get("If-None-Match", None)
+    if match is not None and match == "mybestscript-v1":
+        response.status = (304, "YEP")
+        return ""
+    response.headers.set("Access-Control-Allow-Origin", "*")
+    response.headers.set("Cache-Control", "must-revalidate")
+    response.headers.set("ETag", "mybestscript-v1")
+    response.headers.set("Content-Type", "text/javascript")
+    return "function hep() { }"

--- a/cors/script-304.html
+++ b/cors/script-304.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
+    <script src="/common/utils.js"></script>
+  </head>
+  <body>
+    <div id="testDiv"></div>
+    <script>
+
+const scriptURL = get_host_info().HTTP_REMOTE_ORIGIN + "/cors/resources/cache-304.py?" + token();
+
+function loadScript(test)
+{
+    const script = document.createElement("script");
+    script.crossOrigin = "anonymous";
+    script.src = scriptURL;
+    return new Promise((resolve, reject) => {
+        // Let's add a small timeout so that the script is fully loaded in memory cache before reloading it.
+        script.onload = test.step_timeout(resolve, 50);
+        script.onerror = reject;
+        testDiv.appendChild(script);
+    });
+}
+
+promise_test((test) => {
+    return loadScript(test);
+}, "Load a fresh cross-origin script");
+
+promise_test((test) => {
+    return loadScript(test);
+}, "Reload same cross-origin script from the memory cache after revalidation");
+
+</script>
+  </body>
+</html>
+


### PR DESCRIPTION
WebKit export from bug: [NetworkLoadChecker should not check CORS for 304 responses triggered by WebProcess revalidation](https://bugs.webkit.org/show_bug.cgi?id=186939)