### PR TITLE
Extend coverage reporting to wptserve

### DIFF
--- a/tools/.coveragerc
+++ b/tools/.coveragerc
@@ -8,7 +8,6 @@ omit =
   pywebsocket/*
   six/*
   webdriver/*
-  wptserve/*
   */site-packages/*
   */lib_pypy/*
 


### PR DESCRIPTION
So for some reason `wptserve` was omitted from the pytest coverage. I suspect that this is accidental/remnants of an old system, as it would make sense to have coverage reports of wptserve. If I am mistaken and this is intentional, please let me know!