### PR TITLE
Update the media-capabilities IDL file

### DIFF
--- a/interfaces/media-capabilities.idl
+++ b/interfaces/media-capabilities.idl
@@ -1,3 +1,8 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Media Capabilities" spec.
+// See: https://wicg.github.io/media-capabilities/
+
 dictionary MediaConfiguration {
   VideoConfiguration video;
   AudioConfiguration audio;
@@ -36,6 +41,7 @@ dictionary AudioConfiguration {
   unsigned long samplerate;
 };
 
+[Exposed=(Window, Worker)]
 interface MediaCapabilitiesInfo {
   readonly attribute boolean supported;
   readonly attribute boolean smooth;


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the interfaces/ directory (instead of inline copies in the test files).

There are 18 test failures I am getting, but these existed before this update.