### PR TITLE
Create multiple files in single temp directory for upload tests

### DIFF
--- a/webdriver/tests/element_send_keys/conftest.py
+++ b/webdriver/tests/element_send_keys/conftest.py
@@ -12,7 +12,7 @@ def create_file(tmpdir_factory):
     inner.__name__ = "create_file"
     return inner
 
-	
+
 @pytest.fixture
 def create_files(tmpdir_factory):
     def inner(filenames):

--- a/webdriver/tests/element_send_keys/conftest.py
+++ b/webdriver/tests/element_send_keys/conftest.py
@@ -11,3 +11,19 @@ def create_file(tmpdir_factory):
 
     inner.__name__ = "create_file"
     return inner
+
+	
+@pytest.fixture
+def create_files(tmpdir_factory):
+    def inner(filenames):
+        filelist = []
+        tmpdir = tmpdir_factory.mktemp("tmp")
+        for filename in filenames:
+            fh = tmpdir.join(filename)
+            fh.write(filename)
+            filelist.append(fh)
+
+        return filelist
+
+    inner.__name__ = "create_files"
+    return inner

--- a/webdriver/tests/element_send_keys/file_upload.py
+++ b/webdriver/tests/element_send_keys/file_upload.py
@@ -36,7 +36,7 @@ def test_multiple_files(session, create_files):
 
 
 def test_multiple_files_multiple_directories(session, create_file):
-    files = [create_file("foo"_, create_file("bar")]
+    files = [create_file("foo"), create_file("bar")]
 
     session.url = inline("<input type=file multiple>")
     element = session.find.css("input", all=False)

--- a/webdriver/tests/element_send_keys/file_upload.py
+++ b/webdriver/tests/element_send_keys/file_upload.py
@@ -22,8 +22,8 @@ def test_empty_text(session):
     assert_error(response, "invalid argument")
 
 
-def test_multiple_files(session, create_file):
-    files = [create_file("foo"), create_file("bar")]
+def test_multiple_files(session, create_files):
+    files = create_files(["foo", "bar"])
 
     session.url = inline("<input type=file multiple>")
     element = session.find.css("input", all=False)
@@ -35,8 +35,22 @@ def test_multiple_files(session, create_file):
     assert_files_uploaded(session, element, files)
 
 
-def test_multiple_files_last_path_not_found(session, create_file):
-    files = [create_file("foo"), create_file("bar"), "foo bar"]
+def test_multiple_files_multiple_directories(session, create_file):
+    files = [create_file("foo"_, create_file("bar")]
+
+    session.url = inline("<input type=file multiple>")
+    element = session.find.css("input", all=False)
+
+    response = element_send_keys(session, element,
+                                 map_files_to_multiline_text(files))
+    assert_success(response)
+
+    assert_files_uploaded(session, element, files)
+
+
+def test_multiple_files_last_path_not_found(session, create_files):
+    files = create_files(["foo", "bar"])
+    files.append("foo bar")
 
     session.url = inline("<input type=file multiple>")
     element = session.find.css("input", all=False)
@@ -48,8 +62,8 @@ def test_multiple_files_last_path_not_found(session, create_file):
     assert_files_uploaded(session, element, [])
 
 
-def test_multiple_files_without_multiple_attribute(session, create_file):
-    files = [create_file("foo"), create_file("bar")]
+def test_multiple_files_without_multiple_attribute(session, create_files):
+    files = create_files(["foo", "bar"])
 
     session.url = inline("<input type=file>")
     element = session.find.css("input", all=False)
@@ -61,9 +75,9 @@ def test_multiple_files_without_multiple_attribute(session, create_file):
     assert_files_uploaded(session, element, [])
 
 
-def test_multiple_files_send_twice(session, create_file):
-    first_files = [create_file("foo"), create_file("bar")]
-    second_files = [create_file("john"), create_file("doe")]
+def test_multiple_files_send_twice(session, create_files):
+    first_files = create_files(["foo", "bar"])
+    second_files = create_files(["john", "doe"])
 
     session.url = inline("<input type=file multiple>")
     element = session.find.css("input", all=False)
@@ -79,9 +93,9 @@ def test_multiple_files_send_twice(session, create_file):
     assert_files_uploaded(session, element, first_files + second_files)
 
 
-def test_multiple_files_reset_with_element_clear(session, create_file):
-    first_files = [create_file("foo"), create_file("bar")]
-    second_files = [create_file("john"), create_file("doe")]
+def test_multiple_files_reset_with_element_clear(session, create_files):
+    first_files = create_files(["foo", "bar"])
+    second_files = create_files(["john", "doe"])
 
     session.url = inline("<input type=file multiple>")
     element = session.find.css("input", all=False)
@@ -129,7 +143,22 @@ def test_single_file_replaces_without_multiple_attribute(session, create_file):
     assert_files_uploaded(session, element, [second_file])
 
 
-def test_single_file_appends_with_multiple_attribute(session, create_file):
+def test_single_file_appends_with_multiple_attribute(session, create_files):
+    files = create_files(["foo", "bar"])
+
+    session.url = inline("<input type=file multiple>")
+    element = session.find.css("input", all=False)
+
+    response = element_send_keys(session, element, str(files[0]))
+    assert_success(response)
+
+    response = element_send_keys(session, element, str(files[1]))
+    assert_success(response)
+
+    assert_files_uploaded(session, element, files)
+
+
+def test_single_file_multiple_directory_appends_with_multiple_attribute(session, create_file):
     first_file = create_file("foo")
     second_file = create_file("bar")
 


### PR DESCRIPTION
Some user agents do not support multiple files in input elements in the
file upload state if the files selected are in different directories.
This commit adds the ability to create multiple temporary files in a
single temp directory instead of creating each file in its own
directory. Additionally, it adds a test uploading multiple files in
different directories for coverage of that case.