### PR TITLE
Add missing </script> tag

### DIFF
--- a/html/editing/dnd/cross-document/002-manual.html
+++ b/html/editing/dnd/cross-document/002-manual.html
@@ -21,5 +21,5 @@ window.onload = function() {
 
 <div draggable="true"></div>
 <p><iframe height="300" width="500"></iframe></p>
-<script>document.getElementsByTagName("iframe")[0].src = crossOriginUrl("www", "001-1.html");
+<script>document.getElementsByTagName("iframe")[0].src = crossOriginUrl("www", "001-1.html");</script>
 <noscript><p>Enable JavaScript and reload</p></noscript>


### PR DESCRIPTION
Fix #4183 as followings:
- Add missing </script> tag.
- Rename 002.manual.html as 002-manual.html, since manual test should use `-manual` suffix.

@inexorabletash, PTAL.