### PR TITLE
Handle (+ test) 'namespace' in idlharness

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3033,9 +3033,6 @@ function IdlNamespace(obj)
 
     /** An array of IdlInterfaceMembers. */
     this.members = obj.members.map(m => new IdlInterfaceMember(m));
-    if (this.has_extended_attribute("Unforgeable")) {
-        this.members.forEach(m => { m.isUnforgeable = true; });
-    }
 }
 //@}
 
@@ -3062,13 +3059,6 @@ IdlNamespace.prototype.do_member_operation_asserts = function (memberHolderObjec
         typeof memberHolderObject[member.name],
         "function",
          "property must be a function");
-
-    var args = member.arguments.map(function(a) {
-        return create_suitable_object(a.idlType);
-    });
-    this.array.assert_type_is(
-        memberHolderObject[member.name].call(null, args),
-        member.idlType);
 
     assert_equals(
         memberHolderObject[member.name].length,
@@ -3125,14 +3115,8 @@ IdlNamespace.prototype.test_member_attribute = function (member)
             member.name,
             this.name + ' does not have property ' + format_value(member.name));
 
-        // "The attribute setter is undefined if the attribute is declared
-        // readonly and has neither a [PutForwards] nor a [Replaceable]
-        // extended attribute declared on it."
-        if (!member.has_extended_attribute("PutForwards")
-            && !member.has_extended_attribute("Replaceable")) {
-            var desc = Object.getOwnPropertyDescriptor(self[this.name], member.name);
-            assert_equals(desc.set, undefined, "setter must be undefined for readonly attributes");
-        }
+        var desc = Object.getOwnPropertyDescriptor(self[this.name], member.name);
+        assert_equals(desc.set, undefined, "setter must be undefined for namespace members");
         a_test.done();
     }.bind(this));
 };

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -70,6 +70,11 @@ function constValue (cnt)
 function minOverloadLength(overloads)
 //@{
 {
+    // "The value of the Function object’s “length” property is
+    // a Number determined as follows:
+    // ". . .
+    // "Return the length of the shortest argument list of the
+    // entries in S."
     if (!overloads.length) {
         return 0;
     }
@@ -365,7 +370,8 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
 
     parsed_idls.forEach(function(parsed_idl)
     {
-        if (parsed_idl.partial && ["interface", "dictionary"].includes(parsed_idl.type))
+        if (parsed_idl.partial
+            && ["interface", "dictionary", "namespace"].includes(parsed_idl.type))
         {
             if (should_skip(parsed_idl.name))
             {
@@ -457,6 +463,10 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
         case "callback interface":
             this.members[parsed_idl.name] =
                 new IdlInterface(parsed_idl, /* is_callback = */ true, /* is_mixin = */ false);
+            break;
+
+        case "namespace":
+            this.members[parsed_idl.name] = new IdlNamespace(parsed_idl);
             break;
 
         default:
@@ -845,7 +855,8 @@ IdlArray.prototype.collapse_partials = function()
     {
         const originalExists = parsed_idl.name in this.members
             && (this.members[parsed_idl.name] instanceof IdlInterface
-                || this.members[parsed_idl.name] instanceof IdlDictionary);
+                || this.members[parsed_idl.name] instanceof IdlDictionary
+                || this.members[parsed_idl.name] instanceof IdlNamespace);
 
         let partialTestName = parsed_idl.name;
         if (!parsed_idl.untested) {
@@ -1310,7 +1321,7 @@ IdlInterface.prototype.get_inheritance_stack = function() {
     while (idl_interface.base) {
         var base = this.array.members[idl_interface.base];
         if (!base) {
-            throw new Error(idl_interface.type + " " + idl_interface.base + " not found (inherited by " + idl_interface.name + ")");
+            throw new IdlHarnessError(`${idl_interface.name} base ${idl_interface.base} not found`);
         } else if (stack.indexOf(base) > -1) {
             stack.push(base);
             let dep_chain = stack.map(i => i.name).join(',');
@@ -2255,15 +2266,12 @@ IdlInterface.prototype.do_member_operation_asserts = function(memberHolderObject
     // behavior is as follows . . ."
     assert_equals(typeof memberHolderObject[member.name], "function",
                   "property must be a function");
-    // "The value of the Function object’s “length” property is
-    // a Number determined as follows:
-    // ". . .
-    // "Return the length of the shortest argument list of the
-    // entries in S."
-    assert_equals(memberHolderObject[member.name].length,
-        minOverloadLength(this.members.filter(function(m) {
-            return m.type == "operation" && m.name == member.name;
-        })),
+
+    const ctors = this.members
+        .filter(m => m.type == "operation" && m.name == member.name);
+    assert_equals(
+        minOverloadLength(ctors),
+        memberHolderObject[member.name].length,
         "property has wrong .length");
 
     // Make some suitable arguments
@@ -3010,7 +3018,143 @@ function IdlTypedef(obj)
 }
 //@}
 
-IdlTypedef.prototype = Object.create(IdlObject.prototype);
+IdlNamespace.prototype = Object.create(IdlObject.prototype);
+
+/// IdlNamespace ///
+function IdlNamespace(obj)
+//@{
+{
+    this.name = obj.name;
+    this.extAttrs = obj.extAttrs;
+    this.untested = obj.untested;
+    /** A back-reference to our IdlArray. */
+    this.array = obj.array;
+
+    /** An array of IdlInterfaceMembers. */
+    this.members = obj.members.map(m => new IdlInterfaceMember(m));
+    if (this.has_extended_attribute("Unforgeable")) {
+        this.members.forEach(m => { m.isUnforgeable = true; });
+    }
+}
+//@}
+
+IdlNamespace.prototype.do_member_operation_asserts = function (memberHolderObject, member, a_test)
+//@{
+{
+    var done = a_test.done.bind(a_test);
+    var operationUnforgeable = member.has_extended_attribute("Unforgeable");
+    var desc = Object.getOwnPropertyDescriptor(memberHolderObject, member.name);
+
+    assert_false("get" in desc, "property should not have a getter");
+    assert_false("set" in desc, "property should not have a setter");
+    assert_equals(
+        desc.writable,
+        !operationUnforgeable,
+        "property should be writable if and only if not unforgeable");
+    assert_true(desc.enumerable, "property should be enumerable");
+    assert_equals(
+        desc.configurable,
+        !operationUnforgeable,
+        "property should be configurable if and only if not unforgeable");
+
+    assert_equals(
+        typeof memberHolderObject[member.name],
+        "function",
+         "property must be a function");
+
+    var args = member.arguments.map(a => create_suitable_object(a.idlType));
+    this.array.assert_type_is(
+        memberHolderObject[member.name].call(null, ...args),
+        member.idlType);
+
+    assert_equals(memberHolderObject[member.name].length,
+        minOverloadLength(this.members.filter(function(m) {
+            return m.type == "operation" && m.name == member.name;
+        })),
+        "operation has wrong .length");
+    done();
+}
+//@}
+
+IdlNamespace.prototype.test_member_operation = function(member)
+//@{
+{
+    if (!shouldRunSubTest(this.name)) {
+        return;
+    }
+    const args = member.arguments
+        .map(a => `${a.idlType.idlType}${a.variadic ? '...' : ''}`)
+        .join(", ");
+    var a_test = subsetTestByKey(
+        this.name,
+        async_test,
+        `${this.name} namespace: operation ${member.name}(${args})`);
+    a_test.step(() => {
+        assert_own_property(
+            self[this.name],
+            member.name,
+            `namespace object missing operation ${format_value(member.name)}`);
+
+        this.do_member_operation_asserts(self[this.name], member, a_test);
+    });
+};
+//@}
+
+IdlNamespace.prototype.test_member_attribute = function (member)
+//@{
+{
+    if (!shouldRunSubTest(this.name)) {
+        return;
+    }
+    var a_test = subsetTestByKey(
+        this.name,
+        async_test,
+        `${this.name} namespace: attribute ${member.name}`);
+    a_test.step(function()
+    {
+        assert_own_property(
+            self[this.name],
+            member.name,
+            `${this.name} does not have property ${format_value(member.name)}`);
+
+        var desc = Object.getOwnPropertyDescriptor(self[this.name], member.name);
+        // "The attribute setter is undefined if the attribute is declared
+        // readonly and has neither a [PutForwards] nor a [Replaceable]
+        // extended attribute declared on it."
+        assert_equals(desc.set, undefined, "setter must be undefined for readonly attributes");
+        a_test.done();
+    }.bind(this));
+};
+//@}
+
+IdlNamespace.prototype.test = function ()
+//@{
+{
+    /**
+     * TODO(lukebjerring): Assert:
+     * - "Note that unlike interfaces or dictionaries, namespaces do not create types."
+     * - "Of the extended attributes defined in this specification, only the
+     *     [Exposed] and [SecureContext] extended attributes are applicable to namespaces."
+     * - "Namespaces must be annotated with the [Exposed] extended attribute."
+     */
+
+    for (const v of Object.values(this.members)) {
+        switch (v.type) {
+
+        case 'operation':
+            this.test_member_operation(v);
+            break;
+
+        case 'attribute':
+            this.test_member_attribute(v);
+            break;
+
+        default:
+            throw `Invalid namespace member ${v.name}: ${v.type} not supported`;
+        }
+    };
+};
+//@}
 
 }());
 // vim: set expandtab shiftwidth=4 tabstop=4 foldmarker=@{,@} foldmethod=marker:

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_attribute.html
@@ -1,0 +1,55 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
+  <title>idlharness: namespace attribute</title>
+  <script src="../../../../variants.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+</head>
+<body>
+<p>Verify the series of sub-tests that are executed for namespace attributes.</p>
+<script>
+"use strict";
+
+self.foo = {
+  truth: true
+};
+
+var idlArray = new IdlArray();
+idlArray.add_idls(
+`namespace foo {
+  readonly attribute bool truth;
+  readonly attribute bool lies;
+};`);
+idlArray.test();
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "name": "foo namespace: attribute truth",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "foo namespace: attribute lies",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_own_property: foo does not have property \"lies\" expected property \"lies\" missing"
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -1,0 +1,93 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
+  <title>idlharness: namespace operation</title>
+  <script src="../../../../variants.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+</head>
+<body>
+<p>Verify the series of sub-tests that are executed for namespace operations.</p>
+<script>
+"use strict";
+
+self.foo = {
+  Truth: function() {},
+};
+Object.defineProperty(self.foo, "Truth", { writable: true });
+
+self.bar = {
+  Truth: function() {},
+}
+Object.defineProperty(self.bar, "Truth", {
+  writable: false,
+  configurable: false,
+});
+
+self.baz = {
+  LongStory: function(hero, ...details) {
+    return `${hero} went and ${details.join(', then')}`
+  },
+  ShortStory: function(...details) {
+    return `${details.join('. ')}`;
+  },
+};
+
+var idlArray = new IdlArray();
+idlArray.add_idls(
+`namespace foo {
+  void Truth();
+  void Lies();
+};
+namespace bar {
+  [Unforgeable]
+  void Truth();
+};
+namespace baz {
+  DOMString LongStory(any hero, DOMString... details);
+  DOMString ShortStory(DOMString... details);
+};`);
+idlArray.test();
+</script>
+<script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "name": "bar namespace: operation Truth()",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "baz namespace: operation LongStory(any, DOMString...)",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "foo namespace: operation Truth()",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "foo namespace: operation Lies()",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_own_property: namespace object missing operation \"Lies\" expected property \"Lies\" missing"
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+</html>

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_operation.html
@@ -74,6 +74,12 @@ idlArray.test();
       "message": null
     },
     {
+      "name": "baz namespace: operation ShortStory(DOMString...)",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
       "name": "foo namespace: operation Truth()",
       "status_string": "PASS",
       "properties": {},

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
@@ -1,0 +1,113 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="variant" content="">
+  <meta name="variant" content="?keep-promise">
+  <title>idlharness: Partial namespace</title>
+  <script src="/resources/test/variants.js"></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/WebIDLParser.js"></script>
+  <script src="/resources/idlharness.js"></script>
+</head>
+
+<body>
+  <p>Verify the series of sub-tests that are executed for "partial" namespace objects.</p>
+  <script>
+    "use strict";
+
+    // No original existence
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls('partial namespace A {};');
+      idlArray.test();
+    })();
+
+    // Valid exposure (Note: Worker -> {Shared,Dedicated,Service}Worker)
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_untested_idls(`
+        [Exposed=(Worker)]
+        namespace B {};
+
+        [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
+        namespace C {};`);
+      idlArray.add_idls(`
+        [Exposed=(DedicatedWorker, ServiceWorker, SharedWorker)]
+        partial namespace B {};
+
+        [Exposed=(Worker)]
+        partial namespace C {};`);
+      idlArray.collapse_partials();
+    })();
+
+    // Invalid exposure
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_untested_idls(`
+        [Exposed=(Window, ServiceWorker)]
+        namespace D {};`);
+      idlArray.add_idls(`
+        [Exposed=(DedicatedWorker)]
+        partial namespace D {};`);
+      idlArray.collapse_partials();
+    })();
+  </script>
+  <script type="text/json" id="expected">
+{
+  "summarized_status": {
+    "status_string": "OK",
+    "message": null
+  },
+  "summarized_tests": [
+    {
+      "name": "Partial namespace A: original namespace defined",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_true: Original namespace should be defined expected true got false"
+    },
+    {
+      "name": "Partial namespace B: original namespace defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial namespace B: valid exposure set",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial namespace C: original namespace defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial namespace C: valid exposure set",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial namespace D: original namespace defined",
+      "status_string": "PASS",
+      "properties": {},
+      "message": null
+    },
+    {
+      "name": "Partial namespace D: valid exposure set",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "Partial D namespace is exposed to 'DedicatedWorker', the original namespace is not."
+    }
+  ],
+  "type": "complete"
+}
+</script>
+</body>
+
+</html>

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -13,4 +13,4 @@ deps =
   selenium
   requests
 
-commands = pytest {posargs} -vv tests/functional/idlharness
+commands = pytest {posargs} -vv tests

--- a/resources/test/tox.ini
+++ b/resources/test/tox.ini
@@ -13,4 +13,4 @@ deps =
   selenium
   requests
 
-commands = pytest {posargs} -vv tests
+commands = pytest {posargs} -vv tests/functional/idlharness


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt/issues/7583

Runs some basic tests on `namespace` definitions in IDL.
- Tests partial definitions are valid
- Tests exposure set of partial interface are subset of original namespace
- Tests the `length` property of `namespace` `operation` definitions (`optional` params is handled incorrectly in Chrome, it seems..)
- Tests the type of the return value for the methods