### PR TITLE
Verify that invalid selectors cause errors to be thrown for empty elements

### DIFF
--- a/dom/nodes/ParentNode-querySelector-All-xht.xht
+++ b/dom/nodes/ParentNode-querySelector-All-xht.xht
@@ -87,6 +87,8 @@ function init(target) {
   var fragment = doc.createDocumentFragment(); // Fragment Node tests
   fragment.appendChild(element.cloneNode(true));
 
+  var empty = document.createElement("div"); // Empty Node tests
+
   // Setup Tests
   interfaceCheck("Document", doc);
   interfaceCheck("Detached Element", detached);
@@ -107,6 +109,7 @@ function init(target) {
   runInvalidSelectorTest("Detached Element", detached, invalidSelectors);
   runInvalidSelectorTest("Fragment", fragment, invalidSelectors);
   runInvalidSelectorTest("In-document Element", element, invalidSelectors);
+  runInvalidSelectorTest("Empty Element", empty, invalidSelectors);
 
   runValidSelectorTest("Document", doc, validSelectors, testType, docType);
   runValidSelectorTest("Detached Element", detached, validSelectors, testType, docType);

--- a/dom/nodes/ParentNode-querySelector-All.html
+++ b/dom/nodes/ParentNode-querySelector-All.html
@@ -85,6 +85,8 @@ function init(target) {
   var fragment = doc.createDocumentFragment(); // Fragment Node tests
   fragment.appendChild(element.cloneNode(true));
 
+  var empty = document.createElement("div"); // Empty Node tests
+
   // Setup Tests
   interfaceCheck("Document", doc);
   interfaceCheck("Detached Element", detached);
@@ -105,6 +107,7 @@ function init(target) {
   runInvalidSelectorTest("Detached Element", detached, invalidSelectors);
   runInvalidSelectorTest("Fragment", fragment, invalidSelectors);
   runInvalidSelectorTest("In-document Element", element, invalidSelectors);
+  runInvalidSelectorTest("Empty Element", empty, invalidSelectors);
 
   runValidSelectorTest("Document", doc, validSelectors, testType, docType);
   runValidSelectorTest("Detached Element", detached, validSelectors, testType, docType);


### PR DESCRIPTION
This adds tests verifying that invalid selectors cause errors to be thrown even for elements that are empty. `querySelector()`/`querySelectorAll()` in [jsdom](https://github.com/jsdom/jsdom) previously included a fast-path returning an empty result for empty elements, without checking the validity of the selector first.

The tests are passing in Chrome, Firefox and Safari.