### PR TITLE
Update the cssom IDL file

### DIFF
--- a/css/cssom/interfaces.html
+++ b/css/cssom/interfaces.html
@@ -35,7 +35,7 @@ const waitForLoad = new Promise(r => { addEventListener('load', r); });
 idl_test(
   ['cssom'],
   ['SVG', 'uievents', 'html', 'dom'],
-  idlArray => {
+  async idlArray => {
     idlArray.add_objects({
       Document: ['document', 'new Document()'],
       StyleSheetList: ['document.styleSheets'],
@@ -65,6 +65,7 @@ idl_test(
       SVGElement: ['svg_element'],
     });
 
+    await waitForLoad;
     self.style_element = document.getElementById('styleElement');
     self.sheet = style_element.sheet;
     self.svg_element = document.getElementById('svgElement');

--- a/css/cssom/interfaces.html
+++ b/css/cssom/interfaces.html
@@ -28,70 +28,49 @@ Use a non-empty style attribute to get a non-empty CSSStyleDeclaration.
 <div id=log></div>
 
 <script>
-"use strict";
-var style_element, svg_element, xmlss_pi;
+'use strict';
 
-function doTest([html, dom, uievents, cssom]) {
-  style_element = document.getElementById('styleElement');
-  svg_element = document.getElementById('svgElement');
-  xmlss_pi = document.getElementById('xmlssPiIframe').contentDocument.firstChild;
+const waitForLoad = new Promise(r => { addEventListener('load', r); });
 
-  var idlArray = new IdlArray();
-  var svg = "interface SVGElement : Element {};";
-  idlArray.add_untested_idls(html + dom + svg);
-  idlArray.add_untested_idls(uievents, { only: [
-    'UIEvent',
-    'UIEventInit',
-    'MouseEvent',
-    'MouseEventInit',
-    'EventModifierInit'
-  ]});
-  idlArray.add_idls(cssom);
+idl_test(
+  ['cssom'],
+  ['SVG', 'uievents', 'html', 'dom'],
+  idlArray => {
+    idlArray.add_objects({
+      Document: ['document', 'new Document()'],
+      StyleSheetList: ['document.styleSheets'],
+      CSSStyleSheet: ['sheet'],
+      MediaList: ['sheet.media'],
+      CSSRuleList: ['sheet.cssRules'],
+      CSSImportRule: ['sheet.cssRules[0]'],
+      CSSNamespaceRule: ['sheet.cssRules[1]'],
+      CSSPageRule: ['sheet.cssRules[2]'],
+      CSSMarginRule: ['sheet.cssRules[2].cssRules[0]'],
+      CSSMediaRule: ['sheet.cssRules[3]'],
+      CSSStyleRule: ['sheet.cssRules[4]'],
+      CSSStyleDeclaration: [
+        'sheet.cssRules[4].style', // CSSStyleRule
+        'sheet.cssRules[2].style', // CSSPageRule
+        'sheet.cssRules[2].cssRules[0].style', // CSSMarginRule
+        'style_element.style', // ElementCSSInlineStyle for HTMLElement
+        'svg_element.style', // ElementCSSInlineStyle for SVGElement
+        'getComputedStyle(svg_element)'
+      ],
+      ProcessingInstruction: ['xmlss_pi'],
+      Window: ['window'],
+      HTMLElement: [
+        'style_element',
+        'document.createElement("unknownelement")'
+      ],
+      SVGElement: ['svg_element'],
+    });
 
-  idlArray.add_objects({
-    "Document": ["document", "new Document()"],
-    "StyleSheetList": ["document.styleSheets"],
-    "CSSStyleSheet": ["style_element.sheet"],
-    "MediaList": ["style_element.sheet.media"],
-    "CSSRuleList": ["style_element.sheet.cssRules"],
-    "CSSImportRule": ["style_element.sheet.cssRules[0]"],
-    "CSSNamespaceRule": ["style_element.sheet.cssRules[1]"],
-    "CSSPageRule": ["style_element.sheet.cssRules[2]"],
-    "CSSMarginRule": ["style_element.sheet.cssRules[2].cssRules[0]"],
-    "CSSMediaRule": ["style_element.sheet.cssRules[3]"],
-    "CSSStyleRule": ["style_element.sheet.cssRules[4]"],
-    "CSSStyleDeclaration": ["style_element.sheet.cssRules[4].style", // CSSStyleRule
-                            "style_element.sheet.cssRules[2].style", // CSSPageRule
-                            "style_element.sheet.cssRules[2].cssRules[0].style", // CSSMarginRule
-                            "style_element.style", // ElementCSSInlineStyle for HTMLElement
-                            "svg_element.style", // ElementCSSInlineStyle for SVGElement
-                            "getComputedStyle(svg_element)"],
-    "ProcessingInstruction": ["xmlss_pi"],
-    "Window": ["window"],
-    "HTMLElement": ["style_element", "document.createElement('unknownelement')"],
-    "SVGElement": ["svg_element"],
-  });
-  idlArray.test();
-};
-
-function fetchData(url) {
-  return fetch(url).then((response) => response.text());
-}
-
-function waitForLoad() {
-  return new Promise(function(resolve) {
-    addEventListener("load", resolve);
-  });
-}
-
-promise_test(function() {
-  // Have to wait for onload
-  return Promise.all([fetchData("/interfaces/html.idl"),
-                      fetchData("/interfaces/dom.idl"),
-                      fetchData("/interfaces/uievents.idl"),
-                      fetchData("/interfaces/cssom.idl"),
-                      waitForLoad()])
-                .then(doTest);
-}, "Test driver");
+    self.style_element = document.getElementById('styleElement');
+    self.sheet = style_element.sheet;
+    self.svg_element = document.getElementById('svgElement');
+    self.xmlss_pi = document.getElementById('xmlssPiIframe').contentDocument.firstChild;
+  },
+  'Test driver'
+);
 
 </script>

--- a/interfaces/cssom.idl
+++ b/interfaces/cssom.idl
@@ -1,6 +1,7 @@
 // GENERATED CONTENT - DO NOT EDIT
-// Content of this file was automatically extracted from the CSS Object Model (CSSOM) spec.
-// See https://drafts.csswg.org/cssom/
+// Content of this file was automatically extracted from the
+// "CSS Object Model (CSSOM)" spec.
+// See: https://drafts.csswg.org/cssom/
 
 typedef USVString CSSOMString;
 
@@ -42,14 +43,11 @@ partial interface Document {
   [SameObject] readonly attribute StyleSheetList styleSheets;
 };
 
-[Exposed=Window,
- NoInterfaceObject]
-interface LinkStyle {
+interface mixin LinkStyle {
   readonly attribute StyleSheet? sheet;
 };
 
-ProcessingInstruction implements LinkStyle;
-
+ProcessingInstruction includes LinkStyle;
 [Exposed=Window]
 interface CSSRuleList {
   getter CSSRule? item(unsigned long index);
@@ -123,21 +121,19 @@ interface CSSStyleDeclaration {
   [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString cssFloat;
 };
 
-[Exposed=Window,
- NoInterfaceObject]
-interface ElementCSSInlineStyle {
+interface mixin ElementCSSInlineStyle {
   [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
 };
 
-HTMLElement implements ElementCSSInlineStyle;
+HTMLElement includes ElementCSSInlineStyle;
 
-SVGElement implements ElementCSSInlineStyle;
+SVGElement includes ElementCSSInlineStyle;
 
 partial interface Window {
   [NewObject] CSSStyleDeclaration getComputedStyle(Element elt, optional CSSOMString? pseudoElt);
 };
 
 [Exposed=Window]
-interface CSS {
-  static CSSOMString escape(CSSOMString ident);
+namespace CSS {
+  CSSOMString escape(CSSOMString ident);
 };


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
