### PR TITLE
Auto-update the WebIDL IDL file

### DIFF
--- a/WebIDL/interfaces.html
+++ b/WebIDL/interfaces.html
@@ -22,7 +22,7 @@ function doTest(idl) {
 }
 
 promise_test(function() {
-  return fetch("/interfaces/webidl.idl").then(response => response.text())
+  return fetch("/interfaces/WebIDL.idl").then(response => response.text())
                                         .then(doTest);
 }, "Test driver");
 </script>

--- a/interfaces/WebIDL.idl
+++ b/interfaces/WebIDL.idl
@@ -1,9 +1,13 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Web IDL" spec.
+// See: https://heycam.github.io/webidl/
+
 typedef (Int8Array or Int16Array or Int32Array or
          Uint8Array or Uint16Array or Uint32Array or Uint8ClampedArray or
          Float32Array or Float64Array or DataView) ArrayBufferView;
 
 typedef (ArrayBufferView or ArrayBuffer) BufferSource;
-
 [
  Exposed=(Window,Worker),
  Constructor(optional DOMString message = "", optional DOMString name = "Error")
@@ -41,7 +45,5 @@ interface DOMException { // but see below note about ECMAScript binding
 };
 
 typedef unsigned long long DOMTimeStamp;
-
 callback Function = any (any... arguments);
-
 callback VoidFunction = void ();


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
