### PR TITLE
Fold "Unscopable handled correctly" tests into the attribute/operation tests

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2109,7 +2109,12 @@ IdlInterface.prototype.test_member_attribute = function(member)
                 "The interface object must have a property " +
                 format_value(member.name));
             a_test.done();
-        } else if (this.is_global()) {
+            return;
+        }
+
+        this.do_member_unscopable_asserts(member);
+
+        if (this.is_global()) {
             assert_own_property(self, member.name,
                 "The global object must have a property " +
                 format_value(member.name));
@@ -2170,13 +2175,8 @@ IdlInterface.prototype.test_member_attribute = function(member)
               // since it will call done() on a_test.
               this.do_interface_attribute_asserts(self[this.name].prototype, member, a_test);
             }
-
         }
     }.bind(this));
-
-    subsetTestByKey(this.name, test, function () {
-        this.do_member_unscopable_asserts(member);
-    }.bind(this), 'Unscopable handled correctly for ' + member.name + ' property on ' + this.name);
 };
 
 //@}
@@ -2242,16 +2242,9 @@ IdlInterface.prototype.test_member_operation = function(member)
                     "interface prototype object missing non-static operation");
             memberHolderObject = self[this.name].prototype;
         }
+        this.do_member_unscopable_asserts(member);
         this.do_member_operation_asserts(memberHolderObject, member, a_test);
     }.bind(this));
-
-    subsetTestByKey(this.name, test, function () {
-        this.do_member_unscopable_asserts(member);
-    }.bind(this),
-         'Unscopable handled correctly for ' + member.name + "(" +
-         member.arguments.map(
-             function(m) {return m.idlType.idlType; } ).join(", ")
-         + ")" + ' on ' + this.name);
 };
 
 IdlInterface.prototype.do_member_unscopable_asserts = function(member)

--- a/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
+++ b/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
@@ -11,7 +11,7 @@
 <script src="/resources/idlharness.js"></script>
 <script src="../../../idl-helper.js"></script>
 <script>
-    "use strict";
+    'use strict';
     function mock_interface_A(unscopables) {
         self.A = function A() {};
         A.prototype[Symbol.unscopables] = unscopables;

--- a/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
+++ b/resources/test/tests/unit/IdlInterface/do_member_unscopable_asserts.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<title>IdlDictionary.prototype.do_member_unscopable_asserts()</title>
+</head>
+<body>
+<div id="log"></div>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+<script src="../../../idl-helper.js"></script>
+<script>
+    "use strict";
+    function mock_interface_A(unscopables) {
+        self.A = function A() {};
+        A.prototype[Symbol.unscopables] = unscopables;
+    }
+
+    test(function() {
+        const i = interfaceFrom('interface A { [Unscopable] attribute any x; };');
+        const member = i.members[0];
+        assert_true(member.isUnscopable);
+        mock_interface_A({ x: true });
+        i.do_member_unscopable_asserts(member);
+    }, 'should not throw for [Unscopable] with property in @@unscopables');
+
+    test(function() {
+        const i = interfaceFrom('interface A { [Unscopable] attribute any x; };');
+        const member = i.members[0];
+        assert_true(member.isUnscopable);
+        mock_interface_A({});
+        // assert_throws can't be used because it rethrows AssertionErrors.
+        try {
+            i.do_member_unscopable_asserts(member);
+        } catch(e) {
+            assert_true(e.message.includes('Symbol.unscopables'));
+            return;
+        }
+        assert_unreached('did not throw');
+    }, 'should throw for [Unscopable] with property missing from @@unscopables');
+
+    // This test checks that for attributes/methods which aren't [Unscopable]
+    // in the IDL, we don't assert that @@unscopables is missing the property.
+    // This could miss implementation bugs, but [Unscopable] is so rarely used
+    // that it's fairly unlikely to ever happen.
+    test(function() {
+        const i = interfaceFrom('interface A { attribute any x; };');
+        const member = i.members[0];
+        assert_false(member.isUnscopable);
+        mock_interface_A({ x: true });
+        i.do_member_unscopable_asserts(member);
+    }, 'should not throw if [Unscopable] is used but property is in @@unscopables');
+</script>
+</body>
+</html>


### PR DESCRIPTION
The `[Unscopable]` checks were added here:
https://github.com/web-platform-tests/wpt/pull/9490

However, this extended attribute is very rarely used, currently only
in DOM and Fullscreen. And yet, every property and operation generates
a test like this, which is normally passing, example:
https://wpt.fyi/results/compat/interfaces.any.html

Just fold these into the existing tests for attributes/operations like
the many other aspects already covered. Because of the
"do_interface_attribute_asserts must be the last thing" problem,
change of structure for the attribute test.