### PR TITLE
Simplify the embedded-enforcement IDL test

### DIFF
--- a/content-security-policy/embedded-enforcement/idlharness.window.js
+++ b/content-security-policy/embedded-enforcement/idlharness.window.js
@@ -5,17 +5,13 @@
 
 'use strict';
 
-promise_test(async () => {
-  const idl = await fetch('/interfaces/csp-embedded-enforcement.idl').then(r => r.text());
-  const html = await fetch('/interfaces/html.idl').then(r => r.text());
-  const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_objects({
-    HTMLIFrameElement: ['document.createElement("iframe")'],
-  });
-  idl_array.test();
-}, 'csp-embedded-enforcement IDL');
+idl_test(
+  ['csp-embedded-enforcement'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      HTMLIFrameElement: ['document.createElement("iframe")'],
+    });
+  },
+  'csp-embedded-enforcement IDL'
+);

--- a/interfaces/webappsec-csp-embedded.idl
+++ b/interfaces/webappsec-csp-embedded.idl
@@ -1,0 +1,3 @@
+partial interface HTMLIFrameElement {
+  [CEReactions] attribute DOMString csp;
+};

--- a/interfaces/webappsec-csp-embedded.idl
+++ b/interfaces/webappsec-csp-embedded.idl
@@ -1,3 +1,7 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the Content Security Policy: Embedded Enforcement spec.
+// See https://w3c.github.io/webappsec-csp/embedded/
+
 partial interface HTMLIFrameElement {
   [CEReactions] attribute DOMString csp;
 };

--- a/interfaces/webappsec-csp-embedded.idl
+++ b/interfaces/webappsec-csp-embedded.idl
@@ -1,7 +1,0 @@
-// GENERATED CONTENT - DO NOT EDIT
-// Content of this file was automatically extracted from the Content Security Policy: Embedded Enforcement spec.
-// See https://w3c.github.io/webappsec-csp/embedded/
-
-partial interface HTMLIFrameElement {
-  [CEReactions] attribute DOMString csp;
-};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
