### PR TITLE
Update the wasm-js-api IDL file

### DIFF
--- a/interfaces/wasm-js-api.idl
+++ b/interfaces/wasm-js-api.idl
@@ -1,0 +1,105 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "WebAssembly JavaScript Interface" spec.
+// See: https://webassembly.github.io/spec/js-api/
+
+dictionary WebAssemblyInstantiatedSource {
+    required Module module;
+    required Instance instance;
+};
+
+// Commented out until namespace is supported.
+// See https://github.com/web-platform-tests/wpt/issues/7583
+// [Exposed=(Window,Worker,Worklet)]
+// namespace WebAssembly {
+//     boolean validate(BufferSource bytes);
+//     Promise<Module> compile(BufferSource bytes);
+//
+//     Promise<WebAssemblyInstantiatedSource> instantiate(
+//         BufferSource bytes, optional object importObject);
+//
+//     Promise<Instance> instantiate(
+//         Module moduleObject, optional object importObject);
+// };
+
+enum ImportExportKind {
+  "function",
+  "table",
+  "memory",
+  "global"
+};
+
+dictionary ModuleExportDescriptor {
+  required USVString name;
+  required ImportExportKind kind;
+  // Note: Other fields such as signature may be added in the future.
+};
+
+dictionary ModuleImportDescriptor {
+  required USVString module;
+  required USVString name;
+  required ImportExportKind kind;
+};
+
+[LegacyNamespace=WebAssembly, Constructor(BufferSource bytes), Exposed=(Window,Worker,Worklet)]
+interface Module {
+  static sequence<ModuleExportDescriptor> exports(Module module);
+  static sequence<ModuleImportDescriptor> imports(Module module);
+  static sequence<ArrayBuffer> customSections(Module module, USVString sectionName);
+};
+
+[LegacyNamespace=WebAssembly, Constructor(Module module, optional object importObject), Exposed=(Window,Worker,Worklet)]
+interface Instance {
+  readonly attribute object exports;
+};
+
+dictionary MemoryDescriptor {
+  required [EnforceRange] unsigned long initial;
+  [EnforceRange] unsigned long maximum;
+};
+
+[LegacyNamespace=WebAssembly, Constructor(MemoryDescriptor descriptor), Exposed=(Window,Worker,Worklet)]
+interface Memory {
+  unsigned long grow([EnforceRange] unsigned long delta);
+  readonly attribute ArrayBuffer buffer;
+};
+
+enum TableKind {
+  "anyfunc",
+  // Note: More values may be added in future iterations,
+  // e.g., typed function references, typed GC references
+};
+
+dictionary TableDescriptor {
+  required TableKind element;
+  required [EnforceRange] unsigned long initial;
+  [EnforceRange] unsigned long maximum;
+};
+
+[LegacyNamespace=WebAssembly, Constructor(TableDescriptor descriptor), Exposed=(Window,Worker,Worklet)]
+interface Table {
+  unsigned long grow([EnforceRange] unsigned long delta);
+  Function? get([EnforceRange] unsigned long index);
+  void set([EnforceRange] unsigned long index, Function? value);
+  readonly attribute unsigned long length;
+};
+
+dictionary GlobalDescriptor {
+  required USVString value;
+  boolean mutable = false;
+};
+
+[LegacyNamespace=WebAssembly, Constructor(GlobalDescriptor descriptor, optional any value), Exposed=(Window,Worker,Worklet)]
+interface Global {
+  any valueOf();
+  attribute any value;
+};
+
+[LegacyNamespace=WebAssembly]
+interface CompileError { };
+
+[LegacyNamespace=WebAssembly]
+interface LinkError { };
+
+[LegacyNamespace=WebAssembly]
+interface RuntimeError { };

--- a/wasm/idlharness.any.js
+++ b/wasm/idlharness.any.js
@@ -1,0 +1,33 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+// META: script=resources/load_wasm.js
+
+'use strict';
+
+// https://webassembly.github.io/spec/js-api/
+
+promise_test(async () => {
+  const srcs = ['wasm-js-api'];
+  const [wasm] = await Promise.all(
+    srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
+
+  const idl_array = new IdlArray();
+  idl_array.add_idls(wasm);
+  // Ignored errors are surfaced in idlharness.js's test_object below.
+  try {
+    self.memory = new Memory({initial: 1024});
+  } catch (e) { }
+
+  try {
+    self.mod = await createWasmModule();
+    self.instance = new Instance(self.mod);
+  } catch (e) { }
+
+  idl_array.add_objects({
+    Memory: ['memory'],
+    Module: ['mod'],
+    Instance: ['instance'],
+  });
+  idl_array.test();
+}, 'wasm-js-api interfaces.');
+


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
