### PR TITLE
Sync Mozilla tests as of 2018-07-07

### DIFF
--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-multicol-001-ref.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-multicol-001-ref.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <style>
+    .cols {
+      column-count: 3;
+      column-rule: 1px dotted blue;
+      column-fill: auto;
+      border: 2px solid blue;
+      height: 50px;
+      width: 300px;
+    }
+    .innerObject {
+      height: 200px;
+      width: 100px;
+      background: orange;
+    }
+  </style>
+</head>
+  <body>
+    <div class="cols">
+      <canvas class="innerObject">
+        <!-- Note: We use a canvas object here as a generic reference for
+             something monolithic/non-fragmentable. -->
+      </canvas>
+    </div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-multicol-001.html
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-multicol-001.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+  <title>CSS Test: 'contain: size' should force elements to be monolithic, i.e. to not fragment inside a multicol element.</title>
+  <link rel="author" title="Morgan Rae Reschenberg" href="mailto:mreschenberg@berkeley.edu">
+  <link rel="help" href="https://drafts.csswg.org/css-contain/#containment-size">
+  <link rel="match" href="contain-size-multicol-001-ref.html">
+  <style>
+    .contain {
+      contain:size;
+    }
+    .cols {
+      column-count: 3;
+      column-rule: 1px dotted blue;
+      column-fill: auto;
+      border: 2px solid blue;
+      height: 50px;
+      width: 300px;
+    }
+    .innerObject {
+      height: 200px;
+      width: 100px;
+      background: orange;
+    }
+  </style>
+</head>
+  <body>
+    <div class="cols">
+      <div class="contain innerObject">
+      </div>
+    </div>
+  </body>
+</html>

--- a/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
+++ b/css/vendor-imports/mozilla/mozilla-central-reftests/contain/reftest.list
@@ -16,3 +16,4 @@
 == contain-paint-ignored-cases-ruby-stacking-and-clipping-001.html contain-paint-ignored-cases-ruby-stacking-and-clipping-001-ref.html
 == contain-paint-stacking-context-001a.html contain-paint-stacking-context-001-ref.html
 == contain-paint-stacking-context-001b.html contain-paint-stacking-context-001-ref.html
+== contain-size-multicol-001.html contain-size-multicol-001-ref.html


### PR DESCRIPTION
Sync Mozilla tests as of https://hg.mozilla.org/mozilla-central/rev/9849ea3937e2e7c97f79b1d2b601f956181b4629 .

This contains a single change, from [bug 1470329](https://bugzilla.mozilla.org/show_bug.cgi?id=1470329) by @MReschenberg, reviewed by @dholbert.