### PR TITLE
sensors: Stop passing undefined as an invalid SensorOptions value

### DIFF
--- a/generic-sensor/generic-sensor-tests.js
+++ b/generic-sensor/generic-sensor-tests.js
@@ -337,8 +337,7 @@ function runGenericSensorTests(sensorName) {
       NaN,
       Infinity,
       -Infinity,
-      {},
-      undefined
+      {}
     ];
     invalidFreqs.map(freq => {
       assert_throws(new TypeError(),


### PR DESCRIPTION
While the undefined -> double conversion in WebIDL should indeed throw a
TypeError, we cannot forget we have a WebIDL dictionary (SensorOptions) in
the middle:

    {frequency: undefined}

is essentially equivalent to

    {}

so we do not actually throw a TypeError in this case at all.