### PR TITLE
[html] Add tests for document.open() after window.stop()

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
@@ -1,23 +1,23 @@
+// For more details, see https://bugzilla.mozilla.org/show_bug.cgi?id=1475000.
+
 window.handlers = {};
 
 async_test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   frame.src = "resources/aborted-parser-frame.html";
-  window.handlers.afterOpen = t.step_func(() => {
+  window.handlers.afterOpen = t.step_func_done(() => {
     const openCalled = frame.contentDocument.childNodes.length === 0;
     frame.remove();
     assert_true(openCalled, "child document should be empty");
-    t.done();
   });
 }, "document.open() after parser is aborted");
 
 async_test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   frame.src = "resources/aborted-parser-async-frame.html";
-  window.handlers.afterOpenAsync = t.step_func(() => {
+  window.handlers.afterOpenAsync = t.step_func_done(() => {
     const openCalled = frame.contentDocument.childNodes.length === 0;
     frame.remove();
     assert_true(openCalled, "child document should be empty");
-    t.done();
   });
 }, "async document.open() after parser is aborted");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
@@ -1,3 +1,6 @@
+// document.open() bails out early if there is an **active parser** with
+// non-zero script nesting level. window.stop() aborts the current parser and
+// makes it no longer active, and should allow document.open() to work.
 // For more details, see https://bugzilla.mozilla.org/show_bug.cgi?id=1475000.
 
 window.handlers = {};

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
@@ -1,0 +1,23 @@
+window.handlers = {};
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  frame.src = "resources/aborted-parser-frame.html";
+  window.handlers.afterOpen = t.step_func(() => {
+    const openCalled = frame.contentDocument.childNodes.length === 0;
+    frame.remove();
+    assert_true(openCalled, "child document should be empty");
+    t.done();
+  });
+}, "document.open() after parser is aborted");
+
+async_test(t => {
+  const frame = document.body.appendChild(document.createElement("iframe"));
+  frame.src = "resources/aborted-parser-async-frame.html";
+  window.handlers.afterOpenAsync = t.step_func(() => {
+    const openCalled = frame.contentDocument.childNodes.length === 0;
+    frame.remove();
+    assert_true(openCalled, "child document should be empty");
+    t.done();
+  });
+}, "async document.open() after parser is aborted");

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/aborted-parser.window.js
@@ -15,6 +15,8 @@ async_test(t => {
   });
 }, "document.open() after parser is aborted");
 
+// Note: This test should pass even if window.close() is not there, as
+// document.open() is not executed synchronously in an inline script.
 async_test(t => {
   const frame = document.body.appendChild(document.createElement("iframe"));
   frame.src = "resources/aborted-parser-async-frame.html";

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
@@ -2,7 +2,7 @@
 <p>Text</p>
 <script>
 window.stop();
-setTimeout(() => {
+parent.step_timeout(() => {
   document.open();
   parent.handlers.afterOpenAsync();
 });

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
@@ -5,5 +5,5 @@ window.stop();
 parent.step_timeout(() => {
   document.open();
   parent.handlers.afterOpenAsync();
-});
+}, 10);
 </script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<p>Text</p>
+<script>
+window.stop();
+setTimeout(() => {
+  document.open();
+  parent.handlers.afterOpenAsync();
+});
+</script>

--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-frame.html
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-frame.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<p>Text</p>
+<script>
+window.stop();
+document.open();
+parent.handlers.afterOpen();
+</script>


### PR DESCRIPTION
Passes on Chrome and Safari, but fails on Firefox and Edge.