### PR TITLE
[idlharness.js] Add inheritor as dep for includes

### DIFF
--- a/WebCryptoAPI/idlharness.https.any.js
+++ b/WebCryptoAPI/idlharness.https.any.js
@@ -3,14 +3,14 @@
 
 // https://w3c.github.io/webcrypto/Overview.html
 
-promise_test(async () => {
-  const idl = await fetch(`/interfaces/WebCryptoAPI.idl`).then(r => r.text());
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_objects({
-    Crypto: ['crypto'],
-    SubtleCrypto: ['crypto.subtle']
-  });
-  idl_array.test();
-}, 'WebCryptoAPI interfaces');
+idl_test(
+  ['WebCryptoAPI'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      Crypto: ['crypto'],
+      SubtleCrypto: ['crypto.subtle']
+    });
+  },
+  'WebCryptoAPI interfaces'
+);

--- a/css/css-animations/idlharness.html
+++ b/css/css-animations/idlharness.html
@@ -26,7 +26,7 @@
 
     idl_test(
       ['css-animations'],
-      ['dom', 'cssom'],
+      ['html', 'dom', 'cssom'],
       idl_array => {
         try {
           window.keyframes = document.styleSheets[0].cssRules[0];

--- a/css/css-transitions/idlharness.html
+++ b/css/css-transitions/idlharness.html
@@ -13,7 +13,7 @@
     ['cssom', 'html', 'dom'],
     idl_array => {
       idl_array.add_objects({
-        TransitionEvent: ['new TransitionEvent("transition")'],
+        TransitionEvent: ['new TransitionEvent("transitionend")'],
         // These include GlobalEventHandlers
         Document: ['document'],
         HTMLElement: ['document'],

--- a/css/css-transitions/idlharness.html
+++ b/css/css-transitions/idlharness.html
@@ -8,16 +8,18 @@
 <script>
   "use strict";
 
-  promise_test(async () => {
-    const idl_array = new IdlArray();
-    const idl = await fetch("/interfaces/css-transitions.idl").then(r => r.text());
-    const cssom = await fetch("/interfaces/cssom.idl").then(r => r.text());
-    const html = await fetch("/interfaces/html.idl").then(r => r.text());
-    const dom = await fetch("/interfaces/dom.idl").then(r => r.text());
-    idl_array.add_idls(idl);
-    idl_array.add_dependency_idls(cssom);
-    idl_array.add_dependency_idls(html);
-    idl_array.add_dependency_idls(dom);
-    idl_array.test();
-  }, "Test IDL implementation of css-transitions API");
+  idl_test(
+    ['css-transitions'],
+    ['cssom', 'html', 'dom'],
+    idl_array => {
+      idl_array.add_objects({
+        TransitionEvent: ['new TransitionEvent("transition")'],
+        // These include GlobalEventHandlers
+        Document: ['document'],
+        HTMLElement: ['document'],
+        Window: ['window'],
+      })
+    },
+    'Test IDL implementation of css-transitions API'
+  );
 </script>

--- a/fetch/api/idl.any.js
+++ b/fetch/api/idl.any.js
@@ -2,18 +2,20 @@
 // META: script=/resources/WebIDLParser.js
 // META: script=/resources/idlharness.js
 
-promise_test(async() => {
-  const text = await (await fetch("/interfaces/fetch.idl")).text();
-  const referrer_policy = await (await fetch("/interfaces/referrer-policy.idl")).text();
-  const idl_array = new IdlArray();
-  idl_array.add_idls(text);
-  idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface AbortSignal {};");
-  idl_array.add_untested_idls("[Exposed=(Window,Worker)] interface ReadableStream {};");
-  idl_array.add_dependency_idls(referrer_policy);
-  idl_array.add_objects({
-    Headers: ["new Headers()"],
-    Request: ["new Request('about:blank')"],
-    Response: ["new Response()"],
-  });
-  idl_array.test();
-}, "Fetch Standard IDL");
+idl_test(
+  ['fetch'],
+  ['referrer-policy', 'html', 'dom'],
+  idl_array => {
+    idl_array.add_objects({
+      Headers: ["new Headers()"],
+      Request: ["new Request('about:blank')"],
+      Response: ["new Response()"],
+    });
+    if (self.GLOBAL.isWindow()) {
+      idl_array.add_objects({ Window: ['window'] });
+    } else if (self.GLOBAL.isWorker()) {
+      idl_array.add_objects({ WorkerGlobalScope: ['self'] });
+    }
+  },
+  'Fetch Standard IDL'
+);

--- a/mediacapture-record/idlharness.window.js
+++ b/mediacapture-record/idlharness.window.js
@@ -7,7 +7,7 @@
 
 idl_test(
   ['mediastream-recording'],
-  ['mediacapture-main', 'html', 'dom', 'FileAPI'],
+  ['mediacapture-streams', 'FileAPI', 'html', 'dom'],
   idl_array => {
     // Ignored errors will be surfaced in idlharness.js's test_object below.
     let recorder, blob, error;

--- a/push-api/idlharness.https.any.js
+++ b/push-api/idlharness.https.any.js
@@ -4,20 +4,19 @@
 
 // https://w3c.github.io/push-api/
 
-promise_test(async () => {
-  const srcs = [
-    'push-api',
-    'service-workers',
-    'dom',
-    'html'
-  ];
-  const [idl, worker, dom, html] = await Promise.all(
-    srcs.map(i => fetch(`/interfaces/${i}.idl`).then(r => r.text())));
-
-  const idl_array = new IdlArray();
-  idl_array.add_idls(idl);
-  idl_array.add_dependency_idls(worker);
-  idl_array.add_dependency_idls(dom);
-  idl_array.add_dependency_idls(html);
-  idl_array.test();
-}, 'push-api interfaces');
+idl_test(
+  ['push-api'],
+  ['service-workers', 'html', 'dom'],
+  idl_array => {
+    // TODO: ServiceWorkerRegisrtation objects
+    if ('ServiceWorkerGlobalScope' in self
+        && self instanceof ServiceWorkerGlobalScope) {
+      idl_array.add_objects({
+        PushSubscriptionChangeEvent: [
+          'new PushSubscriptionChangeEvent("pushsubscriptionchange")'
+        ],
+      })
+    }
+  },
+  'push-api interfaces'
+);

--- a/push-api/idlharness.https.any.js
+++ b/push-api/idlharness.https.any.js
@@ -8,7 +8,7 @@ idl_test(
   ['push-api'],
   ['service-workers', 'html', 'dom'],
   idl_array => {
-    // TODO: ServiceWorkerRegisrtation objects
+    // TODO: ServiceWorkerRegistration objects
     if ('ServiceWorkerGlobalScope' in self
         && self instanceof ServiceWorkerGlobalScope) {
       idl_array.add_objects({

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -299,36 +299,59 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
     // Maps name -> [parsed_idl, ...]
     const skipped = new Map();
     const process = function(parsed) {
-        let name = parsed.name
-            || parsed.type == "implements" && parsed.target
-            || parsed.type == "includes" && parsed.target;
-        if (!name || should_skip(name) || !all_deps.has(name)) {
-            name &&
-                skipped.has(name)
-                    ? skipped.get(name).push(parsed)
-                    : skipped.set(name, [parsed]);
-            return;
+        var deps = [];
+        if (parsed.name) {
+            deps.push(parsed.name);
+        } else if (parsed.type === "implements") {
+            deps.push(parsed.target);
+            deps.push(parsed.implements);
+        } else if (parsed.type === "includes") {
+            deps.push(parsed.target);
+            deps.push(parsed.includes);
         }
 
-        new_options.only.push(name);
-        const follow_up = [];
-        for (const dep_type of ["inheritance", "implements", "includes"]) {
-            if (parsed[dep_type]) {
-                const dep = parsed[dep_type];
-                new_options.only.push(dep);
-                all_deps.add(dep);
-                follow_up.push(dep);
+        deps = deps.filter(function(name) {
+            if (!name || should_skip(name) || !all_deps.has(name)) {
+                // Flag as skipped, if it's not already processed, so we can
+                // come back to it later if we retrospectively call it a dep.
+                if (!(name in this.members)) {
+                    name &&
+                        skipped.has(name)
+                            ? skipped.get(name).push(parsed)
+                            : skipped.set(name, [parsed]);
+                    (name.includes('Global') || name.includes('Window')) && console.log("Skipped", parsed);
+                }
+                return false;
             }
-        }
+            return true;
+        }.bind(this));
 
-        for (const deferred of follow_up) {
-            if (skipped.has(deferred)) {
-                const next = skipped.get(deferred);
-                skipped.delete(deferred);
-                next.forEach(process);
+        deps.forEach(function(name) {
+            new_options.only.push(name);
+
+            const follow_up = new Set();
+            for (const dep_type of ["inheritance", "implements", "includes"]) {
+                if (parsed[dep_type]) {
+                    const inheriting = parsed[dep_type];
+                    const inheritor = parsed.name || parsed.target;
+                    for (const dep of [inheriting, inheritor]) {
+                        new_options.only.push(dep);
+                        all_deps.add(dep);
+                        follow_up.add(dep);
+                    }
+                }
             }
-        }
-    }
+
+            for (const deferred of follow_up) {
+                if (skipped.has(deferred)) {
+                    const next = skipped.get(deferred);
+                    skipped.delete(deferred);
+                    next.forEach(process);
+                }
+            }
+        });
+    }.bind(this);
+
     for (let parsed of parsed_idls) {
         process(parsed);
     }
@@ -370,8 +393,13 @@ IdlArray.prototype.internal_add_idls = function(parsed_idls, options)
 
     parsed_idls.forEach(function(parsed_idl)
     {
-        if (parsed_idl.partial
-            && ["interface", "dictionary", "namespace"].includes(parsed_idl.type))
+        var partial_types = [
+            "interface",
+            "interface mixin",
+            "dictionary",
+            "namespace",
+        ];
+        if (parsed_idl.partial && partial_types.includes(parsed_idl.type))
         {
             if (should_skip(parsed_idl.name))
             {
@@ -3174,9 +3202,7 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
         deps = (deps instanceof Array) ? deps : [deps] || [];
         return Promise.all(
             srcs.concat(deps).map(function(spec) {
-                return fetch('/interfaces/' + spec + '.idl').then(function(r) {
-                    return r.text();
-                });
+                return fetch_spec(spec);
             }))
             .then(function(idls) {
                 for (var i = 0; i < srcs.length; i++) {
@@ -3191,9 +3217,24 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
             })
             .then(function() { idl_array.test(); })
             .catch(function (reason) {
-                idl_array.test(); // Test what we can.
+                try {
+                    idl_array.test(); // Test what we can.
+                } catch (e) {
+                    // If testing fails hard here, the original setup error
+                    // is more likely to be the real cause.
+                    reason = reason || e;
+                }
                 return Promise.reject(reason || 'IDL setup failed.');
             });
     }, test_name);
+}
+
+/**
+ * fetch_spec is a shorthand for a Promise that fetches the spec's content.
+ */
+function fetch_spec(spec) {
+    return fetch('/interfaces/' + spec + '.idl').then(function (r) {
+        return r.text();
+    });
 }
 // vim: set expandtab shiftwidth=4 tabstop=4 foldmarker=@{,@} foldmethod=marker:

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -314,11 +314,10 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
             if (!name || should_skip(name) || !all_deps.has(name)) {
                 // Flag as skipped, if it's not already processed, so we can
                 // come back to it later if we retrospectively call it a dep.
-                if (!(name in this.members)) {
-                    name && skipped.has(name)
+                if (name && !(name in this.members)) {
+                    skipped.has(name)
                         ? skipped.get(name).push(parsed)
                         : skipped.set(name, [parsed]);
-                    (name.includes('Global') || name.includes('Window')) && console.log("Skipped", parsed);
                 }
                 return false;
             }

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -315,10 +315,9 @@ IdlArray.prototype.add_dependency_idls = function(raw_idls, options)
                 // Flag as skipped, if it's not already processed, so we can
                 // come back to it later if we retrospectively call it a dep.
                 if (!(name in this.members)) {
-                    name &&
-                        skipped.has(name)
-                            ? skipped.get(name).push(parsed)
-                            : skipped.set(name, [parsed]);
+                    name && skipped.has(name)
+                        ? skipped.get(name).push(parsed)
+                        : skipped.set(name, [parsed]);
                     (name.includes('Global') || name.includes('Window')) && console.log("Skipped", parsed);
                 }
                 return false;

--- a/selection/idlharness.window.js
+++ b/selection/idlharness.window.js
@@ -13,7 +13,6 @@ idl_test(
       Window: ['window'],
       Document: ['document'],
       Selection: ['getSelection()'],
-      GlobalEventHandlers: ['self'],
     });
   },
   'selection-api interfaces'

--- a/webxr/interfaces.https.html
+++ b/webxr/interfaces.https.html
@@ -9,18 +9,15 @@
 <script>
 "use strict";
 
-promise_test(async () => {
-  const idl_array = new IdlArray();
-  const dom_idl = await fetch("/interfaces/dom.idl").then(r => r.text());
-  const webxr_idl = await fetch("/interfaces/webxr.idl").then(r => r.text());
-
-  idl_array.add_untested_idls(dom_idl);
-  idl_array.add_untested_idls("interface Navigator {};");
-  idl_array.add_idls(webxr_idl);
-  idl_array.add_idls("dictionary WebGLContextAttributes {};");
-  idl_array.add_objects({
-    Navigator:['navigator'],
-  });
-  idl_array.test();
-}, "Test IDL implementation of WebXR API");
+idl_test(
+  ['webxr'],
+  ['html', 'dom'],
+  idl_array => {
+    idl_array.add_untested_idls("dictionary WebGLContextAttributes {};");
+    idl_array.add_untested_idls("interface WebGLRenderingContextBase {};");
+    idl_array.add_objects({
+      Navigator:['navigator'],
+    });
+  },
+  'Test IDL implementation of WebXR API');
 </script>


### PR DESCRIPTION
This addresses an issue where, when testing a partial interface, we are not including the parents that implement said interface as dependencies.

Specific example:
In `pointerevents`, we have `partial interface GlobalEventHandlers`
`Window includes GlobalEventHandlers`, but we do not include `Window` as an untested dep, so none of the members added in the partial are tested.

To fix this, we treat both sides of `A includes B` as being deps.
I tested this in combination with #11922 locally, and the result was 129 tests (nearly double status quo).