### PR TITLE
Updating OS identifier in WebDriver control+click tests

### DIFF
--- a/webdriver/tests/actions/control_click.py
+++ b/webdriver/tests/actions/control_click.py
@@ -18,7 +18,7 @@ def test_control_click(session, test_actions_page, key_chain, mouse_chain, modif
     outer = session.find.css("#outer", all=False)
     mouse_chain.click(element=outer)
     session.actions.perform([key_chain.dict, mouse_chain.dict])
-    if os == "windows_nt":
+    if os == "windows":
         expected = [
             {"type": "mousemove"},
             {"type": "mousedown"},


### PR DESCRIPTION
The identifier for the platform/OS should be "windows", not "windows_nt".