### PR TITLE
Wrap a stray assert (causing harness error) in a test

### DIFF
--- a/priority-hints/img-attr-named-constructor.tentative.html
+++ b/priority-hints/img-attr-named-constructor.tentative.html
@@ -19,6 +19,8 @@
     assert_equals(img5.importance, "auto", "missing importance reflects as 'auto' IDL attribute on the image element");
   }, "importance attribute on <img> elements should reflect valid IDL values");
 
-  const img = new Image();
-  assert_equals(img.importance, "auto");
+  test(() => {
+    const img = new Image();
+    assert_equals(img.importance, "auto");
+  }, "importance of new Image() is 'auto'");
 </script>


### PR DESCRIPTION
Found via https://github.com/web-platform-tests/wpt/issues/10877#issuecomment-410348344.