### PR TITLE
[fetch] Do not return value from cleanup fns

### DIFF
--- a/fetch/sec-metadata/script.tentative.https.sub.html
+++ b/fetch/sec-metadata/script.tentative.https.sub.html
@@ -7,7 +7,7 @@
 <script src="https://{{host}}:{{ports[https][0]}}/fetch/sec-metadata/resources/echo-as-script.py"></script>
 <script>
   test(t => {
-    t.add_cleanup(_ => header = null);
+    t.add_cleanup(_ => { header = null; });
 
     assert_header_equals(header, {
       "cause": undefined,
@@ -22,7 +22,7 @@
 <script src="https://{{hosts[][www]}}:{{ports[https][0]}}/fetch/sec-metadata/resources/echo-as-script.py"></script>
 <script>
   test(t => {
-    t.add_cleanup(_ => header = null);
+    t.add_cleanup(_ => { header = null; });
 
     assert_header_equals(header, {
       "cause": undefined,
@@ -37,7 +37,7 @@
 <script src="https://{{hosts[alt][www]}}:{{ports[https][0]}}/fetch/sec-metadata/resources/echo-as-script.py"></script>
 <script>
   test(t => {
-    t.add_cleanup(_ => header = null);
+    t.add_cleanup(_ => { header = null; });
 
     assert_header_equals(header, {
       "cause": undefined,


### PR DESCRIPTION
Today, the return value of functions provided to the `Test#add_cleanup`
function has no effect on the behavior of the test runner. Despite this,
some existing tests have already been authored to return the `null`
value.

An upcoming feature addition to testharness.js will cause the return
value to influence test results [1]. To allow the new test harness
feature to land without introducing harness errors, refactor existing
tests to omit a return value.

[1] https://github.com/web-platform-tests/wpt/issues/6075