### PR TITLE
[Streams] Add a test for piping to errored

### DIFF
--- a/streams/piping/multiple-propagation.js
+++ b/streams/piping/multiple-propagation.js
@@ -24,7 +24,7 @@ promise_test(t => {
     }
   });
 
-  // Trying to abort a stream that was errored will give that error back
+  // Trying to abort a stream that is erroring will give the writable's error
   return promise_rejects(t, error2, rs.pipeTo(ws), 'pipeTo must reject with the writable stream\'s error').then(() => {
     assert_array_equals(rs.events, []);
     assert_array_equals(ws.events, []);
@@ -49,17 +49,17 @@ promise_test(t => {
     }
   });
 
-  // Trying to abort a stream that was errored will give that error back
-  return Promise.resolve()
-      .then(() => promise_rejects(t, error1, rs.pipeTo(ws), 'pipeTo must reject with the readable stream\'s error'))
+  const writer = ws.getWriter();
+  return promise_rejects(t, error2, writer.closed, 'the writable stream must be errored with error2')
+      .then(() => {
+        writer.releaseLock();
+        return promise_rejects(t, error1, rs.pipeTo(ws), 'pipeTo must reject with the readable stream\'s error');
+      })
       .then(() => {
         assert_array_equals(rs.events, []);
         assert_array_equals(ws.events, []);
 
-        return Promise.all([
-          promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1'),
-          promise_rejects(t, error2, ws.getWriter().closed, 'the writable stream must be errored with error2')
-        ]);
+        return promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1');
       });
 }, 'Piping from an errored readable stream to an errored writable stream');
 
@@ -85,6 +85,34 @@ promise_test(t => {
       promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1'),
       promise_rejects(t, error2, ws.getWriter().closed, 'the writable stream must be errored with error2')
     ]);
+  });
+
+}, 'Piping from an errored readable stream to an erroring writable stream; preventAbort = true');
+
+promise_test(t => {
+  const rs = recordingReadableStream({
+    start(c) {
+      c.error(error1);
+    }
+  });
+  const ws = recordingWritableStream({
+    start(c) {
+      c.error(error2);
+    }
+  });
+
+  const writer = ws.getWriter();
+  return promise_rejects(t, error2, writer.closed, 'the writable stream must be errored with error2')
+  .then(() => {
+    writer.releaseLock();
+    return promise_rejects(t, error1, rs.pipeTo(ws, { preventAbort: true }),
+                           'pipeTo must reject with the readable stream\'s error');
+  })
+  .then(() => {
+    assert_array_equals(rs.events, []);
+    assert_array_equals(ws.events, []);
+
+    return promise_rejects(t, error1, rs.getReader().closed, 'the readable stream must be errored with error1');
   });
 
 }, 'Piping from an errored readable stream to an errored writable stream; preventAbort = true');
@@ -161,6 +189,32 @@ promise_test(t => {
       rs.getReader().closed,
       promise_rejects(t, error1, ws.getWriter().closed, 'the writable stream must be errored with error1')
     ]);
+  });
+
+}, 'Piping from a closed readable stream to an erroring writable stream');
+
+promise_test(t => {
+  const rs = recordingReadableStream({
+    start(c) {
+      c.close();
+    }
+  });
+  const ws = recordingWritableStream({
+    start(c) {
+      c.error(error1);
+    }
+  });
+
+  const writer = ws.getWriter();
+  return promise_rejects(t, error1, writer.closed, 'writer must be errored with error1')
+  .then(() => {
+    writer.releaseLock();
+    promise_rejects(t, error1, rs.pipeTo(ws), 'pipeTo must reject with the writable stream\'s error');
+  }).then(() => {
+    assert_array_equals(rs.events, []);
+    assert_array_equals(ws.events, []);
+
+    return rs.getReader().closed;
   });
 
 }, 'Piping from a closed readable stream to an errored writable stream');


### PR DESCRIPTION
The test 'Piping from an errored readable stream to an errored writable
stream' was misnamed, as the destination writable was erroring, not
errored. Rename it. Add a variant of the test where pipeTo() isn't
called until the destination is errored.