### PR TITLE
Don’t reverse-forward port "None"

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -99,6 +99,7 @@ class ServoWebDriverBrowser(Browser):
             str(port)
             for _protocol, ports in self.server_ports.items()
             for port in ports
+            if port
         )
 
         debug_args, command = browser_command(


### PR DESCRIPTION

```
 0:27.48 pid:4157 Traceback (most recent call last):
 0:27.48 pid:4157   File "/home/simon/servo1/etc/run_in_headless_android_emulator.py", line 212, in <module>
 0:27.48 pid:4157     sys.exit(main(*sys.argv[1:]))
 0:27.48 pid:4157   File "/home/simon/servo1/etc/run_in_headless_android_emulator.py", line 72, in main
 0:27.48 pid:4157     forward_webdriver(adb, args)
 0:27.48 pid:4157   File "/home/simon/servo1/etc/run_in_headless_android_emulator.py", line 163, in forward_webdriver
 0:27.48 pid:4157     ports = [int(part) for part in split if part]
 0:27.48 pid:4157 ValueError: invalid literal for int() with base 10: 'None'
```

Upstreamed from https://github.com/servo/servo/pull/21213 [ci skip]