### PR TITLE
Correcting expected exception type for WebDriver delete session test

### DIFF
--- a/webdriver/tests/delete_session/delete.py
+++ b/webdriver/tests/delete_session/delete.py
@@ -25,5 +25,5 @@ def test_delete_session_with_dismissed_beforeunload_prompt(session):
     assert_success(response)
 
     # A beforeunload prompt has to be automatically dismissed, and the session deleted
-    with pytest.raises(error.SessionNotCreatedException):
+    with pytest.raises(error.InvalidSessionIdException):
         session.alert.text


### PR DESCRIPTION
The SessionNotCreatedException should be thrown if an attempt to create a
session fails. If a user tries to access a session that existed, but has
already been deleted, the correct exception is InvalidSessionIdException.