### PR TITLE
Avoid using the JavaScript reserved word `arguments`

### DIFF
--- a/dom/nodes/Comment-Text-constructor.js
+++ b/dom/nodes/Comment-Text-constructor.js
@@ -23,7 +23,7 @@ function test_constructor(ctor) {
     assert_equals(object.ownerDocument, document);
   }, "new " + ctor + "(): no arguments");
 
-  var arguments = [
+  var testArgs = [
     [undefined, ""],
     [null, "null"],
     [42, "42"],
@@ -37,7 +37,7 @@ function test_constructor(ctor) {
     ["&amp;", "&amp;"],
   ];
 
-  arguments.forEach(function(a) {
+  testArgs.forEach(function(a) {
     var argument = a[0], expected = a[1];
     test(function() {
       var object = new window[ctor](argument);

--- a/dom/nodes/Node-textContent.html
+++ b/dom/nodes/Node-textContent.html
@@ -111,7 +111,7 @@ doctypes.forEach(function(argument) {
 
 // Setting
 // DocumentFragment, Element:
-var arguments = [
+var testArgs = [
   [null, null],
   [undefined, null],
   ["", null],
@@ -121,7 +121,7 @@ var arguments = [
   ["d\0e", "d\0e"]
   // XXX unpaired surrogate?
 ]
-arguments.forEach(function(aValue) {
+testArgs.forEach(function(aValue) {
   var argument = aValue[0], expectation = aValue[1]
   var check = function(aElementOrDocumentFragment) {
     if (expectation === null) {


### PR DESCRIPTION
ES6 complains if the JS reserved word `arguments` is used in strict mode.  Rename variable to avoid issues --- especially when test cases are reused with other test harnesses.