### PR TITLE
servo: Use config property instead of kwarg for browser kwargs.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tools/wptrunner/wptrunner/browsers/servo.py
@@ -33,7 +33,7 @@ def browser_kwargs(test_type, run_info_data, config, **kwargs):
         "debug_info": kwargs["debug_info"],
         "binary_args": kwargs["binary_args"],
         "user_stylesheets": kwargs.get("user_stylesheets"),
-        "ca_certificate_path": kwargs["ssl_env"].ca_cert_path(),
+        "ca_certificate_path": config.ssl_config["ca_cert_path"],
     }
 
 


### PR DESCRIPTION
This addresses a regression from 3b02e29929bb0062d2c7b5a4ccfaae242bbc4c75 that broke Servo's ability to run tests.