### PR TITLE
Update the css-counter-styles IDL file

### DIFF
--- a/css/css-counter-styles/idlharness.html
+++ b/css/css-counter-styles/idlharness.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<title>css-counter-styles IDL tests</title>
+<link rel="help" href="https://drafts.csswg.org/css-counter-styles/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<style>
+  @counter-style triangle {
+    system: cyclic;
+    symbols: ‣;
+    suffix: " ";
+  }
+</style>
+<script>
+  'use strict';
+  idl_test(
+    ['css-counter-styles'],
+    ['cssom'],
+    idl_array => {
+      try {
+        self.counter = document.styleSheets[0].rules[0];
+      } catch (e) {
+        // Will be surfaced when counter is undefined below.
+      }
+
+      idl_array.add_objects({
+        CSSCounterStyleRule: ['counter'],
+      });
+    },
+    'css-counter-styles interfaces'
+  );
+</script>

--- a/interfaces/css-counter-styles.idl
+++ b/interfaces/css-counter-styles.idl
@@ -1,0 +1,23 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "CSS Counter Styles Level 3" spec.
+// See: https://drafts.csswg.org/css-counter-styles/
+
+partial interface CSSRule {
+    const unsigned short COUNTER_STYLE_RULE = 11;
+};
+
+[Exposed=Window]
+interface CSSCounterStyleRule : CSSRule {
+  attribute CSSOMString name;
+  attribute CSSOMString system;
+  attribute CSSOMString symbols;
+  attribute CSSOMString additiveSymbols;
+  attribute CSSOMString negative;
+  attribute CSSOMString prefix;
+  attribute CSSOMString suffix;
+  attribute CSSOMString range;
+  attribute CSSOMString pad;
+  attribute CSSOMString speakAs;
+  attribute CSSOMString fallback;
+};


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
