### PR TITLE
Start running wptserve/serve tests on Py3

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -12,14 +12,3 @@ settings.register_profile("pypy", settings(suppress_health_check=[HealthCheck.to
 
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE",
                                 "default" if impl != "PyPy" else "pypy"))
-
-# these can't even be imported on Py3, so totally ignore it even from collection
-ignore_dirs = ["serve", "wptserve"]
-
-collect_ignore = []
-if sys.version_info[0] >= 3:
-    for d in ignore_dirs:
-        path = os.path.join(os.path.dirname(__file__), d)
-        collect_ignore.extend([os.path.join(root, f)
-                               for root, _, files in os.walk(path)
-                               for f in files])

--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -1,6 +1,5 @@
 import platform
 import os
-import sys
 
 from hypothesis import settings, HealthCheck
 

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -1,6 +1,7 @@
 import pickle
 import platform
 import os
+import sys
 
 import pytest
 
@@ -11,6 +12,7 @@ from .serve import Config
 
 @pytest.mark.skipif(platform.uname()[0] == "Windows",
                     reason="Expected contents are platform-dependent")
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_make_hosts_file_nix():
     c = Config(browser_host="foo.bar", alternate_hosts={"alt": "foo2.bar"})
     hosts = serve.make_hosts_file(c, "192.168.42.42")
@@ -32,6 +34,7 @@ def test_make_hosts_file_nix():
 
 @pytest.mark.skipif(platform.uname()[0] != "Windows",
                     reason="Expected contents are platform-dependent")
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_make_hosts_file_windows():
     c = Config(browser_host="foo.bar", alternate_hosts={"alt": "foo2.bar"})
     hosts = serve.make_hosts_file(c, "192.168.42.42")
@@ -54,11 +57,13 @@ def test_make_hosts_file_windows():
     assert lines[-1] == ""
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_ws_doc_root_default():
     c = Config()
     assert c.ws_doc_root == os.path.join(localpaths.repo_root, "websockets", "handlers")
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_init_ws_doc_root():
     c = Config(ws_doc_root="/")
     assert c.doc_root == localpaths.repo_root  # check this hasn't changed
@@ -66,6 +71,7 @@ def test_init_ws_doc_root():
     assert c.ws_doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_set_ws_doc_root():
     c = Config()
     c.ws_doc_root = "/"
@@ -74,6 +80,7 @@ def test_set_ws_doc_root():
     assert c.ws_doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="serve only works on Py2")
 def test_pickle():
     # Ensure that the config object can be pickled
     pickle.dumps(Config())

--- a/tools/wptserve/tests/functional/test_cookies.py
+++ b/tools/wptserve/tests/functional/test_cookies.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import pytest
@@ -7,6 +8,7 @@ from .base import TestUsingServer
 
 
 class TestResponseSetCookie(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_name_value(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -19,6 +21,7 @@ class TestResponseSetCookie(TestUsingServer):
 
         self.assertEqual(resp.info()["Set-Cookie"], "name=value; Path=/")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_unset(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -32,6 +35,7 @@ class TestResponseSetCookie(TestUsingServer):
 
         self.assertTrue("Set-Cookie" not in resp.info())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_delete(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -50,6 +54,7 @@ class TestResponseSetCookie(TestUsingServer):
         #Should also check that expires is in the past
 
 class TestRequestCookies(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_set_cookie(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -12,12 +12,14 @@ from .base import TestUsingServer, doc_root
 
 
 class TestFileHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_GET(self):
         resp = self.request("/document.txt")
         self.assertEqual(200, resp.getcode())
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual(open(os.path.join(doc_root, "document.txt"), 'rb').read(), resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_headers(self):
         resp = self.request("/with_headers.txt")
         self.assertEqual(200, resp.getcode())
@@ -29,6 +31,7 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual(resp.info()["Double-Header"], "PA, SS")
 
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-19"})
         self.assertEqual(206, resp.getcode())
@@ -39,6 +42,7 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual("10", resp.info()['Content-Length'])
         self.assertEqual(expected[10:20], data)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_no_end(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-"})
         self.assertEqual(206, resp.getcode())
@@ -48,6 +52,7 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual("bytes 10-%i/%i" % (len(expected) - 1, len(expected)), resp.info()['Content-Range'])
         self.assertEqual(expected[10:], data)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_no_start(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=-10"})
         self.assertEqual(206, resp.getcode())
@@ -58,6 +63,7 @@ class TestFileHandler(TestUsingServer):
                          resp.info()['Content-Range'])
         self.assertEqual(expected[-10:], data)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple_ranges(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=1-2,5-7,6-10"})
         self.assertEqual(206, resp.getcode())
@@ -76,6 +82,7 @@ class TestFileHandler(TestUsingServer):
             self.assertEqual(headers["Content-Range"], "bytes %s/%i" % (expected_part[0], len(expected)))
             self.assertEqual(expected_part[1] + "\r\n", body)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_invalid(self):
         with self.assertRaises(HTTPError) as cm:
             self.request("/document.txt", headers={"Range":"bytes=11-10"})
@@ -86,16 +93,19 @@ class TestFileHandler(TestUsingServer):
             self.request("/document.txt", headers={"Range":"bytes=%i-%i" % (len(expected), len(expected) + 10)})
         self.assertEqual(cm.exception.code, 416)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_config(self):
         resp = self.request("/sub.sub.txt")
         expected = b"localhost localhost %i" % self.server.port
         assert resp.read().rstrip() == expected
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_headers(self):
         resp = self.request("/sub_headers.sub.txt", headers={"X-Test": "PASS"})
         expected = b"PASS"
         assert resp.read().rstrip() == expected
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_params(self):
         resp = self.request("/sub_params.sub.txt", query="test=PASS")
         expected = b"PASS"
@@ -103,6 +113,7 @@ class TestFileHandler(TestUsingServer):
 
 
 class TestFunctionHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_string_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -115,6 +126,7 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("9", resp.info()["Content-Length"])
         self.assertEqual("test data", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_1_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -128,6 +140,7 @@ class TestFunctionHandler(TestUsingServer):
 
         assert cm.value.code == 500
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_2_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -141,6 +154,7 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual("test", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_3_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -153,6 +167,7 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual("test data", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_3_rv_1(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -166,6 +181,7 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual("test data", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_4_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -179,6 +195,7 @@ class TestFunctionHandler(TestUsingServer):
 
         assert cm.value.code == 500
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_none_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -193,6 +210,7 @@ class TestFunctionHandler(TestUsingServer):
 
 
 class TestJSONHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_0(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -204,6 +222,7 @@ class TestJSONHandler(TestUsingServer):
         self.assertEqual(200, resp.getcode())
         self.assertEqual({"data": "test data"}, json.load(resp))
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_tuple_2(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -216,6 +235,7 @@ class TestJSONHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual({"data": "test data"}, json.load(resp))
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_tuple_3(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -231,12 +251,14 @@ class TestJSONHandler(TestUsingServer):
 
 
 class TestPythonHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_string(self):
         resp = self.request("/test_string.py")
         self.assertEqual(200, resp.getcode())
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_2(self):
         resp = self.request("/test_tuple_2.py")
         self.assertEqual(200, resp.getcode())
@@ -244,6 +266,7 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("PASS", resp.info()["X-Test"])
         self.assertEqual("PASS", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_3(self):
         resp = self.request("/test_tuple_3.py")
         self.assertEqual(202, resp.getcode())
@@ -252,6 +275,7 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("PASS", resp.info()["X-Test"])
         self.assertEqual("PASS", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_import(self):
         dir_name = os.path.join(doc_root, "subdir")
         assert dir_name not in sys.path
@@ -263,18 +287,21 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_main(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/no_main.py")
 
         assert cm.value.code == 500
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_invalid(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/invalid.py")
 
         assert cm.value.code == 500
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_missing(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/missing.py")
@@ -283,17 +310,20 @@ class TestPythonHandler(TestUsingServer):
 
 
 class TestDirectoryHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_directory(self):
         resp = self.request("/")
         self.assertEqual(200, resp.getcode())
         self.assertEqual("text/html", resp.info()["Content-Type"])
         #Add a check that the response is actually sane
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_subdirectory_trailing_slash(self):
         resp = self.request("/subdir/")
         assert resp.getcode() == 200
         assert resp.info()["Content-Type"] == "text/html"
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_subdirectory_no_trailing_slash(self):
         # This seems to resolve the 301 transparently, so test for 200
         resp = self.request("/subdir")
@@ -302,6 +332,7 @@ class TestDirectoryHandler(TestUsingServer):
 
 
 class TestAsIsHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_as_is(self):
         resp = self.request("/test.asis")
         self.assertEqual(202, resp.getcode())

--- a/tools/wptserve/tests/functional/test_input_file.py
+++ b/tools/wptserve/tests/functional/test_input_file.py
@@ -1,3 +1,5 @@
+import sys
+
 from wptserve.request import InputFile
 from io import BytesIO
 import pytest
@@ -21,6 +23,7 @@ def teardown_function(function):
     test_file.close()
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_seek():
     input_file.seek(2)
     test_file.seek(2)
@@ -31,6 +34,7 @@ def test_seek():
     assert input_file.read(1) == test_file.read(1)
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_seek_backwards():
     input_file.seek(2)
     test_file.seek(2)
@@ -48,6 +52,7 @@ def test_seek_negative_offset():
         input_file.seek(-1)
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_seek_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10
@@ -66,10 +71,12 @@ def test_seek_file_bigger_than_buffer():
         InputFile.max_buffer_size = old_max_buf
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_read():
     assert input_file.read() == test_file.read()
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_read_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10
@@ -81,6 +88,7 @@ def test_read_file_bigger_than_buffer():
         InputFile.max_buffer_size = old_max_buf
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readline():
     assert input_file.readline() == test_file.readline()
     assert input_file.readline() == test_file.readline()
@@ -90,17 +98,20 @@ def test_readline():
     assert input_file.readline() == test_file.readline()
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readline_max_byte():
     line = test_file.readline()
     assert input_file.readline(max_bytes=len(line)/2) == line[:len(line)/2]
     assert input_file.readline(max_bytes=len(line)) == line[len(line)/2:]
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readline_max_byte_longer_than_file():
     assert input_file.readline(max_bytes=1000) == test_file.readline()
     assert input_file.readline(max_bytes=1000) == test_file.readline()
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readline_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10
@@ -114,10 +125,12 @@ def test_readline_file_bigger_than_buffer():
         InputFile.max_buffer_size = old_max_buf
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readlines():
     assert input_file.readlines() == test_file.readlines()
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_readlines_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10
@@ -130,11 +143,13 @@ def test_readlines_file_bigger_than_buffer():
         InputFile.max_buffer_size = old_max_buf
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_iter():
     for a, b in zip(input_file, test_file):
         assert a == b
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_iter_file_bigger_than_buffer():
     old_max_buf = InputFile.max_buffer_size
     InputFile.max_buffer_size = 10

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -1,8 +1,10 @@
 import os
 import unittest
-import urllib2
 import time
 import json
+import sys
+
+from six.moves import urllib
 
 import pytest
 
@@ -11,54 +13,65 @@ from .base import TestUsingServer, doc_root
 
 
 class TestStatus(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_status(self):
         resp = self.request("/document.txt", query="pipe=status(202)")
         self.assertEqual(resp.getcode(), 202)
 
 class TestHeader(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_not_set(self):
         resp = self.request("/document.txt", query="pipe=header(X-TEST,PASS)")
         self.assertEqual(resp.info()["X-TEST"], "PASS")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_set(self):
         resp = self.request("/document.txt", query="pipe=header(Content-Type,text/html)")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple(self):
         resp = self.request("/document.txt", query="pipe=header(X-Test,PASS)|header(Content-Type,text/html)")
         self.assertEqual(resp.info()["X-TEST"], "PASS")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple_same(self):
         resp = self.request("/document.txt", query="pipe=header(Content-Type,FAIL)|header(Content-Type,text/html)")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple_append(self):
         resp = self.request("/document.txt", query="pipe=header(X-Test,1)|header(X-Test,2,True)")
         self.assertEqual(resp.info()["X-Test"], "1, 2")
 
 class TestSlice(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_both_bounds(self):
         resp = self.request("/document.txt", query="pipe=slice(1,10)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEqual(resp.read(), expected[1:10])
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_upper(self):
         resp = self.request("/document.txt", query="pipe=slice(1)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEqual(resp.read(), expected[1:])
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_lower(self):
         resp = self.request("/document.txt", query="pipe=slice(null,10)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEqual(resp.read(), expected[:10])
 
 class TestSub(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_config(self):
         resp = self.request("/sub.txt", query="pipe=sub")
         expected = "localhost localhost %i" % self.server.port
         self.assertEqual(resp.read().rstrip(), expected)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_file_hash(self):
         resp = self.request("/sub_file_hash.sub.txt")
         expected = """
@@ -71,15 +84,18 @@ sha512: r8eLGRTc7ZznZkFjeVLyo6/FyQdra9qmlYCwKKxm3kfQAswRS9+3HsYk3thLUhcFmmWhK4dX
 JwGFonfXwg=="""
         self.assertEqual(resp.read().rstrip(), expected.strip())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_file_hash_unrecognized(self):
-        with self.assertRaises(urllib2.HTTPError):
+        with self.assertRaises(urllib.error.HTTPError):
             self.request("/sub_file_hash_unrecognized.sub.txt")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_headers(self):
         resp = self.request("/sub_headers.txt", query="pipe=sub", headers={"X-Test": "PASS"})
         expected = "PASS"
         self.assertEqual(resp.read().rstrip(), expected)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_location(self):
         resp = self.request("/sub_location.sub.txt?query_string")
         expected = """
@@ -93,19 +109,23 @@ scheme: http
 server: http://localhost:{0}""".format(self.server.port)
         self.assertEqual(resp.read().rstrip(), expected.strip())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_params(self):
         resp = self.request("/sub_params.txt", query="test=PASS&pipe=sub")
         expected = "PASS"
         self.assertEqual(resp.read().rstrip(), expected)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_url_base(self):
         resp = self.request("/sub_url_base.sub.txt")
         self.assertEqual(resp.read().rstrip(), "Before / After")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_uuid(self):
         resp = self.request("/sub_uuid.sub.txt")
         self.assertRegexpMatches(resp.read().rstrip(), r"Before [a-f0-9-]+ After")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_var(self):
         resp = self.request("/sub_var.sub.txt")
         port = self.server.port
@@ -113,6 +133,7 @@ server: http://localhost:{0}""".format(self.server.port)
         self.assertEqual(resp.read().rstrip(), expected)
 
 class TestTrickle(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_trickle(self):
         #Actually testing that the response trickles in is not that easy
         t0 = time.time()
@@ -122,6 +143,7 @@ class TestTrickle(TestUsingServer):
         self.assertEqual(resp.read(), expected)
         self.assertGreater(6, t1-t0)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_headers(self):
         resp = self.request("/document.txt", query="pipe=trickle(d0.01)")
         self.assertEqual(resp.info()["Cache-Control"], "no-cache, no-store, must-revalidate")
@@ -129,10 +151,12 @@ class TestTrickle(TestUsingServer):
         self.assertEqual(resp.info()["Expires"], "0")
 
 class TestPipesWithVariousHandlers(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_with_python_file_handler(self):
         resp = self.request("/test_string.py", query="pipe=slice(null,2)")
         self.assertEqual(resp.read(), "PA")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_with_python_func_handler(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -142,6 +166,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         resp = self.request(route[1], query="pipe=slice(null,2)")
         self.assertEqual(resp.read(), "PA")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_with_python_func_handler_using_response_writer(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -152,6 +177,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         # slice has not been applied to the response, because response.writer was used.
         self.assertEqual(resp.read(), "PASS")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_header_pipe_with_python_func_using_response_writer(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -163,6 +189,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         self.assertFalse(resp.info().get("X-TEST"))
         self.assertEqual(resp.read(), "CONTENT")
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_with_json_handler(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -172,6 +199,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         resp = self.request(route[1], query="pipe=slice(null,2)")
         self.assertEqual(resp.read(), '"{')
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_slice_with_as_is_handler(self):
         resp = self.request("/test.asis", query="pipe=slice(null,2)")
         self.assertEqual(202, resp.getcode())
@@ -180,6 +208,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         # slice has not been applied to the response, because response.writer was used.
         self.assertEqual("Content", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_headers_with_as_is_handler(self):
         resp = self.request("/test.asis", query="pipe=header(X-TEST,FAIL)")
         self.assertEqual(202, resp.getcode())
@@ -188,6 +217,7 @@ class TestPipesWithVariousHandlers(TestUsingServer):
         self.assertEqual("PASS", resp.info()["X-TEST"])
         self.assertEqual("Content", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_trickle_with_as_is_handler(self):
         t0 = time.time()
         resp = self.request("/test.asis", query="pipe=trickle(1:d2:5:d1:r2)")

--- a/tools/wptserve/tests/functional/test_request.py
+++ b/tools/wptserve/tests/functional/test_request.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 wptserve = pytest.importorskip("wptserve")
@@ -6,6 +8,7 @@ from wptserve.request import InputFile
 
 
 class TestInputFile(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_seek(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -34,6 +37,7 @@ class TestInputFile(TestUsingServer):
                           "12345ab\ncdef", "12345ab\n", "cdef"],
                          resp.read().split(" "))
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_seek_input_longer_than_buffer(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -60,6 +64,7 @@ class TestInputFile(TestUsingServer):
         finally:
             InputFile.max_buffer_size = old_max_buf
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_iter(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -72,6 +77,7 @@ class TestInputFile(TestUsingServer):
         self.assertEqual(200, resp.getcode())
         self.assertEqual(["12345\n", "abcdef\r\n", "zyxwv"], resp.read().split(" "))
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_iter_input_longer_than_buffer(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -92,6 +98,7 @@ class TestInputFile(TestUsingServer):
 
 
 class TestRequest(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_body(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -103,6 +110,7 @@ class TestRequest(TestUsingServer):
         resp = self.request(route[1], method="POST", body="12345ab\ncdef")
         self.assertEqual("12345ab\ncdef", resp.read())
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_route_match(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -115,6 +123,7 @@ class TestRequest(TestUsingServer):
 
 
 class TestAuth(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_auth(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from types import MethodType
 
@@ -15,6 +16,7 @@ def send_body_as_header(self):
     self._headers_complete = True
 
 class TestResponse(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_head_without_body(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -30,6 +32,7 @@ class TestResponse(TestUsingServer):
         self.assertEqual("TEST", resp.info()['x-Test'])
         self.assertEqual("", resp.info()['x-body'])
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_head_with_body(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 
 import pytest
@@ -8,6 +9,7 @@ from .base import TestUsingServer
 
 
 class TestFileHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_not_handled(self):
         with self.assertRaises(HTTPError) as cm:
             self.request("/not_existing")
@@ -15,6 +17,7 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual(cm.exception.code, 404)
 
 class TestRewriter(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_rewrite(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -28,6 +31,7 @@ class TestRewriter(TestUsingServer):
         self.assertEqual("/test/rewritten", resp.read())
 
 class TestRequestHandler(TestUsingServer):
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_exception(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/functional/test_stash.py
+++ b/tools/wptserve/tests/functional/test_stash.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import uuid
 
@@ -14,6 +15,7 @@ class TestResponseSetCookie(TestUsingServer):
         with StashServer(None, authkey=str(uuid.uuid4())):
             super(TestResponseSetCookie, self).run(result)
 
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_put_take(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -1,5 +1,6 @@
 import logging
 import pickle
+import sys
 from logging import handlers
 
 import pytest
@@ -7,10 +8,12 @@ import pytest
 config = pytest.importorskip("wptserve.config")
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_renamed_are_renamed():
     assert len(set(config._renamed_props.viewkeys()) & set(config.Config._default.viewkeys())) == 0
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_renamed_exist():
     assert set(config._renamed_props.viewvalues()).issubset(set(config.Config._default.viewkeys()))
 
@@ -24,15 +27,18 @@ def test_renamed_exist():
     pytest.param({"a": {"b": 1}}, {"a": 2}, {"a": 1}, marks=pytest.mark.xfail),
     pytest.param({"a": 1}, {"a": {"b": 2}}, {"a": 1}, marks=pytest.mark.xfail),
 ])
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_merge_dict(base, override, expected):
     assert expected == config._merge_dict(base, override)
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_logger_created():
     c = config.Config()
     assert c.logger is not None
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_logger_preserved():
     logger = logging.getLogger("test_logger_preserved")
     logger.setLevel(logging.DEBUG)
@@ -41,16 +47,19 @@ def test_logger_preserved():
     assert c.logger is logger
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_basic_prop():
     c = config.Config(browser_host="foo.bar")
     assert c.browser_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_prefixed_prop():
     c = config.Config(doc_root="/")
     assert c._doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_renamed_host():
     logger = logging.getLogger("test_init_renamed_host")
     logger.setLevel(logging.DEBUG)
@@ -65,6 +74,7 @@ def test_init_renamed_host():
     assert c.browser_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_bogus():
     with pytest.raises(TypeError) as e:
         config.Config(foo=1, bar=2)
@@ -72,17 +82,20 @@ def test_init_bogus():
     assert "bar" in e.value.message
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_getitem():
     c = config.Config(browser_host="foo.bar")
     assert c["browser_host"] == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_no_setitem():
     c = config.Config()
     with pytest.raises(TypeError):
         c["browser_host"] = "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_iter():
     c = config.Config()
     s = set(iter(c))
@@ -92,24 +105,28 @@ def test_iter():
     assert "_browser_host" not in s
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_assignment():
     c = config.Config()
     c.browser_host = "foo.bar"
     assert c.browser_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_update_basic():
     c = config.Config()
     c.update({"browser_host": "foo.bar"})
     assert c.browser_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_update_prefixed():
     c = config.Config()
     c.update({"doc_root": "/"})
     assert c._doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_update_renamed_host():
     logger = logging.getLogger("test_update_renamed_host")
     logger.setLevel(logging.DEBUG)
@@ -128,12 +145,14 @@ def test_update_renamed_host():
     assert c.browser_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_update_bogus():
     c = config.Config()
     with pytest.raises(KeyError):
         c.update({"foobar": 1})
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_auto():
     c = config.Config(ports={"http": ["auto"]},
                       ssl={"type": "none"})
@@ -143,6 +162,7 @@ def test_ports_auto():
     assert isinstance(ports["http"][0], int)
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_auto_mutate():
     c = config.Config(ports={"http": [1001]},
                       ssl={"type": "none"})
@@ -157,6 +177,7 @@ def test_ports_auto_mutate():
     assert isinstance(new_ports["http"][0], int)
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_auto_roundtrip():
     c = config.Config(ports={"http": ["auto"]},
                       ssl={"type": "none"})
@@ -166,6 +187,7 @@ def test_ports_auto_roundtrip():
     assert old_ports == new_ports
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_idempotent():
     c = config.Config(ports={"http": ["auto"]},
                       ssl={"type": "none"})
@@ -174,6 +196,7 @@ def test_ports_idempotent():
     assert ports_a == ports_b
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_explicit():
     c = config.Config(ports={"http": [1001]},
                       ssl={"type": "none"})
@@ -182,6 +205,7 @@ def test_ports_explicit():
     assert ports["http"] == [1001]
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_no_ssl():
     c = config.Config(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
                       ssl={"type": "none"})
@@ -193,6 +217,7 @@ def test_ports_no_ssl():
     assert ports["wss"] == [None]
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ports_openssl():
     c = config.Config(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
                       ssl={"type": "openssl"})
@@ -204,12 +229,14 @@ def test_ports_openssl():
     assert ports["wss"] == [1004]
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_doc_root():
     c = config.Config(doc_root="/")
     assert c._doc_root == "/"
     assert c.doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_set_doc_root():
     c = config.Config()
     c.doc_root = "/"
@@ -217,11 +244,13 @@ def test_set_doc_root():
     assert c.doc_root == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_server_host_from_browser_host():
     c = config.Config(browser_host="foo.bar")
     assert c.server_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_init_server_host():
     c = config.Config(server_host="foo.bar")
     assert c.browser_host == "localhost"  # check this hasn't changed
@@ -229,6 +258,7 @@ def test_init_server_host():
     assert c.server_host == "foo.bar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_set_server_host():
     c = config.Config()
     c.server_host = "/"
@@ -237,6 +267,7 @@ def test_set_server_host():
     assert c.server_host == "/"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_domains():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -257,6 +288,7 @@ def test_domains():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_not_domains():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -275,6 +307,7 @@ def test_not_domains():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_domains_not_domains_intersection():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -290,6 +323,7 @@ def test_domains_not_domains_intersection():
         assert len(set(host_domains.itervalues()) & set(host_not_domains.itervalues())) == 0
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_all_domains():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -314,6 +348,7 @@ def test_all_domains():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_domains_set():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -330,6 +365,7 @@ def test_domains_set():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_not_domains_set():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -344,6 +380,7 @@ def test_not_domains_set():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_all_domains_set():
     c = config.Config(browser_host="foo.bar",
                       alternate_hosts={"alt": "foo2.bar"},
@@ -364,17 +401,20 @@ def test_all_domains_set():
     }
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ssl_env_override():
     c = config.Config(override_ssl_env="foobar")
     assert c.ssl_env == "foobar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ssl_env_none():
     c = config.Config(ssl={"type": "none"})
     assert c.ssl_env is not None
     assert c.ssl_env.ssl_enabled is False
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ssl_env_openssl():
     c = config.Config(ssl={"type": "openssl", "openssl": {"openssl_binary": "foobar"}})
     assert c.ssl_env is not None
@@ -382,12 +422,14 @@ def test_ssl_env_openssl():
     assert c.ssl_env.binary == "foobar"
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_ssl_env_bogus():
     c = config.Config(ssl={"type": "foobar"})
     with pytest.raises(ValueError):
         c.ssl_env
 
 
+@pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
 def test_pickle():
     # Ensure that the config object can be pickled
     pickle.dumps(config.Config())

--- a/tools/wptserve/tests/test_replacement_tokenizer.py
+++ b/tools/wptserve/tests/test_replacement_tokenizer.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from wptserve.pipes import ReplacementTokenizer
@@ -10,10 +12,26 @@ from wptserve.pipes import ReplacementTokenizer
         ["$ccc:ddd", [('var', '$ccc'), ('ident', 'ddd')]],
         ["$eee", [('ident', '$eee')]],
         ["fff[0]", [('ident', 'fff'), ('index', 0)]],
-        ["ggg[hhh]", [('ident', 'ggg'), ('index', u'hhh')]],
-        ["[iii]", [('index', u'iii')]],
-        ["jjj['kkk']", [('ident', 'jjj'), ('index', u"'kkk'")]],
-        ["lll[]", [('ident', 'lll'), ('index', u"")]],
+        pytest.param(
+            "ggg[hhh]", [('ident', 'ggg'), ('index', u'hhh')],
+            marks=pytest.mark.xfail(sys.version_info >= (3,),
+                                    reason="wptserve only works on Py2")
+        ),
+        pytest.param(
+            "[iii]", [('index', u'iii')],
+            marks=pytest.mark.xfail(sys.version_info >= (3,),
+                                    reason="wptserve only works on Py2")
+        ),
+        pytest.param(
+            "jjj['kkk']", [('ident', 'jjj'), ('index', u"'kkk'")],
+            marks=pytest.mark.xfail(sys.version_info >= (3,),
+                                    reason="wptserve only works on Py2")
+        ),
+        pytest.param(
+            "lll[]", [('ident', 'lll'), ('index', u"")],
+            marks=pytest.mark.xfail(sys.version_info >= (3,),
+                                    reason="wptserve only works on Py2")
+        ),
         ["111", [('ident', u'111')]],
         ["$111", [('ident', u'$111')]],
     ]


### PR DESCRIPTION
While this may seem pointless when almost all of them are marked as xfail on Py3, it does at least mean we have to keep them importable and should mean we don't regress code that currently works on Py3.

Per https://github.com/web-platform-tests/wpt/pull/11516#issuecomment-398436913.