### PR TITLE
Add an instance of ImageData to the HTML interfaces test.

### DIFF
--- a/html/dom/interfaces.https.html
+++ b/html/dom/interfaces.https.html
@@ -116,7 +116,7 @@ idl_test(
       CanvasGradient: [],
       CanvasPattern: [],
       TextMetrics: [],
-      ImageData: [],
+      ImageData: ['new ImageData(10, 10)'],
       HTMLMapElement: ['document.createElement("map")'],
       HTMLAreaElement: ['document.createElement("area")'],
       HTMLTableElement: ['document.createElement("table")'],


### PR DESCRIPTION
This causes the test to catch a bug in WebKit, where it defines a "data"
property on the instance, along with the correct property on the prototype.