### PR TITLE
Exposed support for multiple document roots

### DIFF
--- a/tools/serve/serve.py
+++ b/tools/serve/serve.py
@@ -787,6 +787,8 @@ def get_parser():
                         help="Path to document root. Overrides config.")
     parser.add_argument("--ws_doc_root", action="store", dest="ws_doc_root",
                         help="Path to WebSockets document root. Overrides config.")
+    parser.add_argument("--alias_file", action="store", dest="alias_file",
+                        help="File with entries for aliases/multiple doc roots. In form of `/ALIAS_NAME/, DOC_ROOT\\n`")
     parser.add_argument("--h2", action="store_true", dest="h2",
                         help="Flag for enabling the HTTP/2.0 server")
     parser.set_defaults(h2=False)
@@ -801,6 +803,15 @@ def run(**kwargs):
         set_logger(logger)
 
         bind_address = config["bind_address"]
+
+        if kwargs.get("alias_file"):
+            with open(kwargs["alias_file"], 'r') as alias_file:
+                for line in alias_file:
+                    alias, doc_root = [x.strip() for x in line.split(',')]
+                    config["aliases"].append({
+                        'url-path': alias,
+                        'local-dir': doc_root,
+                    })
 
         if config["check_subdomains"]:
             check_subdomains(config)


### PR DESCRIPTION
As mentioned in #11554, some teams want to be able to use multiple document roots with `wpt serve`. The functionality was already there but was not really exposed in an easy way. I've added a command line argument `--alias_file` which takes the path of a file containing a list of aliases that looks like this:

    /test/,/home/usr/foo
    /other/,/home/usr2/bar

And invoked like this:

    $ ./wpt serve --alias_file aliases.txt

This will serve the main wpt doc root under `/`, the foo doc root under `/test/` and the bar doc root under `/other/`.

I hope this is the functionality that the issue was trying to find!