### PR TITLE
Add a test to verify that postMessage forwards user gesture.

### DIFF
--- a/webmessaging/postMessage-triggered-by-user-activation-from-subframe-manual.html
+++ b/webmessaging/postMessage-triggered-by-user-activation-from-subframe-manual.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<title>postMessage's task triggered by user activation from a subframe</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<!-- This test is manual since we cannot currently test action triggered by user
+     activation with the test runner (blocking popups is always disabled).
+     Moreover, testdriver does not currently support clicking elements from a
+     subframe. -->
+<script src="support/postMessage-triggered-by-user-activation.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name">
+<body>
+<p>Click all the buttons below. If only "PASS" results appear the test passes,
+  otherwise it fails.</p>
+<script>
+"use strict";
+
+setup({explicit_timeout: true}); // Disable timeout for manual testing.
+
+let windowTest = async_test("With window");
+let click1 = windowTest.step_func(() => {
+  assert_true(canOpenPopup(), "onmessage should be able to open popup");
+  windowTest.done();
+});
+
+let messagePortTest = async_test(() => {
+  assert_true("MessageChannel" in self, "The browser must support MessageChannel");
+}, "With a MessageChannel and its MessagePorts");
+let channel2 = messagePortTest.step_func(port => {
+  port.onmessage = messagePortTest.step_func_done(e => {
+    assert_equals(e.data, "click2");
+    assert_true(canOpenPopup(), "onmessage should be able to open popup");
+  });
+});
+
+async_test(t => {
+  assert_true("BroadcastChannel" in self, "The browser must support BroadcastChannel");
+
+  const channel = new BroadcastChannel("channel3");
+
+  channel.onmessage = t.step_func_done(e => {
+    assert_equals(e.data, "click3");
+    assert_true(canOpenPopup(), "onmessage should be able to open popup");
+  });
+}, "With a BroadcastChannel");
+
+window.onmessage = (e => {
+  if (e.data === "click1")
+    click1();
+  else if (e.data === "channel2") {
+    let port = e.ports[0];
+    channel2(port);
+  } else
+    assert_unreached("Unknown message received.");
+});
+
+</script>
+<iframe src="support/postMessage-triggered-by-user-activation-subframe.html"></iframe>
+</body>

--- a/webmessaging/postMessage-triggered-by-user-activation-manual.html
+++ b/webmessaging/postMessage-triggered-by-user-activation-manual.html
@@ -2,43 +2,34 @@
 <title>postMessage's task triggered by user activation</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<!-- This test is manual since we cannot currently test action triggered by user
+     activation with the test runner (blocking popups is always disabled). -->
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<script src="support/postMessage-triggered-by-user-activation.js"></script>
 <link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">
 <link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name">
 <body>
+<p>Click all the buttons below. If only "PASS" results appear the test passes,
+  otherwise it fails.</p>
 <script>
 "use strict";
 
-function canOpenPopup() {
-  let popup = window.open("about:blank", "_blank");
-  if (popup) {
-    popup.close();
-    return true;
-  }
-  return false;
-}
-
-function appendAndClickButton(buttonText, onClickCallback) {
-    let button = document.createElement("button");
-    button.textContent = buttonText;
-    button.onclick = onClickCallback;
-    document.body.appendChild(button);
-    test_driver.click(button);
-}
+setup({explicit_timeout: true}); // Disable timeout for manual testing.
 
 async_test(t => {
   window.onmessage = t.step_func_done(e => {
-    assert_equals(e.data, "click");
-    assert_true(canOpenPopup(), "onmessage be able to open popup");
+    assert_equals(e.data, "click1");
+    assert_true(canOpenPopup(), "onmessage should be able to open popup");
   });
 
-  appendAndClickButton("Window's postMessage", t.step_func(() => {
-    window.postMessage("click", "*");
+  let button = appendButton("Window's postMessage", t.step_func(() => {
+    window.postMessage("click1", "*");
   }));
+  test_driver.click(button);
 }, "With window");
 
 async_test(t => {
@@ -47,30 +38,31 @@ async_test(t => {
   const channel = new MessageChannel();
 
   channel.port2.onmessage = t.step_func_done(e => {
-    assert_equals(e.data, "click");
-    assert_true(canOpenPopup(), "onmessage be able to open popup");
+    assert_equals(e.data, "click2");
+    assert_true(canOpenPopup(), "onmessage should be able to open popup");
   });
 
-  appendAndClickButton("MessagePort's postMessage", t.step_func(() => {
-    channel.port1.postMessage("click");
+  let button = appendButton("MessagePort's postMessage", t.step_func(() => {
+    channel.port1.postMessage("click2");
   }));
+  test_driver.click(button);
 }, "With a MessageChannel and its MessagePorts");
 
 async_test(t => {
   assert_true("BroadcastChannel" in self, "The browser must support BroadcastChannel");
 
-  const channel = new BroadcastChannel("channel name");
+  const channel = new BroadcastChannel("channel3");
 
   channel.onmessage = t.step_func_done(e => {
-    assert_equals(e.data, "click");
-    assert_true(canOpenPopup(), "onmessage be able to open popup");
+    assert_equals(e.data, "click3");
+    assert_true(canOpenPopup(), "onmessage should be able to open popup");
   });
 
-  appendAndClickButton("BroadcastChannel's postMessage", t.step_func(() => {
-    let myChannel = new BroadcastChannel("channel name");
-    myChannel.postMessage("click");
+  let button = appendButton("BroadcastChannel's postMessage", t.step_func(() => {
+    let myChannel = new BroadcastChannel("channel3");
+    myChannel.postMessage("click3");
   }));
-
+  test_driver.click(button);
 }, "With a BroadcastChannel");
 
 </script>

--- a/webmessaging/postMessage-triggered-by-user-activation.html
+++ b/webmessaging/postMessage-triggered-by-user-activation.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<title>postMessage's task triggered by user activation</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-window-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/comms.html#dom-messageport-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name">
+<body>
+<script>
+"use strict";
+
+function canOpenPopup() {
+  let popup = window.open("about:blank", "_blank");
+  if (popup) {
+    popup.close();
+    return true;
+  }
+  return false;
+}
+
+function appendAndClickButton(buttonText, onClickCallback) {
+    let button = document.createElement("button");
+    button.textContent = buttonText;
+    button.onclick = onClickCallback;
+    document.body.appendChild(button);
+    test_driver.click(button);
+}
+
+async_test(t => {
+  window.onmessage = t.step_func_done(e => {
+    assert_equals(e.data, "click");
+    assert_true(canOpenPopup(), "onmessage be able to open popup");
+  });
+
+  appendAndClickButton("Window's postMessage", t.step_func(() => {
+    window.postMessage("click", "*");
+  }));
+}, "With window");
+
+async_test(t => {
+  assert_true("MessageChannel" in self, "The browser must support MessageChannel");
+
+  const channel = new MessageChannel();
+
+  channel.port2.onmessage = t.step_func_done(e => {
+    assert_equals(e.data, "click");
+    assert_true(canOpenPopup(), "onmessage be able to open popup");
+  });
+
+  appendAndClickButton("MessagePort's postMessage", t.step_func(() => {
+    channel.port1.postMessage("click");
+  }));
+}, "With a MessageChannel and its MessagePorts");
+
+async_test(t => {
+  assert_true("BroadcastChannel" in self, "The browser must support BroadcastChannel");
+
+  const channel = new BroadcastChannel("channel name");
+
+  channel.onmessage = t.step_func_done(e => {
+    assert_equals(e.data, "click");
+    assert_true(canOpenPopup(), "onmessage be able to open popup");
+  });
+
+  appendAndClickButton("BroadcastChannel's postMessage", t.step_func(() => {
+    let myChannel = new BroadcastChannel("channel name");
+    myChannel.postMessage("click");
+  }));
+
+}, "With a BroadcastChannel");
+
+</script>
+</body>

--- a/webmessaging/support/postMessage-triggered-by-user-activation-subframe.html
+++ b/webmessaging/support/postMessage-triggered-by-user-activation-subframe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Subframe for testing postMessage's task triggered by user activation</title>
+    <script src="postMessage-triggered-by-user-activation.js"></script>
+</head>
+<body>
+  <script>
+    appendButton("Window's postMessage", () => {
+      window.parent.postMessage("click1", "*");
+    });
+
+    (() => {
+      const channel = new MessageChannel();
+      window.parent.postMessage("channel2", "*", [channel.port2]);
+      appendButton("MessagePort's postMessage ", () => {
+        channel.port1.postMessage("click2");
+      });
+    })();
+
+    (() => {
+      const channel = new BroadcastChannel("channel3");
+      appendButton("BroadcastChannel's postMessage", () => {
+        channel.postMessage("click3");
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/webmessaging/support/postMessage-triggered-by-user-activation.js
+++ b/webmessaging/support/postMessage-triggered-by-user-activation.js
@@ -1,0 +1,18 @@
+"use strict";
+
+function canOpenPopup() {
+  let popup = window.open("about:blank", "_blank");
+  if (popup) {
+    popup.close();
+    return true;
+  }
+  return false;
+}
+
+function appendButton(buttonText, onClickCallback) {
+    let button = document.createElement("button");
+    button.textContent = buttonText;
+    button.onclick = onClickCallback;
+    document.body.appendChild(button);
+    return button;
+}


### PR DESCRIPTION
I *think* the spec says all versions of postMessage queue a task and so the triggered by user activation flag should be forwarded to the receiver.

At least with window's postMessage, the popup is allowed in all browsers.

I'm not sure if Firefox considers the user activation flag to block popups. It seems to allow them all when using ./wpt run with testdriver's click or blocking them all when running manually.
(--update: Dima opened https://bugzilla.mozilla.org/show_bug.cgi?id=1469422)

On Chromium, the popup is blocked for MessagePort and BroadcastChannel when you run them manually (as expected per https://bugs.chromium.org/p/chromium/issues/detail?id=851493) but not when using ./wpt run with testdriver's click.

On WebKit, BroadcastChannel is not supported ( https://bugs.webkit.org/show_bug.cgi?id=161472 ) and the popup is blocked for MessagePort ( https://bugs.webkit.org/show_bug.cgi?id=186593 ). I tested manually since I'm not sure about the status of ./wpt run or testdriver.

cc' @Ms2ger 