### PR TITLE
Add preamble to testdriver-tutorial.html

### DIFF
--- a/docs/_writing-tests/testdriver-tutorial.md
+++ b/docs/_writing-tests/testdriver-tutorial.md
@@ -1,3 +1,9 @@
+---
+layout: page
+title: testdriver.js Tutorial
+order: 8.6
+---
+
 # Adding new commands to testdriver.js
 
 ## Assumptions


### PR DESCRIPTION
An attempt to make https://web-platform-tests.org/writing-tests/testdriver-tutorial.html appear.