### PR TITLE
Fix Python 3 errors for wpt lint/serve

### DIFF
--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -80,7 +80,7 @@
                         return action();
                     }
                 });
-        };
+        },
 
         /**
          * Triggers a user-initiated click

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -352,7 +352,7 @@ class RoutesBuilder(object):
         for (method, suffix, handler_cls) in routes:
             self.mountpoint_routes[url_base].append(
                 (method,
-                 b"%s%s" % (str(url_base) if url_base != "/" else "", str(suffix)),
+                 "%s%s" % (url_base if url_base != "/" else "", suffix),
                  handler_cls(base_path=path, url_base=url_base)))
 
     def add_file_mount_point(self, file_url, base_path):
@@ -492,7 +492,7 @@ def make_hosts_file(config, host):
 def start_servers(host, ports, paths, routes, bind_address, config, ssl_config,
                   **kwargs):
     servers = defaultdict(list)
-    for scheme, ports in ports.iteritems():
+    for scheme, ports in ports.items():
         assert len(ports) == {"http":2}.get(scheme, 1)
 
         for port in ports:

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 from collections import OrderedDict
+from six import iteritems
 
 from ..manifest import manifest, update
 
@@ -67,7 +68,7 @@ def branch_point():
         branch_point = None
 
         # if there are any commits, take the first parent that is not in commits
-        for commit, parents in commit_parents.items():
+        for commit, parents in iteritems(commit_parents):
             for parent in parents:
                 if parent not in commit_parents:
                     branch_point = parent

--- a/tools/wpt/testfiles.py
+++ b/tools/wpt/testfiles.py
@@ -67,7 +67,7 @@ def branch_point():
         branch_point = None
 
         # if there are any commits, take the first parent that is not in commits
-        for commit, parents in commit_parents.iteritems():
+        for commit, parents in commit_parents.items():
             for parent in parents:
                 if parent not in commit_parents:
                     branch_point = parent

--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -9,6 +9,7 @@ import unittest
 from six.moves.urllib.parse import urlencode, urlunsplit
 from six.moves.urllib.request import Request as BaseRequest
 from six.moves.urllib.request import urlopen
+from six import iteritems
 
 wptserve = pytest.importorskip("wptserve")
 
@@ -57,7 +58,7 @@ class TestUsingServer(unittest.TestCase):
         if headers is None:
             headers = {}
 
-        for name, value in headers.items():
+        for name, value in iteritems(headers):
             req.add_header(name, value)
 
         if body is not None:

--- a/tools/wptserve/tests/functional/base.py
+++ b/tools/wptserve/tests/functional/base.py
@@ -29,7 +29,7 @@ class Request(BaseRequest):
         return self.method
 
     def add_data(self, data):
-        if hasattr(data, "iteritems"):
+        if hasattr(data, "items"):
             data = urlencode(data)
         print(data)
         self.add_header("Content-Length", str(len(data)))
@@ -57,7 +57,7 @@ class TestUsingServer(unittest.TestCase):
         if headers is None:
             headers = {}
 
-        for name, value in headers.iteritems():
+        for name, value in headers.items():
             req.add_header(name, value)
 
         if body is not None:

--- a/tools/wptserve/tests/functional/test_cookies.py
+++ b/tools/wptserve/tests/functional/test_cookies.py
@@ -8,7 +8,6 @@ from .base import TestUsingServer
 
 
 class TestResponseSetCookie(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_name_value(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -21,7 +20,6 @@ class TestResponseSetCookie(TestUsingServer):
 
         self.assertEqual(resp.info()["Set-Cookie"], "name=value; Path=/")
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_unset(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -35,7 +33,6 @@ class TestResponseSetCookie(TestUsingServer):
 
         self.assertTrue("Set-Cookie" not in resp.info())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_delete(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -12,7 +12,6 @@ from .base import TestUsingServer, doc_root
 
 
 class TestFileHandler(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_GET(self):
         resp = self.request("/document.txt")
         self.assertEqual(200, resp.getcode())
@@ -82,7 +81,6 @@ class TestFileHandler(TestUsingServer):
             self.assertEqual(headers["Content-Range"], "bytes %s/%i" % (expected_part[0], len(expected)))
             self.assertEqual(expected_part[1] + "\r\n", body)
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_invalid(self):
         with self.assertRaises(HTTPError) as cm:
             self.request("/document.txt", headers={"Range":"bytes=11-10"})
@@ -126,7 +124,6 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("9", resp.info()["Content-Length"])
         self.assertEqual("test data", resp.read())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_1_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -181,7 +178,6 @@ class TestFunctionHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual("test data", resp.read())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_4_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -195,7 +191,6 @@ class TestFunctionHandler(TestUsingServer):
 
         assert cm.value.code == 500
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_none_rv(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -210,7 +205,6 @@ class TestFunctionHandler(TestUsingServer):
 
 
 class TestJSONHandler(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_0(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -222,7 +216,6 @@ class TestJSONHandler(TestUsingServer):
         self.assertEqual(200, resp.getcode())
         self.assertEqual({"data": "test data"}, json.load(resp))
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_tuple_2(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -235,7 +228,6 @@ class TestJSONHandler(TestUsingServer):
         self.assertEqual("test-value", resp.info()["test-header"])
         self.assertEqual({"data": "test data"}, json.load(resp))
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_json_tuple_3(self):
         @wptserve.handlers.json_handler
         def handler(request, response):
@@ -258,22 +250,20 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.read())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_2(self):
         resp = self.request("/test_tuple_2.py")
         self.assertEqual(200, resp.getcode())
         self.assertEqual("text/html", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.info()["X-Test"])
-        self.assertEqual("PASS", resp.read())
+        self.assertEqual(b"PASS", resp.read())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_tuple_3(self):
         resp = self.request("/test_tuple_3.py")
         self.assertEqual(202, resp.getcode())
         self.assertEqual("Giraffe", resp.msg)
         self.assertEqual("text/html", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.info()["X-Test"])
-        self.assertEqual("PASS", resp.read())
+        self.assertEqual(b"PASS", resp.read())
 
     @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_import(self):
@@ -287,21 +277,18 @@ class TestPythonHandler(TestUsingServer):
         self.assertEqual("text/plain", resp.info()["Content-Type"])
         self.assertEqual("PASS", resp.read())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_main(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/no_main.py")
 
         assert cm.value.code == 500
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_invalid(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/invalid.py")
 
         assert cm.value.code == 500
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_missing(self):
         with pytest.raises(HTTPError) as cm:
             self.request("/missing.py")
@@ -310,20 +297,17 @@ class TestPythonHandler(TestUsingServer):
 
 
 class TestDirectoryHandler(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_directory(self):
         resp = self.request("/")
         self.assertEqual(200, resp.getcode())
         self.assertEqual("text/html", resp.info()["Content-Type"])
         #Add a check that the response is actually sane
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_subdirectory_trailing_slash(self):
         resp = self.request("/subdir/")
         assert resp.getcode() == 200
         assert resp.info()["Content-Type"] == "text/html"
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_subdirectory_no_trailing_slash(self):
         # This seems to resolve the 301 transparently, so test for 200
         resp = self.request("/subdir")

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -13,29 +13,24 @@ from .base import TestUsingServer, doc_root
 
 
 class TestStatus(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_status(self):
         resp = self.request("/document.txt", query="pipe=status(202)")
         self.assertEqual(resp.getcode(), 202)
 
 class TestHeader(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_not_set(self):
         resp = self.request("/document.txt", query="pipe=header(X-TEST,PASS)")
         self.assertEqual(resp.info()["X-TEST"], "PASS")
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_set(self):
         resp = self.request("/document.txt", query="pipe=header(Content-Type,text/html)")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple(self):
         resp = self.request("/document.txt", query="pipe=header(X-Test,PASS)|header(Content-Type,text/html)")
         self.assertEqual(resp.info()["X-TEST"], "PASS")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_multiple_same(self):
         resp = self.request("/document.txt", query="pipe=header(Content-Type,FAIL)|header(Content-Type,text/html)")
         self.assertEqual(resp.info()["Content-Type"], "text/html")
@@ -84,7 +79,6 @@ sha512: r8eLGRTc7ZznZkFjeVLyo6/FyQdra9qmlYCwKKxm3kfQAswRS9+3HsYk3thLUhcFmmWhK4dX
 JwGFonfXwg=="""
         self.assertEqual(resp.read().rstrip(), expected.strip())
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_sub_file_hash_unrecognized(self):
         with self.assertRaises(urllib.error.HTTPError):
             self.request("/sub_file_hash_unrecognized.sub.txt")
@@ -133,7 +127,6 @@ server: http://localhost:{0}""".format(self.server.port)
         self.assertEqual(resp.read().rstrip(), expected)
 
 class TestTrickle(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_trickle(self):
         #Actually testing that the response trickles in is not that easy
         t0 = time.time()
@@ -143,7 +136,6 @@ class TestTrickle(TestUsingServer):
         self.assertEqual(resp.read(), expected)
         self.assertGreater(6, t1-t0)
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_headers(self):
         resp = self.request("/document.txt", query="pipe=trickle(d0.01)")
         self.assertEqual(resp.info()["Cache-Control"], "no-cache, no-store, must-revalidate")

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 import pytest

--- a/tools/wptserve/tests/functional/test_server.py
+++ b/tools/wptserve/tests/functional/test_server.py
@@ -9,7 +9,6 @@ from .base import TestUsingServer
 
 
 class TestFileHandler(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_not_handled(self):
         with self.assertRaises(HTTPError) as cm:
             self.request("/not_existing")
@@ -17,7 +16,6 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual(cm.exception.code, 404)
 
 class TestRewriter(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_rewrite(self):
         @wptserve.handlers.handler
         def handler(request, response):
@@ -28,10 +26,9 @@ class TestRewriter(TestUsingServer):
         self.server.router.register(*route)
         resp = self.request("/test/original")
         self.assertEqual(200, resp.getcode())
-        self.assertEqual("/test/rewritten", resp.read())
+        self.assertEqual(b"/test/rewritten", resp.read())
 
 class TestRequestHandler(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_exception(self):
         @wptserve.handlers.handler
         def handler(request, response):

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -238,7 +238,7 @@ class PythonScriptHandler(object):
         try:
             environ = {"__file__": path}
             sys.path.insert(0, os.path.dirname(path))
-            with open(path) as f:
+            with open(path, 'rb') as f:
                 exec(compile(f.read(), path, 'exec'), environ, environ)
             if "main" in environ:
                 handler = FunctionHandler(environ["main"])

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -237,7 +237,7 @@ class PythonScriptHandler(object):
         try:
             environ = {"__file__": path}
             sys.path.insert(0, os.path.dirname(path))
-            execfile(path, environ, environ)
+            exec(compile(open(path).read(), path, 'exec'), environ, environ)
             if "main" in environ:
                 handler = FunctionHandler(environ["main"])
                 handler(request, response)
@@ -375,7 +375,7 @@ class StringHandler(object):
         self.data = data
 
         self.resp_headers = [("Content-Type", content_type)]
-        for k, v in headers.iteritems():
+        for k, v in headers.items():
             self.resp_headers.append((k.replace("_", "-"), v))
 
         self.handler = handler(self.handle_request)

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -5,6 +5,7 @@ import sys
 import traceback
 
 from six.moves.urllib.parse import parse_qs, quote, unquote, urljoin
+from six import iteritems
 
 from .constants import content_types
 from .pipes import Pipeline, template
@@ -375,7 +376,7 @@ class StringHandler(object):
         self.data = data
 
         self.resp_headers = [("Content-Type", content_type)]
-        for k, v in headers.items():
+        for k, v in iteritems(headers):
             self.resp_headers.append((k.replace("_", "-"), v))
 
         self.handler = handler(self.handle_request)

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -238,7 +238,8 @@ class PythonScriptHandler(object):
         try:
             environ = {"__file__": path}
             sys.path.insert(0, os.path.dirname(path))
-            exec(compile(open(path).read(), path, 'exec'), environ, environ)
+            with open(path) as f:
+                exec(compile(f.read(), path, 'exec'), environ, environ)
             if "main" in environ:
                 handler = FunctionHandler(environ["main"])
                 handler(request, response)

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from six.moves import StringIO
 
-from six import text_type
+from six import text_type, string_types
 
 def resolve_content(response):
     return b"".join(item for item in response.iter_content(read_file=True))
@@ -479,7 +479,7 @@ def template(request, content, escape_type="html"):
                     "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
                 )
 
-        assert isinstance(value, (int, str)), tokens
+        assert isinstance(value, (int, string_types)), tokens
 
         if variable is not None:
             variables[variable] = value

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import re
 import time
-import types
 import uuid
 from six.moves import StringIO
 
@@ -282,7 +281,7 @@ def slice(request, response, start, end=None):
 class ReplacementTokenizer(object):
     def arguments(self, token):
         unwrapped = token[1:-1]
-        return ("arguments", re.split(r",\s*", token[1:-1]) if unwrapped else [])
+        return ("arguments", re.split(br",\s*", token[1:-1]) if unwrapped else [])
 
     def ident(self, token):
         return ("ident", token)
@@ -392,6 +391,7 @@ class SubFunctions(object):
 
     @staticmethod
     def file_hash(request, algorithm, path):
+        algorithm = algorithm.decode("ascii")
         if algorithm not in SubFunctions.supported_algorithms:
             raise ValueError("Unsupported encryption algorithm: '%s'" % algorithm)
 
@@ -424,6 +424,7 @@ def template(request, content, escape_type="html"):
         tokens = deque(tokens)
 
         token_type, field = tokens.popleft()
+        field = field.decode("ascii")
 
         if token_type == "var":
             variable = field
@@ -478,7 +479,7 @@ def template(request, content, escape_type="html"):
                     "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
                 )
 
-        assert isinstance(value, (int,) + types.StringTypes), tokens
+        assert isinstance(value, (int, str)), tokens
 
         if variable is not None:
             variables[variable] = value
@@ -490,7 +491,7 @@ def template(request, content, escape_type="html"):
         #TODO: read the encoding of the response
         return escape_func(text_type(value)).encode("utf-8")
 
-    template_regexp = re.compile(r"{{([^}]*)}}")
+    template_regexp = re.compile(br"{{([^}]*)}}")
     new_content = template_regexp.sub(config_replacement, content)
 
     return new_content

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from six.moves.http_cookies import BaseCookie, Morsel
 import json
-import types
 import uuid
 import socket
 
@@ -182,7 +181,7 @@ class Response(object):
         True, the entire content of the file will be returned as a string facilitating
         non-streaming operations like template substitution.
         """
-        if isinstance(self.content, types.StringTypes):
+        if isinstance(self.content, str):
             yield self.content
         elif hasattr(self.content, "read"):
             if read_file:
@@ -337,7 +336,7 @@ class ResponseHeaders(object):
         self.set(key, value)
 
     def __iter__(self):
-        for key, values in self.data.itervalues():
+        for key, values in self.data.values():
             for value in values:
                 yield key, value
 
@@ -426,7 +425,7 @@ class ResponseWriter(object):
 
     def write_content(self, data):
         """Write the body of the response."""
-        if isinstance(data, types.StringTypes):
+        if isinstance(data, (text_type, binary_type)):
             self.write(data)
         else:
             self.write_content_file(data)

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -8,7 +8,7 @@ import socket
 from .constants import response_codes
 from .logger import get_logger
 
-from six import string_types, binary_type, text_type
+from six import string_types, binary_type, text_type, itervalues
 
 missing = object()
 
@@ -181,7 +181,7 @@ class Response(object):
         True, the entire content of the file will be returned as a string facilitating
         non-streaming operations like template substitution.
         """
-        if isinstance(self.content, str):
+        if isinstance(self.content, string_types):
             yield self.content
         elif hasattr(self.content, "read"):
             if read_file:
@@ -336,7 +336,7 @@ class ResponseHeaders(object):
         self.set(key, value)
 
     def __iter__(self):
-        for key, values in self.data.values():
+        for key, values in itervalues(self.data):
             for value in values:
                 yield key, value
 
@@ -426,6 +426,7 @@ class ResponseWriter(object):
     def write_content(self, data):
         """Write the body of the response."""
         if isinstance(data, (text_type, binary_type)):
+            # Deliberately allows both text and binary types. See `self.encode`.
             self.write(data)
         else:
             self.write_content_file(data)

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -2,6 +2,7 @@ import itertools
 import re
 
 from .logger import get_logger
+from six import string_types
 
 any_method = object()
 
@@ -134,7 +135,7 @@ class Router(object):
                         object and the response object.
 
         """
-        if type(methods) is str or methods in (any_method, "*"):
+        if isinstance(methods, string_types) or methods in (any_method, "*"):
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -135,7 +135,7 @@ class Router(object):
                         object and the response object.
 
         """
-        if type(methods) in types.StringTypes or methods in (any_method, "*"):
+        if type(methods) is str or methods in (any_method, "*"):
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -1,6 +1,5 @@
 import itertools
 import re
-import types
 
 from .logger import get_logger
 

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -8,6 +8,7 @@ import sys
 import threading
 import time
 import traceback
+from six import string_types
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
@@ -79,7 +80,7 @@ class RequestRewriter(object):
         :param output_path: Path to replace the input path with in
                             the request.
         """
-        if type(methods) is str:
+        if isinstance(methods, string_types):
             methods = [methods]
         self.rules[input_path] = (methods, output_path)
 

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -80,7 +80,7 @@ class RequestRewriter(object):
         :param output_path: Path to replace the input path with in
                             the request.
         """
-        if type(methods) in types.StringTypes:
+        if type(methods) is str:
             methods = [methods]
         self.rules[input_path] = (methods, output_path)
 

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -255,8 +255,9 @@ class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 except HTTPException as e:
                     response.set_error(e.code, e.message)
                 except Exception as e:
-                    if e.message:
-                        err = [e.message]
+                    message = str(e)
+                    if message:
+                        err = [message]
                     else:
                         err = []
                     err.append(traceback.format_exc())

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -8,7 +8,6 @@ import sys
 import threading
 import time
 import traceback
-import types
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -4,6 +4,7 @@ import os
 import uuid
 import threading
 from multiprocessing.managers import AcquirerProxy, BaseManager, DictProxy
+from six import text_type
 
 class ServerDictManager(BaseManager):
     shared_data = {}
@@ -50,7 +51,7 @@ def store_env_config(address, authkey):
     os.environ["WPT_STASH_CONFIG"] = json.dumps((address, authkey.decode("ascii")))
 
 def start_server(address=None, authkey=None):
-    if type(authkey) is str:
+    if isinstance(authkey, text_type):
         authkey = authkey.encode("ascii")
     manager = ServerDictManager(address, authkey)
     manager.start()

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -50,7 +50,9 @@ def store_env_config(address, authkey):
     os.environ["WPT_STASH_CONFIG"] = json.dumps((address, authkey.decode("ascii")))
 
 def start_server(address=None, authkey=None):
-    manager = ServerDictManager(address, authkey.encode("ascii"))
+    if type(authkey) is str:
+        authkey = authkey.encode("ascii")
+    manager = ServerDictManager(address, authkey)
     manager.start()
 
     return (manager, manager._address, manager._authkey)

--- a/tools/wptserve/wptserve/stash.py
+++ b/tools/wptserve/wptserve/stash.py
@@ -42,15 +42,15 @@ def load_env_config():
         address = tuple(address)
     else:
         address = str(address)
-    authkey = base64.decodestring(authkey)
+    authkey = base64.b64decode(authkey)
     return address, authkey
 
 def store_env_config(address, authkey):
-    authkey = base64.encodestring(authkey)
-    os.environ["WPT_STASH_CONFIG"] = json.dumps((address, authkey))
+    authkey = base64.b64encode(authkey)
+    os.environ["WPT_STASH_CONFIG"] = json.dumps((address, authkey.decode("ascii")))
 
 def start_server(address=None, authkey=None):
-    manager = ServerDictManager(address, authkey)
+    manager = ServerDictManager(address, authkey.encode("ascii"))
     manager.start()
 
     return (manager, manager._address, manager._authkey)

--- a/websockets/handlers/set-cookie-secure_wsh.py
+++ b/websockets/handlers/set-cookie-secure_wsh.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
-import urlparse
+from six.moves import urllib
 
 
 def web_socket_do_extra_handshake(request):
-    url_parts = urlparse.urlsplit(request.uri)
+    url_parts = urllib.parse.urlsplit(request.uri)
     request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Secure; Path=/'))
 
 def web_socket_transfer_data(request):

--- a/websockets/handlers/set-cookie_http_wsh.py
+++ b/websockets/handlers/set-cookie_http_wsh.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
 
-import urlparse
+from six.moves import urllib
 
 def web_socket_do_extra_handshake(request):
-    url_parts = urlparse.urlsplit(request.uri)
+    url_parts = urllib.parse.urlsplit(request.uri)
     request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Path=/; HttpOnly\x0D\x0ASec-WebSocket-Origin: '+request.ws_origin))
 
 def web_socket_transfer_data(request):

--- a/websockets/handlers/set-cookie_wsh.py
+++ b/websockets/handlers/set-cookie_wsh.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
-import urlparse
+from six.moves import urllib
 
 
 def web_socket_do_extra_handshake(request):
-    url_parts = urlparse.urlsplit(request.uri)
+    url_parts = urllib.parse.urlsplit(request.uri)
     request.extra_headers.append(('Set-Cookie', 'ws_test_'+(url_parts.query or '')+'=test; Path=/'))
 
 def web_socket_transfer_data(request):

--- a/websockets/handlers/stash_responder_wsh.py
+++ b/websockets/handlers/stash_responder_wsh.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
-import urlparse, json
+from six.moves import urllib
+import json
 from mod_pywebsocket import common, msgutil, util
 from mod_pywebsocket.handshake import hybi
 from wptserve import stash
@@ -15,7 +16,7 @@ def web_socket_transfer_data(request):
         line = request.ws_stream.receive_message()
         if line == "echo":
             query = request.unparsed_uri.split('?')[1]
-            GET = dict(urlparse.parse_qsl(query))
+            GET = dict(urllib.parse.parse_qsl(query))
 
             # TODO(kristijanburnik): This code should be reused from
             # /mixed-content/generic/expect.py or implemented more generally


### PR DESCRIPTION
`python3 wpt serve` still somehow fails to serve the directories with a strange HTTP 500 message, but at least any Py3 errors that was visible are now fixed.