### PR TITLE
Fix manifest paths obtained from the file system

### DIFF
--- a/tools/manifest/vcs.py
+++ b/tools/manifest/vcs.py
@@ -75,21 +75,19 @@ class FileSystem(object):
         self.root = root
         self.url_base = url_base
         from gitignore import gitignore
-        self.path_filter = gitignore.PathFilter(self.root)
+        self.path_filter = gitignore.PathFilter(self.root, extras=[".git/"])
 
     def __iter__(self):
-        is_root = True
-        for dir_path, dir_names, filenames in os.walk(self.root):
-            rel_root = os.path.relpath(dir_path, self.root)
+        paths = self.get_paths()
+        for path in paths:
+            yield SourceFile(self.root, path, self.url_base)
 
-            if is_root:
-                dir_names[:] = [item for item in dir_names if item not in
-                                ["tools", "resources", ".git"]]
-                is_root = False
-
+    def get_paths(self):
+        for dirpath, dirnames, filenames in os.walk(self.root):
             for filename in filenames:
-                rel_path = os.path.join(rel_root, filename)
-                if self.path_filter(rel_path):
-                    yield SourceFile(self.root,
-                                     rel_path,
-                                     self.url_base)
+                path = os.path.relpath(os.path.join(dirpath, filename), self.root)
+                if self.path_filter(path):
+                    yield path
+
+            dirnames[:] = [item for item in dirnames if self.path_filter(
+                           os.path.relpath(os.path.join(dirpath, item), self.root) + "/")]


### PR DESCRIPTION
Earlier, the manifest generated using the file system didn't honour .gitignore, leading to some weird differences between the working-tree manifest and the one for HEAD.
This does slow down the working-tree manifest update by about 15%, though.