### PR TITLE
Compress wpt_report.json on Taskcluster

### DIFF
--- a/tools/ci/ci_taskcluster.sh
+++ b/tools/ci/ci_taskcluster.sh
@@ -7,3 +7,4 @@ if [ $1 == "firefox" ]; then
 elif [ $1 == "chrome" ]; then
     ./wpt run chrome --log-tbpl=../artifacts/log_tbpl.log --log-tbpl-level=info --log-wptreport=../artifacts/wpt_report.json --log-mach=- --this-chunk=$3 --total-chunks=$4 --test-type=$2 -y  --no-pause --no-restart-on-unexpected --install-fonts --no-fail-on-unexpected
 fi
+gzip ../artifacts/wpt_report.json


### PR DESCRIPTION
Use gzip to compress the output artifcat wpt_report.json in place.

Fixes #12265.

I think no one else is currently fetching the artifacts, so I chose in-place compression. If it breaks anything and/or causes any concern, I'm fine with preserving the original file.