### PR TITLE
Update the appmanifest IDL file + test

### DIFF
--- a/appmanifest/idlharness.window.js
+++ b/appmanifest/idlharness.window.js
@@ -5,18 +5,14 @@
 
 'use strict';
 
-promise_test(async () => {
-  const srcs = ['appmanifest', 'dom', 'html'];
-  const [idl, dom, html] = await Promise.all(
-    srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_objects({
-    Window: ['window'],
-    BeforeInstallPromptEvent: ['new BeforeInstallPromptEvent("type")'],
-  });
-  idl_array.test();
-}, 'appmanifest interfaces');
+idl_test(
+  ['appmanifest'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      Window: ['window'],
+      BeforeInstallPromptEvent: ['new BeforeInstallPromptEvent("type")'],
+    });
+  },
+  'appmanifest interfaces'
+);

--- a/interfaces/appmanifest.idl
+++ b/interfaces/appmanifest.idl
@@ -7,7 +7,8 @@ enum AppBannerPromptOutcome {
   "accepted",
   "dismissed"
 };
-[Constructor, Exposed=Window]
+[Constructor(DOMString type, optional EventInit eventInitDict),
+ Exposed=Window]
 interface BeforeInstallPromptEvent : Event {
     Promise<PromptResponseObject> prompt();
 };


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
