### PR TITLE
Remove reviewers who have not joined the web-platform-tests org

### DIFF
--- a/IndexedDB/META.yml
+++ b/IndexedDB/META.yml
@@ -1,8 +1,4 @@
 suggested_reviewers:
   - odinho
   - inexorabletash
-  - chunywang
-  - dumbmatter
   - zqzhang
-  - yunxiaoxie
-  - zhaozihao

--- a/WebCryptoAPI/META.yml
+++ b/WebCryptoAPI/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - Wafflespeanut
   - jimsch
-  - engelke

--- a/ambient-light/META.yml
+++ b/ambient-light/META.yml
@@ -1,6 +1,5 @@
 suggested_reviewers:
   - zqzhang
-  - Volker-E
   - dontcallmedom
   - riju
   - alexshalamov

--- a/annotation-model/META.yml
+++ b/annotation-model/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - halindrome
   - bigbluehat
-  - tcole3

--- a/appmanifest/META.yml
+++ b/appmanifest/META.yml
@@ -4,4 +4,3 @@ suggested_reviewers:
   - marcoscaceres
   - mgiuca
   - mounirlamouri
-  - RobDolin

--- a/clipboard-apis/META.yml
+++ b/clipboard-apis/META.yml
@@ -1,3 +1,2 @@
 suggested_reviewers:
   - garykac
-  - hallvors

--- a/css/CSS2/META.yml
+++ b/css/CSS2/META.yml
@@ -2,8 +2,6 @@ suggested_reviewers:
   - fantasai
   - dbaron
   - svgeesus
-  - chenxix
   - kojiishi
-  - kwkbtr
   - frivoal
   - bert-github

--- a/css/WOFF2/META.yml
+++ b/css/WOFF2/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - svgeesus
-  - khaledhosny
   - rsheeter

--- a/css/compositing/META.yml
+++ b/css/compositing/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
-  - cabanier
   - plinss
   - nikosandronikos

--- a/css/css-animations/META.yml
+++ b/css/css-animations/META.yml
@@ -1,7 +1,5 @@
 suggested_reviewers:
   - plinss
-  - chunywang
-  - yunxiaoxie
   - grorg
   - dbaron
   - tabatkins

--- a/css/css-backgrounds/META.yml
+++ b/css/css-backgrounds/META.yml
@@ -1,5 +1,4 @@
 suggested_reviewers:
-  - chenxix
   - dbaron
   - bert-github
   - fantasai

--- a/css/css-color/META.yml
+++ b/css/css-color/META.yml
@@ -1,7 +1,5 @@
 suggested_reviewers:
   - dbaron
-  - JianfengXu
-  - chenxix
   - tantek
   - svgeesus
   - tabatkins

--- a/css/css-flexbox/META.yml
+++ b/css/css-flexbox/META.yml
@@ -3,7 +3,6 @@ suggested_reviewers:
   - plinss
   - mrego
   - cbiesinger
-  - chenxix
   - atanassov
   - fantasai
   - tabatkins

--- a/css/css-fonts/META.yml
+++ b/css/css-fonts/META.yml
@@ -1,6 +1,4 @@
 suggested_reviewers:
   - svgeesus
-  - yunxiaoxie
-  - nattokirai
   - litherum
   - drott

--- a/css/css-fonts/matching/META.yml
+++ b/css/css-fonts/matching/META.yml
@@ -2,5 +2,4 @@ suggested_reviewers:
   - drott
   - fantasai
   - litherum
-  - nattokirai
   - svgeesus

--- a/css/css-fonts/variations/META.yml
+++ b/css/css-fonts/variations/META.yml
@@ -2,5 +2,4 @@ suggested_reviewers:
   - drott
   - fantasai
   - litherum
-  - nattokirai
   - svgeesus

--- a/css/css-shapes/META.yml
+++ b/css/css-shapes/META.yml
@@ -1,7 +1,6 @@
 suggested_reviewers:
   - bemjb
   - kojiishi
-  - zhorvath
   - plinss
   - atanassov
   - astearns

--- a/css/css-style-attr/META.yml
+++ b/css/css-style-attr/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
-  - chenxix
   - tantek
   - fantasai

--- a/css/css-transforms/META.yml
+++ b/css/css-transforms/META.yml
@@ -1,8 +1,6 @@
 suggested_reviewers:
   - dbaron
-  - chunywang
   - plinss
-  - minxhuang
   - dirkschulze
   - hober
   - grorg

--- a/css/css-ui/META.yml
+++ b/css/css-ui/META.yml
@@ -1,7 +1,6 @@
 suggested_reviewers:
   - frivoal
   - mrego
-  - web-flow
   - plinss
   - svgeesus
   - tantek

--- a/css/css-writing-modes/META.yml
+++ b/css/css-writing-modes/META.yml
@@ -1,9 +1,7 @@
 suggested_reviewers:
   - kojiishi
   - fantasai
-  - hshiozawa
   - myakura
-  - snsk
   - r12a
   - plinss
   - upsuper

--- a/css/cssom/META.yml
+++ b/css/cssom/META.yml
@@ -2,4 +2,3 @@ suggested_reviewers:
   - dbaron
   - plinss
   - lilles
-  - therealglazou

--- a/css/selectors/META.yml
+++ b/css/selectors/META.yml
@@ -1,7 +1,6 @@
 suggested_reviewers:
   - tantek
   - fantasai
-  - therealglazou
   - frivoal
   - plinss
   - tabatkins

--- a/custom-elements/META.yml
+++ b/custom-elements/META.yml
@@ -1,11 +1,7 @@
 suggested_reviewers:
   - snuggs
-  - alsemenov
-  - deepak-sa
   - domenic
-  - dominiccooney
   - hayatoito
   - kojiishi
   - rniwa
-  - sgrekhov
   - takayoshikochi

--- a/fullscreen/META.yml
+++ b/fullscreen/META.yml
@@ -1,5 +1,4 @@
 suggested_reviewers:
   - aliams
   - foolip
-  - jernoble
   - upsuper

--- a/images/META.yml
+++ b/images/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - zqzhang
-  - tagawa
   - gsnedders

--- a/intersection-observer/META.yml
+++ b/intersection-observer/META.yml
@@ -1,3 +1,2 @@
 suggested_reviewers:
-  - scottlow
   - szager-chromium

--- a/media-source/META.yml
+++ b/media-source/META.yml
@@ -1,3 +1,2 @@
 suggested_reviewers:
-  - shishimaru
   - wolenetz

--- a/notifications/META.yml
+++ b/notifications/META.yml
@@ -1,5 +1,3 @@
 suggested_reviewers:
-  - chunywang
   - sideshowbarker
-  - xinliux
   - ibelem

--- a/payment-method-basic-card/META.yml
+++ b/payment-method-basic-card/META.yml
@@ -1,5 +1,4 @@
 suggested_reviewers:
-  - edenchuang
   - mnoorenberghe
   - marcoscaceres
   - rsolomakhin

--- a/payment-method-id/META.yml
+++ b/payment-method-id/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
-  - edenchuang
   - alphan102
   - marcoscaceres

--- a/payment-request/META.yml
+++ b/payment-request/META.yml
@@ -4,4 +4,3 @@ suggested_reviewers:
   - domenic
   - MSFTkihans
   - mnoorenberghe
-  - edenchuang

--- a/pointerevents/META.yml
+++ b/pointerevents/META.yml
@@ -1,7 +1,5 @@
 suggested_reviewers:
-  - bethge
   - Steditor
-  - EvgenyAgafonchikov
   - jacobrossi
   - plehegar
   - scottgonzalez

--- a/presentation-api/META.yml
+++ b/presentation-api/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
-  - louaybassbouss
   - tidoust
   - zqzhang

--- a/service-workers/META.yml
+++ b/service-workers/META.yml
@@ -1,6 +1,5 @@
 suggested_reviewers:
   - asutherland
-  - beidson
   - mkruisselbrink
   - mattto
   - wanderview

--- a/speech-api/META.yml
+++ b/speech-api/META.yml
@@ -1,5 +1,3 @@
 suggested_reviewers:
   - andrenatal
-  - fleizach
   - gshires
-  - jdsmith3000

--- a/streams/META.yml
+++ b/streams/META.yml
@@ -1,6 +1,5 @@
 suggested_reviewers:
   - domenic
-  - tyoshino
   - yutakahirano
   - youennf
   - calvaris

--- a/url/META.yml
+++ b/url/META.yml
@@ -1,7 +1,5 @@
 suggested_reviewers:
   - mikewest
-  - rubys
-  - xiaojunwu
   - smola
   - domenic
   - Sebmaster

--- a/vibration/META.yml
+++ b/vibration/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - dontcallmedom
   - zqzhang
-  - xinliux

--- a/web-nfc/META.yml
+++ b/web-nfc/META.yml
@@ -1,5 +1,4 @@
 suggested_reviewers:
   - Honry
   - kenchris
-  - zolkis
   - alexshalamov

--- a/websockets/META.yml
+++ b/websockets/META.yml
@@ -1,4 +1,3 @@
 suggested_reviewers:
   - zqzhang
-  - Jxck
   - jdm

--- a/webstorage/META.yml
+++ b/webstorage/META.yml
@@ -2,7 +2,5 @@ suggested_reviewers:
   - siusin
   - inexorabletash
   - zqzhang
-  - chunywang
-  - kangxu
   - ibelem
   - jdm

--- a/workers/META.yml
+++ b/workers/META.yml
@@ -1,6 +1,5 @@
 suggested_reviewers:
   - zqzhang
-  - chunywang
   - caitp
   - jdm
   - annevk

--- a/xhr/META.yml
+++ b/xhr/META.yml
@@ -1,13 +1,10 @@
 suggested_reviewers:
   - emilio
-  - hallvors
-  - kangxu
   - caitp
   - Manishearth
   - jungkees
   - ibelem
   - mathiasbynens
-  - ronkorving
   - jdm
   - annevk
   - wisniewskit


### PR DESCRIPTION
Part of https://github.com/web-platform-tests/wpt/issues/11293.

Reminder also in https://github.com/web-platform-tests/wpt/issues/11568.

This does not fully resolve #11293, as a few non-responders where
there would be no remaining reviewers are left, and one known to be
out-of-office. These will be handled separately to finish this.