### PR TITLE
SVG ellipse supports rx/ry properties

### DIFF
--- a/svg/shapes/ellipse-01-ref.svg
+++ b/svg/shapes/ellipse-01-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <ellipse cx="50" cy="50" rx="40" ry="30" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-01.svg
+++ b/svg/shapes/ellipse-01.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-01-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="ellipse element uses rx/ry properties."/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: 40px;
+      ry: 30px;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-02-ref.svg
+++ b/svg/shapes/ellipse-02-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <ellipse cx="50" cy="50" rx="40" ry="40" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-02.svg
+++ b/svg/shapes/ellipse-02.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-02-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="ry auto means rx is used"/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: 40px;
+      ry: auto;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-03-ref.svg
+++ b/svg/shapes/ellipse-03-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <ellipse cx="50" cy="50" rx="30" ry="30" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-03.svg
+++ b/svg/shapes/ellipse-03.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-03-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx auto means ry is used."/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: auto;
+      ry: 30px;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-04-ref.svg
+++ b/svg/shapes/ellipse-04-ref.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+</svg>

--- a/svg/shapes/ellipse-04.svg
+++ b/svg/shapes/ellipse-04.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-04-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx and ry auto disables rendering."/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: auto;
+      ry: auto;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="red" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-05.svg
+++ b/svg/shapes/ellipse-05.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-02-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="ry defaults to auto."/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: 40px;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-06.svg
+++ b/svg/shapes/ellipse-06.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-03-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx defaults to auto."/>
+  </metadata>
+  <style>
+    ellipse {
+      ry: 30px;
+    }
+  </style>
+  <ellipse cx="50" cy="50" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-07-ref.svg
+++ b/svg/shapes/ellipse-07-ref.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="240px" height="160px" viewBox="0 0 60 40">
+  <ellipse cx="20" cy="20" rx="15" ry="15" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-07.svg
+++ b/svg/shapes/ellipse-07.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="240px" height="160px" viewBox="0 0 60 40">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-07-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="ry auto means rx absolute length is used"/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: 25%;
+      ry: auto;
+    }
+  </style>
+  <ellipse cx="20" cy="20" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/ellipse-08.svg
+++ b/svg/shapes/ellipse-08.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="240px" height="160px" viewBox="0 0 60 40">
+  <metadata>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <link xmlns="http://www.w3.org/1999/xhtml" rel="match" href="ellipse-07-ref.svg"/>
+    <meta xmlns="http://www.w3.org/1999/xhtml" name="assert" content="rx auto means ry absolute length is used"/>
+  </metadata>
+  <style>
+    ellipse {
+      rx: auto;
+      ry: 37.5%;
+    }
+  </style>
+  <ellipse cx="20" cy="20" fill="none" stroke="blue" stroke-width="5"/>
+</svg>

--- a/svg/shapes/rx-ry-not-inherited.svg
+++ b/svg/shapes/rx-ry-not-inherited.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml">
+  <metadata>
+    <h:link rel="help" href="https://www.w3.org/TR/SVG2/shapes.html#EllipseElement"/>
+    <h:meta name="assert" content="rx,ry are not inherited by default"/>
+  </metadata>
+  <style>
+    g {
+      rx: 10px;
+      ry: 20px;
+    }
+  </style>
+  <g>
+    <ellipse id="spot" cx="50" cy="50"/>
+  </g>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+  <script><![CDATA[
+  test(function() {
+    var spot = document.getElementById('spot');
+    assert_equals(getComputedStyle(spot).rx, "auto");
+    assert_equals(getComputedStyle(spot).ry, "auto");
+    spot.style.rx = 'inherit';
+    spot.style.ry = 'inherit';
+    assert_equals(getComputedStyle(spot).rx, "10px");
+    assert_equals(getComputedStyle(spot).ry, "20px");
+  });
+  ]]></script>
+</svg>


### PR DESCRIPTION
Spec: https://svgwg.org/svg2-draft/shapes.html#EllipseElement

When only rx is not auto, rx is used for both dimensions.
When only ry is not auto, ry is used for both dimensions.