### PR TITLE
Revert "Update selenium from 3.13.0 to 3.14.0"

### DIFF
--- a/tools/wptrunner/requirements_safari.txt
+++ b/tools/wptrunner/requirements_safari.txt
@@ -1,2 +1,2 @@
 mozprocess == 0.26
-selenium==3.14.0
+selenium==3.13.0


### PR DESCRIPTION
This reverts commit c1579120e855828706e6a0c613be7c5def14d7f8.

Version 3.14.0, released on 2018-08-02, includes a bug which regresses
support for the "RemoteDriver" [1]. That interface is used in this
project for integration with Apple Safari. The package upgrade was fully
automated and not motivated by any specific bug fix or feature. Revert
the upgrade to restore functionality.

[1] https://github.com/SeleniumHQ/selenium/issues/6250