### PR TITLE
Update the css-regions IDL file

### DIFF
--- a/css/css-regions/idlharness.html
+++ b/css/css-regions/idlharness.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>css-regions IDL tests</title>
+<link rel="help" href="https://drafts.csswg.org/css-regions/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script>
+  'use strict';
+
+  idl_test(
+    ['css-regions'],
+    ['cssom', 'dom'],
+    idl_array => {
+      idl_array.add_objects({
+        Document: ['document'],
+      })
+    },
+    'css-regions interfaces'
+  );
+</script>

--- a/interfaces/css-regions.idl
+++ b/interfaces/css-regions.idl
@@ -8,7 +8,7 @@ partial interface Document {
 };
 
 [Exposed=Window,
- MapClass(CSSOMString, NamedFlow)] interface NamedFlowMap {
+ MapClass=(CSSOMString, NamedFlow)] interface NamedFlowMap {
   NamedFlow? get(CSSOMString flowName);
   boolean has(CSSOMString flowName);
   NamedFlowMap set(CSSOMString flowName, NamedFlow flowValue);

--- a/interfaces/css-regions.idl
+++ b/interfaces/css-regions.idl
@@ -1,0 +1,35 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "CSS Regions Module Level 1" spec.
+// See: https://drafts.csswg.org/css-regions/
+
+partial interface Document {
+  readonly attribute NamedFlowMap namedFlows;
+};
+
+[Exposed=Window,
+ MapClass(CSSOMString, NamedFlow)] interface NamedFlowMap {
+  NamedFlow? get(CSSOMString flowName);
+  boolean has(CSSOMString flowName);
+  NamedFlowMap set(CSSOMString flowName, NamedFlow flowValue);
+  boolean delete(CSSOMString flowName);
+};
+
+[Exposed=Window]
+interface NamedFlow : EventTarget {
+  readonly attribute CSSOMString name;
+  readonly attribute boolean overset;
+  sequence<Region> getRegions();
+  readonly attribute short firstEmptyRegionIndex;
+  sequence<Node> getContent();
+  sequence<Region> getRegionsByContent(Node node);
+};
+
+[Exposed=Window,
+ NoInterfaceObject]
+interface Region {
+  readonly attribute CSSOMString regionOverset;
+  sequence<Range>? getRegionFlowRanges();
+};
+
+Element implements Region;


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
