### PR TITLE
The hashchange event should not bubble

### DIFF
--- a/html/browsers/browsing-the-web/scroll-to-fragid/004.html
+++ b/html/browsers/browsing-the-web/scroll-to-fragid/004.html
@@ -15,7 +15,7 @@ t.step(function() {
                    t.step_func(function(e) {
                      assert_equals(e.target, window);
                      assert_equals(e.type, "hashchange");
-                     assert_true(e.bubbles, "bubbles");
+                     assert_false(e.bubbles, "bubbles");
                      assert_false(e.cancelable, "cancelable");
                      t.done();
                    }), true)


### PR DESCRIPTION
This brings the `html/browsers/browsing-the-web/scroll-to-fragid/004.html` test up to date with the spec change made here: https://github.com/whatwg/html/pull/3737

Other tests were changed to reflect this in https://github.com/web-platform-tests/wpt/pull/11355.