### PR TITLE
immediate repeated calls to .complete()

### DIFF
--- a/payment-request/payment-response/complete-method-manual.https.html
+++ b/payment-request/payment-response/complete-method-manual.https.html
@@ -16,6 +16,9 @@ async function runManualTest({ completeWith: result }, button) {
       // We .complete() as normal, using the passed test value
       const promise = response.complete(result);
       assert_true(promise instanceof Promise, "returns a promise");
+      // Immediately calling complete() again yields a rejected promise.
+      await promise_rejects(t, "InvalidStateError", response.complete(result));
+      // but the original promise is unaffected
       const returnedValue = await promise;
       assert_equals(
         returnedValue,
@@ -23,17 +26,8 @@ async function runManualTest({ completeWith: result }, button) {
         "Returned value must always be undefined"
       );
       // We now call .complete() again, to force an exception
-      // because [[completeCalled]] is true.
-      try {
-        await response.complete(result);
-        assert_unreached("Expected InvalidStateError to be thrown");
-      } catch (err) {
-        assert_equals(
-          err.code,
-          DOMException.INVALID_STATE_ERR,
-          "Must throw an InvalidStateError"
-        );
-      }
+      // because [[complete]] is true.
+      await promise_rejects(t, "InvalidStateError", response.complete(result));
       button.innerHTML = `✅  ${button.textContent}`;
     } catch (err) {
       button.innerHTML = `❌  ${button.textContent}`;


### PR DESCRIPTION
Tests for https://github.com/w3c/payment-request/pull/732

Makes sure that a rejected promise is returned, and that the `completePromise` doesn't get rejected when complete() is called multiple times. 