### PR TITLE
Update user-timing IDL + test

### DIFF
--- a/interfaces/user-timing.idl
+++ b/interfaces/user-timing.idl
@@ -6,14 +6,14 @@
 partial interface Performance {
     void mark(DOMString markName);
     void clearMarks(optional DOMString markName);
-    void measure(DOMString measureName,
-                 optional DOMString startMark,
-                 optional DOMString endMark);
+    void measure(DOMString measureName, optional DOMString startMark, optional DOMString endMark);
     void clearMeasures(optional DOMString measureName);
 };
+
 [Exposed=(Window,Worker)]
 interface PerformanceMark : PerformanceEntry {
 };
+
 [Exposed=(Window,Worker)]
 interface PerformanceMeasure : PerformanceEntry {
 };

--- a/user-timing/idlharness.any.js
+++ b/user-timing/idlharness.any.js
@@ -6,19 +6,27 @@
 
 'use strict';
 
-promise_test(async () => {
-  const idl_array = new IdlArray();
-  const idl = await fetch("/interfaces/user-timing.idl").then(r => r.text());
-  const hrtime = await fetch("/interfaces/hr-time.idl").then(r => r.text());
-  const perf = await fetch("/interfaces/performance-timeline.idl").then(r => r.text());
-  const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
+idl_test(
+  ['user-timing'],
+  ['hr-time', 'performance-timeline', 'dom'],
+  idl_array => {
+    try {
+      performance.mark('test');
+      performance.measure('test');
+      for (const m of performance.getEntriesByType('mark')) {
+        self.mark = m;
+      }
+      for (const m of performance.getEntriesByType('measure')) {
+        self.measure = m;
+      }
+    } catch (e) {
+      // Will be surfaced when mark is undefined below.
+    }
 
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(hrtime);
-  idl_array.add_dependency_idls(perf);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_objects({
-    Performance: ["performance"]
-  });
-  idl_array.test();
-}, "Test IDL implementation of user-timing API");
+    idl_array.add_objects({
+      Performance: ['performance'],
+      PerformanceMark: ['mark'],
+      PerformanceMeasure: ['measure'],
+    });
+  },
+  'Test IDL implementation of user-timing API');


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
