### PR TITLE
Removing expected focus event from file upload WebDriver test

### DIFF
--- a/webdriver/tests/element_send_keys/events.py
+++ b/webdriver/tests/element_send_keys/events.py
@@ -32,7 +32,6 @@ def element_send_keys(session, element, text):
 
 def test_file_upload(session, create_file, add_event_listeners, tracked_events):
     expected_events = [
-        "focus",
         "input",
         "change",
     ]


### PR DESCRIPTION
The WebDriver specification states that only the "change" and "input"
events. We should not also be expecting the "focus" event.