### PR TITLE
Auto-update the DOM-Parsing IDL file

### DIFF
--- a/interfaces/DOM-Parsing.idl
+++ b/interfaces/DOM-Parsing.idl
@@ -15,7 +15,7 @@ enum SupportedType {
   "application/xhtml+xml",
   "image/svg+xml"
 };
-[Constructor, Exposed=Window] 
+[Constructor, Exposed=Window]
   interface XMLSerializer {
   DOMString serializeToString(Node root);
 };

--- a/interfaces/DOM-Parsing.idl
+++ b/interfaces/DOM-Parsing.idl
@@ -1,6 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
-// Content of this file was automatically extracted from the DOM Parsing and Serialization spec.
-// See https://w3c.github.io/DOM-Parsing/
+// Content of this file was automatically extracted from the
+// "DOM Parsing and Serialization" spec.
+// See: https://w3c.github.io/DOM-Parsing/
 
 [Constructor, Exposed=Window]
 interface DOMParser {
@@ -14,18 +15,15 @@ enum SupportedType {
   "application/xhtml+xml",
   "image/svg+xml"
 };
-
-[Constructor, Exposed=Window]
+[Constructor, Exposed=Window] 
   interface XMLSerializer {
   DOMString serializeToString(Node root);
 };
-
 partial interface Element {
   [CEReactions, TreatNullAs=EmptyString] attribute DOMString innerHTML;
   [CEReactions, TreatNullAs=EmptyString] attribute DOMString outerHTML;
   [CEReactions] void insertAdjacentHTML(DOMString position, DOMString text);
 };
-
 partial interface Range {
   [CEReactions, NewObject] DocumentFragment createContextualFragment(DOMString fragment);
 };


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
