### PR TITLE
Update the paint-timing IDL file

### DIFF
--- a/interfaces/paint-timing.idl
+++ b/interfaces/paint-timing.idl
@@ -1,0 +1,6 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Paint Timing 1" spec.
+// See: https://w3c.github.io/paint-timing/
+
+interface PerformancePaintTiming : PerformanceEntry {};

--- a/paint-timing/idlharness.window.js
+++ b/paint-timing/idlharness.window.js
@@ -1,0 +1,34 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+// https://w3c.github.io/paint-timing/
+
+idl_test(
+  ['paint-timing'],
+  ['performance-timeline'],
+  (idl_array, t) => {
+    idl_array.add_objects({
+      PerformancePaintTiming: ['paintTiming'],
+    });
+
+    const awaitPaint = resolve => {
+      try {
+        const entries = performance.getEntriesByType('paint');
+        if (entries || entries.length) {
+          window.paintTiming = entries[0];
+          resolve();
+          return;
+        }
+        t.step_timeout(awaitPaint, 50);
+      } catch (e) {
+        // Will be surfaced in idlharness.js's test_object.
+      }
+    }
+    const timeout = new Promise((_, reject) => {
+      t.step_timeout(() => reject('Timed out waiting for paint event'), 3000);
+    });
+    return Promise.race([new Promise(awaitPaint), timeout]);
+  },
+  'paint-timing interfaces.');

--- a/paint-timing/idlharness.window.js
+++ b/paint-timing/idlharness.window.js
@@ -13,22 +13,16 @@ idl_test(
       PerformancePaintTiming: ['paintTiming'],
     });
 
-    const awaitPaint = resolve => {
-      try {
-        const entries = performance.getEntriesByType('paint');
-        if (entries || entries.length) {
-          window.paintTiming = entries[0];
-          resolve();
-          return;
-        }
-        t.step_timeout(awaitPaint, 50);
-      } catch (e) {
-        // Will be surfaced in idlharness.js's test_object.
-      }
-    }
+    const awaitPaint = new Promise(resolve => {
+      let observer = new PerformanceObserver(list => {
+        self.paintTiming = list.getEntries()[0];
+        resolve();
+      });
+      observer.observe({ entryTypes: ['paint'] });
+    });
     const timeout = new Promise((_, reject) => {
       t.step_timeout(() => reject('Timed out waiting for paint event'), 3000);
     });
-    return Promise.race([new Promise(awaitPaint), timeout]);
+    return Promise.race([awaitPaint, timeout]);
   },
   'paint-timing interfaces.');

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3028,27 +3028,36 @@ IdlTypedef.prototype = Object.create(IdlObject.prototype);
  *      as adding objects. Do not call idl_array.test() in the setup; it is
  *      called by this function (idl_test).
  */
-function idl_test(srcs, deps, setup_func, test_name) {
+function idl_test(srcs, deps, idl_setup_func, test_name) {
     return promise_test(function (t) {
         var idl_array = new IdlArray();
         srcs = (srcs instanceof Array) ? srcs : [srcs] || [];
         deps = (deps instanceof Array) ? deps : [deps] || [];
         return Promise.all(
-            srcs.concat(deps).map(function(i) {
-                return fetch('/interfaces/' + i + '.idl').then(function(r) {
+            srcs.concat(deps).map(function(spec) {
+                return fetch('/interfaces/' + spec + '.idl').then(function(r) {
                     return r.text();
                 });
-            })).then(function(idls) {
+            }))
+            .then(function(idls) {
                 for (var i = 0; i < srcs.length; i++) {
                     idl_array.add_idls(idls[i]);
                 }
                 for (var i = srcs.length; i < srcs.length + deps.length; i++) {
                     idl_array.add_dependency_idls(idls[i]);
                 }
-                if (setup_func) {
-                    setup_func(idl_array)
-                };
-                idl_array.test();
+            })
+            .then(function() {
+                try {
+                    return idl_setup_func(idl_array, t);
+                } catch (e) {
+                    return Promise.reject(e);
+                }
+            })
+            .then(function() { idl_array.test(); })
+            .catch(function (reason) {
+                idl_array.test(); // Test what we can.
+                return Promise.reject(reason || 'IDL setup failed.');
             });
     }, test_name);
 }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3048,11 +3048,7 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
                 }
             })
             .then(function() {
-                try {
-                    return idl_setup_func(idl_array, t);
-                } catch (e) {
-                    return Promise.reject(e);
-                }
+                return idl_setup_func(idl_array, t);
             })
             .then(function() { idl_array.test(); })
             .catch(function (reason) {


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
