### PR TITLE
Update the performance-timeline IDL file + test

### DIFF
--- a/interfaces/performance-timeline.idl
+++ b/interfaces/performance-timeline.idl
@@ -1,0 +1,40 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Performance Timeline Level 2" spec.
+// See: https://w3c.github.io/performance-timeline/
+
+partial interface Performance {
+    PerformanceEntryList getEntries();
+    PerformanceEntryList getEntriesByType(DOMString type);
+    PerformanceEntryList getEntriesByName(DOMString name,
+                                          optional DOMString type);
+};
+typedef sequence<PerformanceEntry> PerformanceEntryList;
+[Exposed=(Window,Worker)]
+interface PerformanceEntry {
+    readonly attribute DOMString           name;
+    readonly attribute DOMString           entryType;
+    readonly attribute DOMHighResTimeStamp startTime;
+    readonly attribute DOMHighResTimeStamp duration;
+    [Default] object toJSON();
+};
+callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
+                                             PerformanceObserver observer);
+[Constructor(PerformanceObserverCallback callback),
+ Exposed=(Window,Worker)]
+interface PerformanceObserver {
+    void                 observe(PerformanceObserverInit options);
+    void                 disconnect();
+    PerformanceEntryList takeRecords();
+};
+dictionary PerformanceObserverInit {
+    required sequence<DOMString> entryTypes;
+             boolean             buffered = false;
+};
+[Exposed=(Window,Worker)]
+interface PerformanceObserverEntryList {
+    PerformanceEntryList getEntries();
+    PerformanceEntryList getEntriesByType(DOMString type);
+    PerformanceEntryList getEntriesByName(DOMString name,
+                                          optional DOMString type);
+};

--- a/interfaces/performance-timeline.idl
+++ b/interfaces/performance-timeline.idl
@@ -4,37 +4,33 @@
 // See: https://w3c.github.io/performance-timeline/
 
 partial interface Performance {
-    PerformanceEntryList getEntries();
-    PerformanceEntryList getEntriesByType(DOMString type);
-    PerformanceEntryList getEntriesByName(DOMString name,
-                                          optional DOMString type);
-};
-typedef sequence<PerformanceEntry> PerformanceEntryList;
+  PerformanceEntryList getEntries();
+  PerformanceEntryList getEntriesByType(DOMString type);
+  PerformanceEntryList getEntriesByName(DOMString name, optional DOMString type);
+};typedef sequence<PerformanceEntry> PerformanceEntryList;
 [Exposed=(Window,Worker)]
 interface PerformanceEntry {
-    readonly attribute DOMString           name;
-    readonly attribute DOMString           entryType;
-    readonly attribute DOMHighResTimeStamp startTime;
-    readonly attribute DOMHighResTimeStamp duration;
-    [Default] object toJSON();
+  readonly    attribute DOMString name;
+  readonly    attribute DOMString entryType;
+  readonly    attribute DOMHighResTimeStamp startTime;
+  readonly    attribute DOMHighResTimeStamp duration;
+  [Default] object toJSON();
 };
 callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
                                              PerformanceObserver observer);
-[Constructor(PerformanceObserverCallback callback),
- Exposed=(Window,Worker)]
+[Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
 interface PerformanceObserver {
-    void                 observe(PerformanceObserverInit options);
-    void                 disconnect();
-    PerformanceEntryList takeRecords();
+  void observe(PerformanceObserverInit options);
+  void disconnect();
+  PerformanceEntryList takeRecords();
 };
 dictionary PerformanceObserverInit {
-    required sequence<DOMString> entryTypes;
-             boolean             buffered = false;
+  required sequence<DOMString> entryTypes;
+  boolean buffered = false;
 };
 [Exposed=(Window,Worker)]
 interface PerformanceObserverEntryList {
-    PerformanceEntryList getEntries();
-    PerformanceEntryList getEntriesByType(DOMString type);
-    PerformanceEntryList getEntriesByName(DOMString name,
-                                          optional DOMString type);
+  PerformanceEntryList getEntries();
+  PerformanceEntryList getEntriesByType(DOMString type);
+  PerformanceEntryList getEntriesByName(DOMString name, optional DOMString type);
 };

--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -6,21 +6,22 @@
 
 'use strict';
 
-promise_test(async () => {
-  const idl_array = new IdlArray();
-  const idl = await fetch("/interfaces/performance-timeline.idl").then(r => r.text());
-  const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
-  const hrtime = await fetch("/interfaces/hr-time.idl").then(r => r.text());
+idl_test(
+  ['performance-timeline'],
+  ['hr-time', 'dom'],
+  idl_array => {
+    try {
+      const callback = (e, o) => {};
+      self.observerEntry = new ResizeObserverEntry(callback);
+    } catch (e) {
+      // Will be surfaced when entry is undefined below.
+    }
 
-  // create first mark
-  self.performance.mark("mark");
-
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(hrtime);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_objects({
-    Performance: ["performance"],
-    PerformanceMark: [self.performance.getEntriesByName("mark")[0]],
-  });
-  idl_array.test();
-}, "Test IDL implementation of performance-timeline API");
+    idl_array.add_objects({
+      Performance: ['performance'],
+      // PerformanceEntry implicitly tested in user-timing.
+      ResizeObserverEntry: ['observerEntry'],
+    });
+  },
+  'Test IDL implementation of performance-timeline API'
+);


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
