### PR TITLE
Add support for fuzzy matching in reftests.

### DIFF
--- a/docs/_writing-tests/reftests.md
+++ b/docs/_writing-tests/reftests.md
@@ -112,10 +112,67 @@ only guaranteed to be after those events.
 ## Fuzzy Matching
 
 In some situations a test may have subtle differences in rendering
-compared to the reference due to, e.g., anti-aliasing. This may cause
-the test to pass on some platforms but fail on others. In this case
-some affordance for subtle discrepancies is desirable. However no
-mechanism to allow this has yet been standardized.
+compared to the reference due to, e.g., anti-aliasing. To allow for
+these small differences, we allow tests to specify a fuzziness
+characterised by two parameters, both of which must be specified:
+
+ * A maximum difference in the per-channel color value for any pixel.
+ * A number of total pixels that may be different.
+
+The maximum difference in the per pixel color value is formally
+defined as follows: let <code>T<sub>x,y,c</sub></code> be the value of
+colour channel `c` at pixel coordinates `x`, `y` in the test image and
+<code>R<sub>x,y,c</sub></code> be the corresponding value in the
+reference image, and let <code>width</code> and <code>height</code> be
+the dimensions of the image in pixels. Then <code>maxDifference =
+max<sub>x=[0,width) y=[0,height), c={r,g,b}</sub>(|T<sub>x,y,c</sub> -
+R<sub>x,y,c</sub>|)</code>.
+
+To specify the fuzziness in the test file one may add a `<meta
+name=fuzzy>` element (or, in the case of more complex tests, to any
+page containing the `<link rel=[mis]match>` elements). In the simplest
+case this has a `content` attribute containing the parameters above,
+separated by a colon e.g.
+
+```
+<meta name=fuzzy content="maxDifference=15;totalPixels=300">
+```
+
+would allow for a  difference of exactly 15 / 255 on any color channel
+and 300 exactly pixels total difference. The argument names are optional
+and may be elided; the above is the same as:
+
+```
+<meta name=fuzzy content="15;300">
+```
+
+The values may also be given as ranges e.g.
+
+```
+<meta name=fuzzy content="maxDifference=10-15;totalPixels=200-300">
+```
+
+or
+
+```
+<meta name=fuzzy content="10-15;200-300">
+```
+
+In this case the maximum pixel difference must be in the range
+`10-15` and the total number of different pixels must be in the range
+`200-300`.
+
+In cases where a single test has multiple possible refs and the
+fuzziness is not the same for all refs, a ref may be specified by
+prefixing the `content` value with the relative url for the ref e.g.
+
+```
+<meta name=fuzzy content="option1-ref.html:10-15;200-300">
+```
+
+One meta element is required per reference requiring a unique
+fuzziness value, but any unprefixed value will automatically be
+applied to any ref that doesn't have a more specific value.
 
 ## Limitations
 

--- a/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy.html.ini
+++ b/infrastructure/metadata/infrastructure/reftest/reftest_fuzzy.html.ini
@@ -1,0 +1,2 @@
+[reftest_fuzzy.html]
+  fuzzy: fuzzy-ref-1.html:maxDifference=255;100-100

--- a/infrastructure/reftest/fuzzy-ref-1.html
+++ b/infrastructure/reftest/fuzzy-ref-1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+div {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div></div>

--- a/infrastructure/reftest/reftest_fuzzy.html
+++ b/infrastructure/reftest/reftest_fuzzy.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel=match href=fuzzy-ref-1.html>
+<!-- This meta is overridden in the corresponding ini file -->
+<meta name=fuzzy content="fuzzy-ref-1.html:128;100">
+<style>
+div {
+  width: 99px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div></div>
+

--- a/infrastructure/reftest/reftest_fuzzy_1.html
+++ b/infrastructure/reftest/reftest_fuzzy_1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel=match href=fuzzy-ref-1.html>
+<meta name=fuzzy content="fuzzy-ref-1.html:255;100">
+<style>
+div {
+  width: 99px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div></div>
+

--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -1,5 +1,5 @@
 from copy import copy
-
+from six import iteritems
 from six.moves.urllib.parse import urljoin, urlparse
 from abc import ABCMeta, abstractproperty
 
@@ -169,6 +169,14 @@ class RefTestBase(URLManifestItem):
     def dpi(self):
         return self._extras.get("dpi")
 
+    @property
+    def fuzzy(self):
+        rv = self._extras.get("fuzzy", [])
+        if isinstance(rv, list):
+            return {tuple(item[0]): item[1]
+                    for item in self._extras.get("fuzzy", [])}
+        return rv
+
     def meta_key(self):
         return (self.timeout, self.viewport_size, self.dpi)
 
@@ -181,6 +189,8 @@ class RefTestBase(URLManifestItem):
             extras["viewport_size"] = self.viewport_size
         if self.dpi is not None:
             extras["dpi"] = self.dpi
+        if self.fuzzy:
+            extras["fuzzy"] = list(iteritems(self.fuzzy))
         return rv
 
     @classmethod

--- a/tools/manifest/tests/test_sourcefile.py
+++ b/tools/manifest/tests/test_sourcefile.py
@@ -789,3 +789,41 @@ test()"""
                                             u'/_fake_base/html/test.any.worker.html?wss']
 
     assert items[0].url_base == "/_fake_base/"
+
+
+@pytest.mark.parametrize("fuzzy, expected", [
+    (b"ref.html:1;200", {("/foo/test.html", "/foo/ref.html", "=="): [[1, 1], [200, 200]]}),
+    (b"ref.html:0-1;100-200", {("/foo/test.html", "/foo/ref.html", "=="): [[0, 1], [100, 200]]}),
+    (b"0-1;100-200", {None: [[0,1], [100, 200]]}),
+    (b"maxDifference=1;totalPixels=200", {None: [[1, 1], [200, 200]]}),
+    (b"totalPixels=200;maxDifference=1", {None: [[1, 1], [200, 200]]}),
+    (b"totalPixels=200;1", {None: [[1, 1], [200, 200]]}),
+    (b"maxDifference=1;200", {None: [[1, 1], [200, 200]]}),])
+def test_reftest_fuzzy(fuzzy, expected):
+    content = b"""<link rel=match href=ref.html>
+<meta name=fuzzy content="%s">
+""" % fuzzy
+
+    s = create("foo/test.html", content)
+
+    assert s.content_is_ref_node
+    assert s.fuzzy == expected
+
+
+@pytest.mark.parametrize("fuzzy, expected", [
+    ([b"1;200"], {None: [[1, 1], [200, 200]]}),
+    ([b"ref-2.html:0-1;100-200"], {("/foo/test.html", "/foo/ref-2.html", "=="): [[0, 1], [100, 200]]}),
+    ([b"1;200", b"ref-2.html:0-1;100-200"],
+     {None: [[1, 1], [200, 200]],
+      ("/foo/test.html", "/foo/ref-2.html", "=="): [[0,1], [100, 200]]})])
+def test_reftest_fuzzy_multi(fuzzy, expected):
+    content = b"""<link rel=match href=ref-1.html>
+<link rel=match href=ref-2.html>
+"""
+    for item in fuzzy:
+        content += b'\n<meta name=fuzzy content="%s">' % item
+
+    s = create("foo/test.html", content)
+
+    assert s.content_is_ref_node
+    assert s.fuzzy == expected

--- a/tools/wptrunner/docs/expectation.rst
+++ b/tools/wptrunner/docs/expectation.rst
@@ -190,13 +190,6 @@ When used for expectation data, manifests have the following format:
  * A subsection per subtest, with the heading being the title of the
    subtest.
 
- * A key ``type`` indicating the test type. This takes the values
-   ``testharness`` and ``reftest``.
-
- * For reftests, keys ``reftype`` indicating the reference type
-   (``==`` or ``!=``) and ``refurl`` indicating the URL of the
-   reference.
-
  * A key ``expected`` giving the expectation value of each (sub)test.
 
  * A key ``disabled`` which can be set to any value to indicate that
@@ -206,6 +199,19 @@ When used for expectation data, manifests have the following format:
  * A key ``restart-after`` which can be set to any value to indicate that
    the runner should restart the browser after running this test (e.g. to
    clear out unwanted state).
+
+ * A key ``fuzzy`` that is used for reftests. This is interpreted as a
+   list containing entries like ``<meta name=fuzzy>`` content value,
+   which consists of an optional reference identifier followed by a
+   colon, then a range indicating the maximum permitted pixel
+   difference per channel, then semicolon, then a range indicating the
+   maximum permitted total number of differing pixels. The reference
+   identifier is either a single relative URL, resolved against the
+   base test URL, in which case the fuzziness applies to any
+   comparison with that URL, or takes the form lhs url, comparison,
+   rhs url, in which case the fuzziness only applies for any
+   comparison involving that specifc pair of URLs. Some illustrative
+   examples are given below.
 
  * Variables ``debug``, ``os``, ``version``, ``processor`` and
    ``bits`` that describe the configuration of the browser under
@@ -246,3 +252,18 @@ A more complex manifest with conditional properties might be::
 
 Note that ``PASS`` in the above works, but is unnecessary; ``PASS``
 (or ``OK``) is always the default expectation for (sub)tests.
+
+A manifest with fuzzy reftest values might be::
+
+  [reftest.html]
+    fuzzy: [10;200, ref1.html:20;200-300, subtest1.html==ref2.html:10-15;20]
+
+In this case the default fuzziness for any comparison would be to
+require a maximum difference per channel of less than or equal to 10
+and less than or equal to 200 total pixels different. For any
+comparison involving ref1.html on the right hand side, the limits
+would instead be a difference per channel not more than 20 and a total
+difference count of not less than 200 and not more than 300. For the
+specific comparison subtest1.html == ref2.html (both resolved against
+the test URL) these limits would instead be 10 to 15 and 0 to 20,
+respectively.

--- a/tools/wptrunner/requirements.txt
+++ b/tools/wptrunner/requirements.txt
@@ -2,4 +2,6 @@ html5lib == 1.0.1
 mozinfo == 0.10
 mozlog==4.0
 mozdebug==0.1.1
+pillow == 5.2.0
 urllib3[secure]==1.24.1
+

--- a/tools/wptrunner/wptrunner/executors/executormarionette.py
+++ b/tools/wptrunner/wptrunner/executors/executormarionette.py
@@ -846,7 +846,7 @@ class MarionetteRefTestExecutor(RefTestExecutor):
         return screenshot
 
 
-class InternalRefTestImplementation(object):
+class InternalRefTestImplementation(RefTestImplementation):
     def __init__(self, executor):
         self.timeout_multiplier = executor.timeout_multiplier
         self.executor = executor
@@ -870,7 +870,7 @@ class InternalRefTestImplementation(object):
         pass
 
     def run_test(self, test):
-        references = self.get_references(test)
+        references = self.get_references(test, test)
         timeout = (test.timeout * 1000) * self.timeout_multiplier
         rv = self.executor.protocol.marionette._send_message("reftest:run",
                                                              {"test": self.executor.test_url(test),
@@ -881,10 +881,11 @@ class InternalRefTestImplementation(object):
                                                               "height": 600})["value"]
         return rv
 
-    def get_references(self, node):
+    def get_references(self, root_test, node):
         rv = []
         for item, relation in node.references:
-            rv.append([self.executor.test_url(item), self.get_references(item), relation])
+            rv.append([self.executor.test_url(item), self.get_references(root_test, item), relation,
+                       {"fuzzy": self.get_fuzzy(root_test, [node, item], relation)}])
         return rv
 
     def teardown(self):

--- a/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
+++ b/tools/wptrunner/wptrunner/tests/test_manifestexpected.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from io import BytesIO
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from wptrunner import manifestexpected
+
+
+@pytest.mark.parametrize("fuzzy, expected", [
+    (b"ref.html:1;200", [("ref.html", ((1, 1), (200, 200)))]),
+    (b"ref.html:0-1;100-200", [("ref.html", ((0, 1), (100, 200)))]),
+    (b"0-1;100-200", [(None, ((0, 1), (100, 200)))]),
+    (b"maxDifference=1;totalPixels=200", [(None, ((1, 1), (200, 200)))]),
+    (b"totalPixels=200;maxDifference=1", [(None, ((1, 1), (200, 200)))]),
+    (b"totalPixels=200;1", [(None, ((1, 1), (200, 200)))]),
+    (b"maxDifference=1;200", [(None, ((1, 1), (200, 200)))]),
+    (b"test.html==ref.html:maxDifference=1;totalPixels=200",
+     [((u"test.html", u"ref.html", "=="), ((1, 1), (200, 200)))]),
+    (b"test.html!=ref.html:maxDifference=1;totalPixels=200",
+     [((u"test.html", u"ref.html", "!="), ((1, 1), (200, 200)))]),
+    (b"[test.html!=ref.html:maxDifference=1;totalPixels=200, test.html==ref1.html:maxDifference=5-10;100]",
+     [((u"test.html", u"ref.html", "!="), ((1, 1), (200, 200))),
+      ((u"test.html", u"ref1.html", "=="), ((5,10), (100, 100)))]),
+])
+def test_fuzzy(fuzzy, expected):
+    data = """
+[test.html]
+  fuzzy: %s""" % fuzzy
+    f = BytesIO(data)
+    manifest = manifestexpected.static.compile(f,
+                                               {},
+                                               data_cls_getter=manifestexpected.data_cls_getter,
+                                               test_path="test/test.html",
+                                               url_base="/")
+    assert manifest.get_test("/test/test.html").fuzzy == expected

--- a/tools/wptrunner/wptrunner/tests/test_wpttest.py
+++ b/tools/wptrunner/wptrunner/tests/test_wpttest.py
@@ -6,6 +6,7 @@ from mock import Mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
+from manifest import manifest as wptmanifest
 from manifest.item import TestharnessTest
 from wptrunner import manifestexpected, wpttest
 
@@ -42,6 +43,11 @@ test_1 = """\
 test_2 = """\
 [2.html]
   lsan-max-stack-depth: 42
+"""
+
+test_fuzzy = """\
+[fuzzy.html]
+  fuzzy: fuzzy-ref.html:1;200
 """
 
 
@@ -139,3 +145,26 @@ def test_metadata_lsan_stack_depth():
     test_obj = wpttest.from_manifest(tests, test, inherit_metadata, test_metadata.get_test(test.id))
 
     assert test_obj.lsan_max_stack_depth == 42
+
+
+def test_metadata_fuzzy():
+    manifest_data = {
+        "items": {"reftest": {"a/fuzzy.html": [["/a/fuzzy.html",
+                                                [["/a/fuzzy-ref.html", "=="]],
+                                                {"fuzzy": [[["/a/fuzzy.html", '/a/fuzzy-ref.html', '=='],
+                                                            [[2, 3], [10, 15]]]]}]]}},
+        "paths": {"a/fuzzy.html": ["0"*40, "reftest"]},
+        "version": wptmanifest.CURRENT_VERSION,
+        "url_base": "/"}
+    manifest = wptmanifest.Manifest.from_json(".", manifest_data)
+    test_metadata = manifestexpected.static.compile(BytesIO(test_fuzzy),
+                                                    {},
+                                                    data_cls_getter=manifestexpected.data_cls_getter,
+                                                    test_path="a/fuzzy.html",
+                                                    url_base="/")
+
+    test = manifest.iterpath("a/fuzzy.html").next()
+    test_obj = wpttest.from_manifest(manifest, test, [], test_metadata.get_test(test.id))
+
+    assert test_obj.fuzzy == {('/a/fuzzy.html', '/a/fuzzy-ref.html', '=='): [[2, 3], [10, 15]]}
+    assert test_obj.fuzzy_override == {'/a/fuzzy-ref.html': ((1, 1), (200, 200))}

--- a/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
+++ b/tools/wptrunner/wptrunner/wptmanifest/backends/conditional.py
@@ -341,6 +341,8 @@ class ManifestItem(object):
             yield item
 
     def remove_value(self, key, value):
+        if key not in self._data:
+            return
         try:
             self._data[key].remove(value)
         except ValueError:


### PR DESCRIPTION
This allows fuzzy matching in reftests in which a comparison can
succeed if the images are different within a specified tolerance. It
is useful in the case of antialiasing, and in other scenarios where
it's not possible to make an exact match in all cases.

Differences between tests are characterised by two values:

* The maximum difference for any pixel on any color channel (in the
  range 0 to 255)

* The maximum total number of differing pixels

The fuzziness can be supplied in two places, according to whether it's
a property of the test or of the implementation:

* In the reftest itself, using a <meta name=fuzzy> tag

* In the expectation metadata file using a fuzzy: key that takes a
  list

The general format of the fuzziness specifier is

range = [digits, "-"], digits
fuzziness = [ url, "-" ], range, ";", range

The first range represents the maximum difference of any channel per
pixel and the second represents the total number of pixel
differences. So for example a specifier could be:

* "10;300" - meaning a difference of up to 10 per color channel and up to
300 pixels different in total (all ranges are inclusive).

* "5-10;200-300" - meaning a maximum difference of between 5 and 10
  per color channel and between 200 and 300 pixels differing in total

The definition of url is a little different between the meta element
and the expecation metadata. In the first case the url is resolved
against the current file, and applies to any reference in the current
file with that name. So for example

<meta name="fuzzy" content="option-1-ref.html:5;200">

would allow a fuzziness of up to 5 on a specific channel and up to 200
opixels different for comparisons involving the file containing the
meta element and option-1-ref.html.

In the case of expectation metadata, the metadata is always associated
with the root test, so urls are always resolved relative to that. In
the case as above where only a single URL is supplied, any reference
document with that URL will have the fuzziness applied for whatever
comparisons it's involved in e.g.

[test1.html]
  fuzzy: option-1-ref.html:5;200

would apply the fuziness to any comparison involving option-1-ref.html
whilst running the set of reftests rooted on test1.html. To specify an
exact comparison for the fuzziness, one can also supply a full
reference pair e.g.

[test1.html]
  fuzzy: subtest.html==option-1-ref.html:5;200

in which case the fuzziness would only apply to "match" comparison
involving subtest.html on the lhs and option-1-ref.html on the
rhs (both resolved relative to test1.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/web-platform-tests/wpt/12187)
<!-- Reviewable:end -->
