### PR TITLE
Ensure that in-repo files that match gitignore rules are synced.

### DIFF
--- a/tools/wptrunner/wptrunner/update/sync.py
+++ b/tools/wptrunner/wptrunner/update/sync.py
@@ -175,8 +175,9 @@ class CreateSyncPatch(Step):
 
         local_tree.create_patch("web-platform-tests_update_%s" % sync_tree.rev,
                                 "Update %s to revision %s" % (state.suite_name, sync_tree.rev))
-        local_tree.add_new(os.path.relpath(state.tests_path,
-                                           local_tree.root))
+        test_prefix = os.path.relpath(state.tests_path, local_tree.root)
+        local_tree.add_new(test_prefix)
+        local_tree.add_ignored(sync_tree, test_prefix)
         updated = local_tree.update_patch(include=[state.tests_path,
                                                    state.metadata_path])
         local_tree.commit_patch()

--- a/tools/wptrunner/wptrunner/update/tree.py
+++ b/tools/wptrunner/wptrunner/update/tree.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import tempfile
 
 from .. import vcs
 from ..vcs import git, hg
@@ -38,6 +39,9 @@ class NoVCSTree(object):
         return True
 
     def add_new(self, prefix=None):
+        pass
+
+    def add_ignored(self, sync_tree, prefix):
         pass
 
     def create_patch(self, patch_name, message):
@@ -89,6 +93,9 @@ class HgTree(object):
         else:
             args = ()
         self.hg("add", *args)
+
+    def add_ignored(self, sync_tree, prefix):
+        pass
 
     def create_patch(self, patch_name, message):
         try:
@@ -178,10 +185,26 @@ class GitTree(object):
                        add all files under that path.
         """
         if prefix is None:
-            args = ("-a",)
+            args = ["-a"]
         else:
-            args = ("--no-ignore-removal", prefix)
+            args = ["--no-ignore-removal", prefix]
         self.git("add", *args)
+
+    def add_ignored(self, sync_tree, prefix):
+        """Add files to the staging area that are explicitly ignored by git.
+
+        :param prefix: None to include all files or a path prefix to
+                       add all files under that path.
+        """
+        with tempfile.TemporaryFile() as f:
+            sync_tree.git("ls-tree", "-r", "--name-only", "HEAD", stdout=f)
+            f.seek(0)
+            ignored_files = sync_tree.git("check-ignore", "--no-index", "--stdin", "-z", stdin=f)
+        args = []
+        for entry in ignored_files.split('\0'):
+            args.append(os.path.join(prefix, entry))
+        if args:
+            self.git("add", "--force", *args)
 
     def list_refs(self, ref_filter=None):
         """Get a list of sha1, name tuples for references in a repository.

--- a/tools/wptrunner/wptrunner/vcs.py
+++ b/tools/wptrunner/wptrunner/vcs.py
@@ -14,6 +14,8 @@ def vcs(bin_name):
 
         repo = kwargs.pop("repo", None)
         log_error = kwargs.pop("log_error", True)
+        stdout = kwargs.pop("stdout", None)
+        stdin = kwargs.pop("stdin", None)
         if kwargs:
             raise TypeError(kwargs)
 
@@ -22,11 +24,16 @@ def vcs(bin_name):
         proc_kwargs = {}
         if repo is not None:
             proc_kwargs["cwd"] = repo
+        if stdout is not None:
+            proc_kwargs["stdout"] = stdout
+        if stdin is not None:
+            proc_kwargs["stdin"] = stdin
 
         command_line = [bin_name, command] + args
         logger.debug(" ".join(command_line))
         try:
-            return subprocess.check_output(command_line, stderr=subprocess.STDOUT, **proc_kwargs)
+            func = subprocess.check_output if not stdout else subprocess.check_call
+            return func(command_line, stderr=subprocess.STDOUT, **proc_kwargs)
         except OSError as e:
             if log_error:
                 logger.error(e)


### PR DESCRIPTION
This addresses an issue where `tools/third_party/attrs/.coveragerc` was added to that package's gitignore file but the but the file remains in the vendored package.