### PR TITLE
Fix a t.assert_unreached typo in a CSP test helper

### DIFF
--- a/content-security-policy/embedded-enforcement/support/testharness-helper.sub.js
+++ b/content-security-policy/embedded-enforcement/support/testharness-helper.sub.js
@@ -119,11 +119,11 @@ function assert_iframe_with_csp(t, url, csp, shouldBlock, urlId, blockedURI) {
 
   if (shouldBlock) {
     // Assert iframe does not load and is inaccessible.
-    window.onmessage = function (e) {
+    window.onmessage = t.step_func(function(e) {
       if (e.source != i.contentWindow)
           return;
-      t.assert_unreached('No message should be sent from the frame.');
-    }
+      assert_unreached('No message should be sent from the frame.');
+    });
     i.onload = t.step_func(function () {
       // Delay the check until after the postMessage has a chance to execute.
       setTimeout(t.step_func_done(function () {


### PR DESCRIPTION
Found via https://github.com/web-platform-tests/wpt/issues/10877#issuecomment-410348344.