### PR TITLE
Auto-update the appmanifest IDL file

### DIFF
--- a/appmanifest/META.yml
+++ b/appmanifest/META.yml
@@ -1,0 +1,7 @@
+suggested_reviewers:
+  - anssiko
+  - kenchris
+  - marcoscaceres
+  - mgiuca
+  - mounirlamouri
+  - RobDolin

--- a/appmanifest/idlharness.window.js
+++ b/appmanifest/idlharness.window.js
@@ -16,6 +16,7 @@ promise_test(async () => {
   idl_array.add_dependency_idls(dom);
   idl_array.add_objects({
     Window: ['window'],
+    BeforeInstallPromptEvent: ['new BeforeInstallPromptEvent("type")'],
   });
   idl_array.test();
 }, 'appmanifest interfaces');

--- a/appmanifest/idlharness.window.js
+++ b/appmanifest/idlharness.window.js
@@ -1,0 +1,21 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://w3c.github.io/manifest/
+
+'use strict';
+
+promise_test(async () => {
+  const srcs = ['appmanifest', 'dom', 'html'];
+  const [idl, dom, html] = await Promise.all(
+    srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
+
+  const idl_array = new IdlArray();
+  idl_array.add_idls(idl);
+  idl_array.add_dependency_idls(html);
+  idl_array.add_dependency_idls(dom);
+  idl_array.add_objects({
+    Window: ['window'],
+  });
+  idl_array.test();
+}, 'appmanifest interfaces');

--- a/interfaces/appmanifest.idl
+++ b/interfaces/appmanifest.idl
@@ -1,0 +1,71 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Web App Manifest" spec.
+// See: https://w3c.github.io/manifest/
+
+enum AppBannerPromptOutcome {
+  "accepted",
+  "dismissed"
+};
+[Constructor, Exposed=Window]
+interface BeforeInstallPromptEvent : Event {
+    Promise<PromptResponseObject> prompt();
+};
+dictionary PromptResponseObject {
+  AppBannerPromptOutcome userChoice;
+};
+partial interface Window {
+  attribute EventHandler onappinstalled;
+  attribute EventHandler onbeforeinstallprompt;
+};
+dictionary WebAppManifest {
+   TextDirectionType dir = "auto";
+   DOMString lang;
+   USVString name;
+   USVString short_name;
+   USVString description;
+   sequence<ImageResource> icons;
+   sequence<ImageResource> screenshots;
+   sequence<USVString> categories;
+   DOMString iarc_rating_id;
+   USVString start_url;
+   DisplayModeType display = "browser";
+   OrientationLockType orientation;
+   USVString theme_color;
+   USVString background_color;
+   USVString scope;
+   ServiceWorkerRegistrationObject serviceworker;
+   sequence<ExternalApplicationResource> related_applications;
+   boolean prefer_related_applications = "false";
+};
+enum TextDirectionType { "ltr", "rtl", "auto" };
+enum DisplayModeType {
+  "fullscreen",
+  "standalone",
+  "minimal-ui",
+  "browser"
+};
+dictionary ImageResource {
+  required USVString src;
+  DOMString sizes;
+  USVString type;
+  USVString purpose;
+  USVString platform;
+};
+dictionary ServiceWorkerRegistrationObject {
+  required USVString src;
+  USVString scope;
+  WorkerType type = "classic";
+  ServiceWorkerUpdateViaCache update_via_cache = "imports";
+};
+dictionary ExternalApplicationResource {
+  required USVString platform;
+  USVString url;
+  DOMString id;
+  USVString min_version;
+  sequence<Fingerprint> fingerprints;
+};
+dictionary Fingerprint {
+  USVString type;
+  USVString value;
+};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
