### PR TITLE
Fix presentation-api IDL test in non-chrome browsers

### DIFF
--- a/presentation-api/controlling-ua/idlharness.https.html
+++ b/presentation-api/controlling-ua/idlharness.https.html
@@ -26,16 +26,24 @@
     idl_array.add_dependency_idls(dom);
     idl_array.add_dependency_idls(html);
 
-    window.presentation_request = new PresentationRequest("/presentation-api/receiving-ua/idlharness.html");
-    window.presentation_request_urls = new PresentationRequest([
-      "/presentation-api/receiving-ua/idlharness.html",
-      "https://www.example.com/presentation.html"
-    ]);
-    navigator.presentation.defaultRequest = presentation_request;
+    try {
+      window.presentation_request = new PresentationRequest("/presentation-api/receiving-ua/idlharness.html");
+      window.presentation_request_urls = new PresentationRequest([
+        "/presentation-api/receiving-ua/idlharness.html",
+        "https://www.example.com/presentation.html"
+      ]);
+      navigator.presentation.defaultRequest = window.presentation_request;
+    } catch (e) {
+      // Will be surfaced in idlharness.js's test_object below.
+    }
 
     idl_array.add_objects({
-        Presentation: ['navigator.presentation'],
-        PresentationRequest: ['navigator.presentation.defaultRequest', 'presentation_request', 'presentation_request_urls']
+      Presentation: ['navigator.presentation'],
+      PresentationRequest: [
+        'navigator.presentation.defaultRequest',
+        'presentation_request',
+        'presentation_request_urls'
+      ],
     });
     idl_array.test();
   }, "Test IDL implementation of Presentation API");


### PR DESCRIPTION
Currently `ERROR`ing:
https://wpt.fyi/results/presentation-api/controlling-ua/idlharness.https.html?sha=d093f88ec3