### PR TITLE
Auto-update the console IDL file

### DIFF
--- a/console/idlharness.any.js
+++ b/console/idlharness.any.js
@@ -1,0 +1,14 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+// https://console.spec.whatwg.org/
+
+promise_test(async () => {
+  const srcs = ['console'];
+  const [idl] = await Promise.all(
+      srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
+
+  const idl_array = new IdlArray();
+  idl_array.add_idls(idl);
+  idl_array.test();
+}, 'console interfaces');

--- a/interfaces/console.idl
+++ b/interfaces/console.idl
@@ -1,9 +1,13 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Console Standard" spec.
+// See: https://console.spec.whatwg.org/
+
 [Exposed=(Window,Worker,Worklet)]
 namespace console { // but see namespace object requirements below
   // Logging
   void assert(optional boolean condition = false, any... data);
   void clear();
-  void count(optional DOMString label = "default");
   void debug(any... data);
   void error(any... data);
   void info(any... data);
@@ -13,6 +17,10 @@ namespace console { // but see namespace object requirements below
   void warn(any... data);
   void dir(any item, optional object? options);
   void dirxml(any... data);
+
+  // Counting
+  void count(optional DOMString label = "default");
+  void countReset(optional DOMString label = "default");
 
   // Grouping
   void group(any... data);

--- a/interfaces/console.idl
+++ b/interfaces/console.idl
@@ -29,5 +29,6 @@ namespace console { // but see namespace object requirements below
 
   // Timing
   void time(optional DOMString label = "default");
+  void timeLog(optional DOMString label = "default", any... data);
   void timeEnd(optional DOMString label = "default");
 };


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
