### PR TITLE
[idlharness.js] Assert correct type for original definition of partials

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -870,6 +870,16 @@ IdlArray.prototype.collapse_partials = function()
 
             test(function () {
                 assert_true(originalExists, `Original ${parsed_idl.type} should be defined`);
+
+                var expected = IdlInterface;
+                switch (parsed_idl.type) {
+                    case 'interface': expected = IdlInterface; break;
+                    case 'dictionary': expected = IdlDictionary; break;
+                    case 'namespace': expected = IdlNamespace; break;
+                }
+                assert_true(
+                    expected.prototype.isPrototypeOf(this.members[parsed_idl.name]),
+                    `Original ${parsed_idl.name} definition should have type ${parsed_idl.type}`);
             }.bind(this), `Partial ${parsed_idl.type} ${partialTestName}: original ${parsed_idl.type} defined`);
         }
         if (!originalExists) {

--- a/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlDictionary/test_partial_interface_of.html
@@ -35,6 +35,15 @@
       idlArray.add_idls('dictionary B {};');
       idlArray.test();
     })();
+
+    // Original is a namespace, not a dictionary.
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls(`
+        partial dictionary C {};
+        namespace C {};`);
+      idlArray.collapse_partials();
+    })();
   </script>
   <script type="text/json" id="expected">
 {
@@ -66,6 +75,12 @@
       "status_string": "PASS",
       "properties": {},
       "message": null
+    },
+    {
+      "name": "Partial dictionary C: original dictionary defined",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_true: Original C definition should have type dictionary expected true got false"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
+++ b/resources/test/tests/functional/idlharness/IdlInterface/test_partial_interface_of.html
@@ -54,6 +54,15 @@
         partial interface D {};`);
       idlArray.collapse_partials();
     })();
+
+    // Original is a namespace, not an interface.
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls(`
+        partial interface E {};
+        namespace E {};`);
+      idlArray.collapse_partials();
+    })();
   </script>
   <script type="text/json" id="expected">
 {
@@ -103,6 +112,12 @@
       "status_string": "FAIL",
       "properties": {},
       "message": "Partial D interface is exposed to 'DedicatedWorker', the original interface is not."
+    },
+    {
+      "name": "Partial interface E: original interface defined",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_true: Original E definition should have type interface expected true got false"
     }
   ],
   "type": "complete"

--- a/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
+++ b/resources/test/tests/functional/idlharness/IdlNamespace/test_partial_namespace.html
@@ -54,6 +54,15 @@
         partial namespace D {};`);
       idlArray.collapse_partials();
     })();
+
+    // Original is an interface, not a namespace.
+    (() => {
+      const idlArray = new IdlArray();
+      idlArray.add_idls(`
+        partial namespace E {};
+        interface E {};`);
+      idlArray.collapse_partials();
+    })();
   </script>
   <script type="text/json" id="expected">
 {
@@ -103,6 +112,12 @@
       "status_string": "FAIL",
       "properties": {},
       "message": "Partial D namespace is exposed to 'DedicatedWorker', the original namespace is not."
+    },
+    {
+      "name": "Partial namespace E: original namespace defined",
+      "status_string": "FAIL",
+      "properties": {},
+      "message": "assert_true: Original E definition should have type namespace expected true got false"
     }
   ],
   "type": "complete"


### PR DESCRIPTION
Found during authorship of #11980 - The original definition of `CSS` is (currently) an `interface`, but having a `partial namespace CSS` didn't fail any tests.

This fixes that.

Fixes #12123