### PR TITLE
Created a central flake8.ini Config file

### DIFF
--- a/tools/flake8.ini
+++ b/tools/flake8.ini
@@ -1,0 +1,21 @@
+[flake8]
+# flake8 config used in tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
+select = E,W,F,N
+# E128: continuation line under-indented for visual indent
+# E129: visually indented line with same indent as next logical line
+# E221: multiple spaces before operator
+# E226: missing whitespace around arithmetic operator
+# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
+# E251: unexpected spaces around keyword / parameter equals
+# E265: block comment should start with ‘# ‘
+# E302: expected 2 blank lines, found 0
+# E303: too many blank lines (3)
+# E305: expected 2 blank lines after end of function or class
+# E402: module level import not at top of file
+# E731: do not assign a lambda expression, use a def
+# E901: SyntaxError or IndentationError
+# W601: .has_key() is deprecated, use ‘in’
+# N801: class names should use CapWords convention
+# N802: function name should be lowercase
+ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
+max-line-length = 141

--- a/tools/tox.ini
+++ b/tools/tox.ini
@@ -17,30 +17,10 @@ deps =
 
 commands =
   pytest --cov {posargs}
-  flake8
+  flake8 --append-config=flake8.ini
 
 passenv =
   HYPOTHESIS_PROFILE
 
 [flake8]
-# flake8 config should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
-select = E,W,F,N
-# E128: continuation line under-indented for visual indent
-# E129: visually indented line with same indent as next logical line
-# E221: multiple spaces before operator
-# E226: missing whitespace around arithmetic operator
-# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
-# E251: unexpected spaces around keyword / parameter equals
-# E265: block comment should start with ‘# ‘
-# E302: expected 2 blank lines, found 0
-# E303: too many blank lines (3)
-# E305: expected 2 blank lines after end of function or class
-# E402: module level import not at top of file
-# E731: do not assign a lambda expression, use a def
-# E901: SyntaxError or IndentationError
-# W601: .has_key() is deprecated, use ‘in’
-# N801: class names should use CapWords convention
-# N802: function name should be lowercase
-ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
-max-line-length = 141
 exclude = .tox,html5lib,third_party,pywebsocket,six,_venv,webencodings,wptserve/docs,wptserve/tests/functional/docroot/,wpt,wptrunner

--- a/tools/wpt/tox.ini
+++ b/tools/wpt/tox.ini
@@ -23,26 +23,4 @@ deps =
      pep8-naming==0.4.1
 
 commands =
-     flake8 {posargs}
-
-[flake8]
-# flake8 config should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
-select = E,W,F,N
-# E128: continuation line under-indented for visual indent
-# E129: visually indented line with same indent as next logical line
-# E221: multiple spaces before operator
-# E226: missing whitespace around arithmetic operator
-# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
-# E251: unexpected spaces around keyword / parameter equals
-# E265: block comment should start with ‘# ‘
-# E302: expected 2 blank lines, found 0
-# E303: too many blank lines (3)
-# E305: expected 2 blank lines after end of function or class
-# E402: module level import not at top of file
-# E731: do not assign a lambda expression, use a def
-# E901: SyntaxError or IndentationError
-# W601: .has_key() is deprecated, use ‘in’
-# N801: class names should use CapWords convention
-# N802: function name should be lowercase
-ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
-max-line-length = 141
+     flake8 --append-config=../flake8.ini {posargs}

--- a/tools/wptrunner/tox.ini
+++ b/tools/wptrunner/tox.ini
@@ -33,26 +33,4 @@ deps =
      pep8-naming==0.4.1
 
 commands =
-     flake8
-
-[flake8]
-# flake8 config should be kept in sync across tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini
-select = E,W,F,N
-# E128: continuation line under-indented for visual indent
-# E129: visually indented line with same indent as next logical line
-# E221: multiple spaces before operator
-# E226: missing whitespace around arithmetic operator
-# E231: missing whitespace after ‘,’, ‘;’, or ‘:’
-# E251: unexpected spaces around keyword / parameter equals
-# E265: block comment should start with ‘# ‘
-# E302: expected 2 blank lines, found 0
-# E303: too many blank lines (3)
-# E305: expected 2 blank lines after end of function or class
-# E402: module level import not at top of file
-# E731: do not assign a lambda expression, use a def
-# E901: SyntaxError or IndentationError
-# W601: .has_key() is deprecated, use ‘in’
-# N801: class names should use CapWords convention
-# N802: function name should be lowercase
-ignore = E128,E129,E221,E226,E231,E251,E265,E302,E303,E305,E402,E731,E901,W601,N801,N802
-max-line-length = 141
+     flake8 --append-config=../flake8.ini


### PR DESCRIPTION
Currently tools/tox.ini, tools/wpt/tox.ini, and tools/wptrunner/tox.ini all have the same flake8 ignore list and max-line-length, and need to be kept in sync manually. This is obviously not ideal, so I have moved their configurations into a single tools/flake8.ini file, and use the `--append-config` argument to include this config in all of the tox files. 