### PR TITLE
Don't assume opacity computed values are exactly the same as specified on keyframe input

### DIFF
--- a/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
@@ -25,7 +25,7 @@ test(t => {
                              { offset: 1, opacity: 1 } ],
                            { duration: 1000,
                              easing: 'cubic-bezier(0.5, -0.5, 0.5, 1.5)' });
-  assert_opacity_value(getComputedStyle(div).opacity, '0.2',
+  assert_opacity_value(getComputedStyle(div).opacity, 0.2,
                 'When progress is zero the last keyframe with offset 0 should'
                 + ' be used');
   // http://cubic-bezier.com/#.5,-0.5,.5,1.5
@@ -59,15 +59,15 @@ test(t => {
                              { offset: 0.5, opacity: 0.7 },
                              { offset: 1, opacity: 1 } ], 1000);
   anim.currentTime = 250;
-  assert_opacity_value(getComputedStyle(div).opacity, '0.15',
+  assert_opacity_value(getComputedStyle(div).opacity, 0.15,
                 'Before the overlap point, the first keyframe from the'
                 + ' overlap point should be used as interval endpoint');
   anim.currentTime = 500;
-  assert_opacity_value(getComputedStyle(div).opacity, '0.7',
+  assert_opacity_value(getComputedStyle(div).opacity, 0.7,
                 'At the overlap point, the last keyframe from the'
                 + ' overlap point should be used as interval startpoint');
   anim.currentTime = 750;
-  assert_opacity_value(getComputedStyle(div).opacity, '0.85',
+  assert_opacity_value(getComputedStyle(div).opacity, 0.85,
                 'After the overlap point, the last keyframe from the'
                 + ' overlap point should be used as interval startpoint');
 }, 'Overlapping keyframes between 0 and 1 use the appropriate value on each'

--- a/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
+++ b/web-animations/animation-model/keyframe-effects/effect-value-overlapping-keyframes.html
@@ -11,6 +11,10 @@
 <script>
 'use strict';
 
+function assert_opacity_value(opacity, expected, description) {
+  return assert_approx_equals(parseFloat(opacity), expected, 0.0001, description);
+}
+
 test(t => {
   const div = createDiv(t);
   const anim = div.animate([ { offset: 0, opacity: 0 },
@@ -21,7 +25,7 @@ test(t => {
                              { offset: 1, opacity: 1 } ],
                            { duration: 1000,
                              easing: 'cubic-bezier(0.5, -0.5, 0.5, 1.5)' });
-  assert_equals(getComputedStyle(div).opacity, '0.2',
+  assert_opacity_value(getComputedStyle(div).opacity, '0.2',
                 'When progress is zero the last keyframe with offset 0 should'
                 + ' be used');
   // http://cubic-bezier.com/#.5,-0.5,.5,1.5
@@ -55,15 +59,15 @@ test(t => {
                              { offset: 0.5, opacity: 0.7 },
                              { offset: 1, opacity: 1 } ], 1000);
   anim.currentTime = 250;
-  assert_equals(getComputedStyle(div).opacity, '0.15',
+  assert_opacity_value(getComputedStyle(div).opacity, '0.15',
                 'Before the overlap point, the first keyframe from the'
                 + ' overlap point should be used as interval endpoint');
   anim.currentTime = 500;
-  assert_equals(getComputedStyle(div).opacity, '0.7',
+  assert_opacity_value(getComputedStyle(div).opacity, '0.7',
                 'At the overlap point, the last keyframe from the'
                 + ' overlap point should be used as interval startpoint');
   anim.currentTime = 750;
-  assert_equals(getComputedStyle(div).opacity, '0.85',
+  assert_opacity_value(getComputedStyle(div).opacity, '0.85',
                 'After the overlap point, the last keyframe from the'
                 + ' overlap point should be used as interval startpoint');
 }, 'Overlapping keyframes between 0 and 1 use the appropriate value on each'


### PR DESCRIPTION
The CSS Color Module Level 3 specification defines the [opacity](https://drafts.csswg.org/css-color-3/#opacity) property as taking <number> values. Meanwhile, the CSS Values and Units Module Level 3 specification [discusses the precision of numeric data types](https://drafts.csswg.org/css-values-3/#numeric-types) like so:

> CSS theoretically supports infinite precision and infinite ranges for all value types; however in reality implementations have finite capacity. UAs should support reasonably useful ranges and precisions.

This test fails in WebKit because it requires the provided value to be round-tripped through the computed style even though they cannot all be represented as precisely as the test entails. We update the test to compare values with a small alpha.