### PR TITLE
[workers] Detect errors to avoid timeouts

### DIFF
--- a/workers/WorkerGlobalScope_requestAnimationFrame.htm
+++ b/workers/WorkerGlobalScope_requestAnimationFrame.htm
@@ -20,12 +20,13 @@ requestAnimationFrame((dt) => {
 async_test(function(t) {
   var blob = new Blob([document.getElementById('worker').textContent]);
   var worker = new Worker(URL.createObjectURL(blob));
-  worker.addEventListener("message", (ev) => {
+  worker.addEventListener("error", t.unreached_func("No error should be reported"));
+  worker.addEventListener("message", t.step_func((ev) => {
     const ret = ev.data;
     assert_equals(ret.length, 3);
     assert_true(ret[0] < ret[1]);
     assert_true(ret[1] < ret[2]);
     t.done();
-  });
+  }));
 });
 </script>

--- a/workers/modules/dedicated-worker-import-blob-url.any.js
+++ b/workers/modules/dedicated-worker-import-blob-url.any.js
@@ -11,7 +11,10 @@ function import_blob_url_test(testCase) {
     const blobURL = URL.createObjectURL(blob);
 
     const worker = new Worker(blobURL, { type: 'module'});
-    const msgEvent = await new Promise(resolve => worker.onmessage = resolve);
+    const msgEvent = await new Promise((resolve, reject) => {
+      worker.onmessage = resolve;
+      worker.onerror = (error) => reject(error && error.message);
+    });
     assert_array_equals(msgEvent.data, testCase.expectation);
   }, testCase.description);
 }

--- a/workers/modules/dedicated-worker-import-failure.html
+++ b/workers/modules/dedicated-worker-import-failure.html
@@ -35,7 +35,10 @@ promise_test(async () => {
   const worker = new Worker('resources/dynamic-import-given-url-worker.js',
                             { type: 'module' });
   worker.postMessage(scriptURL);
-  const msg_event = await new Promise(resolve => worker.onmessage = resolve);
+  const msg_event = await new Promise((resolve, reject) => {
+    worker.onmessage = resolve;
+    worker.onerror = (error) => reject(error && error.message);
+  });
   assert_equals(msg_event.data, 'TypeError');
 }, 'Dynamic import for non-existent script should throw an exception.');
 

--- a/workers/modules/dedicated-worker-import-meta.html
+++ b/workers/modules/dedicated-worker-import-meta.html
@@ -7,7 +7,10 @@
 promise_test(() => {
   const script_url = 'resources/import-meta-url-worker.js';
   const worker = new Worker(script_url, { type: 'module' });
-  return new Promise(resolve => worker.onmessage = resolve)
+  return new Promise((resolve, reject) => {
+        worker.onmessage = resolve;
+        worker.onerror = (error) => reject(error && error.message);
+      })
       .then(msg_event => assert_true(msg_event.data.endsWith(script_url)));
 }, 'Test import.meta.url on the top-level module script.');
 
@@ -16,7 +19,10 @@ promise_test(() => {
   const worker = new Worker('resources/dynamic-import-given-url-worker.js',
                             { type: 'module' });
   worker.postMessage('./' + script_url);
-  return new Promise(resolve => worker.onmessage = resolve)
+  return new Promise((resolve, reject) => {
+        worker.onmessage = resolve;
+        worker.onerror = (error) => reject(error && error.message);
+      })
       .then(msg_event => assert_true(msg_event.data.endsWith(script_url)));
 }, 'Test import.meta.url on the imported module script.');
 
@@ -26,7 +32,10 @@ promise_test(() => {
                             { type: 'module' });
   worker.postMessage('./' + script_url);
 
-  return new Promise(resolve => worker.onmessage = resolve)
+  return new Promise((resolve, reject) => {
+        worker.onmessage = resolve;
+        worker.onerror = (error) => reject(error && error.message);
+      })
       .then(msg_event => assert_true(msg_event.data.endsWith(script_url)))
       .then(() => {
         worker.postMessage('./' + script_url + '#1');

--- a/workers/modules/dedicated-worker-import.any.js
+++ b/workers/modules/dedicated-worker-import.any.js
@@ -6,7 +6,10 @@
 function import_test(testCase) {
   promise_test(async () => {
     const worker = new Worker(testCase.scriptURL, { type: 'module' });
-    const msgEvent = await new Promise(resolve => worker.onmessage = resolve);
+    const msgEvent = await new Promise((resolve, reject) => {
+      worker.onmessage = resolve;
+      worker.onerror = (error) => reject(error && error.message);
+    });
     assert_array_equals(msgEvent.data, testCase.expectation);
   }, testCase.description);
 }


### PR DESCRIPTION
Ensure that uncaught errors within workers cause test failure. This
makes non-conforming browsers fail more quickly and with more
descriptive messages.