### PR TITLE
Loosen assumptions so actual implementations match them

### DIFF
--- a/docs/_writing-tests/assumptions.md
+++ b/docs/_writing-tests/assumptions.md
@@ -16,8 +16,13 @@ tests can freely rely on these assumptions being true:
  * The user stylesheet is empty (except where indicated by the tests).
  * The device is interactive and uses scroll bars.
  * The device has the Ahem font installed.
- * The HTML `div` element is assigned `display: block;` and no other
-   property declaration.
+ * The HTML `div` element is assigned `display: block;`, the
+   `unicode-bidi` property may be declared, and no other property
+   declarations.
+   <!-- unicode-bidi: isolate should be required; we currently don't
+   assume this because Chrome and Safari are yet to ship this: see
+   https://bugs.chromium.org/p/chromium/issues/detail?id=296863 and
+   https://bugs.webkit.org/show_bug.cgi?id=65617 -->
  * The HTML `span` element is assigned `display: inline;` and no other
    property declaration.
  * The HTML `p` element is assigned `display: block;`

--- a/infrastructure/assumptions/html-elements.html
+++ b/infrastructure/assumptions/html-elements.html
@@ -67,7 +67,9 @@ test(function() {
   for (var i = 0; i < a_styles.length; i++) {
     var property = a_styles[i];
     assert_equals(property, b_styles[i], "Same property on div.a and div.b");
-    assert_equals(a_styles[property], b_styles[property], "Different value for " + property);
+    if (property !== "unicode-bidi") {
+      assert_equals(a_styles[property], b_styles[property], "Different value for " + property);
+    }
   }
 }, "Compare CSS div definitions (only valid if pre-reqs pass)");
 

--- a/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
+++ b/infrastructure/metadata/infrastructure/assumptions/html-elements.html.ini
@@ -1,6 +1,0 @@
-[html-elements.html]
-  [Compare CSS div definitions (only valid if pre-reqs pass)]
-    expected:
-      if product == "chrome": FAIL
-
-


### PR DESCRIPTION
This assumption comes from the CSS test suites:

> The X/HTML div element is assigned display: block; and no other property declaration.

Note this already contradicted the informative appendix D in CSS 2.1:

```
div   { unicode-bidi: embed }
```

HTML now contains:

```
div { unicode-bidi: isolate }
```

We changed the test for the assumption to match HTML in 9ff5d62fc664214b86ec8ef4b07aaa8097f7ebed (#9674), but didn't change the documented assumption.

This changes both to allow *any* value of `unicode-bidi`, because both [Blink](https://bugs.chromium.org/p/chromium/issues/detail?id=296863) and [WebKit](https://bugs.webkit.org/show_bug.cgi?id=65617) have `unicode-bidi: initial` (i.e., `normal`) and we want tests to be runnable in all major browsers, so we can't assume things they don't do.

We could also alternatively allow `unicode-bidi` to be `isolate` or `normal`? (Probably not `embed`, because AFAICT no impl does so?)