### PR TITLE
Expand coverage of performance-timeline IDL test

### DIFF
--- a/interfaces/performance-timeline.idl
+++ b/interfaces/performance-timeline.idl
@@ -8,6 +8,7 @@ partial interface Performance {
   PerformanceEntryList getEntriesByType(DOMString type);
   PerformanceEntryList getEntriesByName(DOMString name, optional DOMString type);
 };typedef sequence<PerformanceEntry> PerformanceEntryList;
+
 [Exposed=(Window,Worker)]
 interface PerformanceEntry {
   readonly    attribute DOMString name;
@@ -16,6 +17,7 @@ interface PerformanceEntry {
   readonly    attribute DOMHighResTimeStamp duration;
   [Default] object toJSON();
 };
+
 callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
                                              PerformanceObserver observer);
 [Constructor(PerformanceObserverCallback callback), Exposed=(Window,Worker)]
@@ -24,10 +26,12 @@ interface PerformanceObserver {
   void disconnect();
   PerformanceEntryList takeRecords();
 };
+
 dictionary PerformanceObserverInit {
   required sequence<DOMString> entryTypes;
   boolean buffered = false;
 };
+
 [Exposed=(Window,Worker)]
 interface PerformanceObserverEntryList {
   PerformanceEntryList getEntries();

--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -9,7 +9,6 @@
 promise_test(async t => {
   const observe = new Promise((resolve, reject) => {
     try {
-      const callback = (e, o) => { };
       self.observer = new PerformanceObserver((entries, observer) => {
         self.entryList = entries;
         resolve();

--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -6,11 +6,16 @@
 
 'use strict';
 
+function cast(i, t) {
+  return Object.assign(Object.create(t.prototype), i);
+}
+
 promise_test(async t => {
   const observe = new Promise((resolve, reject) => {
     try {
       self.observer = new PerformanceObserver((entries, observer) => {
         self.entryList = entries;
+        self.mark = entries.getEntries()[0];
         resolve();
       });
       observer.observe({ entryTypes: ['mark'] });
@@ -22,17 +27,19 @@ promise_test(async t => {
   const timeout = new Promise((_, reject) => {
     t.step_timeout(() => reject('Timed out waiting for observation'), 3000);
   });
+  const user = await fetch('/interfaces/user-timing.idl').then(r => r.text());
   const execute_test = () => {
     idl_test(
       ['performance-timeline'],
       ['hr-time', 'dom'],
       idl_array => {
+        idl_array.add_idls(user, {only: ['PerformanceMark']});
         idl_array.add_objects({
           Performance: ['performance'],
+          // NOTE: PerformanceMark cascadingly tests PerformanceEntry
+          PerformanceMark: ['mark'],
           PerformanceObserver: ['observer'],
-          // NOTE: PerformanceEntry is implicitly tested in user-timing.
           PerformanceObserverEntryList: ['entryList'],
-          PerformanceObserverEntry: ['entryList[0]'],
         });
       },
       'Test IDL implementation of performance-timeline API'

--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -6,10 +6,6 @@
 
 'use strict';
 
-function cast(i, t) {
-  return Object.assign(Object.create(t.prototype), i);
-}
-
 promise_test(async t => {
   const observe = new Promise((resolve, reject) => {
     try {

--- a/performance-timeline/idlharness.any.js
+++ b/performance-timeline/idlharness.any.js
@@ -6,22 +6,45 @@
 
 'use strict';
 
-idl_test(
-  ['performance-timeline'],
-  ['hr-time', 'dom'],
-  idl_array => {
+promise_test(async t => {
+  const observe = new Promise((resolve, reject) => {
     try {
-      const callback = (e, o) => {};
-      self.observerEntry = new ResizeObserverEntry(callback);
+      const callback = (e, o) => { };
+      self.observer = new PerformanceObserver((entries, observer) => {
+        self.entryList = entries;
+        resolve();
+      });
+      observer.observe({ entryTypes: ['mark'] });
+      performance.mark('test');
     } catch (e) {
-      // Will be surfaced when entry is undefined below.
+      reject(e);
     }
+  });
+  const timeout = new Promise((_, reject) => {
+    t.step_timeout(() => reject('Timed out waiting for observation'), 3000);
+  });
+  const execute_test = () => {
+    idl_test(
+      ['performance-timeline'],
+      ['hr-time', 'dom'],
+      idl_array => {
+        idl_array.add_objects({
+          Performance: ['performance'],
+          PerformanceObserver: ['observer'],
+          // NOTE: PerformanceEntry is implicitly tested in user-timing.
+          PerformanceObserverEntryList: ['entryList'],
+          PerformanceObserverEntry: ['entryList[0]'],
+        });
+      },
+      'Test IDL implementation of performance-timeline API'
+    );
+  };
 
-    idl_array.add_objects({
-      Performance: ['performance'],
-      // PerformanceEntry implicitly tested in user-timing.
-      ResizeObserverEntry: ['observerEntry'],
-    });
-  },
-  'Test IDL implementation of performance-timeline API'
-);
+  return Promise.race([observe, timeout]).then(
+    execute_test,
+    reason => {
+      execute_test();
+      return Promise.reject(reason);
+    }
+  );
+})


### PR DESCRIPTION
Follow up from https://github.com/web-platform-tests/wpt/issues/11911

Adds code for grabbing an instance of `PerformanceObserverEntryList` and `PerformanceObserverEntry` (correctly).

Passes (67/67) in Chrome 67.