### PR TITLE
Streams Object.prototype.then interception

### DIFF
--- a/streams/piping/then-interception.dedicatedworker.html
+++ b/streams/piping/then-interception.dedicatedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>then-interception.js dedicated worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new Worker('then-interception.js'));
+</script>

--- a/streams/piping/then-interception.html
+++ b/streams/piping/then-interception.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>then-interception.js browser context wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script src="../resources/test-utils.js"></script>
+<script src="../resources/recording-streams.js"></script>
+
+<script src="then-interception.js"></script>

--- a/streams/piping/then-interception.js
+++ b/streams/piping/then-interception.js
@@ -1,0 +1,64 @@
+'use strict';
+
+if (self.importScripts) {
+  self.importScripts('/resources/testharness.js');
+  self.importScripts('../resources/test-utils.js');
+  self.importScripts('../resources/recording-streams.js');
+}
+
+function interceptThen() {
+  const intercepted = [];
+  const callCount = 0;
+  Object.prototype.then = function(resolver) {
+    if (!this.done) {
+      intercepted.push(this.value);
+    }
+    const retval = Object.create(null);
+    retval.done = ++callCount === 3;
+    retval.value = callCount;
+    resolver(retval);
+    if (retval.done) {
+      delete Object.prototype.then;
+    }
+  }
+  return intercepted;
+}
+
+promise_test(async () => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const ws = recordingWritableStream();
+
+  const intercepted = interceptThen();
+
+  await rs.pipeTo(ws);
+
+  assert_array_equals(intercepted, [], 'nothing should have been intercepted');
+  assert_array_equals(ws.events, ['write', 'a', 'close'], 'written chunk should be "a"');
+}, 'piping should not be observable');
+
+promise_test(async () => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.close();
+    }
+  });
+  const ws = recordingWritableStream();
+
+  const [ branch1, branch2 ] = rs.tee();
+
+  const intercepted = interceptThen();
+
+  await branch1.pipeTo(ws);
+  branch2.cancel();
+
+  assert_array_equals(intercepted, [], 'nothing should have been intercepted');
+  assert_array_equals(ws.events, ['write', 'a', 'close'], 'written chunk should be "a"');
+}, 'tee should not be observable');
+
+done();

--- a/streams/piping/then-interception.serviceworker.https.html
+++ b/streams/piping/then-interception.serviceworker.https.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>then-interception.js service worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+
+<script>
+'use strict';
+service_worker_test('then-interception.js', 'Service worker test setup');
+</script>

--- a/streams/piping/then-interception.sharedworker.html
+++ b/streams/piping/then-interception.sharedworker.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>then-interception.js shared worker wrapper file</title>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+'use strict';
+fetch_tests_from_worker(new SharedWorker('then-interception.js'));
+</script>


### PR DESCRIPTION
Add tests to verify that modifying Object.prototype.then does not make the
internals of pipeTo() and tee() visible.

Equivalent standard change is whatwg/streams#936.