### PR TITLE
servodriver: fix setting preferences

### DIFF
--- a/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -34,17 +34,35 @@ def do_delayed_imports():
         @webdriver.client.command
         def get_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
-            return self.session.send_command("POST", "servo/prefs/get", body)
+            return self.session.send_session_command("POST", "servo/prefs/get", body)
 
         @webdriver.client.command
         def set_prefs(self, prefs):
             body = {"prefs": prefs}
-            return self.session.send_command("POST", "servo/prefs/set", body)
+            return self.session.send_session_command("POST", "servo/prefs/set", body)
 
         @webdriver.client.command
         def reset_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
-            return self.session.send_command("POST", "servo/prefs/reset", body)
+            return self.session.send_session_command("POST", "servo/prefs/reset", body)
+
+        def change_prefs(self, old_prefs, new_prefs):
+            # Servo interprets reset with an empty list as reset everything
+            if old_prefs:
+                self.reset_prefs(*old_prefs.keys())
+            self.set_prefs({k: parse_pref_value(v) for k, v in new_prefs.items()})
+
+
+# See parse_pref_from_command_line() in components/config/opts.rs
+def parse_pref_value(value):
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    try:
+        return float(value)
+    except ValueError:
+        return value
 
 
 class ServoBaseProtocolPart(BaseProtocolPart):
@@ -110,11 +128,6 @@ class ServoWebDriverProtocol(Protocol):
             except Exception as e:
                 self.logger.error(traceback.format_exc(e))
                 break
-
-    def on_environment_change(self, old_environment, new_environment):
-        #Unset all the old prefs
-        self.session.extension.reset_prefs(*old_environment.get("prefs", {}).keys())
-        self.session.extension.set_prefs(new_environment.get("prefs", {}))
 
 
 class ServoWebDriverRun(object):
@@ -215,6 +228,12 @@ class ServoWebDriverTestharnessExecutor(TestharnessExecutor):
         session.back()
         return result
 
+    def on_environment_change(self, new_environment):
+        self.protocol.session.extension.change_prefs(
+            self.last_environment.get("prefs", {}),
+            new_environment.get("prefs", {})
+        )
+
 
 class TimeoutError(Exception):
     pass
@@ -281,3 +300,9 @@ class ServoWebDriverRefTestExecutor(RefTestExecutor):
         session.url = url
         session.execute_async_script(self.wait_script)
         return session.screenshot()
+
+    def on_environment_change(self, new_environment):
+        self.protocol.session.extension.change_prefs(
+            self.last_environment.get("prefs", {}),
+            new_environment.get("prefs", {})
+        )


### PR DESCRIPTION

This makes `/_mozilla/mozilla/webgl/context_creation_error.html` pass,
for example.

```
./ mach test-wpt --product servodriver \
  --binary etc/run_in_headless_android_emulator.py \
  --binary-arg servo-x86 \
  --binary-arg target/i686-linux-android/release/servo.apk \
  /_mozilla/mozilla/webgl/context_creation_error.html
```

Upstreamed from https://github.com/servo/servo/pull/21213 [ci skip]