### PR TITLE
Update the screen-capture IDL file

### DIFF
--- a/interfaces/screen-capture.idl
+++ b/interfaces/screen-capture.idl
@@ -3,7 +3,7 @@
 // "Screen Capture" spec.
 // See: https://w3c.github.io/mediacapture-screen-share/
 
-partial interface NavigatorUserMedia {
+partial interface Navigator {
     Promise<MediaStream> getDisplayMedia(optional MediaStreamConstraints constraints);
 };
 

--- a/interfaces/screen-capture.idl
+++ b/interfaces/screen-capture.idl
@@ -10,6 +10,7 @@ partial interface Navigator {
 partial dictionary MediaTrackConstraintSet {
              ConstrainDOMString displaySurface;
              ConstrainBoolean logicalSurface;
+             ConstrainDOMString cursor;
 };
 
 enum DisplayCaptureSurfaceType {
@@ -17,4 +18,10 @@ enum DisplayCaptureSurfaceType {
     "window",
     "application",
     "browser"
+};
+
+enum CursorCaptureConstraint {
+    "never",
+    "always",
+    "motion"
 };

--- a/interfaces/screen-capture.idl
+++ b/interfaces/screen-capture.idl
@@ -1,0 +1,20 @@
+// GENERATED CONTENT - DO NOT EDIT
+// Content of this file was automatically extracted from the
+// "Screen Capture" spec.
+// See: https://w3c.github.io/mediacapture-screen-share/
+
+partial interface NavigatorUserMedia {
+    Promise<MediaStream> getDisplayMedia(optional MediaStreamConstraints constraints);
+};
+
+partial dictionary MediaTrackConstraintSet {
+             ConstrainDOMString displaySurface;
+             ConstrainBoolean logicalSurface;
+};
+
+enum DisplayCaptureSurfaceType {
+    "monitor",
+    "window",
+    "application",
+    "browser"
+};

--- a/screen-capture/META.yml
+++ b/screen-capture/META.yml
@@ -2,5 +2,4 @@ spec: https://w3c.github.io/mediacapture-screen-share/
 suggested_reviewers:
   - alvestrand
   - martinthomson
-  - suhasHere
   - uysalere

--- a/screen-capture/META.yml
+++ b/screen-capture/META.yml
@@ -1,3 +1,5 @@
 spec: https://w3c.github.io/mediacapture-screen-share/
 suggested_reviewers:
+  - alvestrand
   - martinthomson
+  - suhasHere

--- a/screen-capture/META.yml
+++ b/screen-capture/META.yml
@@ -3,3 +3,4 @@ suggested_reviewers:
   - alvestrand
   - martinthomson
   - suhasHere
+  - uysalere

--- a/screen-capture/META.yml
+++ b/screen-capture/META.yml
@@ -1,2 +1,3 @@
+spec: https://w3c.github.io/mediacapture-screen-share/
 suggested_reviewers:
   - martinthomson

--- a/screen-capture/META.yml
+++ b/screen-capture/META.yml
@@ -1,0 +1,2 @@
+suggested_reviewers:
+  - martinthomson

--- a/screen-capture/idlharness.window.js
+++ b/screen-capture/idlharness.window.js
@@ -7,10 +7,10 @@
 
 idl_test(
   ['screen-capture'],
-  ['mediacapture-streams'],
+  ['mediacapture-streams', 'html'],
   idl_array => {
     idl_array.add_objects({
-      NavigatorUserMedia: ['navigator'],
+      Navigator: ['navigator'],
     });
   }
 );

--- a/screen-capture/idlharness.window.js
+++ b/screen-capture/idlharness.window.js
@@ -1,0 +1,16 @@
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+'use strict';
+
+// https://w3c.github.io/mediacapture-screen-share/
+
+idl_test(
+  ['screen-capture'],
+  ['mediacapture-streams'],
+  idl_array => {
+    idl_array.add_objects({
+      NavigatorUserMedia: ['navigator'],
+    });
+  }
+);


### PR DESCRIPTION
Replacement for the totally borken https://github.com/web-platform-tests/wpt/pull/11835

Hello reviewer(s),

This PR is intended to consolidate the spec’s IDL definition with the WPT test suite’s copy, and any idlharness tests.

The up-to-date copy of the IDL file was automatically extracted from the reffy-reports repo (https://github.com/tidoust/reffy-reports/tree/master/whatwg/idl) which scrapes known specs automatically + regulary.

This PR is part of a migration project which will eventually be automatically updating and creating PRs for changes in spec IDL.

Please check that:
The spec (and its source) is correct and up-to-date
All tests which cover the IDL in the spec have been migrated to fetch + use the idl in the interfaces/ directory (instead of inline copies in the test files).