### PR TITLE
Fix resources/test and prevent infra changes from breaking the suite again

### DIFF
--- a/resources/test/wptserver.py
+++ b/resources/test/wptserver.py
@@ -9,12 +9,15 @@ import urllib2
 class WPTServer(object):
     def __init__(self, wpt_root):
         self.wpt_root = wpt_root
+
+        # This is a terrible hack to get the default config of wptserve.
         sys.path.insert(0, os.path.join(wpt_root, "tools"))
-        from serve.serve import Config
-        config = Config()
-        self.host = config["browser_host"]
-        self.http_port = config["ports"]["http"][0]
-        self.https_port = config["ports"]["https"][0]
+        from serve.serve import build_config
+        with build_config() as config:
+            self.host = config["browser_host"]
+            self.http_port = config["ports"]["http"][0]
+            self.https_port = config["ports"]["https"][0]
+
         self.base_url = 'http://%s:%s' % (self.host, self.http_port)
         self.https_base_url = 'https://%s:%s' % (self.host, self.https_port)
 

--- a/tools/ci/jobs.py
+++ b/tools/ci/jobs.py
@@ -23,7 +23,7 @@ job_path_map = {
                   "!css/[^/]*$"],
     "lint": [".*"],
     "manifest_upload": [".*"],
-    "resources_unittest": ["resources/"],
+    "resources_unittest": ["resources/", "tools/"],
     "tools_unittest": ["tools/"],
     "wptrunner_unittest": ["tools/wptrunner/*"],
     "build_css": ["css/"],

--- a/tools/ci/tests/test_jobs.py
+++ b/tools/ci/tests/test_jobs.py
@@ -7,6 +7,8 @@ def test_testharness():
     assert jobs.get_jobs(["resources/testharness.js"]) == default_jobs | set(["resources_unittest"])
     assert jobs.get_jobs(["resources/testharness.js"],
                          includes=["resources_unittest"]) == set(["resources_unittest"])
+    assert jobs.get_jobs(["tools/wptserve/wptserve/config.py"],
+                         includes=["resources_unittest"]) == set(["resources_unittest"])
     assert jobs.get_jobs(["foo/resources/testharness.js"],
                          includes=["resources_unittest"]) == set()
 


### PR DESCRIPTION
The suite was broken by PR #11976 where the config class was changed.
The suite uses a hack to get the default config of wptserve. This commit
fixes the hack, but unfortunately does not find a less hacky way to get
the default config.

To prevent changes in tools (especially `wpt serve` and its
dependencies) from breaking the resources/test suite again, this commit
adds "tools/" to the watchlist of the suite.