### PR TITLE
Use testfile mtimes to prefilter files iterated over for the manifest update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules/
 
 # WPT repo stuff
 /MANIFEST.json
+/cache.json
 
 testharness_runner.html
 !/testharness_runner.html


### PR DESCRIPTION
This is a pretty broken and terrible implementation of trying to use a local mtime cache to speed-up the manifest update. I'm putting up a PR for this right now because I need to work on moving the manifest out of m-c and so that this stays somewhere and doesn't get lost. 

Current improvements I can think of - 
1. Create the cache while iterating over FileSystem.get_paths() instead of having a separate function for this. 
2. We could completely ignore pre-filtering for now and just focus on the no-op case - performing an update if _any_ mtime has changed. 

Current issues with this -

1. Because the cache is generated right before we run the update (and assuming most people will have modified files before trying to run any tests), the manifest won't get updated on the same run as where the cache is generated the first time. This can be fixed by improvement (1). 
2. Deletions aren't working as they should be. This can be fixed if we just _don't_ do any pre-filtering or spend more time ensuring everything works.
3. All old manifest tests fail because AFAICT, this code is essentially broken. (A lot of them also fail because of a check for `if not os.path.exists(source_file.path)`, and passing a Mock to this breaks things.)

With reference to https://github.com/web-platform-tests/wpt/issues/11388