### PR TITLE
Update the css-font-loading IDL file

### DIFF
--- a/css/css-font-loading/idlharness.https.html
+++ b/css/css-font-loading/idlharness.https.html
@@ -8,22 +8,17 @@
 <script>
 'use strict';
 
-promise_test(async () => {
-  const srcs = ['css-font-loading', 'dom', 'html', 'cssom'];
-  const [cssfontloading, dom, html, cssom] = await Promise.all(
-      srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(cssfontloading);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_dependency_idls(html);
-  idl_array.add_dependency_idls(cssom);
-  idl_array.add_objects({
-    Document: ['document'],
-    FontFace: ['new FontFace("family", "src")'],
-    FontFaceSetLoadEvent: ['new FontFaceSetLoadEvent("type")'],
-    FontFaceSet: ['document.fonts'],
-  });
-  idl_array.test();
-}, 'css-font-loading interfaces');
+idl_test(
+  ['css-font-loading'],
+  ['dom', 'html', 'cssom'],
+  idl_array => {
+    idl_array.add_objects({
+      Document: ['document'],
+      FontFace: ['new FontFace("family", "src")'],
+      FontFaceSetLoadEvent: ['new FontFaceSetLoadEvent("type")'],
+      FontFaceSet: ['document.fonts'],
+    });
+  },
+  'css-font-loading interfaces'
+);
 </script>


### PR DESCRIPTION
Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the `interfaces/` directory (instead of inline copies in the test files).
