### PR TITLE
Adding explicit call to session.end for WebDriver delete session tests

### DIFF
--- a/webdriver/tests/delete_session/delete.py
+++ b/webdriver/tests/delete_session/delete.py
@@ -13,6 +13,9 @@ def test_null_response_value(session):
     response = delete_session(session)
     value = assert_success(response)
     assert value is None
+    # Need an explicit call to session.end() to notify the test harness
+    # that a new session needs to be created for subsequent tests.
+    session.end()
 
 
 def test_dismissed_beforeunload_prompt(session):
@@ -33,3 +36,7 @@ def test_dismissed_beforeunload_prompt(session):
     # A beforeunload prompt has to be automatically dismissed, and the session deleted
     with pytest.raises(error.InvalidSessionIdException):
         session.alert.text
+
+    # Need an explicit call to session.end() to notify the test harness
+    # that a new session needs to be created for subsequent tests.
+    session.end()


### PR DESCRIPTION
For the "delete session" command tests, the recent changes to the fixture
to create and delete sessions are bypassed. This means that at the end of
each delete session test, the harness thinks a valid session still exists.
Making an explicit call to `session.end()` at the end of each test will
put the tracking variables in the correct state for the harness to start a
new session with the next test.