### PR TITLE
Ensure that `write_content` performs checks before writing

### DIFF
--- a/tools/wptserve/tests/functional/test_response.py
+++ b/tools/wptserve/tests/functional/test_response.py
@@ -1,11 +1,12 @@
 import sys
+import os
 import unittest
 from types import MethodType
 
 import pytest
 
 wptserve = pytest.importorskip("wptserve")
-from .base import TestUsingServer
+from .base import TestUsingServer, doc_root
 
 
 def send_body_as_header(self):
@@ -48,6 +49,138 @@ class TestResponse(TestUsingServer):
         self.assertEqual("6", resp.info()['Content-Length'])
         self.assertEqual("TEST", resp.info()['x-Test'])
         self.assertEqual("body", resp.info()['X-Body'])
+
+    def test_write_content_no_status_no_header(self):
+        resp_content = b"TEST"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_content(resp_content)
+
+        route = ("GET", "/test/test_write_content_no_status_no_header", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 200
+        assert resp.read() == resp_content
+        assert resp.info()["Content-Length"] == str(len(resp_content))
+        assert "Date" in resp.info()
+        assert "Server" in resp.info()
+
+    def test_write_content_no_headers(self):
+        resp_content = b"TEST"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_status(201)
+            response.writer.write_content(resp_content)
+
+        route = ("GET", "/test/test_write_content_no_headers", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 201
+        assert resp.read() == resp_content
+        assert resp.info()["Content-Length"] == str(len(resp_content))
+        assert "Date" in resp.info()
+        assert "Server" in resp.info()
+
+    def test_write_content_no_status(self):
+        resp_content = b"TEST"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_header("test-header", "test-value")
+            response.writer.write_content(resp_content)
+
+        route = ("GET", "/test/test_write_content_no_status", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 200
+        assert resp.read() == resp_content
+        assert sorted([x.lower() for x in resp.info().keys()]) == sorted(['test-header', 'date', 'server', 'content-length'])
+
+    def test_write_content_no_status_no_required_headers(self):
+        resp_content = b"TEST"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.add_required_headers = False
+            response.writer.write_header("test-header", "test-value")
+            response.writer.write_content(resp_content)
+
+        route = ("GET", "/test/test_write_content_no_status_no_required_headers", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 200
+        assert resp.read() == resp_content
+        assert resp.info().items() == [('test-header', 'test-value')]
+
+    def test_write_content_no_status_no_headers_no_required_headers(self):
+        resp_content = b"TEST"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.add_required_headers = False
+            response.writer.write_content(resp_content)
+
+        route = ("GET", "/test/test_write_content_no_status_no_headers_no_required_headers", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 200
+        assert resp.read() == resp_content
+        assert resp.info().items() == []
+
+    def test_write_raw_content(self):
+        resp_content = b"HTTP/1.1 202 Giraffe\n" \
+            b"X-TEST: PASS\n" \
+            b"Content-Length: 7\n\n" \
+            b"Content"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_raw_content(resp_content)
+
+        route = ("GET", "/test/test_write_raw_content", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 202
+        assert resp.info()["X-TEST"] == "PASS"
+        assert resp.read() == b"Content"
+
+    def test_write_raw_content_file(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            with open(os.path.join(doc_root, "test.asis"), 'rb') as infile:
+                response.writer.write_raw_content(infile)
+
+        route = ("GET", "/test/test_write_raw_content", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.getcode() == 202
+        assert resp.info()["X-TEST"] == "PASS"
+        assert resp.read() == b"Content"
+
+    def test_write_raw_none(self):
+        @wptserve.handlers.handler
+        def handler(request, response):
+            with pytest.raises(ValueError, message="data cannot be None"):
+                response.writer.write_raw_content(None)
+
+        route = ("GET", "/test/test_write_raw_content", handler)
+        self.server.router.register(*route)
+        self.request(route[1])
+
+    @pytest.mark.xfail(sys.version_info >= (3,), reason="py3 urllib doesn't handle invalid HTTP very well")
+    def test_write_raw_contents_invalid_http(self):
+        resp_content = b"INVALID HTTP"
+
+        @wptserve.handlers.handler
+        def handler(request, response):
+            response.writer.write_raw_content(resp_content)
+
+        route = ("GET", "/test/test_write_raw_content", handler)
+        self.server.router.register(*route)
+        resp = self.request(route[1])
+        assert resp.read() == resp_content
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/wptserve/wptserve/handlers.py
+++ b/tools/wptserve/wptserve/handlers.py
@@ -322,7 +322,7 @@ class AsIsHandler(object):
 
         try:
             with open(path) as f:
-                response.writer.write_content(f.read())
+                response.writer.write_raw_content(f.read())
             wrap_pipeline(path, request, response)
             response.close_connection = True
         except IOError:

--- a/tools/wptserve/wptserve/response.py
+++ b/tools/wptserve/wptserve/response.py
@@ -470,11 +470,13 @@ class ResponseWriter(object):
         self._wfile = handler.wfile
         self._response = response
         self._handler = handler
+        self._status_written = False
         self._headers_seen = set()
         self._headers_complete = False
         self.content_written = False
         self.request = response.request
         self.file_chunk_size = 32 * 1024
+        self.default_status = 200
 
     def write_status(self, code, message=None):
         """Write out the status line of a response.
@@ -489,13 +491,18 @@ class ResponseWriter(object):
                 message = ''
         self.write("%s %d %s\r\n" %
                    (self._response.request.protocol_version, code, message))
+        self._status_written = True
 
     def write_header(self, name, value):
         """Write out a single header for the response.
 
+        If a status has not been written, a default status will be written (currently 200)
+
         :param name: Name of the header field
         :param value: Value of the header field
         """
+        if not self._status_written:
+            self.write_status(self.default_status)
         self._headers_seen.add(name.lower())
         self.write("%s: %s\r\n" % (name, value))
         if not self._response.explicit_flush:
@@ -530,7 +537,20 @@ class ResponseWriter(object):
         self._headers_complete = True
 
     def write_content(self, data):
-        """Write the body of the response."""
+        """Write the body of the response.
+
+        HTTP-mandated headers will be automatically added with status default to 200 if they have not been explicitly set."""
+        if not self._status_written:
+            self.write_status(self.default_status)
+        if not self._headers_complete:
+            self._response.content = data
+            self.end_headers()
+        self.write_raw_content(data)
+
+    def write_raw_content(self, data):
+        """Writes the data 'as is'"""
+        if data is None:
+            raise ValueError('data cannot be None')
         if isinstance(data, (text_type, binary_type)):
             # Deliberately allows both text and binary types. See `self.encode`.
             self.write(data)


### PR DESCRIPTION
As mentioned in #11764, the python3 HTTP lib doesn't support simply writing HTTP body without writing status and headers. To help with this, I've changed the way `write_content` behaves by no longer blindly writing the data given to it, but instead performing checks to see if a status has been written and if required headers have been written (if at all needed). 

I've moved the original behaviour of `write_content` to `write_raw_content` which blindly tries to write the data given to it to the `wfile`.