### PR TITLE
Add a test for the absence of XMLDocument.prototype.load

### DIFF
--- a/dom/historical.html
+++ b/dom/historical.html
@@ -67,6 +67,12 @@ test(function() {
 }, "document.load");
 
 test(function() {
+  // https://github.com/whatwg/html/commit/523f7a8773d2ab8a1eb0da6510651e8c5d2a7531
+  var doc = document.implementation.createDocument(null, null, null);
+  assert_false("load" in doc);
+}, "XMLDocument.load");
+
+test(function() {
   assert_equals(document.implementation["getFeature"], undefined)
 }, "DOMImplementation.getFeature() must be nuked.")
 


### PR DESCRIPTION
Fix #3519, @Ms2ger, PTAL.

The test for the absence of Document.load is already existing ([link](https://github.com/web-platform-tests/wpt/blob/master/dom/historical.html#L64)).