### PR TITLE
webrtc: Fix bogus merge from #11789

### DIFF
--- a/webrtc/RTCPeerConnection-setLocalDescription.html
+++ b/webrtc/RTCPeerConnection-setLocalDescription.html
@@ -63,19 +63,12 @@
         pc.setLocalDescription(offer2)
         .then(() => {
           assert_equals(pc.signalingState, 'have-local-offer');
-<<<<<<< HEAD
-          assert_session_desc_not_equals(offer1, offer2);
-          assert_session_desc_equals(pc.localDescription, offer2);
-          assert_session_desc_equals(pc.currentLocalDescription, offer1);
-          assert_session_desc_equals(pc.pendingLocalDescription, offer2);
-
-          assert_array_equals(states, ['have-local-offer', 'stable', 'have-local-offer']);
-=======
           assert_session_desc_not_similar(offer1, offer2);
           assert_session_desc_similar(pc.localDescription, offer2);
           assert_session_desc_similar(pc.currentLocalDescription, offer1);
           assert_session_desc_similar(pc.pendingLocalDescription, offer2);
->>>>>>> s/assert_session_desc_(not_)equals/assert_session_desc_(not_)similar
+
+          assert_array_equals(states, ['have-local-offer', 'stable', 'have-local-offer']);
         })));
   }, 'Calling createOffer() and setLocalDescription() again after one round of local-offer/remote-answer should succeed');
 
@@ -96,16 +89,9 @@
         pc.setLocalDescription(offer)
         .then(() => {
           assert_equals(pc.signalingState, 'have-local-offer');
-<<<<<<< HEAD
-          assert_session_desc_equals(pc.localDescription, offer);
-          assert_session_desc_equals(pc.currentLocalDescription, answer);
-          assert_session_desc_equals(pc.pendingLocalDescription, offer);
-=======
           assert_session_desc_similar(pc.localDescription, offer);
           assert_session_desc_similar(pc.currentLocalDescription, answer);
           assert_session_desc_similar(pc.pendingLocalDescription, offer);
-        })));
->>>>>>> s/assert_session_desc_(not_)equals/assert_session_desc_(not_)similar
 
           assert_array_equals(states, ['have-remote-offer', 'stable', 'have-local-offer']);
         })));


### PR DESCRIPTION
PR #11789 upstreamed some Mozilla changes that were originally committed
downstream before #11177 landed in this repository.

The resulting pull request had some unresolved conflicts that did not
prevent it from being merged, resulting in a bogus file.