### PR TITLE
Use the empty string as the host when opening a socket to find an unu…

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -434,7 +434,7 @@ def check_subdomains(config):
     aliases = config.aliases
 
     host = config.server_host
-    port = get_port(host)
+    port = get_port()
     logger.debug("Going to use port %d to check subdomains" % port)
 
     wrapper = ServerProc()
@@ -789,7 +789,7 @@ def run(**kwargs):
 
     stash_address = None
     if bind_address:
-        stash_address = (config.server_host, get_port(config.server_host))
+        stash_address = (config.server_host, get_port())
         logger.debug("Going to use port %d for stash" % stash_address[1])
 
     with stash.StashServer(stash_address, authkey=str(uuid.uuid4())):

--- a/tools/wptserve/wptserve/config.py
+++ b/tools/wptserve/wptserve/config.py
@@ -155,7 +155,7 @@ class Config(Mapping):
                     try:
                         port = old_ports[scheme][i]
                     except (KeyError, IndexError):
-                        port = get_port(self.server_host)
+                        port = get_port()
                 else:
                     port = port
                 new_ports[scheme].append(port)

--- a/tools/wptserve/wptserve/utils.py
+++ b/tools/wptserve/wptserve/utils.py
@@ -98,7 +98,7 @@ def is_bad_port(port):
         6697,  # irc+tls
     ]
 
-def get_port(host):
+def get_port(host=''):
     port = 0
     while True:
         free_socket = _open_socket(host, 0)


### PR DESCRIPTION
…sed port

I was setting up web-platform-tests in a new environment with a custom `config.json` in the project root and I hit an error case where ` ./wpt make-hosts-file` was erring with an unfriendly `socket.gaierror: [Errno 8] nodename nor servname provided, or not known` error message.

It turns out this error message was occurring because web-platform-test was attempting to open a socket connection to `web-platform.test` in order to identify an unused port but the socket could not connect because my `/etc/hosts` file had not been correctly configured yet. 

This code path does not occur with a clean checkout of web-platform-tests but I was hitting it because I had a custom `config.json` in the root of my project that specified alternate ports for the server. When overriding the default port values the Config class attempts to translate port values of "auto" into a concrete number by open a connection to `web-platform.test`.

Below is the console output when attempting to run `make-hosts-file` with a `config.json` that sets one of the `ports` values to `"auto"` before and after this change.


#### Before
```
$ ./wpt make-hosts-file 
Traceback (most recent call last):
  File "./wpt", line 5, in <module>
    wpt.main()
  File "/Users/bmac/code/web-platform-tests/tools/wpt/wpt.py", line 132, in main
    rv = script(*args, **kwargs)
  File "/Users/bmac/code/web-platform-tests/tools/ci/make_hosts_file.py", line 14, in run
    config = load_config(os.path.join(repo_root, "config.json"))
  File "/Users/bmac/code/web-platform-tests/tools/serve/serve.py", line 665, in load_config
    rv.update(override_obj)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/config.py", line 116, in update
    self._set_override(k, override.pop(k))
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/config.py", line 133, in _set_override
    old_v = getattr(self, k)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/config.py", line 158, in ports
    port = get_port(self.server_host)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/utils.py", line 104, in get_port
    free_socket = _open_socket(host, 0)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/utils.py", line 23, in _open_socket
    sock.bind((host, port))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

#### After
```
$ ./wpt make-hosts-file 
127.0.0.1	xn--lve-6lad.not-web-platform.test
127.0.0.1	xn--lve-6lad.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.not-web-platform.test
127.0.0.1	www1.web-platform.test
127.0.0.1	www2.web-platform.test
127.0.0.1	not-web-platform.test
127.0.0.1	web-platform.test
127.0.0.1	www2.not-web-platform.test
127.0.0.1	www1.not-web-platform.test
127.0.0.1	www.not-web-platform.test
127.0.0.1	www.web-platform.test
127.0.0.1	xn--n8j6ds53lwwkrqhv28a.web-platform.test
```

Another side effect of this change is there is now a better error message when running `./wpt serve` for uses that have not correctly setup their `/etc/hosts` file.

#### Before
```
$ ./wpt serve
Traceback (most recent call last):
  File "./wpt", line 5, in <module>
    wpt.main()
  File "/Users/bmac/code/web-platform-tests/tools/wpt/wpt.py", line 132, in main
    rv = script(*args, **kwargs)
  File "/Users/bmac/code/web-platform-tests/tools/serve/serve.py", line 788, in run
    check_subdomains(config)
  File "/Users/bmac/code/web-platform-tests/tools/serve/serve.py", line 437, in check_subdomains
    port = get_port(host)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/utils.py", line 104, in get_port
    free_socket = _open_socket(host, 0)
  File "/Users/bmac/code/web-platform-tests/tools/wptserve/wptserve/utils.py", line 23, in _open_socket
    sock.bind((host, port))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.gaierror: [Errno 8] nodename nor servname provided, or not known
```

#### After
```
$ ./wpt serve
DEBUG:web-platform-tests:Going to use port 64348 to check subdomains
DEBUG:web-platform-tests:Route pattern: ^/(.*)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.py)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.asis)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.any\.worker\.js)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.https\.any\.serviceworker\.html)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.any\.sharedworker\.html)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.any\.html)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.window\.html)$
DEBUG:web-platform-tests:Route pattern: ^/(.*\.worker\.html)$
DEBUG:web-platform-tests:Route pattern: ^/serve\.py$
DEBUG:web-platform-tests:Route pattern: ^/(?P<spec>[^/]+)/tools/(.*)$
DEBUG:web-platform-tests:Route pattern: ^/tools/(.*)$
DEBUG:web-platform-tests:Route pattern: ^/\_certs/(.*)$
DEBUG:web-platform-tests:Route pattern: ^/tools/runner/update\_manifest\.py$
DEBUG:web-platform-tests:Route pattern: ^/tools/runner/(.*)$
DEBUG:web-platform-tests:Using default configuration
INFO:web-platform-tests:Starting http server on web-platform.test:64348
CRITICAL:web-platform-tests:Failed to connect to test server on http://web-platform.test:64348. You may need to edit /etc/hosts or similar, see README.md.
```