### PR TITLE
servodriver: Use config property instead of kwarg for browser kwargs.

### DIFF
--- a/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -38,7 +38,7 @@ def browser_kwargs(test_type, run_info_data, config, **kwargs):
         "binary": kwargs["binary"],
         "binary_args": kwargs["binary_args"],
         "debug_info": kwargs["debug_info"],
-        "server_config": kwargs["config"],
+        "server_config": config.ssl_config["ca_cert_path"],
         "user_stylesheets": kwargs.get("user_stylesheets"),
     }
 


### PR DESCRIPTION
This extends the fix from #12203 to encompass servodriver as well, since Servo now relies on that executor in its CI.