### PR TITLE
[client-hints] Detect errors to avoid timeouts

### DIFF
--- a/client-hints/accept_ch_lifetime_same_origin_iframe.tentative.https.html
+++ b/client-hints/accept_ch_lifetime_same_origin_iframe.tentative.https.html
@@ -39,8 +39,16 @@ promise_test(t => {
   });
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
+var acceptChLifetimeLoaded;
+
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  acceptChLifetimeLoaded = t.step_func(() => {
+    // Open a new window. Verify that the user agent attaches the client hints.
+    var verify_win = window.open("resources/expect_client_hints_headers.html");
+    assert_not_equals(verify_win, null, "Popup windows not allowed?");
+  });
+
+  window.addEventListener('message', t.step_func((e) => {
     if(!e.source.location.pathname.includes("expect_client_hints_headers.html")) {
       return;
     }
@@ -48,15 +56,8 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/expect_client_hints_headers.html did not finish.");
-
-function acceptChLifetimeLoaded() {
-  // Open a new window. Verify that the user agent attaches the client hints.
-  var verify_win = window.open("resources/expect_client_hints_headers.html");
-  assert_not_equals(verify_win, null, "Popup windows not allowed?");
-}
-
 </script>
 
 <!-- Fetching this webpage should cause user-agent to persist client hint

--- a/client-hints/http_equiv_accept_ch_lifetime_same_origin_iframe.tentative.https.html
+++ b/client-hints/http_equiv_accept_ch_lifetime_same_origin_iframe.tentative.https.html
@@ -39,8 +39,16 @@ promise_test(t => {
   });
 }, "Precondition: Test that the browser does not have client hints preferences cached");
 
+var acceptChLifetimeLoaded;
+
 async_test(t => {
-  window.addEventListener('message', function(e) {
+  acceptChLifetimeLoaded = t.step_func(() => {
+    // Open a new window. Verify that the user agent attaches the client hints.
+    var verify_win = window.open("resources/expect_client_hints_headers.html");
+    assert_not_equals(verify_win, null, "Popup windows not allowed?");
+  });
+
+  window.addEventListener('message', t.step_func((e) => {
     if(!e.source.location.pathname.includes("expect_client_hints_headers.html")) {
       return;
     }
@@ -48,14 +56,8 @@ async_test(t => {
       return;
     assert_equals(e.data, "PASS");
     t.done();
-  })
+  }));
 }, "Loading of resources/expect_client_hints_headers.html did not finish.");
-
-function acceptChLifetimeLoaded() {
-  // Open a new window. Verify that the user agent attaches the client hints.
-  var verify_win = window.open("resources/expect_client_hints_headers.html");
-  assert_not_equals(verify_win, null, "Popup windows not allowed?");
-}
 
 </script>
 


### PR DESCRIPTION
Define callback functions in terms of the `step_func` API so the tests
fail gracefully in non-supporting browsers.