### PR TITLE
Generate directory listings from MANIFEST.json rather than the filesystem

### DIFF
--- a/tools/manifest/loader.py
+++ b/tools/manifest/loader.py
@@ -1,0 +1,79 @@
+import json
+import os
+
+from . import log
+from . import manifest
+from . import update
+from .download import download_from_github
+
+
+class ManifestLoader(object):
+    def __init__(self, logger, test_paths, force_manifest_update=False, manifest_download=False,
+                 types=None, meta_filters=None):
+        self.test_paths = test_paths
+        self.force_manifest_update = force_manifest_update
+        self.manifest_download = manifest_download
+        self.types = types
+        self.meta_filters = meta_filters or []
+        self.logger = logger
+
+    def load(self):
+        rv = {}
+        for url_base, paths in self.test_paths.iteritems():
+            manifest_file = self.load_manifest(url_base=url_base,
+                                               **paths)
+            path_data = {"url_base": url_base}
+            path_data.update(paths)
+            rv[manifest_file] = path_data
+        return rv
+
+    def create_manifest(self, manifest_path, tests_path, url_base="/"):
+        self.update_manifest(manifest_path, tests_path, url_base,
+                             recreate=True, download=self.manifest_download)
+
+    def update_manifest(self, manifest_path, tests_path, url_base="/",
+                        recreate=False, download=False):
+        self.logger.info("Updating test manifest %s" % manifest_path)
+
+        json_data = None
+        if download:
+            # TODO: make this not github-specific
+            download_from_github(manifest_path, tests_path)
+
+        if not recreate:
+            try:
+                with open(manifest_path) as f:
+                    json_data = json.load(f)
+            except IOError:
+                self.logger.info("Unable to find test manifest")
+            except ValueError:
+                self.logger.info("Unable to parse test manifest")
+
+        if not json_data:
+            self.logger.info("Creating test manifest")
+            manifest_file = manifest.Manifest(url_base)
+        else:
+            try:
+                manifest_file = manifest.Manifest.from_json(tests_path, json_data)
+            except manifest.ManifestVersionMismatch:
+                manifest_file = manifest.Manifest(url_base)
+
+        update.update(tests_path, manifest_file, True)
+
+        manifest.write(manifest_file, manifest_path)
+
+    def load_manifest(self, tests_path, manifest_path, url_base="/", **kwargs):
+        if (not os.path.exists(manifest_path) or
+            self.force_manifest_update):
+            self.update_manifest(manifest_path, tests_path, url_base,
+                                 download=self.manifest_download)
+        manifest_file = manifest.load(tests_path, manifest_path,
+                                      types=self.types,
+                                      meta_filters=self.meta_filters)
+        if manifest_file.url_base != url_base:
+            self.logger.info("Updating url_base in manifest from %s to %s" %
+                             (manifest_file.url_base, url_base))
+            manifest_file.url_base = url_base
+            manifest.write(manifest_file, manifest_path)
+
+        return manifest_file

--- a/tools/manifest/loader.py
+++ b/tools/manifest/loader.py
@@ -1,7 +1,6 @@
 import json
 import os
 
-from . import log
 from . import manifest
 from . import update
 from .download import download_from_github

--- a/tools/serve/wpthandlers.py
+++ b/tools/serve/wpthandlers.py
@@ -1,0 +1,112 @@
+import cgi
+import itertools
+import os
+from six.moves.urllib.parse import quote, urljoin, urlsplit
+
+from wptserve import handlers
+from manifest import loader
+
+
+class FileHandler(handlers.FileHandler):
+    def __init__(self, config, base_path=None, url_base="/"):
+        self.base_path = base_path
+        self.url_base = url_base
+        self.directory_handler = ManifestDirectoryHandler(config,
+                                                          self.base_path,
+                                                          self.url_base)
+
+
+class ManifestDirectoryHandler(handlers.DirectoryHandler):
+    """Directory listing that gets the relevant data from the
+    wpt MANIFEST.json file(s)"""
+
+    # This is a class attribute so we can share the data between instances
+    # That's needed because each url_base has a seperate instance of this
+    # class.
+    by_dir = {}
+
+    def __init__(self, config, base_path=None, url_base="/"):
+        self.process_manifest(config, url_base)
+        self.base_path = base_path
+        self.url_base = url_base
+
+    def process_manifest(self, config, url_base):
+        config.logger.info("Loading manifest data")
+        if url_base not in config.test_paths:
+            return
+
+        test_paths = {url_base: config.test_paths[url_base]}
+        manifests = loader.ManifestLoader(config.logger,
+                                          test_paths,
+                                          force_manifest_update=config.manifest_update,
+                                          manifest_download=config.manifest_update).load()
+        for manifest in manifests:
+            for item_type, path, tests in manifest:
+                for test in tests:
+                    if hasattr(test, "url"):
+                        url_parts = urlsplit(test.url)
+                    else:
+                        url_parts = urlsplit("/" + test.path.replace(os.path.sep, "/"))
+                    url_path = url_parts.path
+                    is_last = True
+                    while url_path:
+                        test_dir, name = url_path.rsplit("/", 1)
+
+                        if test_dir not in self.by_dir:
+                            self.by_dir[test_dir] = (set(), [])
+
+                        if not is_last:
+                            if name not in self.by_dir[test_dir][0]:
+                                self.by_dir[test_dir][0].add(name)
+                            else:
+                                break
+                        else:
+                            if url_parts.query:
+                                name += ("?" + url_parts.query)
+                            if url_parts.fragment:
+                                name += ("#" + url_parts.fragment)
+                            self.by_dir[test_dir][1].append(name)
+                        is_last = False
+                        url_path = test_dir
+
+    def __repr__(self):
+        return "<%s base_path:%s url_base:%s>" % (self.__class__.__name__, self.base_path, self.url_base)
+
+    def __call__(self, request, response):
+        url_path = request.url_parts.path
+
+        if not url_path.endswith("/"):
+            response.status = 301
+            response.headers = [("Location", "%s/" % request.url)]
+            return
+
+        dir_path = url_path[:-1]
+
+        response.headers = [("Content-Type", "text/html")]
+        response.content = """<!doctype html>
+<meta name="viewport" content="width=device-width">
+<title>Directory listing for %(path)s</title>
+<h1>Directory listing for %(path)s</h1>
+<ul>
+%(items)s
+</ul>
+""" % {"path": cgi.escape(url_path),
+       "items": "\n".join(self.list_items(dir_path))}  # flake8: noqa
+
+    def list_items(self, dir_path):
+        dirs, tests = self.by_dir[dir_path]
+
+        if dir_path:
+            link = urljoin(dir_path, "..")
+            yield ("""<li class="dir"><a href="%(link)s">%(name)s</a></li>""" %
+                   {"link": link, "name": ".."})
+        for item, is_dir in itertools.chain(((item, True) for item in sorted(dirs)),
+                                            ((item, False) for item in sorted(tests))):
+            link = cgi.escape(quote(item))
+            if is_dir:
+                link += "/"
+                class_ = "dir"
+            else:
+                class_ = "file"
+            yield ("""<li class="%(class)s"><a href="%(link)s">%(name)s</a></li>""" %
+                   {"link": link, "name": cgi.escape(item), "class": class_})

--- a/tools/wptrunner/wptrunner/environment.py
+++ b/tools/wptrunner/wptrunner/environment.py
@@ -123,6 +123,9 @@ class TestEnvironment(object):
             "wss": [8889],
         }
 
+        config.test_paths = self.test_paths
+        config.manifest_update = False
+
         if os.path.exists(override_path):
             with open(override_path) as f:
                 override_obj = json.load(f)
@@ -164,7 +167,7 @@ class TestEnvironment(object):
             pass
 
     def get_routes(self):
-        route_builder = serve.RoutesBuilder()
+        route_builder = serve.RoutesBuilder(self.config)
 
         for path, format_args, content_type, route in [
                 ("testharness_runner.html", {}, "text/html", "/testharness_runner.html"),

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -28,8 +28,7 @@ except ImportError:
 
 def load_test_manifests(serve_root, test_paths):
     do_delayed_imports(serve_root)
-    manifest_loader = testloader.ManifestLoader(test_paths, False)
-    return manifest_loader.load()
+    return testloader.load_manifests(test_paths, False)
 
 
 def update_expected(test_paths, serve_root, log_file_names,

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import os
 import urlparse
 from abc import ABCMeta, abstractmethod

--- a/tools/wptrunner/wptrunner/testloader.py
+++ b/tools/wptrunner/wptrunner/testloader.py
@@ -12,18 +12,38 @@ import manifestexpected
 import wpttest
 from mozlog import structured
 
-manifest = None
-manifest_update = None
-download_from_github = None
-manifest_log = None
+manifest_loader = None
+
 
 def do_delayed_imports():
-    # This relies on an already loaded module having set the sys.path correctly :(
-    global manifest, manifest_update, download_from_github, manifest_log
-    from manifest import manifest
-    from manifest import update as manifest_update
-    from manifest.download import download_from_github
-    from manifest import log as manifest_log
+    global manifest_loader
+    from manifest import loader as manifest_loader
+
+
+# This function is here for backwards compat with the old class
+def ManifestLoader(test_paths, force_manifest_update=False, manifest_download=False,
+                   types=None, meta_filters=None, logger=None):
+    do_delayed_imports()
+    if logger is None:
+        logger = structured.get_default_logger()
+    if logger is None:
+        logger = structured.structuredlog.StructuredLogger("wptrunner")
+    return manifest_loader.ManifestLoader(logger,
+                                          test_paths,
+                                          force_manifest_update=force_manifest_update,
+                                          manifest_download=manifest_download,
+                                          types=types,
+                                          meta_filters=meta_filters)
+
+
+def load_manifests(test_paths, force_manifest_update=False, manifest_download=False,
+                   types=None, meta_filters=None, logger=None):
+    return ManifestLoader(test_paths,
+                          force_manifest_update=force_manifest_update,
+                          manifest_download=manifest_download,
+                          types=types,
+                          meta_filters=meta_filters,
+                          logger=logger).load()
 
 
 class TestChunker(object):
@@ -367,6 +387,7 @@ class TestFilter(object):
             if include_tests:
                 yield test_type, test_path, include_tests
 
+
 class TagFilter(object):
     def __init__(self, tags):
         self.tags = set(tags)
@@ -375,78 +396,6 @@ class TagFilter(object):
         for test in test_iter:
             if test.tags & self.tags:
                 yield test
-
-
-class ManifestLoader(object):
-    def __init__(self, test_paths, force_manifest_update=False, manifest_download=False, types=None, meta_filters=None):
-        do_delayed_imports()
-        self.test_paths = test_paths
-        self.force_manifest_update = force_manifest_update
-        self.manifest_download = manifest_download
-        self.types = types
-        self.meta_filters = meta_filters or []
-        self.logger = structured.get_default_logger()
-        if self.logger is None:
-            self.logger = structured.structuredlog.StructuredLogger("ManifestLoader")
-
-    def load(self):
-        rv = {}
-        for url_base, paths in self.test_paths.iteritems():
-            manifest_file = self.load_manifest(url_base=url_base,
-                                               **paths)
-            path_data = {"url_base": url_base}
-            path_data.update(paths)
-            rv[manifest_file] = path_data
-        return rv
-
-    def create_manifest(self, manifest_path, tests_path, url_base="/"):
-        self.update_manifest(manifest_path, tests_path, url_base, recreate=True,
-                             download=self.manifest_download)
-
-    def update_manifest(self, manifest_path, tests_path, url_base="/",
-                        recreate=False, download=False):
-        self.logger.info("Updating test manifest %s" % manifest_path)
-        manifest_log.setup()
-
-        json_data = None
-        if download:
-            # TODO: make this not github-specific
-            download_from_github(manifest_path, tests_path)
-
-        if not recreate:
-            try:
-                with open(manifest_path) as f:
-                    json_data = json.load(f)
-            except IOError:
-                self.logger.info("Unable to find test manifest")
-            except ValueError:
-                self.logger.info("Unable to parse test manifest")
-
-        if not json_data:
-            self.logger.info("Creating test manifest")
-            manifest_file = manifest.Manifest(url_base)
-        else:
-            try:
-                manifest_file = manifest.Manifest.from_json(tests_path, json_data)
-            except manifest.ManifestVersionMismatch:
-                manifest_file = manifest.Manifest(url_base)
-
-        manifest_update.update(tests_path, manifest_file, True)
-
-        manifest.write(manifest_file, manifest_path)
-
-    def load_manifest(self, tests_path, manifest_path, url_base="/", **kwargs):
-        if (not os.path.exists(manifest_path) or
-            self.force_manifest_update):
-            self.update_manifest(manifest_path, tests_path, url_base, download=self.manifest_download)
-        manifest_file = manifest.load(tests_path, manifest_path, types=self.types, meta_filters=self.meta_filters)
-        if manifest_file.url_base != url_base:
-            self.logger.info("Updating url_base in manifest from %s to %s" % (manifest_file.url_base,
-                                                                              url_base))
-            manifest_file.url_base = url_base
-            manifest.write(manifest_file, manifest_path)
-
-        return manifest_file
 
 
 def iterfilter(filters, iter):

--- a/tools/wptrunner/wptrunner/tests/test_products.py
+++ b/tools/wptrunner/wptrunner/tests/test_products.py
@@ -1,6 +1,6 @@
 import sys
 
-from os.path import join, dirname
+from os.path import abspath, join, dirname
 
 import mock
 import pytest
@@ -13,7 +13,10 @@ from tools import localpaths  # noqa: flake8
 from wptrunner import environment
 from wptrunner import products
 
-test_paths = {"/": {"tests_path": join(dirname(__file__), "..", "..", "..", "..")}}  # repo root
+repo_root = abspath(join(dirname(__file__), "..", "..", "..", ".."))
+
+test_paths = {"/": {"tests_path": repo_root,
+                    "manifest_path": join(repo_root, "MANIFEST.json")}}
 environment.do_delayed_imports(None, test_paths)
 
 

--- a/tools/wptrunner/wptrunner/wptcommandline.py
+++ b/tools/wptrunner/wptrunner/wptcommandline.py
@@ -354,6 +354,7 @@ def set_from_config(kwargs):
 
     check_paths(kwargs)
 
+
 def get_test_paths(config):
     # Set up test_paths
     test_paths = OrderedDict()

--- a/tools/wptrunner/wptrunner/wptrunner.py
+++ b/tools/wptrunner/wptrunner/wptrunner.py
@@ -50,8 +50,10 @@ def get_loader(test_paths, product, debug=None, run_info_extras=None, **kwargs):
                                     debug=debug,
                                     extras=run_info_extras)
 
-    test_manifests = testloader.ManifestLoader(test_paths, force_manifest_update=kwargs["manifest_update"],
-                                               manifest_download=kwargs["manifest_download"]).load()
+    test_manifests = testloader.load_manifests(test_paths,
+                                               force_manifest_update=kwargs["manifest_update"],
+                                               manifest_download=kwargs["manifest_download"],
+                                               logger=logger)
 
     manifest_filters = []
     meta_filters = []


### PR DESCRIPTION
This ensures that all tests (including variants) and most support files (exclusing ones that don't appear in the manifest) are listed in the directory listings.