### PR TITLE
Add test for document.open() in custom element constructor

### DIFF
--- a/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/custom-element.window.js
+++ b/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/custom-element.window.js
@@ -1,0 +1,39 @@
+// The document open steps have:
+//
+// 2. If document's throw-on-dynamic-markup-insertion counter is greater than
+//    0, then throw an "InvalidStateError" DOMException.
+//
+// The throw-on-dynamic-markup-insertion counter is only incremented when the
+// parser creates a custom element, not when createElement is called. Test for
+// this.
+//
+// See: https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document-open-steps
+
+const noError = Symbol("no error");
+let err = noError;
+
+class CustomElement extends HTMLElement {
+  constructor() {
+    super();
+    try {
+      document.open();
+    } catch (e) {
+      err = e;
+    }
+  }
+}
+customElements.define("custom-element", CustomElement);
+
+test(t => {
+  err = noError;
+  document.createElement("custom-element");
+  assert_equals(err, noError);
+}, "document.open() works in custom element constructor for createElement()");
+
+test(t => {
+  err = noError;
+  document.write("<custom-element></custom-element>");
+  assert_throws("InvalidStateError", () => {
+    throw err;
+  });
+}, "document.open() is forbidden in custom element constructor when creating element from parser");


### PR DESCRIPTION
Blink and Gecko pass both tests. WebKit has a [bug](https://bugs.webkit.org/show_bug.cgi?id=187319) open, as well as a [FIXME](https://github.com/WebKit/webkit/blob/e50db3db8d808b34f1e37655aa8a371d9f891dcc/Source/WebCore/dom/Document.cpp#L2615-L2616) in the source code. Edge doesn't yet implement custom elements.