### PR TITLE
Convert config to a builder pattern

### DIFF
--- a/tools/ci/ci_wpt.sh
+++ b/tools/ci/ci_wpt.sh
@@ -8,7 +8,7 @@ cd $WPT_ROOT
 source tools/ci/lib.sh
 
 main() {
-    git fetch --unshallow https://github.com/web-platform-tests/wpt.git +refs/heads/*:refs/remotes/origin/*
+    git fetch --quiet --unshallow https://github.com/web-platform-tests/wpt.git +refs/heads/*:refs/remotes/origin/*
     hosts_fixup
     install_chrome unstable
     pip install -U tox codecov

--- a/tools/ci/make_hosts_file.py
+++ b/tools/ci/make_hosts_file.py
@@ -3,14 +3,19 @@ import os
 
 from ..localpaths import repo_root
 
-from ..serve.serve import load_config, make_hosts_file
+from ..serve.serve import build_config, make_hosts_file
+
 
 def create_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument("address", default="127.0.0.1", nargs="?", help="Address that hosts should point at")
+    parser.add_argument("address", default="127.0.0.1", nargs="?",
+                        help="Address that hosts should point at")
     return parser
 
-def run(**kwargs):
-    config = load_config(os.path.join(repo_root, "config.json"))
 
-    print(make_hosts_file(config, kwargs["address"]))
+def run(**kwargs):
+    config_builder = build_config(os.path.join(repo_root, "config.json"),
+                                  ssl={"type": "none"})
+
+    with config_builder as config:
+        print(make_hosts_file(config, kwargs["address"]))

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -430,7 +430,6 @@ class ServerProc(object):
 def check_subdomains(config):
     paths = config.paths
     bind_address = config.bind_address
-    ssl_config = config.ssl_config
     aliases = config.aliases
 
     host = config.server_host
@@ -656,8 +655,8 @@ def iter_procs(servers):
             yield server.proc
 
 
-def load_config(override_path=None, **kwargs):
-    rv = Config()
+def build_config(override_path=None, **kwargs):
+    rv = ConfigBuilder()
 
     if override_path and os.path.exists(override_path):
         with open(override_path) as f:
@@ -695,10 +694,10 @@ _subdomains = {u"www",
 _not_subdomains = {u"nonexistent"}
 
 
-class Config(config.Config):
+class ConfigBuilder(config.ConfigBuilder):
     """serve config
 
-    this subclasses wptserve.config.Config to add serve config options"""
+    this subclasses wptserve.config.ConfigBuilder to add serve config options"""
 
     _default = {
         "browser_host": "web-platform.test",
@@ -735,29 +734,30 @@ class Config(config.Config):
         "aliases": []
     }
 
+    computed_properties = ["ws_doc_root"] + config.ConfigBuilder.computed_properties
+
     def __init__(self, *args, **kwargs):
-        super(Config, self).__init__(
+        super(ConfigBuilder, self).__init__(
             subdomains=_subdomains,
             not_subdomains=_not_subdomains,
             *args,
             **kwargs
         )
 
-    @property
-    def ws_doc_root(self):
-        if self._ws_doc_root is not None:
-            return self._ws_doc_root
+    def _get_ws_doc_root(self, data):
+        if data["ws_doc_root"] is not None:
+            return data["ws_doc_root"]
         else:
-            return os.path.join(self.doc_root, "websockets", "handlers")
+            return os.path.join(data["doc_root"], "websockets", "handlers")
 
-    @ws_doc_root.setter
     def ws_doc_root(self, v):
         self._ws_doc_root = v
 
-    @property
-    def paths(self):
-        rv = super(Config, self).paths
-        rv["ws_doc_root"] = self.ws_doc_root
+    ws_doc_root = property(None, ws_doc_root)
+
+    def _get_paths(self, data):
+        rv = super(ConfigBuilder, self)._get_paths(data)
+        rv["ws_doc_root"] = data["ws_doc_root"]
         return rv
 
 
@@ -775,32 +775,31 @@ def get_parser():
 
 
 def run(**kwargs):
-    config = load_config(os.path.join(repo_root, "config.json"),
-                         **kwargs)
+    with build_config(os.path.join(repo_root, "config.json"),
+                      **kwargs) as config:
+        global logger
+        logger = config.logger
+        set_logger(logger)
 
-    global logger
-    logger = config.logger
-    set_logger(logger)
+        bind_address = config["bind_address"]
 
-    bind_address = config["bind_address"]
+        if config["check_subdomains"]:
+            check_subdomains(config)
 
-    if config["check_subdomains"]:
-        check_subdomains(config)
+        stash_address = None
+        if bind_address:
+            stash_address = (config.server_host, get_port(""))
+            logger.debug("Going to use port %d for stash" % stash_address[1])
 
-    stash_address = None
-    if bind_address:
-        stash_address = (config.server_host, get_port())
-        logger.debug("Going to use port %d for stash" % stash_address[1])
+        with stash.StashServer(stash_address, authkey=str(uuid.uuid4())):
+            servers = start(config, config.ssl_config, build_routes(config["aliases"]), **kwargs)
 
-    with stash.StashServer(stash_address, authkey=str(uuid.uuid4())):
-        servers = start(config, config.ssl_env, build_routes(config["aliases"]), **kwargs)
-
-        try:
-            while any(item.is_alive() for item in iter_procs(servers)):
-                for item in iter_procs(servers):
-                    item.join(1)
-        except KeyboardInterrupt:
-            logger.info("Shutting down")
+            try:
+                while any(item.is_alive() for item in iter_procs(servers)):
+                    for item in iter_procs(servers):
+                        item.join(1)
+            except KeyboardInterrupt:
+                logger.info("Shutting down")
 
 
 def main():

--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -382,20 +382,18 @@ class ServerProc(object):
         self.daemon = None
         self.stop = Event()
 
-    def start(self, init_func, host, port, paths, routes, bind_address, config,
-              ssl_config, **kwargs):
+    def start(self, init_func, host, port, paths, routes, bind_address, config, **kwargs):
         self.proc = Process(target=self.create_daemon,
                             args=(init_func, host, port, paths, routes, bind_address,
-                                  config, ssl_config),
+                                  config),
                             kwargs=kwargs)
         self.proc.daemon = True
         self.proc.start()
 
     def create_daemon(self, init_func, host, port, paths, routes, bind_address,
-                      config, ssl_config, **kwargs):
+                      config, **kwargs):
         try:
-            self.daemon = init_func(host, port, paths, routes, bind_address, config,
-                                    ssl_config, **kwargs)
+            self.daemon = init_func(host, port, paths, routes, bind_address, config, **kwargs)
         except socket.error:
             print("Socket error on port %s" % port, file=sys.stderr)
             raise
@@ -437,8 +435,8 @@ def check_subdomains(config):
     logger.debug("Going to use port %d to check subdomains" % port)
 
     wrapper = ServerProc()
-    wrapper.start(start_http_server, host, port, paths, build_routes(aliases), bind_address,
-                  None, ssl_config)
+    wrapper.start(start_http_server, host, port, paths, build_routes(aliases),
+                  bind_address, config)
 
     connected = False
     for i in range(10):
@@ -488,8 +486,7 @@ def make_hosts_file(config, host):
     return "".join(rv)
 
 
-def start_servers(host, ports, paths, routes, bind_address, config, ssl_config,
-                  **kwargs):
+def start_servers(host, ports, paths, routes, bind_address, config, **kwargs):
     servers = defaultdict(list)
     for scheme, ports in ports.items():
         assert len(ports) == {"http":2}.get(scheme, 1)
@@ -504,14 +501,13 @@ def start_servers(host, ports, paths, routes, bind_address, config, ssl_config,
 
             server_proc = ServerProc()
             server_proc.start(init_func, host, port, paths, routes, bind_address,
-                              config, ssl_config, **kwargs)
+                              config, **kwargs)
             servers[scheme].append((port, server_proc))
 
     return servers
 
 
-def start_http_server(host, port, paths, routes, bind_address, config, ssl_config,
-                      **kwargs):
+def start_http_server(host, port, paths, routes, bind_address, config, **kwargs):
     return wptserve.WebTestHttpd(host=host,
                                  port=port,
                                  doc_root=paths["doc_root"],
@@ -525,8 +521,7 @@ def start_http_server(host, port, paths, routes, bind_address, config, ssl_confi
                                  latency=kwargs.get("latency"))
 
 
-def start_https_server(host, port, paths, routes, bind_address, config, ssl_config,
-                       **kwargs):
+def start_https_server(host, port, paths, routes, bind_address, config, **kwargs):
     return wptserve.WebTestHttpd(host=host,
                                  port=port,
                                  doc_root=paths["doc_root"],
@@ -535,9 +530,9 @@ def start_https_server(host, port, paths, routes, bind_address, config, ssl_conf
                                  bind_address=bind_address,
                                  config=config,
                                  use_ssl=True,
-                                 key_file=ssl_config["key_path"],
-                                 certificate=ssl_config["cert_path"],
-                                 encrypt_after_connect=ssl_config["encrypt_after_connect"],
+                                 key_file=config.ssl_config["key_path"],
+                                 certificate=config.ssl_config["cert_path"],
+                                 encrypt_after_connect=config.ssl_config["encrypt_after_connect"],
                                  latency=kwargs.get("latency"))
 
 
@@ -606,45 +601,41 @@ class WebSocketDaemon(object):
         self.server = None
 
 
-def start_ws_server(host, port, paths, routes, bind_address, config, ssl_config,
-                    **kwargs):
+def start_ws_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we don't inherit the
     # global lock in the logging module
     reload_module(logging)
     return WebSocketDaemon(host,
                            str(port),
                            repo_root,
-                           paths["ws_doc_root"],
+                           config.paths["ws_doc_root"],
                            "debug",
                            bind_address,
                            ssl_config = None)
 
 
-def start_wss_server(host, port, paths, routes, bind_address, config, ssl_config,
-                     **kwargs):
+def start_wss_server(host, port, paths, routes, bind_address, config, **kwargs):
     # Ensure that when we start this in a new process we don't inherit the
     # global lock in the logging module
     reload_module(logging)
     return WebSocketDaemon(host,
                            str(port),
                            repo_root,
-                           paths["ws_doc_root"],
+                           config.paths["ws_doc_root"],
                            "debug",
                            bind_address,
-                           ssl_config)
+                           config.ssl_config)
 
 
-def start(config, ssl_environment, routes, **kwargs):
+def start(config, routes, **kwargs):
     host = config["server_host"]
     ports = config.ports
     paths = config.paths
     bind_address = config["bind_address"]
-    ssl_config = config.ssl_config
 
     logger.debug("Using ports: %r" % ports)
 
-    servers = start_servers(host, ports, paths, routes, bind_address, config,
-                            ssl_config, **kwargs)
+    servers = start_servers(host, ports, paths, routes, bind_address, config, **kwargs)
 
     return servers
 
@@ -792,7 +783,7 @@ def run(**kwargs):
             logger.debug("Going to use port %d for stash" % stash_address[1])
 
         with stash.StashServer(stash_address, authkey=str(uuid.uuid4())):
-            servers = start(config, config.ssl_config, build_routes(config["aliases"]), **kwargs)
+            servers = start(config, build_routes(config["aliases"]), **kwargs)
 
             try:
                 while any(item.is_alive() for item in iter_procs(servers)):

--- a/tools/serve/test_serve.py
+++ b/tools/serve/test_serve.py
@@ -6,74 +6,78 @@ import pytest
 
 import localpaths
 from . import serve
-from .serve import Config
+from .serve import ConfigBuilder
 
 
 @pytest.mark.skipif(platform.uname()[0] == "Windows",
                     reason="Expected contents are platform-dependent")
 def test_make_hosts_file_nix():
-    c = Config(browser_host="foo.bar", alternate_hosts={"alt": "foo2.bar"})
-    hosts = serve.make_hosts_file(c, "192.168.42.42")
-    lines = hosts.split("\n")
-    assert set(lines) == {"",
-                          "192.168.42.42\tfoo.bar",
-                          "192.168.42.42\tfoo2.bar",
-                          "192.168.42.42\twww.foo.bar",
-                          "192.168.42.42\twww.foo2.bar",
-                          "192.168.42.42\twww1.foo.bar",
-                          "192.168.42.42\twww1.foo2.bar",
-                          "192.168.42.42\twww2.foo.bar",
-                          "192.168.42.42\twww2.foo2.bar",
-                          "192.168.42.42\txn--lve-6lad.foo.bar",
-                          "192.168.42.42\txn--lve-6lad.foo2.bar",
-                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo.bar",
-                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo2.bar"}
-    assert lines[-1] == ""
+    with ConfigBuilder(ports={"http": [8000]},
+                       browser_host="foo.bar",
+                       alternate_hosts={"alt": "foo2.bar"}) as c:
+        hosts = serve.make_hosts_file(c, "192.168.42.42")
+        lines = hosts.split("\n")
+        assert set(lines) == {"",
+                              "192.168.42.42\tfoo.bar",
+                              "192.168.42.42\tfoo2.bar",
+                              "192.168.42.42\twww.foo.bar",
+                              "192.168.42.42\twww.foo2.bar",
+                              "192.168.42.42\twww1.foo.bar",
+                              "192.168.42.42\twww1.foo2.bar",
+                              "192.168.42.42\twww2.foo.bar",
+                              "192.168.42.42\twww2.foo2.bar",
+                              "192.168.42.42\txn--lve-6lad.foo.bar",
+                              "192.168.42.42\txn--lve-6lad.foo2.bar",
+                              "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo.bar",
+                              "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo2.bar"}
+        assert lines[-1] == ""
 
 @pytest.mark.skipif(platform.uname()[0] != "Windows",
                     reason="Expected contents are platform-dependent")
 def test_make_hosts_file_windows():
-    c = Config(browser_host="foo.bar", alternate_hosts={"alt": "foo2.bar"})
-    hosts = serve.make_hosts_file(c, "192.168.42.42")
-    lines = hosts.split("\n")
-    assert set(lines) == {"",
-                          "0.0.0.0\tnonexistent.foo.bar",
-                          "0.0.0.0\tnonexistent.foo2.bar",
-                          "192.168.42.42\tfoo.bar",
-                          "192.168.42.42\tfoo2.bar",
-                          "192.168.42.42\twww.foo.bar",
-                          "192.168.42.42\twww.foo2.bar",
-                          "192.168.42.42\twww1.foo.bar",
-                          "192.168.42.42\twww1.foo2.bar",
-                          "192.168.42.42\twww2.foo.bar",
-                          "192.168.42.42\twww2.foo2.bar",
-                          "192.168.42.42\txn--lve-6lad.foo.bar",
-                          "192.168.42.42\txn--lve-6lad.foo2.bar",
-                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo.bar",
-                          "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo2.bar"}
-    assert lines[-1] == ""
+    with ConfigBuilder(ports={"http": [8000]},
+                       browser_host="foo.bar",
+                       alternate_hosts={"alt": "foo2.bar"}) as c:
+        hosts = serve.make_hosts_file(c, "192.168.42.42")
+        lines = hosts.split("\n")
+        assert set(lines) == {"",
+                              "0.0.0.0\tnonexistent.foo.bar",
+                              "0.0.0.0\tnonexistent.foo2.bar",
+                              "192.168.42.42\tfoo.bar",
+                              "192.168.42.42\tfoo2.bar",
+                              "192.168.42.42\twww.foo.bar",
+                              "192.168.42.42\twww.foo2.bar",
+                              "192.168.42.42\twww1.foo.bar",
+                              "192.168.42.42\twww1.foo2.bar",
+                              "192.168.42.42\twww2.foo.bar",
+                              "192.168.42.42\twww2.foo2.bar",
+                              "192.168.42.42\txn--lve-6lad.foo.bar",
+                              "192.168.42.42\txn--lve-6lad.foo2.bar",
+                              "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo.bar",
+                              "192.168.42.42\txn--n8j6ds53lwwkrqhv28a.foo2.bar"}
+        assert lines[-1] == ""
 
 
 def test_ws_doc_root_default():
-    c = Config()
-    assert c.ws_doc_root == os.path.join(localpaths.repo_root, "websockets", "handlers")
+    with ConfigBuilder() as c:
+        assert c.ws_doc_root == os.path.join(localpaths.repo_root, "websockets", "handlers")
 
 
 def test_init_ws_doc_root():
-    c = Config(ws_doc_root="/")
-    assert c.doc_root == localpaths.repo_root  # check this hasn't changed
-    assert c._ws_doc_root == "/"
-    assert c.ws_doc_root == "/"
+    with ConfigBuilder(ws_doc_root="/") as c:
+        assert c.doc_root == localpaths.repo_root  # check this hasn't changed
+        assert c.ws_doc_root == "/"
 
 
 def test_set_ws_doc_root():
-    c = Config()
-    c.ws_doc_root = "/"
-    assert c.doc_root == localpaths.repo_root  # check this hasn't changed
-    assert c._ws_doc_root == "/"
-    assert c.ws_doc_root == "/"
+    cb = ConfigBuilder()
+    cb.ws_doc_root = "/"
+    with cb as c:
+        assert c.doc_root == localpaths.repo_root  # check this hasn't changed
+        assert c.ws_doc_root == "/"
 
 
 def test_pickle():
     # Ensure that the config object can be pickled
-    pickle.dumps(Config())
+    with ConfigBuilder() as c:
+        pickle.dumps(c)

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -93,7 +93,7 @@ def check_environ(product):
     if product not in ("firefox", "servo"):
         config_builder = serve.build_config(os.path.join(wpt_root, "config.json"))
         # Ovveride the ports to avoid looking for free ports
-        config_builder.ssl["type"] = "none"
+        config_builder.ssl = {"type": "none"}
         config_builder.ports = {"http": [8000]}
 
         is_windows = platform.uname()[0] == "Windows"

--- a/tools/wpt/run.py
+++ b/tools/wpt/run.py
@@ -91,12 +91,17 @@ otherwise install OpenSSL and ensure that it's on your $PATH.""")
 
 def check_environ(product):
     if product not in ("firefox", "servo"):
-        config = serve.load_config(os.path.join(wpt_root, "config.json"))
-        expected_hosts = set(config.domains_set)
+        config_builder = serve.build_config(os.path.join(wpt_root, "config.json"))
+        # Ovveride the ports to avoid looking for free ports
+        config_builder.ssl["type"] = "none"
+        config_builder.ports = {"http": [8000]}
+
         is_windows = platform.uname()[0] == "Windows"
 
-        if is_windows:
-            expected_hosts.update(config.not_domains_set)
+        with config_builder as config:
+            expected_hosts = set(config.domains_set)
+            if is_windows:
+                expected_hosts.update(config.not_domains_set)
 
         missing_hosts = set(expected_hosts)
         if is_windows:

--- a/tools/wptrunner/wptrunner/browsers/chrome.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome.py
@@ -22,7 +22,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}

--- a/tools/wptrunner/wptrunner/browsers/chrome_android.py
+++ b/tools/wptrunner/wptrunner/browsers/chrome_android.py
@@ -26,7 +26,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}

--- a/tools/wptrunner/wptrunner/browsers/edge.py
+++ b/tools/wptrunner/wptrunner/browsers/edge.py
@@ -26,7 +26,7 @@ def get_timeout_multiplier(test_type, run_info_data, **kwargs):
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args"),
             "timeout_multiplier": get_timeout_multiplier(test_type,

--- a/tools/wptrunner/wptrunner/browsers/fennec.py
+++ b/tools/wptrunner/wptrunner/browsers/fennec.py
@@ -83,7 +83,7 @@ class FennecProfile(FirefoxProfile):
 def check_args(**kwargs):
     pass
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"package_name": kwargs["package_name"],
             "device_serial": kwargs["device_serial"],
             "prefs_root": kwargs["prefs_root"],
@@ -102,7 +102,7 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
             "leak_check": kwargs["leak_check"],
             "stylo_threads": kwargs["stylo_threads"],
             "chaos_mode_flags": kwargs["chaos_mode_flags"],
-            "config": kwargs["config"]}
+            "config": config}
 
 
 def env_extras(**kwargs):

--- a/tools/wptrunner/wptrunner/browsers/firefox.py
+++ b/tools/wptrunner/wptrunner/browsers/firefox.py
@@ -63,7 +63,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "prefs_root": kwargs["prefs_root"],
             "extra_prefs": kwargs["extra_prefs"],
@@ -72,7 +72,7 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
             "symbols_path": kwargs["symbols_path"],
             "stackwalk_binary": kwargs["stackwalk_binary"],
             "certutil_binary": kwargs["certutil_binary"],
-            "ca_certificate_path": kwargs["ssl_env"].ca_cert_path(),
+            "ca_certificate_path": config.ssl_config["ca_cert_path"],
             "e10s": kwargs["gecko_e10s"],
             "stackfix_dir": kwargs["stackfix_dir"],
             "binary_args": kwargs["binary_args"],
@@ -82,7 +82,7 @@ def browser_kwargs(test_type, run_info_data, **kwargs):
             "leak_check": kwargs["leak_check"],
             "stylo_threads": kwargs["stylo_threads"],
             "chaos_mode_flags": kwargs["chaos_mode_flags"],
-            "config": kwargs["config"]}
+            "config": config}
 
 
 def executor_kwargs(test_type, server_config, cache_manager, run_info_data,

--- a/tools/wptrunner/wptrunner/browsers/ie.py
+++ b/tools/wptrunner/wptrunner/browsers/ie.py
@@ -20,7 +20,7 @@ __wptrunner__ = {"product": "ie",
 def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}
 

--- a/tools/wptrunner/wptrunner/browsers/opera.py
+++ b/tools/wptrunner/wptrunner/browsers/opera.py
@@ -22,7 +22,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}

--- a/tools/wptrunner/wptrunner/browsers/safari.py
+++ b/tools/wptrunner/wptrunner/browsers/safari.py
@@ -22,7 +22,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "webdriver_binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}
 

--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -95,7 +95,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "sauce_key")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     sauce_config = get_sauce_config(**kwargs)
 
     return {"sauce_config": sauce_config}

--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -27,7 +27,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],

--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -34,7 +34,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],

--- a/tools/wptrunner/wptrunner/browsers/webkit.py
+++ b/tools/wptrunner/wptrunner/browsers/webkit.py
@@ -24,7 +24,7 @@ def check_args(**kwargs):
     require_arg(kwargs, "webkit_port")
 
 
-def browser_kwargs(test_type, run_info_data, **kwargs):
+def browser_kwargs(test_type, run_info_data, config, **kwargs):
     return {"binary": kwargs["binary"],
             "webdriver_binary": kwargs["webdriver_binary"],
             "webdriver_args": kwargs.get("webdriver_args")}

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -41,34 +41,17 @@ def serve_path(test_paths):
     return test_paths["/"]["tests_path"]
 
 
-def get_ssl_kwargs(**kwargs):
-    if kwargs["ssl_type"] == "openssl":
-        args = {"openssl_binary": kwargs["openssl_binary"]}
-    elif kwargs["ssl_type"] == "pregenerated":
-        args = {"host_key_path": kwargs["host_key_path"],
-                "host_cert_path": kwargs["host_cert_path"],
-                "ca_cert_path": kwargs["ca_cert_path"]}
-    else:
-        args = {}
-    return args
-
-
-def ssl_env(logger, **kwargs):
-    ssl_env_cls = sslutils.environments[kwargs["ssl_type"]]
-    return ssl_env_cls(logger, **get_ssl_kwargs(**kwargs))
-
-
 class TestEnvironmentError(Exception):
     pass
 
 
 class TestEnvironment(object):
-    def __init__(self, test_paths, ssl_env, pause_after_test, debug_info, options, env_extras):
+    def __init__(self, test_paths, pause_after_test, debug_info, options, ssl_config, env_extras):
         """Context manager that owns the test environment i.e. the http and
         websockets servers"""
         self.test_paths = test_paths
-        self.ssl_env = ssl_env
         self.server = None
+        self.config_ctx = None
         self.config = None
         self.pause_after_test = pause_after_test
         self.test_server_port = options.pop("test_server_port", True)
@@ -79,14 +62,16 @@ class TestEnvironment(object):
         self.stash = serve.stash.StashServer()
         self.env_extras = env_extras
         self.env_extras_cms = None
-
+        self.ssl_config = ssl_config
 
     def __enter__(self):
+        self.config_ctx = self.build_config()
+
+        self.config = self.config_ctx.__enter__()
+
         self.stash.__enter__()
-        self.ssl_env.__enter__()
         self.cache_manager.__enter__()
 
-        self.config = self.load_config()
         self.setup_server_logging()
 
         assert self.env_extras_cms is None, (
@@ -100,7 +85,6 @@ class TestEnvironment(object):
             self.env_extras_cms.append(cm)
 
         self.servers = serve.start(self.config,
-                                   self.ssl_env,
                                    self.get_routes())
         if self.options.get("supports_debugger") and self.debug_info and self.debug_info.interactive:
             self.ignore_interrupts()
@@ -118,8 +102,8 @@ class TestEnvironment(object):
         self.env_extras_cms = None
 
         self.cache_manager.__exit__(exc_type, exc_val, exc_tb)
-        self.ssl_env.__exit__(exc_type, exc_val, exc_tb)
         self.stash.__exit__()
+        self.config_ctx.__exit__(exc_type, exc_val, exc_tb)
 
     def ignore_interrupts(self):
         signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -127,10 +111,10 @@ class TestEnvironment(object):
     def process_interrupts(self):
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    def load_config(self):
+    def build_config(self):
         override_path = os.path.join(serve_path(self.test_paths), "config.json")
 
-        config = serve.Config(override_ssl_env=self.ssl_env)
+        config = serve.ConfigBuilder()
 
         config.ports = {
             "http": [8000, 8001],
@@ -145,7 +129,10 @@ class TestEnvironment(object):
             config.update(override_obj)
 
         config.check_subdomains = False
-        config.ssl = {}
+
+        ssl_config = self.ssl_config.copy()
+        ssl_config["encrypt_after_connect"] = self.options.get("encrypt_after_connect", False)
+        config.ssl = ssl_config
 
         if "browser_host" in self.options:
             config.browser_host = self.options["browser_host"]
@@ -154,7 +141,6 @@ class TestEnvironment(object):
             config.bind_address = self.options["bind_address"]
 
         config.server_host = self.options.get("server_host", None)
-        config.ssl["encrypt_after_connect"] = self.options.get("encrypt_after_connect", False)
         config.doc_root = serve_path(self.test_paths)
 
         return config

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -10,7 +10,6 @@ from mozlog import get_default_logger, handlers, proxy
 
 from wptlogging import LogLevelRewriter
 from wptserve.handlers import StringHandler
-from wptserve import sslutils
 
 here = os.path.split(__file__)[0]
 repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir, os.pardir))
@@ -19,7 +18,7 @@ serve = None
 
 
 def do_delayed_imports(logger, test_paths):
-    global serve, sslutils
+    global serve
 
     serve_root = serve_path(test_paths)
     sys.path.insert(0, serve_root)

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -49,7 +49,7 @@ def test_server_start_config(product):
                                          False,
                                          None,
                                          env_options,
-                                         {},
+                                         {"type": "none"},
                                          env_extras):
             start.assert_called_once()
             args = start.call_args

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -9,7 +9,6 @@ from .base import all_products, active_products
 
 sys.path.insert(0, join(dirname(__file__), "..", "..", "..", ".."))  # repo root
 from tools import localpaths  # noqa: flake8
-from wptserve import sslutils
 
 from wptrunner import environment
 from wptrunner import products
@@ -47,10 +46,10 @@ def test_server_start_config(product):
 
     with mock.patch.object(environment.serve, "start") as start:
         with environment.TestEnvironment(test_paths,
-                                         sslutils.environments["none"](None),
                                          False,
                                          None,
                                          env_options,
+                                         {},
                                          env_extras):
             start.assert_called_once()
             args = start.call_args

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -4,6 +4,8 @@ import json
 import os
 import sys
 
+from wptserve import sslutils
+
 import environment as env
 import products
 import testloader
@@ -39,7 +41,7 @@ def setup_logging(*args, **kwargs):
     logger = wptlogging.setup(*args, **kwargs)
 
 
-def get_loader(test_paths, product, ssl_env, debug=None, run_info_extras=None, **kwargs):
+def get_loader(test_paths, product, debug=None, run_info_extras=None, **kwargs):
     if run_info_extras is None:
         run_info_extras = {}
 
@@ -62,6 +64,7 @@ def get_loader(test_paths, product, ssl_env, debug=None, run_info_extras=None, *
     if kwargs["tags"]:
         meta_filters.append(testloader.TagFilter(tags=kwargs["tags"]))
 
+    ssl_enabled = sslutils.get_cls(kwargs["ssl_type"]).ssl_enabled
     test_loader = testloader.TestLoader(test_manifests,
                                         kwargs["test_types"],
                                         run_info,
@@ -70,7 +73,7 @@ def get_loader(test_paths, product, ssl_env, debug=None, run_info_extras=None, *
                                         chunk_type=kwargs["chunk_type"],
                                         total_chunks=kwargs["total_chunks"],
                                         chunk_number=kwargs["this_chunk"],
-                                        include_https=ssl_env.ssl_enabled,
+                                        include_https=ssl_enabled,
                                         skip_timeout=kwargs["skip_timeout"])
     return run_info, test_loader
 
@@ -78,11 +81,9 @@ def get_loader(test_paths, product, ssl_env, debug=None, run_info_extras=None, *
 def list_test_groups(test_paths, product, **kwargs):
     env.do_delayed_imports(logger, test_paths)
 
-    ssl_env = env.ssl_env(logger, **kwargs)
-
     run_info_extras = products.load_product(kwargs["config"], product)[-1](**kwargs)
 
-    run_info, test_loader = get_loader(test_paths, product, ssl_env,
+    run_info, test_loader = get_loader(test_paths, product,
                                        run_info_extras=run_info_extras, **kwargs)
 
     for item in sorted(test_loader.groups(kwargs["test_types"])):
@@ -96,9 +97,7 @@ def list_disabled(test_paths, product, **kwargs):
 
     run_info_extras = products.load_product(kwargs["config"], product)[-1](**kwargs)
 
-    ssl_env = env.ssl_env(logger, **kwargs)
-
-    run_info, test_loader = get_loader(test_paths, product, ssl_env,
+    run_info, test_loader = get_loader(test_paths, product,
                                        run_info_extras=run_info_extras, **kwargs)
 
     for test_type, tests in test_loader.disabled_tests.iteritems():
@@ -110,11 +109,9 @@ def list_disabled(test_paths, product, **kwargs):
 def list_tests(test_paths, product, **kwargs):
     env.do_delayed_imports(logger, test_paths)
 
-    ssl_env = env.ssl_env(logger, **kwargs)
-
     run_info_extras = products.load_product(kwargs["config"], product)[-1](**kwargs)
 
-    run_info, test_loader = get_loader(test_paths, product, ssl_env,
+    run_info, test_loader = get_loader(test_paths, product,
                                        run_info_extras=run_info_extras, **kwargs)
 
     for test in test_loader.test_ids:
@@ -141,7 +138,6 @@ def run_tests(config, test_paths, product, **kwargs):
          executor_classes, get_executor_kwargs,
          env_options, get_env_extras, run_info_extras) = products.load_product(config, product)
 
-        ssl_env = env.ssl_env(logger, **kwargs)
         env_extras = get_env_extras(**kwargs)
 
         check_args(**kwargs)
@@ -161,7 +157,6 @@ def run_tests(config, test_paths, product, **kwargs):
         else:
             run_info, test_loader = get_loader(test_paths,
                                                product,
-                                               ssl_env,
                                                run_info_extras=run_info_extras(**kwargs),
                                                **kwargs)
 
@@ -180,11 +175,17 @@ def run_tests(config, test_paths, product, **kwargs):
 
         kwargs["pause_after_test"] = get_pause_after_test(test_loader, **kwargs)
 
+        ssl_config = {"type": kwargs["ssl_type"],
+                      "openssl": {"openssl_binary": kwargs["openssl_binary"]},
+                      "pregenerated": {"host_key_path": kwargs["host_key_path"],
+                                       "host_cert_path": kwargs["host_cert_path"],
+                                       "ca_cert_path": kwargs["ca_cert_path"]}}
+
         with env.TestEnvironment(test_paths,
-                                 ssl_env,
                                  kwargs["pause_after_test"],
                                  kwargs["debug_info"],
                                  env_options,
+                                 ssl_config,
                                  env_extras) as test_environment:
             try:
                 test_environment.ensure_started()
@@ -221,7 +222,6 @@ def run_tests(config, test_paths, product, **kwargs):
 
                     browser_kwargs = get_browser_kwargs(test_type,
                                                         run_info,
-                                                        ssl_env=ssl_env,
                                                         config=test_environment.config,
                                                         **kwargs)
 

--- a/tools/wptserve/tests/test_config.py
+++ b/tools/wptserve/tests/test_config.py
@@ -8,11 +8,11 @@ config = pytest.importorskip("wptserve.config")
 
 
 def test_renamed_are_renamed():
-    assert len(set(config._renamed_props.keys()) & set(config.Config._default.keys())) == 0
+    assert len(set(config._renamed_props.keys()) & set(config.ConfigBuilder._default.keys())) == 0
 
 
 def test_renamed_exist():
-    assert set(config._renamed_props.values()).issubset(set(config.Config._default.keys()))
+    assert set(config._renamed_props.values()).issubset(set(config.ConfigBuilder._default.keys()))
 
 
 @pytest.mark.parametrize("base, override, expected", [
@@ -29,26 +29,26 @@ def test_merge_dict(base, override, expected):
 
 
 def test_logger_created():
-    c = config.Config()
-    assert c.logger is not None
+    with config.ConfigBuilder() as c:
+        assert c.logger is not None
 
 
 def test_logger_preserved():
     logger = logging.getLogger("test_logger_preserved")
     logger.setLevel(logging.DEBUG)
 
-    c = config.Config(logger=logger)
-    assert c.logger is logger
+    with config.ConfigBuilder(logger=logger) as c:
+        assert c.logger is logger
 
 
 def test_init_basic_prop():
-    c = config.Config(browser_host="foo.bar")
-    assert c.browser_host == "foo.bar"
+    with config.ConfigBuilder(browser_host="foo.bar") as c:
+        assert c.browser_host == "foo.bar"
 
 
 def test_init_prefixed_prop():
-    c = config.Config(doc_root="/")
-    assert c._doc_root == "/"
+    with config.ConfigBuilder(doc_root="/") as c:
+        assert c.doc_root == "/"
 
 
 def test_init_renamed_host():
@@ -57,58 +57,61 @@ def test_init_renamed_host():
     handler = handlers.BufferingHandler(100)
     logger.addHandler(handler)
 
-    c = config.Config(logger=logger, host="foo.bar")
-    assert c.logger is logger
-    assert len(handler.buffer) == 1
-    assert "browser_host" in handler.buffer[0].getMessage()  # check we give the new name in the message
-    assert not hasattr(c, "host")
-    assert c.browser_host == "foo.bar"
+    with config.ConfigBuilder(logger=logger, host="foo.bar") as c:
+        assert c.logger is logger
+        assert len(handler.buffer) == 1
+        assert "browser_host" in handler.buffer[0].getMessage()  # check we give the new name in the message
+        assert not hasattr(c, "host")
+        assert c.browser_host == "foo.bar"
 
 
 def test_init_bogus():
     with pytest.raises(TypeError) as e:
-        config.Config(foo=1, bar=2)
+        config.ConfigBuilder(foo=1, bar=2)
     message = e.value.args[0]
     assert "foo" in message
     assert "bar" in message
 
 
 def test_getitem():
-    c = config.Config(browser_host="foo.bar")
-    assert c["browser_host"] == "foo.bar"
+    with config.ConfigBuilder(browser_host="foo.bar") as c:
+        assert c["browser_host"] == "foo.bar"
 
 
 def test_no_setitem():
-    c = config.Config()
-    with pytest.raises(TypeError):
-        c["browser_host"] = "foo.bar"
+    with config.ConfigBuilder() as c:
+        with pytest.raises(TypeError):
+            c["browser_host"] = "foo.bar"
 
 
 def test_iter():
-    c = config.Config()
-    s = set(iter(c))
-    assert "browser_host" in s
-    assert "host" not in s
-    assert "__getitem__" not in s
-    assert "_browser_host" not in s
+    with config.ConfigBuilder() as c:
+        s = set(iter(c))
+        assert "browser_host" in s
+        assert "host" not in s
+        assert "__getitem__" not in s
+        assert "_browser_host" not in s
 
 
 def test_assignment():
-    c = config.Config()
-    c.browser_host = "foo.bar"
-    assert c.browser_host == "foo.bar"
+    cb = config.ConfigBuilder()
+    cb.browser_host = "foo.bar"
+    with cb as c:
+        assert c.browser_host == "foo.bar"
 
 
 def test_update_basic():
-    c = config.Config()
-    c.update({"browser_host": "foo.bar"})
-    assert c.browser_host == "foo.bar"
+    cb = config.ConfigBuilder()
+    cb.update({"browser_host": "foo.bar"})
+    with cb as c:
+        assert c.browser_host == "foo.bar"
 
 
 def test_update_prefixed():
-    c = config.Config()
-    c.update({"doc_root": "/"})
-    assert c._doc_root == "/"
+    cb = config.ConfigBuilder()
+    cb.update({"doc_root": "/"})
+    with cb as c:
+        assert c.doc_root == "/"
 
 
 def test_update_renamed_host():
@@ -117,278 +120,251 @@ def test_update_renamed_host():
     handler = handlers.BufferingHandler(100)
     logger.addHandler(handler)
 
-    c = config.Config(logger=logger)
-    assert c.logger is logger
+    cb = config.ConfigBuilder(logger=logger)
+    assert cb.logger is logger
     assert len(handler.buffer) == 0
 
-    c.update({"host": "foo.bar"})
+    cb.update({"host": "foo.bar"})
 
-    assert len(handler.buffer) == 1
-    assert "browser_host" in handler.buffer[0].getMessage()  # check we give the new name in the message
-    assert not hasattr(c, "host")
-    assert c.browser_host == "foo.bar"
+    with cb as c:
+        assert len(handler.buffer) == 1
+        assert "browser_host" in handler.buffer[0].getMessage()  # check we give the new name in the message
+        assert not hasattr(c, "host")
+        assert c.browser_host == "foo.bar"
 
 
 def test_update_bogus():
-    c = config.Config()
+    cb = config.ConfigBuilder()
     with pytest.raises(KeyError):
-        c.update({"foobar": 1})
+        cb.update({"foobar": 1})
 
 
 def test_ports_auto():
-    c = config.Config(ports={"http": ["auto"]},
-                      ssl={"type": "none"})
-    ports = c.ports
-    assert set(ports.keys()) == {"http"}
-    assert len(ports["http"]) == 1
-    assert isinstance(ports["http"][0], int)
+    with config.ConfigBuilder(ports={"http": ["auto"]},
+                              ssl={"type": "none"}) as c:
+        ports = c.ports
+        assert set(ports.keys()) == {"http"}
+        assert len(ports["http"]) == 1
+        assert isinstance(ports["http"][0], int)
 
 
 def test_ports_auto_mutate():
-    c = config.Config(ports={"http": [1001]},
-                      ssl={"type": "none"})
-    orig_ports = c.ports
-    assert set(orig_ports.keys()) == {"http"}
-    assert orig_ports["http"] == [1001]
-
-    c.ports = {"http": ["auto"]}
-    new_ports = c.ports
-    assert set(new_ports.keys()) == {"http"}
-    assert len(new_ports["http"]) == 1
-    assert isinstance(new_ports["http"][0], int)
-
-
-def test_ports_auto_roundtrip():
-    c = config.Config(ports={"http": ["auto"]},
-                      ssl={"type": "none"})
-    old_ports = c.ports
-    c.ports = old_ports
-    new_ports = c.ports
-    assert old_ports == new_ports
-
-
-def test_ports_idempotent():
-    c = config.Config(ports={"http": ["auto"]},
-                      ssl={"type": "none"})
-    ports_a = c.ports
-    ports_b = c.ports
-    assert ports_a == ports_b
+    cb = config.ConfigBuilder(ports={"http": [1001]},
+                              ssl={"type": "none"})
+    cb.ports = {"http": ["auto"]}
+    with cb as c:
+        new_ports = c.ports
+        assert set(new_ports.keys()) == {"http"}
+        assert len(new_ports["http"]) == 1
+        assert isinstance(new_ports["http"][0], int)
 
 
 def test_ports_explicit():
-    c = config.Config(ports={"http": [1001]},
-                      ssl={"type": "none"})
-    ports = c.ports
-    assert set(ports.keys()) == {"http"}
-    assert ports["http"] == [1001]
+    with config.ConfigBuilder(ports={"http": [1001]},
+                              ssl={"type": "none"}) as c:
+        ports = c.ports
+        assert set(ports.keys()) == {"http"}
+        assert ports["http"] == [1001]
 
 
 def test_ports_no_ssl():
-    c = config.Config(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
-                      ssl={"type": "none"})
-    ports = c.ports
-    assert set(ports.keys()) == {"http", "https", "ws", "wss"}
-    assert ports["http"] == [1001]
-    assert ports["https"] == [None]
-    assert ports["ws"] == [1003]
-    assert ports["wss"] == [None]
+    with config.ConfigBuilder(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
+                              ssl={"type": "none"}) as c:
+        ports = c.ports
+        assert set(ports.keys()) == {"http", "ws"}
+        assert ports["http"] == [1001]
+        assert ports["ws"] == [1003]
 
 
 def test_ports_openssl():
-    c = config.Config(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
-                      ssl={"type": "openssl"})
-    ports = c.ports
-    assert set(ports.keys()) == {"http", "https", "ws", "wss"}
-    assert ports["http"] == [1001]
-    assert ports["https"] == [1002]
-    assert ports["ws"] == [1003]
-    assert ports["wss"] == [1004]
+    with config.ConfigBuilder(ports={"http": [1001], "https": [1002], "ws": [1003], "wss": [1004]},
+                              ssl={"type": "openssl"}) as c:
+        ports = c.ports
+        assert set(ports.keys()) == {"http", "https", "ws", "wss"}
+        assert ports["http"] == [1001]
+        assert ports["https"] == [1002]
+        assert ports["ws"] == [1003]
+        assert ports["wss"] == [1004]
 
 
 def test_init_doc_root():
-    c = config.Config(doc_root="/")
-    assert c._doc_root == "/"
-    assert c.doc_root == "/"
+    with config.ConfigBuilder(doc_root="/") as c:
+        assert c.doc_root == "/"
 
 
 def test_set_doc_root():
-    c = config.Config()
-    c.doc_root = "/"
-    assert c._doc_root == "/"
-    assert c.doc_root == "/"
+    cb = config.ConfigBuilder()
+    cb.doc_root = "/"
+    with cb as c:
+        assert c.doc_root == "/"
 
 
 def test_server_host_from_browser_host():
-    c = config.Config(browser_host="foo.bar")
-    assert c.server_host == "foo.bar"
+    with config.ConfigBuilder(browser_host="foo.bar") as c:
+        assert c.server_host == "foo.bar"
 
 
 def test_init_server_host():
-    c = config.Config(server_host="foo.bar")
-    assert c.browser_host == "localhost"  # check this hasn't changed
-    assert c._server_host == "foo.bar"
-    assert c.server_host == "foo.bar"
+    with config.ConfigBuilder(server_host="foo.bar") as c:
+        assert c.browser_host == "localhost"  # check this hasn't changed
+        assert c.server_host == "foo.bar"
 
 
 def test_set_server_host():
-    c = config.Config()
-    c.server_host = "/"
-    assert c.browser_host == "localhost"  # check this hasn't changed
-    assert c._server_host == "/"
-    assert c.server_host == "/"
+    cb = config.ConfigBuilder()
+    cb.server_host = "/"
+    with cb as c:
+        assert c.browser_host == "localhost"  # check this hasn't changed
+        assert c.server_host == "/"
 
 
 def test_domains():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    domains = c.domains
-    assert domains == {
-        "": {
-            "": "foo.bar",
-            "a": "a.foo.bar",
-            "b": "b.foo.bar",
-        },
-        "alt": {
-            "": "foo2.bar",
-            "a": "a.foo2.bar",
-            "b": "b.foo2.bar",
-        },
-    }
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        assert c.domains == {
+            "": {
+                "": "foo.bar",
+                "a": "a.foo.bar",
+                "b": "b.foo.bar",
+            },
+            "alt": {
+                "": "foo2.bar",
+                "a": "a.foo2.bar",
+                "b": "b.foo2.bar",
+            },
+        }
 
 
 def test_not_domains():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    not_domains = c.not_domains
-    assert not_domains == {
-        "": {
-            "x": "x.foo.bar",
-            "y": "y.foo.bar",
-        },
-        "alt": {
-            "x": "x.foo2.bar",
-            "y": "y.foo2.bar",
-        },
-    }
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        not_domains = c.not_domains
+        assert not_domains == {
+            "": {
+                "x": "x.foo.bar",
+                "y": "y.foo.bar",
+            },
+            "alt": {
+                "x": "x.foo2.bar",
+                "y": "y.foo2.bar",
+            },
+        }
 
 
 def test_domains_not_domains_intersection():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    domains = c.domains
-    not_domains = c.not_domains
-    assert len(set(domains.keys()) ^ set(not_domains.keys())) == 0
-    for host in domains.keys():
-        host_domains = domains[host]
-        host_not_domains = not_domains[host]
-        assert len(set(host_domains.keys()) & set(host_not_domains.keys())) == 0
-        assert len(set(host_domains.values()) & set(host_not_domains.values())) == 0
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        domains = c.domains
+        not_domains = c.not_domains
+        assert len(set(domains.keys()) ^ set(not_domains.keys())) == 0
+        for host in domains.keys():
+            host_domains = domains[host]
+            host_not_domains = not_domains[host]
+            assert len(set(host_domains.keys()) & set(host_not_domains.keys())) == 0
+            assert len(set(host_domains.values()) & set(host_not_domains.values())) == 0
 
 
 def test_all_domains():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    all_domains = c.all_domains
-    assert all_domains == {
-        "": {
-            "": "foo.bar",
-            "a": "a.foo.bar",
-            "b": "b.foo.bar",
-            "x": "x.foo.bar",
-            "y": "y.foo.bar",
-        },
-        "alt": {
-            "": "foo2.bar",
-            "a": "a.foo2.bar",
-            "b": "b.foo2.bar",
-            "x": "x.foo2.bar",
-            "y": "y.foo2.bar",
-        },
-    }
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        all_domains = c.all_domains
+        assert all_domains == {
+            "": {
+                "": "foo.bar",
+                "a": "a.foo.bar",
+                "b": "b.foo.bar",
+                "x": "x.foo.bar",
+                "y": "y.foo.bar",
+            },
+            "alt": {
+                "": "foo2.bar",
+                "a": "a.foo2.bar",
+                "b": "b.foo2.bar",
+                "x": "x.foo2.bar",
+                "y": "y.foo2.bar",
+            },
+        }
 
 
 def test_domains_set():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    domains_set = c.domains_set
-    assert domains_set == {
-        "foo.bar",
-        "a.foo.bar",
-        "b.foo.bar",
-        "foo2.bar",
-        "a.foo2.bar",
-        "b.foo2.bar",
-    }
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        domains_set = c.domains_set
+        assert domains_set == {
+            "foo.bar",
+            "a.foo.bar",
+            "b.foo.bar",
+            "foo2.bar",
+            "a.foo2.bar",
+            "b.foo2.bar",
+        }
 
 
 def test_not_domains_set():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    not_domains_set = c.not_domains_set
-    assert not_domains_set == {
-        "x.foo.bar",
-        "y.foo.bar",
-        "x.foo2.bar",
-        "y.foo2.bar",
-    }
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        not_domains_set = c.not_domains_set
+        assert not_domains_set == {
+            "x.foo.bar",
+            "y.foo.bar",
+            "x.foo2.bar",
+            "y.foo2.bar",
+        }
 
 
 def test_all_domains_set():
-    c = config.Config(browser_host="foo.bar",
-                      alternate_hosts={"alt": "foo2.bar"},
-                      subdomains={"a", "b"},
-                      not_subdomains={"x", "y"})
-    all_domains_set = c.all_domains_set
-    assert all_domains_set == {
-        "foo.bar",
-        "a.foo.bar",
-        "b.foo.bar",
-        "x.foo.bar",
-        "y.foo.bar",
-        "foo2.bar",
-        "a.foo2.bar",
-        "b.foo2.bar",
-        "x.foo2.bar",
-        "y.foo2.bar",
-    }
-
-
-def test_ssl_env_override():
-    c = config.Config(override_ssl_env="foobar")
-    assert c.ssl_env == "foobar"
+    with config.ConfigBuilder(browser_host="foo.bar",
+                              alternate_hosts={"alt": "foo2.bar"},
+                              subdomains={"a", "b"},
+                              not_subdomains={"x", "y"}) as c:
+        all_domains_set = c.all_domains_set
+        assert all_domains_set == {
+            "foo.bar",
+            "a.foo.bar",
+            "b.foo.bar",
+            "x.foo.bar",
+            "y.foo.bar",
+            "foo2.bar",
+            "a.foo2.bar",
+            "b.foo2.bar",
+            "x.foo2.bar",
+            "y.foo2.bar",
+        }
 
 
 def test_ssl_env_none():
-    c = config.Config(ssl={"type": "none"})
-    assert c.ssl_env is not None
-    assert c.ssl_env.ssl_enabled is False
+    with config.ConfigBuilder(ssl={"type": "none"}) as c:
+        assert c.ssl_config is None
 
 
 def test_ssl_env_openssl():
-    c = config.Config(ssl={"type": "openssl", "openssl": {"openssl_binary": "foobar"}})
-    assert c.ssl_env is not None
-    assert c.ssl_env.ssl_enabled is True
-    assert c.ssl_env.binary == "foobar"
+    # TODO: this currently actually tries to start OpenSSL, which isn't ideal
+    # with config.ConfigBuilder(ssl={"type": "openssl", "openssl": {"openssl_binary": "foobar"}}) as c:
+    #     assert c.ssl_env is not None
+    #     assert c.ssl_env.ssl_enabled is True
+    #     assert c.ssl_env.binary == "foobar"
+    pass
 
 
 def test_ssl_env_bogus():
-    c = config.Config(ssl={"type": "foobar"})
-    with pytest.raises(ValueError):
-        c.ssl_env
+        with pytest.raises(ValueError):
+            with config.ConfigBuilder(ssl={"type": "foobar"}):
+                pass
 
 
 def test_pickle():
     # Ensure that the config object can be pickled
-    pickle.dumps(config.Config())
+    with config.ConfigBuilder() as c:
+        pickle.dumps(c)

--- a/tools/wptserve/wptserve/server.py
+++ b/tools/wptserve/wptserve/server.py
@@ -13,7 +13,7 @@ from six import binary_type, text_type
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
 from . import routes as default_routes
-from .config import Config
+from .config import ConfigBuilder
 from .logger import get_logger
 from .request import Server, Request
 from .response import Response
@@ -169,8 +169,11 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
             Server.config = config
         else:
             self.logger.debug("Using default configuration")
-            Server.config = Config(browser_host=server_address[0],
-                                   ports={"http": [self.server_address[1]]})
+            with ConfigBuilder(browser_host=server_address[0],
+                               ports={"http": [self.server_address[1]]}) as config:
+                assert config["ssl_config"] is None
+                Server.config = config
+
 
 
         self.key_file = key_file

--- a/tools/wptserve/wptserve/sslutils/__init__.py
+++ b/tools/wptserve/wptserve/sslutils/__init__.py
@@ -5,3 +5,10 @@ from .pregenerated import PregeneratedSSLEnvironment
 environments = {"none": NoSSLEnvironment,
                 "openssl": OpenSSLEnvironment,
                 "pregenerated": PregeneratedSSLEnvironment}
+
+
+def get_cls(name):
+    try:
+        return environments[name]
+    except KeyError:
+        raise ValueError("%s is not a vaid ssl type." % name)

--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 from datetime import datetime, timedelta
 
+from six import iteritems
+
 # Amount of time beyond the present to consider certificates "expired." This
 # allows certificates to be proactively re-generated in the "buffer" period
 # prior to their exact expiration time.
@@ -67,7 +69,7 @@ class OpenSSL(object):
         # StartProcess is picky about all the keys/values being plain strings,
         # but at least in MSYS shells, the os.environ dictionary can be mixed.
         env = {}
-        for k, v in os.environ.iteritems():
+        for k, v in iteritems(os.environ):
             try:
                 env[k.encode("utf8")] = v.encode("utf8")
             except UnicodeDecodeError:

--- a/tools/wptserve/wptserve/sslutils/openssl.py
+++ b/tools/wptserve/wptserve/sslutils/openssl.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 # prior to their exact expiration time.
 CERT_EXPIRY_BUFFER = dict(hours=6)
 
+
 class OpenSSL(object):
     def __init__(self, logger, binary, base_path, conf_path, hosts, duration,
                  base_conf_path=None):
@@ -361,7 +362,7 @@ class OpenSSLEnvironment(object):
 
         hosts must be a list of all hosts to appear on the certificate, with
         the primary hostname first."""
-        hosts = tuple(sorted(hosts, key=lambda x:-len(x)))
+        hosts = tuple(sorted(hosts, key=lambda x:len(x)))
         if hosts not in self.host_certificates:
             if not self.force_regenerate:
                 key_cert = self._load_host_cert(hosts)


### PR DESCRIPTION
This solves several problems with the curent design, notably:
* Config is created once and then shared, so multiple processses/threads can't race when creating the configuration data
* It unbreaks the SSL environments that expect to be used as context managers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/web-platform-tests/wpt/11976)
<!-- Reviewable:end -->
