### PR TITLE
Suppress two lint warnings about overlapping file names.

### DIFF
--- a/lint.whitelist
+++ b/lint.whitelist
@@ -638,6 +638,8 @@ CSS-COLLIDING-REF-NAME: css/css-transforms/individual-transform/individual-trans
 CSS-COLLIDING-REF-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/transforms/individual-transform-1-ref.html
 CSS-COLLIDING-REF-NAME: css/css-flexbox/reference/percentage-size-subitems-001-ref.html
 CSS-COLLIDING-REF-NAME: css/css-grid/grid-items/percentage-size-subitems-001-ref.html
+CSS-COLLIDING-REF-NAME: css/css-contain/reference/contain-size-button-001-ref.html
+CSS-COLLIDING-REF-NAME: css/vendor-imports/mozilla/mozilla-central-reftests/contain/contain-size-button-001-ref.html
 CSS-COLLIDING-SUPPORT-NAME: css/css-backgrounds/support/red.png
 CSS-COLLIDING-SUPPORT-NAME: css/compositing/mix-blend-mode/support/red.png
 CSS-COLLIDING-SUPPORT-NAME: css/compositing/background-blending/support/red.png


### PR DESCRIPTION
Fixes #11864 and unbreaks Servo's sync process.