### PR TITLE
Include subset-tests.js correctly in encoding tests

### DIFF
--- a/encoding/legacy-mb-korean/euc-kr/euckr-decode-ksc_5601.html
+++ b/encoding/legacy-mb-korean/euc-kr/euckr-decode-ksc_5601.html
@@ -6,6 +6,7 @@
 <meta name="timeout" content="long">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/subset-tests.js"></script>
 <link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
 <link rel="help" href="https://encoding.spec.whatwg.org/#names-and-labels">
 <meta name="assert" content="The browser produces the same decoding behavior for a document labeled 'ksc_5601' as for a document labeled 'euc-kr'.">


### PR DESCRIPTION
Add missing subset-tests.js to fix
"Uncaught ReferenceError: subsetTest is not defined."
https://wpt.fyi/results/encoding/legacy-mb-korean/euc-kr/euckr-decode-ksc_5601.html

Fixed #11531