### PR TITLE
Make servodriver wait until the server starts accepting TCP connections

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -57,6 +57,9 @@ class ServoWebDriverProtocol(Protocol):
 
     def connect(self):
         """Connect to browser via WebDriver."""
+        # Largish timeout for the case where we're booting an Android emulator.
+        wait_for_service((self.host, self.port), timeout=120)
+
         self.session = webdriver.Session(self.host, self.port, extension=ServoCommandExtensions)
         self.session.start()
 


### PR DESCRIPTION

Upstreamed from https://github.com/servo/servo/pull/21213 [ci skip]