### PR TITLE
Create a dictionary of {item_type: ManifestItemClass}

### DIFF
--- a/tools/manifest/item.py
+++ b/tools/manifest/item.py
@@ -17,8 +17,23 @@ def get_source_file(source_files, tests_root, manifest, path):
     return source_files[path]
 
 
+item_types = {}
+
+
+class ManifestItemMeta(ABCMeta):
+    """Custom metaclass that registers all the subclasses in the
+    item_types dictionary according to the value of their item_type
+    attribute, and otherwise behaves like an ABCMeta."""
+
+    def __new__(cls, name, bases, attrs, **kwargs):
+        rv = ABCMeta.__new__(cls, name, bases, attrs, **kwargs)
+        item_types[rv.item_type] = rv
+
+        return rv
+
+
 class ManifestItem(object):
-    __metaclass__ = ABCMeta
+    __metaclass__ = ManifestItemMeta
 
     item_type = None
 

--- a/tools/wptrunner/wptrunner/metadata.py
+++ b/tools/wptrunner/wptrunner/metadata.py
@@ -329,10 +329,7 @@ def create_test_tree(metadata_path, test_manifest, property_order=None,
     """
     id_test_map = {}
     exclude_types = frozenset(["stub", "helper", "manual", "support", "conformancechecker"])
-    all_types = [item.item_type for item in manifestitem.__dict__.itervalues()
-                 if type(item) == type and
-                 issubclass(item, manifestitem.ManifestItem) and
-                 item.item_type is not None]
+    all_types = manifestitem.item_types.keys()
     include_types = set(all_types) - exclude_types
     for _, test_path, tests in test_manifest.itertypes(*include_types):
         expected_data = load_or_create_expected(test_manifest, metadata_path, test_path, tests,


### PR DESCRIPTION
Sometimes we need to know all the types of test that exist. Typically
this has either been done by hardcoding a list or using some custom
approach to finding all the subclasses of the original. Instead it
makes sense to have the classes register themselves on creation so
that we can simply look in the registry for the types.

To do this we use a cusom metaclass that first constucts the class
object and then adds it to the registry.