### PR TITLE
Update the FileAPI IDL tests

### DIFF
--- a/FileAPI/idlharness.html
+++ b/FileAPI/idlharness.html
@@ -22,28 +22,22 @@
     <script>
       'use strict';
 
-      promise_test(async () => {
-        const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
-        const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
-        const html = await fetch('/interfaces/html.idl').then(r => r.text());
-        const url = await fetch('/interfaces/url.idl').then(r => r.text());
-
-        const idl_array = new IdlArray();
-        idl_array.add_idls(idl);
-        idl_array.add_dependency_idls(url);
-        idl_array.add_dependency_idls(html);
-        idl_array.add_dependency_idls(dom);
-        idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
-
-        idl_array.add_objects({
-          Blob: ['new Blob(["TEST"])'],
-          File: ['new File(["myFileBits"], "myFileName")'],
-          FileList: ['document.querySelector("#fileChooser").files'],
-          FileReader: ['new FileReader()']
-        });
-
-        idl_array.test();
-      }, 'Test FileAPI IDL implementation');
+      idl_test(
+        ['FileAPI'],
+        ['dom', 'html', 'url'],
+        idl_array => {
+          idl_array.add_untested_idls(
+            "[Exposed=(Window,Worker)] interface ArrayBuffer {};"
+          );
+          idl_array.add_objects({
+            Blob: ['new Blob(["TEST"])'],
+            File: ['new File(["myFileBits"], "myFileName")'],
+            FileList: ['document.querySelector("#fileChooser").files'],
+            FileReader: ['new FileReader()']
+          });
+        },
+        'Test FileAPI IDL implementation'
+      );
     </script>
 
   </body>

--- a/FileAPI/idlharness.worker.js
+++ b/FileAPI/idlharness.worker.js
@@ -1,25 +1,22 @@
 importScripts("/resources/testharness.js");
 importScripts("/resources/WebIDLParser.js", "/resources/idlharness.js");
 
-promise_test(async () => {
-  const idl = await fetch('/interfaces/FileAPI.idl').then(r => r.text());
-  const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
-  const html = await fetch('/interfaces/html.idl').then(r => r.text());
-  const url = await fetch('/interfaces/url.idl').then(r => r.text());
+'use strict';
 
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_dependency_idls(url);
-  idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
-  idl_array.add_objects({
-    Blob: ['new Blob(["TEST"])'],
-    File: ['new File(["myFileBits"], "myFileName")'],
-    FileReader: ['new FileReader()'],
-    FileReaderSync: ['new FileReaderSync()']
-  });
+// https://w3c.github.io/FileAPI/
 
-  idl_array.test();
-}, 'Test FileAPI IDL implementation');
+idl_test(
+  ['FileAPI'],
+  ['dom', 'html', 'url'],
+  idl_array => {
+    idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ArrayBuffer {};");
+    idl_array.add_objects({
+      Blob: ['new Blob(["TEST"])'],
+      File: ['new File(["myFileBits"], "myFileName")'],
+      FileReader: ['new FileReader()'],
+      FileReaderSync: ['new FileReaderSync()']
+    });
+  },
+  'Test FileAPI IDL implementation'
+);
 done();


### PR DESCRIPTION
Context: having some timeout problems.
https://bugs.chromium.org/p/chromium/issues/detail?id=856601

`idl_test` helper executes the fetches of the IDL files in parallel, so we should at least not be hanging around waiting for each request. Not convinced this will be enough, but it's cleaner none-the-less.