### PR TITLE
Adding custom pytest marker registration to WebDriver tests

### DIFF
--- a/webdriver/tests/conftest.py
+++ b/webdriver/tests/conftest.py
@@ -17,6 +17,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers",
         "capabilities: mark test to use capabilities")
 
+
 @pytest.fixture
 def capabilities():
     """Default capabilities to use for a new WebDriver session."""

--- a/webdriver/tests/conftest.py
+++ b/webdriver/tests/conftest.py
@@ -12,6 +12,10 @@ from tests.support.fixtures import (
     session,
     url)
 
+def pytest_configure(config):
+    # register the capabilities marker
+    config.addinivalue_line("markers",
+        "capabilities: mark test to use capabilities")
 
 @pytest.fixture
 def capabilities():


### PR DESCRIPTION
The WebDriver tests can now use a custom pytest marker to specify the
capabilities for a session in a specific test. The marker must be
registered with the system to be valid, however.