### PR TITLE
[idlharness.js] Catch IdlArray.test bugs better

### DIFF
--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2363,7 +2363,6 @@ IdlInterface.prototype.add_iterable_members = function(member)
 IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, member) {
     var instanceName = memberHolderObject && memberHolderObject.constructor.name
         || member.name + " object";
-    // var instanceName = memberHolderObject.constructor.name;
     if (member.has_extended_attribute("Default")) {
         subsetTestByKey(this.name, test, function() {
             var map = this.default_to_json_operation();

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -2361,10 +2361,12 @@ IdlInterface.prototype.add_iterable_members = function(member)
 };
 
 IdlInterface.prototype.test_to_json_operation = function(memberHolderObject, member) {
-    var instanceName = memberHolderObject.constructor.name;
+    var instanceName = memberHolderObject && memberHolderObject.constructor.name
+        || member.name + " object";
+    // var instanceName = memberHolderObject.constructor.name;
     if (member.has_extended_attribute("Default")) {
-        var map = this.default_to_json_operation();
         subsetTestByKey(this.name, test, function() {
+            var map = this.default_to_json_operation();
             var json = memberHolderObject.toJSON();
             map.forEach(function(type, k) {
                 assert_true(k in json, "property " + JSON.stringify(k) + " should be present in the output of " + this.name + ".prototype.toJSON()");
@@ -3201,6 +3203,7 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
         var idl_array = new IdlArray();
         srcs = (srcs instanceof Array) ? srcs : [srcs] || [];
         deps = (deps instanceof Array) ? deps : [deps] || [];
+        var setup_error = null;
         return Promise.all(
             srcs.concat(deps).map(function(spec) {
                 return fetch_spec(spec);
@@ -3218,16 +3221,19 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
                     return idl_setup_func(idl_array, t);
                 }
             })
-            .then(function() { idl_array.test(); })
-            .catch(function (reason) {
+            .catch(function(e) { setup_error = e || 'IDL setup failed.'; })
+            .finally(function () {
+                var error = setup_error;
                 try {
                     idl_array.test(); // Test what we can.
                 } catch (e) {
                     // If testing fails hard here, the original setup error
                     // is more likely to be the real cause.
-                    reason = reason || e;
+                    error = error || e;
                 }
-                return Promise.reject(reason || 'IDL setup failed.');
+                if (error) {
+                    throw error;
+                }
             });
     }, test_name);
 }


### PR DESCRIPTION
When a bug exists in `IdlArray.test`, `idl_test`'s `catch` flow is incorrectly re-attempting to run the tests (causing a double-up of the tests).

This changes the flow to call `IdlArray.test` in a `finally` (regardless of whether any setup errors have occurred), preventing the possibility of double-ups when bugs in `IdlArray.test` occur.

Also fixes the bug that highlighted this problem (passing a `null` object when the interface contains a `toJSON` operation).