### PR TITLE
[fullscreen] Do not return value from cleanup fns

### DIFF
--- a/fullscreen/api/element-ready-check-allowed-cross-origin-manual.sub.html
+++ b/fullscreen/api/element-ready-check-allowed-cross-origin-manual.sub.html
@@ -7,7 +7,9 @@
 <script>
 
 async_test((t) => {
-  t.add_cleanup(() => document.exitFullscreen());
+  t.add_cleanup(() => {
+    Promise.resolve(document.exitFullscreen()).catch(() => {});
+  });
 
   // When a message is received from a child frame, ensure that the report
   // matches the expectations.

--- a/fullscreen/model/move-to-iframe-manual.html
+++ b/fullscreen/model/move-to-iframe-manual.html
@@ -7,7 +7,9 @@
 <iframe></iframe>
 <script>
 async_test(t => {
-  t.add_cleanup(() => document.exitFullscreen());
+  t.add_cleanup(() => {
+    Promise.resolve(document.exitFullscreen()).catch(() => {});
+  });
   const div = document.querySelector("div");
   const iframe = document.querySelector("iframe");
   document.onfullscreenchange = t.step_func(event => {

--- a/fullscreen/model/move-to-inactive-document-manual.html
+++ b/fullscreen/model/move-to-inactive-document-manual.html
@@ -6,7 +6,9 @@
 <div></div>
 <script>
 async_test(t => {
-  t.add_cleanup(() => document.exitFullscreen());
+  t.add_cleanup(() => {
+    Promise.resolve(document.exitFullscreen()).catch(() => {});
+  });
   const div = document.querySelector("div");
   document.onfullscreenchange = t.step_func(event => {
     const inactiveDocument = document.implementation.createDocument(null, "");

--- a/fullscreen/model/remove-child-manual.html
+++ b/fullscreen/model/remove-child-manual.html
@@ -10,7 +10,9 @@
 <script>
 async_test(function(t)
 {
-    t.add_cleanup(() => document.exitFullscreen());
+    t.add_cleanup(() => {
+        Promise.resolve(document.exitFullscreen()).catch(() => {});
+    });
     var parent = document.getElementById("parent");
     trusted_request(t, parent);
     document.onfullscreenchange = t.step_func(function()

--- a/fullscreen/model/remove-first-manual.html
+++ b/fullscreen/model/remove-first-manual.html
@@ -10,7 +10,9 @@
 <script>
 async_test(function(t)
 {
-    t.add_cleanup(() => document.exitFullscreen());
+    t.add_cleanup(() => {
+        Promise.resolve(document.exitFullscreen()).catch(() => {});
+    });
     var first = document.getElementById("first");
     trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function(event)

--- a/fullscreen/model/remove-last-manual.html
+++ b/fullscreen/model/remove-last-manual.html
@@ -10,7 +10,9 @@
 <script>
 async_test(function(t)
 {
-    t.add_cleanup(() => document.exitFullscreen());
+    t.add_cleanup(() => {
+        Promise.resolve(document.exitFullscreen()).catch(() => {});
+    });
     var first = document.getElementById("first");
     trusted_request(t, first);
     document.onfullscreenchange = t.step_func(function(event)

--- a/fullscreen/model/remove-parent-manual.html
+++ b/fullscreen/model/remove-parent-manual.html
@@ -10,7 +10,9 @@
 <script>
 async_test(function(t)
 {
-    t.add_cleanup(() => document.exitFullscreen());
+    t.add_cleanup(() => {
+        Promise.resolve(document.exitFullscreen()).catch(() => {});
+    });
     var child = document.getElementById("child");
     trusted_request(t, child);
     document.onfullscreenchange = t.step_func(function(event)

--- a/fullscreen/model/remove-single-manual.html
+++ b/fullscreen/model/remove-single-manual.html
@@ -8,7 +8,9 @@
 <script>
 async_test(function(t)
 {
-    t.add_cleanup(() => document.exitFullscreen());
+    t.add_cleanup(() => {
+        Promise.resolve(document.exitFullscreen()).catch(() => {});
+    });
     var single = document.getElementById("single");
     document.onfullscreenchange = t.step_func(function(event)
     {


### PR DESCRIPTION
Today, the return value of functions provided to the global
`add_cleanup` function has no effect on the behavior of the test runner.
An upcoming feature addition to testharness.js will cause the return
value to influence test results [1].

Despite this, some existing tests have already been authored to return a
value: the result of `document.exitFullScreen`. Although this is
expected to be a Promise in conforming implementations, some browsers do
not yet implement this functionality.

To allow the new test harness feature to land without introducing
harness errors, refactor existing tests to omit a return value.

Additionally, use `Promise.prototype.catch` to avoid race conditions
resulting from unhandled Promise rejections (which trigger a harness
error in testharness.js today).

[1] https://github.com/web-platform-tests/wpt/issues/6075

---

@clelland This could be simplified slightly by simply returning the result of
`Promise.resolve`. The current version of the harness doesn't care about the
return value, and the new version will receive a thenable regardless of the
implementation status.

That patch would be slightly simpler and also progressive in some sense, but
it has a downside. That is, the update to testharness.js will implicitly modify
the behavior of the test. If this alters test results, it may be difficult for
consumers to determine how/why the change occurred.