### PR TITLE
Sync Mozilla tests as of 2018-06-28

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-001-ref.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0
+-->
+<!--
+     Reference for the correctness of gaps in horizontal and vertical multi-line
+     flex containers.
+-->
+<html>
+<head>
+  <title>Reference: Testing row and column gaps in horizontal and vertical multi-line flex containers with the space-around property and auto margins</title>
+  <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
+  <meta charset="utf-8">
+  <style>
+    .outerBox {
+      width: 200px;
+      height: 220px;
+      border: 1px solid black;
+      float: left;
+    }
+    .flexContainer {
+      display: flex;
+      align-content: space-around;
+      justify-content: space-around;
+    }
+    .rowNoWrap {
+      flex-flow: row nowrap;
+    }
+    .columnNoWrap {
+      flex-flow: column nowrap;
+    }
+    .item {
+      border: 1px solid blue;
+      background: lightblue;
+      width: 28px;
+      height: 28px;
+    }
+    .autoLBMargins {
+      margin-left: auto;
+      margin-bottom: auto;
+    }
+    .autoBMargin {
+      margin-bottom: auto;
+    }
+    .right20 {
+      margin-right: 20px;
+    }
+    .bottom40 {
+      margin-bottom: 40px;
+    }
+    .tb30100 {
+      margin-top: 30px;
+      margin-bottom: 100px;
+    }
+    .lr3080 {
+      margin-left: 30px;
+      margin-right: 80px;
+    }
+    .w200 {
+      width: 200px;
+    }
+    .h220 {
+      height: 220px;
+    }
+    .fleft {
+      float: left;
+    }
+  </style>
+</head>
+<body>
+  <div class="outerBox">
+    <div class="flexContainer w200 rowNoWrap tb30100">
+      <div class="item right20"></div>
+      <div class="item right20"></div>
+      <div class="item right20"></div>
+      <div class="item"></div>
+    </div>
+    <div class="flexContainer w200 rowNoWrap">
+      <div class="item autoLBMargins right20"></div>
+      <div class="item"></div>
+    </div>
+  </div>
+  <div class="outerBox">
+    <div class="flexContainer fleft h220 columnNoWrap lr3080">
+      <div class="item bottom40"></div>
+      <div class="item bottom40"></div>
+      <div class="item"></div>
+    </div>
+    <div class="flexContainer fleft  h220 columnNoWrap">
+      <div class="item bottom40"></div>
+      <div class="item bottom40"></div>
+      <div class="item autoBMargin"></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-001.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0
+-->
+<!--
+     Testcase for the correctness of gaps in horizontal and vertical multi-line
+     flex containers.
+-->
+<html>
+<head>
+  <title>CSS Test: Testing row and column gaps in horizontal and vertical multi-line flex containers with the space-around property and auto margins</title>
+  <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
+  <link rel="help" href="https://drafts.csswg.org/css-align/#gap-flex">
+  <link rel="match" href="flexbox-column-row-gap-001-ref.html">
+  <meta charset="utf-8">
+  <style>
+    .flexContainer {
+      display: flex;
+      width: 200px;
+      height: 220px;
+      border: 1px solid black;
+      column-gap: 10%;
+      row-gap: 40px;
+      align-content: space-around;
+      justify-content: space-around;
+      float: left;
+    }
+    .rowWrap {
+      flex-flow: row wrap;
+    }
+    .columnWrap {
+      flex-flow: column wrap;
+    }
+    .item {
+      border: 1px solid blue;
+      background: lightblue;
+      width: 28px;
+      height: 28px;
+    }
+    .autoLBMargins {
+      margin-left: auto;
+      margin-bottom: auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="flexContainer rowWrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item autoLBMargins"></div>
+    <div class="item"></div>
+  </div>
+  <div class="flexContainer columnWrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item autoLBMargins"></div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-002-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-002-ref.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0
+-->
+<!--
+     Testcase for the correctness of gaps in vertical writing mode
+     multi-line flex containers.
+-->
+<html>
+<head>
+  <title>Reference: Testing row and column gaps in vertical writing mode multi-line flex containers</title>
+  <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
+  <meta charset="utf-8">
+  <style>
+    .flexContainer {
+      display: flex;
+      width: 220px;
+      height: 200px;
+      border: 1px solid black;
+      align-content: flex-start;
+      justify-content: flex-end;
+      float: left;
+      writing-mode: vertical-lr;
+    }
+    .rowWrap {
+      flex-flow: row wrap;
+    }
+    .columnWrap {
+      flex-flow: column wrap;
+    }
+    .item {
+      border: 1px solid blue;
+      background: lightblue;
+      width: 28px;
+      height: 28px;
+    }
+    .b20 {
+      margin-bottom: 20px;
+    }
+    .t20 {
+      margin-top: 20px;
+    }
+    .l10 {
+      margin-left: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div class="flexContainer rowWrap">
+    <div class="item b20"></div>
+    <div class="item b20"></div>
+    <div class="item b20"></div>
+    <div class="item"></div>
+    <div class="item l10 b20"></div>
+    <div class="item l10"></div>
+  </div>
+  <div class="flexContainer columnWrap">
+    <div class="item"></div>
+    <div class="item l10"></div>
+    <div class="item l10"></div>
+    <div class="item l10"></div>
+    <div class="item l10"></div>
+    <div class="item l10 t20"></div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-002.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/flexbox-column-row-gap-002.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0
+-->
+<!--
+     Testcase for the correctness of gaps in vertical writing mode multi-line
+     flex containers.
+-->
+<html>
+<head>
+  <title>CSS Test: Testing row and column gaps in vertical writing mode multi-line flex containers</title>
+  <link rel="author" title="Mihir Iyer" href="mailto:miyer@mozilla.com">
+  <link rel="help" href="https://drafts.csswg.org/css-align/#gap-flex">
+  <link rel="match" href="flexbox-column-row-gap-002-ref.html">
+  <meta charset="utf-8">
+  <style>
+    .flexContainer {
+      display: flex;
+      width: 220px;
+      height: 200px;
+      border: 1px solid black;
+      column-gap: 10%;
+      row-gap: 10px;
+      align-content: flex-start;
+      justify-content: flex-end;
+      float: left;
+      writing-mode: vertical-lr;
+    }
+    .rowWrap {
+      flex-flow: row wrap;
+    }
+    .columnWrap {
+      flex-flow: column wrap;
+    }
+    .item {
+      border: 1px solid blue;
+      background: lightblue;
+      width: 28px;
+      height: 28px;
+    }
+  </style>
+</head>
+<body>
+  <div class="flexContainer rowWrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+  </div>
+  <div class="flexContainer columnWrap">
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+    <div class="item"></div>
+  </div>
+</body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/flexbox/reftest.list
@@ -98,6 +98,10 @@
 == flexbox-collapsed-item-horiz-002.html flexbox-collapsed-item-horiz-002-ref.html
 == flexbox-collapsed-item-horiz-003.html flexbox-collapsed-item-horiz-003-ref.html
 
+# Tests for "row gap" and "column gap"
+== flexbox-column-row-gap-001.html flexbox-column-row-gap-001-ref.html
+== flexbox-column-row-gap-002.html flexbox-column-row-gap-002-ref.html
+
 # Tests for "flex-basis: content"
 == flexbox-flex-basis-content-001a.html flexbox-flex-basis-content-001-ref.html
 == flexbox-flex-basis-content-001b.html flexbox-flex-basis-content-001-ref.html

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-005-ref.html
@@ -44,11 +44,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 128px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 128px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-006-ref.html
@@ -45,11 +45,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 128px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 128px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-007-ref.html
@@ -44,11 +44,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-008-ref.html
@@ -45,11 +45,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-009-ref.html
@@ -44,11 +44,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-010-ref.html
@@ -45,11 +45,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-011-ref.html
@@ -44,11 +44,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-border-box-border-radius-012-ref.html
@@ -45,11 +45,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="longbox" style="offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 20px; offset-inline-start: 140px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 140px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 116px; offset-inline-start: 132px;"></div> <!-- Box at corner -->
-    <div class="longbox" style="offset-block-start: 140px; offset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="longbox" style="inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 20px; inset-inline-start: 140px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 140px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 116px; inset-inline-start: 132px;"></div> <!-- Box at corner -->
+    <div class="longbox" style="inset-block-start: 140px; inset-inline-start: 0;"></div> <!-- Saturate the margin space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-048-ref.html
@@ -43,12 +43,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-049-ref.html
@@ -44,12 +44,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-050-ref.html
@@ -43,12 +43,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-051-ref.html
@@ -43,12 +43,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-052-ref.html
@@ -43,12 +43,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-053-ref.html
@@ -44,12 +44,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-054-ref.html
@@ -43,12 +43,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-circle-055-ref.html
@@ -44,12 +44,12 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 20px; offset-block-start: 0px; offset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
-    <div class="box" style="block-size: 12px; offset-block-start: 20px; offset-inline-start: 96px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 12px; offset-block-start: 32px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 44px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 12px; offset-block-start: 116px; offset-inline-start: 108px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 20px; offset-block-start: 128px; offset-inline-start: 0;"></div>
+    <div class="long box" style="block-size: 20px; inset-block-start: 0px; inset-inline-start: 0;"></div> <!-- Fill the border area due to the circle shifted -->
+    <div class="box" style="block-size: 12px; inset-block-start: 20px; inset-inline-start: 96px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 12px; inset-block-start: 32px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 44px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 12px; inset-block-start: 116px; inset-inline-start: 108px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 20px; inset-block-start: 128px; inset-inline-start: 0;"></div>
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-046-ref.html
@@ -38,9 +38,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-047-ref.html
@@ -39,9 +39,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-048-ref.html
@@ -38,9 +38,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-049-ref.html
@@ -39,9 +39,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-050-ref.html
@@ -38,9 +38,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-ellipse-051-ref.html
@@ -39,9 +39,9 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 0px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 24px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 96px; offset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 24px; inset-block-start: 0px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 24px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 96px; inset-inline-start: 72px;"></div> <!-- Box at corner -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-020-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-021-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-022-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-023-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-024-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-025-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-026-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-inset-027-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 10px; offset-block-start: 0px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
-    <div class="box" style="block-size: 24px; offset-block-start: 10px; offset-inline-start: 90px;"></div> <!-- Box at corner -->
-    <div class="box" style="block-size: 36px; offset-block-start: 34px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 36px; offset-block-start: 70px; offset-inline-start: 90px;"></div>
-    <div class="box" style="block-size: 24px; offset-block-start: 106px; offset-inline-start: 82px;"></div> <!-- Box at corner -->
-    <div class="long box" style="block-size: 10px; offset-block-start: 130px; offset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 0px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
+    <div class="box" style="block-size: 24px; inset-block-start: 10px; inset-inline-start: 90px;"></div> <!-- Box at corner -->
+    <div class="box" style="block-size: 36px; inset-block-start: 34px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 36px; inset-block-start: 70px; inset-inline-start: 90px;"></div>
+    <div class="box" style="block-size: 24px; inset-block-start: 106px; inset-inline-start: 82px;"></div> <!-- Box at corner -->
+    <div class="long box" style="block-size: 10px; inset-block-start: 130px; inset-inline-start: 0px;"></div> <!-- Fill the inset space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-020-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 100px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-021-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 100px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 80px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-022-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 100px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 80px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-023-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 100px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-024-ref.html
@@ -41,11 +41,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 100px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 100px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/shapes1/shape-outside-polygon-025-ref.html
@@ -42,11 +42,11 @@
 
   <body class="container">
     <div class="shape"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 0; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
-    <div class="box" style="block-size: 30px; offset-block-start: 30px; offset-inline-start: 100px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 60px; offset-inline-start: 120px;"></div>
-    <div class="box" style="block-size: 20px; offset-block-start: 80px; offset-inline-start: 80px;"></div>
-    <div class="box" style="block-size: 30px; offset-block-start: 100px; offset-inline-start: 80px;"></div>
-    <div class="long box" style="block-size: 30px; offset-block-start: 130px; offset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="long box" style="block-size: 30px; inset-block-start: 0; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
+    <div class="box" style="block-size: 30px; inset-block-start: 30px; inset-inline-start: 100px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 60px; inset-inline-start: 120px;"></div>
+    <div class="box" style="block-size: 20px; inset-block-start: 80px; inset-inline-start: 80px;"></div>
+    <div class="box" style="block-size: 30px; inset-block-start: 100px; inset-inline-start: 80px;"></div>
+    <div class="long box" style="block-size: 30px; inset-block-start: 130px; inset-inline-start: 0;"></div> <!-- Fill the margin and partial border space -->
   </body>
 </html>


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/6041c030780420b6205cf2d6640513606609884c

This contains two changes:

 * One by Mihir Iyer from [bug 1398483](https://bugzil.la/1398483), reviewed by
   @dholbert, adding flexbox column-{row,gap} reftests.

 * One by myself from [bug 1464782](https://bugzil.la/1464782), replacing the
   usage of offset-* logical properties by the standard name inset-*, reviewed
   by @upsuper.