### PR TITLE
Add tests for element setCustomValidity

### DIFF
--- a/html/semantics/embedded-content/the-object-element/object-setcustomvalidity.html
+++ b/html/semantics/embedded-content/the-object-element/object-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<object id='test'></object>
+<object id='object_test'></object>
 
 <script>
 
 test(() => {
-  let object = document.getElementById("test");
-  assert_false(object.validity.customError);
-  object.setCustomValidity("custom error");
-  assert_true(object.validity.customError);
+  let elem = document.getElementById("object_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "object setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-button-element/button-setcustomvalidity.html
+++ b/html/semantics/forms/the-button-element/button-setcustomvalidity.html
@@ -1,43 +1,17 @@
 <!DOCTYPE HTML>
-<html>
- <head>
-  <title>Forms</title>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
- </head>
- <body>
-  <p>
-    <h3>button_setCustomValidity</h3>
-  </p>
+<title>button setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 
-  <hr>
+<button id='test'></button>
 
-  <div id="log"></div>
+<script>
 
-  <form method="post"
-      enctype="application/x-www-form-urlencoded"
-      action=""
-      id="input_form">
-    <p><button id='button_id'>button</button></p>
-  </form>
-  <script>
+test(() => {
+  let button = document.getElementById("test");
+  assert_false(button.validity.customError);
+  button.setCustomValidity("custom error");
+  assert_true(button.validity.customError);
+}, "button setCustomValidity is correct")
 
-    var button = document.getElementById("button_id");
-
-    try
-    {
-      button.setCustomValidity("custom error");
-      test(function() {
-        assert_true(true, "calling of setCustomValidity method is successed.");
-      });
-    }
-    catch (e) {
-      test(function() {
-        assert_unreached("Error is raised.");
-      });
-    }
-
-  </script>
-
- </body>
-</html>
+</script>

--- a/html/semantics/forms/the-button-element/button-setcustomvalidity.html
+++ b/html/semantics/forms/the-button-element/button-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<button id='test'></button>
+<button id='button_test'></button>
 
 <script>
 
 test(() => {
-  let button = document.getElementById("test");
-  assert_false(button.validity.customError);
-  button.setCustomValidity("custom error");
-  assert_true(button.validity.customError);
+  let elem = document.getElementById("button_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "button setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-fieldset-element/fieldset-setcustomvalidity.html
+++ b/html/semantics/forms/the-fieldset-element/fieldset-setcustomvalidity.html
@@ -1,44 +1,17 @@
 <!DOCTYPE HTML>
-<html>
- <head>
-  <title>Forms</title>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
- </head>
- <body>
-  <p>
-    <h3>FieldSet_setCustomValidity</h3>
-  </p>
+<title>fieldset setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 
-  <hr>
+<fieldset id='test'></fieldset>
 
-  <div id="log"></div>
+<script>
 
-  <form method="post"
-      enctype="application/x-www-form-urlencoded"
-      action=""
-      id="input_form">
-    <fieldset id="input_field">
-     </fieldset>
-  </form>
-  <script>
+test(() => {
+  let fieldset = document.getElementById("test");
+  assert_false(fieldset.validity.customError);
+  fieldset.setCustomValidity("custom error");
+  assert_true(fieldset.validity.customError);
+}, "fieldset setCustomValidity is correct")
 
-    var field = document.getElementById("input_field");
-
-    try
-    {
-      field.setCustomValidity("custom error");
-      test(function() {
-        assert_true(true, "calling of setCustomValidity method is successed.");
-      });
-    }
-    catch (e) {
-      test(function() {
-        assert_unreached("Error is raised.");
-      });
-    }
-
-  </script>
-
- </body>
-</html>
+</script>

--- a/html/semantics/forms/the-fieldset-element/fieldset-setcustomvalidity.html
+++ b/html/semantics/forms/the-fieldset-element/fieldset-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<fieldset id='test'></fieldset>
+<fieldset id='fieldset_test'></fieldset>
 
 <script>
 
 test(() => {
-  let fieldset = document.getElementById("test");
-  assert_false(fieldset.validity.customError);
-  fieldset.setCustomValidity("custom error");
-  assert_true(fieldset.validity.customError);
+  let elem = document.getElementById("fieldset_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "fieldset setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-input-element/input-setcustomvalidity.html
+++ b/html/semantics/forms/the-input-element/input-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<input id='test'>
+<input id='input_test'>
 
 <script>
 
 test(() => {
-  let input = document.getElementById("test");
-  assert_false(input.validity.customError);
-  input.setCustomValidity("custom error");
-  assert_true(input.validity.customError);
+  let elem = document.getElementById("input_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "input setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-input-element/input-setcustomvalidity.html
+++ b/html/semantics/forms/the-input-element/input-setcustomvalidity.html
@@ -1,43 +1,17 @@
 <!DOCTYPE HTML>
-<html>
- <head>
-  <title>Forms</title>
-  <script src="/resources/testharness.js"></script>
-  <script src="/resources/testharnessreport.js"></script>
- </head>
- <body>
-  <p>
-    <h3>input_setCustomValidity</h3>
-  </p>
+<title>input setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 
-  <hr>
+<input id='test'>
 
-  <div id="log"></div>
+<script>
 
-  <form method="post"
-      enctype="application/x-www-form-urlencoded"
-      action=""
-      id="input_form">
-    <p><input type='hidden' id='input_text'></p>
-  </form>
-  <script>
+test(() => {
+  let input = document.getElementById("test");
+  assert_false(input.validity.customError);
+  input.setCustomValidity("custom error");
+  assert_true(input.validity.customError);
+}, "input setCustomValidity is correct")
 
-    var input = document.getElementById("input_text");
-
-    try
-    {
-      input.setCustomValidity("custom error");
-      test(function() {
-        assert_true(true, "calling of setCustomValidity method is successed.");
-      });
-    }
-    catch (e) {
-      test(function() {
-        assert_unreached("Error is raised.");
-      });
-    }
-
-  </script>
-
- </body>
-</html>
+</script>

--- a/html/semantics/forms/the-object-element/object-setcustomvalidity.html
+++ b/html/semantics/forms/the-object-element/object-setcustomvalidity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<title>object setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<object id='test'></object>
+
+<script>
+
+test(() => {
+  let object = document.getElementById("test");
+  assert_false(object.validity.customError);
+  object.setCustomValidity("custom error");
+  assert_true(object.validity.customError);
+}, "object setCustomValidity is correct")
+
+</script>

--- a/html/semantics/forms/the-output-element/output-setcustomvalidity.html
+++ b/html/semantics/forms/the-output-element/output-setcustomvalidity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<title>output setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<output id='test'></output>
+
+<script>
+
+test(() => {
+  let output = document.getElementById("test");
+  assert_false(output.validity.customError);
+  output.setCustomValidity("custom error");
+  assert_true(output.validity.customError);
+}, "output setCustomValidity is correct")
+
+</script>

--- a/html/semantics/forms/the-output-element/output-setcustomvalidity.html
+++ b/html/semantics/forms/the-output-element/output-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<output id='test'></output>
+<output id='output_test'></output>
 
 <script>
 
 test(() => {
-  let output = document.getElementById("test");
-  assert_false(output.validity.customError);
-  output.setCustomValidity("custom error");
-  assert_true(output.validity.customError);
+  let elem = document.getElementById("output_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "output setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-select-element/select-setcustomvalidity.html
+++ b/html/semantics/forms/the-select-element/select-setcustomvalidity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<title>select setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<select id='test'></select>
+
+<script>
+
+test(() => {
+  let select = document.getElementById("test");
+  assert_false(select.validity.customError);
+  select.setCustomValidity("custom error");
+  assert_true(select.validity.customError);
+}, "select setCustomValidity is correct")
+
+</script>

--- a/html/semantics/forms/the-select-element/select-setcustomvalidity.html
+++ b/html/semantics/forms/the-select-element/select-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<select id='test'></select>
+<select id='select_test'></select>
 
 <script>
 
 test(() => {
-  let select = document.getElementById("test");
-  assert_false(select.validity.customError);
-  select.setCustomValidity("custom error");
-  assert_true(select.validity.customError);
+  let elem = document.getElementById("select_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "select setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-textarea-element/textarea-setcustomvalidity.html
+++ b/html/semantics/forms/the-textarea-element/textarea-setcustomvalidity.html
@@ -3,15 +3,15 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 
-<textarea id='test'></textarea>
+<textarea id='textarea_test'></textarea>
 
 <script>
 
 test(() => {
-  let textarea = document.getElementById("test");
-  assert_false(textarea.validity.customError);
-  textarea.setCustomValidity("custom error");
-  assert_true(textarea.validity.customError);
+  let elem = document.getElementById("textarea_test");
+  assert_false(elem.validity.customError);
+  elem.setCustomValidity("custom error");
+  assert_true(elem.validity.customError);
 }, "textarea setCustomValidity is correct")
 
 </script>

--- a/html/semantics/forms/the-textarea-element/textarea-setcustomvalidity.html
+++ b/html/semantics/forms/the-textarea-element/textarea-setcustomvalidity.html
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<title>textarea setCustomValidity</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<textarea id='test'></textarea>
+
+<script>
+
+test(() => {
+  let textarea = document.getElementById("test");
+  assert_false(textarea.validity.customError);
+  textarea.setCustomValidity("custom error");
+  assert_true(textarea.validity.customError);
+}, "textarea setCustomValidity is correct")
+
+</script>


### PR DESCRIPTION
Add following tests (Fix #993):

- Add tests for output/object/select/textarea setCustomValidity
- Optimize tests for input/button/fieldset setCustomValidity by using element.validity.customError to check if the element has a custom error

@foolip, PTAL.

