### PR TITLE
Update the gamepad IDL file

### DIFF
--- a/gamepad/idlharness.html
+++ b/gamepad/idlharness.html
@@ -12,12 +12,12 @@
   "use strict";
 
   promise_test(async () => {
-    const idl_array = new IdlArray();
-    const gamepad_idl = await fetch("/interfaces/gamepad.idl").then(r => r.text());
-    const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
-    const html = await fetch("/interfaces/html.idl").then(r => r.text());
+    const srcs = ['gamepad', 'dom', 'html'];
+    const [idl, dom, html] = await Promise.all(
+      srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
 
-    idl_array.add_idls(gamepad_idl);
+    const idl_array = new IdlArray();
+    idl_array.add_idls(idl);
     idl_array.add_dependency_idls(dom);
     idl_array.add_dependency_idls(html);
 

--- a/interfaces/gamepad.idl
+++ b/interfaces/gamepad.idl
@@ -1,7 +1,9 @@
 // GENERATED CONTENT - DO NOT EDIT
-// Content of this file was automatically extracted from the Gamepad spec.
-// See https://w3c.github.io/gamepad/
+// Content of this file was automatically extracted from the
+// "Gamepad" spec.
+// See: https://w3c.github.io/gamepad/
 
+[Exposed=Window]
 interface Gamepad {
   readonly attribute DOMString id;
   readonly attribute long index;
@@ -12,6 +14,7 @@ interface Gamepad {
   readonly attribute FrozenArray<GamepadButton> buttons;
 };
 
+[Exposed=Window]
 interface GamepadButton {
   readonly attribute boolean pressed;
   readonly attribute boolean touched;
@@ -23,15 +26,17 @@ enum GamepadMappingType {
   "standard",
 };
 
+[Exposed=Window]
 partial interface Navigator {
   sequence<Gamepad?> getGamepads();
 };
 
-[Constructor(GamepadEventInit eventInitDict)]
-interface GamepadEvent: Event {
-  readonly attribute Gamepad gamepad;
+[Constructor(DOMString type, GamepadEventInit eventInitDict), Exposed=Window]
+
+interface GamepadEvent : Event {
+  [SameObject] readonly attribute Gamepad gamepad;
 };
 
-dictionary GamepadEventInit: EventInit {
+dictionary GamepadEventInit : EventInit {
   required Gamepad gamepad;
 };


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
