### PR TITLE
Request pip via trusted click

### DIFF
--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -9,8 +9,7 @@
 
 promise_test(async () => {
   try {
-    const video = await loadVideo();
-    self.video = video;
+    self.video = await loadVideo();
     self.pipw = await requestPictureInPictureWithTrustedClick(video);
   } catch (e) {
     // Will be surfaced when video/pipw are undefined below.

--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -10,7 +10,6 @@
 promise_test(async () => {
   try {
     const video = await loadVideo();
-    document.body.appendChild(video);
     self.video = video;
     self.pipw = await requestPictureInPictureWithTrustedClick(video);
   } catch (e) {

--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -1,6 +1,7 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 // META: script=/resources/testdriver.js
+// META: script=/resources/testdriver-vendor.js
 // META: script=resources/picture-in-picture-helpers.js
 
 'use strict';

--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -12,7 +12,6 @@ promise_test(async () => {
     const video = await loadVideo();
     document.body.appendChild(video);
     self.video = video;
-    video.autoplay = true;
     self.pipw = await requestPictureInPictureWithTrustedClick(video);
   } catch (e) {
     // Will be surfaced when video/pipw are undefined below.

--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -1,5 +1,6 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
+// META: script=/resources/testdriver.js
 // META: script=resources/picture-in-picture-helpers.js
 
 'use strict';
@@ -11,7 +12,8 @@ promise_test(async () => {
     const video = await loadVideo();
     document.body.appendChild(video);
     self.video = video;
-    self.pipw = await video.requestPictureInPicture();
+    video.autoplay = true;
+    self.pipw = await requestPictureInPictureWithTrustedClick(video);
   } catch (e) {
     // Will be surfaced when video/pipw are undefined below.
   }


### PR DESCRIPTION
Fixes a bug in the picture-in-picture IDL test, which intends to obtain a `PictureInPictureWindow` object for testing IDL.