### PR TITLE
[html] Do not return value from cleanup fns

### DIFF
--- a/html/infrastructure/urls/resolving-urls/query-encoding/attributes.sub.html
+++ b/html/infrastructure/urls/resolving-urls/query-encoding/attributes.sub.html
@@ -25,7 +25,7 @@ function assert_ends_with(input, endsWith) {
   test(t => {
     const elm = document.createElement(localName);
     document.body.appendChild(elm);
-    t.add_cleanup(() => document.body.removeChild(elm));
+    t.add_cleanup(() => { document.body.removeChild(elm); });
     elm.setAttribute("background", "?\u00FF");
     assert_ends_with(getComputedStyle(elm).backgroundImage, expected(document.characterSet) + "\")");
   }, "getComputedStyle <" + localName + " background>");


### PR DESCRIPTION
Today, the return value of functions provided to the `Test#add_cleanup`
function has no effect on the behavior of the test runner. Despite this,
some existing tests have already been authored to return a value: the
result of `Element#removeChild`.

An upcoming feature addition to testharness.js will cause the return
value to influence test results [1]. To allow the new test harness
feature to land without introducing harness errors, refactor existing
tests to omit a return value.

[1] https://github.com/web-platform-tests/wpt/issues/6075