### PR TITLE
Update the resource-timing IDL + test

### DIFF
--- a/interfaces/resource-timing.idl
+++ b/interfaces/resource-timing.idl
@@ -5,27 +5,28 @@
 
 [Exposed=(Window,Worker)]
 interface PerformanceResourceTiming : PerformanceEntry {
-    readonly attribute DOMString           initiatorType;
-    readonly attribute DOMString           nextHopProtocol;
-    readonly attribute DOMHighResTimeStamp workerStart;
-    readonly attribute DOMHighResTimeStamp redirectStart;
-    readonly attribute DOMHighResTimeStamp redirectEnd;
-    readonly attribute DOMHighResTimeStamp fetchStart;
-    readonly attribute DOMHighResTimeStamp domainLookupStart;
-    readonly attribute DOMHighResTimeStamp domainLookupEnd;
-    readonly attribute DOMHighResTimeStamp connectStart;
-    readonly attribute DOMHighResTimeStamp connectEnd;
-    readonly attribute DOMHighResTimeStamp secureConnectionStart;
-    readonly attribute DOMHighResTimeStamp requestStart;
-    readonly attribute DOMHighResTimeStamp responseStart;
-    readonly attribute DOMHighResTimeStamp responseEnd;
-    readonly attribute unsigned long long  transferSize;
-    readonly attribute unsigned long long  encodedBodySize;
-    readonly attribute unsigned long long  decodedBodySize;
+    readonly        attribute DOMString initiatorType;
+    readonly        attribute DOMString nextHopProtocol;
+    readonly        attribute DOMHighResTimeStamp workerStart;
+    readonly        attribute DOMHighResTimeStamp redirectStart;
+    readonly        attribute DOMHighResTimeStamp redirectEnd;
+    readonly        attribute DOMHighResTimeStamp fetchStart;
+    readonly        attribute DOMHighResTimeStamp domainLookupStart;
+    readonly        attribute DOMHighResTimeStamp domainLookupEnd;
+    readonly        attribute DOMHighResTimeStamp connectStart;
+    readonly        attribute DOMHighResTimeStamp connectEnd;
+    readonly        attribute DOMHighResTimeStamp secureConnectionStart;
+    readonly        attribute DOMHighResTimeStamp requestStart;
+    readonly        attribute DOMHighResTimeStamp responseStart;
+    readonly        attribute DOMHighResTimeStamp responseEnd;
+    readonly        attribute unsigned long long transferSize;
+    readonly        attribute unsigned long long encodedBodySize;
+    readonly        attribute unsigned long long decodedBodySize;
     [Default] object toJSON();
 };
+
 partial interface Performance {
-    void clearResourceTimings();
-    void setResourceTimingBufferSize(unsigned long maxSize);
-    attribute EventHandler onresourcetimingbufferfull;
+  void clearResourceTimings();
+  void setResourceTimingBufferSize(unsigned long maxSize);
+              attribute EventHandler onresourcetimingbufferfull;
 };

--- a/resource-timing/idlharness.any.js
+++ b/resource-timing/idlharness.any.js
@@ -5,24 +5,20 @@
 
 // https://w3c.github.io/resource-timing/
 
-promise_test(async () => {
-  const [idl, perf, hrtime, dom, html] = await Promise.all([
-    '/interfaces/resource-timing.idl',
-    '/interfaces/performance-timeline.idl',
-    '/interfaces/hr-time.idl',
-    '/interfaces/dom.idl',
-    '/interfaces/html.idl',
-  ].map(url => fetch(url).then(r => r.text())));
+idl_test(
+  ['resource-timing'],
+  ['performance-timeline', 'hr-time', 'dom', 'html'],
+  idl_array => {
+    try {
+      self.resource = performance.getEntriesByType('resource')[0];
+    } catch (e) {
+      // Will be surfaced when resource is undefined below.
+    }
 
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(perf);
-  idl_array.add_dependency_idls(hrtime);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_objects({
-    Performance: ['performance'],
-    PerformanceResourceTiming: ["performance.getEntriesByType('resource')[0]"]
-  });
-  idl_array.test();
-}, 'Test server-timing IDL implementation');
+    idl_array.add_objects({
+      Performance: ['performance'],
+      PerformanceResourceTiming: ['resource']
+    });
+  },
+  'Test server-timing IDL implementation'
+);


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
