### PR TITLE
Mark some tests as failing in python 3.0-3.5.

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -204,6 +204,7 @@ class TestFunctionHandler(TestUsingServer):
         assert resp.read() == b""
 
 
+@pytest.mark.xfail((3,) <= sys.version_info < (3, 6), reason="wptserve only works on Py2")
 class TestJSONHandler(TestUsingServer):
     def test_json_0(self):
         @wptserve.handlers.json_handler


### PR DESCRIPTION
The json.loads API did not accept binary strings in these python versions.
This change does not affect the testing in CI, but helps with certain older
local setups.