### PR TITLE
Add a default name ("idl_test setup") for idl_test

### DIFF
--- a/encoding/idlharness.any.js
+++ b/encoding/idlharness.any.js
@@ -10,6 +10,5 @@ idl_test(
       TextEncoder: ['new TextEncoder()'],
       TextDecoder: ['new TextDecoder()']
     });
-  },
-  'Encoding Standard IDL'
+  }
 );

--- a/resources/idlharness.js
+++ b/resources/idlharness.js
@@ -3234,7 +3234,7 @@ function idl_test(srcs, deps, idl_setup_func, test_name) {
                     throw error;
                 }
             });
-    }, test_name);
+    }, test_name || 'idl_test setup');
 }
 
 /**


### PR DESCRIPTION
The name given is never very meaningful. Remove the name in one test
to show it working.