### PR TITLE
[wptrunner] Fix regression in Sauce Labs browser

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/sauce.py
+++ b/tools/wptrunner/wptrunner/browsers/sauce.py
@@ -233,7 +233,7 @@ class SauceBrowser(Browser):
         Browser.__init__(self, logger)
         self.sauce_config = sauce_config
 
-    def start(self):
+    def start(self, **kwargs):
         pass
 
     def stop(self, force=False):


### PR DESCRIPTION
A recent commit [1] updated the invocation of the `start` method for
"Browser" instances by introducing a new keyword argument. This
interfered with the use of the "Sauce Labs" browser because its
implementation of the `start` method did not accommodate any keyword
arguments.

Update the `start` method to support (but ignore) all keyword arguments.

[1] 91803e3a25afd8e0c201bc57cd05fffd5d543551

---

@jgraham do you have any thoughts on how we could test for this?