### PR TITLE
[css-backgrounds] don't serialize as currentColor

### DIFF
--- a/css/css-backgrounds/parsing/background-color-valid.html
+++ b/css/css-backgrounds/parsing/background-color-valid.html
@@ -12,9 +12,8 @@
 </head>
 <body>
 <script>
-// Edge serializes as "currentColor".
-test_valid_value("background-color", "currentcolor", ["currentcolor", "currentColor"]);
-test_valid_value("background-color", "currentColor", ["currentcolor", "currentColor"]);
+test_valid_value("background-color", "currentcolor", "currentcolor");
+test_valid_value("background-color", "currentColor", "currentcolor");
 
 test_valid_value("background-color", "red");
 test_valid_value("background-color", "#00FF00", "rgb(0, 255, 0)");

--- a/css/css-backgrounds/parsing/border-color-valid.html
+++ b/css/css-backgrounds/parsing/border-color-valid.html
@@ -12,9 +12,8 @@
 </head>
 <body>
 <script>
-// Edge serializes as "currentColor".
-test_valid_value("border-color", "currentcolor", ["currentcolor", "currentColor"]);
-test_valid_value("border-color", "currentColor", ["currentcolor", "currentColor"]);
+test_valid_value("border-color", "currentcolor", "currentcolor");
+test_valid_value("border-color", "currentColor", "currentcolor");
 
 test_valid_value("border-color", "red yellow green blue");
 

--- a/css/css-color/parsing/color-valid.html
+++ b/css/css-color/parsing/color-valid.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <script>
-test_valid_value("color", "currentcolor"); // Edge serializes as currentColor.
+test_valid_value("color", "currentcolor");
 test_valid_value("color", "transparent");
 test_valid_value("color", "red");
 test_valid_value("color", "magenta");

--- a/css/filter-effects/parsing/lighting-color-parsing-valid.html
+++ b/css/filter-effects/parsing/lighting-color-parsing-valid.html
@@ -16,9 +16,8 @@ test_valid_value("lighting-color", "rgb(1,2,3)", "rgb(1, 2, 3)");
 test_valid_value("lighting-color", "#102030", "rgb(16, 32, 48)");
 test_valid_value("lighting-color", "rgba(1, 2, 3, 0.5)");
 
-// Edge serializes this keyword as mixed case. Blink, WebKit, Firefox serialize as lowercase.
-test_valid_value("lighting-color", "currentColor", ["currentColor", "currentcolor"]);
-test_valid_value("lighting-color", "currentcolor", ["currentColor", "currentcolor"]);
+test_valid_value("lighting-color", "currentColor", "currentcolor");
+test_valid_value("lighting-color", "currentcolor", "currentcolor");
 </script>
 </body>
 </html>


### PR DESCRIPTION
CSS keywords serialize as lower case.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/16905526/