### PR TITLE
Don't use six.string_types in wptserve.

### DIFF
--- a/tools/wptserve/tests/functional/test_handlers.py
+++ b/tools/wptserve/tests/functional/test_handlers.py
@@ -30,7 +30,6 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual(resp.info()["Double-Header"], "PA, SS")
 
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-19"})
         self.assertEqual(206, resp.getcode())
@@ -41,7 +40,6 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual("10", resp.info()['Content-Length'])
         self.assertEqual(expected[10:20], data)
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_no_end(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-"})
         self.assertEqual(206, resp.getcode())
@@ -51,7 +49,6 @@ class TestFileHandler(TestUsingServer):
         self.assertEqual("bytes 10-%i/%i" % (len(expected) - 1, len(expected)), resp.info()['Content-Range'])
         self.assertEqual(expected[10:], data)
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_range_no_start(self):
         resp = self.request("/document.txt", headers={"Range":"bytes=-10"})
         self.assertEqual(206, resp.getcode())

--- a/tools/wptserve/tests/functional/test_pipes.py
+++ b/tools/wptserve/tests/functional/test_pipes.py
@@ -41,19 +41,16 @@ class TestHeader(TestUsingServer):
         self.assertEqual(resp.info()["X-Test"], "1, 2")
 
 class TestSlice(TestUsingServer):
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_both_bounds(self):
         resp = self.request("/document.txt", query="pipe=slice(1,10)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEqual(resp.read(), expected[1:10])
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_upper(self):
         resp = self.request("/document.txt", query="pipe=slice(1)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEqual(resp.read(), expected[1:])
 
-    @pytest.mark.xfail(sys.version_info >= (3,), reason="wptserve only works on Py2")
     def test_no_lower(self):
         resp = self.request("/document.txt", query="pipe=slice(null,10)")
         expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()

--- a/tools/wptserve/wptserve/pipes.py
+++ b/tools/wptserve/wptserve/pipes.py
@@ -8,7 +8,7 @@ import time
 import uuid
 from six.moves import StringIO
 
-from six import text_type, binary_type, string_types
+from six import text_type, binary_type
 
 def resolve_content(response):
     return b"".join(item for item in response.iter_content(read_file=True))
@@ -480,7 +480,7 @@ def template(request, content, escape_type="html"):
                     "unexpected token type %s (token '%r'), expected ident or arguments" % (ttype, field)
                 )
 
-        assert isinstance(value, (int, string_types)), tokens
+        assert isinstance(value, (int, (binary_type, text_type))), tokens
 
         if variable is not None:
             variables[variable] = value

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -8,7 +8,7 @@ import socket
 from .constants import response_codes
 from .logger import get_logger
 
-from six import string_types, binary_type, text_type, itervalues
+from six import binary_type, text_type, itervalues
 
 missing = object()
 
@@ -181,7 +181,7 @@ class Response(object):
         True, the entire content of the file will be returned as a string facilitating
         non-streaming operations like template substitution.
         """
-        if isinstance(self.content, string_types):
+        if isinstance(self.content, (binary_type, text_type)):
             yield self.content
         elif hasattr(self.content, "read"):
             if read_file:
@@ -401,7 +401,7 @@ class ResponseWriter(object):
             if name.lower() not in self._headers_seen:
                 self.write_header(name, f())
 
-        if (isinstance(self._response.content, string_types) and
+        if (isinstance(self._response.content, (binary_type, text_type)) and
             "content-length" not in self._headers_seen):
             #Would be nice to avoid double-encoding here
             self.write_header("Content-Length", len(self.encode(self._response.content)))

--- a/tools/wptserve/wptserve/router.py
+++ b/tools/wptserve/wptserve/router.py
@@ -2,7 +2,7 @@ import itertools
 import re
 
 from .logger import get_logger
-from six import string_types
+from six import binary_type, text_type
 
 any_method = object()
 
@@ -135,7 +135,7 @@ class Router(object):
                         object and the response object.
 
         """
-        if isinstance(methods, string_types) or methods in (any_method, "*"):
+        if isinstance(methods, (binary_type, text_type)) or methods is any_method:
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -8,7 +8,7 @@ import sys
 import threading
 import time
 import traceback
-from six import string_types
+from six import binary_type, text_type
 
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
@@ -80,7 +80,7 @@ class RequestRewriter(object):
         :param output_path: Path to replace the input path with in
                             the request.
         """
-        if isinstance(methods, string_types):
+        if isinstance(methods, (binary_type, text_type)):
             methods = [methods]
         self.rules[input_path] = (methods, output_path)
 


### PR DESCRIPTION
In python 2, it's defined as basestring, so it matches both str and unicode,
but in python 3, it matches only str (and not bytes). This does not seem like
a useful approach as we add python 3 support, and the now-passing tests
support that view.