### PR TITLE
Update the cors-rfc1918 IDL test

### DIFF
--- a/fetch/cors-rfc1918/idlharness.tentative.any.js
+++ b/fetch/cors-rfc1918/idlharness.tentative.any.js
@@ -1,20 +1,24 @@
+// META: global=window,worker
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 
-promise_test(async () => {
-  const idl = await fetch('/interfaces/cors-rfc1918.idl').then(r => r.text());
-  const html = await fetch('/interfaces/html.idl').then(r => r.text());
-  const dom = await fetch('/interfaces/dom.idl').then(r => r.text());
+'use strict';
 
-  const idlArray = new IdlArray();
-  idlArray.add_idls(idl);
-  idlArray.add_dependency_idls(html);
-  idlArray.add_dependency_idls(dom);
+// https://wicg.github.io/cors-rfc1918/
 
-  const objects = {
-    Document: ['document'],
-    WorkerGlobalScope: ['self'],
-  };
-  idlArray.add_objects(objects);
-  idlArray.test();
-}, 'Test CORS RFC1918 interfaces');
+idl_test(
+  ['cors-rfc1918'],
+  ['html', 'dom'],
+  idlArray => {
+    if (self.GLOBAL.isWorker()) {
+      idlArray.add_objects({
+        WorkerGlobalScope: ['self'],
+      });
+    } else {
+      idlArray.add_objects({
+        Document: ['document'],
+      });
+    }
+  },
+  'Test CORS RFC1918 interfaces'
+);


### PR DESCRIPTION
Use the `idl_test` helper, which parallelizes the fetches, and 

    // META: global=window,worker

which tests all workers (not just dedicatedworker, the default behaviour).