### PR TITLE
More Python fixes for servodriver

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -6,6 +6,7 @@ import time
 import traceback
 
 from .base import (Protocol,
+                   BaseProtocolPart,
                    RefTestExecutor,
                    RefTestImplementation,
                    TestharnessExecutor,
@@ -46,7 +47,23 @@ def do_delayed_imports():
             return self.session.send_command("POST", "servo/prefs/reset", body)
 
 
+class ServoBaseProtocolPart(BaseProtocolPart):
+    def execute_script(self, script, async=False):
+        pass
+
+    def set_timeout(self, timeout):
+        pass
+
+    def wait(self):
+        pass
+
+    def set_window(self, handle):
+        pass
+
+
 class ServoWebDriverProtocol(Protocol):
+    implements = [ServoBaseProtocolPart]
+
     def __init__(self, executor, browser, capabilities, **kwargs):
         do_delayed_imports()
         Protocol.__init__(self, executor, browser)


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/home/simon/servo1/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/testrunner.py", line 90, in run
    rv = commands[command](*args)
  File "/home/simon/servo1/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/testrunner.py", line 110, in wait
    self.executor.wait()
  File "/home/simon/servo1/tests/wpt/web-platform-tests/tools/wptrunner/wptrunner/executors/base.py", line 209, in wait
    self.protocol.base.wait()
AttributeError: 'ServoWebDriverProtocol' object has no attribute 'base'
```

Upstreamed from https://github.com/servo/servo/pull/21213 [ci skip]