### PR TITLE
Wrap an assert in step_func in a CSP test

### DIFF
--- a/content-security-policy/unsafe-hashes/style_attribute_allowed.html
+++ b/content-security-policy/unsafe-hashes/style_attribute_allowed.html
@@ -17,10 +17,9 @@
     <script>
         var t1 = async_test("Test that the inline style attribute is loaded");
 
-        function check_for_style() {
+        self.check_for_style = t1.step_func_done(function() {
           assert_equals("green", document.getElementById('test').style.background);
-          t1.done();
-        }
+        });
 
         window.addEventListener('securitypolicyviolation', t1.unreached_func("Should have not raised any event"));
     </script>


### PR DESCRIPTION
Previously, this test caused a harness error in Firefox and Safari, now
the test itself fails correctly instead.

Found via https://github.com/web-platform-tests/wpt/issues/10877#issuecomment-410348344.