### PR TITLE
Clean up picture-in-picture tests

### DIFF
--- a/picture-in-picture/disable-picture-in-picture.html
+++ b/picture-in-picture/disable-picture-in-picture.html
@@ -33,7 +33,7 @@ promise_test(async t => {
 
 promise_test(async t => {
   const video = await loadVideo();
-  return callWithTrustedClick(async () => {
+  return test_driver.bless('request picture in picture', async () => {
     const promise = video.requestPictureInPicture();
     video.disablePictureInPicture = true;
     await promise_rejects(t, 'InvalidStateError', promise);

--- a/picture-in-picture/idlharness.window.js
+++ b/picture-in-picture/idlharness.window.js
@@ -8,24 +8,19 @@
 
 // https://wicg.github.io/picture-in-picture/
 
-promise_test(async () => {
-  try {
+idl_test(
+  ['picture-in-picture'],
+  ['html', 'dom'],
+  async idl_array => {
+    idl_array.add_objects({
+      Document: ['document'],
+      DocumentOrShadowRoot: ['document'],
+      HTMLVideoElement: ['video'],
+      PictureInPictureWindow: ['pipw'],
+    });
+
     self.video = await loadVideo();
     self.pipw = await requestPictureInPictureWithTrustedClick(video);
-  } catch (e) {
-    // Will be surfaced when video/pipw are undefined below.
-  }
-
-  idl_test(
-    ['picture-in-picture'],
-    ['html', 'dom'],
-    idl_array => {
-      idl_array.add_objects({
-        Document: ['document'],
-        DocumentOrShadowRoot: ['document'],
-        HTMLVideoElement: ['video'],
-        PictureInPictureWindow: ['pipw'],
-      });
-    },
-    'picture-in-picture interfaces.');
-})
+  },
+  'picture-in-picture interfaces.'
+);

--- a/picture-in-picture/request-picture-in-picture-twice.html
+++ b/picture-in-picture/request-picture-in-picture-twice.html
@@ -10,13 +10,12 @@
 promise_test(async t => {
   const video1 = await loadVideo();
   const video2 = await loadVideo();
-  return callWithTrustedClick(() => {
-    const first = video1.requestPictureInPicture();
-    const second = video2.requestPictureInPicture();
-    return Promise.all([
-      first,
-      promise_rejects(t, 'NotAllowedError', second)
-    ]);
-  });
+  return test_driver.bless(
+    'request picture in picture',
+    async () => {
+      await video1.requestPictureInPicture();
+      promise_rejects(t, 'NotAllowedError', video2.requestPictureInPicture());
+    }
+  );
 }, 'request Picture-in-Picture consumes user gesture');
 </script>

--- a/picture-in-picture/resources/picture-in-picture-helpers.js
+++ b/picture-in-picture/resources/picture-in-picture-helpers.js
@@ -4,38 +4,19 @@ if (!('pictureInPictureEnabled' in document)) {
   }
 }
 
-function callWithTrustedClick(callback) {
-  return new Promise((resolve, reject) => {
-    let button = document.createElement('button');
-    button.textContent = 'click to continue test';
-    button.style.display = 'block';
-    button.style.fontSize = '20px';
-    button.style.padding = '10px';
-    button.onclick = () => {
-      document.body.removeChild(button);
-      resolve(callback());
-    };
-    document.body.appendChild(button);
-    test_driver.click(button).catch(_ => reject('Click failed'));
-  });
-}
-
 function loadVideo(activeDocument, sourceUrl) {
   return new Promise((resolve, reject) => {
     const document = activeDocument || window.document;
     const video = document.createElement('video');
     video.src = sourceUrl || '/media/movie_5.ogv';
-    video.onloadedmetadata = () => {
-      resolve(video);
-    };
-    video.onerror = error => {
-      reject(error);
-    };
+    video.onloadedmetadata = () => { resolve(video); };
+    video.onerror = error => { reject(error); };
   });
 }
 
 // Calls requestPictureInPicture() in a context that's 'allowed to request PiP'.
 function requestPictureInPictureWithTrustedClick(videoElement) {
-  return callWithTrustedClick(
-      () => videoElement.requestPictureInPicture());
+  return test_driver.bless(
+    'request picture in picture',
+    () => videoElement.requestPictureInPicture());
 }


### PR DESCRIPTION
Simplifies the IDL test (now that it supports async/promises in the setup function).
Removes the redundant `callWithTrustedClick` method in favor of the almost-identical `test_driver.bless` method.

Chrome 69:
Ran 76 checks (10 tests, 66 subtests)
Expected results: 76