### PR TITLE
Update the css-images IDL file

### DIFF
--- a/css/css-images/idlharness.html
+++ b/css/css-images/idlharness.html
@@ -10,8 +10,10 @@
 
   idl_test(
     ['css-images'],
-    [], // No deps
-    null, // No objects,
+    ['cssom'],
+    idl_array => {
+      // No objects,
+    },
     'Test IDL implementation of css-masking'
   );
 </script>

--- a/css/css-images/idlharness.html
+++ b/css/css-images/idlharness.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>css-images IDL tests</title>
+<link rel="help" href="https://drafts.csswg.org/css-images-4/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script>
+  'use strict';
+
+  idl_test(
+    ['css-images'],
+    [], // No deps
+    null, // No objects,
+    'Test IDL implementation of css-masking'
+  );
+</script>

--- a/interfaces/css-images.idl
+++ b/interfaces/css-images.idl
@@ -1,0 +1,8 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "CSS Images Module Level 4" spec.
+// See: https://drafts.csswg.org/css-images-4/
+
+partial namespace CSS {
+  // [SameObject] readonly attribute Map elementSources;
+};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
