### PR TITLE
Use generic hasOwnProperty call for asserted objects

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1007,7 +1007,7 @@ policies and contribution forms [3].
 
              var p;
              for (p in actual) {
-                 assert(expected.hasOwnProperty(p), "assert_object_equals", description,
+                 assert(Object.prototype.hasOwnProperty.call(expected, p), "assert_object_equals", description,
                                                     "unexpected property ${p}", {p:p});
 
                  if (typeof actual[p] === "object" && actual[p] !== null) {
@@ -1021,7 +1021,7 @@ policies and contribution forms [3].
                  }
              }
              for (p in expected) {
-                 assert(actual.hasOwnProperty(p),
+                 assert(Object.prototype.hasOwnProperty.call(actual, p),
                         "assert_object_equals", description,
                         "expected property ${p} missing", {p:p});
              }
@@ -1043,11 +1043,11 @@ policies and contribution forms [3].
                {expected:expected.length, actual:actual.length});
 
         for (var i = 0; i < actual.length; i++) {
-            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+            assert(Object.prototype.hasOwnProperty.call(actual, i) === Object.prototype.hasOwnProperty.call(expected, i),
                    "assert_array_equals", description,
                    "property ${i}, property expected to be ${expected} but was ${actual}",
-                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
-                   actual:actual.hasOwnProperty(i) ? "present" : "missing"});
+                   {i:i, expected:Object.prototype.hasOwnProperty.call(expected, i) ? "present" : "missing",
+                   actual:Object.prototype.hasOwnProperty.call(actual, i) ? "present" : "missing"});
             assert(same_value(expected[i], actual[i]),
                    "assert_array_equals", description,
                    "property ${i}, expected ${expected} but got ${actual}",
@@ -1067,11 +1067,11 @@ policies and contribution forms [3].
                {expected:expected.length, actual:actual.length});
 
         for (var i = 0; i < actual.length; i++) {
-            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
+            assert(Object.prototype.hasOwnProperty.call(actual, i) === Object.prototype.hasOwnProperty.call(expected, i),
                    "assert_array_approx_equals", description,
                    "property ${i}, property expected to be ${expected} but was ${actual}",
-                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
-                   actual:actual.hasOwnProperty(i) ? "present" : "missing"});
+                   {i:i, expected:Object.prototype.hasOwnProperty.call(expected, i) ? "present" : "missing",
+                   actual:Object.prototype.hasOwnProperty.call(actual, i) ? "present" : "missing"});
             assert(typeof actual[i] === "number",
                    "assert_array_approx_equals", description,
                    "property ${i}, expected a number but got a ${type_actual}",
@@ -1226,7 +1226,7 @@ policies and contribution forms [3].
     function _assert_own_property(name) {
         return function(object, property_name, description)
         {
-            assert(object.hasOwnProperty(property_name),
+            assert(Object.prototype.hasOwnProperty.call(object, property_name),
                    name, description,
                    "expected property ${p} missing", {p:property_name});
         };
@@ -1236,7 +1236,7 @@ policies and contribution forms [3].
 
     function assert_not_exists(object, property_name, description)
     {
-        assert(!object.hasOwnProperty(property_name),
+        assert(!Object.prototype.hasOwnProperty.call(object, property_name),
                "assert_not_exists", description,
                "unexpected property ${p} found", {p:property_name});
     }

--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -1043,11 +1043,11 @@ policies and contribution forms [3].
                {expected:expected.length, actual:actual.length});
 
         for (var i = 0; i < actual.length; i++) {
-            assert(Object.prototype.hasOwnProperty.call(actual, i) === Object.prototype.hasOwnProperty.call(expected, i),
+            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
                    "assert_array_equals", description,
                    "property ${i}, property expected to be ${expected} but was ${actual}",
-                   {i:i, expected:Object.prototype.hasOwnProperty.call(expected, i) ? "present" : "missing",
-                   actual:Object.prototype.hasOwnProperty.call(actual, i) ? "present" : "missing"});
+                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
+                   actual:actual.hasOwnProperty(i) ? "present" : "missing"});
             assert(same_value(expected[i], actual[i]),
                    "assert_array_equals", description,
                    "property ${i}, expected ${expected} but got ${actual}",
@@ -1067,11 +1067,11 @@ policies and contribution forms [3].
                {expected:expected.length, actual:actual.length});
 
         for (var i = 0; i < actual.length; i++) {
-            assert(Object.prototype.hasOwnProperty.call(actual, i) === Object.prototype.hasOwnProperty.call(expected, i),
+            assert(actual.hasOwnProperty(i) === expected.hasOwnProperty(i),
                    "assert_array_approx_equals", description,
                    "property ${i}, property expected to be ${expected} but was ${actual}",
-                   {i:i, expected:Object.prototype.hasOwnProperty.call(expected, i) ? "present" : "missing",
-                   actual:Object.prototype.hasOwnProperty.call(actual, i) ? "present" : "missing"});
+                   {i:i, expected:expected.hasOwnProperty(i) ? "present" : "missing",
+                   actual:actual.hasOwnProperty(i) ? "present" : "missing"});
             assert(typeof actual[i] === "number",
                    "assert_array_approx_equals", description,
                    "property ${i}, expected a number but got a ${type_actual}",


### PR DESCRIPTION
This fixes issues in the streams tests that call assert_equal and friends on objects explicitly created with a null prototype.  Only the calls to hasOwnProperty on external objects are replaced.

Changed in main harness as it (likely?) is not a bad idea to assume other oddly-shaped objects will be passed to the assert functions.

The commit making the changes to streams that breaks these fixes is: https://github.com/whatwg/streams/commit/a27a1fd0f8640d6054e0cbc8b6d7f5464dd096ab