### PR TITLE
Rely on git hashes for manifest update

### DIFF
--- a/tools/manifest/sourcefile.py
+++ b/tools/manifest/sourcefile.py
@@ -157,7 +157,7 @@ class SourceFile(object):
                          ("css", "CSS2", "archive"),
                          ("css", "common")}
 
-    def __init__(self, tests_root, rel_path, url_base, contents=None):
+    def __init__(self, tests_root, rel_path, url_base, hash=None, contents=None):
         """Object representing a file in a source tree.
 
         :param tests_root: Path to the root of the source tree
@@ -188,6 +188,7 @@ class SourceFile(object):
         self.meta_flags = self.name.split(".")[1:]
 
         self.items_cache = None
+        self._hash = hash
 
     def __getstate__(self):
         # Remove computed properties if we pickle this class
@@ -237,8 +238,12 @@ class SourceFile(object):
 
     @cached_property
     def hash(self):
-        with self.open() as f:
-            return hashlib.sha1(f.read()).hexdigest()
+        if not self._hash:
+            with self.open() as f:
+                content = f.read()
+            data = "".join(("blob ", str(len(content)), "\0", content))
+            self._hash = hashlib.sha1(data).hexdigest()
+        return self._hash
 
     def in_non_test_dir(self):
         if self.dir_path == "":

--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -56,9 +56,11 @@ class Git(object):
         return self.git("show", "HEAD:%s" % path)
 
     def __iter__(self):
-        cmd = ["ls-tree", "-r", "-z", "--name-only", "HEAD"]
+        cmd = ["ls-tree", "-r", "-z", "HEAD"]
         local_changes = self._local_changes()
-        for rel_path in self.git(*cmd).split("\0")[:-1]:
+        for result in self.git(*cmd).split("\0")[:-1]:
+            rel_path = result.split("\t")[-1]
+            hash = result.split()[2]
             if not os.path.isdir(os.path.join(self.root, rel_path)):
                 if rel_path in local_changes:
                     contents = self._show_file(rel_path)
@@ -67,6 +69,7 @@ class Git(object):
                 yield SourceFile(self.root,
                                  rel_path,
                                  self.url_base,
+                                 hash,
                                  contents=contents)
 
 


### PR DESCRIPTION
We earlier hashed all in-tree files when updating the manifest.
Relying on git hashes instead gives us a speedup of ~50%
when running |wpt manifest|

With reference to https://github.com/web-platform-tests/wpt/issues/11388