### PR TITLE
Test for 304 updates on Content-* headers

### DIFF
--- a/fetch/http-cache/304-update.html
+++ b/fetch/http-cache/304-update.html
@@ -68,6 +68,59 @@
         ]
       },
       {
+        name: "HTTP cache updates returned Content-* headers from a Last-Modified 304",
+        requests: [
+          {
+            response_headers: [
+              ["Expires", -5000],
+              ["Last-Modified", -3000],
+              ["Content-Test-Header", "A"]
+            ]
+          },
+          {
+            response_headers: [
+              ["Expires", -3000],
+              ["Last-Modified", -3000],
+              ["Content-Test-Header", "B"]
+            ],
+            expected_type: "lm_validated",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ]
+          }
+        ]
+      },
+      {
+        name: "HTTP cache updates stored Content-* headers from a Last-Modified 304",
+        requests: [
+          {
+            response_headers: [
+              ["Expires", -5000],
+              ["Last-Modified", -3000],
+              ["Content-Test-Header", "A"]
+            ]
+          },
+          {
+            response_headers: [
+              ["Expires", 3000],
+              ["Last-Modified", -3000],
+              ["Content-Test-Header", "B"]
+            ],
+            expected_type: "lm_validated",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ],
+            pause_after: true
+          },
+          {
+            expected_type: "cached",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ]
+          }
+        ]
+      },
+      {
         name: "HTTP cache updates returned headers from a ETag 304",
         requests: [
           {

--- a/fetch/http-cache/304-update.html
+++ b/fetch/http-cache/304-update.html
@@ -173,6 +173,59 @@
           }
         ]
       },
+      {
+        name: "HTTP cache updates returned Content-* headers from a ETag 304",
+        requests: [
+          {
+            response_headers: [
+              ["Expires", -5000],
+              ["ETag", "ABC"],
+              ["Content-Test-Header", "A"]
+            ]
+          },
+          {
+            response_headers: [
+              ["Expires", -3000],
+              ["ETag", "ABC"],
+              ["Content-Test-Header", "B"]
+            ],
+            expected_type: "etag_validated",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ]
+          }
+        ]
+      },
+      {
+        name: "HTTP cache updates stored Content-* headers from a ETag 304",
+        requests: [
+          {
+            response_headers: [
+              ["Expires", -5000],
+              ["ETag", "DEF"],
+              ["Content-Test-Header", "A"]
+            ]
+          },
+          {
+            response_headers: [
+              ["Expires", 3000],
+              ["ETag", "DEF"],
+              ["Content-Test-Header", "B"]
+            ],
+            expected_type: "etag_validated",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ],
+            pause_after: true
+          },
+          {
+            expected_type: "cached",
+            expected_response_headers: [
+              ["Content-Test-Header", "B"]
+            ]
+          }
+        ]
+      }
     ];
     run_tests(tests);
     </script>

--- a/fetch/http-cache/304-update.html
+++ b/fetch/http-cache/304-update.html
@@ -121,7 +121,7 @@
         ]
       },
       {
-        name: "HTTP cache updates returned headers from a ETag 304",
+        name: "HTTP cache updates returned headers from an ETag 304",
         requests: [
           {
             response_headers: [
@@ -144,7 +144,7 @@
         ]
       },
       {
-        name: "HTTP cache updates stored headers from a ETag 304",
+        name: "HTTP cache updates stored headers from an ETag 304",
         requests: [
           {
             response_headers: [
@@ -174,7 +174,7 @@
         ]
       },
       {
-        name: "HTTP cache updates returned Content-* headers from a ETag 304",
+        name: "HTTP cache updates returned Content-* headers from an ETag 304",
         requests: [
           {
             response_headers: [
@@ -197,7 +197,7 @@
         ]
       },
       {
-        name: "HTTP cache updates stored Content-* headers from a ETag 304",
+        name: "HTTP cache updates stored Content-* headers from an ETag 304",
         requests: [
           {
             response_headers: [


### PR DESCRIPTION
Some browsers seem to exempt Content-* headers from 304 updates; this is to see how widespread that is.