### PR TITLE
Update the page-visibility IDL file

### DIFF
--- a/interfaces/page-visibility.idl
+++ b/interfaces/page-visibility.idl
@@ -1,0 +1,15 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Page Visibility Level 2" spec.
+// See: https://w3c.github.io/page-visibility/
+
+enum VisibilityState {
+    "hidden",
+    "visible",
+    "prerender"
+};
+partial interface Document {
+    readonly attribute boolean         hidden;
+    readonly attribute VisibilityState visibilityState;
+             attribute EventHandler    onvisibilitychange;
+};

--- a/page-visibility/idlharness.html
+++ b/page-visibility/idlharness.html
@@ -13,41 +13,23 @@
 <body>
 <h1>Page Visibility IDL tests</h1>
 
-<pre id='untested_idl' style='display:none'>
-interface Document {
-};
-[TreatNonObjectAsNull]
-callback EventHandlerNonNull = any (Event event);
-typedef EventHandlerNonNull? EventHandler;
-</pre>
-
-<pre id='idl'>
-enum VisibilityState {
-    "hidden",
-    "visible",
-    "prerender"
-};
-
-partial interface Document {
-    readonly attribute boolean         hidden;
-    readonly attribute VisibilityState visibilityState;
-             attribute EventHandler    onvisibilitychange;
-};
-</pre>
-
 <script>
+'use strict';
 
-(function() {
-  var idl_array = new IdlArray();
+promise_test(async () => {
+    const srcs = ['page-visibility', 'dom', 'html'];
+    const [idl, dom, html] = await Promise.all(
+      srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
 
-  idl_array.add_untested_idls(document.getElementById("untested_idl").textContent);
-  idl_array.add_idls(document.getElementById("idl").textContent);
+    const idl_array = new IdlArray();
+    idl_array.add_idls(idl);
+    idl_array.add_dependency_idls(html);
+    idl_array.add_dependency_idls(dom);
 
-  idl_array.add_objects({Document: ["window.document"]});
+    idl_array.add_objects({Document: ["window.document"]});
 
-  idl_array.test();
-})();
-
+    idl_array.test();
+});
 </script>
 
 <div id="log"></div>


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the interfaces/ directory (instead of inline copies in the test files).