### PR TITLE
Remove unsupported :has() pseudo-class from Element-closest.html

### DIFF
--- a/dom/nodes/Element-closest.html
+++ b/dom/nodes/Element-closest.html
@@ -59,7 +59,6 @@
   do_test(":scope"                     , "test4",  "test4");
   do_test("select > :scope"            , "test4",  "test4");
   do_test("div > :scope"               , "test4",  "");
-  do_test(":has(> :scope)"             , "test4",  "test3");
 function do_test(aSelector, aElementId, aTargetId) {
   test(function() {
     var el = document.getElementById(aElementId).closest(aSelector);


### PR DESCRIPTION
The `:has()` pseudo-class has yet to be supported by any major browser, causing this test to always fail. Until there are signs that it actually will gain support, it seems more appropriate to remove it from the general test of the `closest()`-method.

Resolves: https://github.com/web-platform-tests/wpt/issues/11316