### PR TITLE
Non protocol specific part of pointer actions in testdriver

### DIFF
--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -50,15 +50,9 @@ For example, to send the tab key you would send "\uE004".
 
 ### `test_driver.pointer_action_sequence(actions)`
  - `actions` <[Array]<[Object]>> an array of Action objects`
-  - `action` <[Object]> A single action
-   - `id` The ID of the pointer to use. If one with this id does not exist a new one will be used
-   - `pointerType` The type of pointer to use, an enum of `mouse`, `touch` and `pen`.
-   - `subtype` The type of action to perform, an enum of `pointerUp`, `pointerMove`, `pointerDown` and `pause`
-   - `coordinates` An Object with exactly two integer attrbutes `x` and `y`.
-   - `duration` The duration in ms before the next action in the sequence should start
+  - `action` <[Object]> A single action. See [spec](https://www.w3.org/TR/webdriver/#actions) for format
 
-
-This function causes a sequence of pointer actions to be sent to the browser. It returns a `Promise` that
+This function causes a sequence of actions to be sent to the browser. It is based of the [WebDriver API](https://www.w3.org/TR/webdriver/#actions) The action can be a keyboard event, a pointer event or a pause. It returns a `Promise` that
 resolves after the actions have been sent or rejects if an error was thrown.
 
 ### `test_driver.send_keys(element, keys)`

--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -48,4 +48,34 @@ between the function being called and the promise settling.
 To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
 For example, to send the tab key you would send "\uE004".
 
+### `test_driver.pointer_action_sequence(actions)`
+ - `actions` <[Array]<[Object]>> an array of Action objects`
+  - `action` <[Object]> A single action
+   - `id` The ID of the pointer to use. If one with this id does not exist a new one will be used
+   - `pointerType` The type of pointer to use, an enum of `mouse`, `touch` and `pen`.
+   - `subtype` The type of action to perform, an enum of `pointerUp`, `pointerMove`, `pointerDown` and `pause`
+   - `target` Either a DOM Element object or an Object with exactly two integer attrbutes `x` and `y`.
+   - `duration` The duration in ms before the next action in the sequence should start
+
+
+This function causes a sequence of pointer actions to be sent to the browser. It returns a `Promise` that
+resolves after the actions have been sent or rejects if an error was thrown.
+
+### `test_driver.send_keys(element, keys)`
+#### `element: a DOM Element object`
+#### `keys: string to send to the element`
+
+This function causes the string `keys` to be send to the target
+element (an `Element` object), potentially scrolling the document to
+make it possible to send keys. It returns a `Promise` that resolves
+after the keys have been send or rejects if the keys cannot be sent
+to the element.
+
+Note that if the element that's keys need to be send to does not have
+a unique ID, the document must not have any DOM mutations made
+between the function being called and the promise settling.
+
+To send special keys, one must send the respective key's codepoint. Since this uses the WebDriver protocol, you can find a [list for code points to special keys in the spec](https://w3c.github.io/webdriver/webdriver-spec.html#keyboard-actions).
+For example, to send the tab key you would send "\uE004".
+
 [testharness]: {{ site.baseurl }}{% link _writing-tests/testharness.md %}

--- a/docs/_writing-tests/testdriver.md
+++ b/docs/_writing-tests/testdriver.md
@@ -54,7 +54,7 @@ For example, to send the tab key you would send "\uE004".
    - `id` The ID of the pointer to use. If one with this id does not exist a new one will be used
    - `pointerType` The type of pointer to use, an enum of `mouse`, `touch` and `pen`.
    - `subtype` The type of action to perform, an enum of `pointerUp`, `pointerMove`, `pointerDown` and `pause`
-   - `target` Either a DOM Element object or an Object with exactly two integer attrbutes `x` and `y`.
+   - `coordinates` An Object with exactly two integer attrbutes `x` and `y`.
    - `duration` The duration in ms before the next action in the sequence should start
 
 

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -184,8 +184,8 @@
          * @returns {Promise} fufiled after the actions are performed, or rejected in
          *                    the cases the WebDriver command errors
          */
-        pointer_action_sequence() {
-            return window.test_driver_internal.pointer_action_sequence();
+        pointer_action_sequence(actions) {
+            return window.test_driver_internal.pointer_action_sequence(actions);
         }
     };
 

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -173,9 +173,9 @@
         },
 
         /**
-         * Send a sequence of pointer actions
+         * Send a sequence of actions
          *
-         * This function sends a sequence of pointer actions to the top level window
+         * This function sends a sequence of actions to the top level window
          * to perform. It is modeled after the behaviour of {@link
          * https://w3c.github.io/webdriver/#actions|WebDriver Actions Command}
          *
@@ -184,8 +184,8 @@
          * @returns {Promise} fufiled after the actions are performed, or rejected in
          *                    the cases the WebDriver command errors
          */
-        pointer_action_sequence(actions) {
-            return window.test_driver_internal.pointer_action_sequence(actions);
+        action_sequence(actions) {
+            return window.test_driver_internal.action_sequence(actions);
         }
     };
 
@@ -228,7 +228,7 @@
          * @returns {Promise} fufilled after actions are sent, rejected if any actions
          *                    fail
          */
-        pointer_action_sequence: function(actions) {
+        action_sequence: function(actions) {
             return Promise.reject(new Error("unimplemented"));
         }
     };

--- a/resources/testdriver.js
+++ b/resources/testdriver.js
@@ -170,6 +170,22 @@
          */
         freeze: function() {
             return window.test_driver_internal.freeze();
+        },
+
+        /**
+         * Send a sequence of pointer actions
+         *
+         * This function sends a sequence of pointer actions to the top level window
+         * to perform. It is modeled after the behaviour of {@link
+         * https://w3c.github.io/webdriver/#actions|WebDriver Actions Command}
+         *
+         * @param {Array} actions - an array of action objects to perform as
+         *                          described in docs
+         * @returns {Promise} fufiled after the actions are performed, or rejected in
+         *                    the cases the WebDriver command errors
+         */
+        pointer_action_sequence() {
+            return window.test_driver_internal.pointer_action_sequence();
         }
     };
 
@@ -203,6 +219,16 @@
          * it gets rejected
          */
         freeze: function() {
+            return Promise.reject(new Error("unimplemented"));
+        },
+
+        /**
+         * Send a sequence of pointer actions
+         *
+         * @returns {Promise} fufilled after actions are sent, rejected if any actions
+         *                    fail
+         */
+        pointer_action_sequence: function(actions) {
             return Promise.reject(new Error("unimplemented"));
         }
     };

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -509,7 +509,7 @@ class CallbackHandler(object):
         self.actions = {
             "click": ClickAction(self.logger, self.protocol),
             "send_keys": SendKeysAction(self.logger, self.protocol),
-            "pointer_action_sequence": PointerActionSequenceAction(self.logger, self.protocol)
+            "action_sequence": ActionSequenceAction(self.logger, self.protocol)
         }
 
     def __call__(self, result):
@@ -586,7 +586,7 @@ class SendKeysAction(object):
         self.protocol.send_keys.send_keys(elements[0], keys)
 
 
-class PointerActionSequenceAction(object):
+class ActionSequenceAction(object):
     def __init__(self, logger, protocol):
         self.logger = logger
         self.protocol = protocol
@@ -597,5 +597,5 @@ class PointerActionSequenceAction(object):
         actions = payload["actions"]
         self.logger.debug(actions)
         self.logger.debug(payload["action"])
-        self.logger.debug("Sending pointer action sequence to window")
-        self.protocol.pointer_action_sequence.pointer_action_sequence(actions)
+        self.logger.debug("Sending action sequence to window")
+        self.protocol.action_sequence.action_sequence(actions)

--- a/tools/wptrunner/wptrunner/executors/base.py
+++ b/tools/wptrunner/wptrunner/executors/base.py
@@ -508,7 +508,8 @@ class CallbackHandler(object):
 
         self.actions = {
             "click": ClickAction(self.logger, self.protocol),
-            "send_keys": SendKeysAction(self.logger, self.protocol)
+            "send_keys": SendKeysAction(self.logger, self.protocol),
+            "pointer_action_sequence": PointerActionSequenceAction(self.logger, self.protocol)
         }
 
     def __call__(self, result):
@@ -583,3 +584,18 @@ class SendKeysAction(object):
             raise ValueError("Selector matches multiple elements")
         self.logger.debug("Sending keys to element: %s" % selector)
         self.protocol.send_keys.send_keys(elements[0], keys)
+
+
+class PointerActionSequenceAction(object):
+    def __init__(self, logger, protocol):
+        self.logger = logger
+        self.protocol = protocol
+
+    def __call__(self, payload):
+        # TODO: some sort of shallow error checking
+
+        actions = payload["actions"]
+        self.logger.debug(actions)
+        self.logger.debug(payload["action"])
+        self.logger.debug("Sending pointer action sequence to window")
+        self.protocol.pointer_action_sequence.pointer_action_sequence(actions)

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -273,6 +273,19 @@ class SendKeysProtocolPart(ProtocolPart):
         :param keys: A protocol-specific handle to a string of input keys."""
         pass
 
+class PointerActionSequenceProtocolPart(ProtocolPart):
+    """Protocol part for performing trusted clicks"""
+    __metaclass__ = ABCMeta
+
+    name = "pointer_action_sequence"
+
+    @abstractmethod
+    def pointer_action_sequence(self, actions):
+        """Send a sequence of pointer actions to the window.
+
+        :param actions: A protocol-specific handle to an array of actions."""
+        pass
+
 
 class TestDriverProtocolPart(ProtocolPart):
     """Protocol part that implements the basic functionality required for

--- a/tools/wptrunner/wptrunner/executors/protocol.py
+++ b/tools/wptrunner/wptrunner/executors/protocol.py
@@ -273,15 +273,15 @@ class SendKeysProtocolPart(ProtocolPart):
         :param keys: A protocol-specific handle to a string of input keys."""
         pass
 
-class PointerActionSequenceProtocolPart(ProtocolPart):
+class ActionSequenceProtocolPart(ProtocolPart):
     """Protocol part for performing trusted clicks"""
     __metaclass__ = ABCMeta
 
-    name = "pointer_action_sequence"
+    name = "action_sequence"
 
     @abstractmethod
-    def pointer_action_sequence(self, actions):
-        """Send a sequence of pointer actions to the window.
+    def action_sequence(self, actions):
+        """Send a sequence of actions to the window.
 
         :param actions: A protocol-specific handle to an array of actions."""
         pass

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -70,4 +70,13 @@
         window.opener.postMessage({"type": "action", "action": "send_keys", "selector": selector, "keys": keys}, "*");
         return pending_promise;
     };
+
+    window.test_driver_internal.pointer_action_sequence = function(actions) {
+        const pending_promise = new Promise(function(resolve, reject) {
+            pending_resolve = resolve;
+            pending_reject = reject;
+        });
+        window.opener.postMessage({"type": "action", "action": "pointer_action_sequence", "actions": actions}, "*");
+        return pending_promise;
+    };
 })();

--- a/tools/wptrunner/wptrunner/testdriver-extra.js
+++ b/tools/wptrunner/wptrunner/testdriver-extra.js
@@ -76,7 +76,7 @@
             pending_resolve = resolve;
             pending_reject = reject;
         });
-        window.opener.postMessage({"type": "action", "action": "pointer_action_sequence", "actions": actions}, "*");
+        window.opener.postMessage({"type": "action", "action": "action_sequence", "actions": actions}, "*");
         return pending_promise;
     };
 })();


### PR DESCRIPTION
This PR adds a `pointer_action_sequence` method to testdriver aimed to automate pointerevent tests and more. It contains the basic non-protocol specific code and allows for vendors to add their own routines in their own tests. It does **not** contain protocol specific implementations. This will be in a follow up CL.

Please check the docs and function parameters of the API surface. I think a lot of the checking and logic should be left to the protocol specific executors.

cc/ @NavidZ 